### PR TITLE
Fix main CI: update doc-target fixture for description frontmatter

### DIFF
--- a/packages/agency-lang/tests/integration/cli-main/fixtures/expected/doc-target.expected.md
+++ b/packages/agency-lang/tests/integration/cli-main/fixtures/expected/doc-target.expected.md
@@ -1,5 +1,6 @@
 ---
 name: "doc-target"
+description: "Helpers used by CLI integration tests."
 ---
 
 # doc-target


### PR DESCRIPTION
## What is failing

CI on `main` has been red since #577 merged. Example: [run 29648383242](https://github.com/egonSchiele/agency-lang/actions/runs/29648383242/job/88090397777). The `build` job fails at the "Main-only CLI command integration tests" step:

```
[ASSERT FAILED] Expected .../generated-docs/doc-target.md to match
  tests/integration/cli-main/fixtures/expected/doc-target.expected.md
```

`build (23.x)` did not fail on its own; the matrix cancelled it once 22.x failed.

## Why

#577 taught `agency doc` to emit a `description:` frontmatter line, taken from the module's `@module` doc comment (`lib/cli/doc.ts:171-173`). The `doc-target` expected fixture still listed only `name:`, so generated and expected output differ by one line:

```diff
 ---
 name: "doc-target"
+description: "Helpers used by CLI integration tests."
 ---
```

The `cli-main` integration step only runs on pushes to `main`, which is why #577's own PR CI was green.

## The fix

Add the missing line to the fixture. No product code changes.

## Verification

Ran `agency doc` on the fixture source and diffed against the updated expectation. The frontmatter matches exactly; the only remaining differences were the `[source](...)` links, which the integration test's project setup does not emit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
