### PR TITLE
Verify-at-checkpoint coding agent + time-boxed expert consult

### DIFF
--- a/packages/agency-lang/docs/site/stdlib/agents/coding.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/coding.md
@@ -21,6 +21,7 @@ codingAgent(
   maxAttempts: number = 3,
   maxCost: number = $50.00,
   maxTime: number = 30m,
+  checkpoint: number = 0,
 ): string
 ```
 
@@ -36,6 +37,9 @@ General-purpose coding agent. Writes and runs code to complete a task and
   @param maxAttempts - Max verify-and-fix attempts before returning (default 3).
   @param maxCost - Hard spend cap for the whole run (default $50).
   @param maxTime - Hard wall-clock cap for the whole run (default 30 minutes).
+  @param checkpoint - If > 0, verify the disk output at this interval and either
+    redirect the agent (when it is making progress) or stop it (when it is
+    thrashing or out of time). 0 keeps the plain single-guard behavior.
 
 **Parameters:**
 
@@ -47,7 +51,8 @@ General-purpose coding agent. Writes and runs code to complete a task and
 | maxAttempts | `number` | 3 |
 | maxCost | `number` | $50.00 |
 | maxTime | `number` | 30m |
+| checkpoint | `number` | 0 |
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/coding.agency#L31))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/coding.agency#L32))

--- a/packages/agency-lang/docs/site/stdlib/agents/expert.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/expert.md
@@ -133,6 +133,9 @@ expertAgent(
   maxTime: number = 15m,
   expertModel: string = "",
   expertProvider: string = "",
+  expertBudget: number = 3m,
+  expertCost: number = $5.00,
+  checkpoint: number = 5m,
 ): string
 ```
 
@@ -149,6 +152,11 @@ Expert-guided coding agent. Consults a domain expert for the task's rules and
     solver (empty = the ambient model). Lets a caller put the one-shot expert
     consult on a stronger model while the solve loop stays on the default.
   @param expertProvider - optional provider for expertModel (empty = auto-resolve).
+  @param expertBudget - max time for the upfront consult (default 3m). On
+    overrun the consult fails open to empty guidance.
+  @param expertCost - spend cap for the consult (default $5).
+  @param checkpoint - interval at which the solver verifies its disk output and
+    is redirected or stopped (default 5m). Passed through to codingAgent.
 
 **Parameters:**
 
@@ -160,7 +168,10 @@ Expert-guided coding agent. Consults a domain expert for the task's rules and
 | maxTime | `number` | 15m |
 | expertModel | `string` | "" |
 | expertProvider | `string` | "" |
+| expertBudget | `number` | 3m |
+| expertCost | `number` | $5.00 |
+| checkpoint | `number` | 5m |
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/expert.agency#L169))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/expert.agency#L185))

--- a/packages/agency-lang/stdlib/agents/coding.agency
+++ b/packages/agency-lang/stdlib/agents/coding.agency
@@ -5,7 +5,7 @@
 */
 import { bash, ls, glob, grep } from "std::shell"
 import { edit } from "std::fs"
-import { systemMessage } from "std::thread"
+import { systemMessage, GuardFailureData } from "std::thread"
 import { verify, feedbackHasErrors, renderFeedback } from "std::agency"
 import { withContext, unwrapGuard } from "std::agents/shared"
 
@@ -24,11 +24,12 @@ static const codingSysPrompt = """You are an expert software engineer. Solve the
 - The deliverable is a working artifact backed by real tool output, not a description. Actually run and exercise what you build.
 - Match the output contract exactly: the requested filename, path, format, and fields. Follow the task's stated whitespace and trailing-newline requirement precisely, whether it asks for one or forbids one. A near-miss fails.
 - When an exact check decides success (a numeric tolerance, an exact match, or a hidden test), do not stop at the first solution that passes your own check. Write down the judgment calls you made to reach it. If a choice could have gone another way and still fit the task, it is an assumption, not a fact, and your answer may only be correct under your reading of it. Re-check that it still passes under the other readings, and prefer a solution that holds under all of them.
+- Keep a valid, best-effort version of the required output file on disk at all times. The moment you have any plausible answer, write it to the exact required path. When a check finds a problem, fix the file before running another check. Never leave the deliverable unwritten while you analyze — an analyzed but unwritten answer scores zero.
 - NEVER fabricate output you did not actually produce."""
 
 static const finalizeReminder = "Before finishing, re-read the task's exact output requirements (filename, format, fields, whitespace, trailing newline) and confirm the artifact on disk matches them exactly."
 
-export def codingAgent(task: string, context: string = "", criteria: string[] = [], maxAttempts: number = 3, maxCost: number = $50.00, maxTime: number = 30m): string {
+export def codingAgent(task: string, context: string = "", criteria: string[] = [], maxAttempts: number = 3, maxCost: number = $50.00, maxTime: number = 30m, checkpoint: number = 0): string {
   """
   General-purpose coding agent. Writes and runs code to complete a task and
   verifies the result against the task's success criteria. Returns a short
@@ -42,26 +43,83 @@ export def codingAgent(task: string, context: string = "", criteria: string[] = 
   @param maxAttempts - Max verify-and-fix attempts before returning (default 3).
   @param maxCost - Hard spend cap for the whole run (default $50).
   @param maxTime - Hard wall-clock cap for the whole run (default 30 minutes).
+  @param checkpoint - If > 0, verify the disk output at this interval and either
+    redirect the agent (when it is making progress) or stop it (when it is
+    thrashing or out of time). 0 keeps the plain single-guard behavior.
   """
-  const captured = guard(cost: maxCost, time: maxTime) {
-    let reply = ""
-    let msg = withContext(task, context)
-    thread(label: "codingAgent") {
-      systemMessage(codingSysPrompt)
-      let done = false
-      let attemptsLeft = maxAttempts
-      while (!done && attemptsLeft > 0) {
-        reply = llm("${msg}\n\n${finalizeReminder}", { tools: codingTools })
-        const fb = verify(task, criteria)
-        if (feedbackHasErrors(fb)) {
-          msg = "Not done yet. A strict review found:\n\n${renderFeedback(fb)}\n\nFix each problem exactly."
-          attemptsLeft = attemptsLeft - 1
-        } else {
-          done = true
+  if (checkpoint <= 0) {
+    const captured = guard(cost: maxCost, time: maxTime) {
+      let reply = ""
+      let msg = withContext(task, context)
+      thread(label: "codingAgent") {
+        systemMessage(codingSysPrompt)
+        let done = false
+        let attemptsLeft = maxAttempts
+        while (!done && attemptsLeft > 0) {
+          reply = llm("${msg}\n\n${finalizeReminder}", { tools: codingTools })
+          const fb = verify(task, criteria)
+          if (feedbackHasErrors(fb)) {
+            msg = "Not done yet. A strict review found:\n\n${renderFeedback(fb)}\n\nFix each problem exactly."
+            attemptsLeft = attemptsLeft - 1
+          } else {
+            done = true
+          }
         }
       }
+      return reply
     }
-    return reply
+    return unwrapGuard(captured, "Coding")
   }
-  return unwrapGuard(captured, "Coding")
+
+  // checkpoint > 0: a re-arming checkpoint guard fires mid-tool-loop and an
+  // interrupt-free handler reads the body's latest verify result, then either
+  // extends with a "commit the fix now" message or stops. verify runs directly
+  // in the body (not a nested guard) so its result survives the trip -> approve
+  // -> resume cycle; the checkpoint interval bounds it. Overall time is the
+  // handler's `spent >= maxTime` graceful stop.
+  let reply = ""
+  let msg = withContext(task, context)
+  let lastGaps = ""          // gap text from the body's most recent verify
+  let handlerSeenGaps = ""   // what the handler compared against last checkpoint
+  let noProgress = 0
+  let outcome: Result<string, GuardFailureData> = success("")
+
+  handle {
+    outcome = guard(cost: maxCost, time: checkpoint, label: "checkpoint") {
+      thread(label: "codingAgent") {
+        systemMessage(codingSysPrompt)
+        let done = false
+        let attemptsLeft = maxAttempts
+        while (!done && attemptsLeft > 0) {
+          reply = llm("${msg}\n\n${finalizeReminder}", { tools: codingTools })
+          saveDraft(reply)
+          const fb = verify(task, criteria)
+          if (feedbackHasErrors(fb)) {
+            lastGaps = renderFeedback(fb)
+            msg = "Not done yet. A strict review of the files on disk found:\n\n${lastGaps}\n\nFix each problem on disk."
+            attemptsLeft = attemptsLeft - 1
+          } else {
+            done = true
+          }
+        }
+      }
+      return reply
+    }
+  } with (i) {
+    if (i.effect == "std::guard" && i.data.label == "checkpoint") {
+      if (i.data.dimension == "time" && i.data.spent < maxTime) {
+        if (lastGaps == "" || lastGaps == handlerSeenGaps) {
+          noProgress = noProgress + 1
+          if (noProgress >= 2) { return reject() }
+        } else {
+          noProgress = 0
+        }
+        handlerSeenGaps = lastGaps
+        return approve({ maxTime: checkpoint, message: "You are over the checkpoint budget. Stop analyzing and writing new scripts. Make the concrete fix to the required output file on disk now, then finish. Latest known gaps:\n${lastGaps}" })
+      }
+      return reject()
+    }
+    return pass()
+  }
+  return unwrapGuard(outcome, "Coding")
 }

--- a/packages/agency-lang/stdlib/agents/expert.agency
+++ b/packages/agency-lang/stdlib/agents/expert.agency
@@ -147,11 +147,27 @@ static const emptyGuidance: ExpertGuidance = { domain: "", rules: [], checklist:
 // structured guidance, so the structured output fails validation — yields empty
 // guidance, so the coding agent still runs exactly as it would without a
 // consult. Guidance can only help, never block.
-def consultOrEmpty(task: string, expertModel: string = "", expertProvider: string = ""): ExpertGuidance {
-  return match (try consultExpert(task, expertModel, expertProvider)) {
-    success(g) => g
-    failure(_) => emptyGuidance
+def consultOrEmpty(task: string, expertModel: string = "", expertProvider: string = "", expertBudget: number = 3m, expertCost: number = $5.00): ExpertGuidance {
+  // Fail-open AND time-boxed. The guard block converts both a raised exception
+  // (e.g. the model returns prose that fails structured-output validation) and a
+  // budget overrun into a `failure`, so this replaces the old `try`. The local
+  // handler rejects the guard's trip so the consult can never eat the run's
+  // budget; the match reads the result inside the handle (a rejected guard's
+  // Result read after the handle closes returns null).
+  let guidance = emptyGuidance
+  handle {
+    const captured = guard(time: expertBudget, cost: expertCost) {
+      return consultExpert(task, expertModel, expertProvider)
+    }
+    guidance = match (captured) {
+      success(g) => g
+      failure(_) => emptyGuidance
+    }
+  } with (i) {
+    if (i.effect == "std::guard") { return reject() }
+    return pass()
   }
+  return guidance
 }
 
 // Fold expert guidance into a context block the coding agent reads before it
@@ -166,7 +182,7 @@ def renderGuidance(g: ExpertGuidance): string {
   return "Domain expertise for this task (${g.domain}):\n\nKey rules and conventions:\n${rules}\n\nAcceptance checklist — your finished work MUST satisfy every item:\n${checks}"
 }
 
-export def expertAgent(task: string, context: string = "", maxCost: number = $20.00, maxTime: number = 15m, expertModel: string = "", expertProvider: string = ""): string {
+export def expertAgent(task: string, context: string = "", maxCost: number = $20.00, maxTime: number = 15m, expertModel: string = "", expertProvider: string = "", expertBudget: number = 3m, expertCost: number = $5.00, checkpoint: number = 5m): string {
   """
   Expert-guided coding agent. Consults a domain expert for the task's rules and
   acceptance criteria, then solves the task with that guidance in hand. A
@@ -181,9 +197,14 @@ export def expertAgent(task: string, context: string = "", maxCost: number = $20
     solver (empty = the ambient model). Lets a caller put the one-shot expert
     consult on a stronger model while the solve loop stays on the default.
   @param expertProvider - optional provider for expertModel (empty = auto-resolve).
+  @param expertBudget - max time for the upfront consult (default 3m). On
+    overrun the consult fails open to empty guidance.
+  @param expertCost - spend cap for the consult (default $5).
+  @param checkpoint - interval at which the solver verifies its disk output and
+    is redirected or stopped (default 5m). Passed through to codingAgent.
   """
   const captured = guard(cost: maxCost, time: maxTime) {
-    const guidance = consultOrEmpty(task, expertModel, expertProvider)
+    const guidance = consultOrEmpty(task, expertModel, expertProvider, expertBudget, expertCost)
     let solverContext = renderGuidance(guidance)
     if (context != "") {
       solverContext = if solverContext == "" then context else "${solverContext}\n\n${context}"
@@ -191,7 +212,14 @@ export def expertAgent(task: string, context: string = "", maxCost: number = $20
     // Pass the expert checklist to the solver's verify step too (not just its
     // system context), so the SAME authoritative criteria drive both building
     // and checking — no independent blind spot between solve and verify.
-    return codingAgent(task, context: solverContext, criteria: guidance.checklist, maxCost: maxCost, maxTime: maxTime)
+    //
+    // Give the solver a time budget that fits inside this outer guard's
+    // remaining time (outer = expertBudget + codingBudget + buffer), so
+    // codingAgent's checkpoint handler reaches its graceful stop before the
+    // outer guard's handler-less hard abort. Clamp so tiny budgets stay positive.
+    const rawCodingBudget = maxTime - expertBudget - 30s
+    const codingBudget = if rawCodingBudget < 60s then 60s else rawCodingBudget
+    return codingAgent(task, context: solverContext, criteria: guidance.checklist, maxCost: maxCost, maxTime: codingBudget, checkpoint: checkpoint)
   }
   return unwrapGuard(captured, "Expert")
 }

--- a/packages/agency-lang/tests/agency/guards/checkpoint-verify-mechanism.agency
+++ b/packages/agency-lang/tests/agency/guards/checkpoint-verify-mechanism.agency
@@ -1,0 +1,81 @@
+// Validates the exact guard/handler composition codingAgent uses:
+//   - the handler reads a `let` the guarded body updated (spike item 2)
+//   - a labelled inner "verify" guard trips and routes to its own reject,
+//     NOT the checkpoint handler (spike item 4)
+//   - approve re-arms the checkpoint (loop runs to completion)
+//   - reject on the checkpoint returns the saved draft (spike item 3)
+// LLM-free: pure time guards + spin, with huge margins (ms limits vs seconds
+// of spin), so timer starvation cannot flake it.
+
+def spin(rounds: number): string {
+  let i = 0
+  while (i < rounds) {
+    i = i + 1
+  }
+  return "spun"
+}
+
+// The checkpoint handler reads a `let` the guarded body updated, and that read
+// survives the trip → approve → resume cycle. This is what codingAgent's
+// no-progress detection depends on (the handler reads `lastGaps`, which the body
+// sets from the most recent verify).
+node checkpointHandlerReadsBodyState(): string {
+  let lastGaps = ""
+  let sawGaps = "none"
+  handle {
+    const captured = guard(time: 100ms, label: "checkpoint") {
+      lastGaps = "gap-A"
+      // Overrun the checkpoint → trips → handler reads lastGaps and grants.
+      const s2 = spin(300000)
+      return "body-done"
+    }
+    if (isFailure(captured)) { return "rejected|saw=${sawGaps}" }
+    return "ok:${captured.value}|saw=${sawGaps}"
+  } with (i) {
+    if (i.effect == "std::guard" && i.data.label == "checkpoint") {
+      sawGaps = lastGaps
+      return approve({ maxTime: 600000, message: "keep going" })
+    }
+    return pass()
+  }
+}
+
+// A checkpoint reject returns the saved draft, not a bare failure.
+node checkpointRejectKeepsDraft(): string {
+  handle {
+    const captured = guard(time: 100ms, label: "checkpoint") {
+      saveDraft("best-so-far")
+      const s = spin(300000)
+      return "full-result"
+    }
+    if (isFailure(captured)) { return "no-draft" }
+    return "kept:${captured.value}"
+  } with (i) {
+    if (i.effect == "std::guard" && i.data.label == "checkpoint") {
+      return reject()
+    }
+    return pass()
+  }
+}
+
+// The exact fail-open composition consultOrEmpty (Task 3) uses: a guard with NO
+// saved draft trips, nobody grants (handler passes, mirroring the auto-approve
+// pass on std::guard), so the guard rejects → failure → match returns the
+// fallback default.
+node guardFailureFallsBackToDefault(): string {
+  let out = ""
+  handle {
+    const captured = guard(time: 20ms, label: "consult") {
+      const s = spin(300000)
+      return "real-guidance"
+    }
+    out = match (captured) {
+      success(v) => v
+      failure(_) => "empty-fallback"
+    }
+  } with (i) {
+    if (i.effect == "std::guard") { return reject() }
+    return pass()
+  }
+  return out
+}

--- a/packages/agency-lang/tests/agency/guards/checkpoint-verify-mechanism.test.json
+++ b/packages/agency-lang/tests/agency/guards/checkpoint-verify-mechanism.test.json
@@ -1,0 +1,31 @@
+{
+  "tests": [
+    {
+      "nodeName": "checkpointHandlerReadsBodyState",
+      "input": "",
+      "expectedOutput": "\"ok:body-done|saw=gap-A\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [],
+      "description": "The checkpoint handler reads the body's lastGaps write (saw=gap-A) at the trip, approve re-arms, and the loop finishes (body-done). The read survives trip → approve → resume."
+    },
+    {
+      "nodeName": "checkpointRejectKeepsDraft",
+      "input": "",
+      "expectedOutput": "\"kept:best-so-far\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [],
+      "description": "A checkpoint reject returns the saved draft."
+    },
+    {
+      "nodeName": "guardFailureFallsBackToDefault",
+      "input": "",
+      "expectedOutput": "\"empty-fallback\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [],
+      "description": "A guard with no saved draft trips and nobody grants → failure → match returns the fallback. This is consultOrEmpty's fail-open composition."
+    }
+  ]
+}


### PR DESCRIPTION
## Why

On Terminal-Bench, the bundled coding agent thrashes until timeout on hard tasks. On `dna-insert` it wrote `primers.fasta` once (wrong), then wrote 18 analysis scripts without ever re-committing, and the 30-minute wall clock killed it with nothing gradeable — the most expensive trial in the run (~$4.9) for a zero. Its inner verify loop can't catch this: one `llm()` turn is a whole tool loop, so a runaway turn never returns to be re-verified.

## What

Three composed changes built on the new interrupt-raising guards + partial results.

**Feature A — verify-at-checkpoint (`codingAgent`).** When `checkpoint > 0`, the coding loop runs under a re-arming checkpoint time guard plus an interrupt-free handler. The guard fires *mid*-tool-loop (where the inner loop can't reach), and the handler reads the body's latest verify gaps and either:
- extends with a "stop analyzing, commit the fix now" message (progress), or
- stops gracefully — `noProgress >= 2` thrash detection, or `spent >= maxTime`.

`checkpoint == 0` keeps today's single-guard behavior verbatim.

**Feature B1 — time-boxed consult (`consultOrEmpty`).** The upfront expert consult now runs under a guard (`expertBudget`/`expertCost`, defaults 3m/$5) and fails open to empty guidance on overrun, so it can no longer eat the solver's time budget. The guard subsumes the old `try` (it converts both exceptions and budget trips to a failure).

**Feature C — commit-early prompt.** `codingSysPrompt` now tells the agent to keep a valid output file on disk at all times and fix the file before running another check.

**Two-guard reconciliation.** `expertAgent` carves its outer budget into `expertBudget + codingBudget + buffer` and hands `codingAgent` a `codingBudget` that fits inside the outer guard, so `codingAgent`'s checkpoint handler owns the graceful stop and the outer guard is a rare hard-abort backstop.

## Two deviations from the approved plan (found during execution)

Both came out of the spike (`tests/agency/guards/checkpoint-verify-mechanism.agency`), which gates the whole design:

1. **No separate verify guard.** The plan bounded `verify` in its own nested guard. But reading a *nested* guard's Result after a checkpoint resume returns `null` (plain `let`s survive fine — the handler reading `lastGaps` works). So `verify` runs directly in the body, bounded by the checkpoint interval. This also drops the `verifyTime`/`verifyCost` params.
2. **Guards are rejected explicitly, not by an assumed default.** An unhandled guard trip does not auto-reject in the test harness, so the consult guard is rejected by a local handler rather than relying on a CLI default.

## Tests

- `tests/agency/guards/checkpoint-verify-mechanism.agency` (new, LLM-free, 3/3): the handler reads body state across trip→approve→resume; a checkpoint reject keeps the saved draft; the guard+local-handle+reject fail-open composition.
- Typechecks clean; structural linter clean; `checkpoint == 0` path unchanged.

## Remaining validation (not in this PR)

Real-LLM end-to-end on `dna-insert` via the bench container: confirm the checkpoint fires, the redirect message lands, and a `primers.fasta` is on disk even on a graceful stop. This needs the Terminal-Bench container and is a manual run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
