### PR TITLE
Thread guard Result<T> annotations into block codegen: honest saveDraft schemas (#580)

### DIFF
--- a/docs/superpowers/plans/2026-07-17-guard-annotation-threading-REVIEW.md
+++ b/docs/superpowers/plans/2026-07-17-guard-annotation-threading-REVIEW.md
@@ -1,0 +1,644 @@
+# Plan review: guard annotation threading (#580)
+
+**Reviewing:** `docs/superpowers/plans/2026-07-17-guard-annotation-threading.md`
+**Verdict:** Executable, and unusually well-verified — every code fact I
+spot-checked held, including the one the whole design rests on. Both spec-review
+round-2 fixes are genuinely folded, not just name-checked. **One substantive
+gap:** the return-target reset rule keys on `blockAncestor`, which marks only
+`functionCall` block arguments — but inline handler bodies and finalize bodies
+*also* retarget `return`, so they inherit the def's type and can be mis-stamped.
+That is the same bug class the plan exists to fix, just through a different
+slot. Plus one cheap coverage gap the plan's own honesty note implies. No
+blockers.
+
+All line references are `packages/agency-lang/`, verified today on the
+`guard-annotation-threading` worktree.
+
+---
+
+# What I verified (so these can be taken as settled)
+
+- **`blockAncestor` is real and covers non-inline blocks.** `bodySlots.ts`'s
+  `case "functionCall"` sets `blockAncestor: block` for *any* `n.block`, with no
+  `inline` check. This matters: guards desugar with `inline: false`, so had the
+  marker been inline-only the entire reset rule would silently no-op. It isn't.
+  (Note the `BodySlot.blockAncestor` doc comment *says* "the functionCall's
+  inline `block:` argument" — the comment is misleading, the code is right.
+  Worth fixing that comment while you're in there.)
+- **Every AST type string the tests assert on is correct:** `assignment`
+  (`types.ts:221`), `returnStatement` (`types/returnStatement.ts:5`), `function`
+  and `graphNode` and `functionCall` (all confirmed as `bodySlots` switch cases).
+  `Assignment.typeHint?: VariableType` exists (`types.ts:225`), and
+  `ResultType.successType` is at `types/typeHints.ts:158-160`. Task 1 can be
+  written as drafted.
+- **Targeting only the ~1775 push site is correct.** There are three
+  `scopes.push({ type: "block", blockName })` sites. 1775 is inside
+  `processBlockArgument` — the one guards reach (the desugared `_guard`
+  `functionCall.block` flows through `processBlockArgument`, called at 2734 /
+  2781 / 2802). 1829 is `processBlockAsExpression` (a block as a standalone
+  expression / named-arg value) and 2852 is the fork lowering; neither ever
+  carries a guard's block argument. **The plan is right — but say so** (see
+  minor 4), because a reader who greps will find three sites and wonder.
+- **The nesting composition is sound.** `desugarGuardBlock` stamps the unwrapped
+  `T` and then walks its own body with `{ returnTarget: T }`, and a nested
+  `return guard(){}` unwraps *again* via `yieldTypeFrom`. I traced
+  `Result<Result<string>>`: outer stamp `Result<string>`, inner stamp `string`. ✓
+  And the degenerate `Result<string>` case correctly stamps nothing on an inner
+  return-position guard (`yieldTypeFrom("string")` → undefined), which is right,
+  because a guard returning `Result<T>` into a `string` slot is a type error the
+  checker owns.
+
+# Substantive
+
+## 1. The reset rule misses two other return-retargeting boundaries
+
+`slotContext` resets the return target on exactly one condition:
+`slot.blockAncestor`. But `blockAncestor` is set by `bodySlots` for *one* node
+kind — `functionCall` with a block. Look at what else `bodySlots` yields:
+
+- **`handleBlock`** returns two slots: `n.body` and, when
+  `n.handler.kind === "inline"`, `n.handler.body`. Neither carries a
+  `blockAncestor`. An inline handler compiles to its own arrow function
+  (`async (i) => { ... }`), so a `return` inside it returns from the *handler*,
+  not the def.
+- **`finalizeBlock`** returns one slot, no `blockAncestor`. The finalize body
+  compiles into the `__finalize` closure, so a `return` there returns the
+  finalize's value.
+
+Both therefore fall through `slotContext` to the `return ctx` inherit branch, and
+a `return guard(){}` inside either gets stamped with the **enclosing def's**
+`Result<T>`. That is exactly the mis-stamp the fork-branch test in Task 1 Step 1
+exists to prevent — the plan closed the block-argument door and left the handler
+and finalize doors open.
+
+Severity is moderate-low (these are exotic shapes), but note the failure is
+**silent**: the stamp only feeds `draftSchema` and `responseFormat`, which are
+best-effort hints, so a wrong stamp produces a wrong schema, not a compile error.
+Nothing catches it. That is the same reason the fork case was worth guarding.
+
+There is a wrinkle that makes the naive fix awkward: `slotContext(node, slot, ctx)`
+receives the *node*, and for `handleBlock` the two slots need **opposite**
+treatment — `n.body` should inherit (a return in the guarded body returns from
+the def), `n.handler.body` should reset. A `node.type === "handleBlock"` check
+cannot tell them apart.
+
+Two ways out, in order of preference:
+
+- **Mark it at the source of truth.** `bodySlots` already exists to be the one
+  place that knows the shape of every body-bearing node ("Adding a new
+  body-bearing node type means adding ONE case here"), and it already carries a
+  per-slot marker for a structurally similar fact. Add
+  `retargetsReturn?: boolean` to `BodySlot`, set it on the `functionCall` block
+  slot, the inline-handler slot, and the `finalizeBlock` slot. Then the rule is
+  one line — `if (slot.retargetsReturn) return { returnTarget: slot.blockAncestor?.declaredYieldType }`
+  — and the next construct that retargets `return` gets handled by whoever adds
+  its `bodySlots` case, instead of silently regressing this feature.
+- **Or scope it out explicitly.** Keep `blockAncestor`, and add a Task 1 test
+  asserting a `return guard(){}` inside an inline handler and inside a finalize
+  stamps **nothing**, with a comment saying handler/finalize return positions are
+  deliberately unstamped. That is honest and cheap, but it is a decision that
+  should be written down rather than an omission.
+
+Either is fine; the first is better altitude and is a genuinely small change.
+**Do not leave it undecided.**
+
+## 2. No codegen test that a structured annotation produces a structured `draftSchema` — the one assertion the fixture provably cannot make
+
+The plan's Background says plainly (and correctly) that no fixture outcome can
+distinguish a threaded schema from the fallback, so "the distinguishing
+assertions live in the codegen tests." Good. But then check what the codegen
+tests actually assert for a structured type:
+
+- The four threading tests assert `draftSchema: z.string()` — a **primitive**,
+  and in the return-position case indistinguishable from the pre-change
+  `Result`-shaped thread only by absence.
+- The one structured test (`Result<{ title: string }>`) asserts **only**
+  `responseFormat: z.object(...)`. It never asserts the `draftSchema`.
+
+So the object-schema path for `draftSchema` — rendering a structured
+`VariableType` through `zodSchemaFor` into the tool definition — is asserted
+**nowhere**: not in the codegen tests, and not in the fixture (by the plan's own
+admission). The spec's Part 3 test list explicitly asked for "a structured
+`Result<Report>` annotation threads the object schema for **BOTH** consumers";
+only one consumer got the assertion.
+
+**Fix:** extend the existing structured test to assert both in one shot —
+`expect(out).toMatch(/draftSchema: z\.object\(/)` alongside the `responseFormat`
+match. One line, and it closes the only untested rendering path in the feature.
+
+# Minor
+
+## 3. Nothing pins the double-run idempotency, and the second run computes context differently
+
+The desugar runs twice (`typescriptPreprocessor.ts:331`, `typeChecker/index.ts:111`)
+on the same in-place-mutated nodes. Run 2 finds no `guardBlock` nodes, so it
+stamps nothing and the run-1 stamps survive — that reasoning is right. But note a
+subtlety the plan doesn't mention: on run 2, `slotContext`'s
+`blockAncestor.declaredYieldType` read is **no longer always undefined**, because
+the guard blocks are now stamped. So the two runs walk with genuinely different
+contexts. It's harmless today (nothing left to stamp), but it means the
+`blockAncestor.declaredYieldType` read earns its keep only on run 2 — worth a
+one-line code comment so it doesn't read as dead code, and worth a two-line test:
+call `desugarGuardsInBody` twice on the same body and assert the stamp is
+unchanged. Cheap insurance on an invariant the whole pass depends on.
+
+## 4. Say why the other two block push sites are deliberately unstamped
+
+Task 2 Step 3 targets `~1775` without explaining the other two. I confirmed
+1775 is correct and exclusive (see verified facts), but add one sentence naming
+`processBlockAsExpression` (1829) and the fork lowering (2852) as never carrying
+a guard block — otherwise the first executor to grep will either wonder or
+"helpfully" stamp all three.
+
+## 5. Test-sketch hygiene and two fragile assertions
+
+- Task 1 Step 1's code block defines `guardBlockArgOf`, whose body is
+  `throw new Error("use direct path reads in each test instead")`, and the prose
+  below then says to delete it. Just remove it from the block — a plan that tells
+  you to write dead code and then delete it invites someone to paste it and move
+  on.
+- `expect(out).not.toContain("responseFormat")` matches against the whole
+  generated file. It works for that specific source, but it's brittle to any
+  unrelated emission. Scoping it to the guard's own call region (or asserting on
+  the `runPrompt` args object) is sturdier.
+- Every test uses `def`. `slotContext`'s `node.type === "graphNode"` branch is
+  never exercised — one return-position test in a `node main(): Result<string>`
+  would pin it.
+
+# What is right
+
+The Background section does real work: each of its six facts is load-bearing for
+a later task, and I checked all six against the code rather than taking them —
+they hold, including the `bodySlots` `blockAncestor` claim that the entire reset
+rule stands on, and the "both consumers are already wired to the right lookups"
+claim (`typescriptBuilder.ts:3190` really does call `scopes.returnType()`, so the
+`responseFormat` half of this feature is genuinely free). That is the difference
+between a plan that asserts and a plan that has been verified.
+
+The round-2 fixes are folded for real, not cosmetically: Task 1 Step 4 is a
+*rewrite* of the walk rather than a patch, which is the honest shape for adding
+context to a context-free recursion, and the return-target reset is implemented
+(via `slotContext`) *and* pinned (via the fork-branch test) rather than merely
+described. The `desugarGuardsInBody(body, ctx = {})` default keeping both entry
+points source-compatible is the right call.
+
+Best thing in the plan: the Background's "what the e2e fixture can and cannot
+pin" paragraph, repeated verbatim in the fixture's own comment. Naming the limit
+of your own test at the point a future reader will meet it is exactly the rigor
+that was asked for — finding 2 above is just holding the plan to that standard
+one step further.
+
+# Recommended next steps
+
+1. Decide finding 1 — either add `retargetsReturn` to `BodySlot` (preferred) or
+   add the handler/finalize no-stamp tests plus a written decision. This is the
+   one correctness gap worth closing before execution.
+2. Add the `draftSchema: z.object(...)` assertion to the structured test
+   (finding 2) — one line, closes the only untested rendering path.
+3. Add the double-run stamp-stability test and the `blockAncestor` comment
+   (finding 3).
+4. Fold findings 4 and 5 in as written; none change the design.
+
+---
+
+# Addendum: audit against `docs/dev/anti-patterns.md`
+
+**Direct answer to "does it write declarative interfaces that encapsulate
+complexity, or imperative code?": the instincts are right and applied
+inconsistently.** Task 1 extracts the feature's two hard rules into pure,
+named functions — and then writes a third rule of exactly the same kind inline
+and imperatively. Task 2 goes further: it *argues itself out* of the declarative
+form, on a premise I checked and found false. Six findings, ordered by how much
+they bear on that question.
+
+## A1. The stamp rule is inlined and imperative — while its sibling rule is extracted (*Imperative code everywhere* + *Order-dependent mutable state*)
+
+The feature has exactly two rules. The plan extracts one and inlines the other.
+
+Extracted, declarative, good — `slotContext(node, slot, ctx)` answers "what
+context does this body walk under?" as a pure function. Inlined, imperative —
+"what type does a guard in this position get stamped with?", sitting in the
+middle of `desugarNode`:
+
+```ts
+let stamp: VariableType | undefined;
+if (node.type === "assignment") {
+  stamp = yieldTypeFrom(holder.typeHint);
+} else if (node.type === "returnStatement") {
+  stamp = yieldTypeFrom(ctx.returnTarget);
+}
+holder.value = desugarGuardBlock(valueNode as GuardBlock, stamp);
+```
+
+That is a `let` mutated across an if/else-if chain to produce one value — the
+shape the *Order-dependent mutable state* entry says to replace with a `const`
+derived from its inputs. And it is the *same kind of rule* as `slotContext`,
+written the opposite way. Extract it:
+
+```ts
+/** The type a guard sitting in this node's `value` slot is stamped with:
+ *  an assignment names its own slot; a return yields to the current
+ *  return target; anything else stamps nothing. */
+function stampFor(node: AgencyNode, ctx: DesugarContext): VariableType | undefined {
+  if (node.type === "assignment") {
+    return yieldTypeFrom((node as Assignment).typeHint);
+  }
+  if (node.type === "returnStatement") {
+    return yieldTypeFrom(ctx.returnTarget);
+  }
+  return undefined;
+}
+```
+
+Then the walk reads `holder.value = desugarGuardBlock(valueNode, stampFor(node, ctx))`,
+and the whole feature is legible as two small pure functions — "what context does
+a body get" and "what stamp does a guard get" — with `desugarNode` reduced to
+pure traversal. That is the what/how split the catalog is asking for. Bonus:
+`stampFor` reads `typeHint` off a properly-typed `Assignment`, so the `typeHint`
+member drops off the `holder` cast and it narrows back to the original
+`{ value?: unknown }`.
+
+## A2. `enclosingDeclaredReturnType` abandons `.find()` for a hand-rolled loop — on a false premise (*Imperative code everywhere* + *Inconsistent patterns*)
+
+Task 2 Step 4 replaces the existing `.find()`-based method with a `for...of` over
+a reversed copy using `continue` and four `return`s, and justifies it in
+parentheses:
+
+> (A `for...of` over a reversed copy with an early `continue` — the two-list
+> `.find` from #578 cannot express "skip unstamped blocks but stop at stamped
+> ones".)
+
+**It can.** That requirement is one predicate:
+
+```ts
+const owner = [...this.stack]
+  .reverse()
+  .find((scope) => scope.type !== "block" || scope.declaredYieldType !== undefined);
+```
+
+"The first scope that either isn't a block, or is a stamped block" is exactly
+"skip unstamped blocks, stop at stamped ones." The existing method's `switch`
+then needs one new arm (`case "block": return owner.declaredYieldType;`) and
+nothing else changes. So the real diff is **one predicate edit plus one switch
+case** — instead of a rewrite that discards the method's structure, its
+explanatory comment about the push invariant, and the `.find` idiom the
+neighbouring `returnType()` and the #578 original both use.
+
+This is the most consequential finding in the addendum, not because the loop is
+wrong (it works) but because the plan wrote down a justification for going
+imperative and the justification doesn't hold. An executor will read that
+parenthetical and not re-check it.
+
+## A3. `desugarGuardBlock` builds by mutation what the original built as one literal (*Order-dependent mutable state* + *Ugly code* + *Inconsistent patterns*)
+
+The current function returns a single expression. The plan's replacement builds
+the same node in three ordered steps:
+
+```ts
+const block: { type: "blockArgument"; inline: boolean; params: never[];
+               body: AgencyNode[]; declaredYieldType?: VariableType } = {
+  type: "blockArgument", inline: false, params: [], body: [],
+};
+if (yieldType !== undefined) { block.declaredYieldType = yieldType; }
+block.body = desugarGuardsInBody(g.body, { returnTarget: yieldType });
+```
+
+Three separate problems, all avoidable:
+
+1. **Build-by-mutation.** Declare-empty → conditionally-add-field → assign-body
+   is order-dependent accumulation replacing a declarative literal. Straight
+   *Order-dependent mutable state*, and a regression from the code being replaced.
+2. **The conditional-field dance is the banned idiom in a new spelling.** The
+   catalog's *Ugly code* entry bans `...(x ? { x } : {})` outright; the `if`
+   version is the same avoidance of an `undefined`-valued key. It isn't needed:
+   the field is optional, and **an absent key is equivalent to a key set to
+   `undefined` for every consumer here** — the Task 2 copy passes it through,
+   the reads are `?? undefined` / `!== undefined`, `JSON.stringify` (so
+   `pnpm run ast`) drops undefined-valued keys so no fixture churn, and the
+   plan's own `toBeUndefined()` assertions pass either way. Just always assign it.
+3. **The inline structural type annotation** exists only to make the conditional
+   assignment typecheck, and is a nested object type written inline
+   (*Nested objects in type definitions*). It disappears with the literal.
+
+All three dissolve at once:
+
+```ts
+function desugarGuardBlock(g: GuardBlock, yieldType: VariableType | undefined): AgencyNode {
+  return {
+    type: "functionCall",
+    functionName: "_guard",
+    arguments: g.arguments,
+    block: {
+      type: "blockArgument",
+      inline: false,
+      params: [],
+      declaredYieldType: yieldType,
+      body: desugarGuardsInBody(g.body, { returnTarget: yieldType }),
+    },
+    scope: "imported",
+    loc: g.loc,
+  } as unknown as AgencyNode;
+}
+```
+
+One literal, no mutation, no inline type, no conditional — and it preserves the
+shape of the function it replaces, which is the *Inconsistent patterns* half.
+
+## A4. Structural casts that shadow types the codebase already names (*Leaky abstractions* + *Nested objects in type definitions*)
+
+```ts
+slot: { blockAncestor?: { declaredYieldType?: VariableType } }
+```
+
+`BodySlot` is **exported** from `lib/utils/bodySlots.ts:34` (I checked), and
+`BlockArgument` is a named type. This inline nested structural literal
+re-describes a shape the codebase owns, so if `BodySlot` changes, `slotContext`
+keeps compiling against a stale shadow. Use `slot: BodySlot`. Same for
+`(node as { returnType?: VariableType | null })` — `FunctionDefinition` and
+`GraphNodeDefinition` are already imported by `bodySlots.ts`, so the import is
+free. The plan's prose actually says "adjust the casts to the actual types rather
+than `any` where the imports are cheap" — the drafted code just doesn't do it,
+and executors paste what's drafted.
+
+## A5. A one-line `if` (*One-line if statements*)
+
+```ts
+if (t && t.type === "resultType") return t.successType;
+```
+
+Literal catalog entry. Brace it. (Task 2's code is correctly braced throughout —
+this is the only instance.)
+
+## A6. `?? undefined` on an already-optional field (*Useless special cases*)
+
+```ts
+case "block":
+  return scope.declaredYieldType ?? undefined;
+```
+
+`declaredYieldType` is `VariableType | undefined`; the coalesce is a no-op.
+`return scope.declaredYieldType;` says the same thing. (Note the surrounding
+method uses `?? undefined` meaningfully — to collapse `null` from
+`functionDefinitions[...]?.returnType` — so this reads as cargo-culted from its
+neighbours.)
+
+## Not anti-patterns (checked, to be fair)
+
+- **No duplicated code.** I searched for an existing Result unwrapper: there is
+  **no** `isResultType` and no shared `successType` helper anywhere in `lib/`.
+  The unwrap is inlined at `checker.ts:1023`, `checker.ts:1073`, and inside
+  `typeToZodSchema.ts` / `validationDescriptor.ts`, but nothing is exported to
+  reuse. So `yieldTypeFrom` is **not** a duplication violation — writing it is
+  correct. (Adjacent observation, not a finding: it becomes the fourth private
+  spelling of the same unwrap. If a shared `resultSuccessType` is ever worth
+  having, this is the natural moment — but do not build it as scope creep here.)
+- **The context design is genuinely not order-dependent mutable state.** The
+  context is a parameter threaded down the walk, never stored on the module or
+  the walker, and `desugarGuardsInBody`'s default keeps both entry points
+  source-compatible. This was the single biggest anti-pattern risk in the whole
+  feature — the spec explicitly rejected a builder-side pending field for being
+  order-dependent — and the plan got it right. Credit where due; the plan's own
+  Task 3 Step 4 audit note names this correctly.
+- No nested ternaries. No dynamic imports. No unlogged catch blocks. No magic
+  numbers. No `unlinkSync`. No catastrophic-failure tests. The guard-clause early
+  return in `desugarNode` is a readability improvement, not a special case.
+
+## Test-code nits (minor)
+
+The Task 1 tests lean on `(n: any) => ...` throughout and use the single-char
+name `n` (*Single character variable names*). Test code, low stakes, and `n` is
+the file's existing convention in places — but `node` costs nothing, and typing
+the finds would catch a renamed AST field at compile time instead of at
+assertion time.
+
+## Where this lands
+
+A1, A2, and A3 are one theme seen three times: the plan knows how to write the
+declarative form (it did, in `slotContext`, `yieldTypeFrom`, and `DesugarContext`)
+and then didn't, in the three places where the imperative version was slightly
+more convenient to draft. None of them change the design — they are all local
+rewrites of code the plan already specifies, and A2 in particular makes the diff
+*smaller*. A4–A6 are one-line cleanups. Fix A2's parenthetical justification
+first: it is the only one that will actively talk an executor out of the right
+thing.
+
+---
+
+# Addendum 2: the test plan
+
+Two questions: will each test fail when the thing it guards breaks, and what is
+missing? The desugar tests are mostly honest and the fork test in particular is
+a genuinely good discriminator. But **one codegen test asserts on a program that
+does not compile**, and chasing why led somewhere much bigger than a test bug:
+**the `responseFormat` half of this feature may not be reachable by any
+type-correct program.** That finding is T1 and it should be settled before
+execution starts.
+
+Everything below marked "verified" was run against the current build on `main`
+(which contains #574), not reasoned about.
+
+## Tests that will not fail when the code breaks
+
+### T1. Task 2 test 4 asserts on a program the checker rejects — and that exposes a possibly-dead feature half
+
+The test source is:
+
+```ts
+def f(): Result<{ title: string }> {
+  return guard(cost: $1) {
+    return llm("hi")
+  }
+}
+```
+
+**Verified — this does not typecheck:**
+
+```
+AG2001: Type 'Result<string, any>' is not assignable to
+        type 'Result<{ title: string }, string>' (return in 'f').
+```
+
+The checker synthesizes `llm("hi")` as `string` (no expected type is pushed into
+it), so the block yields `Result<string>`, which is not the declared
+`Result<{ title: string }>`. I checked the spec's *primary* annotation form too,
+in case return-position was the problem — same error:
+
+```
+const r: Result<{ title: string }> = guard(cost: $1) { return llm("hi") }
+→ AG2001: Type 'Result<string, any>' is not assignable to
+          type 'Result<{ title: string }, string>' (assignment to 'r').
+```
+
+So the test is green-or-broken for the wrong reason either way: if `gen()` runs
+the typechecker the test errors out; if `gen()` skips it, the test passes while
+pinning codegen for a program the compiler would reject. Neither outcome tells
+you the feature works.
+
+**The larger problem this uncovers.** The `responseFormat` change is only
+*observable* when the annotation is structured — a `Result<string>` annotation
+produces the same string default the block already had. So ask: is there any
+type-correct program where the stamp changes the emitted `responseFormat`? I
+tried all three shapes and verified each:
+
+| Program shape | Typechecks? | `responseFormat` today | After the stamp | Stamp observable? |
+|---|---|---|---|---|
+| `Result<string>` + `return llm("hi")` | ✓ (verified) | string default (none emitted) | string | **No** — identical |
+| `Result<{title}>` + `return llm("hi")` | ✗ **AG2001** (verified, both forms) | — | — | **Unreachable** |
+| `Result<{title}>` + `const x: {title} = llm(...)` | ✓ (verified) | **already `z.object({...})`** (verified in generated JS) | `z.object({...})` | **No** — the assignment annotation already did it |
+
+That third row is the Task 3 fixture's own shape, and I compiled it: it emits
+`responseFormat: z.object({` **today**, before any of this work, driven by the
+assignment's type hint rather than the scope return type. So in the one shape
+that both compiles and is structured, the stamp contributes nothing.
+
+**I could not construct a type-correct program where the `responseFormat` stamp
+changes behavior.** I am stating that as a failure to find one, not a proof that
+none exists — but the plan should not proceed on the assumption that it does
+without producing one.
+
+This contradicts two things the plan and spec currently assert: the Background's
+"Making both answer a stamped block fixes both features," and decision 1's
+accepted "visible behavior change" for `responseFormat` inside annotated guard
+blocks. If the change is invisible, the owner agreed to a trade-off that does not
+occur.
+
+The root cause is precisely the thing the plan excludes. "Why the checker needs
+no changes" is right for `draftSchema` (a runtime hint the checker never sees)
+and wrong for `responseFormat` (which describes a value the checker *does* type).
+`return llm("hi")` infers `string` because `synthGuardCall` synthesizes from the
+block's returns with no expected type pushed inward; teaching the checker to
+propagate the block's declared yield into the `llm()` call is what would make row
+2 compile — and only then is the stamp load-bearing.
+
+**Three ways out, owner's call:**
+- **(a)** Produce a type-correct program where the stamp is observable and rebuild
+  test 4 on it. If someone finds one, everything else here stands and this is just
+  a test fix.
+- **(b) Descope `responseFormat` from this PR** — drop the `returnType()` block
+  case, ship `draftSchema` alone (which is genuinely reachable and genuinely
+  fixed), and record the `responseFormat` hole as still open, blocked on checker
+  work. This is my recommendation: it shrinks the diff, removes the behavior
+  change that needed justifying, and stops the feature claiming something it does
+  not deliver.
+- **(c)** Extend scope to the checker so row 2 compiles. Real work, and a
+  different PR.
+
+### T2. The vacuous negative assertions in Task 2 tests 1 and 3
+
+```ts
+expect(out).not.toContain("draftSchema: Report");
+```
+
+`zodSchemaFor` renders a *zod* schema, so the fallback for a `Report` return
+emits `draftSchema: z.object({ title: z.string() })` — the literal text
+`"draftSchema: Report"` never appears in generated output, with or without the
+bug. The assertion cannot fire. The positive assertion in each test
+(`toContain("draftSchema: z.string()")`) is doing all the work; the negative is
+false comfort that reads like a second guard.
+
+Replace with the shape the fallback would actually emit:
+`expect(out).not.toMatch(/draftSchema: z\.object\(/)`.
+
+## Tests that are weaker than they look
+
+### T3. Task 1 test 1 does not visibly discriminate its two candidate sources
+
+```ts
+def f(): string {
+  const r: Result<string> = guard(cost: $1) { return "x" }
+}
+```
+
+The annotation's `successType` is `string` and the def's declared return is also
+`string`. To be fair, I traced the likely bugs and the test *does* catch them (an
+implementation reading `ctx.returnTarget` would call `yieldTypeFrom("string")` →
+`undefined` → assertion fails). So this is not a false negative. But nothing in
+the test *shows* a reader that the annotation is the source, and Task 2 test 1
+gets this right by making the def `Report` and the annotation `string`. Make the
+def's return type differ here too (`def f(): number`) so the test is
+self-evidently discriminating rather than accidentally so.
+
+### T4. Task 2 test 5's `not.toContain("responseFormat")` is correct today but scans the whole file
+
+Verified: a string-typed llm call emits no `responseFormat` at all (only the
+annotated-assignment probe produced one), so the assertion holds. But it matches
+against the entire generated module, so any unrelated `responseFormat` emission
+anywhere in the file — now or later — breaks it for reasons that have nothing to
+do with this feature. Scope it to the `runPrompt` args for that call.
+
+## Missing tests
+
+### M1. Nothing unit-tests the `enclosingDeclaredReturnType` walk directly
+
+`scopeManager.test.ts` already exists (it unit-tests `blockFrameVar` by pushing
+scopes onto a `ScopeManager` directly), so the harness and precedent are both
+there. The new walk is the trickiest logic in Task 2 — stamped block answers,
+unstamped block defers outward, stamped-inside-unstamped, block under a `node`
+rather than a `function` — and every one of those paths is currently tested only
+through string-matching on generated TypeScript, two layers away. Four direct
+unit tests would localize failures and cover combinations no codegen test spells
+out. **This is the most valuable addition after T1.**
+
+### M2. No regression guard that `returnType()` still answers `undefined` for an *unstamped* block
+
+Task 2 changes `case "block"` on a method with five callers. Task 2 test 5 covers
+it only indirectly (via absence of `responseFormat`). One direct assertion —
+push an unstamped block scope, expect `returnType()` to be `undefined` — pins the
+half of the change that must *not* move.
+
+### M3. `slotContext`'s inherit branch has no coverage
+
+Every `return`-position test puts the `return` directly in a def body, which is
+the *capture* branch (the function's own body slot). No test puts a
+return-position guard inside an `if` / `while` / `for` — slots with no
+`blockAncestor` on a non-function node, which must **inherit**. If someone made
+`slotContext` reset on every slot, all existing tests still pass. Add:
+
+```ts
+def f(): Result<string> {
+  if (cond) { return guard(cost: $1) { return "x" } }
+  return guard(cost: $1) { return "y" }
+}
+// expect the guard inside the `if` to be stamped `string`
+```
+
+That is the positive counterpart to the fork test, and together they pin both
+directions of the rule.
+
+### M4–M8 (carried from the main review, listed here for one checklist)
+
+- **M4.** No `graphNode` test — `slotContext`'s `node.type === "graphNode"` branch
+  is never exercised.
+- **M5.** No handler / finalize retarget test (main review finding 1) — whichever
+  way that decision goes, it needs a test.
+- **M6.** No double-run stamp-stability test (main review finding 3).
+- **M7.** No `let r: Result<T> = guard(...)` test; the spec says "`let` alike."
+  One line, and it pins that the stamp reads the assignment node rather than
+  const-specific handling.
+- **M8.** No codegen assertion that a structured annotation yields
+  `draftSchema: z.object(...)` (main review finding 2) — note this one survives
+  even under option (b) above, since it is the `draftSchema` consumer.
+
+## What the tests get right
+
+The fork test (Task 1 test 5) is the best test in the plan and it is genuinely
+load-bearing: I traced the no-reset case and it stamps `string` where the test
+expects `undefined`, so removing the reset rule fails it loudly. That is the
+round-2 spec fix pinned properly rather than merely described. The
+`Result<Result<string>>` composition test is a real two-level check that would
+catch a single-unwrap bug, and the `Result<number, string>` test correctly
+discriminates `successType` from `failureType`. Task 2 test 2 is also a true
+discriminator: pre-change that call site emits the whole Result-shaped zod, so
+`z.string()` can only appear if the unwrap works. And the fixture's own comment
+naming what it cannot pin is the right instinct — T1 above is what happens when
+that same skepticism is applied one level further out.
+
+## Priority
+
+1. **Settle T1 before writing any code.** Either produce a type-correct program
+   where the `responseFormat` stamp is observable, or descope `responseFormat`
+   (my recommendation) and ship the `draftSchema` half, which is real. This is an
+   owner decision, not an executor one — it changes what the PR claims.
+2. Add M1 (direct `ScopeManager` walk unit tests) and M3 (the inherit branch).
+3. Fix T2's vacuous negatives and T4's whole-file scan; strengthen T3.
+4. Add M2, M4, M6, M7, and M8; M5 follows whichever way finding 1 is decided.

--- a/docs/superpowers/plans/2026-07-17-guard-annotation-threading.md
+++ b/docs/superpowers/plans/2026-07-17-guard-annotation-threading.md
@@ -1,0 +1,623 @@
+# Guard Annotation Threading Implementation Plan (#580)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Thread a guard's `Result<T>` annotation (on the assignment, or on the enclosing def's declared return for return-position guards) into the guard block's codegen, so the saveDraft tool schema and `responseFormat` inside the block use `T` instead of falling back.
+
+**Architecture:** Three moves, one per task. (1) `guardDesugar` becomes context-aware — a walk context carries the "current return target", captured from def returns, reset at every block body — and stamps `successType` onto the `BlockArgument` it creates. (2) The builder copies the stamp onto the block scope it pushes, and the two `ScopeManager` lookups answer block-first. (3) Fixtures + sweep + PR.
+
+**Tech Stack:** TypeScript, vitest, the Agency fixture harness.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-17-guard-annotation-threading-design.md` (on this branch, with both review rounds folded). Branch: `guard-annotation-threading`, already created from post-#578 main.
+- All paths below are relative to `packages/agency-lang/`.
+- Run `make` before running any Agency fixture; save test output to files (`2>&1 | tee "$TMPDIR/<name>.log"`); never run the full Agency suite locally.
+- Commit messages via file + `git commit -F` (apostrophes break `-m`); end with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`; check `git branch --show-current` before every commit.
+- Codebase rules: no dynamic imports, objects over maps, arrays over sets, `type` over `interface`, no nested ternaries, no C-style loops where `for...of`/array methods read better. `pnpm run lint:structure` before the final commit.
+- `docs/site/guide/llm.md`'s block-limitation note is owner-authored — do NOT edit; list it as a doc follow-up in the PR body.
+
+---
+
+## Background: the load-bearing facts (read first)
+
+**The desugar today is context-free.** `guardDesugar.ts` exports `desugarGuardsInBody(body)`; its `desugarNode` recurses through `bodySlots(node)` and follows a generic `holder.value` field with no parent-awareness and no threaded context. Both entry points (`typescriptPreprocessor.ts:331` and `typeChecker/index.ts:111`) call it on the WHOLE program, so the walk itself descends into defs. The spec's round-2 honesty note: making this context-aware is new structural work, and this plan owns it.
+
+**`bodySlots` already tells you which slots are block bodies.** Each slot for a `functionCall`'s inline block carries `blockAncestor: BlockArgument` (`lib/utils/bodySlots.ts:41`). That is the discriminator the reset rule needs: a slot WITH `blockAncestor` is a block body (the return target resets to that block's own yield); a slot without one inherits, except `function`/`graphNode` nodes, which capture their declared `returnType`.
+
+**Guards appear in exactly three positions** (the desugar's own doc comment): statement, `assignment.value`, `return.value`. The parser registers `guardBlockParser` at those three points, so the two stamping positions (assignment, return) plus the no-stamp statement case are exhaustive.
+
+**The Result type is easy to unwrap.** `ResultType = { type: "resultType", successType, failureType }` (`lib/types/typeHints.ts:157`). The stamp is `successType`; `failureType` plays no role.
+
+**The two consumers are already wired to the right lookups.** `return llm(...)` inside a block calls `this.scopes.returnType()` (`typescriptBuilder.ts:3190`) — today that answers `undefined` for blocks, and the comment at 3181-3183 documents the string fallback. The saveDraft schema calls `this.scopes.enclosingDeclaredReturnType()` (#578), which today walks PAST all blocks. Making both answer a stamped block fixes both features with zero `processLlmCall` changes.
+
+**Why the checker needs no changes.** The checker already types these programs correctly (`synthGuardCall` infers `Result<union of block returns>` and checks assignability against the annotation). This feature is codegen-only: it carries the annotation to a place codegen can read; the checker keeps judging it.
+
+**What the e2e fixture can and cannot pin.** The deterministic client ignores schemas, and the intrinsic saves mismatched values anyway (with a warning ack) — so no fixture OUTCOME can distinguish the threaded schema from the fallback. The fixture in Task 3 exercises the non-fallback PATH end to end (an object schema flows codegen → `draftSchema` → `buildDefinition` → provider without breaking anything); the distinguishing assertions live in the codegen tests (Task 2) and the already-merged runtime seam test (`intrinsicToolSchema.test.ts`).
+
+## File map
+
+| File | Change |
+|---|---|
+| `lib/types/blockArgument.ts` | `declaredYieldType?: VariableType` field |
+| `lib/preprocessors/guardDesugar.ts` | walk context, parent-aware value follow, stamping |
+| `lib/preprocessors/guardDesugar.test.ts` | stamp tests (extend existing file) |
+| `lib/types.ts` (`BlockScope`, ~line 176) | `declaredYieldType?: VariableType` field |
+| `lib/backends/typescriptBuilder.ts` (`processBlockArgument`, ~1775) | copy the stamp onto the pushed scope |
+| `lib/backends/typescriptBuilder/scopeManager.ts` | `returnType()` + `enclosingDeclaredReturnType()` answer block-first |
+| `lib/backends/draftSchemaCodegen.test.ts` | annotation-threading codegen tests (extend) |
+| `tests/agency/guards/savedraft-annotated-structured.agency/.test.json` | NEW fixture |
+
+---
+
+### Task 1: Context-aware guard desugar with stamping
+
+**Files:**
+- Modify: `lib/types/blockArgument.ts`
+- Modify: `lib/preprocessors/guardDesugar.ts`
+- Test: `lib/preprocessors/guardDesugar.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: `ResultType` (`successType` unwrap), `bodySlots` slot shape (`blockAncestor?: BlockArgument`).
+- Produces: `BlockArgument.declaredYieldType?: VariableType` — Task 2 reads this off the AST node. `desugarGuardsInBody(body)` keeps its public signature (the context parameter defaults, so both entry points are untouched).
+
+- [ ] **Step 1: Write the failing stamp tests**
+
+Read `lib/preprocessors/guardDesugar.test.ts` first and reuse its parse helper (it parses source and runs `desugarGuardsInBody`). Append:
+
+```ts
+/** Find the desugared _guard call's block argument under `node`. */
+function guardBlockArgOf(node: any): any {
+  // Walk shallowly: tests construct one known shape each, so a direct
+  // path read keeps failures readable. Adjust per test.
+  throw new Error("use direct path reads in each test instead");
+}
+
+describe("guardDesugar — declaredYieldType stamping (#580)", () => {
+  it("stamps successType from an annotated assignment", () => {
+    const nodes = desugarSource(
+      'def f(): string {\n  const r: Result<string> = guard(cost: $1) {\n    return "x"\n  }\n  return "y"\n}\n',
+    );
+    const def = nodes.find((n: any) => n.type === "function") as any;
+    const assign = def.body.find((n: any) => n.type === "assignment");
+    expect(assign.value.functionName).toBe("_guard");
+    expect(assign.value.block.declaredYieldType).toEqual({
+      type: "primitiveType",
+      value: "string",
+    });
+  });
+
+  it("stamps nothing on an unannotated assignment", () => {
+    const nodes = desugarSource(
+      'def f(): string {\n  const r = guard(cost: $1) {\n    return "x"\n  }\n  return "y"\n}\n',
+    );
+    const def = nodes.find((n: any) => n.type === "function") as any;
+    const assign = def.body.find((n: any) => n.type === "assignment");
+    expect(assign.value.block.declaredYieldType).toBeUndefined();
+  });
+
+  it("stamps nothing from a non-Result annotation", () => {
+    const nodes = desugarSource(
+      'def f(): string {\n  const r: string = guard(cost: $1) {\n    return "x"\n  }\n  return "y"\n}\n',
+    );
+    const def = nodes.find((n: any) => n.type === "function") as any;
+    const assign = def.body.find((n: any) => n.type === "assignment");
+    expect(assign.value.block.declaredYieldType).toBeUndefined();
+  });
+
+  it("stamps a return-position guard from the enclosing def's declared Result return", () => {
+    const nodes = desugarSource(
+      'def f(): Result<string> {\n  return guard(cost: $1) {\n    return "x"\n  }\n}\n',
+    );
+    const def = nodes.find((n: any) => n.type === "function") as any;
+    const ret = def.body.find((n: any) => n.type === "returnStatement");
+    expect(ret.value.block.declaredYieldType).toEqual({
+      type: "primitiveType",
+      value: "string",
+    });
+  });
+
+  it("does NOT stamp a return-position guard inside another block (target resets)", () => {
+    // The return inside the fork branch yields to the BRANCH, not to
+    // f — stamping it with f's Result<string> would be the round-2
+    // mis-stamp. The branch has no yield type, so: no stamp.
+    const nodes = desugarSource(
+      'def f(): Result<string> {\n  const r = fork([1]) as n {\n    return guard(cost: $1) {\n      return "x"\n    }\n  }\n  return guard(cost: $1) { return "y" }\n}\n',
+    );
+    const def = nodes.find((n: any) => n.type === "function") as any;
+    const forkAssign = def.body.find((n: any) => n.type === "assignment");
+    const innerReturn = forkAssign.value.block.body.find(
+      (n: any) => n.type === "returnStatement",
+    );
+    expect(innerReturn.value.block.declaredYieldType).toBeUndefined();
+  });
+
+  it("composes: a stamped guard block becomes the return target for its own body", () => {
+    const nodes = desugarSource(
+      'def f(): string {\n  const r: Result<Result<string>> = guard(cost: $1) {\n    return guard(cost: $1) {\n      return "x"\n    }\n  }\n  return "y"\n}\n',
+    );
+    const def = nodes.find((n: any) => n.type === "function") as any;
+    const outer = def.body.find((n: any) => n.type === "assignment").value;
+    expect(outer.block.declaredYieldType.type).toBe("resultType");
+    const innerReturn = outer.block.body.find(
+      (n: any) => n.type === "returnStatement",
+    );
+    expect(innerReturn.value.block.declaredYieldType).toEqual({
+      type: "primitiveType",
+      value: "string",
+    });
+  });
+
+  it("unwraps only successType from Result<T, E>", () => {
+    const nodes = desugarSource(
+      'def f(): string {\n  const r: Result<number, string> = guard(cost: $1) {\n    return 1\n  }\n  return "y"\n}\n',
+    );
+    const def = nodes.find((n: any) => n.type === "function") as any;
+    const assign = def.body.find((n: any) => n.type === "assignment");
+    expect(assign.value.block.declaredYieldType).toEqual({
+      type: "primitiveType",
+      value: "number",
+    });
+  });
+
+  it("a statement-position guard stamps nothing", () => {
+    const nodes = desugarSource(
+      'def f(): Result<string> {\n  guard(cost: $1) {\n    return "x"\n  }\n  return guard(cost: $1) { return "y" }\n}\n',
+    );
+    const def = nodes.find((n: any) => n.type === "function") as any;
+    const stmt = def.body.find(
+      (n: any) => n.type === "functionCall" && n.functionName === "_guard",
+    );
+    expect(stmt.block.declaredYieldType).toBeUndefined();
+  });
+});
+```
+
+Delete the unused `guardBlockArgOf` sketch — each test reads its path directly, as written. If the existing file's helper is named differently than `desugarSource`, use the file's actual helper; if none parses source, add one with `parseAgency(src, {}, false)` + `desugarGuardsInBody(parsed.result.nodes)`. Check the exact AST shape of `Result<string>` annotations before asserting `primitiveType` (run `pnpm run ast` on a one-liner if unsure) and adjust the expected objects to the real parser output — the assertions above are the intent, the parser's shape is the truth.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm test:run lib/preprocessors/guardDesugar.test.ts 2>&1 | tee "$TMPDIR/desugar-stamp.log"`
+Expected: the new tests FAIL (`declaredYieldType` is undefined everywhere / field does not exist); existing tests still pass.
+
+- [ ] **Step 3: Add the AST field**
+
+In `lib/types/blockArgument.ts`:
+
+```ts
+import { AgencyNode, VariableType } from "../types.js";
+import { BaseNode } from "./base.js";
+import { FunctionParameter } from "./function.js";
+
+export type BlockArgument = BaseNode & {
+  type: "blockArgument";
+  params: FunctionParameter[];
+  body: AgencyNode[];
+  inline?: boolean;
+  /** The block's declared yield type, when the user wrote it adjacent
+   *  to the guard this block belongs to: the `T` of a `Result<T>`
+   *  assignment annotation, or of the enclosing def's declared return
+   *  for a return-position guard. Stamped by guardDesugar (#580);
+   *  absent on every other block. Codegen reads it to type the
+   *  saveDraft schema and responseFormat inside the block. */
+  declaredYieldType?: VariableType;
+};
+```
+
+(Fix the `VariableType` import path if `../types.js` does not export it — it does today.)
+
+- [ ] **Step 4: Rewrite the desugar walk with context**
+
+Replace the walk portion of `lib/preprocessors/guardDesugar.ts` (keep the module doc comment, updating its last paragraph):
+
+```ts
+import { AgencyNode, VariableType } from "@/types.js";
+import { GuardBlock } from "@/types/guardBlock.js";
+import { bodySlots } from "@/utils/bodySlots.js";
+
+/** The walk context: the type a `return` statement at this point in
+ *  the tree yields to. Captured from the declared return when the
+ *  walk enters a def/node body; RESET at every block body (a return
+ *  inside a block yields to the BLOCK) — to the block's own stamp
+ *  for a just-stamped guard block, to nothing for any other block.
+ *  Absent at top level. */
+type DesugarContext = {
+  returnTarget?: VariableType;
+};
+
+export function desugarGuardsInBody(
+  body: AgencyNode[],
+  ctx: DesugarContext = {},
+): AgencyNode[] {
+  body.forEach((node, i) => {
+    body[i] = desugarNode(node, ctx);
+  });
+  return body;
+}
+
+/** `successType` of a Result annotation; undefined for anything else.
+ *  The desugar never validates — a non-Result annotation simply
+ *  stamps nothing, and the checker owns diagnosing it. */
+function yieldTypeFrom(t: VariableType | null | undefined): VariableType | undefined {
+  if (t && t.type === "resultType") return t.successType;
+  return undefined;
+}
+
+/** The context a slot's body walks under: block bodies RESET the
+ *  return target to the block's own yield (undefined for non-guard
+ *  blocks); def/node bodies capture the declared return; every other
+ *  body inherits. */
+function slotContext(
+  node: AgencyNode,
+  slot: { blockAncestor?: { declaredYieldType?: VariableType } },
+  ctx: DesugarContext,
+): DesugarContext {
+  if (slot.blockAncestor) {
+    return { returnTarget: slot.blockAncestor.declaredYieldType };
+  }
+  if (node.type === "function" || node.type === "graphNode") {
+    const declared = (node as { returnType?: VariableType | null }).returnType;
+    return { returnTarget: declared ?? undefined };
+  }
+  return ctx;
+}
+
+function desugarNode(node: AgencyNode, ctx: DesugarContext): AgencyNode {
+  if (node.type === "guardBlock") {
+    // Statement position: nothing to yield to, no stamp.
+    return desugarGuardBlock(node as GuardBlock, undefined);
+  }
+  for (const slot of bodySlots(node)) {
+    desugarGuardsInBody(slot.body, slotContext(node, slot, ctx));
+  }
+  // Parent-aware value follow (spec round 2): the two positions that
+  // can stamp are handled by holder type; everything else follows the
+  // generic path with no stamp source.
+  const holder = node as { value?: unknown; typeHint?: VariableType | null };
+  const value = holder.value;
+  if (!value || typeof value !== "object" || !("type" in (value as object))) {
+    return node;
+  }
+  const valueNode = value as AgencyNode;
+  if (valueNode.type === "guardBlock") {
+    let stamp: VariableType | undefined;
+    if (node.type === "assignment") {
+      stamp = yieldTypeFrom(holder.typeHint);
+    } else if (node.type === "returnStatement") {
+      stamp = yieldTypeFrom(ctx.returnTarget);
+    }
+    holder.value = desugarGuardBlock(valueNode as GuardBlock, stamp);
+    return node;
+  }
+  const rewritten = desugarNode(valueNode, ctx);
+  if (rewritten !== valueNode) {
+    holder.value = rewritten;
+  }
+  return node;
+}
+
+function desugarGuardBlock(
+  g: GuardBlock,
+  yieldType: VariableType | undefined,
+): AgencyNode {
+  // The head arguments forward VERBATIM (unchanged from #574). The
+  // stamp, when present, becomes the return target for the block's
+  // own body — which is how nested return-position guards compose.
+  const block: {
+    type: "blockArgument";
+    inline: boolean;
+    params: never[];
+    body: AgencyNode[];
+    declaredYieldType?: VariableType;
+  } = {
+    type: "blockArgument",
+    inline: false,
+    params: [],
+    body: [],
+  };
+  if (yieldType !== undefined) {
+    block.declaredYieldType = yieldType;
+  }
+  block.body = desugarGuardsInBody(g.body, { returnTarget: yieldType });
+  return {
+    type: "functionCall",
+    functionName: "_guard",
+    arguments: g.arguments,
+    block,
+    scope: "imported",
+    loc: g.loc,
+  } as unknown as AgencyNode;
+}
+```
+
+Check the real field names before finishing: the assignment annotation field (`typeHint` — verify on the `Assignment` type) and def/node return fields (`returnType` on both `FunctionDefinition` and `GraphNodeDefinition`). Adjust the casts to the actual types rather than `any` where the imports are cheap.
+
+- [ ] **Step 5: Run the tests**
+
+Run: `pnpm test:run lib/preprocessors/guardDesugar.test.ts lib/typeChecker/guardConstruct.test.ts 2>&1 | tee "$TMPDIR/desugar-stamp2.log"`
+Expected: PASS, including the pre-existing desugar and guard-construct suites (the checker runs the same desugar in its constructor — the context default keeps it identical for unannotated code).
+
+- [ ] **Step 6: Typecheck and commit**
+
+```bash
+pnpm exec tsc --noEmit 2>&1 | tee "$TMPDIR/tsc-580-1.log"
+git branch --show-current   # must be guard-annotation-threading
+printf 'feat: guardDesugar stamps Result<T> annotations onto guard block arguments\n\nCo-Authored-By: Claude Fable 5 <noreply@anthropic.com>\n' > "$TMPDIR/cm.txt"
+git add packages/agency-lang/lib/types/blockArgument.ts packages/agency-lang/lib/preprocessors/guardDesugar.ts packages/agency-lang/lib/preprocessors/guardDesugar.test.ts
+git commit -F "$TMPDIR/cm.txt"
+```
+
+---
+
+### Task 2: Builder plumbing — the stamp reaches both consumers
+
+**Files:**
+- Modify: `lib/types.ts` (`BlockScope`, ~line 176)
+- Modify: `lib/backends/typescriptBuilder.ts` (`processBlockArgument`, the `scopes.push({ type: "block", blockName })` at ~1775; the stale comment at ~3181)
+- Modify: `lib/backends/typescriptBuilder/scopeManager.ts` (`returnType()` block case; `enclosingDeclaredReturnType()` walk)
+- Test: `lib/backends/draftSchemaCodegen.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: `BlockArgument.declaredYieldType` (Task 1).
+- Produces: `BlockScope.declaredYieldType?: VariableType`; `returnType()` answers a stamped block's yield; `enclosingDeclaredReturnType()` walks innermost-first and returns the FIRST answer (stamped block, else nearest function/node declared return, else undefined).
+
+- [ ] **Step 1: Write the failing codegen tests**
+
+Append to `lib/backends/draftSchemaCodegen.test.ts` (its `gen` helper already exists):
+
+```ts
+describe("draftSchema threading — guard annotations (#580)", () => {
+  it("an annotated assignment beats the enclosing def's type", () => {
+    // def declares Report-ish; the guard annotation says string; the
+    // schema must follow the annotation (the slot), not the def.
+    const out = gen(
+      'type Report = { title: string }\ndef f(): Report {\n  const notes: Result<string> = guard(cost: $1) {\n    return llm("hi", tools: [print])\n  }\n  if (isSuccess(notes)) { return { title: notes.value } }\n  return { title: "x" }\n}\nnode main() { const x = f()\n return "ok" }\n',
+    );
+    expect(out).toContain("draftSchema: z.string()");
+    expect(out).not.toContain("draftSchema: Report");
+  });
+
+  it("a return-position guard unwraps the declared Result return", () => {
+    // Today this threads the WHOLE Result shape from the def walk;
+    // with the stamp it must be the unwrapped T.
+    const out = gen(
+      'def f(): Result<string> {\n  return guard(cost: $1) {\n    return llm("hi", tools: [print])\n  }\n}\nnode main() { const x = f()\n return "ok" }\n',
+    );
+    expect(out).toContain("draftSchema: z.string()");
+  });
+
+  it("nested: an unannotated inner guard defers to the outer stamp", () => {
+    const out = gen(
+      'type Report = { title: string }\ndef f(): Report {\n  const outer: Result<string> = guard(cost: $1) {\n    const inner = guard(cost: $0.1) {\n      return llm("hi", tools: [print])\n    }\n    if (isSuccess(inner)) { return inner.value }\n    return "x"\n  }\n  return { title: "x" }\n}\nnode main() { const x = f()\n return "ok" }\n',
+    );
+    expect(out).toContain("draftSchema: z.string()");
+    expect(out).not.toContain("draftSchema: Report");
+  });
+
+  it("responseFormat inside an annotated guard follows the annotation", () => {
+    // A structured annotation must produce a structured responseFormat
+    // for `return llm(...)` in the block — the documented limitation
+    // being fixed. (A string annotation is indistinguishable from the
+    // old default, which is why this test uses an object type.)
+    const out = gen(
+      'def f(): Result<{ title: string }> {\n  return guard(cost: $1) {\n    return llm("hi")\n  }\n}\nnode main() { const x = f()\n return "ok" }\n',
+    );
+    expect(out).toMatch(/responseFormat: z\.object\(/);
+  });
+
+  it("an unannotated guard keeps the old fallbacks (byte-stability spot check)", () => {
+    const out = gen(
+      'def f(): string {\n  const r = guard(cost: $1) {\n    return llm("hi", tools: [print])\n  }\n  if (isSuccess(r)) { return r.value }\n  return "x"\n}\nnode main() { return f() }\n',
+    );
+    // Falls through to the def's declared string, exactly as in #578.
+    expect(out).toContain("draftSchema: z.string()");
+    expect(out).not.toContain("responseFormat");
+  });
+});
+```
+
+Before finalizing the `responseFormat` assertion, check how `processLlmCall` renders a structured response format (`$.z().prop("object").namedArgs(...)` — see typescriptBuilder.ts:3641) and match the real emitted text (it may render as `responseFormat: z.object({ response: ... })`); the assertions are intent, the emitted shape is truth.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm test:run lib/backends/draftSchemaCodegen.test.ts 2>&1 | tee "$TMPDIR/580-codegen.log"`
+Expected: the four new threading tests FAIL (annotation ignored, Result shape threaded, no responseFormat); the byte-stability spot check may already pass.
+
+- [ ] **Step 3: Add the scope field and copy the stamp**
+
+In `lib/types.ts`:
+
+```ts
+export type BlockScope = {
+  type: "block";
+  blockName: string;
+  /** The block's declared yield type, copied from the stamped
+   *  BlockArgument (#580) when the builder pushes this scope. */
+  declaredYieldType?: VariableType;
+};
+```
+
+In `lib/backends/typescriptBuilder.ts`, `processBlockArgument` (~1775):
+
+```ts
+this.scopes.push({
+  type: "block",
+  blockName,
+  declaredYieldType: block.declaredYieldType,
+});
+```
+
+- [ ] **Step 4: Teach the two lookups**
+
+In `lib/backends/typescriptBuilder/scopeManager.ts`, `returnType()` — replace the `case "block"` arm and trim the now-stale part of its doc comment:
+
+```ts
+      case "block":
+        // Annotated guard blocks carry their yield (#580); every
+        // other block still has no declared type.
+        return scope.declaredYieldType ?? undefined;
+```
+
+And `enclosingDeclaredReturnType()` — the walk now takes the first ANSWER, not the first non-block scope:
+
+```ts
+  enclosingDeclaredReturnType(): VariableType | undefined {
+    // Innermost-first, first answer wins: a stamped guard block
+    // answers its yield; an unstamped block defers outward; the
+    // nearest function/node answers its declared return; global ends
+    // the walk. (Only function/node/block are ever pushed over the
+    // root global — the invariant returnType()'s throwing default
+    // relies on.)
+    for (const scope of [...this.stack].reverse()) {
+      if (scope.type === "block") {
+        if (scope.declaredYieldType !== undefined) {
+          return scope.declaredYieldType;
+        }
+        continue;
+      }
+      if (scope.type === "function") {
+        return (
+          this.compilationUnit.functionDefinitions[scope.functionName]
+            ?.returnType ?? undefined
+        );
+      }
+      if (scope.type === "node") {
+        return (
+          this.compilationUnit.graphNodes.find(
+            (n) => n.nodeName === scope.nodeName,
+          )?.returnType ?? undefined
+        );
+      }
+      return undefined; // global
+    }
+    return undefined;
+  }
+```
+
+(A `for...of` over a reversed copy with an early `continue` — the two-list `.find` from #578 cannot express "skip unstamped blocks but stop at stamped ones".) Also update the stale comment at `typescriptBuilder.ts:3181` ("The block's declared return type is unknown to the builder") to say annotated guard blocks are now the exception.
+
+- [ ] **Step 5: Run the tests**
+
+Run: `pnpm test:run lib/backends/draftSchemaCodegen.test.ts lib/backends/ 2>&1 | tee "$TMPDIR/580-codegen2.log"`
+Expected: all PASS, including the whole backends suite (the unannotated paths are unchanged).
+
+- [ ] **Step 6: Typecheck and commit**
+
+```bash
+pnpm exec tsc --noEmit 2>&1 | tee "$TMPDIR/tsc-580-2.log"
+git branch --show-current
+printf 'feat: stamped guard yields reach draftSchema and responseFormat\n\nCo-Authored-By: Claude Fable 5 <noreply@anthropic.com>\n' > "$TMPDIR/cm.txt"
+git add packages/agency-lang/lib/types.ts packages/agency-lang/lib/backends/typescriptBuilder.ts packages/agency-lang/lib/backends/typescriptBuilder/scopeManager.ts packages/agency-lang/lib/backends/draftSchemaCodegen.test.ts
+git commit -F "$TMPDIR/cm.txt"
+```
+
+---
+
+### Task 3: Fixture, sweep, PR
+
+**Files:**
+- Create: `tests/agency/guards/savedraft-annotated-structured.agency` + `.test.json`
+- No other code changes (verification + PR prep).
+
+**Interfaces:**
+- Consumes: Tasks 1 + 2.
+
+- [ ] **Step 1: Write the fixture**
+
+`tests/agency/guards/savedraft-annotated-structured.agency`:
+
+```
+// An annotated guard threads a STRUCTURED saveDraft schema — the
+// first e2e through the non-fallback path. Note what this pins and
+// what it cannot: the deterministic client ignores schemas and the
+// intrinsic keeps mismatched saves, so the OUTCOME here would be the
+// same under the string fallback; the codegen tests own the
+// distinguishing assertions. This fixture proves the threaded object
+// schema flows codegen -> draftSchema -> provider without breaking
+// the round-trip, and that a structured draft salvages intact.
+node main() {
+  const r: Result<{ title: string }> = guard(cost: 0.000001) {
+    const report: { title: string } = llm("work", tools: [saveDraft])
+    return report
+  }
+  if (isFailure(r)) { return "no-draft" }
+  return r.value.title
+}
+```
+
+(The `const report: { title: string } = llm(...)` shape keeps the checker happy: it types the llm call via the assignment annotation, so the block's inferred yield matches the guard annotation. A bare `return llm(...)` would infer string and error against `Result<{ title: string }>`.)
+
+`tests/agency/guards/savedraft-annotated-structured.test.json`:
+
+```json
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"t\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "toolCalls": [{ "name": "saveDraft", "args": { "value": { "title": "t" } } }] },
+        { "return": "never-reached" }
+      ],
+      "description": "A structured draft saved against an annotated Result<{title}> guard salvages intact; exercises the threaded (non-fallback) schema path end to end.",
+      "interruptHandlers": [{ "action": "reject" }]
+    }
+  ]
+}
+```
+
+- [ ] **Step 2: Build and run it**
+
+```bash
+make 2>&1 | tail -1
+pnpm run agency test tests/agency/guards/savedraft-annotated-structured.agency 2>&1 | tee "$TMPDIR/fx-580.log"
+```
+
+Expected: PASS. If the checker rejects the guard-block typing, read the error before touching the fixture — the annotated-llm-assignment shape above is the intended fix for exactly that class of error.
+
+- [ ] **Step 3: Byte-stability + spot-check the #578 fixtures**
+
+```bash
+make fixtures 2>&1 | tail -2
+git status --porcelain | grep -v '^??' | tee "$TMPDIR/580-churn.log"
+for f in savedraft-tool-basic savedraft-tool-order finalize-binder-returns-draft; do
+  pnpm run agency test tests/agency/guards/$f.agency 2>&1 | grep -c "1/1 tests passed"
+done
+```
+
+Expected: no tracked-file churn; the three #578 fixtures still pass (they are all unannotated, so their generated code must be unchanged).
+
+- [ ] **Step 4: Full unit suite, lint, anti-pattern audit**
+
+```bash
+pnpm test:run 2>&1 | tee "$TMPDIR/580-unit.log" | tail -3
+pnpm run lint:structure 2>&1 | tail -2
+```
+
+Expected: clean. Then audit `git diff main...HEAD` against `docs/dev/anti-patterns.md` (the walk rewrite in Task 1 is the spot to scrutinize: no order-dependent mutable state — the context is passed, never stored on the module or the walker).
+
+- [ ] **Step 5: As-executed spec notes, commit, PR**
+
+Append an "As executed" section to `docs/superpowers/specs/2026-07-17-guard-annotation-threading-design.md` recording any deviations discovered during execution. Commit the fixture + spec note, then open the PR:
+
+```bash
+git branch --show-current
+printf 'test: structured-annotation saveDraft fixture; as-executed spec notes\n\nCo-Authored-By: Claude Fable 5 <noreply@anthropic.com>\n' > "$TMPDIR/cm.txt"
+git add packages/agency-lang/tests/agency/guards/savedraft-annotated-structured.agency packages/agency-lang/tests/agency/guards/savedraft-annotated-structured.test.json docs/superpowers/specs/2026-07-17-guard-annotation-threading-design.md
+git commit -F "$TMPDIR/cm.txt"
+git push -u origin guard-annotation-threading
+```
+
+Write the PR body to a file (link issue #580 and the spec; state the deliberate behavior change — structured `responseFormat` inside annotated guard blocks — and its justification from decision 1; list the doc follow-up: llm.md's block-limitation note is owner-authored and needs its exception sentence). End with the Claude Code attribution, then `gh pr create --title "Thread guard Result<T> annotations into block codegen (#580)" --body-file ...`.
+
+---
+
+## Self-review notes (checked against the spec)
+
+- **Spec coverage:** Part 2 mechanism steps 1-4 map to Tasks 1 (stamp + context + reset) and 2 (scope copy + both lookups); the walk rule is pinned by the nested codegen test and the fork-branch desugar test; failure modes (non-Result annotation, `Result<T, E>`, statement position) each have a Task 1 test; Part 3's test list maps 1:1, with the fixture's honesty note carried into the fixture comment itself; Part 4 exclusions (inferred yields, `let`-then-assign, non-guard blocks, aliases, llm.md) have no tasks, correctly.
+- **Round-2 fixes honored:** the plan owns the context plumbing as structural work (Task 1 Step 4 is a rewrite, not a patch), and the return-target reset at block bodies is implemented via `slotContext`'s `blockAncestor` branch and pinned by the fork-branch test.
+- **Type consistency:** `declaredYieldType?: VariableType` is the same name on `BlockArgument` (Task 1), `BlockScope` (Task 2), and both ScopeManager reads; `desugarGuardsInBody(body, ctx = {})` keeps both existing entry points source-compatible.
+- **Known honesty point:** the e2e fixture cannot distinguish threaded-vs-fallback outcomes (deterministic client ignores schemas; mismatched saves are kept) — stated in the Background and in the fixture's own comment; the codegen tests are the distinguishing layer.

--- a/docs/superpowers/plans/2026-07-17-guard-annotation-threading.md
+++ b/docs/superpowers/plans/2026-07-17-guard-annotation-threading.md
@@ -2,49 +2,57 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Thread a guard's `Result<T>` annotation (on the assignment, or on the enclosing def's declared return for return-position guards) into the guard block's codegen, so the saveDraft tool schema and `responseFormat` inside the block use `T` instead of falling back.
+**Goal:** Thread a guard's `Result<T>` annotation (on the assignment, or on the enclosing def/node's declared return for return-position guards) into the guard block's codegen, so the saveDraft tool schema uses `T` instead of the enclosing function's type.
 
-**Architecture:** Three moves, one per task. (1) `guardDesugar` becomes context-aware — a walk context carries the "current return target", captured from def returns, reset at every block body — and stamps `successType` onto the `BlockArgument` it creates. (2) The builder copies the stamp onto the block scope it pushes, and the two `ScopeManager` lookups answer block-first. (3) Fixtures + sweep + PR.
+**Architecture:** Three moves, one per task. (1) `guardDesugar` becomes context-aware — a walk context carries the "current return target", captured from def/node returns, reset at every return-retargeting boundary (`bodySlots` gains a per-slot `retargetsReturn` marker) — and stamps `successType` onto the `BlockArgument` it creates. (2) The builder copies the stamp onto the block scope, and `enclosingDeclaredReturnType()` answers block-first (a one-predicate change). (3) Fixture + sweep + PR.
 
 **Tech Stack:** TypeScript, vitest, the Agency fixture harness.
 
+**DESCOPED (plan review T1, owner decision):** `responseFormat` is NOT touched. The review verified no natural type-correct program exists where a responseFormat stamp changes behavior (structured `return llm(...)` fails AG2001; the compiling shape already gets responseFormat from its assignment hint; the only reachable shape — a wider-union annotation — is the type-theoretically muddy one). `ScopeManager.returnType()` stays as-is; #582 tracks the checker expected-type propagation that unblocks it.
+
 ## Global Constraints
 
-- Spec: `docs/superpowers/specs/2026-07-17-guard-annotation-threading-design.md` (on this branch, with both review rounds folded). Branch: `guard-annotation-threading`, already created from post-#578 main.
+- Spec: `docs/superpowers/specs/2026-07-17-guard-annotation-threading-design.md` (this branch, all three review rounds folded). Branch: `guard-annotation-threading`, created from post-#578 main.
 - All paths below are relative to `packages/agency-lang/`.
 - Run `make` before running any Agency fixture; save test output to files (`2>&1 | tee "$TMPDIR/<name>.log"`); never run the full Agency suite locally.
-- Commit messages via file + `git commit -F` (apostrophes break `-m`); end with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`; check `git branch --show-current` before every commit.
-- Codebase rules: no dynamic imports, objects over maps, arrays over sets, `type` over `interface`, no nested ternaries, no C-style loops where `for...of`/array methods read better. `pnpm run lint:structure` before the final commit.
-- `docs/site/guide/llm.md`'s block-limitation note is owner-authored — do NOT edit; list it as a doc follow-up in the PR body.
+- Commit messages via file + `git commit -F`; end with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`; check `git branch --show-current` before every commit.
+- Codebase rules: no dynamic imports, objects over maps, arrays over sets, `type` over `interface`, no nested ternaries, no build-by-mutation where a literal serves, no one-line ifs, use exported types over inline structural casts. `pnpm run lint:structure` before the final commit.
+- `docs/site/guide/llm.md` is owner-authored — do NOT edit; the PR body notes its responseFormat limitation stays true until #582.
 
 ---
 
-## Background: the load-bearing facts (read first)
+## Background: the load-bearing facts (all verified against this worktree)
 
-**The desugar today is context-free.** `guardDesugar.ts` exports `desugarGuardsInBody(body)`; its `desugarNode` recurses through `bodySlots(node)` and follows a generic `holder.value` field with no parent-awareness and no threaded context. Both entry points (`typescriptPreprocessor.ts:331` and `typeChecker/index.ts:111`) call it on the WHOLE program, so the walk itself descends into defs. The spec's round-2 honesty note: making this context-aware is new structural work, and this plan owns it.
+**The desugar today is context-free.** `guardDesugar.ts`'s `desugarNode` recurses through `bodySlots(node)` and follows a generic `holder.value` field with no parent-awareness. Both entry points (`typescriptPreprocessor.ts:331`, `typeChecker/index.ts:111`) call `desugarGuardsInBody` on the whole program. The context parameter defaults, so neither entry point changes.
 
-**`bodySlots` already tells you which slots are block bodies.** Each slot for a `functionCall`'s inline block carries `blockAncestor: BlockArgument` (`lib/utils/bodySlots.ts:41`). That is the discriminator the reset rule needs: a slot WITH `blockAncestor` is a block body (the return target resets to that block's own yield); a slot without one inherits, except `function`/`graphNode` nodes, which capture their declared `returnType`.
+**Three constructs retarget `return`, and only one is marked today.** A `return` yields to its innermost closure: a block argument (own function via `__block_N` lifting), an inline handler body (its own arrow — `async (i) => {...}`), and a finalize body (the `__finalize` closure). `bodySlots` currently marks only the first (`blockAncestor` on `functionCall` block slots — set for ANY block, the "inline" in its doc comment is misleading and gets fixed here). Plan-review finding 1: the reset rule must cover all three, so `BodySlot` gains `retargetsReturn?: boolean` at the single source of truth, and the rule keys on it.
 
-**Guards appear in exactly three positions** (the desugar's own doc comment): statement, `assignment.value`, `return.value`. The parser registers `guardBlockParser` at those three points, so the two stamping positions (assignment, return) plus the no-stamp statement case are exhaustive.
+**Guards appear in exactly three positions** (statement, `assignment.value`, `return.value` — the parser's three registration points), so the stamping rule is exhaustive over assignment/return holders.
 
-**The Result type is easy to unwrap.** `ResultType = { type: "resultType", successType, failureType }` (`lib/types/typeHints.ts:157`). The stamp is `successType`; `failureType` plays no role.
+**`ResultType` is `{ type: "resultType", successType, failureType }`** (`types/typeHints.ts:157`); the stamp is `successType`. There is no existing exported Result unwrap helper anywhere in `lib/` (verified), so `yieldTypeFrom` is new code, not duplication.
 
-**The two consumers are already wired to the right lookups.** `return llm(...)` inside a block calls `this.scopes.returnType()` (`typescriptBuilder.ts:3190`) — today that answers `undefined` for blocks, and the comment at 3181-3183 documents the string fallback. The saveDraft schema calls `this.scopes.enclosingDeclaredReturnType()` (#578), which today walks PAST all blocks. Making both answer a stamped block fixes both features with zero `processLlmCall` changes.
+**The draftSchema lookup is `enclosingDeclaredReturnType()`** (#578, `scopeManager.ts`). The change to it is ONE predicate plus one switch arm — the existing `.find` structure expresses "skip unstamped blocks, stop at stamped ones" as `scope.type !== "block" || scope.declaredYieldType !== undefined` (plan review A2; do not rewrite the method).
 
-**Why the checker needs no changes.** The checker already types these programs correctly (`synthGuardCall` infers `Result<union of block returns>` and checks assignability against the annotation). This feature is codegen-only: it carries the annotation to a place codegen can read; the checker keeps judging it.
+**Three block-scope push sites exist; only one matters.** `processBlockArgument` (~1775) is the path every desugared `_guard` block takes (called from 2734/2781/2802). `processBlockAsExpression` (1829) and the fork lowering (2852) never carry a guard's block argument — deliberately unstamped.
 
-**What the e2e fixture can and cannot pin.** The deterministic client ignores schemas, and the intrinsic saves mismatched values anyway (with a warning ack) — so no fixture OUTCOME can distinguish the threaded schema from the fallback. The fixture in Task 3 exercises the non-fallback PATH end to end (an object schema flows codegen → `draftSchema` → `buildDefinition` → provider without breaking anything); the distinguishing assertions live in the codegen tests (Task 2) and the already-merged runtime seam test (`intrinsicToolSchema.test.ts`).
+**Absent and undefined are equivalent for the stamp field.** Every consumer reads it with `!== undefined` checks, and `JSON.stringify` (so `pnpm run ast` output and AST fixtures) drops undefined-valued keys. So the field is ALWAYS assigned (possibly undefined) — no conditional-field dance (plan review A3).
+
+**The double run is safe but asymmetric** (plan review finding 3): run 2 finds no `guardBlock` nodes, so nothing re-stamps — but the reset rule's `blockAncestor.declaredYieldType` read returns run-1 stamps, so the runs walk with different contexts. Harmless; pinned by a stability test; noted in a comment so the read doesn't look dead on run 1.
+
+**What the e2e fixture can and cannot pin.** The deterministic client ignores schemas and the intrinsic keeps mismatched saves, so no fixture OUTCOME distinguishes threaded-vs-fallback. The fixture exercises the non-fallback PATH; the codegen tests are the distinguishing layer — including the structured `draftSchema: z.object(...)` assertion the fixture provably cannot make (plan review finding 2/M8).
 
 ## File map
 
 | File | Change |
 |---|---|
+| `lib/utils/bodySlots.ts` | `retargetsReturn?: boolean` on `BodySlot`; set on 3 slots; fix `blockAncestor` doc comment |
 | `lib/types/blockArgument.ts` | `declaredYieldType?: VariableType` field |
-| `lib/preprocessors/guardDesugar.ts` | walk context, parent-aware value follow, stamping |
-| `lib/preprocessors/guardDesugar.test.ts` | stamp tests (extend existing file) |
-| `lib/types.ts` (`BlockScope`, ~line 176) | `declaredYieldType?: VariableType` field |
-| `lib/backends/typescriptBuilder.ts` (`processBlockArgument`, ~1775) | copy the stamp onto the pushed scope |
-| `lib/backends/typescriptBuilder/scopeManager.ts` | `returnType()` + `enclosingDeclaredReturnType()` answer block-first |
+| `lib/preprocessors/guardDesugar.ts` | walk context, `slotContext`, `stampFor`, stamping |
+| `lib/preprocessors/guardDesugar.test.ts` | stamp tests (extend) |
+| `lib/types.ts` (`BlockScope`) | `declaredYieldType?: VariableType` field |
+| `lib/backends/typescriptBuilder.ts` (~1775) | copy the stamp onto the pushed scope |
+| `lib/backends/typescriptBuilder/scopeManager.ts` | `enclosingDeclaredReturnType()` predicate + switch arm |
+| `lib/backends/typescriptBuilder/scopeManager.test.ts` | direct walk unit tests (extend) |
 | `lib/backends/draftSchemaCodegen.test.ts` | annotation-threading codegen tests (extend) |
 | `tests/agency/guards/savedraft-annotated-structured.agency/.test.json` | NEW fixture |
 
@@ -53,34 +61,40 @@
 ### Task 1: Context-aware guard desugar with stamping
 
 **Files:**
-- Modify: `lib/types/blockArgument.ts`
-- Modify: `lib/preprocessors/guardDesugar.ts`
+- Modify: `lib/utils/bodySlots.ts`, `lib/types/blockArgument.ts`, `lib/preprocessors/guardDesugar.ts`
 - Test: `lib/preprocessors/guardDesugar.test.ts` (extend)
 
 **Interfaces:**
-- Consumes: `ResultType` (`successType` unwrap), `bodySlots` slot shape (`blockAncestor?: BlockArgument`).
-- Produces: `BlockArgument.declaredYieldType?: VariableType` — Task 2 reads this off the AST node. `desugarGuardsInBody(body)` keeps its public signature (the context parameter defaults, so both entry points are untouched).
+- Consumes: `BodySlot` (exported, `bodySlots.ts:34`), `ResultType.successType`, `FunctionDefinition`/`GraphNodeDefinition` `.returnType`.
+- Produces: `BodySlot.retargetsReturn?: boolean`; `BlockArgument.declaredYieldType?: VariableType` (Task 2 reads it); `desugarGuardsInBody(body, ctx?)` — public call sites unchanged.
 
 - [ ] **Step 1: Write the failing stamp tests**
 
-Read `lib/preprocessors/guardDesugar.test.ts` first and reuse its parse helper (it parses source and runs `desugarGuardsInBody`). Append:
+Read `lib/preprocessors/guardDesugar.test.ts` first; reuse its parse helper (add one if it lacks a parse-source helper: `parseAgency(src, {}, false)` then `desugarGuardsInBody(parsed.result.nodes)`). Check the real AST shape of `Result<string>` annotations with `pnpm run ast` on a one-liner before finalizing the expected objects — the assertions below are intent, the parser's shape is truth. Use `node`-style variable names, not `n`. Append:
 
 ```ts
-/** Find the desugared _guard call's block argument under `node`. */
-function guardBlockArgOf(node: any): any {
-  // Walk shallowly: tests construct one known shape each, so a direct
-  // path read keeps failures readable. Adjust per test.
-  throw new Error("use direct path reads in each test instead");
-}
-
 describe("guardDesugar — declaredYieldType stamping (#580)", () => {
-  it("stamps successType from an annotated assignment", () => {
+  it("stamps successType from an annotated const assignment (def type differs, so the source is visible)", () => {
+    // def returns number; the annotation says string. Only the
+    // annotation can produce the string stamp.
     const nodes = desugarSource(
-      'def f(): string {\n  const r: Result<string> = guard(cost: $1) {\n    return "x"\n  }\n  return "y"\n}\n',
+      'def f(): number {\n  const r: Result<string> = guard(cost: $1) {\n    return "x"\n  }\n  return 1\n}\n',
     );
-    const def = nodes.find((n: any) => n.type === "function") as any;
-    const assign = def.body.find((n: any) => n.type === "assignment");
+    const def = nodes.find((node: any) => node.type === "function") as any;
+    const assign = def.body.find((node: any) => node.type === "assignment");
     expect(assign.value.functionName).toBe("_guard");
+    expect(assign.value.block.declaredYieldType).toEqual({
+      type: "primitiveType",
+      value: "string",
+    });
+  });
+
+  it("stamps a `let` annotation the same way", () => {
+    const nodes = desugarSource(
+      'def f(): number {\n  let r: Result<string> = guard(cost: $1) {\n    return "x"\n  }\n  return 1\n}\n',
+    );
+    const def = nodes.find((node: any) => node.type === "function") as any;
+    const assign = def.body.find((node: any) => node.type === "assignment");
     expect(assign.value.block.declaredYieldType).toEqual({
       type: "primitiveType",
       value: "string",
@@ -91,8 +105,8 @@ describe("guardDesugar — declaredYieldType stamping (#580)", () => {
     const nodes = desugarSource(
       'def f(): string {\n  const r = guard(cost: $1) {\n    return "x"\n  }\n  return "y"\n}\n',
     );
-    const def = nodes.find((n: any) => n.type === "function") as any;
-    const assign = def.body.find((n: any) => n.type === "assignment");
+    const def = nodes.find((node: any) => node.type === "function") as any;
+    const assign = def.body.find((node: any) => node.type === "assignment");
     expect(assign.value.block.declaredYieldType).toBeUndefined();
   });
 
@@ -100,8 +114,8 @@ describe("guardDesugar — declaredYieldType stamping (#580)", () => {
     const nodes = desugarSource(
       'def f(): string {\n  const r: string = guard(cost: $1) {\n    return "x"\n  }\n  return "y"\n}\n',
     );
-    const def = nodes.find((n: any) => n.type === "function") as any;
-    const assign = def.body.find((n: any) => n.type === "assignment");
+    const def = nodes.find((node: any) => node.type === "function") as any;
+    const assign = def.body.find((node: any) => node.type === "assignment");
     expect(assign.value.block.declaredYieldType).toBeUndefined();
   });
 
@@ -109,38 +123,98 @@ describe("guardDesugar — declaredYieldType stamping (#580)", () => {
     const nodes = desugarSource(
       'def f(): Result<string> {\n  return guard(cost: $1) {\n    return "x"\n  }\n}\n',
     );
-    const def = nodes.find((n: any) => n.type === "function") as any;
-    const ret = def.body.find((n: any) => n.type === "returnStatement");
+    const def = nodes.find((node: any) => node.type === "function") as any;
+    const ret = def.body.find((node: any) => node.type === "returnStatement");
     expect(ret.value.block.declaredYieldType).toEqual({
       type: "primitiveType",
       value: "string",
     });
   });
 
-  it("does NOT stamp a return-position guard inside another block (target resets)", () => {
-    // The return inside the fork branch yields to the BRANCH, not to
-    // f — stamping it with f's Result<string> would be the round-2
-    // mis-stamp. The branch has no yield type, so: no stamp.
+  it("stamps a return-position guard inside a NODE from the node's declared return", () => {
+    const nodes = desugarSource(
+      'node main(): Result<string> {\n  return guard(cost: $1) {\n    return "x"\n  }\n}\n',
+    );
+    const graphNode = nodes.find((node: any) => node.type === "graphNode") as any;
+    const ret = graphNode.body.find(
+      (node: any) => node.type === "returnStatement",
+    );
+    expect(ret.value.block.declaredYieldType).toEqual({
+      type: "primitiveType",
+      value: "string",
+    });
+  });
+
+  it("a return-position guard inside an `if` INHERITS the def target (positive counterpart to the resets)", () => {
+    const nodes = desugarSource(
+      'def f(cond: boolean): Result<string> {\n  if (cond) {\n    return guard(cost: $1) {\n      return "x"\n    }\n  }\n  return guard(cost: $1) { return "y" }\n}\n',
+    );
+    const def = nodes.find((node: any) => node.type === "function") as any;
+    const ifNode = def.body.find((node: any) => node.type === "ifElse");
+    const innerReturn = ifNode.thenBody.find(
+      (node: any) => node.type === "returnStatement",
+    );
+    expect(innerReturn.value.block.declaredYieldType).toEqual({
+      type: "primitiveType",
+      value: "string",
+    });
+  });
+
+  it("does NOT stamp a return-position guard inside a fork branch (block boundary resets)", () => {
     const nodes = desugarSource(
       'def f(): Result<string> {\n  const r = fork([1]) as n {\n    return guard(cost: $1) {\n      return "x"\n    }\n  }\n  return guard(cost: $1) { return "y" }\n}\n',
     );
-    const def = nodes.find((n: any) => n.type === "function") as any;
-    const forkAssign = def.body.find((n: any) => n.type === "assignment");
+    const def = nodes.find((node: any) => node.type === "function") as any;
+    const forkAssign = def.body.find((node: any) => node.type === "assignment");
     const innerReturn = forkAssign.value.block.body.find(
-      (n: any) => n.type === "returnStatement",
+      (node: any) => node.type === "returnStatement",
     );
     expect(innerReturn.value.block.declaredYieldType).toBeUndefined();
+  });
+
+  it("does NOT stamp a return-position guard inside an inline handler body (handler boundary resets)", () => {
+    const nodes = desugarSource(
+      'def f(): Result<string> {\n  handle {\n  return guard(cost: $1) { return "ok" }\n  } with (i) {\n    return guard(cost: $1) {\n      return "x"\n    }\n  }\n}\n',
+    );
+    const def = nodes.find((node: any) => node.type === "function") as any;
+    const handle = def.body.find((node: any) => node.type === "handleBlock");
+    const handlerReturn = handle.handler.body.find(
+      (node: any) => node.type === "returnStatement",
+    );
+    expect(handlerReturn.value.block.declaredYieldType).toBeUndefined();
+    // The guarded body itself INHERITS (a return there returns from f):
+    const bodyReturn = handle.body.find(
+      (node: any) => node.type === "returnStatement",
+    );
+    expect(bodyReturn.value.block.declaredYieldType).toEqual({
+      type: "primitiveType",
+      value: "string",
+    });
+  });
+
+  it("does NOT stamp a return-position guard inside a finalize body (finalize boundary resets)", () => {
+    const nodes = desugarSource(
+      'def f(): Result<string> {\n  return guard(cost: $1) { return "ok" }\n\n  finalize {\n    return guard(cost: $1) {\n      return "x"\n    }\n  }\n}\n',
+    );
+    const def = nodes.find((node: any) => node.type === "function") as any;
+    const finalize = def.body.find(
+      (node: any) => node.type === "finalizeBlock",
+    );
+    const finReturn = finalize.body.find(
+      (node: any) => node.type === "returnStatement",
+    );
+    expect(finReturn.value.block.declaredYieldType).toBeUndefined();
   });
 
   it("composes: a stamped guard block becomes the return target for its own body", () => {
     const nodes = desugarSource(
       'def f(): string {\n  const r: Result<Result<string>> = guard(cost: $1) {\n    return guard(cost: $1) {\n      return "x"\n    }\n  }\n  return "y"\n}\n',
     );
-    const def = nodes.find((n: any) => n.type === "function") as any;
-    const outer = def.body.find((n: any) => n.type === "assignment").value;
+    const def = nodes.find((node: any) => node.type === "function") as any;
+    const outer = def.body.find((node: any) => node.type === "assignment").value;
     expect(outer.block.declaredYieldType.type).toBe("resultType");
     const innerReturn = outer.block.body.find(
-      (n: any) => n.type === "returnStatement",
+      (node: any) => node.type === "returnStatement",
     );
     expect(innerReturn.value.block.declaredYieldType).toEqual({
       type: "primitiveType",
@@ -152,8 +226,8 @@ describe("guardDesugar — declaredYieldType stamping (#580)", () => {
     const nodes = desugarSource(
       'def f(): string {\n  const r: Result<number, string> = guard(cost: $1) {\n    return 1\n  }\n  return "y"\n}\n',
     );
-    const def = nodes.find((n: any) => n.type === "function") as any;
-    const assign = def.body.find((n: any) => n.type === "assignment");
+    const def = nodes.find((node: any) => node.type === "function") as any;
+    const assign = def.body.find((node: any) => node.type === "assignment");
     expect(assign.value.block.declaredYieldType).toEqual({
       type: "primitiveType",
       value: "number",
@@ -164,23 +238,47 @@ describe("guardDesugar — declaredYieldType stamping (#580)", () => {
     const nodes = desugarSource(
       'def f(): Result<string> {\n  guard(cost: $1) {\n    return "x"\n  }\n  return guard(cost: $1) { return "y" }\n}\n',
     );
-    const def = nodes.find((n: any) => n.type === "function") as any;
+    const def = nodes.find((node: any) => node.type === "function") as any;
     const stmt = def.body.find(
-      (n: any) => n.type === "functionCall" && n.functionName === "_guard",
+      (node: any) =>
+        node.type === "functionCall" && node.functionName === "_guard",
     );
     expect(stmt.block.declaredYieldType).toBeUndefined();
+  });
+
+  it("a second desugar run leaves the stamps unchanged (double-run stability)", () => {
+    const nodes = desugarSource(
+      'def f(): number {\n  const r: Result<string> = guard(cost: $1) {\n    return "x"\n  }\n  return 1\n}\n',
+    );
+    const before = JSON.stringify(nodes);
+    desugarGuardsInBody(nodes as any);
+    expect(JSON.stringify(nodes)).toBe(before);
   });
 });
 ```
 
-Delete the unused `guardBlockArgOf` sketch — each test reads its path directly, as written. If the existing file's helper is named differently than `desugarSource`, use the file's actual helper; if none parses source, add one with `parseAgency(src, {}, false)` + `desugarGuardsInBody(parsed.result.nodes)`. Check the exact AST shape of `Result<string>` annotations before asserting `primitiveType` (run `pnpm run ast` on a one-liner if unsure) and adjust the expected objects to the real parser output — the assertions above are the intent, the parser's shape is the truth.
+If the handler/finalize sources trip unrelated checker-free parse constraints (e.g. finalize needing a non-node scope — it is in a def here, fine), adjust the surrounding shell, not the assertion.
 
 - [ ] **Step 2: Run to verify failure**
 
 Run: `pnpm test:run lib/preprocessors/guardDesugar.test.ts 2>&1 | tee "$TMPDIR/desugar-stamp.log"`
-Expected: the new tests FAIL (`declaredYieldType` is undefined everywhere / field does not exist); existing tests still pass.
+Expected: the new tests FAIL; existing tests still pass.
 
-- [ ] **Step 3: Add the AST field**
+- [ ] **Step 3: Mark the retargeting slots and add the AST field**
+
+In `lib/utils/bodySlots.ts`: add to the exported `BodySlot` type:
+
+```ts
+  /** True when a `return` inside this slot's body yields to the slot's
+   *  own closure rather than the enclosing def: block arguments (the
+   *  __block_N lifting), inline handler bodies (their own arrow), and
+   *  finalize bodies (the __finalize closure). guardDesugar's return-
+   *  target rule keys on this — a new return-retargeting construct
+   *  must set it here or that feature silently mis-stamps. */
+  retargetsReturn?: boolean;
+```
+
+Set `retargetsReturn: true` on three slots: the `functionCall` block slot (the one that carries `blockAncestor`), the inline-handler slot in `case "handleBlock"` (the `n.handler.body` slot ONLY — `n.body` inherits), and the `case "finalizeBlock"` slot. While there, fix `blockAncestor`'s doc comment: it says "inline `block:` argument" but the code sets it for ANY block; change to "the functionCall's `block:` argument (inline or not)".
 
 In `lib/types/blockArgument.ts`:
 
@@ -196,30 +294,32 @@ export type BlockArgument = BaseNode & {
   inline?: boolean;
   /** The block's declared yield type, when the user wrote it adjacent
    *  to the guard this block belongs to: the `T` of a `Result<T>`
-   *  assignment annotation, or of the enclosing def's declared return
-   *  for a return-position guard. Stamped by guardDesugar (#580);
-   *  absent on every other block. Codegen reads it to type the
-   *  saveDraft schema and responseFormat inside the block. */
+   *  assignment annotation, or of the enclosing def/node's declared
+   *  return for a return-position guard. Stamped by guardDesugar
+   *  (#580); undefined on every other block. Codegen reads it to type
+   *  the saveDraft schema inside the block. */
   declaredYieldType?: VariableType;
 };
 ```
 
-(Fix the `VariableType` import path if `../types.js` does not export it — it does today.)
-
 - [ ] **Step 4: Rewrite the desugar walk with context**
 
-Replace the walk portion of `lib/preprocessors/guardDesugar.ts` (keep the module doc comment, updating its last paragraph):
+Replace the walk portion of `lib/preprocessors/guardDesugar.ts` (keep the module doc comment; update its final paragraph to mention the context). Note the shapes deliberately chosen per the review: `slotContext` and `stampFor` are the feature's two rules as pure functions; `desugarGuardBlock` stays a single literal (the optional field is ALWAYS assigned — absent and undefined are equivalent here, and `JSON.stringify` drops undefined keys so AST output is unchanged); `slot` is typed with the exported `BodySlot`.
 
 ```ts
 import { AgencyNode, VariableType } from "@/types.js";
+import { Assignment } from "@/types.js";
+import { FunctionDefinition } from "@/types/function.js";
+import { GraphNodeDefinition } from "@/types/graphNode.js";
 import { GuardBlock } from "@/types/guardBlock.js";
-import { bodySlots } from "@/utils/bodySlots.js";
+import { bodySlots, BodySlot } from "@/utils/bodySlots.js";
 
 /** The walk context: the type a `return` statement at this point in
  *  the tree yields to. Captured from the declared return when the
- *  walk enters a def/node body; RESET at every block body (a return
- *  inside a block yields to the BLOCK) — to the block's own stamp
- *  for a just-stamped guard block, to nothing for any other block.
+ *  walk enters a def/node body; RESET at every return-retargeting
+ *  slot (block arguments, inline handler bodies, finalize bodies —
+ *  marked by BodySlot.retargetsReturn) to that slot's own yield: the
+ *  stamp a guard block just received, nothing for any other closure.
  *  Absent at top level. */
 type DesugarContext = {
   returnTarget?: VariableType;
@@ -238,28 +338,50 @@ export function desugarGuardsInBody(
 /** `successType` of a Result annotation; undefined for anything else.
  *  The desugar never validates — a non-Result annotation simply
  *  stamps nothing, and the checker owns diagnosing it. */
-function yieldTypeFrom(t: VariableType | null | undefined): VariableType | undefined {
-  if (t && t.type === "resultType") return t.successType;
+function yieldTypeFrom(
+  t: VariableType | null | undefined,
+): VariableType | undefined {
+  if (t && t.type === "resultType") {
+    return t.successType;
+  }
   return undefined;
 }
 
-/** The context a slot's body walks under: block bodies RESET the
- *  return target to the block's own yield (undefined for non-guard
- *  blocks); def/node bodies capture the declared return; every other
- *  body inherits. */
+/** The context a slot's body walks under: return-retargeting slots
+ *  RESET the target to the slot's own yield (a guard block's stamp;
+ *  nothing for handlers/finalizes/other blocks — on the second
+ *  desugar run the blockAncestor read returns run-1 stamps, which is
+ *  when it earns its keep); def/node bodies capture the declared
+ *  return; every other body inherits. */
 function slotContext(
   node: AgencyNode,
-  slot: { blockAncestor?: { declaredYieldType?: VariableType } },
+  slot: BodySlot,
   ctx: DesugarContext,
 ): DesugarContext {
-  if (slot.blockAncestor) {
-    return { returnTarget: slot.blockAncestor.declaredYieldType };
+  if (slot.retargetsReturn) {
+    return { returnTarget: slot.blockAncestor?.declaredYieldType };
   }
   if (node.type === "function" || node.type === "graphNode") {
-    const declared = (node as { returnType?: VariableType | null }).returnType;
-    return { returnTarget: declared ?? undefined };
+    const def = node as FunctionDefinition | GraphNodeDefinition;
+    return { returnTarget: def.returnType ?? undefined };
   }
   return ctx;
+}
+
+/** The type a guard sitting in this node's `value` slot is stamped
+ *  with: an assignment names its own slot; a return yields to the
+ *  current return target; anything else stamps nothing. */
+function stampFor(
+  node: AgencyNode,
+  ctx: DesugarContext,
+): VariableType | undefined {
+  if (node.type === "assignment") {
+    return yieldTypeFrom((node as Assignment).typeHint);
+  }
+  if (node.type === "returnStatement") {
+    return yieldTypeFrom(ctx.returnTarget);
+  }
+  return undefined;
 }
 
 function desugarNode(node: AgencyNode, ctx: DesugarContext): AgencyNode {
@@ -270,23 +392,17 @@ function desugarNode(node: AgencyNode, ctx: DesugarContext): AgencyNode {
   for (const slot of bodySlots(node)) {
     desugarGuardsInBody(slot.body, slotContext(node, slot, ctx));
   }
-  // Parent-aware value follow (spec round 2): the two positions that
-  // can stamp are handled by holder type; everything else follows the
-  // generic path with no stamp source.
-  const holder = node as { value?: unknown; typeHint?: VariableType | null };
+  const holder = node as { value?: unknown };
   const value = holder.value;
   if (!value || typeof value !== "object" || !("type" in (value as object))) {
     return node;
   }
   const valueNode = value as AgencyNode;
   if (valueNode.type === "guardBlock") {
-    let stamp: VariableType | undefined;
-    if (node.type === "assignment") {
-      stamp = yieldTypeFrom(holder.typeHint);
-    } else if (node.type === "returnStatement") {
-      stamp = yieldTypeFrom(ctx.returnTarget);
-    }
-    holder.value = desugarGuardBlock(valueNode as GuardBlock, stamp);
+    holder.value = desugarGuardBlock(
+      valueNode as GuardBlock,
+      stampFor(node, ctx),
+    );
     return node;
   }
   const rewritten = desugarNode(valueNode, ctx);
@@ -303,83 +419,111 @@ function desugarGuardBlock(
   // The head arguments forward VERBATIM (unchanged from #574). The
   // stamp, when present, becomes the return target for the block's
   // own body — which is how nested return-position guards compose.
-  const block: {
-    type: "blockArgument";
-    inline: boolean;
-    params: never[];
-    body: AgencyNode[];
-    declaredYieldType?: VariableType;
-  } = {
-    type: "blockArgument",
-    inline: false,
-    params: [],
-    body: [],
-  };
-  if (yieldType !== undefined) {
-    block.declaredYieldType = yieldType;
-  }
-  block.body = desugarGuardsInBody(g.body, { returnTarget: yieldType });
+  // declaredYieldType is always assigned: absent and undefined are
+  // equivalent for every consumer, and JSON.stringify drops undefined
+  // keys, so AST output for unstamped guards is unchanged.
   return {
     type: "functionCall",
     functionName: "_guard",
     arguments: g.arguments,
-    block,
+    block: {
+      type: "blockArgument",
+      inline: false,
+      params: [],
+      declaredYieldType: yieldType,
+      body: desugarGuardsInBody(g.body, { returnTarget: yieldType }),
+    },
     scope: "imported",
     loc: g.loc,
   } as unknown as AgencyNode;
 }
 ```
 
-Check the real field names before finishing: the assignment annotation field (`typeHint` — verify on the `Assignment` type) and def/node return fields (`returnType` on both `FunctionDefinition` and `GraphNodeDefinition`). Adjust the casts to the actual types rather than `any` where the imports are cheap.
+Verify `Assignment` is exported from `@/types.js` (it is — `types.ts:221`) and adjust imports if the real paths differ.
 
 - [ ] **Step 5: Run the tests**
 
 Run: `pnpm test:run lib/preprocessors/guardDesugar.test.ts lib/typeChecker/guardConstruct.test.ts 2>&1 | tee "$TMPDIR/desugar-stamp2.log"`
-Expected: PASS, including the pre-existing desugar and guard-construct suites (the checker runs the same desugar in its constructor — the context default keeps it identical for unannotated code).
+Expected: PASS, including the pre-existing suites.
 
 - [ ] **Step 6: Typecheck and commit**
 
 ```bash
 pnpm exec tsc --noEmit 2>&1 | tee "$TMPDIR/tsc-580-1.log"
 git branch --show-current   # must be guard-annotation-threading
-printf 'feat: guardDesugar stamps Result<T> annotations onto guard block arguments\n\nCo-Authored-By: Claude Fable 5 <noreply@anthropic.com>\n' > "$TMPDIR/cm.txt"
-git add packages/agency-lang/lib/types/blockArgument.ts packages/agency-lang/lib/preprocessors/guardDesugar.ts packages/agency-lang/lib/preprocessors/guardDesugar.test.ts
+printf 'feat: guardDesugar stamps Result annotations onto guard block arguments\n\nCo-Authored-By: Claude Fable 5 <noreply@anthropic.com>\n' > "$TMPDIR/cm.txt"
+git add packages/agency-lang/lib/utils/bodySlots.ts packages/agency-lang/lib/types/blockArgument.ts packages/agency-lang/lib/preprocessors/guardDesugar.ts packages/agency-lang/lib/preprocessors/guardDesugar.test.ts
 git commit -F "$TMPDIR/cm.txt"
 ```
 
 ---
 
-### Task 2: Builder plumbing — the stamp reaches both consumers
+### Task 2: The stamp reaches the draftSchema lookup
 
 **Files:**
-- Modify: `lib/types.ts` (`BlockScope`, ~line 176)
-- Modify: `lib/backends/typescriptBuilder.ts` (`processBlockArgument`, the `scopes.push({ type: "block", blockName })` at ~1775; the stale comment at ~3181)
-- Modify: `lib/backends/typescriptBuilder/scopeManager.ts` (`returnType()` block case; `enclosingDeclaredReturnType()` walk)
-- Test: `lib/backends/draftSchemaCodegen.test.ts` (extend)
+- Modify: `lib/types.ts` (`BlockScope`), `lib/backends/typescriptBuilder.ts` (~1775), `lib/backends/typescriptBuilder/scopeManager.ts`
+- Test: `lib/backends/typescriptBuilder/scopeManager.test.ts` (extend), `lib/backends/draftSchemaCodegen.test.ts` (extend)
 
 **Interfaces:**
 - Consumes: `BlockArgument.declaredYieldType` (Task 1).
-- Produces: `BlockScope.declaredYieldType?: VariableType`; `returnType()` answers a stamped block's yield; `enclosingDeclaredReturnType()` walks innermost-first and returns the FIRST answer (stamped block, else nearest function/node declared return, else undefined).
+- Produces: `BlockScope.declaredYieldType?: VariableType`; `enclosingDeclaredReturnType()` returns a stamped block's yield before walking outward. `returnType()` is NOT touched (descope).
 
-- [ ] **Step 1: Write the failing codegen tests**
+- [ ] **Step 1: Write the failing ScopeManager unit tests**
 
-Append to `lib/backends/draftSchemaCodegen.test.ts` (its `gen` helper already exists):
+Read `lib/backends/typescriptBuilder/scopeManager.test.ts` and reuse its construction pattern (it builds a `ScopeManager` and pushes scopes directly). Append — adjusting the constructor/compilationUnit stub to the file's existing idiom:
+
+```ts
+describe("enclosingDeclaredReturnType — stamped blocks (#580)", () => {
+  const STR = { type: "primitiveType", value: "string" } as any;
+
+  it("a stamped block answers its yield", () => {
+    const scopes = makeScopeManagerWithFunction("f", /* returnType */ undefined);
+    scopes.push({ type: "block", blockName: "b1", declaredYieldType: STR });
+    expect(scopes.enclosingDeclaredReturnType()).toEqual(STR);
+  });
+
+  it("an unstamped block defers to a stamped outer block", () => {
+    const scopes = makeScopeManagerWithFunction("f", undefined);
+    scopes.push({ type: "block", blockName: "outer", declaredYieldType: STR });
+    scopes.push({ type: "block", blockName: "inner" });
+    expect(scopes.enclosingDeclaredReturnType()).toEqual(STR);
+  });
+
+  it("an unstamped block defers to the function's declared return", () => {
+    const scopes = makeScopeManagerWithFunction("f", STR);
+    scopes.push({ type: "block", blockName: "b1" });
+    expect(scopes.enclosingDeclaredReturnType()).toEqual(STR);
+  });
+
+  it("a stamped block under a node answers the stamp, not the node", () => {
+    const scopes = makeScopeManagerWithNode("main", /* returnType */ { type: "primitiveType", value: "number" } as any);
+    scopes.push({ type: "block", blockName: "b1", declaredYieldType: STR });
+    expect(scopes.enclosingDeclaredReturnType()).toEqual(STR);
+  });
+});
+```
+
+Write the two `makeScopeManagerWith...` helpers against the file's real `CompilationUnit` stubbing (or reuse its existing fixtures) — the tests' point is the walk order, not the stub shape.
+
+- [ ] **Step 2: Write the failing codegen tests**
+
+Append to `lib/backends/draftSchemaCodegen.test.ts`:
 
 ```ts
 describe("draftSchema threading — guard annotations (#580)", () => {
   it("an annotated assignment beats the enclosing def's type", () => {
-    // def declares Report-ish; the guard annotation says string; the
-    // schema must follow the annotation (the slot), not the def.
     const out = gen(
       'type Report = { title: string }\ndef f(): Report {\n  const notes: Result<string> = guard(cost: $1) {\n    return llm("hi", tools: [print])\n  }\n  if (isSuccess(notes)) { return { title: notes.value } }\n  return { title: "x" }\n}\nnode main() { const x = f()\n return "ok" }\n',
     );
     expect(out).toContain("draftSchema: z.string()");
+    // The fallback would render the def's Report as an object schema.
+    expect(out).not.toMatch(/draftSchema: z\.object\(/);
     expect(out).not.toContain("draftSchema: Report");
   });
 
   it("a return-position guard unwraps the declared Result return", () => {
-    // Today this threads the WHOLE Result shape from the def walk;
-    // with the stamp it must be the unwrapped T.
+    // Pre-change this call site threads the WHOLE Result-shaped zod;
+    // z.string() can only appear if the unwrap works.
     const out = gen(
       'def f(): Result<string> {\n  return guard(cost: $1) {\n    return llm("hi", tools: [print])\n  }\n}\nnode main() { const x = f()\n return "ok" }\n',
     );
@@ -391,39 +535,34 @@ describe("draftSchema threading — guard annotations (#580)", () => {
       'type Report = { title: string }\ndef f(): Report {\n  const outer: Result<string> = guard(cost: $1) {\n    const inner = guard(cost: $0.1) {\n      return llm("hi", tools: [print])\n    }\n    if (isSuccess(inner)) { return inner.value }\n    return "x"\n  }\n  return { title: "x" }\n}\nnode main() { const x = f()\n return "ok" }\n',
     );
     expect(out).toContain("draftSchema: z.string()");
-    expect(out).not.toContain("draftSchema: Report");
+    expect(out).not.toMatch(/draftSchema: z\.object\(/);
   });
 
-  it("responseFormat inside an annotated guard follows the annotation", () => {
-    // A structured annotation must produce a structured responseFormat
-    // for `return llm(...)` in the block — the documented limitation
-    // being fixed. (A string annotation is indistinguishable from the
-    // old default, which is why this test uses an object type.)
+  it("a structured annotation threads an OBJECT draftSchema (the assertion no fixture can make)", () => {
+    // The llm result binds through an annotated local so the checker
+    // accepts the block yield (a bare `return llm()` infers string
+    // and errors against Result<{title}> — see #582).
     const out = gen(
-      'def f(): Result<{ title: string }> {\n  return guard(cost: $1) {\n    return llm("hi")\n  }\n}\nnode main() { const x = f()\n return "ok" }\n',
+      'def f(): string {\n  const r: Result<{ title: string }> = guard(cost: $1) {\n    const report: { title: string } = llm("hi", tools: [print])\n    return report\n  }\n  return "y"\n}\nnode main() { return f() }\n',
     );
-    expect(out).toMatch(/responseFormat: z\.object\(/);
+    expect(out).toMatch(/draftSchema: z\.object\(/);
   });
 
-  it("an unannotated guard keeps the old fallbacks (byte-stability spot check)", () => {
+  it("an unannotated guard keeps the #578 fallbacks (byte-stability spot check)", () => {
     const out = gen(
       'def f(): string {\n  const r = guard(cost: $1) {\n    return llm("hi", tools: [print])\n  }\n  if (isSuccess(r)) { return r.value }\n  return "x"\n}\nnode main() { return f() }\n',
     );
-    // Falls through to the def's declared string, exactly as in #578.
     expect(out).toContain("draftSchema: z.string()");
-    expect(out).not.toContain("responseFormat");
   });
 });
 ```
 
-Before finalizing the `responseFormat` assertion, check how `processLlmCall` renders a structured response format (`$.z().prop("object").namedArgs(...)` — see typescriptBuilder.ts:3641) and match the real emitted text (it may render as `responseFormat: z.object({ response: ... })`); the assertions are intent, the emitted shape is truth.
+- [ ] **Step 3: Run to verify failure**
 
-- [ ] **Step 2: Run to verify failure**
+Run: `pnpm test:run lib/backends/typescriptBuilder/scopeManager.test.ts lib/backends/draftSchemaCodegen.test.ts 2>&1 | tee "$TMPDIR/580-codegen.log"`
+Expected: the new tests FAIL (`declaredYieldType` unknown on `BlockScope`; walk ignores stamps; return-position threads the Result shape).
 
-Run: `pnpm test:run lib/backends/draftSchemaCodegen.test.ts 2>&1 | tee "$TMPDIR/580-codegen.log"`
-Expected: the four new threading tests FAIL (annotation ignored, Result shape threaded, no responseFormat); the byte-stability spot check may already pass.
-
-- [ ] **Step 3: Add the scope field and copy the stamp**
+- [ ] **Step 4: Implement — one field, one copy, one predicate, one switch arm**
 
 In `lib/types.ts`:
 
@@ -437,77 +576,47 @@ export type BlockScope = {
 };
 ```
 
-In `lib/backends/typescriptBuilder.ts`, `processBlockArgument` (~1775):
+In `lib/backends/typescriptBuilder.ts`, `processBlockArgument` (~1775) — the ONLY push site guards reach (`processBlockAsExpression` at 1829 and the fork lowering at 2852 never carry a guard's block argument; leave them):
 
 ```ts
-this.scopes.push({
-  type: "block",
-  blockName,
-  declaredYieldType: block.declaredYieldType,
-});
+    this.scopes.push({
+      type: "block",
+      blockName,
+      declaredYieldType: block.declaredYieldType,
+    });
 ```
 
-- [ ] **Step 4: Teach the two lookups**
-
-In `lib/backends/typescriptBuilder/scopeManager.ts`, `returnType()` — replace the `case "block"` arm and trim the now-stale part of its doc comment:
+In `lib/backends/typescriptBuilder/scopeManager.ts`, `enclosingDeclaredReturnType()` — keep the method's existing structure (plan review A2: the diff is one predicate and one switch arm, not a rewrite):
 
 ```ts
+    // Innermost-first: the nearest scope with an ANSWER — a stamped
+    // guard block (#580), else the nearest non-block scope.
+    const owner = [...this.stack]
+      .reverse()
+      .find(
+        (scope) =>
+          scope.type !== "block" || scope.declaredYieldType !== undefined,
+      );
+    if (owner === undefined) return undefined;
+    switch (owner.type) {
       case "block":
-        // Annotated guard blocks carry their yield (#580); every
-        // other block still has no declared type.
-        return scope.declaredYieldType ?? undefined;
+        return owner.declaredYieldType;
+      case "function":
+        ...existing arm unchanged...
 ```
-
-And `enclosingDeclaredReturnType()` — the walk now takes the first ANSWER, not the first non-block scope:
-
-```ts
-  enclosingDeclaredReturnType(): VariableType | undefined {
-    // Innermost-first, first answer wins: a stamped guard block
-    // answers its yield; an unstamped block defers outward; the
-    // nearest function/node answers its declared return; global ends
-    // the walk. (Only function/node/block are ever pushed over the
-    // root global — the invariant returnType()'s throwing default
-    // relies on.)
-    for (const scope of [...this.stack].reverse()) {
-      if (scope.type === "block") {
-        if (scope.declaredYieldType !== undefined) {
-          return scope.declaredYieldType;
-        }
-        continue;
-      }
-      if (scope.type === "function") {
-        return (
-          this.compilationUnit.functionDefinitions[scope.functionName]
-            ?.returnType ?? undefined
-        );
-      }
-      if (scope.type === "node") {
-        return (
-          this.compilationUnit.graphNodes.find(
-            (n) => n.nodeName === scope.nodeName,
-          )?.returnType ?? undefined
-        );
-      }
-      return undefined; // global
-    }
-    return undefined;
-  }
-```
-
-(A `for...of` over a reversed copy with an early `continue` — the two-list `.find` from #578 cannot express "skip unstamped blocks but stop at stamped ones".) Also update the stale comment at `typescriptBuilder.ts:3181` ("The block's declared return type is unknown to the builder") to say annotated guard blocks are now the exception.
 
 - [ ] **Step 5: Run the tests**
 
-Run: `pnpm test:run lib/backends/draftSchemaCodegen.test.ts lib/backends/ 2>&1 | tee "$TMPDIR/580-codegen2.log"`
-Expected: all PASS, including the whole backends suite (the unannotated paths are unchanged).
+Run: `pnpm test:run lib/backends/ 2>&1 | tee "$TMPDIR/580-codegen2.log"`
+Expected: all PASS (the unannotated paths are unchanged, so the whole backends suite stays green).
 
 - [ ] **Step 6: Typecheck and commit**
 
 ```bash
 pnpm exec tsc --noEmit 2>&1 | tee "$TMPDIR/tsc-580-2.log"
 git branch --show-current
-printf 'feat: stamped guard yields reach draftSchema and responseFormat\n\nCo-Authored-By: Claude Fable 5 <noreply@anthropic.com>\n' > "$TMPDIR/cm.txt"
-git add packages/agency-lang/lib/types.ts packages/agency-lang/lib/backends/typescriptBuilder.ts packages/agency-lang/lib/backends/typescriptBuilder/scopeManager.ts packages/agency-lang/lib/backends/draftSchemaCodegen.test.ts
+printf 'feat: stamped guard yields reach the saveDraft draftSchema lookup\n\nCo-Authored-By: Claude Fable 5 <noreply@anthropic.com>\n' > "$TMPDIR/cm.txt"
+git add packages/agency-lang/lib/types.ts packages/agency-lang/lib/backends/typescriptBuilder.ts packages/agency-lang/lib/backends/typescriptBuilder/scopeManager.ts packages/agency-lang/lib/backends/typescriptBuilder/scopeManager.test.ts packages/agency-lang/lib/backends/draftSchemaCodegen.test.ts
 git commit -F "$TMPDIR/cm.txt"
 ```
 
@@ -517,10 +626,6 @@ git commit -F "$TMPDIR/cm.txt"
 
 **Files:**
 - Create: `tests/agency/guards/savedraft-annotated-structured.agency` + `.test.json`
-- No other code changes (verification + PR prep).
-
-**Interfaces:**
-- Consumes: Tasks 1 + 2.
 
 - [ ] **Step 1: Write the fixture**
 
@@ -545,7 +650,7 @@ node main() {
 }
 ```
 
-(The `const report: { title: string } = llm(...)` shape keeps the checker happy: it types the llm call via the assignment annotation, so the block's inferred yield matches the guard annotation. A bare `return llm(...)` would infer string and error against `Result<{ title: string }>`.)
+(The annotated-local shape keeps the checker happy — a bare `return llm(...)` infers string and errors against `Result<{ title: string }>`; see #582.)
 
 `tests/agency/guards/savedraft-annotated-structured.test.json`:
 
@@ -576,7 +681,7 @@ make 2>&1 | tail -1
 pnpm run agency test tests/agency/guards/savedraft-annotated-structured.agency 2>&1 | tee "$TMPDIR/fx-580.log"
 ```
 
-Expected: PASS. If the checker rejects the guard-block typing, read the error before touching the fixture — the annotated-llm-assignment shape above is the intended fix for exactly that class of error.
+Expected: PASS.
 
 - [ ] **Step 3: Byte-stability + spot-check the #578 fixtures**
 
@@ -588,7 +693,7 @@ for f in savedraft-tool-basic savedraft-tool-order finalize-binder-returns-draft
 done
 ```
 
-Expected: no tracked-file churn; the three #578 fixtures still pass (they are all unannotated, so their generated code must be unchanged).
+Expected: no tracked-file churn; the three #578 fixtures still pass (all unannotated, so their generated code must be unchanged).
 
 - [ ] **Step 4: Full unit suite, lint, anti-pattern audit**
 
@@ -597,27 +702,15 @@ pnpm test:run 2>&1 | tee "$TMPDIR/580-unit.log" | tail -3
 pnpm run lint:structure 2>&1 | tail -2
 ```
 
-Expected: clean. Then audit `git diff main...HEAD` against `docs/dev/anti-patterns.md` (the walk rewrite in Task 1 is the spot to scrutinize: no order-dependent mutable state — the context is passed, never stored on the module or the walker).
+Then audit `git diff main...HEAD` against `docs/dev/anti-patterns.md` (the review's A-findings are already folded into the drafted code; verify the executed code kept them).
 
 - [ ] **Step 5: As-executed spec notes, commit, PR**
 
-Append an "As executed" section to `docs/superpowers/specs/2026-07-17-guard-annotation-threading-design.md` recording any deviations discovered during execution. Commit the fixture + spec note, then open the PR:
-
-```bash
-git branch --show-current
-printf 'test: structured-annotation saveDraft fixture; as-executed spec notes\n\nCo-Authored-By: Claude Fable 5 <noreply@anthropic.com>\n' > "$TMPDIR/cm.txt"
-git add packages/agency-lang/tests/agency/guards/savedraft-annotated-structured.agency packages/agency-lang/tests/agency/guards/savedraft-annotated-structured.test.json docs/superpowers/specs/2026-07-17-guard-annotation-threading-design.md
-git commit -F "$TMPDIR/cm.txt"
-git push -u origin guard-annotation-threading
-```
-
-Write the PR body to a file (link issue #580 and the spec; state the deliberate behavior change — structured `responseFormat` inside annotated guard blocks — and its justification from decision 1; list the doc follow-up: llm.md's block-limitation note is owner-authored and needs its exception sentence). End with the Claude Code attribution, then `gh pr create --title "Thread guard Result<T> annotations into block codegen (#580)" --body-file ...`.
+Append an "As executed" section to the spec recording deviations. Commit, push, and open the PR. The PR body must: link #580 and #582 and the spec; state the DESCOPE plainly (draftSchema only; responseFormat proved unreachable in natural type-correct programs, blocked on checker expected-type propagation — #582 — which will consume the same stamp); note llm.md's limitation note stays true until #582; end with the Claude Code attribution.
 
 ---
 
-## Self-review notes (checked against the spec)
+## Self-review notes
 
-- **Spec coverage:** Part 2 mechanism steps 1-4 map to Tasks 1 (stamp + context + reset) and 2 (scope copy + both lookups); the walk rule is pinned by the nested codegen test and the fork-branch desugar test; failure modes (non-Result annotation, `Result<T, E>`, statement position) each have a Task 1 test; Part 3's test list maps 1:1, with the fixture's honesty note carried into the fixture comment itself; Part 4 exclusions (inferred yields, `let`-then-assign, non-guard blocks, aliases, llm.md) have no tasks, correctly.
-- **Round-2 fixes honored:** the plan owns the context plumbing as structural work (Task 1 Step 4 is a rewrite, not a patch), and the return-target reset at block bodies is implemented via `slotContext`'s `blockAncestor` branch and pinned by the fork-branch test.
-- **Type consistency:** `declaredYieldType?: VariableType` is the same name on `BlockArgument` (Task 1), `BlockScope` (Task 2), and both ScopeManager reads; `desugarGuardsInBody(body, ctx = {})` keeps both existing entry points source-compatible.
-- **Known honesty point:** the e2e fixture cannot distinguish threaded-vs-fallback outcomes (deterministic client ignores schemas; mismatched saves are kept) — stated in the Background and in the fixture's own comment; the codegen tests are the distinguishing layer.
+- **All three review layers folded:** finding 1 → `retargetsReturn` at the `bodySlots` source of truth + handler/finalize/fork no-stamp tests + inherit-branch and graphNode positives (M3/M4/M5); finding 2/M8 → the structured `z.object` draftSchema assertion; finding 3/M6 → double-run test + the run-2 comment; finding 4 → push-site sentence in Task 2 Step 4; finding 5/T2/T3/T4 → sketch deleted, negatives rewritten to the shape the fallback actually emits, discriminating def types, whole-file responseFormat scan gone (with the descope); M1 → direct ScopeManager tests; M2 → moot (returnType untouched); M7 → the `let` test. A1 → `stampFor`; A2 → predicate + arm, no rewrite; A3 → single literal, always-assigned field; A4 → `BodySlot`/`FunctionDefinition`/`GraphNodeDefinition` types; A5 → braced; A6 → moot.
+- **T1 resolved by owner decision:** responseFormat descoped; #582 filed; spec decision 1 rewritten; `returnType()` untouched, which also moots M2/A6 and shrinks Task 2 to one field + one copy + one predicate + one arm.

--- a/docs/superpowers/specs/2026-07-17-guard-annotation-threading-design.md
+++ b/docs/superpowers/specs/2026-07-17-guard-annotation-threading-design.md
@@ -85,14 +85,43 @@ the eventual subsumer of this spec, recorded in Part 4.
 
 The chosen mechanism is pure data flow — the type rides the AST node:
 
-1. **`guardDesugar` stamps.** The desugar pass already walks every
-   position a guard can appear in, and it sees the surrounding
-   context the builder later cannot: when the guard sits in
-   `assignment.value` it reads the assignment's `typeHint`; when it
-   sits in `return.value` it knows the enclosing def's declared
-   return type (threaded down its walk as a parameter). If that
-   context type is a `resultType`, the pass stamps its `successType`
-   onto the `BlockArgument` it creates for the block body.
+1. **`guardDesugar` stamps.** An honesty note first (owner review
+   round 2): the desugar does NOT currently see any surrounding
+   context. Its walk (`desugarNode`) follows registered body slots
+   and a generic `holder.value` field with no parent-awareness and
+   threads nothing downward. Making it context-aware is real
+   structural work this spec is adding, and the plan owns it:
+
+   - **A walk context parameter.** `desugarGuardsInBody` /
+     `desugarNode` gain a context argument carrying one value: the
+     **current return target** — the type a `return` statement at
+     this point in the tree yields to.
+   - **Def-return capture on body entry.** When the walk enters a
+     `function` or `graphNode` body, the context's return target
+     becomes that def's declared `returnType` (or absent when
+     undeclared).
+   - **Parent-awareness at the value-follow.** The generic
+     `holder.value` follow splits by holder: an `assignment` holder
+     stamps its guard from the assignment's own `typeHint`; a
+     `returnStatement` holder stamps from the context's current
+     return target. Other holders stamp nothing.
+
+   **The return target resets at every block body** — this is the
+   round-2 gap fix. A `return` inside a block argument yields to the
+   BLOCK, not to the def, so when the walk enters any block body the
+   target resets to that block's own yield type: the stamp the block
+   just received, if it is a guard block that got one, and absent
+   otherwise. Without this reset, a return-position guard inside a
+   fork branch (or any block) would mis-stamp with the def's return
+   type — a type that has nothing to do with the block it actually
+   yields to. With it, stamping composes: in
+   `const r: Result<Result<string>> = guard(...) { return guard(...)
+   { ... } }` the outer stamp (`Result<string>`) becomes the return
+   target inside the outer block, so the inner guard stamps `string`.
+
+   In every stamping position, the rule is the same: if the source
+   type is a `resultType`, stamp its `successType` onto the
+   `BlockArgument` the desugar creates; otherwise stamp nothing.
 2. **`BlockArgument` gains the field.**
    `declaredYieldType?: VariableType` — optional, absent everywhere
    except stamped guard blocks. (The stamp is on the BLOCK ARGUMENT

--- a/docs/superpowers/specs/2026-07-17-guard-annotation-threading-design.md
+++ b/docs/superpowers/specs/2026-07-17-guard-annotation-threading-design.md
@@ -291,3 +291,26 @@ unchanged everywhere (decision 1 / #582).
   which will consume this spec's stamp when it lands.
 - llm.md's limitation note update — owner-authored file (note the
   responseFormat half of that note now stays true until #582).
+
+---
+
+## As executed (2026-07-18, `guard-annotation-threading` branch)
+
+Execution matched the reviewed plan with three notes:
+
+1. **`bodySlots` also marks the standalone `blockArgument` case.** The
+   plan named three retargeting slots (functionCall block, inline
+   handler, finalize). Execution also set `retargetsReturn` on the
+   standalone `blockArgument` case's slot — if a walk ever descends
+   into a block-as-expression body, its returns retarget too. (The
+   desugar walk cannot currently reach a guard there — the walk does
+   not descend into call arguments, a pre-existing #574 property —
+   so this is defensive marking at the source of truth, not reachable
+   behavior.)
+2. **The structured fixture's generated code was inspected directly:**
+   `draftSchema: z.object({ "title": z.string() ... })` appears in the
+   compiled fixture JS, confirming the non-fallback path end to end
+   beyond the salvage outcome.
+3. **Byte-stability held exactly:** zero tracked-file churn after
+   `make fixtures`; the #578 fixtures (all unannotated) pass
+   unchanged; full unit suite 8594 green.

--- a/docs/superpowers/specs/2026-07-17-guard-annotation-threading-design.md
+++ b/docs/superpowers/specs/2026-07-17-guard-annotation-threading-design.md
@@ -44,20 +44,29 @@ assignment's value, in a scope that carries no type information.
 ### What this spec does
 
 Move the annotation from where the user wrote it to where the block
-compiles. When it arrives, both consumers use it: the saveDraft
-schema unwraps `T` from `Result<T>`, and `return llm(...)` inside the
-block gets `T`-shaped structured output.
+compiles. The saveDraft schema unwraps `T` from `Result<T>` and uses
+it as the tool's value schema.
 
-### Decisions from the brainstorm (owner, 2026-07-17)
+### Decisions from the brainstorm and reviews (owner, 2026-07-17)
 
-1. **Both consumers in v1**, not just draftSchema. Fixing
-   responseFormat changes behavior for existing programs — a
-   `return llm(...)` inside an annotated guard switches from string
-   to structured output — but that is the documented limitation being
-   fixed, and it fires only where the user explicitly wrote
-   `Result<T>`. The change does what the annotation says. llm.md's
-   limitation note needs a touch-up (owner-authored file; flagged,
-   not edited here).
+1. **draftSchema only — responseFormat is DESCOPED** (plan review
+   T1, overturning the original "both consumers" decision on
+   empirical grounds). The plan review verified that no natural
+   type-correct program exists where a responseFormat stamp changes
+   behavior: a structured annotation with `return llm(...)` fails
+   AG2001 (the checker infers `string` with no expected type pushed
+   inward), and the shape that does compile (an annotated local
+   holding the llm result) already gets its responseFormat from the
+   assignment hint. The one reachable shape — an annotation WIDER
+   than the inferred llm type (`Result<string | number>` +
+   `return llm()`) — is exactly the case where structured output
+   would produce runtime values the checker statically typed away.
+   So `ScopeManager.returnType()` is NOT touched; only the
+   draftSchema lookup changes. The responseFormat fix is blocked on
+   checker expected-type propagation, tracked in #582; the codegen
+   plumbing this spec ships (the stamp on the block scope) is the
+   same plumbing #582 will consume, so re-adding responseFormat
+   later is a two-line change.
 2. **Two annotation forms**: the annotated assignment
    (`const r: Result<T> = guard(...) { }`, `let` alike) and the
    return-position guard (`return guard(...) { }` inside a def
@@ -106,18 +115,27 @@ The chosen mechanism is pure data flow — the type rides the AST node:
      `returnStatement` holder stamps from the context's current
      return target. Other holders stamp nothing.
 
-   **The return target resets at every block body** — this is the
-   round-2 gap fix. A `return` inside a block argument yields to the
-   BLOCK, not to the def, so when the walk enters any block body the
-   target resets to that block's own yield type: the stamp the block
-   just received, if it is a guard block that got one, and absent
-   otherwise. Without this reset, a return-position guard inside a
-   fork branch (or any block) would mis-stamp with the def's return
-   type — a type that has nothing to do with the block it actually
-   yields to. With it, stamping composes: in
-   `const r: Result<Result<string>> = guard(...) { return guard(...)
-   { ... } }` the outer stamp (`Result<string>`) becomes the return
-   target inside the outer block, so the inner guard stamps `string`.
+   **The return target resets at every return-retargeting boundary**
+   — this is the round-2 gap fix, widened by plan-review finding 1.
+   A `return` inside a block argument yields to the BLOCK, not to the
+   def — and the same is true inside an inline handler body (its own
+   arrow function) and a finalize body (the `__finalize` closure). So
+   `bodySlots`, the declared single source of truth for body shapes,
+   gains a per-slot `retargetsReturn` marker, set on the functionCall
+   block slot, the inline-handler slot, and the finalizeBlock slot.
+   When the walk enters a retargeting slot, the target resets to that
+   slot's own yield type: the stamp the block just received for a
+   guard block, absent for everything else. Without this reset, a
+   return-position guard inside a fork branch, a handler, or a
+   finalize would mis-stamp with the def's return type — silently,
+   since the stamp only feeds best-effort schemas. Keying the rule on
+   the `bodySlots` marker (not on node types) means the next
+   return-retargeting construct gets handled by whoever adds its
+   `bodySlots` case instead of silently regressing this feature. With
+   the reset, stamping composes: in `const r: Result<Result<string>>
+   = guard(...) { return guard(...) { ... } }` the outer stamp
+   (`Result<string>`) becomes the return target inside the outer
+   block, so the inner guard stamps `string`.
 
    In every stamping position, the rule is the same: if the source
    type is a `resultType`, stamp its `successType` onto the
@@ -130,18 +148,23 @@ The chosen mechanism is pure data flow — the type rides the AST node:
 3. **`processBlockArgument` copies the stamp onto the scope.** The
    `BlockScope` entry it pushes gains the same optional field:
    `{ type: "block", blockName, declaredYieldType }`.
-4. **The two ScopeManager lookups answer block-first.**
-   `returnType()` (the responseFormat source for `return llm(...)`)
-   answers a block scope's `declaredYieldType` when present, keeping
-   `undefined` otherwise. `enclosingDeclaredReturnType()` (the
-   draftSchema source) walks innermost-first and returns the FIRST
-   answer: a stamped block's yield, else onward to the enclosing
-   function/node's declared return, else `undefined` (string
-   fallback downstream, as today).
+4. **The draftSchema lookup answers block-first.**
+   `enclosingDeclaredReturnType()` (the draftSchema source) walks
+   innermost-first and returns the FIRST answer: a stamped block's
+   yield, else onward to the enclosing function/node's declared
+   return, else `undefined` (string fallback downstream, as today).
+   `ScopeManager.returnType()` — the responseFormat source — is
+   deliberately NOT changed (decision 1; #582 will consume the same
+   stamp when the checker work lands).
 
 Note the desugar runs twice (typescriptPreprocessor and the
 TypeChecker constructor) and mutates in place; stamping is
-idempotent, so the double run is harmless.
+idempotent, so the double run is harmless. One subtlety (plan review
+finding 3): on the SECOND run the guard blocks are already stamped,
+so the reset rule's read of the block's yield is no longer always
+undefined — the two runs walk with genuinely different contexts, and
+there is nothing left to stamp, so the run-1 stamps survive
+unchanged. A double-run stability test pins this.
 
 ### The walk rule for nested guards
 
@@ -168,19 +191,16 @@ def f(): Report {
 }
 ```
 
-### What each consumer sees
+### What the consumer sees
 
 Given `const notes: Result<string> = guard(...) { return llm("...",
-tools: [saveDraft]) }`:
-
-- **draftSchema:** the llm call site emits
-  `draftSchema: z.string()` — `successType` unwrapped, rendered by
-  the same `zodSchemaFor` bridge, same `isAnyType` skip, same
-  post-prompt-args emission condition as #578.
-- **responseFormat:** the `return llm(...)` compiles with a string
-  response format explicitly derived from the annotation rather than
-  the accidental string default. With `Result<Report>`, both become
-  Report-shaped — the visible behavior change decision 1 accepted.
+tools: [saveDraft]) }`: the llm call site emits
+`draftSchema: z.string()` — `successType` unwrapped, rendered by the
+same `zodSchemaFor` bridge, same `isAnyType` skip, same
+post-prompt-args emission condition as #578. With a structured
+annotation the schema is the object shape (`draftSchema:
+z.object(...)` or the hoisted alias const). responseFormat is
+unchanged everywhere (decision 1 / #582).
 
 ### Failure modes considered
 
@@ -221,14 +241,28 @@ tools: [saveDraft]) }`:
 
 ## Part 3: Testing
 
+- Desugar unit tests: annotated assignment stamps (with the def's
+  return type DIFFERENT from the annotation, so the test visibly
+  discriminates its source); `let` form; non-Result annotation and
+  statement position stamp nothing; return-position stamps in a def
+  AND in a `node` (the graphNode capture branch); a return-position
+  guard inside an `if` stamps (the inherit branch); inside a fork
+  branch, an inline handler, and a finalize stamps NOTHING (the
+  three retargeting boundaries); `Result<Result<string>>` composes;
+  `Result<T, E>` unwraps only `successType`; a double run leaves
+  stamps unchanged.
+- ScopeManager unit tests (direct, on a pushed stack — the codegen
+  string-match is two layers away): stamped block answers; unstamped
+  block defers to a stamped outer block; unstamped block defers to
+  the function; block under a `node`.
 - Codegen: annotated assignment threads `draftSchema: z.string()`
-  from `Result<string>`; return-position guard in a
-  `def f(): Result<string>` does the same; `responseFormat` is
-  emitted for `return llm(...)` inside an annotated block (and stays
-  absent — string default — in an unannotated one); nested
-  unannotated-inside-annotated pins the walk rule; a structured
-  `Result<Report>` annotation threads the object schema for BOTH
-  consumers.
+  and beats the enclosing def's type; return-position guard in a
+  `def f(): Result<string>` threads the unwrapped `z.string()` (not
+  the Result shape); nested unannotated-inside-annotated pins the
+  walk rule; a structured annotation threads
+  `draftSchema: z.object(...)` (the one assertion the fixture
+  provably cannot make); an unannotated guard keeps the #578
+  fallbacks byte-identically.
 - Byte-stability: unannotated programs compile byte-identically
   (`make fixtures`, zero churn outside deliberate cases).
 - Fixture: a guard annotated `Result<{ title: string }>` whose mock
@@ -251,4 +285,9 @@ tools: [saveDraft]) }`:
 - Non-guard blocks (`fork`, `map`, ...): their result types relate
   to block yields differently (arrays, races).
 - Alias-typed annotations resolving to Result (see failure modes).
-- llm.md's limitation note update — owner-authored file.
+- `responseFormat` inside guard blocks — descoped by decision 1
+  after the plan review proved it unreachable in natural type-correct
+  programs; blocked on checker expected-type propagation (#582),
+  which will consume this spec's stamp when it lands.
+- llm.md's limitation note update — owner-authored file (note the
+  responseFormat half of that note now stays true until #582).

--- a/docs/superpowers/specs/2026-07-17-guard-annotation-threading-design.md
+++ b/docs/superpowers/specs/2026-07-17-guard-annotation-threading-design.md
@@ -155,6 +155,26 @@ tools: [saveDraft]) }`:
 
 ### Failure modes considered
 
+- **The annotation and the block's return types differ (owner review
+  round 1).** The stamp never looks at the block's returns, and no
+  widening is computed — the annotation is the single source, taken
+  verbatim. That is sufficient because only two cases exist. In a
+  well-typed program the returns are NARROWER than the annotation
+  (`return "done"` under `Result<string>`; `return "a"` under
+  `Result<string | number>`): the user already did the widening by
+  writing the annotation, and the declared contract is exactly the
+  right schema for the model — wider than any one incidental return.
+  If the returns are INCOMPATIBLE with the annotation
+  (`return 42` under `Result<string>`), the checker already errors on
+  that assignment — `synthGuardCall` types the guard as
+  `Result<union of block returns>`, and assignability against the
+  declared `Result<T>` fails — so the stamp is wrong only in a
+  program that is already red, and even then the schema is advisory
+  (a mismatched save is kept with a warning ack; #578's validation
+  stance). Computing a union at desugar time is not possible anyway:
+  the desugar has no synthesizer and no alias table. The division of
+  labor is deliberate — the desugar CARRIES the user's words, the
+  checker JUDGES them.
 - **Annotation is not a `resultType`** (user wrote something else, or
   the checker is already erroring): no stamp, today's behavior. The
   desugar never validates — the checker owns diagnosing a bad

--- a/packages/agency-lang/lib/backends/draftSchemaCodegen.test.ts
+++ b/packages/agency-lang/lib/backends/draftSchemaCodegen.test.ts
@@ -54,3 +54,50 @@ describe("draftSchema threading (saveDraft tool, spec Part 2)", () => {
     expect(out).toMatch(/draftSchema: z\.object\(/);
   });
 });
+
+describe("draftSchema threading — guard annotations (#580)", () => {
+  it("an annotated assignment beats the enclosing def's type", () => {
+    const out = gen(
+      'type Report = { title: string }\ndef f(): Report {\n  const notes: Result<string> = guard(cost: $1) {\n    return llm("hi", tools: [print])\n  }\n  if (isSuccess(notes)) { return { title: notes.value } }\n  return { title: "x" }\n}\nnode main() { const x = f()\n return "ok" }\n',
+    );
+    expect(out).toContain("draftSchema: z.string()");
+    // The fallback would render the def's Report as an object schema
+    // (or its hoisted alias const).
+    expect(out).not.toMatch(/draftSchema: z\.object\(/);
+    expect(out).not.toContain("draftSchema: Report");
+  });
+
+  it("a return-position guard unwraps the declared Result return", () => {
+    // Pre-change this call site threads the WHOLE Result-shaped zod;
+    // z.string() can only appear if the unwrap works.
+    const out = gen(
+      'def f(): Result<string> {\n  return guard(cost: $1) {\n    return llm("hi", tools: [print])\n  }\n}\nnode main() { const x = f()\n return "ok" }\n',
+    );
+    expect(out).toContain("draftSchema: z.string()");
+  });
+
+  it("nested: an unannotated inner guard defers to the outer stamp", () => {
+    const out = gen(
+      'type Report = { title: string }\ndef f(): Report {\n  const outer: Result<string> = guard(cost: $1) {\n    const inner = guard(cost: $0.1) {\n      return llm("hi", tools: [print])\n    }\n    if (isSuccess(inner)) { return inner.value }\n    return "x"\n  }\n  return { title: "x" }\n}\nnode main() { const x = f()\n return "ok" }\n',
+    );
+    expect(out).toContain("draftSchema: z.string()");
+    expect(out).not.toMatch(/draftSchema: z\.object\(/);
+  });
+
+  it("a structured annotation threads an OBJECT draftSchema (the assertion no fixture can make)", () => {
+    // The llm result binds through an annotated local so the checker
+    // accepts the block yield (a bare `return llm()` infers string
+    // and errors against Result<{title}> — see #582).
+    const out = gen(
+      'def f(): string {\n  const r: Result<{ title: string }> = guard(cost: $1) {\n    const report: { title: string } = llm("hi", tools: [print])\n    return report\n  }\n  return "y"\n}\nnode main() { return f() }\n',
+    );
+    expect(out).toMatch(/draftSchema: z\.object\(/);
+  });
+
+  it("an unannotated guard keeps the #578 fallbacks (byte-stability spot check)", () => {
+    const out = gen(
+      'def f(): string {\n  const r = guard(cost: $1) {\n    return llm("hi", tools: [print])\n  }\n  if (isSuccess(r)) { return r.value }\n  return "x"\n}\nnode main() { return f() }\n',
+    );
+    expect(out).toContain("draftSchema: z.string()");
+  });
+});

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -1772,7 +1772,14 @@ export class TypeScriptBuilder {
 
     const blockName = this.steps.nextBlockName();
     const parentScopeName = this.scopes.currentName();
-    this.scopes.push({ type: "block", blockName });
+    // The stamped yield (annotated guards, #580) rides along; the other
+    // two block push sites (processBlockAsExpression, the fork
+    // lowering) never carry a guard's block argument and stay bare.
+    this.scopes.push({
+      type: "block",
+      blockName,
+      declaredYieldType: block.declaredYieldType,
+    });
     this._sourceMapBuilder.enterScope(this.moduleId, blockName);
     const compiledFinalize = this.finalize.compileScope({
       body: block.body,

--- a/packages/agency-lang/lib/backends/typescriptBuilder/scopeManager.test.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder/scopeManager.test.ts
@@ -31,3 +31,46 @@ describe("ScopeManager.blockFrameVar", () => {
     expect(m.blockFrameVar(2)).toBe("__bframe___block_0");
   });
 });
+
+describe("ScopeManager.enclosingDeclaredReturnType — stamped blocks (#580)", () => {
+  const STR = { type: "primitiveType", value: "string" } as any;
+  const NUM = { type: "primitiveType", value: "number" } as any;
+
+  /** A ScopeManager whose compilationUnit knows one def and one node,
+   *  each with an optional declared return. Only the fields the
+   *  return-type lookups touch are stubbed. */
+  const smWithDefs = (opts: { fnReturn?: any; nodeReturn?: any }) =>
+    new ScopeManager({
+      functionDefinitions: { f: { returnType: opts.fnReturn } },
+      graphNodes: [{ nodeName: "main", returnType: opts.nodeReturn }],
+    } as any);
+
+  it("a stamped block answers its yield", () => {
+    const m = smWithDefs({ fnReturn: undefined });
+    m.push({ type: "function", functionName: "f" });
+    m.push({ type: "block", blockName: "b1", declaredYieldType: STR });
+    expect(m.enclosingDeclaredReturnType()).toEqual(STR);
+  });
+
+  it("an unstamped block defers to a stamped outer block", () => {
+    const m = smWithDefs({ fnReturn: undefined });
+    m.push({ type: "function", functionName: "f" });
+    m.push({ type: "block", blockName: "outer", declaredYieldType: STR });
+    m.push({ type: "block", blockName: "inner" });
+    expect(m.enclosingDeclaredReturnType()).toEqual(STR);
+  });
+
+  it("an unstamped block defers to the function's declared return", () => {
+    const m = smWithDefs({ fnReturn: STR });
+    m.push({ type: "function", functionName: "f" });
+    m.push({ type: "block", blockName: "b1" });
+    expect(m.enclosingDeclaredReturnType()).toEqual(STR);
+  });
+
+  it("a stamped block under a node answers the stamp, not the node", () => {
+    const m = smWithDefs({ nodeReturn: NUM });
+    m.push({ type: "node", nodeName: "main" });
+    m.push({ type: "block", blockName: "b1", declaredYieldType: STR });
+    expect(m.enclosingDeclaredReturnType()).toEqual(STR);
+  });
+});

--- a/packages/agency-lang/lib/backends/typescriptBuilder/scopeManager.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder/scopeManager.ts
@@ -151,25 +151,32 @@ export class ScopeManager {
   }
 
   /**
-   * Declared return type of the nearest ENCLOSING function or node,
-   * walking outward past block scopes. Unlike `returnType()`, which
-   * answers for the CURRENT scope (and answers `undefined` for blocks),
-   * this is the saveDraft tool's schema key (partials-ergonomics spec
-   * Part 2): a guard block owns the draft slot but carries no declared
-   * type, so the enclosing def's declared type is the best-effort hint.
+   * Declared return type of the nearest enclosing scope that has an
+   * ANSWER: a guard block whose result the user annotated `Result<T>`
+   * (its stamped yield, #580), else — walking outward past unstamped
+   * blocks — the nearest function or node's declared return. Unlike
+   * `returnType()`, which answers for the CURRENT scope (and answers
+   * `undefined` for blocks), this is the saveDraft tool's schema key
+   * (partials-ergonomics spec Part 2): the block owning the draft
+   * slot answers exactly when the user named its type.
    */
   enclosingDeclaredReturnType(): VariableType | undefined {
-    // Innermost-first: the nearest non-block scope answers. The Scope
-    // union names more kinds (imported/static/local), but the builder
-    // only ever PUSHES function, node, and block onto this stack, over
-    // the root global — the same invariant `returnType()`'s throwing
-    // default relies on — so the walk always lands on one of those
-    // three, and the default arm below covers only `global`.
+    // Innermost-first, first answer wins. The Scope union names more
+    // kinds (imported/static/local), but the builder only ever PUSHES
+    // function, node, and block onto this stack, over the root global
+    // — the same invariant `returnType()`'s throwing default relies
+    // on — so the walk always lands on one of those three, and the
+    // default arm below covers only `global`.
     const owner = [...this.stack]
       .reverse()
-      .find((scope) => scope.type !== "block");
+      .find(
+        (scope) =>
+          scope.type !== "block" || scope.declaredYieldType !== undefined,
+      );
     if (owner === undefined) return undefined;
     switch (owner.type) {
+      case "block":
+        return owner.declaredYieldType;
       case "function":
         return (
           this.compilationUnit.functionDefinitions[owner.functionName]

--- a/packages/agency-lang/lib/preprocessors/guardDesugar.test.ts
+++ b/packages/agency-lang/lib/preprocessors/guardDesugar.test.ts
@@ -63,3 +63,179 @@ describe("desugarGuardsInBody", () => {
     expect(ret.value.functionName).toBe("_guard");
   });
 });
+
+/** Parse a whole program and desugar all of it (defs and nodes). */
+function desugarSource(src: string): any[] {
+  const r = parseAgency(src, {}, false);
+  expect(r.success).toBe(true);
+  if (!r.success) return [];
+  return desugarGuardsInBody(r.result.nodes) as any[];
+}
+
+const STRING_T = { type: "primitiveType", value: "string" };
+
+describe("guardDesugar — declaredYieldType stamping (#580)", () => {
+  it("stamps successType from an annotated const assignment (def type differs, so the source is visible)", () => {
+    // def returns number; the annotation says string. Only the
+    // annotation can produce the string stamp.
+    const nodes = desugarSource(
+      'def f(): number {\n  const r: Result<string> = guard(cost: $1) {\n    return "x"\n  }\n  return 1\n}\n',
+    );
+    const def = nodes.find((node: any) => node.type === "function") as any;
+    const assign = def.body.find((node: any) => node.type === "assignment");
+    expect(assign.value.functionName).toBe("_guard");
+    expect(assign.value.block.declaredYieldType).toEqual(STRING_T);
+  });
+
+  it("stamps a `let` annotation the same way", () => {
+    const nodes = desugarSource(
+      'def f(): number {\n  let r: Result<string> = guard(cost: $1) {\n    return "x"\n  }\n  return 1\n}\n',
+    );
+    const def = nodes.find((node: any) => node.type === "function") as any;
+    const assign = def.body.find((node: any) => node.type === "assignment");
+    expect(assign.value.block.declaredYieldType).toEqual(STRING_T);
+  });
+
+  it("stamps nothing on an unannotated assignment", () => {
+    const nodes = desugarSource(
+      'def f(): string {\n  const r = guard(cost: $1) {\n    return "x"\n  }\n  return "y"\n}\n',
+    );
+    const def = nodes.find((node: any) => node.type === "function") as any;
+    const assign = def.body.find((node: any) => node.type === "assignment");
+    expect(assign.value.block.declaredYieldType).toBeUndefined();
+  });
+
+  it("stamps nothing from a non-Result annotation", () => {
+    const nodes = desugarSource(
+      'def f(): string {\n  const r: string = guard(cost: $1) {\n    return "x"\n  }\n  return "y"\n}\n',
+    );
+    const def = nodes.find((node: any) => node.type === "function") as any;
+    const assign = def.body.find((node: any) => node.type === "assignment");
+    expect(assign.value.block.declaredYieldType).toBeUndefined();
+  });
+
+  it("stamps a return-position guard from the enclosing def's declared Result return", () => {
+    const nodes = desugarSource(
+      'def f(): Result<string> {\n  return guard(cost: $1) {\n    return "x"\n  }\n}\n',
+    );
+    const def = nodes.find((node: any) => node.type === "function") as any;
+    const ret = def.body.find((node: any) => node.type === "returnStatement");
+    expect(ret.value.block.declaredYieldType).toEqual(STRING_T);
+  });
+
+  it("stamps a return-position guard inside a NODE from the node's declared return", () => {
+    const nodes = desugarSource(
+      'node main(): Result<string> {\n  return guard(cost: $1) {\n    return "x"\n  }\n}\n',
+    );
+    const graphNode = nodes.find(
+      (node: any) => node.type === "graphNode",
+    ) as any;
+    const ret = graphNode.body.find(
+      (node: any) => node.type === "returnStatement",
+    );
+    expect(ret.value.block.declaredYieldType).toEqual(STRING_T);
+  });
+
+  it("a return-position guard inside an `if` INHERITS the def target (positive counterpart to the resets)", () => {
+    const nodes = desugarSource(
+      'def f(cond: boolean): Result<string> {\n  if (cond) {\n    return guard(cost: $1) {\n      return "x"\n    }\n  }\n  return guard(cost: $1) { return "y" }\n}\n',
+    );
+    const def = nodes.find((node: any) => node.type === "function") as any;
+    const ifNode = def.body.find((node: any) => node.type === "ifElse");
+    const innerReturn = ifNode.thenBody.find(
+      (node: any) => node.type === "returnStatement",
+    );
+    expect(innerReturn.value.block.declaredYieldType).toEqual(STRING_T);
+  });
+
+  it("does NOT stamp a return-position guard inside a fork branch (block boundary resets)", () => {
+    const nodes = desugarSource(
+      'def f(): Result<string> {\n  const r = fork([1]) as n {\n    return guard(cost: $1) {\n      return "x"\n    }\n  }\n  return guard(cost: $1) { return "y" }\n}\n',
+    );
+    const def = nodes.find((node: any) => node.type === "function") as any;
+    const forkAssign = def.body.find((node: any) => node.type === "assignment");
+    const innerReturn = forkAssign.value.block.body.find(
+      (node: any) => node.type === "returnStatement",
+    );
+    expect(innerReturn.value.block.declaredYieldType).toBeUndefined();
+  });
+
+  it("does NOT stamp a return-position guard inside an inline handler body (handler boundary resets)", () => {
+    const nodes = desugarSource(
+      'def f(): Result<string> {\n  handle {\n  return guard(cost: $1) { return "ok" }\n  } with (i) {\n    return guard(cost: $1) {\n      return "x"\n    }\n  }\n}\n',
+    );
+    const def = nodes.find((node: any) => node.type === "function") as any;
+    const handle = def.body.find((node: any) => node.type === "handleBlock");
+    const handlerReturn = handle.handler.body.find(
+      (node: any) => node.type === "returnStatement",
+    );
+    expect(handlerReturn.value.block.declaredYieldType).toBeUndefined();
+    // The guarded body itself INHERITS (a return there returns from f):
+    const bodyReturn = handle.body.find(
+      (node: any) => node.type === "returnStatement",
+    );
+    expect(bodyReturn.value.block.declaredYieldType).toEqual(STRING_T);
+  });
+
+  it("does NOT stamp a return-position guard inside a finalize body (finalize boundary resets)", () => {
+    const nodes = desugarSource(
+      'def f(): Result<string> {\n  return guard(cost: $1) { return "ok" }\n\n  finalize {\n    return guard(cost: $1) {\n      return "x"\n    }\n  }\n}\n',
+    );
+    const def = nodes.find((node: any) => node.type === "function") as any;
+    const finalize = def.body.find(
+      (node: any) => node.type === "finalizeBlock",
+    );
+    const finReturn = finalize.body.find(
+      (node: any) => node.type === "returnStatement",
+    );
+    expect(finReturn.value.block.declaredYieldType).toBeUndefined();
+  });
+
+  it("composes: a stamped guard block becomes the return target for its own body", () => {
+    const nodes = desugarSource(
+      'def f(): string {\n  const r: Result<Result<string>> = guard(cost: $1) {\n    return guard(cost: $1) {\n      return "x"\n    }\n  }\n  return "y"\n}\n',
+    );
+    const def = nodes.find((node: any) => node.type === "function") as any;
+    const outer = def.body.find(
+      (node: any) => node.type === "assignment",
+    ).value;
+    expect(outer.block.declaredYieldType.type).toBe("resultType");
+    const innerReturn = outer.block.body.find(
+      (node: any) => node.type === "returnStatement",
+    );
+    expect(innerReturn.value.block.declaredYieldType).toEqual(STRING_T);
+  });
+
+  it("unwraps only successType from Result<T, E>", () => {
+    const nodes = desugarSource(
+      'def f(): string {\n  const r: Result<number, string> = guard(cost: $1) {\n    return 1\n  }\n  return "y"\n}\n',
+    );
+    const def = nodes.find((node: any) => node.type === "function") as any;
+    const assign = def.body.find((node: any) => node.type === "assignment");
+    expect(assign.value.block.declaredYieldType).toEqual({
+      type: "primitiveType",
+      value: "number",
+    });
+  });
+
+  it("a statement-position guard stamps nothing", () => {
+    const nodes = desugarSource(
+      'def f(): Result<string> {\n  guard(cost: $1) {\n    return "x"\n  }\n  return guard(cost: $1) { return "y" }\n}\n',
+    );
+    const def = nodes.find((node: any) => node.type === "function") as any;
+    const stmt = def.body.find(
+      (node: any) =>
+        node.type === "functionCall" && node.functionName === "_guard",
+    );
+    expect(stmt.block.declaredYieldType).toBeUndefined();
+  });
+
+  it("a second desugar run leaves the stamps unchanged (double-run stability)", () => {
+    const nodes = desugarSource(
+      'def f(): number {\n  const r: Result<string> = guard(cost: $1) {\n    return "x"\n  }\n  return 1\n}\n',
+    );
+    const before = JSON.stringify(nodes);
+    desugarGuardsInBody(nodes as any);
+    expect(JSON.stringify(nodes)).toBe(before);
+  });
+});

--- a/packages/agency-lang/lib/preprocessors/guardDesugar.ts
+++ b/packages/agency-lang/lib/preprocessors/guardDesugar.ts
@@ -1,6 +1,8 @@
-import { AgencyNode } from "@/types.js";
+import { AgencyNode, Assignment, VariableType } from "@/types.js";
+import { FunctionDefinition } from "@/types/function.js";
+import { GraphNodeDefinition } from "@/types/graphNode.js";
 import { GuardBlock } from "@/types/guardBlock.js";
-import { bodySlots } from "@/utils/bodySlots.js";
+import { bodySlots, BodySlot } from "@/utils/bodySlots.js";
 
 /**
  * Rewrite every `guardBlock` construct into the legacy
@@ -22,40 +24,125 @@ import { bodySlots } from "@/utils/bodySlots.js";
  * The walk is bodySlots-driven with one extension: `guardBlock` only
  * occurs as a statement, an assignment value, or a return value (the
  * parser's three registration points), so `value` fields are followed
- * in addition to registered body slots.
+ * in addition to registered body slots. The walk threads a context —
+ * the current return target (#580) — so annotated guards can stamp
+ * their yield type onto the block argument they desugar to.
  */
-export function desugarGuardsInBody(body: AgencyNode[]): AgencyNode[] {
+
+/** The walk context: the type a `return` statement at this point in
+ *  the tree yields to. Captured from the declared return when the
+ *  walk enters a def/node body; RESET at every return-retargeting
+ *  slot (block arguments, inline handler bodies, finalize bodies —
+ *  marked by BodySlot.retargetsReturn) to that slot's own yield: the
+ *  stamp a guard block just received, nothing for any other closure.
+ *  Absent at top level. */
+type DesugarContext = {
+  returnTarget?: VariableType;
+};
+
+export function desugarGuardsInBody(
+  body: AgencyNode[],
+  ctx: DesugarContext = {},
+): AgencyNode[] {
   body.forEach((node, i) => {
-    body[i] = desugarNode(node);
+    body[i] = desugarNode(node, ctx);
   });
   return body;
 }
 
-function desugarNode(node: AgencyNode): AgencyNode {
+/** `successType` of a Result annotation; undefined for anything else.
+ *  The desugar never validates — a non-Result annotation simply
+ *  stamps nothing, and the checker owns diagnosing it. */
+function yieldTypeFrom(
+  t: VariableType | null | undefined,
+): VariableType | undefined {
+  if (t && t.type === "resultType") {
+    return t.successType;
+  }
+  return undefined;
+}
+
+/** The context a slot's body walks under: return-retargeting slots
+ *  RESET the target to the slot's own yield (a guard block's stamp;
+ *  nothing for handlers/finalizes/other blocks — on the second
+ *  desugar run the blockAncestor read returns run-1 stamps, which is
+ *  when it earns its keep); def/node bodies capture the declared
+ *  return; every other body inherits. */
+function slotContext(
+  node: AgencyNode,
+  slot: BodySlot,
+  ctx: DesugarContext,
+): DesugarContext {
+  if (slot.retargetsReturn) {
+    return { returnTarget: slot.blockAncestor?.declaredYieldType };
+  }
+  if (node.type === "function" || node.type === "graphNode") {
+    const def = node as FunctionDefinition | GraphNodeDefinition;
+    return { returnTarget: def.returnType ?? undefined };
+  }
+  return ctx;
+}
+
+/** The type a guard sitting in this node's `value` slot is stamped
+ *  with: an assignment names its own slot; a return yields to the
+ *  current return target; anything else stamps nothing. */
+function stampFor(
+  node: AgencyNode,
+  ctx: DesugarContext,
+): VariableType | undefined {
+  if (node.type === "assignment") {
+    return yieldTypeFrom((node as Assignment).typeHint);
+  }
+  if (node.type === "returnStatement") {
+    return yieldTypeFrom(ctx.returnTarget);
+  }
+  return undefined;
+}
+
+function desugarNode(node: AgencyNode, ctx: DesugarContext): AgencyNode {
   if (node.type === "guardBlock") {
-    return desugarGuardBlock(node as GuardBlock);
+    // Statement position: nothing to yield to, no stamp.
+    return desugarGuardBlock(node as GuardBlock, undefined);
   }
   // slot.body is the node's actual array; recursing mutates it in
   // place, so no slot.write copies are made.
   for (const slot of bodySlots(node)) {
-    desugarGuardsInBody(slot.body);
+    desugarGuardsInBody(slot.body, slotContext(node, slot, ctx));
   }
   const holder = node as { value?: unknown };
   const value = holder.value;
-  if (value && typeof value === "object" && "type" in (value as object)) {
-    const rewritten = desugarNode(value as AgencyNode);
-    if (rewritten !== value) {
-      holder.value = rewritten;
-    }
+  if (!value || typeof value !== "object" || !("type" in (value as object))) {
+    return node;
+  }
+  const valueNode = value as AgencyNode;
+  if (valueNode.type === "guardBlock") {
+    holder.value = desugarGuardBlock(
+      valueNode as GuardBlock,
+      stampFor(node, ctx),
+    );
+    return node;
+  }
+  const rewritten = desugarNode(valueNode, ctx);
+  if (rewritten !== valueNode) {
+    holder.value = rewritten;
   }
   return node;
 }
 
-function desugarGuardBlock(g: GuardBlock): AgencyNode {
+function desugarGuardBlock(
+  g: GuardBlock,
+  yieldType: VariableType | undefined,
+): AgencyNode {
   // The head arguments forward VERBATIM. Named, positional, unknown,
   // duplicated — all of it lands on the `_guard` call and gets exactly
   // the validation and diagnostics the legacy call syntax got from the
   // same signature. The desugar validates nothing.
+  //
+  // The stamp, when present, becomes the return target for the block's
+  // own body — which is how nested return-position guards compose.
+  // declaredYieldType is always assigned: absent and undefined are
+  // equivalent for every consumer, and JSON.stringify drops undefined
+  // keys, so AST output for unstamped guards is unchanged.
   return {
     type: "functionCall",
     functionName: "_guard",
@@ -64,7 +151,8 @@ function desugarGuardBlock(g: GuardBlock): AgencyNode {
       type: "blockArgument",
       inline: false,
       params: [],
-      body: desugarGuardsInBody(g.body),
+      declaredYieldType: yieldType,
+      body: desugarGuardsInBody(g.body, { returnTarget: yieldType }),
     },
     // The prelude import is what resolves `_guard`, so the call's
     // symbol scope matches what the legacy imported call carried.

--- a/packages/agency-lang/lib/types.ts
+++ b/packages/agency-lang/lib/types.ts
@@ -176,6 +176,10 @@ each call will get its own copy of `globalVar`.
 export type BlockScope = {
   type: "block";
   blockName: string;
+  /** The block's declared yield type, copied from the stamped
+   *  BlockArgument (#580) when the builder pushes this scope. Set only
+   *  for guard blocks whose result the user annotated `Result<T>`. */
+  declaredYieldType?: VariableType;
 };
 
 export type Scope =

--- a/packages/agency-lang/lib/types/blockArgument.ts
+++ b/packages/agency-lang/lib/types/blockArgument.ts
@@ -1,4 +1,4 @@
-import { AgencyNode } from "../types.js";
+import { AgencyNode, VariableType } from "../types.js";
 import { BaseNode } from "./base.js";
 import { FunctionParameter } from "./function.js";
 
@@ -7,4 +7,11 @@ export type BlockArgument = BaseNode & {
   params: FunctionParameter[];
   body: AgencyNode[];
   inline?: boolean;
+  /** The block's declared yield type, when the user wrote it adjacent
+   *  to the guard this block belongs to: the `T` of a `Result<T>`
+   *  assignment annotation, or of the enclosing def/node's declared
+   *  return for a return-position guard. Stamped by guardDesugar
+   *  (#580); undefined on every other block. Codegen reads it to type
+   *  the saveDraft schema inside the block. */
+  declaredYieldType?: VariableType;
 };

--- a/packages/agency-lang/lib/utils/bodySlots.ts
+++ b/packages/agency-lang/lib/utils/bodySlots.ts
@@ -145,7 +145,9 @@ export function bodySlots(node: AgencyNode): BodySlot[] {
     case "finalizeBlock": {
       // Same-scope statements (like an if body): the finalize reads the
       // enclosing scope's locals, so every walker and rewriter must
-      // descend into it as part of that scope.
+      // descend into it as part of that scope — though a `return`
+      // inside yields to the `__finalize` closure, not the enclosing
+      // def, hence `retargetsReturn`.
       const n = node as FinalizeBlock;
       return [
         {
@@ -158,11 +160,19 @@ export function bodySlots(node: AgencyNode): BodySlot[] {
     case "guardBlock": {
       // The guarded block. Distinct-scope statements (the body compiles
       // to a lifted closure after desugaring), but walkers and
-      // rewriters must descend into it like any other body.
+      // rewriters must descend into it like any other body. Marked
+      // retargetsReturn like its post-desugar twin (blockArgument):
+      // guardDesugar currently bypasses this slot (desugarNode
+      // special-cases guardBlock and walks the body itself, with the
+      // stamp as the target), so the flag is inert there — but anyone
+      // merging that special case into the generic slot walk gets the
+      // reset by construction instead of silently inheriting the
+      // def's return target into guard bodies.
       const n = node as GuardBlock;
       return [
         {
           body: n.body,
+          retargetsReturn: true,
           write: (owner, body) => ({ ...owner, body }) as AgencyNode,
         },
       ];

--- a/packages/agency-lang/lib/utils/bodySlots.ts
+++ b/packages/agency-lang/lib/utils/bodySlots.ts
@@ -38,8 +38,15 @@ export type BodySlot = {
    *  `static ...`): a rewrite must map the one statement to exactly one. */
   single?: boolean;
   /** Extra ancestor between the owner and the body during walks — the
-   *  functionCall's inline `block:` argument. */
+   *  functionCall's `block:` argument (inline or not). */
   blockAncestor?: BlockArgument;
+  /** True when a `return` inside this slot's body yields to the slot's
+   *  own closure rather than the enclosing def: block arguments (the
+   *  __block_N lifting), inline handler bodies (their own arrow), and
+   *  finalize bodies (the __finalize closure). guardDesugar's return-
+   *  target rule keys on this — a new return-retargeting construct
+   *  must set it here or that feature silently mis-stamps. */
+  retargetsReturn?: boolean;
   /** Fresh copy of `owner` with this slot's statements replaced. Takes the
    *  CURRENT owner (not the node bodySlots was called on) so a fold over
    *  several slots composes: each write builds on the previous one. */
@@ -126,6 +133,7 @@ export function bodySlots(node: AgencyNode): BodySlot[] {
       if (n.handler.kind === "inline") {
         slots.push({
           body: n.handler.body,
+          retargetsReturn: true,
           write: (owner, body) => {
             const o = owner as HandleBlock;
             return { ...o, handler: { ...o.handler, body } } as AgencyNode;
@@ -142,6 +150,7 @@ export function bodySlots(node: AgencyNode): BodySlot[] {
       return [
         {
           body: n.body,
+          retargetsReturn: true,
           write: (owner, body) => ({ ...owner, body }) as AgencyNode,
         },
       ];
@@ -167,8 +176,16 @@ export function bodySlots(node: AgencyNode): BodySlot[] {
       return [];
     case "messageThread":
       return [bodyField(node as MessageThread)];
-    case "blockArgument":
-      return [bodyField(node as unknown as BlockArgument)];
+    case "blockArgument": {
+      const n = node as unknown as BlockArgument;
+      return [
+        {
+          body: n.body,
+          retargetsReturn: true,
+          write: (owner, body) => ({ ...owner, body }) as AgencyNode,
+        },
+      ];
+    }
     case "functionCall": {
       const n = node as FunctionCall;
       if (!n.block) {
@@ -179,6 +196,7 @@ export function bodySlots(node: AgencyNode): BodySlot[] {
         {
           body: block.body,
           blockAncestor: block,
+          retargetsReturn: true,
           write: (owner, body) => {
             const o = owner as FunctionCall;
             if (!o.block) {

--- a/packages/agency-lang/tests/agency/guards/savedraft-annotated-structured.agency
+++ b/packages/agency-lang/tests/agency/guards/savedraft-annotated-structured.agency
@@ -1,0 +1,16 @@
+// An annotated guard threads a STRUCTURED saveDraft schema — the
+// first e2e through the non-fallback path. Note what this pins and
+// what it cannot: the deterministic client ignores schemas and the
+// intrinsic keeps mismatched saves, so the OUTCOME here would be the
+// same under the string fallback; the codegen tests own the
+// distinguishing assertions. This fixture proves the threaded object
+// schema flows codegen -> draftSchema -> provider without breaking
+// the round-trip, and that a structured draft salvages intact.
+node main() {
+  const r: Result<{ title: string }> = guard(cost: 0.000001) {
+    const report: { title: string } = llm("work", tools: [saveDraft])
+    return report
+  }
+  if (isFailure(r)) { return "no-draft" }
+  return r.value.title
+}

--- a/packages/agency-lang/tests/agency/guards/savedraft-annotated-structured.test.json
+++ b/packages/agency-lang/tests/agency/guards/savedraft-annotated-structured.test.json
@@ -1,0 +1,17 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"t\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "toolCalls": [{ "name": "saveDraft", "args": { "value": { "title": "t" } } }] },
+        { "return": "never-reached" }
+      ],
+      "description": "A structured draft saved against an annotated Result<{title}> guard salvages intact; exercises the threaded (non-fallback) schema path end to end.",
+      "interruptHandlers": [{ "action": "reject" }]
+    }
+  ]
+}


### PR DESCRIPTION
Closes #580.

An annotated guard's `Result<T>` now reaches codegen inside the guard block, so the saveDraft tool's value schema describes the actual slot instead of the enclosing function's type:

```ts
def makeReport(topic: string): Report {
  const notes: Result<string> = guard(cost: $0.50) {
    return llm("Research " + topic, tools: [saveDraft])
  }
  ...
}
// saveDraft's schema is now z.string() (the slot), not the Report shape.
```

Spec (with all three review rounds folded and as-executed notes): `docs/superpowers/specs/2026-07-17-guard-annotation-threading-design.md`. Plan: `docs/superpowers/plans/2026-07-17-guard-annotation-threading.md`, review alongside.

## How it works

- **`guardDesugar` stamps.** The desugar walk gains a context — the *current return target*, captured from def/node declared returns — and stamps `successType` onto the `BlockArgument` it creates when a guard sits in an annotated assignment or in return position. Two pure rules carry the whole feature: `slotContext` (what context a body walks under) and `stampFor` (what a guard in a value slot gets stamped with).
- **The reset rule covers every return-retargeting boundary.** A `return` inside a block argument, an inline handler, or a finalize yields to its own closure, not the def — so `bodySlots` (the single source of truth for body shapes) gains a per-slot `retargetsReturn` marker, and the walk resets its target there. A return-position guard inside a fork branch / handler / finalize stamps nothing; a stamped guard block becomes the return target for its own body, so `Result<Result<string>>` nesting composes.
- **The builder side is deliberately tiny:** one optional field on `BlockScope`, one copy at the `processBlockArgument` push, one predicate + one switch arm in `enclosingDeclaredReturnType()` (first answer wins: stamped block, else nearest function/node).

## Descoped: responseFormat (#582)

The plan review proved empirically that no natural type-correct program exists where a responseFormat stamp changes behavior: a structured annotation with `return llm(...)` fails AG2001 (the checker infers `string` — no expected type is pushed into block returns), and the shape that does compile (an annotated local) already gets its responseFormat from the assignment hint. The one reachable shape — an annotation *wider* than the inferred llm type — is exactly the case where structured output would produce values the checker statically typed away. So `ScopeManager.returnType()` is untouched, and #582 tracks the checker expected-type propagation that makes the natural shapes compile — at which point the stamp this PR ships is the plumbing it consumes. (llm.md's block-limitation note stays true until then; not edited here — owner-authored.)

## Testing

- 14 desugar unit tests: both annotation forms (`const` and `let`), def and node return-position, the `if`-inherit branch, the three no-stamp boundaries (fork branch, inline handler, finalize), nested composition, `Result<T, E>` unwrap, statement position, double-run stability.
- 4 direct `ScopeManager` walk tests (stamped answers; unstamped defers to stamped-outer / function / node).
- 5 codegen tests, including the structured `draftSchema: z.object(...)` assertion no fixture can make, and annotation-beats-def-type discrimination.
- Fixture `savedraft-annotated-structured`: a structured draft salvages intact through the threaded schema path; the compiled JS was inspected and carries `draftSchema: z.object({ "title": z.string() ... })`.
- Byte-stability: zero tracked churn after `make fixtures`; the #578 fixtures (all unannotated) pass unchanged; full unit suite 8594 green; structural lint clean.

## Known limitations (tracked)

- Unannotated guards still fall back to the enclosing function's type (inferred yields need the typechecker-to-codegen handoff; #582's expected-type propagation is the adjacent piece).
- Alias-typed annotations (`type R = Result<string>`) are not chased — the desugar has no alias table.
- `let r: Result<T>` declared on one line and assigned later carries no annotation at the assignment site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
