### PR TITLE
Sticky interrupt prompt for the line-mode agent

### DIFF
--- a/docs/superpowers/plans/2026-07-17-sticky-interrupt-prompt.md
+++ b/docs/superpowers/plans/2026-07-17-sticky-interrupt-prompt.md
@@ -1,0 +1,1372 @@
+# Sticky interrupt prompt for the line-mode agent — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** In the line-mode CLI agent, pin the policy approval prompt to the bottom of the terminal so tool-call traces from concurrent branches stream into scrollback above it instead of burying it.
+
+**Architecture:** Generalize the "Thinking" spinner's `process.stdout.write` monkeypatch into a shared bottom-region coordinator that redraws a multi-line footer above every outside write. Split the "what" from the "how" throughout: pure cores decide (`buildFrame` produces the exact terminal bytes; `reduceInterrupt` decides the next widget state and outcome), and thin imperative shells wire them to stdout and `readline`. Route only the policy prompt to the widget through a new `interruptChoice` primitive that falls back to `chooseOption` everywhere else.
+
+**Tech Stack:** TypeScript (`lib/stdlib/cli.ts`, the line-mode bridge), Agency stdlib (`stdlib/ui/cli.agency`, `stdlib/policy.agency`), Vitest, `@/utils/termcolors` for colors, `lib/stdlib/layout/ansi.ts` for ANSI width/wrapping, raw ANSI only for cursor control.
+
+## Global Constraints
+
+Every task implicitly includes these. Values copied from the design spec (`docs/superpowers/specs/2026-07-17-sticky-interrupt-prompt-design.md`).
+
+- **Line mode only.** Do not touch the TUI path (`std::ui`'s render loop / `_openChoicePrompt`) or the non-TTY input-loop fallback.
+- **One changed call site.** The only behavioral switch is `askUser` in `stdlib/policy.agency` calling `interruptChoice` instead of `chooseOption`. Do not change `chooseOption` or any other caller of it.
+- **Reuse, don't reinvent.** Measure and wrap strings with `visualWidth` / `wrapText` from `lib/stdlib/layout/ansi.ts` (they already handle SGR-aware width and wrapping). Colors via `styles` / `RESET` / `color` from termcolors. Raw ANSI (`\x1b[...`) is allowed ONLY for cursor movement, screen clearing, cursor visibility, and synchronized-output — matching escapes already in `cli.ts`.
+- **What vs how.** Business logic lives in pure functions (`buildFrame`, `reduceInterrupt`, `classifyInterruptKey`, `renderInterruptFooter`, `packOptions`). Imperative shells (`installBottomRegion`, `stickyInterruptPrompt`) only do I/O and wiring; they contain no branching business logic beyond dispatching an outcome.
+- **Style.** No C-style `for` loops (use `forEach` / `flatMap` / array methods). No one-line `if` statements (always block bodies). No nested ternaries. No single-character variable names. Named constants, not magic numbers.
+- **Anti-flicker (hard requirements).** One atomic `process.stdout.write` per repaint frame (built by `buildFrame`); synchronized-output brackets (`\x1b[?2026h`…`\x1b[?2026l`) around each frame; redraw on events, never on a timer (the spinner's own animation timer drives `refresh()`); footer lines wrapped to `columns - 1` so physical rows are counted correctly.
+- **Cursor.** Hiding the cursor is scoped to the interrupt widget (via `installBottomRegion`'s `hideCursor` option); the spinner does not hide it. A one-time `process.once("exit")` handler restores the cursor as crash-safety. The widget renders its own caret glyph in the reason line because the real cursor is hidden.
+- **Rebuild after stdlib edits.** After editing `.agency` files run `make`. After editing `cli.ts`, `make` (the TS build) is required before the Agency side can import the new bridge functions.
+
+---
+
+## File Structure
+
+- `lib/stdlib/cli.ts` (modify) — the line-mode bridge. Gains: pure ANSI-frame builder (`buildFrame` + `eraseRows`), the coordinator shell (`installBottomRegion`), the spinner refactored onto it, the pure widget core (`classifyInterruptKey`, `reduceInterrupt`, `renderInterruptFooter`, `packOptions`), the widget shell (`stickyInterruptPrompt`), the bridge exports (`_interruptChoice`, `_stickyInterruptAvailable`), and the `__agencyInterruptPrompt` hook in `_runLineRepl`. New pure helpers join the existing `_internal` export for testing.
+- `lib/stdlib/cli.test.ts` (modify) — a shared `captureStdout()` helper plus tests for every pure core and thin integration smoke tests.
+- `stdlib/ui/cli.agency` (modify) — the `interruptChoice` primitive (gates on `_stickyInterruptAvailable()`, falls back to `chooseOption`).
+- `stdlib/policy.agency` (modify) — `askUser` calls `interruptChoice`.
+
+No new files.
+
+---
+
+## Task 1: Pure ANSI-frame builder + bottom-region coordinator
+
+Create the pure frame builder and the thin coordinator shell around it. Reuse `visualWidth`/`wrapText`.
+
+**Files:**
+- Modify: `lib/stdlib/cli.ts`
+- Test: `lib/stdlib/cli.test.ts`
+
+**Interfaces:**
+- Consumes: `wrapText`, `visualWidth` from `./layout/ansi.js`.
+- Produces:
+  - `eraseRows(rows: number): string`
+  - `type FrameCursor = "hide" | "show" | "keep"`
+  - `type FrameSpec = { above: string | null; footerLines: string[]; prevRows: number; columns: number; cursor: FrameCursor }`
+  - `type FrameResult = { seq: string; rows: number }`
+  - `buildFrame(spec: FrameSpec): FrameResult`
+  - `export type BottomRegion = { refresh: () => void; teardown: () => void }`
+  - `export function installBottomRegion(render: () => string[], useTTY: boolean, options?: { hideCursor: boolean }): BottomRegion`
+
+- [ ] **Step 1: Write failing tests for `eraseRows` and `buildFrame`**
+
+Add to `lib/stdlib/cli.test.ts` (destructure the new names from `_internal`):
+
+```typescript
+describe("eraseRows", () => {
+  it("returns nothing when there is no footer yet", () => {
+    expect(eraseRows(0)).toBe("");
+  });
+  it("clears a single row with CR + clear-down, no cursor move", () => {
+    expect(eraseRows(1)).toBe("\r\x1b[0J");
+  });
+  it("moves up rows-1 before clearing for a multi-row footer", () => {
+    expect(eraseRows(3)).toBe("\x1b[2A\r\x1b[0J");
+  });
+});
+
+describe("buildFrame", () => {
+  it("first frame of a 1-row footer: sync brackets + footer, no erase", () => {
+    const result = buildFrame({ above: null, footerLines: ["FOOTER"], prevRows: 0, columns: 80, cursor: "keep" });
+    expect(result.rows).toBe(1);
+    expect(result.seq).toBe("\x1b[?2026h" + "FOOTER" + "\x1b[?2026l");
+  });
+  it("erases the previous footer, then emits `above`, then redraws", () => {
+    const result = buildFrame({ above: "trace\n", footerLines: ["A", "B"], prevRows: 3, columns: 80, cursor: "keep" });
+    expect(result.seq).toBe("\x1b[?2026h" + "\x1b[2A\r\x1b[0J" + "trace\n" + "A\nB" + "\x1b[?2026l");
+    expect(result.rows).toBe(2);
+  });
+  it("appends a newline to `above` when missing so the footer starts fresh", () => {
+    const result = buildFrame({ above: "x", footerLines: ["F"], prevRows: 1, columns: 80, cursor: "keep" });
+    expect(result.seq).toContain("x\n");
+  });
+  it("emits hide/show cursor when asked", () => {
+    expect(buildFrame({ above: null, footerLines: ["F"], prevRows: 0, columns: 80, cursor: "hide" }).seq).toContain("\x1b[?25l");
+    expect(buildFrame({ above: null, footerLines: [], prevRows: 1, columns: 80, cursor: "show" }).seq).toContain("\x1b[?25h");
+  });
+  it("counts wrapped rows for an over-wide footer line", () => {
+    const wide = "w".repeat(50);
+    expect(buildFrame({ above: null, footerLines: [wide], prevRows: 0, columns: 20, cursor: "keep" }).rows).toBeGreaterThan(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `pnpm exec vitest run lib/stdlib/cli.test.ts -t "eraseRows|buildFrame"`
+Expected: FAIL — `eraseRows is not a function`.
+
+- [ ] **Step 3: Implement the pure builder**
+
+Add to `lib/stdlib/cli.ts`. Add the import near the other stdlib imports at the top:
+
+```typescript
+import { visualWidth, wrapText } from "./layout/ansi.js";
+```
+
+Add the constants near the existing ANSI constants (around `cli.ts:191`):
+
+```typescript
+const HIDE_CURSOR = "\x1b[?25l";
+const SHOW_CURSOR = "\x1b[?25h";
+const SYNC_BEGIN = "\x1b[?2026h"; // DEC synchronized-update begin
+const SYNC_END = "\x1b[?2026l";   // DEC synchronized-update end
+const CLEAR_DOWN = "\x1b[0J";     // clear from cursor to end of screen
+const MIN_FOOTER_WIDTH = 20;
+```
+
+Add the pure builder:
+
+```typescript
+/** Cursor moves that erase a footer of `rows` physical rows, leaving the
+ *  cursor at column 0 of where the footer's first row began. Empty when
+ *  there is no footer yet. */
+function eraseRows(rows: number): string {
+  if (rows === 0) {
+    return "";
+  }
+  const moveUp = rows > 1 ? `\x1b[${rows - 1}A` : "";
+  return `${moveUp}\r${CLEAR_DOWN}`;
+}
+
+type FrameCursor = "hide" | "show" | "keep";
+
+type FrameSpec = {
+  above: string | null;
+  footerLines: string[];
+  prevRows: number;
+  columns: number;
+  cursor: FrameCursor;
+};
+
+type FrameResult = { seq: string; rows: number };
+
+function cursorSequence(cursor: FrameCursor): string {
+  if (cursor === "hide") {
+    return HIDE_CURSOR;
+  }
+  if (cursor === "show") {
+    return SHOW_CURSOR;
+  }
+  return "";
+}
+
+function withTrailingNewline(text: string): string {
+  if (text.endsWith("\n")) {
+    return text;
+  }
+  return `${text}\n`;
+}
+
+/** Build ONE atomic terminal frame: erase the previous footer, optionally
+ *  emit `above` into scrollback, then redraw the footer wrapped to width.
+ *  Pure — the exact bytes and the new physical-row count are a function of
+ *  the inputs, so the anti-flicker guarantees are unit-testable. */
+function buildFrame(spec: FrameSpec): FrameResult {
+  const width = Math.max(MIN_FOOTER_WIDTH, spec.columns - 1);
+  const physical = spec.footerLines.flatMap((line) => wrapText(line, width));
+  const above = spec.above === null ? "" : withTrailingNewline(spec.above);
+  const seq =
+    SYNC_BEGIN +
+    eraseRows(spec.prevRows) +
+    above +
+    physical.join("\n") +
+    cursorSequence(spec.cursor) +
+    SYNC_END;
+  return { seq, rows: physical.length };
+}
+```
+
+Add to the `_internal` export (`cli.ts:1240`):
+
+```typescript
+  eraseRows,
+  buildFrame,
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `pnpm exec vitest run lib/stdlib/cli.test.ts -t "eraseRows|buildFrame"`
+Expected: PASS.
+
+- [ ] **Step 5: Write a failing test for `installBottomRegion` (with a shared capture helper)**
+
+Add this helper once, near the top of `lib/stdlib/cli.test.ts` (below the imports), so no describe block repeats stdout plumbing:
+
+```typescript
+/** Replace process.stdout.write with a capturing sink and force isTTY on.
+ *  installBottomRegion binds this sink as its realWrite, so every frame is
+ *  captured. Returns the buffer and a restore fn. */
+function captureStdout(): { captured: string[]; restore: () => void } {
+  const captured: string[] = [];
+  const originalWrite = process.stdout.write;
+  const originalIsTTY = (process.stdout as any).isTTY;
+  (process.stdout as any).write = (chunk: any) => { captured.push(String(chunk)); return true; };
+  (process.stdout as any).isTTY = true;
+  return {
+    captured,
+    restore: () => {
+      (process.stdout as any).write = originalWrite;
+      (process.stdout as any).isTTY = originalIsTTY;
+    },
+  };
+}
+```
+
+Then the tests:
+
+```typescript
+describe("installBottomRegion", () => {
+  it("no-ops on non-TTY (passes writes straight through)", () => {
+    const cap = captureStdout();
+    const region = installBottomRegion(() => ["footer"], false);
+    process.stdout.write("hello");
+    region.teardown();
+    cap.restore();
+    expect(cap.captured).toEqual(["hello"]);
+  });
+  it("redraws the footer above an outside write", () => {
+    const cap = captureStdout();
+    const region = installBottomRegion(() => ["FOOTER"], true);
+    cap.captured.length = 0; // drop the initial paint
+    process.stdout.write("trace line\n");
+    region.teardown();
+    cap.restore();
+    const text = cap.captured.join("");
+    expect(text).toContain("trace line\n");
+    expect(text.indexOf("trace line")).toBeLessThan(text.lastIndexOf("FOOTER"));
+  });
+});
+```
+
+- [ ] **Step 6: Run to verify it fails**
+
+Run: `pnpm exec vitest run lib/stdlib/cli.test.ts -t "installBottomRegion"`
+Expected: FAIL — `installBottomRegion is not a function`.
+
+- [ ] **Step 7: Implement the coordinator shell**
+
+Add to `lib/stdlib/cli.ts`:
+
+```typescript
+export type BottomRegion = { refresh: () => void; teardown: () => void };
+
+type RegionOptions = { hideCursor: boolean };
+
+const NOOP_REGION: BottomRegion = { refresh: () => { }, teardown: () => { } };
+
+// At most one bottom region owns process.stdout.write at a time. Folding
+// the spinner onto this coordinator (Task 2) makes single-ownership
+// structural rather than an ordering discipline.
+let activeRegion: BottomRegion | null = null;
+
+// Crash-safety: if the process exits while a region still hides the
+// cursor, restore it. Registered once.
+let cursorRestoreRegistered = false;
+function registerCursorRestore(): void {
+  if (cursorRestoreRegistered) {
+    return;
+  }
+  cursorRestoreRegistered = true;
+  process.once("exit", () => {
+    if (activeRegion) {
+      process.stdout.write(SHOW_CURSOR);
+    }
+  });
+}
+
+function chunkToText(chunk: unknown): string {
+  if (typeof chunk === "string") {
+    return chunk;
+  }
+  return String(chunk);
+}
+
+/** Pin `render()`'s lines to the bottom of the terminal. While installed,
+ *  every other write to process.stdout is redrawn ABOVE the footer as one
+ *  atomic frame (via buildFrame). No-op on non-TTY. `hideCursor` scopes
+ *  cursor-hiding to callers that draw their own caret (the interrupt
+ *  widget); the spinner leaves the cursor alone. */
+export function installBottomRegion(
+  render: () => string[],
+  useTTY: boolean,
+  options: RegionOptions = { hideCursor: false },
+): BottomRegion {
+  if (!useTTY) {
+    return NOOP_REGION;
+  }
+  if (activeRegion) {
+    activeRegion.teardown();
+  }
+  registerCursorRestore();
+
+  const stdoutAny = process.stdout as unknown as {
+    write: (chunk: any, ...rest: any[]) => any;
+  };
+  const realWrite = stdoutAny.write.bind(process.stdout);
+  let rows = 0;
+  let firstPaint = true;
+
+  const paint = (above: string | null): boolean => {
+    const hideNow = options.hideCursor && firstPaint;
+    const frame = buildFrame({
+      above,
+      footerLines: render(),
+      prevRows: rows,
+      columns: process.stdout.columns || 80,
+      cursor: hideNow ? "hide" : "keep",
+    });
+    firstPaint = false;
+    rows = frame.rows;
+    return realWrite(frame.seq);
+  };
+
+  paint(null);
+  stdoutAny.write = (chunk: any): boolean => paint(chunkToText(chunk));
+
+  const region: BottomRegion = {
+    refresh: () => { paint(null); },
+    teardown: () => {
+      stdoutAny.write = realWrite;
+      const frame = buildFrame({
+        above: null,
+        footerLines: [],
+        prevRows: rows,
+        columns: process.stdout.columns || 80,
+        cursor: options.hideCursor ? "show" : "keep",
+      });
+      realWrite(frame.seq);
+      rows = 0;
+      if (activeRegion === region) {
+        activeRegion = null;
+      }
+    },
+  };
+  activeRegion = region;
+  return region;
+}
+```
+
+- [ ] **Step 8: Run the coordinator tests and the full file**
+
+Run: `pnpm exec vitest run lib/stdlib/cli.test.ts`
+Expected: PASS (existing tests plus the new ones). Update the import line in the test file to pull the direct export:
+
+```typescript
+import { _internal, _clearHistory, installBottomRegion, type PasteState } from "./cli.js";
+```
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add lib/stdlib/cli.ts lib/stdlib/cli.test.ts
+git commit -m "feat(cli): pure ANSI-frame builder + bottom-region coordinator"
+```
+
+---
+
+## Task 2: Fold the spinner onto the coordinator
+
+Replace `startSpinner`'s own monkeypatch with a one-line bottom region. Correctness fix from spec Finding 4, kept as its own reviewable step.
+
+**Files:**
+- Modify: `lib/stdlib/cli.ts:330-373` (`startSpinner`)
+
+**Interfaces:**
+- Consumes: `installBottomRegion` (Task 1).
+- Produces: unchanged `startSpinner(useTTY: boolean): () => void`.
+
+- [ ] **Step 1: Replace the `startSpinner` body**
+
+Replace `startSpinner` (`cli.ts:330-373`) with:
+
+```typescript
+/**
+ * Start a single-line "Thinking Ns" spinner as a one-line bottom region.
+ * Returns a stop function that removes the region. The spinner is now a
+ * client of installBottomRegion: outside writes (tool traces) redraw
+ * above it automatically, and there is exactly one owner of the bottom of
+ * the screen. It does NOT hide the cursor (default RegionOptions). No-op
+ * on non-TTY.
+ */
+function startSpinner(useTTY: boolean): () => void {
+  if (!useTTY) {
+    return () => { };
+  }
+  const startedAt = Date.now();
+  const render = (): string[] => {
+    const elapsedMs = Date.now() - startedAt;
+    const elapsedSec = Math.floor(elapsedMs / 1000);
+    const frameIndex =
+      Math.floor(elapsedMs / SPINNER_INTERVAL_MS) % SPINNER_FRAMES.length;
+    return [`${DIM}${SPINNER_FRAMES[frameIndex]} Thinking ${elapsedSec}s${COLOR_RESET}`];
+  };
+  const region = installBottomRegion(render, useTTY);
+  const timer = setInterval(() => region.refresh(), SPINNER_INTERVAL_MS);
+  return (): void => {
+    clearInterval(timer);
+    region.teardown();
+  };
+}
+```
+
+Then check whether the old `CLEAR_LINE` constant (`cli.ts:191`) is now unused:
+
+```bash
+grep -n "CLEAR_LINE" lib/stdlib/cli.ts
+```
+
+If the only remaining hit is its definition, delete that line.
+
+- [ ] **Step 2: Build the TS**
+
+Run: `make`
+Expected: builds without type errors.
+
+- [ ] **Step 3: Add a spinner-coexistence test**
+
+Add `startSpinner` to `_internal` (`cli.ts:1240`), then:
+
+```typescript
+describe("startSpinner coexists with outside writes", () => {
+  it("redraws the Thinking line after an outside write", () => {
+    const cap = captureStdout();
+    const stop = _internal.startSpinner(true);
+    cap.captured.length = 0;
+    process.stdout.write("tool output\n");
+    stop();
+    cap.restore();
+    const text = cap.captured.join("");
+    expect(text).toContain("tool output\n");
+    expect(text.indexOf("tool output")).toBeLessThan(text.lastIndexOf("Thinking"));
+  });
+});
+```
+
+- [ ] **Step 4: Run the spinner test and the full file**
+
+Run: `pnpm exec vitest run lib/stdlib/cli.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/stdlib/cli.ts lib/stdlib/cli.test.ts
+git commit -m "refactor(cli): fold the Thinking spinner onto the bottom-region coordinator"
+```
+
+---
+
+## Task 3: Pure widget core (classifier, reducer, renderer, option packer)
+
+The decision-making, all pure and exhaustively testable. No terminal I/O.
+
+**Files:**
+- Modify: `lib/stdlib/cli.ts`
+- Test: `lib/stdlib/cli.test.ts`
+
+**Interfaces:**
+- Consumes: `visualWidth` (Task 1 import), `styles`/`RESET`/`color`, `DIM`/`COLOR_RESET`.
+- Produces:
+  - `type InterruptAction = "submit" | "cancel" | "exit" | "backspace" | { append: string } | null`
+  - `type KeyMeta = { name?: string; ctrl?: boolean; meta?: boolean }`
+  - `classifyInterruptKey(sequence: unknown, key: KeyMeta | undefined): InterruptAction`
+  - `type InterruptState = { buffer: string; notice: string }`
+  - `type InterruptOutcome = { kind: "pending" } | { kind: "resolve"; value: string } | { kind: "cancel" } | { kind: "exit" }`
+  - `type InterruptConfig = { validKeys: string[]; allowFreeText: boolean; allowCancel: boolean }`
+  - `type InterruptStep = { state: InterruptState; outcome: InterruptOutcome }`
+  - `const INITIAL_INTERRUPT_STATE: InterruptState`
+  - `reduceInterrupt(state, action, config): InterruptStep`
+  - `packOptions(items: {key:string;label:string}[], width: number): string[]`
+  - `type InterruptFooterInput = { title: string; body: string; items: {key:string;label:string}[]; allowFreeText: boolean; state: InterruptState; columns: number }`
+  - `renderInterruptFooter(input: InterruptFooterInput): string[]`
+
+- [ ] **Step 1: Write failing tests for the classifier and reducer**
+
+```typescript
+describe("classifyInterruptKey", () => {
+  const classify = (sequence: any, key: any) => _internal.classifyInterruptKey(sequence, key);
+  it("Ctrl+C is a hard exit (diverges from paste-mode soft cancel)", () => {
+    expect(classify(null, { name: "c", ctrl: true })).toBe("exit");
+  });
+  it("Escape is a soft cancel", () => {
+    expect(classify(null, { name: "escape" })).toBe("cancel");
+  });
+  it("Enter submits", () => {
+    expect(classify(null, { name: "return" })).toBe("submit");
+    expect(classify(null, { name: "enter" })).toBe("submit");
+  });
+  it("Backspace deletes", () => {
+    expect(classify(null, { name: "backspace" })).toBe("backspace");
+  });
+  it("a printable char appends; chords and arrows are ignored", () => {
+    expect(classify("a", { name: "a" })).toEqual({ append: "a" });
+    expect(classify(null, { name: "up" })).toBeNull();
+    expect(classify("x", { name: "x", meta: true })).toBeNull();
+  });
+});
+
+describe("reduceInterrupt", () => {
+  const config = { validKeys: ["a", "r", "aa", "ap", "rr"], allowFreeText: true, allowCancel: true };
+  const from = (buffer: string) => ({ buffer, notice: "" });
+  const reduce = _internal.reduceInterrupt;
+
+  it("exit action yields an exit outcome", () => {
+    expect(reduce(from(""), "exit", config).outcome).toEqual({ kind: "exit" });
+  });
+  it("Escape cancels when allowCancel, pends otherwise", () => {
+    expect(reduce(from(""), "cancel", config).outcome).toEqual({ kind: "cancel" });
+    expect(reduce(from(""), "cancel", { ...config, allowCancel: false }).outcome).toEqual({ kind: "pending" });
+  });
+  it("appends a printable char and clears the notice", () => {
+    const step = reduce({ buffer: "a", notice: "x" }, { append: "a" }, config);
+    expect(step.state).toEqual({ buffer: "aa", notice: "" });
+    expect(step.outcome).toEqual({ kind: "pending" });
+  });
+  it("strips embedded newlines from an appended chunk (single-line reason)", () => {
+    expect(reduce(from("a"), { append: "b\nc" }, config).state.buffer).toBe("abc");
+  });
+  it("backspace deletes the last char and clears the notice", () => {
+    expect(reduce({ buffer: "aa", notice: "x" }, "backspace", config).state).toEqual({ buffer: "a", notice: "" });
+  });
+  it("submit resolves an exact key — 'a' does NOT early-resolve before 'aa'", () => {
+    expect(reduce(from("aa"), "submit", config).outcome).toEqual({ kind: "resolve", value: "aa" });
+    expect(reduce(from("a"), "submit", config).outcome).toEqual({ kind: "resolve", value: "a" });
+  });
+  it("submit returns a free-text reason even when it starts with an option letter", () => {
+    expect(reduce(from("actually no"), "submit", config).outcome).toEqual({ kind: "resolve", value: "actually no" });
+  });
+  it("submit on empty pends with no notice (must-answer)", () => {
+    const step = reduce(from(""), "submit", config);
+    expect(step.outcome).toEqual({ kind: "pending" });
+    expect(step.state.notice).toBe("");
+  });
+  it("submit on invalid input without free text pends with a notice", () => {
+    const step = reduce(from("zzz"), "submit", { ...config, allowFreeText: false });
+    expect(step.outcome).toEqual({ kind: "pending" });
+    expect(step.state.notice).toBe("not a valid option");
+  });
+  it("an ignored key pends without changing state", () => {
+    expect(reduce(from("a"), null, config)).toEqual({ state: { buffer: "a", notice: "" }, outcome: { kind: "pending" } });
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `pnpm exec vitest run lib/stdlib/cli.test.ts -t "classifyInterruptKey|reduceInterrupt"`
+Expected: FAIL — `classifyInterruptKey is not a function`.
+
+- [ ] **Step 3: Implement the classifier and reducer**
+
+```typescript
+type InterruptAction =
+  | "submit"
+  | "cancel"
+  | "exit"
+  | "backspace"
+  | { append: string }
+  | null;
+
+type KeyMeta = { name?: string; ctrl?: boolean; meta?: boolean };
+
+/** Map a readline keypress to an interrupt-widget action. DELIBERATELY
+ *  DIVERGES from classifyPasteKey: Ctrl+C is a hard "exit" (an approval
+ *  prompt must quit, never soft-cancel-and-continue), Escape is a soft
+ *  "cancel", and Enter is "submit" (there is no Ctrl+D submit). */
+function classifyInterruptKey(sequence: unknown, key: KeyMeta | undefined): InterruptAction {
+  const name = key?.name;
+  if (key?.ctrl && name === "c") {
+    return "exit";
+  }
+  if (name === "escape") {
+    return "cancel";
+  }
+  if (name === "return" || name === "enter") {
+    return "submit";
+  }
+  if (name === "backspace") {
+    return "backspace";
+  }
+  const printable = typeof sequence === "string" && sequence.length > 0 && !key?.ctrl && !key?.meta;
+  if (printable) {
+    return { append: sequence as string };
+  }
+  return null;
+}
+
+type InterruptState = { buffer: string; notice: string };
+
+type InterruptOutcome =
+  | { kind: "pending" }
+  | { kind: "resolve"; value: string }
+  | { kind: "cancel" }
+  | { kind: "exit" };
+
+type InterruptConfig = { validKeys: string[]; allowFreeText: boolean; allowCancel: boolean };
+
+type InterruptStep = { state: InterruptState; outcome: InterruptOutcome };
+
+const INITIAL_INTERRUPT_STATE: InterruptState = { buffer: "", notice: "" };
+const INVALID_NOTICE = "not a valid option";
+
+/** Interpret a committed buffer: exact key match resolves; a non-empty
+ *  buffer with free text allowed resolves as a reason; empty re-prompts
+ *  silently (must-answer); invalid-without-free-text re-prompts with a
+ *  notice. */
+function submitInterrupt(state: InterruptState, config: InterruptConfig): InterruptStep {
+  const answer = state.buffer.trim();
+  if (config.validKeys.includes(answer)) {
+    return { state, outcome: { kind: "resolve", value: answer } };
+  }
+  if (config.allowFreeText && answer !== "") {
+    return { state, outcome: { kind: "resolve", value: answer } };
+  }
+  const notice = answer === "" ? "" : INVALID_NOTICE;
+  return { state: { buffer: state.buffer, notice }, outcome: { kind: "pending" } };
+}
+
+/** Pure state machine for the sticky interrupt prompt: given the current
+ *  state and a key action, return the next state and an outcome. The
+ *  imperative shell acts on the outcome; all decisions live here. */
+function reduceInterrupt(
+  state: InterruptState,
+  action: InterruptAction,
+  config: InterruptConfig,
+): InterruptStep {
+  if (action === "exit") {
+    return { state, outcome: { kind: "exit" } };
+  }
+  if (action === "cancel") {
+    if (config.allowCancel) {
+      return { state, outcome: { kind: "cancel" } };
+    }
+    return { state, outcome: { kind: "pending" } };
+  }
+  if (action === "backspace") {
+    return { state: { buffer: state.buffer.slice(0, -1), notice: "" }, outcome: { kind: "pending" } };
+  }
+  if (action === "submit") {
+    return submitInterrupt(state, config);
+  }
+  if (action !== null && typeof action === "object") {
+    const cleaned = action.append.replace(/[\r\n]/g, "");
+    return { state: { buffer: state.buffer + cleaned, notice: "" }, outcome: { kind: "pending" } };
+  }
+  return { state, outcome: { kind: "pending" } };
+}
+```
+
+Add to `_internal`:
+
+```typescript
+  classifyInterruptKey,
+  reduceInterrupt,
+  INITIAL_INTERRUPT_STATE,
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `pnpm exec vitest run lib/stdlib/cli.test.ts -t "classifyInterruptKey|reduceInterrupt"`
+Expected: PASS.
+
+- [ ] **Step 5: Write failing tests for `packOptions` and `renderInterruptFooter`**
+
+```typescript
+describe("packOptions", () => {
+  it("packs short tokens onto one line", () => {
+    expect(_internal.packOptions([{ key: "a", label: "ok" }, { key: "r", label: "no" }], 40)).toEqual(["a=ok  r=no"]);
+  });
+  it("wraps when the next token would overflow", () => {
+    expect(_internal.packOptions([{ key: "a", label: "approve" }, { key: "r", label: "reject" }], 10)).toEqual(["a=approve", "r=reject"]);
+  });
+});
+
+describe("renderInterruptFooter", () => {
+  const items = [
+    { key: "a", label: "approve once" },
+    { key: "r", label: "reject once" },
+    { key: "rr", label: "reject always" },
+  ];
+  const base = {
+    title: "bash: rm -rf build/ — approve?",
+    body: "",
+    items,
+    allowFreeText: true,
+    state: { buffer: "aa", notice: "" },
+    columns: 80,
+  };
+  it("shows divider, title, options, hint, and the input line with a caret", () => {
+    const lines = _internal.renderInterruptFooter(base);
+    const joined = lines.join("\n");
+    expect(joined).toContain("bash: rm -rf build/ — approve?");
+    expect(joined).toContain("a=approve once");
+    expect(joined).toContain("rr=reject always");
+    expect(joined).toContain("Enter to submit");
+    expect(lines[lines.length - 1]).toContain("> aa");
+    expect(lines[lines.length - 1]).toContain("▏"); // caret glyph
+  });
+  it("caps a long body to 6 lines with an ellipsis", () => {
+    const body = Array.from({ length: 20 }, (_unused, index) => `line${index}`).join("\n");
+    const lines = _internal.renderInterruptFooter({ ...base, body });
+    expect(lines.filter((line) => /line\d/.test(line)).length).toBe(6);
+    expect(lines.some((line) => line.includes("…"))).toBe(true);
+  });
+  it("shows a notice when present", () => {
+    const lines = _internal.renderInterruptFooter({ ...base, state: { buffer: "z", notice: "not a valid option" } });
+    expect(lines.join("\n")).toContain("not a valid option");
+  });
+});
+```
+
+- [ ] **Step 6: Run to verify they fail**
+
+Run: `pnpm exec vitest run lib/stdlib/cli.test.ts -t "packOptions|renderInterruptFooter"`
+Expected: FAIL — `packOptions is not a function`.
+
+- [ ] **Step 7: Implement the packer and renderer**
+
+```typescript
+/** Greedily pack `key=label` tokens into lines no wider than `width`
+ *  visible columns, joined by two spaces. A token wider than `width` gets
+ *  its own line (buildFrame wraps it at render time). */
+function packOptions(items: { key: string; label: string }[], width: number): string[] {
+  const lines: string[] = [];
+  let current = "";
+  items.forEach((item) => {
+    const token = `${item.key}=${item.label}`;
+    if (current === "") {
+      current = token;
+      return;
+    }
+    const fits = visualWidth(current) + 2 + visualWidth(token) <= width;
+    if (fits) {
+      current = `${current}  ${token}`;
+      return;
+    }
+    lines.push(current);
+    current = token;
+  });
+  if (current !== "") {
+    lines.push(current);
+  }
+  return lines;
+}
+
+const INTERRUPT_BODY_MAX_LINES = 6;
+const INTERRUPT_CARET = "▏";
+
+type InterruptFooterInput = {
+  title: string;
+  body: string;
+  items: { key: string; label: string }[];
+  allowFreeText: boolean;
+  state: InterruptState;
+  columns: number;
+};
+
+function bodyLines(body: string): string[] {
+  if (body === "") {
+    return [];
+  }
+  const raw = body.split("\n");
+  const shown = raw.slice(0, INTERRUPT_BODY_MAX_LINES).map((line) => ` ${DIM}${line}${COLOR_RESET}`);
+  if (raw.length > INTERRUPT_BODY_MAX_LINES) {
+    shown.push(` ${DIM}…${COLOR_RESET}`);
+  }
+  return shown;
+}
+
+/** Render the sticky approval prompt as footer lines. Pure. The real
+ *  cursor is hidden by the widget, so the input line ends with a caret
+ *  glyph. buildFrame truncates/wraps each line to width. */
+function renderInterruptFooter(input: InterruptFooterInput): string[] {
+  const width = Math.max(MIN_FOOTER_WIDTH, input.columns - 1);
+  const lines: string[] = [`${DIM}${"─".repeat(width)}${COLOR_RESET}`];
+  if (input.title !== "") {
+    lines.push(` ${input.title}`);
+  }
+  bodyLines(input.body).forEach((line) => lines.push(line));
+  packOptions(input.items, width - 1).forEach((row) => lines.push(` ${row}`));
+  if (input.allowFreeText) {
+    lines.push(` ${DIM}or type a reason · Enter to submit${COLOR_RESET}`);
+  }
+  if (input.state.notice !== "") {
+    lines.push(` ${color.yellow(input.state.notice)}`);
+  }
+  lines.push(` > ${input.state.buffer}${INTERRUPT_CARET}`);
+  return lines;
+}
+```
+
+Add to `_internal`:
+
+```typescript
+  packOptions,
+  renderInterruptFooter,
+```
+
+- [ ] **Step 8: Run the render tests and the full file**
+
+Run: `pnpm exec vitest run lib/stdlib/cli.test.ts`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add lib/stdlib/cli.ts lib/stdlib/cli.test.ts
+git commit -m "feat(cli): pure widget core — classifier, reducer, renderer, option packer"
+```
+
+---
+
+## Task 4: Widget shell + REPL hook + bridge exports
+
+Thin imperative shell wiring keys → `reduceInterrupt` → outcome, plus the `__agencyInterruptPrompt` hook and the two bridge functions.
+
+**Files:**
+- Modify: `lib/stdlib/cli.ts` (widget shell, bridge exports, `_runLineRepl` hook)
+- Test: `lib/stdlib/cli.test.ts`
+
+**Interfaces:**
+- Consumes: `installBottomRegion`, `renderInterruptFooter`, `classifyInterruptKey`, `reduceInterrupt`, `INITIAL_INTERRUPT_STATE`, `AgencyCancelledError` (already imported `cli.ts:17`), `__agencyStopSpinner`.
+- Produces:
+  - `type InterruptOpts = { title: string; body: string; items: {key:string;label:string}[]; allowFreeText: boolean; allowCancel: boolean }`
+  - `stickyInterruptPrompt(rl: readline.Interface, opts: InterruptOpts): Promise<string>`
+  - `export async function _interruptChoice(title, body, items, allowFreeText, allowCancel): Promise<string>`
+  - `export function _stickyInterruptAvailable(): boolean`
+  - global `__agencyInterruptPrompt: (opts: InterruptOpts) => Promise<string>` while a line-mode REPL runs.
+
+- [ ] **Step 1: Implement the shell helpers and widget**
+
+```typescript
+type InterruptOpts = {
+  title: string;
+  body: string;
+  items: { key: string; label: string }[];
+  allowFreeText: boolean;
+  allowCancel: boolean;
+};
+
+/** Stop the "Thinking" spinner if the REPL has one running (which also
+ *  frees the stdout patch before the widget installs its own region). */
+function stopSpinnerIfRunning(): void {
+  const stop = (globalThis as any).__agencyStopSpinner;
+  if (typeof stop === "function") {
+    stop();
+  }
+}
+
+/** Assert raw mode so `_ttyWrite` receives keystrokes (see readMultiline,
+ *  cli.ts:1153, for why). Returns a restore fn. No-op off a TTY. */
+function assertRawMode(): () => void {
+  const stdin = process.stdin as NodeJS.ReadStream & { setRawMode?: (mode: boolean) => void };
+  if (!stdin.isTTY || !stdin.setRawMode) {
+    return () => { };
+  }
+  const wasRaw = !!stdin.isRaw;
+  stdin.setRawMode(true);
+  return () => {
+    if (stdin.setRawMode && stdin.isRaw !== wasRaw) {
+      stdin.setRawMode(wasRaw);
+    }
+  };
+}
+
+/** The line-mode approval prompt. Renders `opts` as a pinned bottom footer
+ *  and reads a typed line terminated by Enter. All decisions come from
+ *  reduceInterrupt; this shell only wires keys → reducer → outcome and does
+ *  the I/O. Resolves with the option key or a free-text reason; rejects
+ *  with AgencyCancelledError on Escape (when allowCancel); exits 130 on
+ *  Ctrl+C. Reuses the outer REPL's readline via `_ttyWrite`. */
+function stickyInterruptPrompt(rl: readline.Interface, opts: InterruptOpts): Promise<string> {
+  stopSpinnerIfRunning();
+  const restoreRaw = assertRawMode();
+  const config: InterruptConfig = {
+    validKeys: opts.items.map((item) => item.key),
+    allowFreeText: opts.allowFreeText,
+    allowCancel: opts.allowCancel,
+  };
+  let state = INITIAL_INTERRUPT_STATE;
+
+  const region = installBottomRegion(
+    () => renderInterruptFooter({
+      title: opts.title,
+      body: opts.body,
+      items: opts.items,
+      allowFreeText: opts.allowFreeText,
+      state,
+      columns: process.stdout.columns || 80,
+    }),
+    process.stdout.isTTY === true,
+    { hideCursor: true },
+  );
+
+  const rlAny = rl as unknown as { _ttyWrite: (sequence: unknown, key: unknown) => void };
+  const originalTtyWrite = rlAny._ttyWrite;
+
+  return new Promise<string>((resolve, reject) => {
+    const settle = (finish: () => void): void => {
+      rlAny._ttyWrite = originalTtyWrite;
+      region.teardown();
+      restoreRaw();
+      finish();
+    };
+    rlAny._ttyWrite = (sequence: unknown, key: unknown): void => {
+      const action = classifyInterruptKey(sequence, key as KeyMeta | undefined);
+      const step = reduceInterrupt(state, action, config);
+      state = step.state;
+      const outcome = step.outcome;
+      if (outcome.kind === "exit") {
+        settle(() => { });
+        process.exit(130);
+        return;
+      }
+      if (outcome.kind === "cancel") {
+        settle(() => reject(new AgencyCancelledError("cancelled by user")));
+        return;
+      }
+      if (outcome.kind === "resolve") {
+        settle(() => resolve(outcome.value));
+        return;
+      }
+      region.refresh();
+    };
+  });
+}
+
+/** Bridge for std::ui/cli's interruptChoice. Delegates to the sticky widget
+ *  wired to the running line-mode REPL. The Agency side gates on
+ *  _stickyInterruptAvailable first, so a missing hook is a programming
+ *  error. */
+export async function _interruptChoice(
+  title: string,
+  body: string,
+  items: { key: string; label: string }[],
+  allowFreeText: boolean,
+  allowCancel: boolean,
+): Promise<string> {
+  const hook = (globalThis as any).__agencyInterruptPrompt;
+  if (typeof hook !== "function") {
+    throw new Error("_interruptChoice: no active line-mode REPL");
+  }
+  return hook({ title, body, items, allowFreeText, allowCancel });
+}
+
+/** True when a line-mode REPL is running and can host a pinned prompt. */
+export function _stickyInterruptAvailable(): boolean {
+  return typeof (globalThis as any).__agencyInterruptPrompt === "function";
+}
+```
+
+- [ ] **Step 2: Install the `__agencyInterruptPrompt` hook in `_runLineRepl`**
+
+Alongside the existing hook installs (near `__agencyStopSpinner` at `cli.ts:843`):
+
+```typescript
+  // Expose the sticky interrupt prompt to std::policy (via std::ui/cli's
+  // interruptChoice → _interruptChoice). Bound to THIS readline so the
+  // widget reuses it; restored on exit like the hooks above.
+  const interruptPromptKey = "__agencyInterruptPrompt";
+  const prevInterruptPrompt = (globalThis as any)[interruptPromptKey];
+  (globalThis as any)[interruptPromptKey] = (opts: InterruptOpts) => stickyInterruptPrompt(rl, opts);
+```
+
+In the `finally` block (around `cli.ts:1028`, with the other restores):
+
+```typescript
+    (globalThis as any)[interruptPromptKey] = prevInterruptPrompt;
+```
+
+- [ ] **Step 3: Build**
+
+Run: `make`
+Expected: builds without type errors.
+
+- [ ] **Step 4: Add integration smoke tests (logic already covered by Task 3)**
+
+Add `stickyInterruptPrompt` to `_internal` (`cli.ts:1240`). These cover the wiring: outcome → resolve/reject and streaming-above. The exhaustive transition coverage lives in the `reduceInterrupt` tests.
+
+```typescript
+describe("stickyInterruptPrompt (integration)", () => {
+  it("resolves 'aa' typed then Enter, with a trace streamed above", async () => {
+    const cap = captureStdout();
+    (process.stdin as any).isTTY = false; // skip real raw-mode toggling
+    const fakeRl: any = { _ttyWrite: (_s: any, _k: any) => { } };
+    const pending = _internal.stickyInterruptPrompt(fakeRl, {
+      title: "approve?", body: "", allowFreeText: true, allowCancel: true,
+      items: [{ key: "a", label: "approve once" }, { key: "aa", label: "approve always" }],
+    });
+    process.stdout.write("⏺ read(\"x\")\n"); // concurrent branch output
+    fakeRl._ttyWrite("a", { name: "a" });
+    fakeRl._ttyWrite("a", { name: "a" });
+    fakeRl._ttyWrite(null, { name: "return" });
+    const answer = await pending;
+    cap.restore();
+    expect(answer).toBe("aa");
+    expect(cap.captured.join("")).toContain("⏺ read(\"x\")\n");
+  });
+
+  it("Escape rejects with AgencyCancelledError", async () => {
+    const cap = captureStdout();
+    (process.stdin as any).isTTY = false;
+    const fakeRl: any = { _ttyWrite: (_s: any, _k: any) => { } };
+    const pending = _internal.stickyInterruptPrompt(fakeRl, {
+      title: "t", body: "", allowFreeText: true, allowCancel: true,
+      items: [{ key: "a", label: "ok" }],
+    });
+    fakeRl._ttyWrite(null, { name: "escape" });
+    await expect(pending).rejects.toThrow(/cancelled/i);
+    cap.restore();
+  });
+});
+```
+
+Note: the Ctrl+C path calls `process.exit(130)`, so it is not driven here (it would kill the runner). Its decision is covered by the `reduceInterrupt` "exit" test in Task 3.
+
+- [ ] **Step 5: Run the smoke tests and the full file**
+
+Run: `pnpm exec vitest run lib/stdlib/cli.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/stdlib/cli.ts lib/stdlib/cli.test.ts
+git commit -m "feat(cli): sticky interrupt widget shell + REPL hook + bridge"
+```
+
+---
+
+## Task 5: The `interruptChoice` Agency primitive
+
+**Files:**
+- Modify: `stdlib/ui/cli.agency`
+
+**Interfaces:**
+- Consumes: `_interruptChoice`, `_stickyInterruptAvailable` (Task 4); `chooseOption` from `std::ui`.
+- Produces: `interruptChoice(title: string, body: string, items: any[], allowFreeText: boolean = false, allowCancel: boolean = false): string`
+
+Note: `items: any[]` (not `ChoiceItem[]`) sidesteps the documented `ChoiceItem` codegen pitfall in this module (see its header comment). Values flow through unchanged; `chooseOption` accepts `ChoiceItem[]` and `any[]` is assignable.
+
+- [ ] **Step 1: Add the imports**
+
+Extend the `agency-lang/stdlib-lib/cli.js` import block (`cli.agency:1-6`):
+
+```
+import {
+  _runLineRepl,
+  _clearScreen,
+  _termWidth,
+  _clearHistory,
+  _interruptChoice,
+  _stickyInterruptAvailable,
+ } from "agency-lang/stdlib-lib/cli.js"
+```
+
+Add after the existing `export { pushMessage, clearMessages } from "std::ui"` line:
+
+```
+import { chooseOption } from "std::ui"
+```
+
+- [ ] **Step 2: Add the primitive**
+
+Near the bottom of `stdlib/ui/cli.agency`:
+
+```
+export def interruptChoice(
+  title: string,
+  body: string,
+  items: any[],
+  allowFreeText: boolean = false,
+  allowCancel: boolean = false,
+): string {
+  """
+  Approval prompt for line mode: renders a sticky footer pinned to the
+  bottom of the terminal so concurrent tool-call output streams above it
+  instead of burying the prompt. Type an option key or a rejection
+  reason, then Enter. Falls back to `chooseOption` when no line-mode REPL
+  is active (the TUI, a non-TTY, or a headless run), so every
+  non-line-mode path keeps its current behavior.
+
+  @param title - Prompt heading (the interrupt message).
+  @param body - Multi-line context shown under the title (or "").
+  @param items - The {key, label} choices.
+  @param allowFreeText - Accept a free-form rejection reason.
+  @param allowCancel - When true, Escape cancels the whole request.
+  """
+  if (_stickyInterruptAvailable()) {
+    return _interruptChoice(title, body, items, allowFreeText, allowCancel)
+  }
+  return chooseOption(title, body, items, allowFreeText: allowFreeText, allowCancel: allowCancel)
+}
+```
+
+- [ ] **Step 3: Build and verify the module loads**
+
+Run: `make`
+Then:
+
+```bash
+node -e "const m = require('./dist/stdlib/ui/cli.js'); console.log(typeof m.interruptChoice)"
+```
+
+Expected: `function`. If `make` reports a `ChoiceItem` codegen error at load, confirm `items` is `any[]` and `chooseOption` is imported (not re-exported).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add stdlib/ui/cli.agency
+git commit -m "feat(ui/cli): add interruptChoice seam (sticky prompt, chooseOption fallback)"
+```
+
+---
+
+## Task 6: Route the policy prompt through `interruptChoice`
+
+**Files:**
+- Modify: `stdlib/policy.agency:6` (import), `stdlib/policy.agency:711` (the call)
+
+**Interfaces:**
+- Consumes: `interruptChoice` (Task 5).
+
+- [ ] **Step 1: Confirm `chooseOption` is used only in `askUser`**
+
+```bash
+grep -n "chooseOption" stdlib/policy.agency
+```
+
+Expected: the comment at line 664 and the call at line 711 only.
+
+- [ ] **Step 2: Adjust imports**
+
+At `stdlib/policy.agency:6` change:
+
+```
+import { chooseOption, ChoiceItem } from "std::ui"
+```
+
+to:
+
+```
+import { ChoiceItem } from "std::ui"
+```
+
+Add after line 8 (with the other `std::ui`-family imports):
+
+```
+import { interruptChoice } from "std::ui/cli"
+```
+
+- [ ] **Step 3: Change the call in `askUser`**
+
+At `stdlib/policy.agency:710-712` change:
+
+```
+  const answer = withLock("std::tty") {
+    return chooseOption(title, body, items, allowFreeText: true, allowCancel: true)
+  }
+```
+
+to:
+
+```
+  const answer = withLock("std::tty") {
+    return interruptChoice(title, body, items, allowFreeText: true, allowCancel: true)
+  }
+```
+
+The `withLock("std::tty")` stays: it keeps "one prompt at a time," which the coordinator's single-owner invariant relies on. Cancellation still unwinds correctly: `_interruptChoice` rejects with `AgencyCancelledError` on Escape (`allowCancel: true`), which propagates the same way `_promptsAutocomplete`'s `cancelOnEscape` throw does today (`ui.ts:863`), and `__tryCall` re-raises it (`ui.ts:859`) so the turn unwinds to the REPL rather than becoming a `Result.failure`.
+
+- [ ] **Step 4: Build**
+
+Run: `make`
+Expected: builds with no import-cycle or unresolved-import errors. (`std::policy → std::ui/cli → std::ui`; nothing imports `std::policy`, so no cycle.)
+
+- [ ] **Step 5: Run the policy tests**
+
+Find and run the policy tests (stay narrow to keep it fast):
+
+```bash
+grep -rl "cliPolicyHandler\|checkPolicy\|parsePolicyFile" lib stdlib --include="*.test.ts"
+pnpm exec vitest run lib/stdlib/policy.test.ts
+```
+
+Expected: PASS (the change only swaps the interactive prompt UI; auto-approve/reject and file handling are untouched).
+
+- [ ] **Step 6: Manual end-to-end check (line-mode agent)**
+
+From `packages/agency-lang`: `make`, then run the agent and issue a request that runs several tools in parallel where one needs approval. Confirm by eye: the prompt stays pinned at the bottom; `⏺ tool(...)` traces scroll above it; `aa`+Enter approves-always; a typed reason + Enter rejects with that reason; empty Enter re-prompts; Escape cancels the turn; the cursor is hidden during the prompt and restored after; and there is no visible flicker at normal output rates. Record the result in the commit message or PR description.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add stdlib/policy.agency
+git commit -m "feat(policy): pin the interactive approval prompt via interruptChoice"
+```
+
+---
+
+## Task 7 (OPTIONAL — decide during review): burst coalescing
+
+Ship only if the un-coalesced version shows visible footer "twitch" when several trace lines land in one event-loop tick (spec open question 2). Emit the erase+text immediately; defer the footer redraw to a microtask so N same-tick writes collapse to one redraw. Reuses `buildFrame`.
+
+**Files:**
+- Modify: `lib/stdlib/cli.ts` (`installBottomRegion` internals only — no signature change)
+- Test: `lib/stdlib/cli.test.ts`
+
+- [ ] **Step 1: Write a failing test asserting one redraw per tick**
+
+```typescript
+describe("installBottomRegion coalescing", () => {
+  it("redraws the footer once for several same-tick writes", async () => {
+    const cap = captureStdout();
+    const region = installBottomRegion(() => ["FOOTER"], true);
+    cap.captured.length = 0;
+    process.stdout.write("a\n");
+    process.stdout.write("b\n");
+    process.stdout.write("c\n");
+    await Promise.resolve(); // let the microtask run
+    region.teardown();
+    cap.restore();
+    const text = cap.captured.join("");
+    expect(text.indexOf("a\n")).toBeLessThan(text.indexOf("b\n"));
+    expect(text.indexOf("b\n")).toBeLessThan(text.indexOf("c\n"));
+    expect(cap.captured.filter((chunk) => chunk.includes("FOOTER")).length).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm exec vitest run lib/stdlib/cli.test.ts -t "coalescing"`
+Expected: FAIL — the un-coalesced version redraws FOOTER three times.
+
+- [ ] **Step 3: Rework the write path in `installBottomRegion`**
+
+Replace the `paint`, the `stdoutAny.write` assignment, and `refresh` with a two-phase version (the outside text is written immediately; only the footer redraw is deferred). `buildFrame` with `footerLines: []` performs the erase+emit with no redraw:
+
+```typescript
+  let footerErased = false;
+  let redrawScheduled = false;
+
+  const drawFooter = (): void => {
+    const frame = buildFrame({
+      above: null,
+      footerLines: render(),
+      prevRows: rows,
+      columns: process.stdout.columns || 80,
+      cursor: options.hideCursor && firstPaint ? "hide" : "keep",
+    });
+    firstPaint = false;
+    rows = frame.rows;
+    footerErased = false;
+    realWrite(frame.seq);
+  };
+  const scheduleFooter = (): void => {
+    if (redrawScheduled) {
+      return;
+    }
+    redrawScheduled = true;
+    queueMicrotask(() => {
+      redrawScheduled = false;
+      if (footerErased) {
+        drawFooter();
+      }
+    });
+  };
+
+  drawFooter(); // initial paint
+  stdoutAny.write = (chunk: any): boolean => {
+    const frame = buildFrame({
+      above: chunkToText(chunk),
+      footerLines: [],
+      prevRows: footerErased ? 0 : rows,
+      columns: process.stdout.columns || 80,
+      cursor: "keep",
+    });
+    rows = 0;
+    footerErased = true;
+    const returnValue = realWrite(frame.seq);
+    scheduleFooter();
+    return returnValue;
+  };
+```
+
+Update `refresh` and `teardown` for the new flags (typing repaints immediately; teardown cancels a pending redraw):
+
+```typescript
+  const region: BottomRegion = {
+    refresh: () => { drawFooter(); },
+    teardown: () => {
+      redrawScheduled = false;
+      stdoutAny.write = realWrite;
+      const frame = buildFrame({
+        above: null,
+        footerLines: [],
+        prevRows: footerErased ? 0 : rows,
+        columns: process.stdout.columns || 80,
+        cursor: options.hideCursor ? "show" : "keep",
+      });
+      realWrite(frame.seq);
+      rows = 0;
+      footerErased = false;
+      if (activeRegion === region) {
+        activeRegion = null;
+      }
+    },
+  };
+```
+
+- [ ] **Step 4: Run the coalescing test**
+
+Run: `pnpm exec vitest run lib/stdlib/cli.test.ts -t "coalescing"`
+Expected: PASS.
+
+- [ ] **Step 5: Re-run the full file**
+
+Run: `pnpm exec vitest run lib/stdlib/cli.test.ts`
+Expected: PASS. If any earlier test asserted a synchronous footer redraw on an outside write, add `await Promise.resolve()` before its footer assertion (the footer now redraws on a microtask).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/stdlib/cli.ts lib/stdlib/cli.test.ts
+git commit -m "perf(cli): coalesce same-tick footer redraws to avoid burst twitch"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage.**
+- Component 1 (coordinator) → Task 1; spinner fold-in (Finding 4) → Task 2.
+- Component 2 (widget): type-then-Enter model (Decision 2, Finding 1) → `reduceInterrupt` submit logic (Task 3) + shell (Task 4); empty-Enter re-prompt (Finding 2) → `submitInterrupt` empty branch + reducer test; raw-mode precondition (Finding 5) → `assertRawMode` (Task 4); Ctrl+C divergence (Finding 3) → `classifyInterruptKey` `"exit"` + `reduceInterrupt` exit outcome + shell `process.exit(130)`.
+- Component 3 (seam) → Task 5; one call-site change + cancellation-path citation → Task 6; mutual-exclusion of the gates (Finding 6) → `_stickyInterruptAvailable` gate.
+- Anti-flicker rules → `buildFrame` (Task 1); burst coalescing → Task 7 (optional).
+- Oversized body / width edge cases → `bodyLines` cap + `wrapText` in `buildFrame`.
+- Status-footer census (Finding 7) → no code (post-turn render); documented in spec.
+- "No second readline" strength → Task 4 reuses `rl` via `_ttyWrite`.
+- Cursor findings (hidden whole turn, crash-safety, caret) → `hideCursor` scoped to the widget, `registerCursorRestore`, `INTERRUPT_CARET`.
+
+**2. Placeholder scan.** No `TBD`/`TODO`/"handle edge cases"/"similar to Task N". Every code step is complete; every test has real assertions; every run step gives command + expected result.
+
+**3. Anti-pattern scan (per docs/dev/anti-patterns.md).** No duplicated code (reuses `visualWidth`/`wrapText`; shared `captureStdout` in tests; `buildFrame` is the single frame builder used by every path). What/how split via `buildFrame` + `reduceInterrupt` with thin shells. No C-style loops (only `forEach`/`flatMap`/`map`). No one-line `if`s. No nested ternaries (`cursorSequence`/`withTrailingNewline` replace them). Named constants (`MIN_FOOTER_WIDTH`, `INTERRUPT_BODY_MAX_LINES`, `INVALID_NOTICE`, `INTERRUPT_CARET`). Descriptive names throughout.
+
+**4. Type consistency.** `FrameSpec`/`FrameResult`/`BottomRegion` stable across Tasks 1, 2, 4, 7. `InterruptState`/`InterruptOutcome`/`InterruptConfig`/`InterruptStep` defined in Task 3 and consumed unchanged in Task 4. `renderInterruptFooter` takes `state: InterruptState` in both Task 3 (definition/tests) and Task 4 (call). `InterruptOpts` fields identical across `stickyInterruptPrompt`, `_interruptChoice`, the hook, and the Agency `interruptChoice` call. `interruptChoice(title, body, items, allowFreeText, allowCancel)` matches the `askUser` call and mirrors `chooseOption`'s parameter order.
+
+**5. Test rigor (does a break fail a test?).** `reduceInterrupt` table tests fail on any transition regression (bare-`a` early-resolve, empty-Enter resolving, missing newline-strip, wrong cancel gating). `buildFrame` tests assert exact bytes, so a broken erase (`\x1b[2A\r\x1b[0J`) or row count fails. `installBottomRegion`/`startSpinner`/widget smoke tests assert traces land above the footer. Ctrl+C's decision is covered by the reducer "exit" test (the shell's `process.exit` is intentionally not driven in-process). No catastrophic-failure tests.
+
+---
+
+## Execution Handoff
+
+**Plan complete and saved to `docs/superpowers/plans/2026-07-17-sticky-interrupt-prompt.md`.**
+
+Per your standing preference (inline execution in the main session, no subagent-driven development) and your dev loop (plan → review → execute), the next step is your review of this revised plan. On your go, I'll execute inline here, task by task, pausing at the commit checkpoints.

--- a/docs/superpowers/specs/2026-07-17-sticky-interrupt-prompt-design.md
+++ b/docs/superpowers/specs/2026-07-17-sticky-interrupt-prompt-design.md
@@ -1,0 +1,773 @@
+# Sticky interrupt prompt for the line-mode agent
+
+**Status:** design, awaiting review
+**Date:** 2026-07-17
+**Author:** Aditya Bhargava (with Claude)
+
+---
+
+## What this is about, in one sentence
+
+When the Agency agent stops to ask you to approve an action, and other
+work is still running in the background and printing as it goes, the
+approval question should stay pinned to the bottom of the terminal while
+the background output scrolls past above it, instead of the question
+getting buried under that output.
+
+The rest of this document explains the pieces you need to understand the
+problem, walks through exactly why the question gets buried today, and
+then lays out the design that fixes it.
+
+---
+
+## Background: the things you need to know first
+
+This section assumes no prior knowledge of how the agent draws to the
+screen. If you already know how line mode, interrupts, and the
+concurrency model work, you can skip to "The problem" below. But the fix
+touches all three, so it is worth being precise.
+
+### The Agency agent and "the agent"
+
+The Agency agent is a terminal program that helps you write and run
+Agency code. Its source lives in `lib/agents/agency-agent/`, written in
+Agency itself. It runs as a chat loop: you type a message, the agent
+works on it (often calling tools like `read`, `write`, `bash`, or one of
+its specialist sub-agents), and it prints a reply. Throughout this
+document, "the agent" means this program.
+
+### Line mode versus the TUI
+
+The agent can draw its interface two different ways.
+
+The first way is a full-screen interface built on an internal rendering
+engine, similar in spirit to a curses program. It takes over the whole
+terminal ("the alt-screen"), keeps a status bar pinned, and repaints the
+visible screen on every frame. In this document that is "the TUI" (text
+user interface). Its code is `std::ui` (`stdlib/ui.agency`, backed by
+`lib/stdlib/ui.ts`).
+
+The agent started on the TUI but then switched to a simpler second way,
+called "line mode." Line mode does not take over the screen. It prints
+plain lines to the terminal the same way any ordinary command-line
+program does, and it reads input with Node's built-in `readline`
+library. The trade-off is deliberate: line mode gives up the pinned
+status bar and the live repaint, and in exchange every message becomes a
+real line in the terminal's scrollback, so you get native scrolling,
+text search, copy-paste, and clickable links for free. The code is
+`std::ui/cli` (`stdlib/ui/cli.agency`, backed by `lib/stdlib/cli.ts`).
+`lib/stdlib/cli.ts` is the single most important file for this project.
+
+**The agent runs in line mode.** The TUI path still exists in the
+codebase, unused by the agent, kept in case we want it back. This
+project changes line mode only. It does not touch the TUI.
+
+The switch is a one-line import change in `agent.agency` (see the comment
+block around `agent.agency:132`), because both modules expose the same
+three functions: `repl` (run the chat loop), `pushMessage` (print a line
+into the transcript), and `clearMessages` (wipe the transcript).
+
+### How line mode actually prints a line
+
+This is the crux, so it is worth tracing end to end with real code.
+
+Everything the agent prints mid-turn goes through `pushMessage`. For
+example, when the agent starts a tool call, this callback fires
+(`agent.agency:203`):
+
+```
+callback("onToolCallStart") as data {
+  if (_showTraces()) {
+    pushMessage(color.yellow("⏺ ${data.toolName}(${formatArgs(data.args)})"))
+  }
+}
+```
+
+`pushMessage` is defined in `stdlib/ui.agency:869`. Its first line is the
+one that matters:
+
+```
+export def pushMessage(message: string) {
+  if (_activeRepl == null) {
+    print(message)
+    return
+  }
+  ... // TUI path: append to transcript, trigger a repaint
+}
+```
+
+`_activeRepl` is the currently-running TUI screen. In line mode there is
+no TUI screen, so `_activeRepl` is `null`, and `pushMessage` falls
+straight through to `print(message)`. `print` is the Agency built-in
+that maps to `_print` in `lib/stdlib/builtins.ts:19`, which is just:
+
+```
+export function _print(...messages: any[]): void {
+  console.log(...messages);
+}
+```
+
+And `console.log` writes to `process.stdout`. So the whole path is:
+
+```
+onToolCallStart → pushMessage → print → console.log → process.stdout.write
+```
+
+The takeaway: **in line mode, every trace line is written directly to
+stdout, one line at a time, wherever the cursor happens to be at that
+moment.** Nothing coordinates these writes with anything else on screen.
+
+### The "Thinking" spinner, and the one trick this whole design builds on
+
+While the agent is working on your turn, line mode shows a one-line
+spinner at the bottom: `⣾ Thinking 3s`. It lives in `startSpinner`
+(`lib/stdlib/cli.ts:330`).
+
+The spinner has already solved a small version of our exact problem.
+A spinner sitting at the bottom of the screen would get overwritten the
+instant a trace line prints. To prevent that, `startSpinner` replaces
+`process.stdout.write` with a wrapped version. The wrapper, on every
+outside write, first emits a "clear this line" escape code, then lets the
+real write through:
+
+```
+stdoutAny.write = function patchedWrite(this, chunk, ...rest) {
+  realWrite(CLEAR_LINE);          // erase the spinner row
+  return realWrite(chunk, ...rest); // then print the trace line
+};
+```
+
+The spinner's own timer then redraws itself on the next tick. The net
+effect: the spinner and the streaming trace lines coexist without
+fighting. **This "wrap `process.stdout.write` so outside writes make room
+for pinned content" is the seed of the entire design below.** We are
+going to generalize it from one pinned line to a multi-line pinned
+prompt.
+
+The spinner is turned off whenever the agent needs to ask you something,
+through a global hook named `__agencyStopSpinner` that the REPL installs
+(`lib/stdlib/cli.ts:843`). "Thinking" is the wrong thing to show while
+you are being asked a question.
+
+### Interrupts and policies
+
+An "interrupt" is Agency's mechanism for pausing execution to get a
+human decision. When the agent tries to take an action that needs
+approval (running a shell command, writing a file), the action raises an
+interrupt instead of just happening.
+
+A "policy" is a saved set of rules that answers interrupts automatically
+so you are not asked every single time. For example, a policy might say
+"reads are always fine, but shell commands always ask." Policies are
+stored in `~/.agency-agent/policy.json`. The reference docs are
+`https://agency-lang.com/guide/interrupts.html` and
+`https://agency-lang.com/guide/policies.html`.
+
+The agent installs one policy handler at startup, `cliPolicyHandler`
+from `std::policy` (`stdlib/policy.agency`). When an interrupt reaches
+it, the handler checks the saved policy. If a rule matches, it approves
+or rejects silently. If nothing matches, it asks you. The asking happens
+in `askUser` (`stdlib/policy.agency:667`), which builds a little menu of
+choices (approve once, reject once, approve always, and so on) and calls
+`chooseOption` to display it:
+
+```
+const answer = withLock("std::tty") {
+  return chooseOption(title, body, items, allowFreeText: true, allowCancel: true)
+}
+```
+
+Two details here are load-bearing for this design:
+
+- **`withLock("std::tty")`.** This is a mutual-exclusion lock. Only one
+  piece of code holding the `"std::tty"` lock runs at a time. Because
+  every interrupt prompt is wrapped in it, **at most one approval
+  question is ever on screen at once.** Two branches that both hit an
+  interrupt take turns; they do not both prompt simultaneously. This is
+  important: our problem is never "two prompts fighting each other." It
+  is always "one prompt fighting with background output."
+
+- **`chooseOption`.** This is the generic menu function
+  (`stdlib/ui.agency:1032`). It has three internal paths. If the TUI is
+  active it draws an in-screen modal. If stdout is not a terminal (piped
+  output, tests) it runs a plain input loop. And in the case that
+  matters for us, an interactive line-mode terminal, it calls the
+  `autocomplete` primitive, which is backed by the third-party npm
+  package `prompts` (`lib/stdlib/ui.ts:840`, `_promptsAutocomplete`).
+
+### What the `prompts` package does, and why it is fragile here
+
+The `prompts` package draws an interactive menu at the current cursor
+position: a question, a list of choices, a highlighted row. As you press
+arrow keys or type to filter, it repaints the menu **in place** by moving
+the cursor up by the number of rows it last drew, clearing them, and
+drawing again.
+
+That in-place repaint is the fragile part. `prompts` assumes it is the
+only thing writing to the bottom of the screen. It has no idea that
+anything else might print. There is no public hook to tell it "content
+appeared above you, recalculate." If some other code writes a line into
+the region `prompts` is managing, `prompts`'s next repaint does its
+cursor arithmetic from the wrong starting point and the menu smears.
+
+### The concurrency model, briefly
+
+Agency can run work in parallel. A `fork` runs a block once per item, in
+parallel; each parallel copy is called a "branch." A single `llm(...)`
+call that asks for several tools at once also runs those tool calls as
+parallel branches. Branches run as ordinary asynchronous work on one
+JavaScript event loop. They are not OS threads. That single-threaded
+detail matters later: two branches never write to stdout at literally the
+same instant. They interleave, one whole write at a time.
+
+The full details are in `docs/dev/concurrent-interrupts.md`. For this
+design you only need three facts:
+
+1. Several branches can run at once.
+2. When one branch hits an interrupt and the policy handler stops to ask
+   you, that branch is blocked waiting for your answer, but the other
+   branches keep running.
+3. A running branch that makes tool calls keeps firing the
+   `onToolCallStart` / `onToolCallEnd` callbacks, which keep calling
+   `pushMessage`, which in line mode keeps printing straight to stdout.
+
+---
+
+## The problem
+
+Put the pieces together.
+
+The agent is working on your turn. Two branches are running in parallel.
+Branch A wants to run `rm -rf build/`. That needs approval, so it raises
+an interrupt, the policy handler catches it, and `askUser` opens the
+`prompts` menu at the bottom of the terminal. The "Thinking" spinner is
+stopped. Branch A is now blocked, waiting for you.
+
+But branch B is still running. It calls `grep`, then `read`, then
+another `read`. Each one fires `onToolCallStart`, which calls
+`pushMessage`, which in line mode calls `console.log`, which writes a
+trace line straight to stdout, right into the middle of the region the
+`prompts` menu is trying to manage.
+
+`prompts` never learns those lines appeared. On your next keypress it
+repaints from the wrong origin. The menu tears, scrolls up, or gets
+shoved off screen under branch B's chatter. The question you are
+supposed to answer is now buried, and it is not obvious that anything is
+even waiting on you.
+
+Here is roughly what you see, with `▮` marking where the menu is trying
+to live:
+
+```
+⏺ grep("build")
+  ⎿ 2 matches
+? bash: rm -rf build/ › approve once     ▮  ← the menu draws here
+⏺ read("Makefile")                          ← branch B prints over it
+  ⎿ 40 lines
+⏺ read("build.ts")                          ← and again
+? bash: rm -rf build/ › approve once     ▮  ← half-redrawn, wrong place
+  ⎿ ...
+```
+
+The desired behavior instead:
+
+```
+⏺ grep("build")             ← background output scrolls up here,
+  ⎿ 2 matches                 as normal scrollback, above the line
+⏺ read("Makefile")
+  ⎿ 40 lines
+⏺ read("build.ts")
+──────────────────────────────────────────
+ bash: rm -rf build/  — approve?      ← and the prompt stays pinned at
+ a=approve once   r=reject once         the very bottom, always visible,
+ aa=always  ap=always here  rr=never    always clearly the thing waiting
+ or type a reason · Enter to submit     on you
+ > _
+```
+
+---
+
+## Goals and non-goals
+
+### Goals
+
+- When an approval prompt is open in line mode and other branches are
+  still producing output, keep the prompt pinned to the bottom of the
+  terminal.
+- Let the background trace lines stream into normal scrollback above the
+  prompt, live, as they are produced.
+- Do this without visible flicker under realistic output rates.
+- Keep the change surgical: only the approval prompt changes. Every other
+  prompt in the agent keeps working exactly as it does today.
+
+### Non-goals
+
+- The TUI path. It already composes the prompt and the transcript in one
+  render loop, so it has no interleaving problem. Untouched.
+- Non-terminal output (piped, tests, headless one-shot runs with no
+  terminal). These already fall back to a plain input loop. Untouched.
+- The other interactive prompts: `/paste`, the slash-command palette,
+  and the `/model`, `/models`, `/search`, `/settings`, `/local`
+  commands. All of these run while the agent is idle and waiting for you
+  to type, so nothing is streaming underneath them. They keep using the
+  `prompts` package. Untouched. (`/model` in particular shows a long,
+  filterable list of models, which the press-a-key prompt below is not
+  suited for. That is a second, independent reason to leave it alone.)
+- Buffering background output until you answer. We considered printing
+  the background traces only after you respond, which would be much
+  simpler. We chose live streaming instead, because seeing the work
+  continue is the point.
+
+---
+
+## Decisions already made (and why)
+
+Two product decisions were settled during design. They are recorded here
+so the plan does not reopen them.
+
+### Decision 1: stream background output live, above the prompt
+
+The alternative was to hold background trace lines while the prompt is
+open and flush them all after you answer. Buffering is simpler because
+nothing on screen moves while you decide. We rejected it. The whole
+reason to keep the prompt visible is so you can watch the rest of the
+work proceed while you decide, so the output has to be live.
+
+### Decision 2: the pinned prompt is a "type your answer, then Enter" line, not a navigable menu
+
+The current line-mode prompt is the `prompts` package's autocomplete
+widget: arrow keys move a highlight, typing filters the list, Enter
+selects, and free text becomes a rejection reason. That widget owns its
+own in-place repaint, which is exactly what fights our
+redraw-after-every-write approach. Coordinating with it would mean
+reaching into its private internals to force a repaint, which is brittle
+across versions of the package. So we render the prompt ourselves and own
+the input loop.
+
+We do **not** resolve on a single bare keypress. An earlier version of
+this decision did, and it was wrong. The option keys are `a`, `r`, `aa`,
+`ap`, `rr` (`stdlib/policy.agency:681-706`), and `a` is a prefix of
+`aa`/`ap` while `r` is a prefix of `rr`. A bare `a` cannot tell "approve
+once" from the first key of "approve always," so instant resolution makes
+`aa`, `ap`, and `rr` unreachable. Worse, a free-text rejection reason
+often starts with `a` or `r` ("actually, do X instead"), so if the first
+keystroke resolved an option, such a reason could never be typed. Free
+text reasons are an existing, valued feature, so dropping them to keep a
+"no Enter" model is not acceptable.
+
+So the pinned prompt is a one-line input you type into, then press Enter.
+On Enter, the typed text is interpreted exactly the way `chooseOption`'s
+existing non-terminal branch already interprets it
+(`stdlib/ui.agency:1078-1087`): if it matches an option key, that option
+fires; otherwise, if free text is allowed and the text is non-empty, it
+becomes a rejection reason; an empty line re-prompts (the must-answer
+contract). Reusing that contract, rather than inventing a new one, means
+the safety-critical "the user can never skip the prompt" guarantee is the
+same one already in the code.
+
+The cost versus a bare keypress is one Enter. For a safety-approval
+prompt that is arguably a feature, because it removes any accidental
+instant-approve on a stray key. The change in feel versus today is that
+there is no live-filtered list and no arrow-key navigation: the options
+are shown statically, and you type the key (or a reason) and press Enter.
+
+---
+
+## The design
+
+Three components. Named pieces below use invented names; each is labeled
+where it first appears.
+
+### Component 1: the bottom-region coordinator (invented name)
+
+**What it does.** It owns a block of text pinned to the bottom of the
+terminal (call it "the footer"), and it makes sure any other write to
+stdout lands *above* the footer, in scrollback, with the footer redrawn
+underneath afterward. It generalizes the spinner's one-line trick to any
+number of lines.
+
+**Where it lives.** `lib/stdlib/cli.ts` (the line-mode module).
+
+**How you use it.** A small interface, invented name `installBottomRegion`:
+
+```
+const region = installBottomRegion(() => footerLines);  // footerLines: string[]
+region.refresh();   // the footer content changed; repaint it
+region.teardown();  // remove the footer; unpatch stdout
+```
+
+`installBottomRegion` takes a render function that returns the current
+footer as an array of lines. On install, it draws the footer and replaces
+`process.stdout.write` with a wrapper. The wrapper, on every outside
+write, produces a single atomic frame (see "Anti-flicker" below) that:
+erases the footer, lets the outside text through so the terminal scrolls
+it up into scrollback, then redraws the footer at the new bottom.
+`teardown` erases the footer and restores the original
+`process.stdout.write`.
+
+**What it depends on.** Only `process.stdout` and the terminal width
+(`process.stdout.columns`). It does not know what the footer contains. It
+does not know about prompts, policies, or interrupts. That ignorance is
+the point: it is a generic "keep this text at the bottom" utility.
+
+**Relationship to the spinner (a correctness argument, not just tidiness).**
+The spinner is the same idea with a one-line footer and a timer. Both
+`startSpinner` and `installBottomRegion` monkeypatch the *same*
+`process.stdout.write`. If they stay as two independent patchers,
+correctness depends on a load-bearing ordering: the spinner must be
+stopped *before* the region installs and torn down *after* it. That is
+because `startSpinner`'s teardown does `stdoutAny.write = realWrite`,
+restoring the real write it captured at spinner start (`cli.ts` teardown
+closure). If the region patched first and the spinner tore down second,
+that teardown would clobber the region's patch with the stale write, and
+the prompt would stop making room for background output. The flow does
+honor that ordering, but leaving two patchers in place means every future
+edit has to preserve it. Folding the spinner into this one coordinator
+makes "exactly one owner of the bottom region" a structural guarantee
+instead of an ordering discipline. That is why we fold it in. Only one
+region is ever active at a time, which the `"std::tty"` lock (one prompt
+at a time) plus the spinner-stops-before-prompt rule already ensure. It
+is called out as its own step in the plan so it can be reviewed on its
+own.
+
+### Component 2: the sticky interrupt prompt (invented name for the widget)
+
+**What it does.** It renders the approval question as the footer, reads a
+typed line terminated by Enter, and returns the user's choice. It is the
+"type your answer, then Enter" widget from Decision 2.
+
+**Where it lives.** `lib/stdlib/cli.ts`.
+
+**What it renders.** The footer is: a divider rule, the interrupt title
+(for example `bash: rm -rf build/  — approve?`), a short body showing the
+action's details, the option rows shown as `key=label`, a hint line, and
+a one-line input showing what you have typed so far. With sample data:
+
+```
+──────────────────────────────────────────
+ bash: rm -rf build/  — approve?
+ a=approve once   r=reject once
+ aa=always  ap=always here  rr=never
+ or type a reason · Enter to submit
+ > aa_
+```
+
+**How it reads input.** By intercepting `readline`'s internal
+`_ttyWrite`, the exact technique three existing features already use:
+the slash-command trigger (`installSlashTrigger`, `cli.ts:496`), the
+Escape-to-cancel key (`installCancelKey`, `cli.ts:548`), and the
+`/paste` multi-line editor (`readMultiline`, `cli.ts:1153`). A keypress
+maps to an action through a small pure classifier in the spirit of the
+existing `classifyPasteKey` (`cli.ts:1134`):
+
+- A printable character appends to the input buffer and refreshes the
+  input line (via `region.refresh()`).
+- Backspace deletes the last character of the buffer.
+- Enter commits the buffer, resolved the way `chooseOption`'s
+  non-terminal branch resolves it: an exact option-key match returns that
+  key; otherwise a non-empty buffer returns as a free-text rejection
+  reason; an **empty buffer is a no-op that re-prompts**, preserving the
+  must-answer contract (Finding 2).
+- Escape cancels the whole request (details under Edge cases).
+- Ctrl+C exits the process with code 130 (details under Edge cases).
+
+**Raw-mode precondition.** The widget installs mid-turn, and `_ttyWrite`
+interception only receives keystrokes while stdin is in raw mode. Like
+`readMultiline` (`cli.ts:1177`, with its long comment on why), the widget
+asserts raw mode on install and restores the prior mode on teardown. This
+is implementation-critical: without it, keystrokes bypass the widget's
+`_ttyWrite` and the pinned prompt responds to nothing (Finding 5).
+
+**What it returns.** The chosen key (`"a"`, `"r"`, `"aa"`, `"ap"`,
+`"rr"`) or the typed reason string. This is exactly what `chooseOption`
+returns today, so the code in `askUser` that interprets the answer does
+not change:
+
+```
+return match(answer) {
+  "a"  => ({ action: "approve", reason: null })
+  "r"  => ({ action: "reject",  reason: null })
+  ...
+  _    => ({ action: "reject",  reason: answer })  // free-text reason
+}
+```
+
+**What it depends on.** Component 1 (it renders itself as that footer),
+the running `readline` interface (which it reuses rather than spawning a
+second one, see "A robustness win" below), raw-mode assertion on stdin,
+and the spinner-stop hook (`__agencyStopSpinner`) so "Thinking"
+disappears the moment it opens.
+
+### Component 3: the integration seam (how the policy prompt reaches the widget)
+
+The tricky part is routing *only* the approval prompt to the new widget,
+while every other caller of `chooseOption` keeps its current behavior.
+
+**Why not just change `chooseOption`.** `chooseOption` is generic and has
+many callers. `/model` and friends call it while idle, and `/model` needs
+the scrollable, filterable list that the press-a-key widget cannot
+provide. So we must not globally swap `chooseOption` to the sticky widget.
+
+**The seam.** Introduce one new Agency primitive in `std::ui/cli`,
+invented name `interruptChoice`, with the same signature as
+`chooseOption`. It is backed by a TS bridge, invented name
+`_interruptChoice`. The bridge asks one question: is a line-mode REPL
+currently running and able to host a pinned footer? If yes, it uses the
+sticky widget. If no, it delegates to the ordinary `chooseOption`, so the
+TUI modal, the non-terminal input loop, and the plain `prompts` path all
+still work untouched (headless one-shot runs, tests, and so on).
+
+**How the bridge detects a running REPL.** The line-mode REPL
+(`_runLineRepl`) already installs several process-global hooks while it
+runs and removes them on exit: `__agencyStopSpinner`,
+`__agencyClearHistory`, and an input override on the runtime context. We
+add one more in the same install-and-restore block: a hook, invented name
+`__agencyInterruptPrompt`, that points at the sticky widget wired to this
+REPL's `readline` interface and coordinator. `_interruptChoice` checks
+for that hook. Present means a REPL is live; absent means fall back.
+
+**The one stdlib change.** `askUser` in `stdlib/policy.agency` calls
+`interruptChoice` instead of `chooseOption`. The surrounding
+`withLock("std::tty")` stays. That single call-site change is the entire
+behavioral switch. Everything else in `policy.agency` is unchanged.
+
+**The two gates never overlap.** `chooseOption`'s first path fires on
+`_activeRepl != null` (the TUI is active). `_interruptChoice`'s sticky
+path fires on `__agencyInterruptPrompt` being set (a line-mode REPL is
+active). These are different globals, but only `_runLineRepl` ever
+installs `__agencyInterruptPrompt`, and it never runs alongside a TUI, so
+the two are mutually exclusive. The "delegate back to `chooseOption`"
+fallback therefore cannot double-handle a case the sticky path already
+owns (Finding 6).
+
+Note the scope of the benefit: because the fix lives in `std::policy` and
+`std::ui/cli`, not in the agent, any line-mode command-line agent built
+on `cliPolicyHandler` gets the pinned prompt, not just this one agent.
+That is the right altitude for the change.
+
+### How it all flows together
+
+The concurrent scenario, end to end:
+
+```
+turn running; spinner is a 1-line bottom region
+ ├─ branch A: tool trips policy
+ │     → handler → askUser → withLock("std::tty") → interruptChoice
+ │       → _interruptChoice sees __agencyInterruptPrompt is set
+ │         → stop the spinner
+ │         → installBottomRegion(render = the approval footer)
+ │         → wait for a keypress
+ └─ branch B: still running
+       → onToolCallStart → pushMessage → print → console.log
+         → the patched process.stdout.write:
+             erase footer · write the trace line (scrolls up) · redraw footer
+ you press [a]
+   → widget resolves "a" → region.teardown() → interruptChoice returns "a"
+   → askUser returns approve() → branch A continues
+```
+
+Because JavaScript is single-threaded, each patched write is one complete
+frame. Branch B's writes and branch A's footer never interleave
+mid-frame, so no extra locking is needed beyond the `"std::tty"` lock
+that already serializes the prompt itself.
+
+### A robustness win: no second readline
+
+Worth stating, because it makes Decision 2 look less like a feel
+trade-off and more like the sturdier design. The `prompts` package
+creates its *own* second `readline` on the shared `process.stdin` and
+calls `rl.close()` when it resolves, which pauses shared stdin and drops
+the terminal out of raw mode. That is exactly why `_runPrompt` has to
+snapshot and restore `wasPaused` and `wasRaw` (`lib/stdlib/ui.ts`), or it
+would silently kill the outer REPL. The sticky widget reuses the
+*existing* readline through `_ttyWrite` interception and never spawns a
+second one, so none of that snapshot-and-restore dance is needed. Owning
+the widget removes a whole hazard class rather than just avoiding a fight
+with `prompts`'s repaint.
+
+---
+
+## Anti-flicker requirements
+
+Flicker is the main risk in any "pin content to the bottom" scheme, so
+these are hard requirements, not nice-to-haves. The reasoning: a naive
+implementation that erases the footer in one write and redraws it in a
+separate write leaves a window where the footer is blank, which the eye
+catches as a flash. The rules below close that window.
+
+1. **One atomic frame per repaint.** Build the entire sequence, move the
+   cursor to the footer's top row, clear from there to the end of the
+   screen, emit the outside text (the terminal scrolls it up naturally),
+   then reprint the footer, as a single string, and hand it to one
+   `process.stdout.write` call. Terminals composite a single write
+   without showing the half-erased middle state.
+
+2. **Hide the cursor while a region is live.** Emit the "hide cursor"
+   escape (`\x1b[?25l`) when a region installs and "show cursor"
+   (`\x1b[?25h`) on teardown, so the cursor does not strobe between the
+   reason line and the top of the next redraw.
+
+3. **Wrap each frame in synchronized-output mode.** Bracket each frame
+   with the DEC synchronized-update escapes (`\x1b[?2026h` before,
+   `\x1b[?2026l` after). Terminals that support it (iTerm2, kitty,
+   WezTerm, recent Windows Terminal) hold the frame until it is complete,
+   eliminating any tearing. Terminals that do not support it ignore the
+   escape harmlessly, and rule 1 still protects them.
+
+4. **Redraw on events, never on a timer.** The footer repaints only when
+   an outside write occurs or when the user types into the reason line.
+   An open prompt with nothing streaming under it repaints zero times.
+   (The spinner keeps its own timer for its animation frames; that is the
+   spinner's business, not the coordinator's.)
+
+### Refinement: coalesce bursts (include in the spec, implement if needed)
+
+One residual risk, named honestly: if several trace lines land in the
+same event-loop tick, they trigger several back-to-back full-footer
+repaints. Rule 1 means none of them blank-flashes, but the footer text
+could visibly "twitch." The fix is to coalesce: on each outside write,
+mark the region dirty and schedule the actual footer repaint on a
+microtask or `setImmediate`, so N writes in one tick collapse into one
+repaint. The outside text itself is still written immediately (it must
+not be delayed or reordered); only the footer redraw is deferred to the
+end of the tick.
+
+This is included in the design as a defined refinement. It should be
+implemented behind the same coordinator interface so turning it on is
+an internal change with no call-site impact. Whether to ship it in the
+first version or add it only if real usage shows visible twitching is a
+judgment call for implementation and review; the plan should treat it as
+a distinct, optional step rather than baking it into the core loop from
+the start.
+
+---
+
+## Edge cases
+
+- **An interrupt body that is very long.** Some actions carry large
+  detail blobs. Cap the footer's body to a small number of lines (about
+  six) and truncate the rest with an ellipsis, so the pinned region
+  always fits on screen and the erase/redraw arithmetic stays bounded.
+  The full detail is still available in the scrollback above once the
+  prompt closes, because auto-approved edits already print their diff and
+  a rejected action's context is in the transcript.
+
+- **A terminal narrower than a footer line, or a resize mid-prompt.**
+  The number of physical rows a footer occupies depends on wrapping, so
+  the coordinator must count rows by *visible* width (with color escape
+  codes stripped) against `process.stdout.columns`, not by the number of
+  logical lines. Recompute on each redraw, and repaint on the terminal
+  resize event so the footer stays coherent if the window changes while
+  you are deciding.
+
+- **The spinner.** It is stopped before the footer installs, through the
+  existing `__agencyStopSpinner` hook, so only one bottom region is ever
+  active. Matching today's behavior, the spinner does not restart for the
+  rest of the turn after any prompt; the turn simply continues and prints
+  its result.
+
+- **The end-of-turn status footer.** `cli.ts` prints a one-line dim
+  status line after a turn completes (`printFooter`, the
+  `─── agency-agent · $… ───` line, `cli.ts:724`). It is a third writer
+  to the bottom of the screen, alongside the spinner and the prompt, but
+  it never collides: it renders only after the turn finishes, when no
+  prompt is open and nothing is streaming. Named here so the census of
+  "who writes to the bottom" is complete rather than quietly omitting a
+  known bottom writer (Finding 7).
+
+- **Escape.** The approval prompt is opened with `allowCancel: true`
+  today, which means Escape cancels the whole request rather than
+  re-prompting. The sticky widget preserves this: Escape raises
+  `AgencyCancelledError`, which unwinds the turn back to the REPL prompt,
+  the same as pressing Escape during the "Thinking" phase.
+
+- **Ctrl+C is a deliberate divergence from the `_ttyWrite` siblings, not
+  an inherited default.** The sticky widget is architecturally a
+  `_ttyWrite` interceptor like `readMultiline` and `installCancelKey`,
+  and those do a *soft* cancel on Ctrl+C: `classifyPasteKey` (`cli.ts:1134`)
+  maps Ctrl+C to `"cancel"` and `readMultiline` resolves it as `null`
+  (no process exit), while `installCancelKey` passes Ctrl+C straight
+  through to the original `_ttyWrite`. Only `_runPrompt` (the `prompts`
+  wrapper) hard-exits with code 130, and it only needs to because
+  `prompts` otherwise swallows Ctrl+C into an infinite re-prompt loop, a
+  problem this widget does not have. For a safety-approval prompt we still
+  choose to exit on Ctrl+C (code 130): quitting is the safe response (it
+  must not approve and must not hang), and it keeps line-mode Ctrl+C
+  consistent whether the prompt came from `prompts` or from this widget.
+  The implementer must therefore **not** copy `classifyPasteKey`'s
+  soft-cancel for Ctrl+C, or the approval prompt would silently
+  reject-and-continue instead of quitting (Finding 3).
+
+- **Free-text rejection reason.** Typing text and pressing Enter returns
+  that text as the reason. `askUser`'s existing final `match` arm turns a
+  non-key answer into `reject(reason)`, so the model sees the reason as
+  the tool's result and can course-correct. Unchanged from today.
+
+---
+
+## Testing
+
+Follow the existing convention in `lib/stdlib/cli.ts`: pure helper
+functions are exported for tests through an `_internal` object
+(`cli.ts:1240`), and the imperative shell is exercised by a smoke test.
+
+Pure, unit-tested helpers:
+
+- Footer row-count given content plus terminal width, including wrapped
+  and color-coded lines (strip escapes before measuring).
+- The atomic-frame builder: given "erase N rows, print this text, redraw
+  this footer," it returns the exact escape-code string. Assert the
+  cursor moves, the clear, the synchronized-output brackets, and the
+  cursor-hide are all present and correctly ordered.
+- The keypress-to-action classifier for the widget, mirroring the tests
+  around `classifyPasteKey`: option key, printable character, Enter,
+  Escape, Ctrl+C, and ignored keys (arrows, function keys).
+- Option-row rendering from a list of `{key, label}` items.
+
+Integration smoke test:
+
+- Drive a scripted keypress sequence at the sticky widget while
+  interleaving calls that write lines through the coordinator, and assert
+  that the footer is present and intact in the final output and that the
+  interleaved lines appear above it in order.
+
+These tests need no LLM calls. They exercise pure rendering and input
+logic, which is exactly what the agency-execution and stdlib unit tests
+are for.
+
+---
+
+## What this design deliberately does not change
+
+Stated plainly so review can hold it to this:
+
+- No change to the TUI (`std::ui`) rendering path.
+- No change to `chooseOption` itself, nor to any caller of it other than
+  `askUser`.
+- No change to `/paste`, the slash palette, `/model`, `/models`,
+  `/search`, `/settings`, or `/local`.
+- No change to the policy data model, the approve/reject/always
+  semantics, or the `"std::tty"` lock.
+- No new concurrency primitive and no new locking. The single-threaded
+  event loop plus the existing `"std::tty"` lock are sufficient.
+
+---
+
+## Open questions for review
+
+1. **RESOLVED — spinner fold-in.** Decided: fold the spinner into the
+   shared coordinator. The reason is correctness, not tidiness. Two
+   patchers of the same `process.stdout.write` otherwise depend on a
+   load-bearing teardown order; a single owner makes it structural. See
+   Component 1. Kept as its own reviewable step in the plan.
+
+2. **Burst coalescing in v1 (still open).** Ship the microtask-coalescing
+   refinement in the first version, or wait until real usage shows visible
+   twitching? Recommendation: build the coordinator so coalescing can be
+   turned on without call-site changes, and decide during implementation
+   review based on how the un-coalesced version looks in practice.
+
+3. **RESOLVED — where the new primitive lives.** `interruptChoice` lives
+   in `std::ui/cli`, because the behavior is inherently line-mode; the
+   altitude review endorsed this placement. `std::policy` calls it and
+   does not re-export it.

--- a/packages/agency-lang/docs/site/stdlib/policy.md
+++ b/packages/agency-lang/docs/site/stdlib/policy.md
@@ -43,7 +43,7 @@ Key of an interrupt's `data` object (e.g. `"dir"`, `"command"`).
 export type InterruptDataKey = string
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L55))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L56))
 
 ### InterruptDataVal
 
@@ -62,7 +62,7 @@ export type InterruptDataKey = string
 export type InterruptDataVal = string
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L63))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L64))
 
 ### InterruptEffect
 
@@ -77,7 +77,7 @@ export type InterruptDataVal = string
 export type InterruptEffect = string
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L69))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L70))
 
 ### PolicyRule
 
@@ -99,7 +99,7 @@ export type PolicyRule = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L77))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L78))
 
 ### Policy
 
@@ -118,7 +118,7 @@ export type PolicyRule = {
 export type Policy = Record<InterruptEffect, PolicyRule[]>
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L88))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L89))
 
 ### Decision
 
@@ -150,7 +150,7 @@ export type Decision =
   | "reject-always"
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L129))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L130))
 
 ### ScopedField
 
@@ -182,7 +182,7 @@ export type ScopedField = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L147))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L148))
 
 ### ScopedRuleFields
 
@@ -225,7 +225,7 @@ export type ScopedField = {
 export type ScopedRuleFields = Record<InterruptEffect, ScopedField[]>
 ````
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L170))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L171))
 
 ### ParsePolicyFailureStatus
 
@@ -237,7 +237,7 @@ export type ParsePolicyFailureStatus =
   | "policy-not-valid"
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L373))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L374))
 
 ### ParsePolicyFailure
 
@@ -248,7 +248,7 @@ export type ParsePolicyFailure = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L379))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L380))
 
 ## Constants
 
@@ -258,7 +258,7 @@ export type ParsePolicyFailure = {
 export static const minimalAutoApprovePolicy = _minimalAutoApprovePolicy
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L102))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L103))
 
 ### recommendedAutoApprovePolicy
 
@@ -266,7 +266,7 @@ export static const minimalAutoApprovePolicy = _minimalAutoApprovePolicy
 export static const recommendedAutoApprovePolicy = _recommendedAutoApprovePolicy
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L103))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L104))
 
 ### approveAllPolicy
 
@@ -274,7 +274,7 @@ export static const recommendedAutoApprovePolicy = _recommendedAutoApprovePolicy
 export static const approveAllPolicy = _approveAllPolicy
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L104))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L105))
 
 ### BUILTIN_POLICIES
 
@@ -282,7 +282,7 @@ export static const approveAllPolicy = _approveAllPolicy
 export static const BUILTIN_POLICIES = _BUILTIN_POLICIES
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L105))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L106))
 
 ## Functions
 
@@ -298,7 +298,7 @@ withWritesPolicy(baseDir: string)
 |---|---|---|
 | baseDir | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L107))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L108))
 
 ### builtinPolicy
 
@@ -315,7 +315,7 @@ builtinPolicy(name: string, baseDir: string): Policy | null
 
 **Returns:** `Policy | null`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L111))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L112))
 
 ### builtinPolicyNames
 
@@ -325,7 +325,7 @@ builtinPolicyNames(): string[]
 
 **Returns:** `string[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L115))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L116))
 
 ### checkPolicy
 
@@ -354,7 +354,7 @@ Evaluate a policy against an interrupt. Returns approve(), reject(), or propagat
 | policy | `Record<string, any>` |  |
 | interrupt | `Record<string, any>` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L205))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L206))
 
 ### validatePolicy
 
@@ -382,7 +382,7 @@ Validate that a policy object is well-formed. Returns { success: true } if valid
 
 **Returns:** `Result<void>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L227))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L228))
 
 ### buildScopedMatch
 
@@ -432,7 +432,7 @@ Build a match object for an interrupt, pinned to the configured fields. Returns 
 
 **Returns:** `Record<string, string>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L262))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L263))
 
 ### recordRule
 
@@ -480,7 +480,7 @@ Return a new policy with a catch-all rule for an effect appended. A single bare 
 
 **Returns:** [Policy](#policy)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L312))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L313))
 
 ### recordScopedRule
 
@@ -522,7 +522,7 @@ Return a new policy with a scoped approve rule prepended for the interrupt's eff
 
 **Returns:** [Policy](#policy)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L349))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L350))
 
 ### parsePolicyFile
 
@@ -554,7 +554,7 @@ Read + parse + validate a policy file from disk. Returns {} on any
 
 **Returns:** `Result<Policy, ParsePolicyFailure>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L395))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L396))
 
 ### setPolicy
 
@@ -575,7 +575,7 @@ setPolicy(path: string, policy: Policy)
 | path | `string` |  |
 | policy | [Policy](#policy) |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L440))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L441))
 
 ### writePolicyFile
 
@@ -606,7 +606,7 @@ Validate and write a policy to a JSON file. Throws if the policy is invalid.
 | policy | [Policy](#policy) |  |
 | allowedPaths | `string[]` | [] |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L456))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L457))
 
 ### flushPolicy
 
@@ -624,7 +624,7 @@ flushPolicy()
  * `std::write` via `with approve` (you opted in by installing the
  * handler).
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L521))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L522))
 
 ### cliPolicyHandler
 
@@ -709,4 +709,4 @@ CLI sugar for an interactive policy handler. Loads and saves the policy file, pr
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L876))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L877))

--- a/packages/agency-lang/docs/site/stdlib/ui/cli.md
+++ b/packages/agency-lang/docs/site/stdlib/ui/cli.md
@@ -69,7 +69,7 @@ Line-mode REPL with the same call signature as the std::ui TUI repl,
 | historyMax | `number` | 1000 |
 | paletteCommands | `any` | null |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/cli.agency#L61))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/cli.agency#L65))
 
 ### clearScreen
 
@@ -77,7 +77,7 @@ Line-mode REPL with the same call signature as the std::ui TUI repl,
 clearScreen()
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/cli.agency#L101))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/cli.agency#L105))
 
 ### clearHistory
 
@@ -89,7 +89,7 @@ Clear the input history of the currently running `repl()` session: both
   its in-session up-arrow recall and the `historyFile` that session was started
   with. A no-op when called outside an interactive `repl()`.
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/cli.agency#L105))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/cli.agency#L109))
 
 ### hline
 
@@ -106,4 +106,43 @@ hline(char: string = "─", width: number = null): string
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/cli.agency#L116))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/cli.agency#L120))
+
+### interruptChoice
+
+```ts
+interruptChoice(
+  title: string,
+  body: string,
+  items: any[],
+  allowFreeText: boolean = false,
+  allowCancel: boolean = false,
+): string
+```
+
+Approval prompt for line mode: renders a sticky footer pinned to the
+  bottom of the terminal so concurrent tool-call output streams above it
+  instead of burying the prompt. Type an option key or a rejection reason,
+  then press Enter. Falls back to `chooseOption` when no line-mode REPL is
+  active (the TUI, a non-TTY, or a headless run), so every non-line-mode
+  path keeps its current behavior.
+
+  @param title - Prompt heading (the interrupt message).
+  @param body - Multi-line context shown under the title (or "").
+  @param items - The {key, label} choices.
+  @param allowFreeText - Accept a free-form rejection reason.
+  @param allowCancel - When true, Escape cancels the whole request.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| title | `string` |  |
+| body | `string` |  |
+| items | `any[]` |  |
+| allowFreeText | `boolean` | false |
+| allowCancel | `boolean` | false |
+
+**Returns:** `string`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/cli.agency#L125))

--- a/packages/agency-lang/lib/stdlib/cli.test.ts
+++ b/packages/agency-lang/lib/stdlib/cli.test.ts
@@ -532,3 +532,17 @@ describe("installBottomRegion", () => {
     expect(text.indexOf("trace line")).toBeLessThan(text.lastIndexOf("FOOTER"));
   });
 });
+
+describe("startSpinner coexists with outside writes", () => {
+  it("redraws the Thinking line after an outside write", () => {
+    const cap = captureStdout();
+    const stop = _internal.startSpinner(true);
+    cap.captured.length = 0;
+    process.stdout.write("tool output\n");
+    stop();
+    cap.restore();
+    const text = cap.captured.join("");
+    expect(text).toContain("tool output\n");
+    expect(text.indexOf("tool output")).toBeLessThan(text.lastIndexOf("Thinking"));
+  });
+});

--- a/packages/agency-lang/lib/stdlib/cli.test.ts
+++ b/packages/agency-lang/lib/stdlib/cli.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { _internal, _clearHistory, installBottomRegion, type PasteState } from "./cli.js";
+import { _internal, _clearHistory, installBottomRegion, _stickyInterruptAvailable, type PasteState } from "./cli.js";
 
 const {
   EMPTY_PASTE,
@@ -689,5 +689,86 @@ describe("stickyInterruptPrompt (integration)", () => {
     fakeRl._ttyWrite(null, { name: "escape" });
     await expect(pending).rejects.toThrow(/cancelled/i);
     cap.restore();
+  });
+});
+
+describe("installBottomRegion — write contract + resize (PR review fixes)", () => {
+  it("forwards the write callback and decodes Buffers/Uint8Arrays", () => {
+    const captured: string[] = [];
+    const origWrite = process.stdout.write;
+    const origTTY = (process.stdout as any).isTTY;
+    (process.stdout as any).isTTY = true;
+    // Sink that honors the completion callback like the real stream.
+    (process.stdout as any).write = (chunk: any, ...rest: any[]) => {
+      captured.push(String(chunk));
+      const cb = rest.find((arg: any) => typeof arg === "function");
+      if (cb) cb();
+      return true;
+    };
+    const region = installBottomRegion(() => ["F"], true);
+    let bufCbCalled = false;
+    (process.stdout as any).write(Buffer.from("hi\n"), () => { bufCbCalled = true; });
+    (process.stdout as any).write(new TextEncoder().encode("bye\n"));
+    region.teardown();
+    (process.stdout as any).write = origWrite;
+    (process.stdout as any).isTTY = origTTY;
+    const text = captured.join("");
+    expect(bufCbCalled).toBe(true);          // callback forwarded
+    expect(text).toContain("hi\n");          // Buffer decoded, not "<Buffer ...>"
+    expect(text).toContain("bye\n");         // Uint8Array decoded, not "98,121,..."
+  });
+
+  it("repaints the footer on terminal resize", () => {
+    const cap = captureStdout();
+    const region = installBottomRegion(() => ["FOOTER"], true);
+    cap.captured.length = 0;
+    process.stdout.emit("resize");
+    region.teardown();
+    cap.restore();
+    expect(cap.captured.join("")).toContain("FOOTER"); // a repaint happened
+  });
+});
+
+describe("_stickyInterruptAvailable requires the hook AND both TTYs", () => {
+  it("returns true only with the hook and both ends a TTY", () => {
+    const globalObj = globalThis as any;
+    const prevHook = globalObj.__agencyInterruptPrompt;
+    const prevOut = (process.stdout as any).isTTY;
+    const prevIn = (process.stdin as any).isTTY;
+    try {
+      globalObj.__agencyInterruptPrompt = () => Promise.resolve("a");
+      (process.stdout as any).isTTY = true;
+      (process.stdin as any).isTTY = true;
+      expect(_stickyInterruptAvailable()).toBe(true);
+      (process.stdin as any).isTTY = false;
+      expect(_stickyInterruptAvailable()).toBe(false); // non-TTY stdin → fallback
+      (process.stdin as any).isTTY = true;
+      (process.stdout as any).isTTY = false;
+      expect(_stickyInterruptAvailable()).toBe(false); // non-TTY stdout → fallback
+      (process.stdout as any).isTTY = true;
+      globalObj.__agencyInterruptPrompt = undefined;
+      expect(_stickyInterruptAvailable()).toBe(false); // no REPL hook
+    } finally {
+      globalObj.__agencyInterruptPrompt = prevHook;
+      (process.stdout as any).isTTY = prevOut;
+      (process.stdin as any).isTTY = prevIn;
+    }
+  });
+});
+
+describe("renderInterruptFooter body cap is by physical rows", () => {
+  it("bounds a single very long body line to the row cap + ellipsis", () => {
+    const lines = _internal.renderInterruptFooter({
+      title: "t",
+      body: "x".repeat(500),
+      items: [{ key: "a", label: "ok" }],
+      allowFreeText: true,
+      state: { buffer: "", notice: "" },
+      columns: 40,
+    });
+    // Body rows are the dim-x lines; capped at 6 physical rows + one "…".
+    const bodyRowCount = lines.filter((line) => line.includes("x")).length;
+    expect(bodyRowCount).toBeLessThanOrEqual(6);
+    expect(lines.some((line) => line.includes("…"))).toBe(true);
   });
 });

--- a/packages/agency-lang/lib/stdlib/cli.test.ts
+++ b/packages/agency-lang/lib/stdlib/cli.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { _internal, _clearHistory, type PasteState } from "./cli.js";
+import { _internal, _clearHistory, installBottomRegion, type PasteState } from "./cli.js";
 
 const {
   EMPTY_PASTE,
@@ -21,7 +21,27 @@ const {
   recordPasteEntry,
   repairSlashHistory,
   summarizeMultiline,
+  eraseRows,
+  buildFrame,
 } = _internal;
+
+/** Replace process.stdout.write with a capturing sink and force isTTY on.
+ *  installBottomRegion binds this sink as its realWrite, so every frame is
+ *  captured. Returns the buffer and a restore fn. */
+function captureStdout(): { captured: string[]; restore: () => void } {
+  const captured: string[] = [];
+  const originalWrite = process.stdout.write;
+  const originalIsTTY = (process.stdout as any).isTTY;
+  (process.stdout as any).write = (chunk: any) => { captured.push(String(chunk)); return true; };
+  (process.stdout as any).isTTY = true;
+  return {
+    captured,
+    restore: () => {
+      (process.stdout as any).write = originalWrite;
+      (process.stdout as any).isTTY = originalIsTTY;
+    },
+  };
+}
 
 /** Build a snapshot shaped like `readTokenSnapshot`'s return value from
  *  a `{model: [tokens, cost]}` shorthand. */
@@ -451,5 +471,64 @@ describe("_clearHistory", () => {
     expect(loadHistory(file, 100).entries).toEqual(["c", "b", "a"]);
     _clearHistory(file);
     expect(loadHistory(file, 100).entries).toEqual([]);
+  });
+});
+
+describe("eraseRows", () => {
+  it("returns nothing when there is no footer yet", () => {
+    expect(eraseRows(0)).toBe("");
+  });
+  it("clears a single row with CR + clear-down, no cursor move", () => {
+    expect(eraseRows(1)).toBe("\r\x1b[0J");
+  });
+  it("moves up rows-1 before clearing for a multi-row footer", () => {
+    expect(eraseRows(3)).toBe("\x1b[2A\r\x1b[0J");
+  });
+});
+
+describe("buildFrame", () => {
+  it("first frame of a 1-row footer: sync brackets + footer, no erase", () => {
+    const result = buildFrame({ above: null, footerLines: ["FOOTER"], prevRows: 0, columns: 80, cursor: "keep" });
+    expect(result.rows).toBe(1);
+    expect(result.seq).toBe("\x1b[?2026h" + "FOOTER" + "\x1b[?2026l");
+  });
+  it("erases the previous footer, then emits `above`, then redraws", () => {
+    const result = buildFrame({ above: "trace\n", footerLines: ["A", "B"], prevRows: 3, columns: 80, cursor: "keep" });
+    expect(result.seq).toBe("\x1b[?2026h" + "\x1b[2A\r\x1b[0J" + "trace\n" + "A\nB" + "\x1b[?2026l");
+    expect(result.rows).toBe(2);
+  });
+  it("appends a newline to `above` when missing so the footer starts fresh", () => {
+    const result = buildFrame({ above: "x", footerLines: ["F"], prevRows: 1, columns: 80, cursor: "keep" });
+    expect(result.seq).toContain("x\n");
+  });
+  it("emits hide/show cursor when asked", () => {
+    expect(buildFrame({ above: null, footerLines: ["F"], prevRows: 0, columns: 80, cursor: "hide" }).seq).toContain("\x1b[?25l");
+    expect(buildFrame({ above: null, footerLines: [], prevRows: 1, columns: 80, cursor: "show" }).seq).toContain("\x1b[?25h");
+  });
+  it("counts wrapped rows for an over-wide footer line", () => {
+    const wide = "w".repeat(50);
+    expect(buildFrame({ above: null, footerLines: [wide], prevRows: 0, columns: 20, cursor: "keep" }).rows).toBeGreaterThan(1);
+  });
+});
+
+describe("installBottomRegion", () => {
+  it("no-ops on non-TTY (passes writes straight through)", () => {
+    const cap = captureStdout();
+    const region = installBottomRegion(() => ["footer"], false);
+    process.stdout.write("hello");
+    region.teardown();
+    cap.restore();
+    expect(cap.captured).toEqual(["hello"]);
+  });
+  it("redraws the footer above an outside write", () => {
+    const cap = captureStdout();
+    const region = installBottomRegion(() => ["FOOTER"], true);
+    cap.captured.length = 0; // drop the initial paint
+    process.stdout.write("trace line\n");
+    region.teardown();
+    cap.restore();
+    const text = cap.captured.join("");
+    expect(text).toContain("trace line\n");
+    expect(text.indexOf("trace line")).toBeLessThan(text.lastIndexOf("FOOTER"));
   });
 });

--- a/packages/agency-lang/lib/stdlib/cli.test.ts
+++ b/packages/agency-lang/lib/stdlib/cli.test.ts
@@ -658,3 +658,36 @@ describe("renderInterruptFooter", () => {
     expect(lines.join("\n")).toContain("not a valid option");
   });
 });
+
+describe("stickyInterruptPrompt (integration)", () => {
+  it("resolves 'aa' typed then Enter, with a trace streamed above", async () => {
+    const cap = captureStdout();
+    (process.stdin as any).isTTY = false; // skip real raw-mode toggling
+    const fakeRl: any = { _ttyWrite: (_s: any, _k: any) => { } };
+    const pending = _internal.stickyInterruptPrompt(fakeRl, {
+      title: "approve?", body: "", allowFreeText: true, allowCancel: true,
+      items: [{ key: "a", label: "approve once" }, { key: "aa", label: "approve always" }],
+    });
+    process.stdout.write("⏺ read(\"x\")\n"); // concurrent branch output
+    fakeRl._ttyWrite("a", { name: "a" });
+    fakeRl._ttyWrite("a", { name: "a" });
+    fakeRl._ttyWrite(null, { name: "return" });
+    const answer = await pending;
+    cap.restore();
+    expect(answer).toBe("aa");
+    expect(cap.captured.join("")).toContain("⏺ read(\"x\")\n");
+  });
+
+  it("Escape rejects with AgencyCancelledError", async () => {
+    const cap = captureStdout();
+    (process.stdin as any).isTTY = false;
+    const fakeRl: any = { _ttyWrite: (_s: any, _k: any) => { } };
+    const pending = _internal.stickyInterruptPrompt(fakeRl, {
+      title: "t", body: "", allowFreeText: true, allowCancel: true,
+      items: [{ key: "a", label: "ok" }],
+    });
+    fakeRl._ttyWrite(null, { name: "escape" });
+    await expect(pending).rejects.toThrow(/cancelled/i);
+    cap.restore();
+  });
+});

--- a/packages/agency-lang/lib/stdlib/cli.test.ts
+++ b/packages/agency-lang/lib/stdlib/cli.test.ts
@@ -546,3 +546,115 @@ describe("startSpinner coexists with outside writes", () => {
     expect(text.indexOf("tool output")).toBeLessThan(text.lastIndexOf("Thinking"));
   });
 });
+
+describe("classifyInterruptKey", () => {
+  const classify = (sequence: any, key: any) => _internal.classifyInterruptKey(sequence, key);
+  it("Ctrl+C is a hard exit (diverges from paste-mode soft cancel)", () => {
+    expect(classify(null, { name: "c", ctrl: true })).toBe("exit");
+  });
+  it("Escape is a soft cancel", () => {
+    expect(classify(null, { name: "escape" })).toBe("cancel");
+  });
+  it("Enter submits", () => {
+    expect(classify(null, { name: "return" })).toBe("submit");
+    expect(classify(null, { name: "enter" })).toBe("submit");
+  });
+  it("Backspace deletes", () => {
+    expect(classify(null, { name: "backspace" })).toBe("backspace");
+  });
+  it("a printable char appends; chords and arrows are ignored", () => {
+    expect(classify("a", { name: "a" })).toEqual({ append: "a" });
+    expect(classify(null, { name: "up" })).toBeNull();
+    expect(classify("x", { name: "x", meta: true })).toBeNull();
+  });
+});
+
+describe("reduceInterrupt", () => {
+  const config = { validKeys: ["a", "r", "aa", "ap", "rr"], allowFreeText: true, allowCancel: true };
+  const from = (buffer: string) => ({ buffer, notice: "" });
+  const reduce = _internal.reduceInterrupt;
+
+  it("exit action yields an exit outcome", () => {
+    expect(reduce(from(""), "exit", config).outcome).toEqual({ kind: "exit" });
+  });
+  it("Escape cancels when allowCancel, pends otherwise", () => {
+    expect(reduce(from(""), "cancel", config).outcome).toEqual({ kind: "cancel" });
+    expect(reduce(from(""), "cancel", { ...config, allowCancel: false }).outcome).toEqual({ kind: "pending" });
+  });
+  it("appends a printable char and clears the notice", () => {
+    const step = reduce({ buffer: "a", notice: "x" }, { append: "a" }, config);
+    expect(step.state).toEqual({ buffer: "aa", notice: "" });
+    expect(step.outcome).toEqual({ kind: "pending" });
+  });
+  it("strips embedded newlines from an appended chunk (single-line reason)", () => {
+    expect(reduce(from("a"), { append: "b\nc" }, config).state.buffer).toBe("abc");
+  });
+  it("backspace deletes the last char and clears the notice", () => {
+    expect(reduce({ buffer: "aa", notice: "x" }, "backspace", config).state).toEqual({ buffer: "a", notice: "" });
+  });
+  it("submit resolves an exact key — 'a' does NOT early-resolve before 'aa'", () => {
+    expect(reduce(from("aa"), "submit", config).outcome).toEqual({ kind: "resolve", value: "aa" });
+    expect(reduce(from("a"), "submit", config).outcome).toEqual({ kind: "resolve", value: "a" });
+  });
+  it("submit returns a free-text reason even when it starts with an option letter", () => {
+    expect(reduce(from("actually no"), "submit", config).outcome).toEqual({ kind: "resolve", value: "actually no" });
+  });
+  it("submit on empty pends with no notice (must-answer)", () => {
+    const step = reduce(from(""), "submit", config);
+    expect(step.outcome).toEqual({ kind: "pending" });
+    expect(step.state.notice).toBe("");
+  });
+  it("submit on invalid input without free text pends with a notice", () => {
+    const step = reduce(from("zzz"), "submit", { ...config, allowFreeText: false });
+    expect(step.outcome).toEqual({ kind: "pending" });
+    expect(step.state.notice).toBe("not a valid option");
+  });
+  it("an ignored key pends without changing state", () => {
+    expect(reduce(from("a"), null, config)).toEqual({ state: { buffer: "a", notice: "" }, outcome: { kind: "pending" } });
+  });
+});
+
+describe("packOptions", () => {
+  it("packs short tokens onto one line", () => {
+    expect(_internal.packOptions([{ key: "a", label: "ok" }, { key: "r", label: "no" }], 40)).toEqual(["a=ok  r=no"]);
+  });
+  it("wraps when the next token would overflow", () => {
+    expect(_internal.packOptions([{ key: "a", label: "approve" }, { key: "r", label: "reject" }], 10)).toEqual(["a=approve", "r=reject"]);
+  });
+});
+
+describe("renderInterruptFooter", () => {
+  const items = [
+    { key: "a", label: "approve once" },
+    { key: "r", label: "reject once" },
+    { key: "rr", label: "reject always" },
+  ];
+  const base = {
+    title: "bash: rm -rf build/ — approve?",
+    body: "",
+    items,
+    allowFreeText: true,
+    state: { buffer: "aa", notice: "" },
+    columns: 80,
+  };
+  it("shows divider, title, options, hint, and the input line with a caret", () => {
+    const lines = _internal.renderInterruptFooter(base);
+    const joined = lines.join("\n");
+    expect(joined).toContain("bash: rm -rf build/ — approve?");
+    expect(joined).toContain("a=approve once");
+    expect(joined).toContain("rr=reject always");
+    expect(joined).toContain("Enter to submit");
+    expect(lines[lines.length - 1]).toContain("> aa");
+    expect(lines[lines.length - 1]).toContain("▏");
+  });
+  it("caps a long body to 6 lines with an ellipsis", () => {
+    const body = Array.from({ length: 20 }, (_unused, index) => `line${index}`).join("\n");
+    const lines = _internal.renderInterruptFooter({ ...base, body });
+    expect(lines.filter((line) => /line\d/.test(line)).length).toBe(6);
+    expect(lines.some((line) => line.includes("…"))).toBe(true);
+  });
+  it("shows a notice when present", () => {
+    const lines = _internal.renderInterruptFooter({ ...base, state: { buffer: "z", notice: "not a valid option" } });
+    expect(lines.join("\n")).toContain("not a valid option");
+  });
+});

--- a/packages/agency-lang/lib/stdlib/cli.ts
+++ b/packages/agency-lang/lib/stdlib/cli.ts
@@ -189,8 +189,6 @@ function recordHistoryEntry(history: string[], entry: string, command: string): 
 const USER_INPUT_COLOR = styles.cyan
 const COLOR_RESET = RESET;
 const DIM = styles.dim;
-const CLEAR_LINE = "\r\x1b[K";
-
 const HIDE_CURSOR = "\x1b[?25l";
 const SHOW_CURSOR = "\x1b[?25h";
 const SYNC_BEGIN = "\x1b[?2026h"; // DEC synchronized-update begin
@@ -489,62 +487,31 @@ const SPINNER_FRAMES = SPINNERS.line.frames;
 const SPINNER_INTERVAL_MS = SPINNERS.line.interval;
 
 /**
- * Start a single-line "Thinking Ns" spinner. Returns a stop function
- * that clears the spinner row and restores `process.stdout.write`.
- *
- * While the spinner is active, every external write to stdout
- * (`console.log`, `process.stdout.write`, etc.) is wrapped to emit
- * a `\r\x1b[K` clear-line first, then the original content. The
- * spinner redraws on the next interval tick. This is the
- * "unconditional clear-on-write" approach the spec endorses for WL4
- * — ~15 lines, handles every tool that logs without needing each
- * tool to coordinate with the spinner.
- *
- * No-op on non-TTY: returns an immediate stop function so piped
- * runs don't get spinner frames in their logs.
+ * Start a single-line "Thinking Ns" spinner as a one-line bottom region.
+ * Returns a stop function that removes the region. The spinner is now a
+ * client of `installBottomRegion`: outside writes (tool traces) redraw
+ * above it automatically, and there is exactly one owner of the bottom of
+ * the screen. It does NOT hide the cursor (default RegionOptions). No-op
+ * on non-TTY: returns an immediate stop function so piped runs don't get
+ * spinner frames in their logs.
  */
 function startSpinner(useTTY: boolean): () => void {
-  if (!useTTY) return () => { };
+  if (!useTTY) {
+    return () => { };
+  }
   const startedAt = Date.now();
-  let stopped = false;
-  // Capture the *real* write before patching so the spinner itself
-  // can draw without recursing through the patched version.
-  const stdoutAny = process.stdout as unknown as {
-    write: (chunk: any, ...rest: any[]) => any;
-  };
-  const realWrite = stdoutAny.write.bind(process.stdout);
-
-  const render = (): void => {
-    if (stopped) return;
+  const render = (): string[] => {
     const elapsedMs = Date.now() - startedAt;
     const elapsedSec = Math.floor(elapsedMs / 1000);
-    const idx = Math.floor(elapsedMs / SPINNER_INTERVAL_MS) % SPINNER_FRAMES.length;
-    const frame = SPINNER_FRAMES[idx];
-    realWrite(`\r${DIM}${frame} Thinking ${elapsedSec}s${COLOR_RESET}\x1b[K`);
+    const frameIndex =
+      Math.floor(elapsedMs / SPINNER_INTERVAL_MS) % SPINNER_FRAMES.length;
+    return [`${DIM}${SPINNER_FRAMES[frameIndex]} Thinking ${elapsedSec}s${COLOR_RESET}`];
   };
-  render();
-  const id = setInterval(render, SPINNER_INTERVAL_MS);
-
-  // Patch stdout so any external write clears the spinner row first.
-  // The patched function uses `realWrite`, never `stdoutAny.write`,
-  // so there's no recursion. Preserves the original return value so
-  // backpressure semantics (the boolean Writable.write returns) stay
-  // correct.
-  stdoutAny.write = function patchedWrite(
-    this: unknown,
-    chunk: any,
-    ...rest: any[]
-  ): any {
-    realWrite(CLEAR_LINE);
-    return realWrite(chunk, ...rest);
-  };
-
+  const region = installBottomRegion(render, useTTY);
+  const timer = setInterval(() => region.refresh(), SPINNER_INTERVAL_MS);
   return (): void => {
-    if (stopped) return;
-    stopped = true;
-    clearInterval(id);
-    stdoutAny.write = realWrite;
-    realWrite(CLEAR_LINE);
+    clearInterval(timer);
+    region.teardown();
   };
 }
 
@@ -1432,6 +1399,7 @@ export const _internal = {
   summarizeMultiline,
   eraseRows,
   buildFrame,
+  startSpinner,
 };
 
 export function _clearScreen(): void {

--- a/packages/agency-lang/lib/stdlib/cli.ts
+++ b/packages/agency-lang/lib/stdlib/cli.ts
@@ -13,6 +13,7 @@ import { getRuntimeContext } from "../runtime/asyncContext.js";
 import { modifiers, RESET, styles } from "@/utils/termcolors.js"
 import { color, colors, bgColors } from "../utils/termcolors.js";
 import { _promptsAutocomplete } from "./ui.js";
+import { visualWidth, wrapText } from "./layout/ansi.js";
 import { isFailure } from "../runtime/result.js";
 import { isAbortError, makeAbortCause } from "../runtime/errors.js";
 import type { AbortCause } from "../runtime/errors.js";
@@ -189,6 +190,181 @@ const USER_INPUT_COLOR = styles.cyan
 const COLOR_RESET = RESET;
 const DIM = styles.dim;
 const CLEAR_LINE = "\r\x1b[K";
+
+const HIDE_CURSOR = "\x1b[?25l";
+const SHOW_CURSOR = "\x1b[?25h";
+const SYNC_BEGIN = "\x1b[?2026h"; // DEC synchronized-update begin
+const SYNC_END = "\x1b[?2026l";   // DEC synchronized-update end
+const CLEAR_DOWN = "\x1b[0J";     // clear from cursor to end of screen
+const MIN_FOOTER_WIDTH = 20;
+
+// ---------------------------------------------------------------------------
+// Bottom-region coordinator.
+//
+// Generalizes the "Thinking" spinner's single-line stdout monkeypatch (see
+// `startSpinner`, which is folded onto this) into a footer of any number of
+// lines pinned to the bottom of the terminal. While a region is installed,
+// every OTHER write to process.stdout is redrawn ABOVE the footer as one
+// atomic frame: erase the footer, emit the outside text into scrollback,
+// redraw the footer beneath it. The "what" (which bytes to emit) lives in
+// the pure `buildFrame`; the "how" (patching stdout, tracking rows) lives in
+// the `installBottomRegion` shell.
+// ---------------------------------------------------------------------------
+
+/** Cursor moves that erase a footer of `rows` physical rows, leaving the
+ *  cursor at column 0 of where the footer's first row began. Empty when
+ *  there is no footer yet. */
+function eraseRows(rows: number): string {
+  if (rows === 0) {
+    return "";
+  }
+  const moveUp = rows > 1 ? `\x1b[${rows - 1}A` : "";
+  return `${moveUp}\r${CLEAR_DOWN}`;
+}
+
+type FrameCursor = "hide" | "show" | "keep";
+
+type FrameSpec = {
+  above: string | null;
+  footerLines: string[];
+  prevRows: number;
+  columns: number;
+  cursor: FrameCursor;
+};
+
+type FrameResult = { seq: string; rows: number };
+
+function cursorSequence(cursor: FrameCursor): string {
+  if (cursor === "hide") {
+    return HIDE_CURSOR;
+  }
+  if (cursor === "show") {
+    return SHOW_CURSOR;
+  }
+  return "";
+}
+
+function withTrailingNewline(text: string): string {
+  if (text.endsWith("\n")) {
+    return text;
+  }
+  return `${text}\n`;
+}
+
+/** Build ONE atomic terminal frame: erase the previous footer, optionally
+ *  emit `above` into scrollback, then redraw the footer wrapped to width.
+ *  Pure — the exact bytes and the new physical-row count are a function of
+ *  the inputs, so the anti-flicker guarantees are unit-testable. */
+function buildFrame(spec: FrameSpec): FrameResult {
+  const width = Math.max(MIN_FOOTER_WIDTH, spec.columns - 1);
+  const physical = spec.footerLines.flatMap((line) => wrapText(line, width));
+  const above = spec.above === null ? "" : withTrailingNewline(spec.above);
+  const seq =
+    SYNC_BEGIN +
+    eraseRows(spec.prevRows) +
+    above +
+    physical.join("\n") +
+    cursorSequence(spec.cursor) +
+    SYNC_END;
+  return { seq, rows: physical.length };
+}
+
+export type BottomRegion = { refresh: () => void; teardown: () => void };
+
+type RegionOptions = { hideCursor: boolean };
+
+const NOOP_REGION: BottomRegion = { refresh: () => { }, teardown: () => { } };
+
+// At most one bottom region owns process.stdout.write at a time. Folding the
+// spinner onto this coordinator makes single-ownership structural rather
+// than an ordering discipline.
+let activeRegion: BottomRegion | null = null;
+
+// Crash-safety: if the process exits while a region still hides the cursor,
+// restore it. Registered once.
+let cursorRestoreRegistered = false;
+function registerCursorRestore(): void {
+  if (cursorRestoreRegistered) {
+    return;
+  }
+  cursorRestoreRegistered = true;
+  process.once("exit", () => {
+    if (activeRegion) {
+      process.stdout.write(SHOW_CURSOR);
+    }
+  });
+}
+
+function chunkToText(chunk: unknown): string {
+  if (typeof chunk === "string") {
+    return chunk;
+  }
+  return String(chunk);
+}
+
+/** Pin `render()`'s lines to the bottom of the terminal. While installed,
+ *  every other write to process.stdout is redrawn ABOVE the footer as one
+ *  atomic frame (via `buildFrame`). No-op on non-TTY. `hideCursor` scopes
+ *  cursor-hiding to callers that draw their own caret (the interrupt
+ *  widget); the spinner leaves the cursor alone. */
+export function installBottomRegion(
+  render: () => string[],
+  useTTY: boolean,
+  options: RegionOptions = { hideCursor: false },
+): BottomRegion {
+  if (!useTTY) {
+    return NOOP_REGION;
+  }
+  if (activeRegion) {
+    activeRegion.teardown();
+  }
+  registerCursorRestore();
+
+  const stdoutAny = process.stdout as unknown as {
+    write: (chunk: any, ...rest: any[]) => any;
+  };
+  const realWrite = stdoutAny.write.bind(process.stdout);
+  let rows = 0;
+  let firstPaint = true;
+
+  const paint = (above: string | null): boolean => {
+    const hideNow = options.hideCursor && firstPaint;
+    const frame = buildFrame({
+      above,
+      footerLines: render(),
+      prevRows: rows,
+      columns: process.stdout.columns || 80,
+      cursor: hideNow ? "hide" : "keep",
+    });
+    firstPaint = false;
+    rows = frame.rows;
+    return realWrite(frame.seq);
+  };
+
+  paint(null);
+  stdoutAny.write = (chunk: any): boolean => paint(chunkToText(chunk));
+
+  const region: BottomRegion = {
+    refresh: () => { paint(null); },
+    teardown: () => {
+      stdoutAny.write = realWrite;
+      const frame = buildFrame({
+        above: null,
+        footerLines: [],
+        prevRows: rows,
+        columns: process.stdout.columns || 80,
+        cursor: options.hideCursor ? "show" : "keep",
+      });
+      realWrite(frame.seq);
+      rows = 0;
+      if (activeRegion === region) {
+        activeRegion = null;
+      }
+    },
+  };
+  activeRegion = region;
+  return region;
+}
 
 const SPINNERS = {
   "line": {
@@ -1254,6 +1430,8 @@ export const _internal = {
   recordPasteEntry,
   repairSlashHistory,
   summarizeMultiline,
+  eraseRows,
+  buildFrame,
 };
 
 export function _clearScreen(): void {

--- a/packages/agency-lang/lib/stdlib/cli.ts
+++ b/packages/agency-lang/lib/stdlib/cli.ts
@@ -15,7 +15,7 @@ import { color, colors, bgColors } from "../utils/termcolors.js";
 import { _promptsAutocomplete } from "./ui.js";
 import { visualWidth, wrapText } from "./layout/ansi.js";
 import { isFailure } from "../runtime/result.js";
-import { isAbortError, makeAbortCause } from "../runtime/errors.js";
+import { isAbortError, makeAbortCause, AgencyCancelledError } from "../runtime/errors.js";
 import type { AbortCause } from "../runtime/errors.js";
 import { normalizeModelUsage } from "../runtime/utils.js";
 // ---------------------------------------------------------------------------
@@ -540,6 +540,129 @@ function renderInterruptFooter(input: InterruptFooterInput): string[] {
   }
   lines.push(` > ${input.state.buffer}${INTERRUPT_CARET}`);
   return lines;
+}
+
+// ---------------------------------------------------------------------------
+// Sticky interrupt prompt — imperative shell + bridge.
+// ---------------------------------------------------------------------------
+
+type InterruptOpts = {
+  title: string;
+  body: string;
+  items: { key: string; label: string }[];
+  allowFreeText: boolean;
+  allowCancel: boolean;
+};
+
+/** Stop the "Thinking" spinner if the REPL has one running (which also
+ *  frees the stdout patch before the widget installs its own region). */
+function stopSpinnerIfRunning(): void {
+  const stop = (globalThis as any).__agencyStopSpinner;
+  if (typeof stop === "function") {
+    stop();
+  }
+}
+
+/** Assert raw mode so `_ttyWrite` receives keystrokes (see readMultiline
+ *  for why). Returns a restore fn. No-op off a TTY. */
+function assertRawMode(): () => void {
+  const stdin = process.stdin as NodeJS.ReadStream & { setRawMode?: (mode: boolean) => void };
+  if (!stdin.isTTY || !stdin.setRawMode) {
+    return () => { };
+  }
+  const wasRaw = !!stdin.isRaw;
+  stdin.setRawMode(true);
+  return () => {
+    if (stdin.setRawMode && stdin.isRaw !== wasRaw) {
+      stdin.setRawMode(wasRaw);
+    }
+  };
+}
+
+/** The line-mode approval prompt. Renders `opts` as a pinned bottom footer
+ *  and reads a typed line terminated by Enter. All decisions come from
+ *  reduceInterrupt; this shell only wires keys → reducer → outcome and does
+ *  the I/O. Resolves with the option key or a free-text reason; rejects
+ *  with AgencyCancelledError on Escape (when allowCancel); exits 130 on
+ *  Ctrl+C. Reuses the outer REPL's readline via `_ttyWrite` — no second
+ *  readline, so none of _runPrompt's paused/raw restoration dance applies. */
+function stickyInterruptPrompt(rl: readline.Interface, opts: InterruptOpts): Promise<string> {
+  stopSpinnerIfRunning();
+  const restoreRaw = assertRawMode();
+  const config: InterruptConfig = {
+    validKeys: opts.items.map((item) => item.key),
+    allowFreeText: opts.allowFreeText,
+    allowCancel: opts.allowCancel,
+  };
+  let state = INITIAL_INTERRUPT_STATE;
+
+  const region = installBottomRegion(
+    () => renderInterruptFooter({
+      title: opts.title,
+      body: opts.body,
+      items: opts.items,
+      allowFreeText: opts.allowFreeText,
+      state,
+      columns: process.stdout.columns || 80,
+    }),
+    process.stdout.isTTY === true,
+    { hideCursor: true },
+  );
+
+  const rlAny = rl as unknown as { _ttyWrite: (sequence: unknown, key: unknown) => void };
+  const originalTtyWrite = rlAny._ttyWrite;
+
+  return new Promise<string>((resolve, reject) => {
+    const settle = (finish: () => void): void => {
+      rlAny._ttyWrite = originalTtyWrite;
+      region.teardown();
+      restoreRaw();
+      finish();
+    };
+    rlAny._ttyWrite = (sequence: unknown, key: unknown): void => {
+      const action = classifyInterruptKey(sequence, key as KeyMeta | undefined);
+      const step = reduceInterrupt(state, action, config);
+      state = step.state;
+      const outcome = step.outcome;
+      if (outcome.kind === "exit") {
+        settle(() => { });
+        process.exit(130);
+        return;
+      }
+      if (outcome.kind === "cancel") {
+        settle(() => reject(new AgencyCancelledError("cancelled by user")));
+        return;
+      }
+      if (outcome.kind === "resolve") {
+        settle(() => resolve(outcome.value));
+        return;
+      }
+      region.refresh();
+    };
+  });
+}
+
+/** Bridge for std::ui/cli's interruptChoice. Delegates to the sticky widget
+ *  wired to the running line-mode REPL. The Agency side gates on
+ *  _stickyInterruptAvailable first, so a missing hook is a programming
+ *  error. */
+export async function _interruptChoice(
+  title: string,
+  body: string,
+  items: { key: string; label: string }[],
+  allowFreeText: boolean,
+  allowCancel: boolean,
+): Promise<string> {
+  const hook = (globalThis as any).__agencyInterruptPrompt;
+  if (typeof hook !== "function") {
+    throw new Error("_interruptChoice: no active line-mode REPL");
+  }
+  return hook({ title, body, items, allowFreeText, allowCancel });
+}
+
+/** True when a line-mode REPL is running and can host a pinned prompt. */
+export function _stickyInterruptAvailable(): boolean {
+  return typeof (globalThis as any).__agencyInterruptPrompt === "function";
 }
 
 const SPINNERS = {
@@ -1182,6 +1305,13 @@ export async function _runLineRepl(
     for (const k of Object.keys(expansions)) delete expansions[k];
   };
 
+  // Expose the sticky interrupt prompt to std::policy (via std::ui/cli's
+  // interruptChoice → _interruptChoice). Bound to THIS readline so the
+  // widget reuses it; restored on exit like the hooks above.
+  const interruptPromptKey = "__agencyInterruptPrompt";
+  const prevInterruptPrompt = (globalThis as any)[interruptPromptKey];
+  (globalThis as any)[interruptPromptKey] = (opts: InterruptOpts) => stickyInterruptPrompt(rl, opts);
+
   // `/` at an empty prompt synthesizes Enter so the bare-`/` branch
   // in the loop body fires immediately and opens the palette modal. The
   // trigger records where history stood the instant `/` was pressed, so the
@@ -1347,6 +1477,7 @@ export async function _runLineRepl(
     teardownSlashTrigger();
     replCtx.inputOverride = prevOverride;
     (globalThis as any)[stopSpinnerKey] = prevStopSpinner;
+    (globalThis as any)[interruptPromptKey] = prevInterruptPrompt;
     (globalThis as any)[clearHistoryKey] = prevClearHistory;
     // Persist whatever entries readline accumulated. `rl.history` is
     // newest-first and already contains the history we loaded at startup
@@ -1583,6 +1714,7 @@ export const _internal = {
   INITIAL_INTERRUPT_STATE,
   packOptions,
   renderInterruptFooter,
+  stickyInterruptPrompt,
 };
 
 export function _clearScreen(): void {

--- a/packages/agency-lang/lib/stdlib/cli.ts
+++ b/packages/agency-lang/lib/stdlib/cli.ts
@@ -1245,6 +1245,48 @@ async function printFooter(
   process.stdout.write(`${DIM}─── ${text} ───${COLOR_RESET}\n`);
 }
 
+/** Install the process-global hooks the line-mode REPL exposes while it
+ *  runs, each bound to this session's `readline`, and return a restore fn
+ *  that puts back whatever was there before. Encapsulated so `_runLineRepl`
+ *  stays focused on the loop rather than hook bookkeeping.
+ *
+ *  - `__agencyStopSpinner` — pause the "Thinking" timer while a line-mode
+ *    prompt bridge (select / autocomplete / prompt / confirm) has the user;
+ *    they bypass `inputOverride` (no readline) but must still stop it.
+ *  - `__agencyClearHistory` — wipe this session's live recall (`rl.history`,
+ *    a Node object owned by the running readline) plus the collapsed-paste
+ *    expansions. The persisted file is cleared separately by `_clearHistory`.
+ *  - `__agencyInterruptPrompt` — the sticky interrupt prompt exposed to
+ *    std::policy (interruptChoice → _interruptChoice), reusing THIS readline. */
+function installReplGlobals(
+  rl: readline.Interface,
+  expansions: Record<string, string>,
+  stopActiveSpinner: () => void,
+): () => void {
+  const globalObj = globalThis as any;
+  const prevStopSpinner = globalObj.__agencyStopSpinner;
+  const prevClearHistory = globalObj.__agencyClearHistory;
+  const prevInterruptPrompt = globalObj.__agencyInterruptPrompt;
+
+  globalObj.__agencyStopSpinner = stopActiveSpinner;
+  globalObj.__agencyClearHistory = () => {
+    const history = (rl as unknown as { history?: string[] }).history;
+    if (history) {
+      history.length = 0;
+    }
+    for (const key of Object.keys(expansions)) {
+      delete expansions[key];
+    }
+  };
+  globalObj.__agencyInterruptPrompt = (opts: InterruptOpts) => stickyInterruptPrompt(rl, opts);
+
+  return () => {
+    globalObj.__agencyStopSpinner = prevStopSpinner;
+    globalObj.__agencyClearHistory = prevClearHistory;
+    globalObj.__agencyInterruptPrompt = prevInterruptPrompt;
+  };
+}
+
 export async function _runLineRepl(
   status: unknown,
   onSubmit: unknown,
@@ -1324,40 +1366,10 @@ export async function _runLineRepl(
     });
   };
 
-  // Register a global "stop spinner" hook for the line-mode prompt
-  // bridges in `lib/stdlib/ui.ts` (select / autocomplete / prompt /
-  // confirm). They bypass `__agencyInputOverride` (they don't use
-  // readline) but still need to pause the "Thinking" timer while the
-  // user is being asked something — otherwise the timer keeps ticking
-  // over an open policy interrupt menu. Same lifecycle as
-  // `__agencyInputOverride`: install on entry, restore on exit.
-  const stopSpinnerKey = "__agencyStopSpinner";
-  const prevStopSpinner = (globalThis as any)[stopSpinnerKey];
-  (globalThis as any)[stopSpinnerKey] = stopActiveSpinner;
-
-  // Register a "clear history" hook so a command handler (e.g. the agent's
-  // `/clear-history`) can wipe this session's *live* recall. The hook only
-  // touches `rl.history` — a Node object owned by this running readline, which
-  // can't live anywhere but TS. The persisted *file* is cleared separately by
-  // `_clearHistory`, using a path Agency holds as a module global (so the file
-  // identity lives in the execution model, not in this closure). Same
-  // install/restore lifecycle as the hooks above.
-  const clearHistoryKey = "__agencyClearHistory";
-  const prevClearHistory = (globalThis as any)[clearHistoryKey];
-  (globalThis as any)[clearHistoryKey] = () => {
-    const h = (rl as unknown as { history?: string[] }).history;
-    if (h) h.length = 0;
-    // Drop the collapsed-paste expansions too, so a cleared history can't
-    // resurrect a paste's full text on the next recall.
-    for (const k of Object.keys(expansions)) delete expansions[k];
-  };
-
-  // Expose the sticky interrupt prompt to std::policy (via std::ui/cli's
-  // interruptChoice → _interruptChoice). Bound to THIS readline so the
-  // widget reuses it; restored on exit like the hooks above.
-  const interruptPromptKey = "__agencyInterruptPrompt";
-  const prevInterruptPrompt = (globalThis as any)[interruptPromptKey];
-  (globalThis as any)[interruptPromptKey] = (opts: InterruptOpts) => stickyInterruptPrompt(rl, opts);
+  // Install the process-global hooks this REPL exposes while it runs
+  // (spinner-stop, clear-history, sticky interrupt prompt), each bound to
+  // this session's readline. Restored on exit via the returned fn.
+  const restoreReplGlobals = installReplGlobals(rl, expansions, stopActiveSpinner);
 
   // `/` at an empty prompt synthesizes Enter so the bare-`/` branch
   // in the loop body fires immediately and opens the palette modal. The
@@ -1523,9 +1535,7 @@ export async function _runLineRepl(
   } finally {
     teardownSlashTrigger();
     replCtx.inputOverride = prevOverride;
-    (globalThis as any)[stopSpinnerKey] = prevStopSpinner;
-    (globalThis as any)[interruptPromptKey] = prevInterruptPrompt;
-    (globalThis as any)[clearHistoryKey] = prevClearHistory;
+    restoreReplGlobals();
     // Persist whatever entries readline accumulated. `rl.history` is
     // newest-first and already contains the history we loaded at startup
     // PLUS everything added this session (including any `/paste` buffer we

--- a/packages/agency-lang/lib/stdlib/cli.ts
+++ b/packages/agency-lang/lib/stdlib/cli.ts
@@ -364,6 +364,184 @@ export function installBottomRegion(
   return region;
 }
 
+// ---------------------------------------------------------------------------
+// Sticky interrupt prompt — pure core.
+//
+// The approval prompt shown mid-turn in line mode. Rendered as the bottom
+// region so concurrent tool traces stream above it. Input is "type your
+// answer, then Enter" (a bare `a` cannot disambiguate `a` from `aa`/`ap`,
+// and a free-text reason can start with any letter). All decisions live in
+// the pure `reduceInterrupt` state machine; the shell (`stickyInterruptPrompt`,
+// added later) only wires keys to it and acts on the outcome.
+// ---------------------------------------------------------------------------
+
+type InterruptAction =
+  | "submit"
+  | "cancel"
+  | "exit"
+  | "backspace"
+  | { append: string }
+  | null;
+
+type KeyMeta = { name?: string; ctrl?: boolean; meta?: boolean };
+
+/** Map a readline keypress to an interrupt-widget action. DELIBERATELY
+ *  DIVERGES from classifyPasteKey: Ctrl+C is a hard "exit" (an approval
+ *  prompt must quit, never soft-cancel-and-continue), Escape is a soft
+ *  "cancel", and Enter is "submit" (there is no Ctrl+D submit). */
+function classifyInterruptKey(sequence: unknown, key: KeyMeta | undefined): InterruptAction {
+  const name = key?.name;
+  if (key?.ctrl && name === "c") {
+    return "exit";
+  }
+  if (name === "escape") {
+    return "cancel";
+  }
+  if (name === "return" || name === "enter") {
+    return "submit";
+  }
+  if (name === "backspace") {
+    return "backspace";
+  }
+  const printable = typeof sequence === "string" && sequence.length > 0 && !key?.ctrl && !key?.meta;
+  if (printable) {
+    return { append: sequence as string };
+  }
+  return null;
+}
+
+type InterruptState = { buffer: string; notice: string };
+
+type InterruptOutcome =
+  | { kind: "pending" }
+  | { kind: "resolve"; value: string }
+  | { kind: "cancel" }
+  | { kind: "exit" };
+
+type InterruptConfig = { validKeys: string[]; allowFreeText: boolean; allowCancel: boolean };
+
+type InterruptStep = { state: InterruptState; outcome: InterruptOutcome };
+
+const INITIAL_INTERRUPT_STATE: InterruptState = { buffer: "", notice: "" };
+const INVALID_NOTICE = "not a valid option";
+
+/** Interpret a committed buffer: an exact key match resolves; a non-empty
+ *  buffer with free text allowed resolves as a reason; empty re-prompts
+ *  silently (must-answer); invalid-without-free-text re-prompts with a
+ *  notice. */
+function submitInterrupt(state: InterruptState, config: InterruptConfig): InterruptStep {
+  const answer = state.buffer.trim();
+  if (config.validKeys.includes(answer)) {
+    return { state, outcome: { kind: "resolve", value: answer } };
+  }
+  if (config.allowFreeText && answer !== "") {
+    return { state, outcome: { kind: "resolve", value: answer } };
+  }
+  const notice = answer === "" ? "" : INVALID_NOTICE;
+  return { state: { buffer: state.buffer, notice }, outcome: { kind: "pending" } };
+}
+
+/** Pure state machine for the sticky interrupt prompt: given the current
+ *  state and a key action, return the next state and an outcome. The
+ *  imperative shell acts on the outcome; every decision lives here. */
+function reduceInterrupt(
+  state: InterruptState,
+  action: InterruptAction,
+  config: InterruptConfig,
+): InterruptStep {
+  if (action === "exit") {
+    return { state, outcome: { kind: "exit" } };
+  }
+  if (action === "cancel") {
+    if (config.allowCancel) {
+      return { state, outcome: { kind: "cancel" } };
+    }
+    return { state, outcome: { kind: "pending" } };
+  }
+  if (action === "backspace") {
+    return { state: { buffer: state.buffer.slice(0, -1), notice: "" }, outcome: { kind: "pending" } };
+  }
+  if (action === "submit") {
+    return submitInterrupt(state, config);
+  }
+  if (action !== null && typeof action === "object") {
+    const cleaned = action.append.replace(/[\r\n]/g, "");
+    return { state: { buffer: state.buffer + cleaned, notice: "" }, outcome: { kind: "pending" } };
+  }
+  return { state, outcome: { kind: "pending" } };
+}
+
+/** Greedily pack `key=label` tokens into lines no wider than `width`
+ *  visible columns, joined by two spaces. A token wider than `width` gets
+ *  its own line (buildFrame wraps it at render time). */
+function packOptions(items: { key: string; label: string }[], width: number): string[] {
+  const lines: string[] = [];
+  let current = "";
+  items.forEach((item) => {
+    const token = `${item.key}=${item.label}`;
+    if (current === "") {
+      current = token;
+      return;
+    }
+    const fits = visualWidth(current) + 2 + visualWidth(token) <= width;
+    if (fits) {
+      current = `${current}  ${token}`;
+      return;
+    }
+    lines.push(current);
+    current = token;
+  });
+  if (current !== "") {
+    lines.push(current);
+  }
+  return lines;
+}
+
+const INTERRUPT_BODY_MAX_LINES = 6;
+const INTERRUPT_CARET = "▏";
+
+type InterruptFooterInput = {
+  title: string;
+  body: string;
+  items: { key: string; label: string }[];
+  allowFreeText: boolean;
+  state: InterruptState;
+  columns: number;
+};
+
+function bodyLines(body: string): string[] {
+  if (body === "") {
+    return [];
+  }
+  const raw = body.split("\n");
+  const shown = raw.slice(0, INTERRUPT_BODY_MAX_LINES).map((line) => ` ${DIM}${line}${COLOR_RESET}`);
+  if (raw.length > INTERRUPT_BODY_MAX_LINES) {
+    shown.push(` ${DIM}…${COLOR_RESET}`);
+  }
+  return shown;
+}
+
+/** Render the sticky approval prompt as footer lines. Pure. The real
+ *  cursor is hidden by the widget, so the input line ends with a caret
+ *  glyph. buildFrame wraps each line to width. */
+function renderInterruptFooter(input: InterruptFooterInput): string[] {
+  const width = Math.max(MIN_FOOTER_WIDTH, input.columns - 1);
+  const lines: string[] = [`${DIM}${"─".repeat(width)}${COLOR_RESET}`];
+  if (input.title !== "") {
+    lines.push(` ${input.title}`);
+  }
+  bodyLines(input.body).forEach((line) => lines.push(line));
+  packOptions(input.items, width - 1).forEach((row) => lines.push(` ${row}`));
+  if (input.allowFreeText) {
+    lines.push(` ${DIM}or type a reason · Enter to submit${COLOR_RESET}`);
+  }
+  if (input.state.notice !== "") {
+    lines.push(` ${color.yellow(input.state.notice)}`);
+  }
+  lines.push(` > ${input.state.buffer}${INTERRUPT_CARET}`);
+  return lines;
+}
+
 const SPINNERS = {
   "line": {
     "interval": 130,
@@ -1400,6 +1578,11 @@ export const _internal = {
   eraseRows,
   buildFrame,
   startSpinner,
+  classifyInterruptKey,
+  reduceInterrupt,
+  INITIAL_INTERRUPT_STATE,
+  packOptions,
+  renderInterruptFooter,
 };
 
 export function _clearScreen(): void {

--- a/packages/agency-lang/lib/stdlib/cli.ts
+++ b/packages/agency-lang/lib/stdlib/cli.ts
@@ -293,9 +293,19 @@ function registerCursorRestore(): void {
   });
 }
 
-function chunkToText(chunk: unknown): string {
+/** Decode a stdout chunk to text so it can be embedded in a frame. Handles
+ *  the shapes `process.stdout.write` accepts: a string, a Buffer, or a raw
+ *  Uint8Array. `String(uint8array)` would give comma-joined bytes, so both
+ *  binary shapes are decoded with the caller's encoding (default utf8). */
+function chunkToText(chunk: unknown, encoding?: BufferEncoding): string {
   if (typeof chunk === "string") {
     return chunk;
+  }
+  if (Buffer.isBuffer(chunk)) {
+    return chunk.toString(encoding ?? "utf8");
+  }
+  if (chunk instanceof Uint8Array) {
+    return Buffer.from(chunk).toString(encoding ?? "utf8");
   }
   return String(chunk);
 }
@@ -325,7 +335,11 @@ export function installBottomRegion(
   let rows = 0;
   let firstPaint = true;
 
-  const paint = (above: string | null): boolean => {
+  // `cb` is the caller's `write(..., cb)` completion callback, threaded to
+  // the frame's realWrite so it fires when the frame (which carries the
+  // caller's text) is flushed. The returned backpressure boolean reflects
+  // the FRAME write, not the original chunk write.
+  const paint = (above: string | null, cb?: (error?: Error | null) => void): boolean => {
     const hideNow = options.hideCursor && firstPaint;
     const frame = buildFrame({
       above,
@@ -336,15 +350,32 @@ export function installBottomRegion(
     });
     firstPaint = false;
     rows = frame.rows;
-    return realWrite(frame.seq);
+    return realWrite(frame.seq, cb);
   };
 
   paint(null);
-  stdoutAny.write = (chunk: any): boolean => paint(chunkToText(chunk));
+  // Preserve the `write(chunk, encoding?, cb?)` contract: decode with the
+  // caller's encoding and forward the completion callback (dropping it
+  // would hang callers that await it). Note: a partial-line write (no
+  // trailing newline, or a `\r`-based progress bar) becomes its own line
+  // under the footer — full-line tool traces are all that stream here.
+  stdoutAny.write = (chunk: any, ...rest: any[]): boolean => {
+    const encoding = typeof rest[0] === "string" ? (rest[0] as BufferEncoding) : undefined;
+    const cb = rest.find((arg) => typeof arg === "function") as
+      | ((error?: Error | null) => void)
+      | undefined;
+    return paint(chunkToText(chunk, encoding), cb);
+  };
+
+  // Repaint on resize so a mid-prompt window change doesn't leave the next
+  // frame erasing a stale row count (rows were measured at the old width).
+  const onResize = (): void => { paint(null); };
+  process.stdout.on("resize", onResize);
 
   const region: BottomRegion = {
     refresh: () => { paint(null); },
     teardown: () => {
+      process.stdout.off("resize", onResize);
       stdoutAny.write = realWrite;
       const frame = buildFrame({
         above: null,
@@ -509,13 +540,19 @@ type InterruptFooterInput = {
   columns: number;
 };
 
-function bodyLines(body: string): string[] {
+/** Body lines for the footer, capped to INTERRUPT_BODY_MAX_LINES *physical*
+ *  rows. Wrapping happens here (to `width - 1`, leaving room for the 1-col
+ *  indent) so the cap bounds real screen rows — buildFrame re-wraps at
+ *  `width`, but each line is already within it, so that is a no-op. Capping
+ *  raw `\n` lines instead would let one very long line re-expand past the
+ *  cap and blow out the pinned region. */
+function bodyLines(body: string, width: number): string[] {
   if (body === "") {
     return [];
   }
-  const raw = body.split("\n");
-  const shown = raw.slice(0, INTERRUPT_BODY_MAX_LINES).map((line) => ` ${DIM}${line}${COLOR_RESET}`);
-  if (raw.length > INTERRUPT_BODY_MAX_LINES) {
+  const wrapped = wrapText(body, Math.max(1, width - 1));
+  const shown = wrapped.slice(0, INTERRUPT_BODY_MAX_LINES).map((line) => ` ${DIM}${line}${COLOR_RESET}`);
+  if (wrapped.length > INTERRUPT_BODY_MAX_LINES) {
     shown.push(` ${DIM}…${COLOR_RESET}`);
   }
   return shown;
@@ -530,7 +567,7 @@ function renderInterruptFooter(input: InterruptFooterInput): string[] {
   if (input.title !== "") {
     lines.push(` ${input.title}`);
   }
-  bodyLines(input.body).forEach((line) => lines.push(line));
+  bodyLines(input.body, width).forEach((line) => lines.push(line));
   packOptions(input.items, width - 1).forEach((row) => lines.push(` ${row}`));
   if (input.allowFreeText) {
     lines.push(` ${DIM}or type a reason · Enter to submit${COLOR_RESET}`);
@@ -660,9 +697,19 @@ export async function _interruptChoice(
   return hook({ title, body, items, allowFreeText, allowCancel });
 }
 
-/** True when a line-mode REPL is running and can host a pinned prompt. */
+/** True when a line-mode REPL is running AND both ends are real terminals,
+ *  so the pinned prompt can actually draw and read keystrokes. The hook is
+ *  installed unconditionally by `_runLineRepl`, so without the TTY checks a
+ *  non-TTY REPL would route here, draw nothing (installBottomRegion no-ops),
+ *  and hang awaiting keystrokes that never reach `_ttyWrite`. Requiring both
+ *  TTYs sends those runs to `chooseOption`'s non-TTY fallback instead
+ *  (mirrors the `/paste` guard). */
 export function _stickyInterruptAvailable(): boolean {
-  return typeof (globalThis as any).__agencyInterruptPrompt === "function";
+  return (
+    typeof (globalThis as any).__agencyInterruptPrompt === "function" &&
+    process.stdout.isTTY === true &&
+    process.stdin.isTTY === true
+  );
 }
 
 const SPINNERS = {

--- a/packages/agency-lang/stdlib/policy.agency
+++ b/packages/agency-lang/stdlib/policy.agency
@@ -3,7 +3,8 @@ import { keys } from "std::object"
 import { dirname, basename } from "std::path"
 import { exists } from "std::shell"
 import { highlight, diff } from "std::syntax"
-import { chooseOption, ChoiceItem } from "std::ui"
+import { ChoiceItem } from "std::ui"
+import { interruptChoice } from "std::ui/cli"
 import { render, text } from "std::ui/layout"
 import { table } from "std::ui/table"
 
@@ -661,7 +662,7 @@ def renderObjAsTable(
 // Renders as a modal over the active repl(); falls back to plain print
 // + input when no REPL is running (e.g. headless agent runs).
 //
-// We pass `allowFreeText: true` to `chooseOption` so the user can
+// We pass `allowFreeText: true` to `interruptChoice` so the user can
 // type a rejection reason instead of picking a key. That single
 // keystroke flow replaces the old two-step "(r), then type reason".
 def askUser(intr: any): AskUserResult {
@@ -708,7 +709,7 @@ def askUser(intr: any): AskUserResult {
   // re-prompting. The "r" option still lets you reject a single action
   // (and optionally tell the agent what to do instead).
   const answer = withLock("std::tty") {
-    return chooseOption(title, body, items, allowFreeText: true, allowCancel: true)
+    return interruptChoice(title, body, items, allowFreeText: true, allowCancel: true)
   }
   return match(answer) {
     "a" => ({

--- a/packages/agency-lang/stdlib/ui/cli.agency
+++ b/packages/agency-lang/stdlib/ui/cli.agency
@@ -3,6 +3,8 @@ import {
   _clearScreen,
   _termWidth,
   _clearHistory,
+  _interruptChoice,
+  _stickyInterruptAvailable,
  } from "agency-lang/stdlib-lib/cli.js"
 
 /** @module
@@ -45,6 +47,8 @@ import {
 // null) is exactly the line-mode behavior. So nothing actually
 // needed to be re-exported here for line mode to work.
 export { pushMessage, clearMessages } from "std::ui"
+
+import { chooseOption } from "std::ui"
 
 // The active `repl()` session's history-file path, held as an Agency module
 // global so it lives in the execution model (serialized, module-isolated)
@@ -116,4 +120,31 @@ def termWidth(): number {
 export def hline(char: string = "─", width: number = null): string {
   let _width = width || termWidth()
   return char.repeat(_width)
+}
+
+export def interruptChoice(
+  title: string,
+  body: string,
+  items: any[],
+  allowFreeText: boolean = false,
+  allowCancel: boolean = false,
+): string {
+  """
+  Approval prompt for line mode: renders a sticky footer pinned to the
+  bottom of the terminal so concurrent tool-call output streams above it
+  instead of burying the prompt. Type an option key or a rejection reason,
+  then press Enter. Falls back to `chooseOption` when no line-mode REPL is
+  active (the TUI, a non-TTY, or a headless run), so every non-line-mode
+  path keeps its current behavior.
+
+  @param title - Prompt heading (the interrupt message).
+  @param body - Multi-line context shown under the title (or "").
+  @param items - The {key, label} choices.
+  @param allowFreeText - Accept a free-form rejection reason.
+  @param allowCancel - When true, Escape cancels the whole request.
+  """
+  if (_stickyInterruptAvailable()) {
+    return _interruptChoice(title, body, items, allowFreeText, allowCancel)
+  }
+  return chooseOption(title, body, items, allowFreeText: allowFreeText, allowCancel: allowCancel)
 }


### PR DESCRIPTION
## What this does

When the line-mode agent stops to ask you to approve an action while other branches are still running and printing, the approval prompt now stays **pinned to the bottom of the terminal** and the concurrent tool-call traces stream into scrollback **above** it, instead of the prompt getting buried and smeared.

Before: a second branch's `⏺ tool(...)` traces printed straight into the region the `prompts` menu was managing, corrupting it. After: the prompt is a sticky footer; traces scroll above it live.

Full background, root-cause trace, and design rationale are in the committed spec and plan:
- `docs/superpowers/specs/2026-07-17-sticky-interrupt-prompt-design.md`
- `docs/superpowers/plans/2026-07-17-sticky-interrupt-prompt.md`

## Approach

Split "what" from "how" throughout, and reuse existing machinery rather than reinventing it:

- **Bottom-region coordinator** (`installBottomRegion` in `lib/stdlib/cli.ts`) generalizes the "Thinking" spinner's `process.stdout.write` monkeypatch from one line to a multi-line footer. The exact terminal bytes come from a pure `buildFrame(spec) -> {seq, rows}`; the shell just patches stdout and tracks rows. Widths/wrapping reuse `visualWidth`/`wrapText` from `lib/stdlib/layout/ansi.ts`.
- **Spinner folded onto the coordinator**, so there is exactly one owner of the bottom of the screen (removes a load-bearing two-patcher ordering dependency).
- **Sticky interrupt widget** rendered as that footer. Input is "type your answer, then Enter" (a bare `a` cannot disambiguate `a` from `aa`/`ap`, and a free-text reason can start with any letter). All decisions live in a pure `reduceInterrupt(state, action, config) -> {state, outcome}` state machine; the shell wires `readline`'s `_ttyWrite` to it and acts on the outcome. It reuses the REPL's existing readline (no second one), so none of `_runPrompt`'s paused/raw-mode restoration dance is needed.
- **Surgical seam**: a new `interruptChoice` primitive in `std::ui/cli` that uses the sticky widget when a line-mode REPL is active and **falls back to `chooseOption`** otherwise (TUI, non-TTY, headless). `std::policy`'s `askUser` calls it instead of `chooseOption` — the single behavioral change. Every other `chooseOption` caller (`/model`, `/search`, slash palette, `/paste`, …) is untouched.

Because the fix lives in `std::policy` + `std::ui/cli`, every line-mode agent built on `cliPolicyHandler` benefits, not just the Agency agent.

## Anti-flicker

Each repaint is one atomic `stdout.write`, wrapped in DEC synchronized-output mode (`\x1b[?2026h/l`), redrawn on events (not a timer). The cursor is hidden only for the widget (the spinner is unchanged), with a `process.once("exit")` restore for crash-safety, and the reason line draws its own caret glyph.

## Testing

- Pure cores are exhaustively unit-tested via the `_internal` convention: `buildFrame` asserts exact byte sequences (catches erase-math regressions), `reduceInterrupt` is a full transition table (bare-`a` does NOT early-resolve, empty-Enter is must-answer, Ctrl+C yields an `exit` outcome, free-text reasons starting with option letters, invalid-with-notice, backspace, newline-stripping).
- Integration smoke tests drive the widget with a trace streamed above it.
- `lib/stdlib/cli.test.ts`: 87 pass. Policy tests: 30 pass. Full `lib/stdlib` + `lib/runtime` unit suites: 2686 pass, 0 failures. `tsc --noEmit` clean. `make` builds; both `stdlib/ui/cli.js` and `stdlib/policy.js` load with no import cycle or load-time error.

## Not included / follow-ups

- **Burst coalescing** (collapse several same-tick footer redraws into one via a microtask) is specified as an optional refinement in the plan (Task 7). Left out of v1; worth adding only if real usage shows visible footer "twitch."
- **Live concurrent-TTY manual check** (drive the real agent with two parallel branches, one needing approval) is still pending — it needs an interactive TTY + LLM, so it was not run in CI/automation. The logic and rendering are covered by the unit/integration tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
