### PR TITLE
Pass AppleScript data as argv instead of escaping it into the source

### DIFF
--- a/packages/agency-lang/lib/stdlib/__tests__/imessage.test.ts
+++ b/packages/agency-lang/lib/stdlib/__tests__/imessage.test.ts
@@ -9,6 +9,12 @@ vi.mock("child_process", () => ({
 
 import { execFile } from "child_process";
 
+/** The args array osascript was called with on the first (only) invocation. */
+function osascriptArgs(): string[] {
+  const calls = (execFile as unknown as ReturnType<typeof vi.fn>).mock.calls;
+  return calls[0][1];
+}
+
 describe("_sendIMessage", () => {
   const originalPlatform = process.platform;
 
@@ -21,58 +27,57 @@ describe("_sendIMessage", () => {
     Object.defineProperty(process, "platform", { value: originalPlatform, writable: true });
   });
 
-  it("calls osascript with AppleScript", async () => {
+  it("passes recipient and message as argv, not as script source", async () => {
     const result = await _sendIMessage("+15551234567", "Hello!");
 
     expect(result).toEqual({ sent: true });
+    // Shape: ["-e", <script>, <recipient>, <message>]. No "-" separator:
+    // osascript passes a bare "-" through as argv item 1 and shifts the rest.
     expect(execFile).toHaveBeenCalledWith(
       "osascript",
-      ["-e", expect.stringContaining("+15551234567")],
-      expect.any(Function)
+      ["-e", expect.any(String), "+15551234567", "Hello!"],
+      expect.any(Function),
     );
   });
 
-  it("includes message in script", async () => {
+  it("keeps the script constant — no caller data is spliced into it", async () => {
     await _sendIMessage("+15551234567", "Test message");
+    const script = osascriptArgs()[1];
 
-    const [, args] = (execFile as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
-    expect(args[1]).toContain("Test message");
+    expect(script).not.toContain("+15551234567");
+    expect(script).not.toContain("Test message");
   });
 
-  it("escapes double quotes in recipient and message", async () => {
-    await _sendIMessage('user"@test.com', 'say "hello"');
+  // The reason this function is worth hardening: `sendIMessage` is handed to an
+  // LLM as a tool, so `message` is model-authored and may echo a web page, an
+  // email, or a file the agent read. These payloads must land as inert data.
+  const hostile = [
+    ['a quote-and-concat break-out', '" & (do shell script "touch /tmp/pwned") & "'],
+    ['a statement injection', 'hi\nend tell\ndo shell script "touch /tmp/pwned"\ntell application "Messages"'],
+    ['an escaped-quote break-out', 'hi\\" & (do shell script "touch /tmp/pwned") & \\"'],
+    ['a tab and backslash payload', 'col1\tcol2\\path\\to\\file'],
+  ] as const;
 
-    const [, args] = (execFile as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
-    const script = args[1];
-    expect(script).toContain('user\\"@test.com');
-    expect(script).toContain('say \\"hello\\"');
-  });
+  for (const [description, payload] of hostile) {
+    it(`treats ${description} as data, not code`, async () => {
+      await _sendIMessage("+15551234567", payload);
+      const args = osascriptArgs();
 
-  it("escapes backslashes", async () => {
-    await _sendIMessage("+15551234567", "path\\to\\file");
+      // Verbatim in argv...
+      expect(args[3]).toBe(payload);
+      // ...and absent from the script osascript actually parses.
+      expect(args[1]).not.toContain("do shell script");
+      expect(args[1]).not.toContain(payload);
+    });
+  }
 
-    const [, args] = (execFile as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
-    const script = args[1];
-    expect(script).toContain("path\\\\to\\\\file");
-  });
+  it("treats a hostile recipient as data, not code", async () => {
+    const payload = '" of targetService\ndo shell script "touch /tmp/pwned"\nset x to participant "';
+    await _sendIMessage(payload, "Hi");
+    const args = osascriptArgs();
 
-  it("escapes newlines to prevent AppleScript injection", async () => {
-    await _sendIMessage("+15551234567", "line1\nline2\rline3\r\nline4");
-
-    const [, args] = (execFile as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
-    const script = args[1];
-    // All line breaks should be escaped as \n, not literal newlines in the AppleScript string
-    expect(script).toContain("line1\\nline2\\nline3\\nline4");
-    // Should not contain unescaped newlines within the send command's string literal
-    expect(script.match(/send "[^"]*\n[^"]*"/)).toBeNull();
-  });
-
-  it("escapes tabs", async () => {
-    await _sendIMessage("+15551234567", "col1\tcol2");
-
-    const [, args] = (execFile as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
-    const script = args[1];
-    expect(script).toContain("col1\\tcol2");
+    expect(args[2]).toBe(payload);
+    expect(args[1]).not.toContain("do shell script");
   });
 
   it("throws on non-macOS platforms", async () => {
@@ -93,7 +98,7 @@ describe("_sendIMessage", () => {
     );
   });
 
-  it("throws with stderr info when osascript fails, without leaking script contents", async () => {
+  it("throws with stderr info when osascript fails, without leaking the message", async () => {
     (execFile as unknown as ReturnType<typeof vi.fn>).mockImplementation(
       (_cmd: string, _args: string[], cb: (err: unknown) => void) => {
         cb({ stderr: "execution error: Messages got an error", code: 1 });

--- a/packages/agency-lang/lib/stdlib/__tests__/notify.test.ts
+++ b/packages/agency-lang/lib/stdlib/__tests__/notify.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("child_process", () => ({
+  execFile: vi.fn((_cmd: string, _args: string[], cb: (err: Error | null, result: { stdout: string; stderr: string }) => void) => {
+    cb(null, { stdout: "", stderr: "" });
+  }),
+}));
+
+// detectPlatform caches its answer, so overriding process.platform is not
+// enough to pin the macOS branch. Mock the detector itself.
+vi.mock("../utils.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../utils.js")>()),
+  detectPlatform: vi.fn(async () => "macos" as const),
+}));
+
+import { execFile } from "child_process";
+import { _notify } from "../builtins.js";
+
+function osascriptArgs(): string[] {
+  const calls = (execFile as unknown as ReturnType<typeof vi.fn>).mock.calls;
+  return calls[0][1];
+}
+
+describe("_notify on macOS", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("passes the message and title as argv, not as script source", async () => {
+    await _notify("Build done", "3 tests failed");
+
+    // _notify(title, message); the script reads message first, then title.
+    expect(execFile).toHaveBeenCalledWith(
+      "osascript",
+      ["-e", expect.any(String), "3 tests failed", "Build done"],
+      expect.any(Function),
+    );
+
+    const script = osascriptArgs()[1];
+    expect(script).not.toContain("Build done");
+    expect(script).not.toContain("3 tests failed");
+  });
+
+  // `notify` is reachable from model-authored text, so treat its arguments as
+  // untrusted the same way `sendIMessage` does.
+  it("treats a hostile message as data, not code", async () => {
+    const payload = '" & (do shell script "touch /tmp/pwned") & "';
+    await _notify("title", payload);
+    const args = osascriptArgs();
+
+    expect(args[2]).toBe(payload);
+    expect(args[1]).not.toContain("do shell script");
+  });
+
+  it("treats a hostile title as data, not code", async () => {
+    const payload = 'hi\ndo shell script "touch /tmp/pwned"\ndisplay notification "x';
+    await _notify(payload, "message");
+    const args = osascriptArgs();
+
+    expect(args[3]).toBe(payload);
+    expect(args[1]).not.toContain("do shell script");
+  });
+});

--- a/packages/agency-lang/lib/stdlib/builtins.ts
+++ b/packages/agency-lang/lib/stdlib/builtins.ts
@@ -258,15 +258,21 @@ export async function _readBinary(dir: string, filename: string): Promise<string
   return data.toString("base64");
 }
 
+/** argv item 1 is the message, item 2 is the title. See `_notify`. */
+const NOTIFY_SCRIPT = `on run argv
+  display notification (item 1 of argv) with title (item 2 of argv)
+end run`;
+
 export async function _notify(title: string, message: string): Promise<boolean> {
   const platform = await detectPlatform();
   if (platform === "macos") {
-    // Escape for AppleScript string literals (backslashes and double quotes).
-    // We use execFileAsync with an args array to bypass the shell entirely,
-    // which eliminates all shell injection concerns.
-    const escapeAS = (s: string) => s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-    const script = `display notification "${escapeAS(message)}" with title "${escapeAS(title)}"`;
-    await execFileAsync("osascript", ["-e", script]);
+    // The title and message arrive as argv rather than being spliced into the
+    // script source, so AppleScript never parses them as code. `notify` is
+    // reachable from model-authored text, and escaping only holds for as long
+    // as the escape function keeps up with every AppleScript metacharacter.
+    // No "-" before the arguments: osascript would pass it through as argv
+    // item 1 and shift every real argument by one.
+    await execFileAsync("osascript", ["-e", NOTIFY_SCRIPT, message, title]);
   } else if (platform === "linux") {
     await execFileAsync("notify-send", [title, message]);
   } else if (platform === "wsl") {

--- a/packages/agency-lang/lib/stdlib/imessage.ts
+++ b/packages/agency-lang/lib/stdlib/imessage.ts
@@ -4,6 +4,25 @@ import { checkRecipients } from "./messaging.js";
 
 const execFileAsync = promisify(execFile);
 
+/** The recipient and the message body arrive as argv, never spliced into this
+ *  source. That matters here more than usual: `sendIMessage` is handed to an
+ *  LLM as a tool, so the body is model-authored text that may echo a web page,
+ *  an email, or a file the agent read. AppleScript does not parse argv values
+ *  as code, so a body like `" & (do shell script "...") & "` is just a string.
+ *
+ *  Escaping the data into the source would also work only for as long as the
+ *  escape function keeps up with every AppleScript metacharacter. Passing
+ *  arguments removes the question instead of answering it repeatedly. */
+const SEND_SCRIPT = `on run argv
+  set recipientId to item 1 of argv
+  set messageBody to item 2 of argv
+  tell application "Messages"
+    set targetService to 1st account whose service type = iMessage
+    set targetBuddy to participant recipientId of targetService
+    send messageBody to targetBuddy
+  end tell
+end run`;
+
 export type IMessageResult = {
   sent: boolean;
 };
@@ -37,36 +56,17 @@ export async function _sendIMessage(
   );
   if (recipientError) throw new Error(recipientError);
 
-  const script = `
-    tell application "Messages"
-      set targetService to 1st account whose service type = iMessage
-      set targetBuddy to participant "${escapeAppleScriptString(to)}" of targetService
-      send "${escapeAppleScriptString(message)}" to targetBuddy
-    end tell
-  `;
-
   try {
-    await execFileAsync("osascript", ["-e", script]);
+    // No "-" before the arguments: osascript passes a bare "-" through as
+    // argv item 1 and shifts every real argument by one. Same as appleNotes.ts.
+    await execFileAsync("osascript", ["-e", SEND_SCRIPT, to, message]);
     return { sent: true };
   } catch (error: unknown) {
-    // Avoid leaking script contents (which contain recipient/message) into error messages.
-    // execFile errors include stderr which has the actionable info.
+    // Report stderr only, which carries the actionable detail. The raw error
+    // also carries the full argv, and that now includes the recipient and the
+    // message body, which should not end up in a thrown message.
     const err = error as { stderr?: string; code?: number };
     const detail = err.stderr?.trim() || `exit code ${err.code ?? "unknown"}`;
     throw new Error(`Failed to send iMessage: ${detail}`);
   }
-}
-
-function escapeAppleScriptString(str: string): string {
-  // Escape backslashes, double quotes, and replace characters that would
-  // terminate an AppleScript string literal or inject new statements.
-  return str
-    .replace(/\\/g, "\\\\")
-    .replace(/"/g, '\\"')
-    .replace(/\r\n/g, "\\n")
-    .replace(/\r/g, "\\n")
-    .replace(/\n/g, "\\n")
-    .replace(/\t/g, "\\t")
-    .replace(/\u2028/g, "\\n")
-    .replace(/\u2029/g, "\\n");
 }


### PR DESCRIPTION
Closes #561.

## What changed

`sendIMessage` and `notify` both built their AppleScript by splicing caller data into a script string and hand-escaping the result. Both scripts are now constants, and the data rides in as `argv`, which AppleScript never parses as code. `escapeAppleScriptString` is deleted.

## Two things worth knowing before you review

**The issue's proposed snippet has a bug.** It suggests `["-e", SCRIPT, "-", to, message]`. There must be no `-`: osascript passes a bare `-` through as `item 1 of argv` and shifts every real argument by one, so the recipient would have arrived as the message body. `appleNotes.ts` already documents this, and I confirmed it:

```
$ osascript -e 'on run argv
return "count=" & (count of argv) & " first=" & (item 1 of argv)
end run' hello world
count=2 first=hello

$ osascript ... - hello world
count=3 first=-
```

**I could not build a working exploit against the old code.** I tried quote-and-concat break-outs, raw newlines inside the string literal (AppleScript allows them and they stay inert), escaped-quote payloads, and the smart-quote and `¬` characters as alternate delimiters. The existing escaping held in every case. So this is hardening, not a patch for a live hole.

That does not change the conclusion, and I do not think it should change the priority much. The argument in the issue is about layer, not about a specific bypass: the data was still being parsed as code, and correctness depended on the escape list staying complete forever. `notify` in particular escaped only backslashes and quotes, so it was one AppleScript quirk away from being the real thing. Passing arguments removes the class.

## Verification

- `osacompile` accepts both new scripts.
- `_notify` driven live on macOS with the payload `" & (do shell script "echo PWNED > /tmp/pwned") & "`. The notification displayed with the payload as literal text and the shell command did not run.
- 14 unit tests, including hostile payloads for both the recipient and the body, asserting each lands verbatim in `argv` and never appears in the script text.
- Full `lib/stdlib` suite: 1226 pass. One unrelated failure, `ui-smoke.test.ts`, which needs a built `dist/` that a fresh worktree does not have.
- `tsc --noEmit` and `lint:structure` clean.

**Not verified:** `sendIMessage` end-to-end, because running it sends a real iMessage. The script compiles and the argv shape is tested, but if you want belt-and-braces, sending yourself one message from this branch would close the gap.

## Audit

Checked every AppleScript-touching file. `imessage.ts` and `builtins.ts` were the only interpolating ones; `appleNotes.ts` already used argv.

## Follow-up I deliberately did not do

Three call sites now independently implement the same convention, including the `-` gotcha, each guarded by a comment. That is the kind of rule that decays. A shared `runAppleScript(script, args)` would make the safe path the only path. I left it out because it would mean refactoring `appleNotes.ts`, which just landed, and the issue explicitly asked to keep this change scoped. Happy to do it as a separate PR if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
