### PR TITLE
Give the stdlib agents the tools their jobs require, add a data agent, and ship per-agent skills

### DIFF
--- a/packages/agency-lang/docs/site/.vitepress/config.mts
+++ b/packages/agency-lang/docs/site/.vitepress/config.mts
@@ -267,6 +267,7 @@ export default defineConfig({
               collapsed: true,
               items: [
                 { text: "agents/coding", link: "/stdlib/agents/coding" },
+                { text: "agents/data", link: "/stdlib/agents/data" },
                 { text: "agents/expert", link: "/stdlib/agents/expert" },
                 { text: "agents/planner", link: "/stdlib/agents/planner" },
                 { text: "agents/researcher", link: "/stdlib/agents/researcher" },
@@ -298,6 +299,10 @@ export default defineConfig({
                 },
                 { text: "agents/lib/search", link: "/stdlib/agents/lib/search" },
                 { text: "agents/lib/shared", link: "/stdlib/agents/lib/shared" },
+                {
+                  text: "agents/lib/toolkits",
+                  link: "/stdlib/agents/lib/toolkits",
+                },
               ],
             },
             { text: "args", link: "/stdlib/args" },

--- a/packages/agency-lang/docs/site/stdlib/agents/agency/coding.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/agency/coding.md
@@ -28,9 +28,23 @@ export type WriteFailure = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/coding.agency#L20))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/coding.agency#L26))
 
 ## Functions
+
+### buildTools
+
+```ts
+buildTools(): any[]
+```
+
+Return the Agency writer's tools: the bundled documentation, the source
+  inspectors it checks drafts with, read-only access to the project it is
+  writing for, and fetches for a named external resource.
+
+**Returns:** `any[]`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/coding.agency#L107))
 
 ### syntaxHintFor
 
@@ -51,7 +65,7 @@ Return a specific syntax reminder to inject next to a diagnostic, or ""
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/coding.agency#L89))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/coding.agency#L124))
 
 ### agencyCodingAgent
 
@@ -65,6 +79,7 @@ agencyCodingAgent(
   model: string = "",
   provider: string = "",
   session: string = "",
+  extraTools: any[] = [],
 ): Result<string, WriteFailure>
 ```
 
@@ -80,6 +95,7 @@ Write an Agency program for the task. Iterates until the source parses,
   @param model - Model override, or "" for the ambient model
   @param provider - Provider for the model override
   @param session - Session name to share a thread across calls, or "" for isolated
+  @param extraTools - Extra tools to offer the LLM, appended to the built-in set
 
 **Parameters:**
 
@@ -93,7 +109,8 @@ Write an Agency program for the task. Iterates until the source parses,
 | model | `string` | "" |
 | provider | `string` | "" |
 | session | `string` | "" |
+| extraTools | `any[]` | [] |
 
 **Returns:** `Result<string, WriteFailure>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/coding.agency#L211))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/coding.agency#L251))

--- a/packages/agency-lang/docs/site/stdlib/agents/agency/expert.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/agency/expert.md
@@ -18,6 +18,19 @@ syntax rules and acceptance checklist a solver needs, grounded in the
 
 ## Functions
 
+### buildTools
+
+```ts
+buildTools(): any[]
+```
+
+Return the Agency expert's tools: the bundled language documentation and
+  the source inspectors it cites in its guidance.
+
+**Returns:** `any[]`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/expert.agency#L24))
+
 ### agencyExpertAgent
 
 ```ts
@@ -29,6 +42,7 @@ agencyExpertAgent(
   model: string = "",
   provider: string = "",
   session: string = "",
+  extraTools: any[] = [],
 ): Result<ExpertGuidance>
 ```
 
@@ -42,6 +56,7 @@ Consult an Agency-language specialist: return the syntax rules and
   @param model - Model override, or "" for the ambient model
   @param provider - Provider for the model override
   @param session - Session name to share a thread across calls, or "" for isolated
+  @param extraTools - Extra tools to offer the LLM, appended to the built-in set
 
 **Parameters:**
 
@@ -54,7 +69,8 @@ Consult an Agency-language specialist: return the syntax rules and
 | model | `string` | "" |
 | provider | `string` | "" |
 | session | `string` | "" |
+| extraTools | `any[]` | [] |
 
 **Returns:** `Result<ExpertGuidance>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/expert.agency#L54))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/expert.agency#L59))

--- a/packages/agency-lang/docs/site/stdlib/agents/agency/review.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/agency/review.md
@@ -7,8 +7,9 @@ description: "Reviews Agency source code: parse findings, typecheck findings, an
 
 an optional LLM judgment of whether the code accomplishes a task.
 
-  Review reads; it never runs the code. To execute a program and judge its
-  actual result, use agencyVerifierAgent instead.
+  Review reads the work and looks things up. The verifier runs the work and
+  measures it. This agent never executes the code it reviews, but it can
+  consult the bundled Agency documentation and the web to check a claim.
 
 ## Functions
 
@@ -29,7 +30,20 @@ Convert a typecheck report into findings: one error item per error, one
 
 **Returns:** `Feedback[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/review.agency#L17))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/review.agency#L21))
+
+### buildTools
+
+```ts
+buildTools(): any[]
+```
+
+Return the Agency reviewer's lookup tools: the bundled language
+  documentation, plus web lookups for anything outside it.
+
+**Returns:** `any[]`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/review.agency#L36))
 
 ### agencyReviewAgent
 
@@ -43,6 +57,7 @@ agencyReviewAgent(
   model: string = "",
   provider: string = "",
   session: string = "",
+  extraTools: any[] = [],
 ): Result<Feedback[]>
 ```
 
@@ -58,6 +73,7 @@ Review Agency source code and return findings. Always includes parse and
   @param model - Model override, or "" for the ambient model
   @param provider - Provider for the model override
   @param session - Session name to share a thread across calls, or "" for isolated
+  @param extraTools - Extra tools to offer the LLM, appended to the built-in set
 
 **Parameters:**
 
@@ -71,7 +87,8 @@ Review Agency source code and return findings. Always includes parse and
 | model | `string` | "" |
 | provider | `string` | "" |
 | session | `string` | "" |
+| extraTools | `any[]` | [] |
 
 **Returns:** `Result<Feedback[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/review.agency#L69))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/review.agency#L94))

--- a/packages/agency-lang/docs/site/stdlib/agents/agency/verifier.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/agency/verifier.md
@@ -10,6 +10,20 @@ The verifier runs; review reads. To check source text without executing it,
 
 ## Functions
 
+### buildTools
+
+```ts
+buildTools(): any[]
+```
+
+Return the Agency verifier's tools. It reads and measures what the program
+  left behind; it has no write tools, because a verifier that can fix things
+  is no longer a verifier.
+
+**Returns:** `any[]`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/verifier.agency#L24))
+
 ### agencyVerifierAgent
 
 ```ts
@@ -22,6 +36,7 @@ agencyVerifierAgent(
   model: string = "",
   provider: string = "",
   session: string = "",
+  extraTools: any[] = [],
 ): Result<Feedback[]>
 ```
 
@@ -37,6 +52,7 @@ Run an Agency program and judge its result against the task. A program that
   @param model - Model override, or "" for the ambient model
   @param provider - Provider for the model override
   @param session - Session name to share a thread across calls, or "" for isolated
+  @param extraTools - Extra tools to offer the LLM, appended to the built-in set
 
 **Parameters:**
 
@@ -50,7 +66,8 @@ Run an Agency program and judge its result against the task. A program that
 | model | `string` | "" |
 | provider | `string` | "" |
 | session | `string` | "" |
+| extraTools | `any[]` | [] |
 
 **Returns:** `Result<Feedback[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/verifier.agency#L55))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/verifier.agency#L89))

--- a/packages/agency-lang/docs/site/stdlib/agents/coding.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/coding.md
@@ -32,7 +32,7 @@ Return the coding agent's tools. Exported so a caller can inspect what the
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/coding.agency#L50))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/coding.agency#L51))
 
 ### codingAgent
 
@@ -76,4 +76,4 @@ Write, edit, and run code to complete a task on disk. Returns a short
 
 **Returns:** `Result<string>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/coding.agency#L96))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/coding.agency#L97))

--- a/packages/agency-lang/docs/site/stdlib/agents/coding.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/coding.md
@@ -21,6 +21,19 @@ honest pass: it works until it believes the task is done, then returns a
 
 ## Functions
 
+### buildTools
+
+```ts
+buildTools(): any[]
+```
+
+Return the coding agent's tools. Exported so a caller can inspect what the
+  agent may do, and so tests can assert it.
+
+**Returns:** `any[]`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/coding.agency#L50))
+
 ### codingAgent
 
 ```ts
@@ -32,6 +45,7 @@ codingAgent(
   model: string = "",
   provider: string = "",
   session: string = "",
+  extraTools: any[] = [],
 ): Result<string>
 ```
 
@@ -45,6 +59,7 @@ Write, edit, and run code to complete a task on disk. Returns a short
   @param model - Model override, or "" for the ambient model
   @param provider - Provider for the model override
   @param session - Session name to share a thread across calls, or "" for isolated
+  @param extraTools - Extra tools to offer the LLM, appended to the built-in set
 
 **Parameters:**
 
@@ -57,7 +72,8 @@ Write, edit, and run code to complete a task on disk. Returns a short
 | model | `string` | "" |
 | provider | `string` | "" |
 | session | `string` | "" |
+| extraTools | `any[]` | [] |
 
 **Returns:** `Result<string>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/coding.agency#L134))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/coding.agency#L96))

--- a/packages/agency-lang/docs/site/stdlib/agents/data.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/data.md
@@ -1,0 +1,73 @@
+---
+name: "data"
+description: "Answers a question using the structured public-data APIs in the"
+---
+
+# data
+
+standard library: economic series, securities filings, federal spending,
+  news, and entity databases.
+
+  This agent works structured sources with exact identifiers. For unstructured
+  web pages and encyclopedia prose, use researcherAgent instead. Querying
+  these APIs usually means finding an identifier first, such as a FRED series
+  ID or an EDGAR CIK, so the agent carries search and fetch tools too.
+
+## Functions
+
+### buildTools
+
+```ts
+buildTools(): any[]
+```
+
+Return the data agent's tools: every connector, plus the search and fetch
+  tools it needs to find an identifier before querying.
+
+**Returns:** `any[]`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/data.agency#L42))
+
+### dataAgent
+
+```ts
+dataAgent(
+  task: string,
+  context: string = "",
+  maxCost: number = $20.00,
+  maxTime: number = 15m,
+  model: string = "",
+  provider: string = "",
+  session: string = "",
+  extraTools: any[] = [],
+): Result<string>
+```
+
+Answer a question from structured public-data APIs, naming the source and
+  identifier behind every figure.
+
+  @param task - The question to answer
+  @param context - Extra material folded into the prompt, or ""
+  @param maxCost - Hard spend cap
+  @param maxTime - Hard wall-clock cap
+  @param model - Model override, or "" for the ambient model
+  @param provider - Provider for the model override
+  @param session - Session name to share a thread across calls, or "" for isolated
+  @param extraTools - Extra tools to offer the LLM, appended to the built-in set
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| task | `string` |  |
+| context | `string` | "" |
+| maxCost | `number` | $20.00 |
+| maxTime | `number` | 15m |
+| model | `string` | "" |
+| provider | `string` | "" |
+| session | `string` | "" |
+| extraTools | `any[]` | [] |
+
+**Returns:** `Result<string>`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/data.agency#L99))

--- a/packages/agency-lang/docs/site/stdlib/agents/expert.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/expert.md
@@ -20,6 +20,19 @@ acceptance checklist a solver needs to get the task right.
 
 ## Functions
 
+### buildTools
+
+```ts
+buildTools(): any[]
+```
+
+Return the expert's tools: the web and encyclopedia lookups it uses to
+  confirm domain specifics.
+
+**Returns:** `any[]`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/expert.agency#L26))
+
 ### expertAgent
 
 ```ts
@@ -31,6 +44,7 @@ expertAgent(
   model: string = "",
   provider: string = "",
   session: string = "",
+  extraTools: any[] = [],
 ): Result<ExpertGuidance>
 ```
 
@@ -44,6 +58,7 @@ Consult a domain expert: identify the task's technical domain and return
   @param model - Model override, or "" for the ambient model
   @param provider - Provider for the model override
   @param session - Session name to share a thread across calls, or "" for isolated
+  @param extraTools - Extra tools to offer the LLM, appended to the built-in set
 
 **Parameters:**
 
@@ -56,6 +71,7 @@ Consult a domain expert: identify the task's technical domain and return
 | model | `string` | "" |
 | provider | `string` | "" |
 | session | `string` | "" |
+| extraTools | `any[]` | [] |
 
 **Returns:** `Result<ExpertGuidance>`
 

--- a/packages/agency-lang/docs/site/stdlib/agents/expert.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/expert.md
@@ -31,7 +31,7 @@ Return the expert's tools: the web and encyclopedia lookups it uses to
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/expert.agency#L26))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/expert.agency#L27))
 
 ### expertAgent
 
@@ -75,4 +75,4 @@ Consult a domain expert: identify the task's technical domain and return
 
 **Returns:** `Result<ExpertGuidance>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/expert.agency#L69))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/expert.agency#L70))

--- a/packages/agency-lang/docs/site/stdlib/agents/lib/search.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/lib/search.md
@@ -30,6 +30,26 @@ Return the web-search tools whose API key is set, or an empty array when
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/search.agency#L44))
 
+### hostedSearchTools
+
+```ts
+hostedSearchTools(model: string = ""): string[]
+```
+
+Return the provider-hosted search capabilities to request.
+
+  @param model - The model that will run the call, or "" for the branch default
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| model | `string` | "" |
+
+**Returns:** `string[]`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/search.agency#L68))
+
 ### searchProviderNames
 
 ```ts
@@ -41,4 +61,4 @@ Return the names of the web-search providers whose API key is set, for
 
 **Returns:** `string[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/search.agency#L53))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/search.agency#L92))

--- a/packages/agency-lang/docs/site/stdlib/agents/lib/toolkits.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/lib/toolkits.md
@@ -1,0 +1,135 @@
+---
+name: "toolkits"
+description: "Named bundles of tools that agents compose into their tool lists."
+---
+
+# toolkits
+
+An agent's tool list should read as a description of what that agent may
+  do. Bundling also means a tool added to a category reaches every agent that
+  claimed the category, instead of drifting between hand-maintained arrays.
+
+  Every bundle is a function rather than a constant, matching searchTools() in
+  std::agents/lib/search, which must be a function because it reads API keys
+  at call time. An agent whose list includes searchTools() must build that
+  list inside a function too, or it freezes the environment at module load.
+
+## Functions
+
+### readOnlyFileTools
+
+```ts
+readOnlyFileTools(): any[]
+```
+
+Return tools that inspect the file system without changing it: read, list,
+  glob, and grep, resolved against the agent working directory.
+
+**Returns:** `any[]`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/toolkits.agency#L53))
+
+### writableFileTools
+
+```ts
+writableFileTools(): any[]
+```
+
+Return the read-only file tools plus write and edit.
+
+**Returns:** `any[]`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/toolkits.agency#L66))
+
+### shellTools
+
+```ts
+shellTools(): any[]
+```
+
+Return tools that run commands: bash for a shell pipeline, exec for a
+  single binary with arguments.
+
+**Returns:** `any[]`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/toolkits.agency#L77))
+
+### gitTools
+
+```ts
+gitTools(): any[]
+```
+
+Return the git tools. The read-only ones run without an approval prompt;
+  the ones that change the repository prompt for approval.
+
+**Returns:** `any[]`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/toolkits.agency#L88))
+
+### webTools
+
+```ts
+webTools(): any[]
+```
+
+Return tools that retrieve a named web resource: HTTP fetches and Wikipedia
+  lookups. These retrieve something you can already name; to discover a
+  source you cannot name yet, add a search tool as well.
+
+**Returns:** `any[]`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/toolkits.agency#L114))
+
+### agencyDocTools
+
+```ts
+agencyDocTools(): any[]
+```
+
+Return the bundled Agency documentation tools: the language guide, the CLI
+  reference, the type-checker diagnostic codes, and the standard-library
+  reference.
+
+**Returns:** `any[]`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/toolkits.agency#L130))
+
+### agencyCodeTools
+
+```ts
+agencyCodeTools(): any[]
+```
+
+Return tools that inspect Agency source without running it: the type
+  checker and the parser.
+
+**Returns:** `any[]`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/toolkits.agency#L139))
+
+### memoryTools
+
+```ts
+memoryTools(): any[]
+```
+
+Return tools that persist and retrieve facts across sessions.
+
+**Returns:** `any[]`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/toolkits.agency#L147))
+
+### planningTools
+
+```ts
+planningTools(): any[]
+```
+
+Return tools an agent uses to organize a long run: a todo list, and
+  saveDraft for checkpointing partial work so an aborted run still returns
+  something.
+
+**Returns:** `any[]`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/toolkits.agency#L154))

--- a/packages/agency-lang/docs/site/stdlib/agents/planner.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/planner.md
@@ -29,9 +29,22 @@ effect std::agents::planApprove {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L18))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L32))
 
 ## Functions
+
+### buildTools
+
+```ts
+buildTools(): any[]
+```
+
+Return the planner's tools: read-only access to the project it is planning
+  for, plus its skills.
+
+**Returns:** `any[]`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L22))
 
 ### planCodePrompt
 
@@ -51,7 +64,7 @@ Build the code-generation instruction: emit a program whose `node main` composes
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L49))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L63))
 
 ### renderEffects
 
@@ -70,7 +83,7 @@ Human-readable capability envelope for the approval prompt, or an honest
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L77))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L91))
 
 ### runApproved
 
@@ -94,7 +107,7 @@ runApproved(
 
 **Returns:** [PlanState](#planstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L164))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L178))
 
 ### plannerAgent
 
@@ -107,6 +120,8 @@ plannerAgent(
   maxTime: number = 60m,
   model: string = "",
   provider: string = "",
+  session: string = "",
+  extraTools: any[] = [],
 ): Result<string> raises <std::agents::planApprove, std::guard>
 ```
 
@@ -123,6 +138,8 @@ Plan-as-code: draft (or use a seed) plan, generate an agent that solves the
   @param maxTime - hard wall-clock cap (default 60 minutes).
   @param model - model override for the planning step only, or "" for the ambient model.
   @param provider - provider for the model override.
+  @param session - Session name to share a thread across calls, or "" for isolated
+  @param extraTools - Extra tools to offer the LLM, appended to the built-in set
 
 **Parameters:**
 
@@ -135,7 +152,9 @@ Plan-as-code: draft (or use a seed) plan, generate an agent that solves the
 | maxTime | `number` | 60m |
 | model | `string` | "" |
 | provider | `string` | "" |
+| session | `string` | "" |
+| extraTools | `any[]` | [] |
 
 **Returns:** `Result<string>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L195))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L209))

--- a/packages/agency-lang/docs/site/stdlib/agents/planner.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/planner.md
@@ -107,7 +107,7 @@ runApproved(
 
 **Returns:** [PlanState](#planstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L178))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L180))
 
 ### plannerAgent
 
@@ -157,4 +157,4 @@ Plan-as-code: draft (or use a seed) plan, generate an agent that solves the
 
 **Returns:** `Result<string>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L209))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L215))

--- a/packages/agency-lang/docs/site/stdlib/agents/researcher.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/researcher.md
@@ -13,6 +13,19 @@ a cited answer, retrying until every claim is grounded.
 
 ## Functions
 
+### buildTools
+
+```ts
+buildTools(): any[]
+```
+
+Return the researcher's tools: the encyclopedia and fetch tools that need
+  no key, plus whichever search providers the environment has a key for.
+
+**Returns:** `any[]`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/researcher.agency#L35))
+
 ### researcherAgent
 
 ```ts
@@ -25,6 +38,7 @@ researcherAgent(
   model: string = "",
   provider: string = "",
   session: string = "",
+  extraTools: any[] = [],
 ): Result<string>
 ```
 
@@ -39,6 +53,7 @@ Answer a research question from web and Wikipedia sources and return a
   @param model - Model override, or "" for the ambient model
   @param provider - Provider for the model override
   @param session - Session name to share a thread across calls, or "" for isolated
+  @param extraTools - Extra tools to offer the LLM, appended to the built-in set
 
 **Parameters:**
 
@@ -52,7 +67,8 @@ Answer a research question from web and Wikipedia sources and return a
 | model | `string` | "" |
 | provider | `string` | "" |
 | session | `string` | "" |
+| extraTools | `any[]` | [] |
 
 **Returns:** `Result<string>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/researcher.agency#L101))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/researcher.agency#L112))

--- a/packages/agency-lang/docs/site/stdlib/agents/researcher.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/researcher.md
@@ -72,4 +72,4 @@ Answer a research question from web and Wikipedia sources and return a
 
 **Returns:** `Result<string>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/researcher.agency#L113))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/researcher.agency#L120))

--- a/packages/agency-lang/docs/site/stdlib/agents/researcher.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/researcher.md
@@ -20,7 +20,8 @@ buildTools(): any[]
 ```
 
 Return the researcher's tools: the encyclopedia and fetch tools that need
-  no key, plus whichever search providers the environment has a key for.
+  no key, a local file read for material the caller points at, and whichever
+  search providers the environment has a key for.
 
 **Returns:** `any[]`
 
@@ -71,4 +72,4 @@ Answer a research question from web and Wikipedia sources and return a
 
 **Returns:** `Result<string>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/researcher.agency#L112))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/researcher.agency#L113))

--- a/packages/agency-lang/docs/site/stdlib/agents/review.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/review.md
@@ -5,12 +5,27 @@ description: "Reviews a work product against a task and returns findings."
 
 # review
 
-The work is handed in as text; review reads it and judges it. It never
-  touches the file system and never runs anything. To verify work on disk by
-  measuring it, use verifierAgent instead. For Agency source specifically,
-  agencyReviewAgent adds parse and typecheck findings.
+Review reads the work and looks things up. The verifier runs the work and
+  measures it. This agent never touches the file system and never executes
+  what it is reviewing, but it can consult the web to check a claim: whether
+  an API is used correctly, whether a cited source says what the work says it
+  does. For Agency source specifically, agencyReviewAgent adds parse and
+  typecheck findings.
 
 ## Functions
+
+### buildTools
+
+```ts
+buildTools(): any[]
+```
+
+Return the reviewer's lookup tools. It reads and checks; it has no tools
+  that change anything.
+
+**Returns:** `any[]`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/review.agency#L24))
 
 ### reviewAgent
 
@@ -24,6 +39,7 @@ reviewAgent(
   model: string = "",
   provider: string = "",
   session: string = "",
+  extraTools: any[] = [],
 ): Result<Feedback[]>
 ```
 
@@ -38,6 +54,7 @@ Review a work product against a task and return findings. error=true marks
   @param model - Model override, or "" for the ambient model
   @param provider - Provider for the model override
   @param session - Session name to share a thread across calls, or "" for isolated
+  @param extraTools - Extra tools to offer the LLM, appended to the built-in set
 
 **Parameters:**
 
@@ -51,7 +68,8 @@ Review a work product against a task and return findings. error=true marks
 | model | `string` | "" |
 | provider | `string` | "" |
 | session | `string` | "" |
+| extraTools | `any[]` | [] |
 
 **Returns:** `Result<Feedback[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/review.agency#L36))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/review.agency#L62))

--- a/packages/agency-lang/docs/site/stdlib/agents/verifier.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/verifier.md
@@ -12,6 +12,20 @@ criteria and computes each one with tools.
 
 ## Functions
 
+### buildTools
+
+```ts
+buildTools(): any[]
+```
+
+Return the verifier's tools. It measures with shell pipelines and reads
+  bytes, because a criterion checked by eye is a criterion not checked. It
+  has no write tools: a verifier that can fix things is no longer a verifier.
+
+**Returns:** `any[]`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/verifier.agency#L23))
+
 ### verifierAgent
 
 ```ts
@@ -24,6 +38,7 @@ verifierAgent(
   model: string = "",
   provider: string = "",
   session: string = "",
+  extraTools: any[] = [],
 ): Result<Feedback[]>
 ```
 
@@ -39,6 +54,7 @@ Verify work on disk against a task: derive measurable success criteria,
   @param model - Model override, or "" for the ambient model
   @param provider - Provider for the model override
   @param session - Session name to share a thread across calls, or "" for isolated
+  @param extraTools - Extra tools to offer the LLM, appended to the built-in set
 
 **Parameters:**
 
@@ -52,7 +68,8 @@ Verify work on disk against a task: derive measurable success criteria,
 | model | `string` | "" |
 | provider | `string` | "" |
 | session | `string` | "" |
+| extraTools | `any[]` | [] |
 
 **Returns:** `Result<Feedback[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/verifier.agency#L37))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/verifier.agency#L48))

--- a/packages/agency-lang/docs/site/stdlib/llm.md
+++ b/packages/agency-lang/docs/site/stdlib/llm.md
@@ -257,4 +257,4 @@ Load model data from a JSON file (the shape `agency models refresh`
 
 **Returns:** `Result<number>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L186))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L187))

--- a/packages/agency-lang/docs/site/stdlib/skills.md
+++ b/packages/agency-lang/docs/site/stdlib/skills.md
@@ -125,6 +125,26 @@ Build a docs tool for an LLM over the packaged Agency documentation.
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L243))
 
+### agentSkill
+
+```ts
+agentSkill(agent: string)
+```
+
+Build a skills tool over the skills shipped for one agent. The returned
+  tool lists every skill in its description and lets the model read any one
+  on demand.
+
+  @param agent - Which agent's skills to serve, as a path under the shipped skills directory
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| agent | `string` |  |
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L263))
+
 ### commandsDir
 
 ```ts
@@ -177,7 +197,7 @@ Discover .md files under `dir` and parse each as a slash-command
 
 **Throws:** `std::skills::commandsDir`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L330))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L350))
 
 ### expandSlash
 
@@ -216,4 +236,4 @@ Expand a /command in `msg` into its command body. Returns the rendered
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L387))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L407))

--- a/packages/agency-lang/lib/stdlib/llm.ts
+++ b/packages/agency-lang/lib/stdlib/llm.ts
@@ -123,6 +123,7 @@ export function _modelSupportsInput(model: string, modality: string): boolean | 
   return modelSupportsInputModality(model, modality) ?? null;
 }
 
+
 /** Fetch the latest model-data blob and return it pre-serialized. No
  *  registration — the CLI prints this to stdout for the user to save and later
  *  load with `std::llm.loadModelData`. */

--- a/packages/agency-lang/lib/stdlib/skills.agentSkillsDir.test.ts
+++ b/packages/agency-lang/lib/stdlib/skills.agentSkillsDir.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import path from "path";
+import { _agentSkillsDir } from "./skills.js";
+
+describe("_agentSkillsDir", () => {
+  it("resolves a plain agent name under the shipped skills directory", () => {
+    const dir = _agentSkillsDir("coding");
+    expect(dir.endsWith(path.join("agents", "skills", "coding"))).toBe(true);
+  });
+
+  it("resolves a nested agent name", () => {
+    const dir = _agentSkillsDir("agency/coding");
+    expect(
+      dir.endsWith(path.join("agents", "skills", "agency", "coding")),
+    ).toBe(true);
+  });
+
+  // agentSkill skips the approval interrupt because the files ship in the
+  // package. That argument only holds while the path cannot leave the
+  // shipped directory.
+  it("rejects a name that escapes the skills directory", () => {
+    expect(() => _agentSkillsDir("../../..")).toThrow(/outside the shipped/);
+    expect(() => _agentSkillsDir("coding/../../../etc")).toThrow(
+      /outside the shipped/,
+    );
+  });
+
+  it("rejects an absolute path", () => {
+    expect(() => _agentSkillsDir("/etc")).toThrow(/outside the shipped/);
+  });
+});

--- a/packages/agency-lang/lib/stdlib/skills.ts
+++ b/packages/agency-lang/lib/stdlib/skills.ts
@@ -36,3 +36,13 @@ export function _readSkill(filepath: string): string {
 export function _docsDir(section: "guide" | "cli" | "diagnostics" | "stdlib"): string {
   return path.join(getStdlibDir(), "docs", section);
 }
+
+/**
+ * Absolute path to the skills we ship for one agent, under
+ * `stdlib/agents/skills/<agent>`. Resolved through getStdlibDir for the
+ * same reason as _docsDir: a path relative to the calling file works in the
+ * repo and breaks once the package is installed into node_modules.
+ */
+export function _agentSkillsDir(agent: string): string {
+  return path.join(getStdlibDir(), "agents", "skills", agent);
+}

--- a/packages/agency-lang/lib/stdlib/skills.ts
+++ b/packages/agency-lang/lib/stdlib/skills.ts
@@ -42,7 +42,22 @@ export function _docsDir(section: "guide" | "cli" | "diagnostics" | "stdlib"): s
  * `stdlib/agents/skills/<agent>`. Resolved through getStdlibDir for the
  * same reason as _docsDir: a path relative to the calling file works in the
  * repo and breaks once the package is installed into node_modules.
+ *
+ * The name is confined to that directory. `agentSkill` deliberately skips
+ * the approval interrupt that `skillsDir` raises, on the grounds that these
+ * files ship inside the package, so an `agent` of `"../../.."` would turn a
+ * trusted scan into an unprompted scan of somewhere else entirely. Confining
+ * here keeps that trust argument true.
  */
 export function _agentSkillsDir(agent: string): string {
-  return path.join(getStdlibDir(), "agents", "skills", agent);
+  const root = path.join(getStdlibDir(), "agents", "skills");
+  const resolved = path.resolve(root, agent);
+  const rootWithSep = root.endsWith(path.sep) ? root : root + path.sep;
+  if (resolved !== root && !resolved.startsWith(rootWithSep)) {
+    throw new Error(
+      `agentSkill: '${agent}' resolves outside the shipped skills directory. ` +
+        `Skill names are relative paths under stdlib/agents/skills.`,
+    );
+  }
+  return resolved;
 }

--- a/packages/agency-lang/package.json
+++ b/packages/agency-lang/package.json
@@ -47,6 +47,7 @@
     "./stdlib/**/*.agency",
     "./stdlib/**/*.js",
     "./stdlib/docs/**/*.md",
+    "./stdlib/agents/skills/**/*.md",
     "./scripts/hooks/postinstall.js"
   ],
   "exports": {

--- a/packages/agency-lang/stdlib/agents/agency/coding.agency
+++ b/packages/agency-lang/stdlib/agents/agency/coding.agency
@@ -18,6 +18,7 @@ import {
  } from "std::agents/lib/toolkits"
 import { fetch, fetchJSON, fetchMarkdown } from "std::http"
 import { Critique, revise } from "std::strategy"
+import { agentSkill } from "std::skills"
 import { systemMessage, threadIsNew } from "std::thread"
 
 /** A failed generation: the last source attempted, with the problems found
@@ -99,6 +100,10 @@ Return only the complete program in the code field."""
 // search returns other languages' idioms, which is the exact failure the
 // system prompt above spends its length fighting. Targeted fetch is fine: it
 // retrieves a page the caller already named.
+// Skills we ship for this agent: markdown the model reads on demand,
+// so teaching it something new costs a file rather than prompt length.
+static const skills = agentSkill("agency/coding")
+
 export def buildTools(): any[] {
   """
   Return the Agency writer's tools: the bundled documentation, the source
@@ -112,6 +117,7 @@ export def buildTools(): any[] {
     fetch,
     fetchJSON,
     fetchMarkdown,
+    skills,
   ]
 }
 

--- a/packages/agency-lang/stdlib/agents/agency/coding.agency
+++ b/packages/agency-lang/stdlib/agents/agency/coding.agency
@@ -183,6 +183,7 @@ def generateLoop(
   maxAttempts: number,
   model: string,
   provider: string,
+  extraTools: any[],
 ): WriteOutcome {
   if (threadIsNew()) {
     systemMessage(systemPrompt)
@@ -200,7 +201,7 @@ def generateLoop(
     }
     const generated: GeneratedCode = llm(
       prompt,
-      llmOptions(model: model, provider: provider, tools: tools),
+      llmOptions(model: model, provider: provider, tools: tools.concat(extraTools)),
     )
     const outcome = outcomeFor(source: generated.code)
     saveDraft(outcome)
@@ -217,6 +218,7 @@ export def agencyCodingAgent(
   model: string = "",
   provider: string = "",
   session: string = "",
+  extraTools: any[] = [],
 ): Result<string, WriteFailure> {
   """
   Write an Agency program for the task. Iterates until the source parses,
@@ -231,11 +233,19 @@ export def agencyCodingAgent(
   @param model - Model override, or "" for the ambient model
   @param provider - Provider for the model override
   @param session - Session name to share a thread across calls, or "" for isolated
+  @param extraTools - Extra tools to offer the LLM, appended to the built-in set
   """
   const captured = guard(cost: maxCost, time: maxTime) {
     let outcome: WriteOutcome = { valid: false, source: "", problems: ["generation never ran"] }
     thread(label: "agencyCodingAgent", session: session) {
-      outcome = generateLoop(task, context, maxAttempts, model, provider)
+      outcome = generateLoop(
+        task: task,
+        context: context,
+        maxAttempts: maxAttempts,
+        model: model,
+        provider: provider,
+        extraTools: extraTools,
+      )
     }
     return outcome
   }

--- a/packages/agency-lang/stdlib/agents/agency/coding.agency
+++ b/packages/agency-lang/stdlib/agents/agency/coding.agency
@@ -11,7 +11,12 @@ import { compile } from "std::agency"
 import { agencyReviewAgent } from "std::agents/agency/review"
 import { renderFeedback, feedbackHasErrors } from "std::agents/lib/feedback"
 import { llmOptions, withContext } from "std::agents/lib/shared"
-import { docsSkill } from "std::skills"
+import {
+  agencyDocTools,
+  agencyCodeTools,
+  readOnlyFileTools,
+ } from "std::agents/lib/toolkits"
+import { fetch, fetchJSON, fetchMarkdown } from "std::http"
 import { Critique, revise } from "std::strategy"
 import { systemMessage, threadIsNew } from "std::thread"
 
@@ -81,10 +86,34 @@ Commonly useful standard library modules:
 - std::agency: runCode (run Agency code)
 
 If you are unsure about syntax or a standard-library function, read the
-relevant page with the docs tool before writing code.
+relevant page with the docs tool before writing code. When a diagnostic code
+(AG####) comes back, look it up in the diagnostics reference rather than
+guessing at the fix.
+
+Typecheck your draft before returning it, and fix what it reports. An
+attempt you already know does not typecheck wastes a whole round.
 Return only the complete program in the code field."""
 
-static const tools: any[] = [docsSkill("guide")]
+// No hosted web search here, unlike codingAgent. This agent writes one
+// language whose authoritative docs ship in this package, and an open-ended
+// search returns other languages' idioms, which is the exact failure the
+// system prompt above spends its length fighting. Targeted fetch is fine: it
+// retrieves a page the caller already named.
+export def buildTools(): any[] {
+  """
+  Return the Agency writer's tools: the bundled documentation, the source
+  inspectors it checks drafts with, read-only access to the project it is
+  writing for, and fetches for a named external resource.
+  """
+  return [
+    ...agencyDocTools(),
+    ...agencyCodeTools(),
+    ...readOnlyFileTools(),
+    fetch,
+    fetchJSON,
+    fetchMarkdown,
+  ]
+}
 
 export def syntaxHintFor(errors: string): string {
   """
@@ -201,7 +230,11 @@ def generateLoop(
     }
     const generated: GeneratedCode = llm(
       prompt,
-      llmOptions(model: model, provider: provider, tools: tools.concat(extraTools)),
+      llmOptions(
+        model: model,
+        provider: provider,
+        tools: buildTools().concat(extraTools),
+      ),
     )
     const outcome = outcomeFor(source: generated.code)
     saveDraft(outcome)

--- a/packages/agency-lang/stdlib/agents/agency/expert.agency
+++ b/packages/agency-lang/stdlib/agents/agency/expert.agency
@@ -11,19 +11,18 @@
   For any other technical domain, use expertAgent, which consults the web
   instead of the bundled docs.
 */
-import { typecheck } from "std::agency"
 import { ExpertGuidance, emptyGuidance } from "std::agents/lib/expertGuidance"
 import { llmOptions, withContext } from "std::agents/lib/shared"
-import { docsSkill } from "std::skills"
+import { agencyDocTools, agencyCodeTools } from "std::agents/lib/toolkits"
 import { systemMessage, threadIsNew } from "std::thread"
 
-// Bundled Agency docs, served via std::skills (no startup approval — they
-// ship with the stdlib). `static` caches the tool across calls.
-static const docSkill = docsSkill("guide")
-static const cliSkill = docsSkill("cli")
-static const diagnosticsSkill = docsSkill("diagnostics")
-
-static const tools: any[] = [docSkill, cliSkill, diagnosticsSkill, typecheck]
+export def buildTools(): any[] {
+  """
+  Return the Agency expert's tools: the bundled language documentation and
+  the source inspectors it cites in its guidance.
+  """
+  return [...agencyDocTools(), ...agencyCodeTools()]
+}
 
 static const systemPrompt = """You are an expert in the Agency programming language, advising a weaker coding agent that is about to attempt the task below.
 
@@ -47,7 +46,7 @@ def consult(
   }
   const guidance: ExpertGuidance = llm(
     "Task:\n${withContext(task: task, context: context)}",
-    llmOptions(model: model, provider: provider, tools: tools.concat(extraTools)),
+    llmOptions(model: model, provider: provider, tools: buildTools().concat(extraTools)),
   )
   return guidance
 }

--- a/packages/agency-lang/stdlib/agents/agency/expert.agency
+++ b/packages/agency-lang/stdlib/agents/agency/expert.agency
@@ -14,14 +14,19 @@
 import { ExpertGuidance, emptyGuidance } from "std::agents/lib/expertGuidance"
 import { llmOptions, withContext } from "std::agents/lib/shared"
 import { agencyDocTools, agencyCodeTools } from "std::agents/lib/toolkits"
+import { agentSkill } from "std::skills"
 import { systemMessage, threadIsNew } from "std::thread"
+
+// Skills we ship for this agent: markdown the model reads on demand,
+// so teaching it something new costs a file rather than prompt length.
+static const skills = agentSkill("agency/expert")
 
 export def buildTools(): any[] {
   """
   Return the Agency expert's tools: the bundled language documentation and
   the source inspectors it cites in its guidance.
   """
-  return [...agencyDocTools(), ...agencyCodeTools()]
+  return [...agencyDocTools(), ...agencyCodeTools(), skills]
 }
 
 static const systemPrompt = """You are an expert in the Agency programming language, advising a weaker coding agent that is about to attempt the task below.

--- a/packages/agency-lang/stdlib/agents/agency/expert.agency
+++ b/packages/agency-lang/stdlib/agents/agency/expert.agency
@@ -40,13 +40,14 @@ def consult(
   context: string,
   model: string,
   provider: string,
+  extraTools: any[],
 ): ExpertGuidance {
   if (threadIsNew()) {
     systemMessage(systemPrompt)
   }
   const guidance: ExpertGuidance = llm(
     "Task:\n${withContext(task: task, context: context)}",
-    llmOptions(model: model, provider: provider, tools: tools),
+    llmOptions(model: model, provider: provider, tools: tools.concat(extraTools)),
   )
   return guidance
 }
@@ -59,6 +60,7 @@ export def agencyExpertAgent(
   model: string = "",
   provider: string = "",
   session: string = "",
+  extraTools: any[] = [],
 ): Result<ExpertGuidance> {
   """
   Consult an Agency-language specialist: return the syntax rules and
@@ -71,6 +73,7 @@ export def agencyExpertAgent(
   @param model - Model override, or "" for the ambient model
   @param provider - Provider for the model override
   @param session - Session name to share a thread across calls, or "" for isolated
+  @param extraTools - Extra tools to offer the LLM, appended to the built-in set
   """
   // The guard Result is the return value: its failure carries whatever
   // actually went wrong, whether that is a tripped budget or a failure from
@@ -78,7 +81,13 @@ export def agencyExpertAgent(
   return guard(cost: maxCost, time: maxTime) {
     let guidance: ExpertGuidance = emptyGuidance
     thread(label: "agencyExpertAgent", session: session) {
-      guidance = consult(task: task, context: context, model: model, provider: provider)
+      guidance = consult(
+        task: task,
+        context: context,
+        model: model,
+        provider: provider,
+        extraTools: extraTools,
+      )
     }
     return guidance
   }

--- a/packages/agency-lang/stdlib/agents/agency/review.agency
+++ b/packages/agency-lang/stdlib/agents/agency/review.agency
@@ -11,6 +11,7 @@ import { Feedback, mergeFeedback, failOpenFeedback } from "std::agents/lib/feedb
 import { searchTools } from "std::agents/lib/search"
 import { llmOptions } from "std::agents/lib/shared"
 import { agencyDocTools, webTools } from "std::agents/lib/toolkits"
+import { agentSkill } from "std::skills"
 import { systemMessage, threadIsNew } from "std::thread"
 
 static const systemPrompt = """You review Agency-language code. Return a list of feedback items. Set error=true only if the code does not accomplish the task. Keep feedback brief and concrete."""
@@ -28,12 +29,16 @@ export def reportFeedback(report: TypeCheckReport): Feedback[] {
   return feedback
 }
 
+// Skills we ship for this agent: markdown the model reads on demand,
+// so teaching it something new costs a file rather than prompt length.
+static const skills = agentSkill("agency/review")
+
 export def buildTools(): any[] {
   """
   Return the Agency reviewer's lookup tools: the bundled language
   documentation, plus web lookups for anything outside it.
   """
-  return [...agencyDocTools(), ...webTools(), ...searchTools()]
+  return [...agencyDocTools(), ...webTools(), ...searchTools(), skills]
 }
 
 def parseFeedback(source: string): Result<Feedback[]> {

--- a/packages/agency-lang/stdlib/agents/agency/review.agency
+++ b/packages/agency-lang/stdlib/agents/agency/review.agency
@@ -46,6 +46,7 @@ def judgeAgainstTask(
   task: string,
   model: string,
   provider: string,
+  extraTools: any[],
 ): Feedback[] {
   if (threadIsNew()) {
     systemMessage(systemPrompt)
@@ -62,7 +63,10 @@ ${source}
 
 Return a list of feedback items.
 """
-  const judged: Feedback[] = llm(prompt, llmOptions(model: model, provider: provider))
+  const judged: Feedback[] = llm(
+    prompt,
+    llmOptions(model: model, provider: provider, tools: extraTools),
+  )
   return judged
 }
 
@@ -75,6 +79,7 @@ export def agencyReviewAgent(
   model: string = "",
   provider: string = "",
   session: string = "",
+  extraTools: any[] = [],
 ): Result<Feedback[]> {
   """
   Review Agency source code and return findings. Always includes parse and
@@ -89,6 +94,7 @@ export def agencyReviewAgent(
   @param model - Model override, or "" for the ambient model
   @param provider - Provider for the model override
   @param session - Session name to share a thread across calls, or "" for isolated
+  @param extraTools - Extra tools to offer the LLM, appended to the built-in set
   """
   let feedback: Result<Feedback[]> = success([])
   feedback = mergeFeedback(feedback, parseFeedback(source))
@@ -104,6 +110,7 @@ export def agencyReviewAgent(
         task: task,
         model: model,
         provider: provider,
+        extraTools: extraTools,
       )
     }
     return judged

--- a/packages/agency-lang/stdlib/agents/agency/review.agency
+++ b/packages/agency-lang/stdlib/agents/agency/review.agency
@@ -2,12 +2,15 @@
   @summary Reviews Agency source code: parse findings, typecheck findings, and
   an optional LLM judgment of whether the code accomplishes a task.
 
-  Review reads; it never runs the code. To execute a program and judge its
-  actual result, use agencyVerifierAgent instead.
+  Review reads the work and looks things up. The verifier runs the work and
+  measures it. This agent never executes the code it reviews, but it can
+  consult the bundled Agency documentation and the web to check a claim.
 */
 import { TypeCheckReport, typecheck, parseAST } from "std::agency"
 import { Feedback, mergeFeedback, failOpenFeedback } from "std::agents/lib/feedback"
+import { searchTools } from "std::agents/lib/search"
 import { llmOptions } from "std::agents/lib/shared"
+import { agencyDocTools, webTools } from "std::agents/lib/toolkits"
 import { systemMessage, threadIsNew } from "std::thread"
 
 static const systemPrompt = """You review Agency-language code. Return a list of feedback items. Set error=true only if the code does not accomplish the task. Keep feedback brief and concrete."""
@@ -23,6 +26,14 @@ export def reportFeedback(report: TypeCheckReport): Feedback[] {
     feedback.push({ error: false, feedback: "Warning: ${warning.message}" })
   }
   return feedback
+}
+
+export def buildTools(): any[] {
+  """
+  Return the Agency reviewer's lookup tools: the bundled language
+  documentation, plus web lookups for anything outside it.
+  """
+  return [...agencyDocTools(), ...webTools(), ...searchTools()]
 }
 
 def parseFeedback(source: string): Result<Feedback[]> {
@@ -65,7 +76,12 @@ Return a list of feedback items.
 """
   const judged: Feedback[] = llm(
     prompt,
-    llmOptions(model: model, provider: provider, tools: extraTools),
+    llmOptions(
+      model: model,
+      provider: provider,
+      tools: buildTools().concat(extraTools),
+      hostedTools: ["web_search"],
+    ),
   )
   return judged
 }

--- a/packages/agency-lang/stdlib/agents/agency/review.agency
+++ b/packages/agency-lang/stdlib/agents/agency/review.agency
@@ -8,7 +8,7 @@
 */
 import { TypeCheckReport, typecheck, parseAST } from "std::agency"
 import { Feedback, mergeFeedback, failOpenFeedback } from "std::agents/lib/feedback"
-import { searchTools } from "std::agents/lib/search"
+import { hostedSearchTools, searchTools } from "std::agents/lib/search"
 import { llmOptions } from "std::agents/lib/shared"
 import { agencyDocTools, webTools } from "std::agents/lib/toolkits"
 import { agentSkill } from "std::skills"
@@ -85,7 +85,7 @@ Return a list of feedback items.
       model: model,
       provider: provider,
       tools: buildTools().concat(extraTools),
-      hostedTools: ["web_search"],
+      hostedTools: hostedSearchTools(model),
     ),
   )
   return judged

--- a/packages/agency-lang/stdlib/agents/agency/verifier.agency
+++ b/packages/agency-lang/stdlib/agents/agency/verifier.agency
@@ -8,6 +8,7 @@ import { runCode } from "std::agency"
 import { Feedback, failOpenFeedback } from "std::agents/lib/feedback"
 import { llmOptions } from "std::agents/lib/shared"
 import { readOnlyFileTools, shellTools } from "std::agents/lib/toolkits"
+import { agentSkill } from "std::skills"
 import { systemMessage, threadIsNew } from "std::thread"
 
 static const systemPrompt = """You judge whether a program's actual result satisfies a task.
@@ -16,13 +17,17 @@ The value the program returned is only part of its result. When the task asks fo
 
 For each finding, return a Feedback item: error=true when it fails the task (name the specific problem), error=false for a satisfied point."""
 
+// Skills we ship for this agent: markdown the model reads on demand,
+// so teaching it something new costs a file rather than prompt length.
+static const skills = agentSkill("agency/verifier")
+
 export def buildTools(): any[] {
   """
   Return the Agency verifier's tools. It reads and measures what the program
   left behind; it has no write tools, because a verifier that can fix things
   is no longer a verifier.
   """
-  return [...readOnlyFileTools(), ...shellTools()]
+  return [...readOnlyFileTools(), ...shellTools(), skills]
 }
 
 def judgeResult(

--- a/packages/agency-lang/stdlib/agents/agency/verifier.agency
+++ b/packages/agency-lang/stdlib/agents/agency/verifier.agency
@@ -16,6 +16,7 @@ def judgeResult(
   data: any,
   model: string,
   provider: string,
+  extraTools: any[],
 ): Feedback[] {
   if (threadIsNew()) {
     systemMessage(systemPrompt)
@@ -27,7 +28,10 @@ ${task}
 The program ran and produced this result:
 ${data}
 """
-  const items: Feedback[] = llm(prompt, llmOptions(model: model, provider: provider))
+  const items: Feedback[] = llm(
+    prompt,
+    llmOptions(model: model, provider: provider, tools: extraTools),
+  )
   return items
 }
 
@@ -40,6 +44,7 @@ def runAndJudge(
   model: string,
   provider: string,
   session: string,
+  extraTools: any[],
 ): Feedback[] {
   const ran = runCode(source)
   if (ran is failure(err)) {
@@ -47,7 +52,13 @@ def runAndJudge(
   }
   let items: Feedback[] = []
   thread(label: "agencyVerifierAgent", session: session) {
-    items = judgeResult(task: task, data: ran.value, model: model, provider: provider)
+    items = judgeResult(
+      task: task,
+      data: ran.value,
+      model: model,
+      provider: provider,
+      extraTools: extraTools,
+    )
   }
   return items
 }
@@ -61,6 +72,7 @@ export def agencyVerifierAgent(
   model: string = "",
   provider: string = "",
   session: string = "",
+  extraTools: any[] = [],
 ): Result<Feedback[]> {
   """
   Run an Agency program and judge its result against the task. A program that
@@ -75,6 +87,7 @@ export def agencyVerifierAgent(
   @param model - Model override, or "" for the ambient model
   @param provider - Provider for the model override
   @param session - Session name to share a thread across calls, or "" for isolated
+  @param extraTools - Extra tools to offer the LLM, appended to the built-in set
   """
   const captured = guard(cost: maxCost, time: maxTime) {
     return runAndJudge(
@@ -83,6 +96,7 @@ export def agencyVerifierAgent(
       model: model,
       provider: provider,
       session: session,
+      extraTools: extraTools,
     )
   }
   // Fail open: a verification that could not run reports no findings rather

--- a/packages/agency-lang/stdlib/agents/agency/verifier.agency
+++ b/packages/agency-lang/stdlib/agents/agency/verifier.agency
@@ -7,9 +7,23 @@
 import { runCode } from "std::agency"
 import { Feedback, failOpenFeedback } from "std::agents/lib/feedback"
 import { llmOptions } from "std::agents/lib/shared"
+import { readOnlyFileTools, shellTools } from "std::agents/lib/toolkits"
 import { systemMessage, threadIsNew } from "std::thread"
 
-static const systemPrompt = """You judge whether a program's actual result satisfies a task. For each finding, return a Feedback item: error=true when it fails the task (name the specific problem), error=false for a satisfied point."""
+static const systemPrompt = """You judge whether a program's actual result satisfies a task.
+
+The value the program returned is only part of its result. When the task asks for a file, inspect what the program actually wrote with your tools and judge that too: a program that returns "done" and writes nothing has not done the task.
+
+For each finding, return a Feedback item: error=true when it fails the task (name the specific problem), error=false for a satisfied point."""
+
+export def buildTools(): any[] {
+  """
+  Return the Agency verifier's tools. It reads and measures what the program
+  left behind; it has no write tools, because a verifier that can fix things
+  is no longer a verifier.
+  """
+  return [...readOnlyFileTools(), ...shellTools()]
+}
 
 def judgeResult(
   task: string,
@@ -30,7 +44,11 @@ ${data}
 """
   const items: Feedback[] = llm(
     prompt,
-    llmOptions(model: model, provider: provider, tools: extraTools),
+    llmOptions(
+      model: model,
+      provider: provider,
+      tools: buildTools().concat(extraTools),
+    ),
   )
   return items
 }

--- a/packages/agency-lang/stdlib/agents/coding.agency
+++ b/packages/agency-lang/stdlib/agents/coding.agency
@@ -23,6 +23,7 @@ import {
   memoryTools,
   agencyDocTools,
   planningTools,
+  webTools,
  } from "std::agents/lib/toolkits"
 import { setAgentCwd, getAgentCwd } from "std::index"
 import { systemMessage, threadIsNew } from "std::thread"
@@ -56,6 +57,7 @@ export def buildTools(): any[] {
     ...memoryTools(),
     ...agencyDocTools(),
     ...planningTools(),
+    ...webTools(),
   ]
 }
 

--- a/packages/agency-lang/stdlib/agents/coding.agency
+++ b/packages/agency-lang/stdlib/agents/coding.agency
@@ -111,6 +111,7 @@ def solve(
   context: string,
   model: string,
   provider: string,
+  extraTools: any[],
 ): string {
   if (threadIsNew()) {
     systemMessage(systemPrompt)
@@ -125,7 +126,7 @@ ${finalizeReminder}
     llmOptions(
       model: model,
       provider: provider,
-      tools: tools,
+      tools: tools.concat(extraTools),
       hostedTools: ["web_search"],
     ),
   )
@@ -139,6 +140,7 @@ export def codingAgent(
   model: string = "",
   provider: string = "",
   session: string = "",
+  extraTools: any[] = [],
 ): Result<string> {
   """
   Write, edit, and run code to complete a task on disk. Returns a short
@@ -151,6 +153,7 @@ export def codingAgent(
   @param model - Model override, or "" for the ambient model
   @param provider - Provider for the model override
   @param session - Session name to share a thread across calls, or "" for isolated
+  @param extraTools - Extra tools to offer the LLM, appended to the built-in set
   """
   // The guard Result is the return value: a success carries the reply (or,
   // when a trip was rejected, the agent's most recent saveDraft), and a
@@ -159,7 +162,13 @@ export def codingAgent(
   return guard(cost: maxCost, time: maxTime) {
     let reply = ""
     thread(label: "codingAgent", session: session) {
-      reply = solve(task: task, context: context, model: model, provider: provider)
+      reply = solve(
+        task: task,
+        context: context,
+        model: model,
+        provider: provider,
+        extraTools: extraTools,
+      )
     }
     return reply
   }

--- a/packages/agency-lang/stdlib/agents/coding.agency
+++ b/packages/agency-lang/stdlib/agents/coding.agency
@@ -26,6 +26,7 @@ import {
   webTools,
  } from "std::agents/lib/toolkits"
 import { setAgentCwd, getAgentCwd } from "std::index"
+import { agentSkill } from "std::skills"
 import { systemMessage, threadIsNew } from "std::thread"
 
 static const systemPrompt = """You are an expert software engineer. Solve the task by writing and running real code with your tools.
@@ -42,6 +43,10 @@ static const finalizeReminder = "Before finishing, re-read the task's exact outp
 
 // A function, not a static const: Task 4 adds searchTools() here, which
 // reads API keys at call time and must not be snapshotted at module load.
+// Skills we ship for this agent: markdown the model reads on demand,
+// so teaching it something new costs a file rather than prompt length.
+static const skills = agentSkill("coding")
+
 export def buildTools(): any[] {
   """
   Return the coding agent's tools. Exported so a caller can inspect what the
@@ -58,6 +63,7 @@ export def buildTools(): any[] {
     ...agencyDocTools(),
     ...planningTools(),
     ...webTools(),
+    skills,
   ]
 }
 

--- a/packages/agency-lang/stdlib/agents/coding.agency
+++ b/packages/agency-lang/stdlib/agents/coding.agency
@@ -14,42 +14,18 @@
 
   For an Agency-specific coding agent, use std::agents/agency/coding.
 */
-import { parseAST, typecheck } from "std::agency"
-import { todoWrite, todoList } from "std::agent"
 import { llmOptions, withContext } from "std::agents/lib/shared"
-import { edit } from "std::fs"
 import {
-  gitStatus,
-  gitLog,
-  gitDiff,
-  gitShow,
-  gitBranchList,
-  gitRemoteList,
-  gitBlame,
-  gitStashList,
-  gitAdd,
-  gitCommit,
-  gitCheckout,
-  gitSwitch,
-  gitBranchCreate,
-  gitBranchDelete,
-  gitStashPush,
-  gitStashPop,
-  gitRestore,
- } from "std::git"
+  writableFileTools,
+  shellTools,
+  gitTools,
+  agencyCodeTools,
+  memoryTools,
+  agencyDocTools,
+  planningTools,
+ } from "std::agents/lib/toolkits"
 import { setAgentCwd, getAgentCwd } from "std::index"
-import { remember, recall } from "std::memory"
-import { bash, ls, glob, grep, exec } from "std::shell"
-import { docsSkill } from "std::skills"
 import { systemMessage, threadIsNew } from "std::thread"
-
-// Bundled Agency docs, served via std::skills. `static` caches each tool
-// across calls. A general coding task often still lands in an Agency repo,
-// so the language reference travels with the agent.
-static const docSkill = docsSkill("guide")
-static const cliSkill = docsSkill("cli")
-static const diagnosticsSkill = docsSkill("diagnostics")
-static const stdlibSkill = docsSkill("stdlib")
 
 static const systemPrompt = """You are an expert software engineer. Solve the task by writing and running real code with your tools.
 
@@ -63,48 +39,25 @@ static const systemPrompt = """You are an expert software engineer. Solve the ta
 
 static const finalizeReminder = "Before finishing, re-read the task's exact output requirements (filename, format, fields, whitespace, trailing newline) and confirm the artifact on disk matches them exactly."
 
-static const tools: any[] = [
-  setAgentCwd,
-  getAgentCwd,
-  read.partial(useAgentCwd: true),
-  write.partial(useAgentCwd: true),
-  edit.partial(useAgentCwd: true),
-  ls.partial(useAgentCwd: true),
-  glob.partial(useAgentCwd: true),
-  grep.partial(useAgentCwd: true),
-  bash.partial(useAgentCwd: true),
-  exec.partial(useAgentCwd: true),
-  gitStatus,
-  gitLog,
-  gitDiff,
-  gitShow,
-  gitBranchList,
-  gitRemoteList,
-  gitBlame,
-  gitStashList,
-  gitAdd,
-  gitCommit,
-  gitCheckout,
-  gitSwitch,
-  gitBranchCreate,
-  gitBranchDelete,
-  gitStashPush,
-  gitStashPop,
-  gitRestore,
-  typecheck,
-  parseAST,
-  remember,
-  recall,
-  docSkill,
-  cliSkill,
-  diagnosticsSkill,
-  stdlibSkill,
-  todoWrite,
-  todoList,
-  // The agent saves its own intermediate progress, so an aborted run still
-  // returns the most recent draft rather than nothing.
-  saveDraft,
-]
+// A function, not a static const: Task 4 adds searchTools() here, which
+// reads API keys at call time and must not be snapshotted at module load.
+export def buildTools(): any[] {
+  """
+  Return the coding agent's tools. Exported so a caller can inspect what the
+  agent may do, and so tests can assert it.
+  """
+  return [
+    setAgentCwd,
+    getAgentCwd,
+    ...writableFileTools(),
+    ...shellTools(),
+    ...gitTools(),
+    ...agencyCodeTools(),
+    ...memoryTools(),
+    ...agencyDocTools(),
+    ...planningTools(),
+  ]
+}
 
 def solve(
   task: string,
@@ -126,7 +79,7 @@ ${finalizeReminder}
     llmOptions(
       model: model,
       provider: provider,
-      tools: tools.concat(extraTools),
+      tools: buildTools().concat(extraTools),
       hostedTools: ["web_search"],
     ),
   )

--- a/packages/agency-lang/stdlib/agents/coding.agency
+++ b/packages/agency-lang/stdlib/agents/coding.agency
@@ -14,6 +14,7 @@
 
   For an Agency-specific coding agent, use std::agents/agency/coding.
 */
+import { hostedSearchTools } from "std::agents/lib/search"
 import { llmOptions, withContext } from "std::agents/lib/shared"
 import {
   writableFileTools,
@@ -88,7 +89,7 @@ ${finalizeReminder}
       model: model,
       provider: provider,
       tools: buildTools().concat(extraTools),
-      hostedTools: ["web_search"],
+      hostedTools: hostedSearchTools(model),
     ),
   )
 }

--- a/packages/agency-lang/stdlib/agents/data.agency
+++ b/packages/agency-lang/stdlib/agents/data.agency
@@ -8,7 +8,7 @@
   these APIs usually means finding an identifier first, such as a FRED series
   ID or an EDGAR CIK, so the agent carries search and fetch tools too.
 */
-import { searchTools } from "std::agents/lib/search"
+import { hostedSearchTools, searchTools } from "std::agents/lib/search"
 import { llmOptions, withContext } from "std::agents/lib/shared"
 import { webTools } from "std::agents/lib/toolkits"
 import { dbnomicsSeries } from "std::data/finance/dbnomics"
@@ -91,7 +91,7 @@ def answer(
       model: model,
       provider: provider,
       tools: buildTools().concat(extraTools),
-      hostedTools: ["web_search"],
+      hostedTools: hostedSearchTools(model),
     ),
   )
 }

--- a/packages/agency-lang/stdlib/agents/data.agency
+++ b/packages/agency-lang/stdlib/agents/data.agency
@@ -25,6 +25,7 @@ import { hnStories, hnItem, hnUser, hnSearch } from "std::data/tech/hackernews"
 import { ycBatch, ycIndustry, ycTag, ycList, ycMeta } from "std::data/tech/yc"
 import { usaspendingAwards, usaspendingAward } from "std::data/usaspending"
 import { wikidataSearch, wikidataEntity, wikidataQuery } from "std::data/wikidata"
+import { agentSkill } from "std::skills"
 import { systemMessage, threadIsNew } from "std::thread"
 
 static const systemPrompt = """You answer questions using structured public-data APIs.
@@ -33,6 +34,10 @@ static const systemPrompt = """You answer questions using structured public-data
 - Name the source and the identifier behind every figure you report, so a reader can check it.
 - State the units, the period, and any revision or seasonal adjustment the source applies. A number without its units is not an answer.
 - When a source has no data for what was asked, say so plainly. NEVER estimate a number and present it as retrieved."""
+
+// Skills we ship for this agent: markdown the model reads on demand,
+// so teaching it something new costs a file rather than prompt length.
+static const skills = agentSkill("data")
 
 export def buildTools(): any[] {
   """
@@ -66,6 +71,7 @@ export def buildTools(): any[] {
     ycMeta,
     ...webTools(),
     ...searchTools(),
+    skills,
   ]
 }
 

--- a/packages/agency-lang/stdlib/agents/data.agency
+++ b/packages/agency-lang/stdlib/agents/data.agency
@@ -1,0 +1,131 @@
+/** @module
+  @summary Answers a question using the structured public-data APIs in the
+  standard library: economic series, securities filings, federal spending,
+  news, and entity databases.
+
+  This agent works structured sources with exact identifiers. For unstructured
+  web pages and encyclopedia prose, use researcherAgent instead. Querying
+  these APIs usually means finding an identifier first, such as a FRED series
+  ID or an EDGAR CIK, so the agent carries search and fetch tools too.
+*/
+import { searchTools } from "std::agents/lib/search"
+import { llmOptions, withContext } from "std::agents/lib/shared"
+import { webTools } from "std::agents/lib/toolkits"
+import { dbnomicsSeries } from "std::data/finance/dbnomics"
+import { edgarFilings, edgarFilingsByCik } from "std::data/finance/edgar"
+import { fredSeries, fredSeriesInfo } from "std::data/finance/fred"
+import { gdeltNews } from "std::data/finance/gdelt"
+import {
+  littlesisSearch,
+  littlesisEntity,
+  littlesisRelationships,
+  littlesisConnections,
+ } from "std::data/people/littlesis"
+import { hnStories, hnItem, hnUser, hnSearch } from "std::data/tech/hackernews"
+import { ycBatch, ycIndustry, ycTag, ycList, ycMeta } from "std::data/tech/yc"
+import { usaspendingAwards, usaspendingAward } from "std::data/usaspending"
+import { wikidataSearch, wikidataEntity, wikidataQuery } from "std::data/wikidata"
+import { systemMessage, threadIsNew } from "std::thread"
+
+static const systemPrompt = """You answer questions using structured public-data APIs.
+
+- Find the exact identifier before you query. A FRED series ID, an EDGAR CIK, a Wikidata Q-number: look it up rather than guessing, because a wrong identifier returns a real answer to the wrong question, which is far worse than an error.
+- Name the source and the identifier behind every figure you report, so a reader can check it.
+- State the units, the period, and any revision or seasonal adjustment the source applies. A number without its units is not an answer.
+- When a source has no data for what was asked, say so plainly. NEVER estimate a number and present it as retrieved."""
+
+export def buildTools(): any[] {
+  """
+  Return the data agent's tools: every connector, plus the search and fetch
+  tools it needs to find an identifier before querying.
+  """
+  return [
+    fredSeries,
+    fredSeriesInfo,
+    dbnomicsSeries,
+    edgarFilings,
+    edgarFilingsByCik,
+    gdeltNews,
+    usaspendingAwards,
+    usaspendingAward,
+    wikidataSearch,
+    wikidataEntity,
+    wikidataQuery,
+    littlesisSearch,
+    littlesisEntity,
+    littlesisRelationships,
+    littlesisConnections,
+    hnStories,
+    hnItem,
+    hnUser,
+    hnSearch,
+    ycBatch,
+    ycIndustry,
+    ycTag,
+    ycList,
+    ycMeta,
+    ...webTools(),
+    ...searchTools(),
+  ]
+}
+
+def answer(
+  task: string,
+  context: string,
+  model: string,
+  provider: string,
+  extraTools: any[],
+): string {
+  if (threadIsNew()) {
+    systemMessage(systemPrompt)
+  }
+  return llm(
+    withContext(task: task, context: context),
+    llmOptions(
+      model: model,
+      provider: provider,
+      tools: buildTools().concat(extraTools),
+      hostedTools: ["web_search"],
+    ),
+  )
+}
+
+export def dataAgent(
+  task: string,
+  context: string = "",
+  maxCost: number = $20.00,
+  maxTime: number = 15m,
+  model: string = "",
+  provider: string = "",
+  session: string = "",
+  extraTools: any[] = [],
+): Result<string> {
+  """
+  Answer a question from structured public-data APIs, naming the source and
+  identifier behind every figure.
+
+  @param task - The question to answer
+  @param context - Extra material folded into the prompt, or ""
+  @param maxCost - Hard spend cap
+  @param maxTime - Hard wall-clock cap
+  @param model - Model override, or "" for the ambient model
+  @param provider - Provider for the model override
+  @param session - Session name to share a thread across calls, or "" for isolated
+  @param extraTools - Extra tools to offer the LLM, appended to the built-in set
+  """
+  // The guard Result is the return value: a success carries the answer, and a
+  // failure carries whatever actually went wrong.
+  return guard(cost: maxCost, time: maxTime) {
+    let reply = ""
+    thread(label: "dataAgent", session: session) {
+      reply = answer(
+        task: task,
+        context: context,
+        model: model,
+        provider: provider,
+        extraTools: extraTools,
+      )
+    }
+    return reply
+  }
+}

--- a/packages/agency-lang/stdlib/agents/expert.agency
+++ b/packages/agency-lang/stdlib/agents/expert.agency
@@ -15,22 +15,16 @@
 */
 import { ExpertGuidance, emptyGuidance } from "std::agents/lib/expertGuidance"
 import { llmOptions, withContext } from "std::agents/lib/shared"
-import { fetch, fetchJSON, fetchMarkdown } from "std::http"
+import { webTools } from "std::agents/lib/toolkits"
 import { systemMessage, threadIsNew } from "std::thread"
-import {
-  search as wikipediaSearch,
-  summary as wikipediaSummary,
-  article as wikipediaArticle,
- } from "std::wikipedia"
 
-static const tools: any[] = [
-  wikipediaSearch,
-  wikipediaSummary,
-  wikipediaArticle,
-  fetch,
-  fetchJSON,
-  fetchMarkdown,
-]
+export def buildTools(): any[] {
+  """
+  Return the expert's tools: the web and encyclopedia lookups it uses to
+  confirm domain specifics.
+  """
+  return webTools()
+}
 
 static const systemPrompt = """You are a domain expert advising a weaker coding agent that is about to attempt the task below and tends to miss domain-specific conventions.
 
@@ -60,7 +54,7 @@ def consult(
     llmOptions(
       model: model,
       provider: provider,
-      tools: tools.concat(extraTools),
+      tools: buildTools().concat(extraTools),
       hostedTools: ["web_search"],
     ),
   )

--- a/packages/agency-lang/stdlib/agents/expert.agency
+++ b/packages/agency-lang/stdlib/agents/expert.agency
@@ -14,6 +14,7 @@
   grounds its guidance in the bundled docs instead of the web.
 */
 import { ExpertGuidance, emptyGuidance } from "std::agents/lib/expertGuidance"
+import { hostedSearchTools } from "std::agents/lib/search"
 import { llmOptions, withContext } from "std::agents/lib/shared"
 import { webTools } from "std::agents/lib/toolkits"
 import { agentSkill } from "std::skills"
@@ -60,7 +61,7 @@ def consult(
       model: model,
       provider: provider,
       tools: buildTools().concat(extraTools),
-      hostedTools: ["web_search"],
+      hostedTools: hostedSearchTools(model),
     ),
   )
   return guidance

--- a/packages/agency-lang/stdlib/agents/expert.agency
+++ b/packages/agency-lang/stdlib/agents/expert.agency
@@ -16,14 +16,19 @@
 import { ExpertGuidance, emptyGuidance } from "std::agents/lib/expertGuidance"
 import { llmOptions, withContext } from "std::agents/lib/shared"
 import { webTools } from "std::agents/lib/toolkits"
+import { agentSkill } from "std::skills"
 import { systemMessage, threadIsNew } from "std::thread"
+
+// Skills we ship for this agent: markdown the model reads on demand,
+// so teaching it something new costs a file rather than prompt length.
+static const skills = agentSkill("expert")
 
 export def buildTools(): any[] {
   """
   Return the expert's tools: the web and encyclopedia lookups it uses to
   confirm domain specifics.
   """
-  return webTools()
+  return [...webTools(), skills]
 }
 
 static const systemPrompt = """You are a domain expert advising a weaker coding agent that is about to attempt the task below and tends to miss domain-specific conventions.

--- a/packages/agency-lang/stdlib/agents/expert.agency
+++ b/packages/agency-lang/stdlib/agents/expert.agency
@@ -47,6 +47,7 @@ def consult(
   context: string,
   model: string,
   provider: string,
+  extraTools: any[],
 ): ExpertGuidance {
   if (threadIsNew()) {
     systemMessage(systemPrompt)
@@ -59,7 +60,7 @@ def consult(
     llmOptions(
       model: model,
       provider: provider,
-      tools: tools,
+      tools: tools.concat(extraTools),
       hostedTools: ["web_search"],
     ),
   )
@@ -74,6 +75,7 @@ export def expertAgent(
   model: string = "",
   provider: string = "",
   session: string = "",
+  extraTools: any[] = [],
 ): Result<ExpertGuidance> {
   """
   Consult a domain expert: identify the task's technical domain and return
@@ -86,6 +88,7 @@ export def expertAgent(
   @param model - Model override, or "" for the ambient model
   @param provider - Provider for the model override
   @param session - Session name to share a thread across calls, or "" for isolated
+  @param extraTools - Extra tools to offer the LLM, appended to the built-in set
   """
   // The guard Result is the return value: its failure carries whatever
   // actually went wrong, whether that is a tripped budget or a failure from
@@ -93,7 +96,13 @@ export def expertAgent(
   return guard(cost: maxCost, time: maxTime) {
     let guidance: ExpertGuidance = emptyGuidance
     thread(label: "expertAgent", session: session) {
-      guidance = consult(task: task, context: context, model: model, provider: provider)
+      guidance = consult(
+        task: task,
+        context: context,
+        model: model,
+        provider: provider,
+        extraTools: extraTools,
+      )
     }
     return guidance
   }

--- a/packages/agency-lang/stdlib/agents/lib/search.agency
+++ b/packages/agency-lang/stdlib/agents/lib/search.agency
@@ -50,6 +50,45 @@ export def searchTools(): any[] {
   return map(available, \provider -> provider.tool)
 }
 
+// Hosted search is a capability of the model, not a tool we hold: the
+// provider runs it server-side, so it needs no API key and works where
+// outbound HTTP is blocked. It lives here so the six agents that want web
+// search name it once, the way they get client-side providers from
+// searchTools().
+//
+// Related but deliberately separate: lib/agents/agency-agent/lib/search.agency
+// has withWebSearch, which does the same job for the agency agent. That one is
+// switched by the user through /search and has exactly one backend active, so
+// it can rename whichever provider is live to a single stable "web_search".
+// This one keys off which API keys are present and may offer several providers
+// at once, which is why its tools carry distinct names. If the agent's backend
+// selection ever moves into the stdlib, these should become one table.
+static const HOSTED_WEB_SEARCH = "web_search"
+
+export def hostedSearchTools(model: string = ""): string[] {
+  """
+  Return the provider-hosted search capabilities to request.
+
+  @param model - The model that will run the call, or "" for the branch default
+  """
+  // Always requested, and not gated on the model, which is a deliberate
+  // limitation rather than an oversight.
+  //
+  // The model catalog keys hosted tools by provider API ("anthropic",
+  // "openai-responses"), not by model, and carries no per-model list. Asking
+  // it about a model name returns nothing for every model, so a gate built on
+  // it would answer "unsupported" universally and silently strip web search
+  // from every agent. Mapping a model to its provider API by hand is the kind
+  // of guess that fails the same way, quietly, the first time a provider adds
+  // or renames an API.
+  //
+  // The cost of asking when a provider cannot deliver falls on that provider's
+  // error, which is visible. The cost of withholding wrongly is an agent that
+  // quietly stops searching, which is not. Until the catalog can answer per
+  // model, the visible failure is the better one.
+  return [HOSTED_WEB_SEARCH]
+}
+
 export def searchProviderNames(): string[] {
   """
   Return the names of the web-search providers whose API key is set, for

--- a/packages/agency-lang/stdlib/agents/lib/toolkits.agency
+++ b/packages/agency-lang/stdlib/agents/lib/toolkits.agency
@@ -1,0 +1,161 @@
+/** @module
+  @summary Named bundles of tools that agents compose into their tool lists.
+
+  An agent's tool list should read as a description of what that agent may
+  do. Bundling also means a tool added to a category reaches every agent that
+  claimed the category, instead of drifting between hand-maintained arrays.
+
+  Every bundle is a function rather than a constant, matching searchTools() in
+  std::agents/lib/search, which must be a function because it reads API keys
+  at call time. An agent whose list includes searchTools() must build that
+  list inside a function too, or it freezes the environment at module load.
+*/
+import { typecheck, parseAST } from "std::agency"
+import { todoWrite, todoList } from "std::agent"
+import { edit } from "std::fs"
+import {
+  gitStatus,
+  gitLog,
+  gitDiff,
+  gitShow,
+  gitBranchList,
+  gitRemoteList,
+  gitBlame,
+  gitStashList,
+  gitAdd,
+  gitCommit,
+  gitCheckout,
+  gitSwitch,
+  gitBranchCreate,
+  gitBranchDelete,
+  gitStashPush,
+  gitStashPop,
+  gitRestore,
+ } from "std::git"
+import { fetch, fetchJSON, fetchMarkdown } from "std::http"
+import { remember, recall } from "std::memory"
+import { bash, ls, glob, grep, exec } from "std::shell"
+import { docsSkill } from "std::skills"
+import {
+  search as wikipediaSearch,
+  summary as wikipediaSummary,
+  article as wikipediaArticle,
+ } from "std::wikipedia"
+
+// Bundled Agency docs. `static` caches each tool across calls. Each gets an
+// explicit name: the name docsSkill derives from a directory embeds the
+// absolute install path, which differs per machine and is truncated to fit.
+static const docSkill = docsSkill("guide").rename("agency_guide")
+static const cliSkill = docsSkill("cli").rename("agency_cli")
+static const diagnosticsSkill = docsSkill("diagnostics").rename("agency_diagnostics")
+static const stdlibSkill = docsSkill("stdlib").rename("agency_stdlib")
+
+export def readOnlyFileTools(): any[] {
+  """
+  Return tools that inspect the file system without changing it: read, list,
+  glob, and grep, resolved against the agent working directory.
+  """
+  return [
+    read.partial(useAgentCwd: true),
+    ls.partial(useAgentCwd: true),
+    glob.partial(useAgentCwd: true),
+    grep.partial(useAgentCwd: true),
+  ]
+}
+
+export def writableFileTools(): any[] {
+  """
+  Return the read-only file tools plus write and edit.
+  """
+  return [
+    ...readOnlyFileTools(),
+    write.partial(useAgentCwd: true),
+    edit.partial(useAgentCwd: true),
+  ]
+}
+
+export def shellTools(): any[] {
+  """
+  Return tools that run commands: bash for a shell pipeline, exec for a
+  single binary with arguments.
+  """
+  return [
+    bash.partial(useAgentCwd: true),
+    exec.partial(useAgentCwd: true),
+  ]
+}
+
+export def gitTools(): any[] {
+  """
+  Return the git tools. The read-only ones run without an approval prompt;
+  the ones that change the repository prompt for approval.
+  """
+  return [
+    gitStatus,
+    gitLog,
+    gitDiff,
+    gitShow,
+    gitBranchList,
+    gitRemoteList,
+    gitBlame,
+    gitStashList,
+    gitAdd,
+    gitCommit,
+    gitCheckout,
+    gitSwitch,
+    gitBranchCreate,
+    gitBranchDelete,
+    gitStashPush,
+    gitStashPop,
+    gitRestore,
+  ]
+}
+
+export def webTools(): any[] {
+  """
+  Return tools that retrieve a named web resource: HTTP fetches and Wikipedia
+  lookups. These retrieve something you can already name; to discover a
+  source you cannot name yet, add a search tool as well.
+  """
+  return [
+    fetch,
+    fetchJSON,
+    fetchMarkdown,
+    wikipediaSearch.rename("wikipedia_search"),
+    wikipediaSummary.rename("wikipedia_summary"),
+    wikipediaArticle.rename("wikipedia_article"),
+  ]
+}
+
+export def agencyDocTools(): any[] {
+  """
+  Return the bundled Agency documentation tools: the language guide, the CLI
+  reference, the type-checker diagnostic codes, and the standard-library
+  reference.
+  """
+  return [docSkill, cliSkill, diagnosticsSkill, stdlibSkill]
+}
+
+export def agencyCodeTools(): any[] {
+  """
+  Return tools that inspect Agency source without running it: the type
+  checker and the parser.
+  """
+  return [typecheck, parseAST]
+}
+
+export def memoryTools(): any[] {
+  """
+  Return tools that persist and retrieve facts across sessions.
+  """
+  return [remember, recall]
+}
+
+export def planningTools(): any[] {
+  """
+  Return tools an agent uses to organize a long run: a todo list, and
+  saveDraft for checkpointing partial work so an aborted run still returns
+  something.
+  """
+  return [todoWrite, todoList, saveDraft]
+}

--- a/packages/agency-lang/stdlib/agents/planner.agency
+++ b/packages/agency-lang/stdlib/agents/planner.agency
@@ -158,7 +158,9 @@ def fallbackState(task: string, state: PlanState): PlanState {
 }
 
 def judgeAfterRun(task: string, state: PlanState): PlanState {
-  const fb = verifierAgent(task: task)
+  // Capped: this runs once per plan attempt inside the planner's budget, and
+  // the verifier's own default would let a single check take a fifth of it.
+  const fb = verifierAgent(task: task, maxCost: $5.00, maxTime: 5m)
   return if feedbackHasErrors(fb) then regenState(state, renderFeedback(fb)) else completedState(state)
 }
 
@@ -196,9 +198,13 @@ def planStep(
   planText: string,
   state: PlanState,
 ): PlanState raises <std::agents::planApprove> {
+  // Capped for the same reason: one attempt of many, inside the planner's
+  // budget rather than alongside it.
   const gen = agencyCodingAgent(
     task: planCodePrompt(task, planText),
     context: state.extra,
+    maxCost: $10.00,
+    maxTime: 10m,
   )
   return match(gen) {
     failure(_) => fallbackState(task, state)

--- a/packages/agency-lang/stdlib/agents/planner.agency
+++ b/packages/agency-lang/stdlib/agents/planner.agency
@@ -12,7 +12,20 @@ import { verifierAgent } from "std::agents/verifier"
 import { feedbackHasErrors, renderFeedback } from "std::agents/lib/feedback"
 import { llmOptions, withContext } from "std::agents/lib/shared"
 import { readOnlyFileTools } from "std::agents/lib/toolkits"
+import { agentSkill } from "std::skills"
 import { getAgentCwd } from "std::index"
+
+// Skills we ship for this agent: markdown the model reads on demand, so
+// teaching it something new costs a file rather than prompt length.
+static const skills = agentSkill("planner")
+
+export def buildTools(): any[] {
+  """
+  Return the planner's tools: read-only access to the project it is planning
+  for, plus its skills.
+  """
+  return [...readOnlyFileTools(), skills]
+}
 
 /** Raised before a generated plan-agent runs, so the plan, source, and
   capability envelope can be shown and approved. Reject halts and fails. */
@@ -237,7 +250,7 @@ export def plannerAgent(
           llmOptions(
             model: model,
             provider: provider,
-            tools: readOnlyFileTools().concat(extraTools),
+            tools: buildTools().concat(extraTools),
           ),
         )
       }

--- a/packages/agency-lang/stdlib/agents/planner.agency
+++ b/packages/agency-lang/stdlib/agents/planner.agency
@@ -11,6 +11,7 @@ import { codingAgent } from "std::agents/coding"
 import { verifierAgent } from "std::agents/verifier"
 import { feedbackHasErrors, renderFeedback } from "std::agents/lib/feedback"
 import { llmOptions, withContext } from "std::agents/lib/shared"
+import { readOnlyFileTools } from "std::agents/lib/toolkits"
 import { getAgentCwd } from "std::index"
 
 /** Raised before a generated plan-agent runs, so the plan, source, and
@@ -200,6 +201,8 @@ export def plannerAgent(
   maxTime: number = 60m,
   model: string = "",
   provider: string = "",
+  session: string = "",
+  extraTools: any[] = [],
 ): Result<string> raises <std::agents::planApprove, std::guard> {
   """
   Plan-as-code: draft (or use a seed) plan, generate an agent that solves the
@@ -215,17 +218,30 @@ export def plannerAgent(
   @param maxTime - hard wall-clock cap (default 60 minutes).
   @param model - model override for the planning step only, or "" for the ambient model.
   @param provider - provider for the model override.
+  @param session - Session name to share a thread across calls, or "" for isolated
+  @param extraTools - Extra tools to offer the LLM, appended to the built-in set
   """
   // The guard Result is the return value: a success carries the summary (or,
   // when a trip was rejected, the last saved draft), and a failure carries
   // whatever actually went wrong.
   const captured = guard(cost: maxCost, time: maxTime) {
-    // The override applies to the planning step only. Each worker agent the
-    // generated plan calls resolves its own model.
-    const planText = if plan == "" then llm(
-      "Analyse this task and outline the steps:\n${withContext(task: task, context: context)}",
-      llmOptions(model: model, provider: provider),
-    ) else plan
+    // The drafting call runs in its own thread so the planner honors the
+    // same session contract as every other agent. The model override applies
+    // to this step only: each worker agent the generated plan calls resolves
+    // its own model.
+    let planText = plan
+    if (plan == "") {
+      thread(label: "plannerAgent", session: session) {
+        planText = llm(
+          "Analyse this task and outline the steps:\n${withContext(task: task, context: context)}",
+          llmOptions(
+            model: model,
+            provider: provider,
+            tools: readOnlyFileTools().concat(extraTools),
+          ),
+        )
+      }
+    }
     let state: PlanState = {
       summary: "",
       done: false,

--- a/packages/agency-lang/stdlib/agents/researcher.agency
+++ b/packages/agency-lang/stdlib/agents/researcher.agency
@@ -70,6 +70,7 @@ def researchLoop(
   maxAttempts: number,
   model: string,
   provider: string,
+  extraTools: any[],
 ): string {
   const researchTools = buildTools()
   if (threadIsNew()) {
@@ -91,7 +92,11 @@ def researchLoop(
     }
     const answer = llm(
       msg,
-      llmOptions(model: model, provider: provider, tools: researchTools),
+      llmOptions(
+        model: model,
+        provider: provider,
+        tools: researchTools.concat(extraTools),
+      ),
     )
     saveDraft(answer)
     return answer
@@ -107,6 +112,7 @@ export def researcherAgent(
   model: string = "",
   provider: string = "",
   session: string = "",
+  extraTools: any[] = [],
 ): Result<string> {
   """
   Answer a research question from web and Wikipedia sources and return a
@@ -120,6 +126,7 @@ export def researcherAgent(
   @param model - Model override, or "" for the ambient model
   @param provider - Provider for the model override
   @param session - Session name to share a thread across calls, or "" for isolated
+  @param extraTools - Extra tools to offer the LLM, appended to the built-in set
   """
   // The guard Result is the return value: a success carries the answer (or,
   // when a trip was rejected, the best draft so far), and a failure carries
@@ -133,6 +140,7 @@ export def researcherAgent(
         maxAttempts: maxAttempts,
         model: model,
         provider: provider,
+        extraTools: extraTools,
       )
     }
     return answer

--- a/packages/agency-lang/stdlib/agents/researcher.agency
+++ b/packages/agency-lang/stdlib/agents/researcher.agency
@@ -35,7 +35,8 @@ static const skills = agentSkill("researcher")
 export def buildTools(): any[] {
   """
   Return the researcher's tools: the encyclopedia and fetch tools that need
-  no key, plus whichever search providers the environment has a key for.
+  no key, a local file read for material the caller points at, and whichever
+  search providers the environment has a key for.
   """
   return [...webTools(), read.partial(useAgentCwd: true), ...searchTools(), skills]
 }

--- a/packages/agency-lang/stdlib/agents/researcher.agency
+++ b/packages/agency-lang/stdlib/agents/researcher.agency
@@ -10,10 +10,9 @@ import { reviewAgent } from "std::agents/review"
 import { feedbackHasErrors, renderFeedback } from "std::agents/lib/feedback"
 import { searchTools } from "std::agents/lib/search"
 import { llmOptions, withContext } from "std::agents/lib/shared"
-import { fetch, fetchMarkdown } from "std::http"
+import { webTools } from "std::agents/lib/toolkits"
 import { Critique, revise } from "std::strategy"
 import { systemMessage, threadIsNew } from "std::thread"
-import { search as wikiSearch } from "std::wikipedia"
 
 static const systemPrompt = """You are a research analyst. Answer the task using your source tools.
 
@@ -28,14 +27,12 @@ static const systemPrompt = """You are a research analyst. Answer the task using
 // The wikipedia tool is renamed because an import alias renames only the
 // binding: without this its tool name stays `search` and collides with a
 // search provider.
-def buildTools(): any[] {
-  const baseTools: any[] = [
-    wikiSearch.rename("wikipedia_search"),
-    fetchMarkdown,
-    fetch,
-    read.partial(useAgentCwd: true),
-  ]
-  return baseTools.concat(searchTools())
+export def buildTools(): any[] {
+  """
+  Return the researcher's tools: the encyclopedia and fetch tools that need
+  no key, plus whichever search providers the environment has a key for.
+  """
+  return [...webTools(), read.partial(useAgentCwd: true), ...searchTools()]
 }
 
 static const groundingInstruction = "Judge grounding: error=true if a claim is ungrounded or uncited or the task is not fully answered."

--- a/packages/agency-lang/stdlib/agents/researcher.agency
+++ b/packages/agency-lang/stdlib/agents/researcher.agency
@@ -8,7 +8,7 @@
 */
 import { reviewAgent } from "std::agents/review"
 import { feedbackHasErrors, renderFeedback } from "std::agents/lib/feedback"
-import { searchTools } from "std::agents/lib/search"
+import { hostedSearchTools, searchTools } from "std::agents/lib/search"
 import { llmOptions, withContext } from "std::agents/lib/shared"
 import { webTools } from "std::agents/lib/toolkits"
 import { Critique, revise } from "std::strategy"
@@ -47,10 +47,17 @@ static const groundingInstruction = "Judge grounding: error=true if a claim is u
 // uncited claim is an error finding, which becomes the critique the next
 // attempt has to address.
 def checkGrounding(task: string, answer: any): Critique {
+  // Capped well below the reviewer's own defaults, and deliberately. The
+  // reviewer now carries fetch and search, and this call runs once per
+  // attempt inside the researcher's budget. Left uncapped, a question this
+  // call site can answer from the answer text alone could turn into a
+  // research session of its own, charged to the researcher.
   const reviewed = reviewAgent(
     work: "${answer}",
     task: task,
     context: groundingInstruction,
+    maxCost: $1.00,
+    maxTime: 2m,
   )
   if (!feedbackHasErrors(reviewed)) {
     return { accepted: true, feedback: "" }
@@ -102,7 +109,7 @@ def researchLoop(
         model: model,
         provider: provider,
         tools: researchTools.concat(extraTools),
-        hostedTools: ["web_search"],
+        hostedTools: hostedSearchTools(model),
       ),
     )
     saveDraft(answer)

--- a/packages/agency-lang/stdlib/agents/researcher.agency
+++ b/packages/agency-lang/stdlib/agents/researcher.agency
@@ -87,12 +87,16 @@ def researchLoop(
     if (critique == "") {
       msg = question
     }
+    // Provider-hosted search runs server-side, needs no API key, and works
+    // where outbound HTTP is blocked, so it complements the client-side
+    // providers in researchTools rather than replacing them.
     const answer = llm(
       msg,
       llmOptions(
         model: model,
         provider: provider,
         tools: researchTools.concat(extraTools),
+        hostedTools: ["web_search"],
       ),
     )
     saveDraft(answer)

--- a/packages/agency-lang/stdlib/agents/researcher.agency
+++ b/packages/agency-lang/stdlib/agents/researcher.agency
@@ -12,6 +12,7 @@ import { searchTools } from "std::agents/lib/search"
 import { llmOptions, withContext } from "std::agents/lib/shared"
 import { webTools } from "std::agents/lib/toolkits"
 import { Critique, revise } from "std::strategy"
+import { agentSkill } from "std::skills"
 import { systemMessage, threadIsNew } from "std::thread"
 
 static const systemPrompt = """You are a research analyst. Answer the task using your source tools.
@@ -27,12 +28,16 @@ static const systemPrompt = """You are a research analyst. Answer the task using
 // The wikipedia tool is renamed because an import alias renames only the
 // binding: without this its tool name stays `search` and collides with a
 // search provider.
+// Skills we ship for this agent: markdown the model reads on demand,
+// so teaching it something new costs a file rather than prompt length.
+static const skills = agentSkill("researcher")
+
 export def buildTools(): any[] {
   """
   Return the researcher's tools: the encyclopedia and fetch tools that need
   no key, plus whichever search providers the environment has a key for.
   """
-  return [...webTools(), read.partial(useAgentCwd: true), ...searchTools()]
+  return [...webTools(), read.partial(useAgentCwd: true), ...searchTools(), skills]
 }
 
 static const groundingInstruction = "Judge grounding: error=true if a claim is ungrounded or uncited or the task is not fully answered."

--- a/packages/agency-lang/stdlib/agents/review.agency
+++ b/packages/agency-lang/stdlib/agents/review.agency
@@ -1,16 +1,28 @@
 /** @module
   @summary Reviews a work product against a task and returns findings.
 
-  The work is handed in as text; review reads it and judges it. It never
-  touches the file system and never runs anything. To verify work on disk by
-  measuring it, use verifierAgent instead. For Agency source specifically,
-  agencyReviewAgent adds parse and typecheck findings.
+  Review reads the work and looks things up. The verifier runs the work and
+  measures it. This agent never touches the file system and never executes
+  what it is reviewing, but it can consult the web to check a claim: whether
+  an API is used correctly, whether a cited source says what the work says it
+  does. For Agency source specifically, agencyReviewAgent adds parse and
+  typecheck findings.
 */
 import { Feedback, failOpenFeedback } from "std::agents/lib/feedback"
+import { searchTools } from "std::agents/lib/search"
 import { llmOptions, withContext } from "std::agents/lib/shared"
+import { webTools } from "std::agents/lib/toolkits"
 import { systemMessage, threadIsNew } from "std::thread"
 
 static const systemPrompt = """You review a work product against a task. For each finding, return a Feedback item: error=true when the work fails the task on that point (name the specific problem), error=false for a satisfied point. Be brief and concrete. Judge only against the task and context given; do not invent requirements."""
+
+export def buildTools(): any[] {
+  """
+  Return the reviewer's lookup tools. It reads and checks; it has no tools
+  that change anything.
+  """
+  return [...webTools(), ...searchTools()]
+}
 
 def judgeWork(
   work: string,
@@ -32,7 +44,12 @@ ${work}
 """
   const items: Feedback[] = llm(
     prompt,
-    llmOptions(model: model, provider: provider, tools: extraTools),
+    llmOptions(
+      model: model,
+      provider: provider,
+      tools: buildTools().concat(extraTools),
+      hostedTools: ["web_search"],
+    ),
   )
   return items
 }

--- a/packages/agency-lang/stdlib/agents/review.agency
+++ b/packages/agency-lang/stdlib/agents/review.agency
@@ -18,6 +18,7 @@ def judgeWork(
   context: string,
   model: string,
   provider: string,
+  extraTools: any[],
 ): Feedback[] {
   if (threadIsNew()) {
     systemMessage(systemPrompt)
@@ -29,7 +30,10 @@ ${withContext(task: task, context: context)}
 Work product:
 ${work}
 """
-  const items: Feedback[] = llm(prompt, llmOptions(model: model, provider: provider))
+  const items: Feedback[] = llm(
+    prompt,
+    llmOptions(model: model, provider: provider, tools: extraTools),
+  )
   return items
 }
 
@@ -42,6 +46,7 @@ export def reviewAgent(
   model: string = "",
   provider: string = "",
   session: string = "",
+  extraTools: any[] = [],
 ): Result<Feedback[]> {
   """
   Review a work product against a task and return findings. error=true marks
@@ -55,6 +60,7 @@ export def reviewAgent(
   @param model - Model override, or "" for the ambient model
   @param provider - Provider for the model override
   @param session - Session name to share a thread across calls, or "" for isolated
+  @param extraTools - Extra tools to offer the LLM, appended to the built-in set
   """
   const captured = guard(cost: maxCost, time: maxTime) {
     let items: Feedback[] = []
@@ -65,6 +71,7 @@ export def reviewAgent(
         context: context,
         model: model,
         provider: provider,
+        extraTools: extraTools,
       )
     }
     return items

--- a/packages/agency-lang/stdlib/agents/review.agency
+++ b/packages/agency-lang/stdlib/agents/review.agency
@@ -9,7 +9,7 @@
   typecheck findings.
 */
 import { Feedback, failOpenFeedback } from "std::agents/lib/feedback"
-import { searchTools } from "std::agents/lib/search"
+import { hostedSearchTools, searchTools } from "std::agents/lib/search"
 import { llmOptions, withContext } from "std::agents/lib/shared"
 import { webTools } from "std::agents/lib/toolkits"
 import { agentSkill } from "std::skills"
@@ -53,7 +53,7 @@ ${work}
       model: model,
       provider: provider,
       tools: buildTools().concat(extraTools),
-      hostedTools: ["web_search"],
+      hostedTools: hostedSearchTools(model),
     ),
   )
   return items

--- a/packages/agency-lang/stdlib/agents/review.agency
+++ b/packages/agency-lang/stdlib/agents/review.agency
@@ -12,16 +12,21 @@ import { Feedback, failOpenFeedback } from "std::agents/lib/feedback"
 import { searchTools } from "std::agents/lib/search"
 import { llmOptions, withContext } from "std::agents/lib/shared"
 import { webTools } from "std::agents/lib/toolkits"
+import { agentSkill } from "std::skills"
 import { systemMessage, threadIsNew } from "std::thread"
 
 static const systemPrompt = """You review a work product against a task. For each finding, return a Feedback item: error=true when the work fails the task on that point (name the specific problem), error=false for a satisfied point. Be brief and concrete. Judge only against the task and context given; do not invent requirements."""
+
+// Skills we ship for this agent: markdown the model reads on demand,
+// so teaching it something new costs a file rather than prompt length.
+static const skills = agentSkill("review")
 
 export def buildTools(): any[] {
   """
   Return the reviewer's lookup tools. It reads and checks; it has no tools
   that change anything.
   """
-  return [...webTools(), ...searchTools()]
+  return [...webTools(), ...searchTools(), skills]
 }
 
 def judgeWork(

--- a/packages/agency-lang/stdlib/agents/skills/agency/coding/README.md
+++ b/packages/agency-lang/stdlib/agents/skills/agency/coding/README.md
@@ -1,0 +1,16 @@
+# Skills for the Agency coding agent
+
+Each file in this directory is one skill: a short markdown document the Agency coding agent
+reads on demand, when the task in front of it calls for that knowledge.
+
+Skills exist so we can teach an agent something without making its system
+prompt longer. A prompt is paid for on every call; a skill is read only when
+the agent decides it is relevant.
+
+Add a skill here when the agent repeatedly gets something wrong that a page
+of instruction would fix, and the knowledge is too specific to justify space
+in every prompt. Name the situation it applies to in the first line, so the
+agent can tell from the listing whether to open it.
+
+Do not add a skill for something a capable model already knows. A skill that
+restates general good practice costs context and teaches nothing.

--- a/packages/agency-lang/stdlib/agents/skills/agency/expert/README.md
+++ b/packages/agency-lang/stdlib/agents/skills/agency/expert/README.md
@@ -1,0 +1,16 @@
+# Skills for the Agency expert
+
+Each file in this directory is one skill: a short markdown document the Agency expert
+reads on demand, when the task in front of it calls for that knowledge.
+
+Skills exist so we can teach an agent something without making its system
+prompt longer. A prompt is paid for on every call; a skill is read only when
+the agent decides it is relevant.
+
+Add a skill here when the agent repeatedly gets something wrong that a page
+of instruction would fix, and the knowledge is too specific to justify space
+in every prompt. Name the situation it applies to in the first line, so the
+agent can tell from the listing whether to open it.
+
+Do not add a skill for something a capable model already knows. A skill that
+restates general good practice costs context and teaches nothing.

--- a/packages/agency-lang/stdlib/agents/skills/agency/review/README.md
+++ b/packages/agency-lang/stdlib/agents/skills/agency/review/README.md
@@ -1,0 +1,16 @@
+# Skills for the Agency reviewer
+
+Each file in this directory is one skill: a short markdown document the Agency reviewer
+reads on demand, when the task in front of it calls for that knowledge.
+
+Skills exist so we can teach an agent something without making its system
+prompt longer. A prompt is paid for on every call; a skill is read only when
+the agent decides it is relevant.
+
+Add a skill here when the agent repeatedly gets something wrong that a page
+of instruction would fix, and the knowledge is too specific to justify space
+in every prompt. Name the situation it applies to in the first line, so the
+agent can tell from the listing whether to open it.
+
+Do not add a skill for something a capable model already knows. A skill that
+restates general good practice costs context and teaches nothing.

--- a/packages/agency-lang/stdlib/agents/skills/agency/verifier/README.md
+++ b/packages/agency-lang/stdlib/agents/skills/agency/verifier/README.md
@@ -1,0 +1,16 @@
+# Skills for the Agency verifier
+
+Each file in this directory is one skill: a short markdown document the Agency verifier
+reads on demand, when the task in front of it calls for that knowledge.
+
+Skills exist so we can teach an agent something without making its system
+prompt longer. A prompt is paid for on every call; a skill is read only when
+the agent decides it is relevant.
+
+Add a skill here when the agent repeatedly gets something wrong that a page
+of instruction would fix, and the knowledge is too specific to justify space
+in every prompt. Name the situation it applies to in the first line, so the
+agent can tell from the listing whether to open it.
+
+Do not add a skill for something a capable model already knows. A skill that
+restates general good practice costs context and teaches nothing.

--- a/packages/agency-lang/stdlib/agents/skills/coding/README.md
+++ b/packages/agency-lang/stdlib/agents/skills/coding/README.md
@@ -1,0 +1,16 @@
+# Skills for the coding agent
+
+Each file in this directory is one skill: a short markdown document the coding agent
+reads on demand, when the task in front of it calls for that knowledge.
+
+Skills exist so we can teach an agent something without making its system
+prompt longer. A prompt is paid for on every call; a skill is read only when
+the agent decides it is relevant.
+
+Add a skill here when the agent repeatedly gets something wrong that a page
+of instruction would fix, and the knowledge is too specific to justify space
+in every prompt. Name the situation it applies to in the first line, so the
+agent can tell from the listing whether to open it.
+
+Do not add a skill for something a capable model already knows. A skill that
+restates general good practice costs context and teaches nothing.

--- a/packages/agency-lang/stdlib/agents/skills/data/README.md
+++ b/packages/agency-lang/stdlib/agents/skills/data/README.md
@@ -1,0 +1,16 @@
+# Skills for the data agent
+
+Each file in this directory is one skill: a short markdown document the data agent
+reads on demand, when the task in front of it calls for that knowledge.
+
+Skills exist so we can teach an agent something without making its system
+prompt longer. A prompt is paid for on every call; a skill is read only when
+the agent decides it is relevant.
+
+Add a skill here when the agent repeatedly gets something wrong that a page
+of instruction would fix, and the knowledge is too specific to justify space
+in every prompt. Name the situation it applies to in the first line, so the
+agent can tell from the listing whether to open it.
+
+Do not add a skill for something a capable model already knows. A skill that
+restates general good practice costs context and teaches nothing.

--- a/packages/agency-lang/stdlib/agents/skills/data/finding-identifiers.md
+++ b/packages/agency-lang/stdlib/agents/skills/data/finding-identifiers.md
@@ -1,0 +1,26 @@
+# Finding the identifier before you query
+
+Every connector here takes an exact identifier, and a wrong identifier
+returns a real answer to the wrong question rather than an error. That is
+the failure this skill exists to prevent.
+
+- **FRED** wants a series ID such as `UNRATE` or `GDPC1`. Search for the
+  series by description first, then confirm the ID with `fredSeriesInfo`,
+  which also reports the units and whether the series is seasonally
+  adjusted. `UNRATE` and `UNRATENSA` are different series.
+- **EDGAR** wants a CIK, a zero-padded number identifying a filer. Look it
+  up from the company name before calling `edgarFilingsByCik`. A parent
+  company and its subsidiaries have different CIKs, and an acquired company
+  keeps filing under its old CIK for a while.
+- **Wikidata** wants a Q-number such as `Q42`. `wikidataSearch` maps a label
+  to candidates, and labels are ambiguous: several people and a film may
+  share one. Read the description before committing to a candidate.
+- **DBnomics** wants provider, dataset, and series together as a path. The
+  provider code is not guessable from the country or agency name, so list
+  the provider's datasets first.
+- **USAspending** identifies awards by an award ID whose format differs
+  between contracts and grants.
+
+When a search returns several plausible candidates, say which one you chose
+and why, rather than picking silently. When it returns none, say so rather
+than substituting a series that looks close.

--- a/packages/agency-lang/stdlib/agents/skills/expert/README.md
+++ b/packages/agency-lang/stdlib/agents/skills/expert/README.md
@@ -1,0 +1,16 @@
+# Skills for the domain expert
+
+Each file in this directory is one skill: a short markdown document the domain expert
+reads on demand, when the task in front of it calls for that knowledge.
+
+Skills exist so we can teach an agent something without making its system
+prompt longer. A prompt is paid for on every call; a skill is read only when
+the agent decides it is relevant.
+
+Add a skill here when the agent repeatedly gets something wrong that a page
+of instruction would fix, and the knowledge is too specific to justify space
+in every prompt. Name the situation it applies to in the first line, so the
+agent can tell from the listing whether to open it.
+
+Do not add a skill for something a capable model already knows. A skill that
+restates general good practice costs context and teaches nothing.

--- a/packages/agency-lang/stdlib/agents/skills/planner/README.md
+++ b/packages/agency-lang/stdlib/agents/skills/planner/README.md
@@ -1,0 +1,16 @@
+# Skills for the planner
+
+Each file in this directory is one skill: a short markdown document the planner
+reads on demand, when the task in front of it calls for that knowledge.
+
+Skills exist so we can teach an agent something without making its system
+prompt longer. A prompt is paid for on every call; a skill is read only when
+the agent decides it is relevant.
+
+Add a skill here when the agent repeatedly gets something wrong that a page
+of instruction would fix, and the knowledge is too specific to justify space
+in every prompt. Name the situation it applies to in the first line, so the
+agent can tell from the listing whether to open it.
+
+Do not add a skill for something a capable model already knows. A skill that
+restates general good practice costs context and teaches nothing.

--- a/packages/agency-lang/stdlib/agents/skills/researcher/README.md
+++ b/packages/agency-lang/stdlib/agents/skills/researcher/README.md
@@ -1,0 +1,16 @@
+# Skills for the researcher
+
+Each file in this directory is one skill: a short markdown document the researcher
+reads on demand, when the task in front of it calls for that knowledge.
+
+Skills exist so we can teach an agent something without making its system
+prompt longer. A prompt is paid for on every call; a skill is read only when
+the agent decides it is relevant.
+
+Add a skill here when the agent repeatedly gets something wrong that a page
+of instruction would fix, and the knowledge is too specific to justify space
+in every prompt. Name the situation it applies to in the first line, so the
+agent can tell from the listing whether to open it.
+
+Do not add a skill for something a capable model already knows. A skill that
+restates general good practice costs context and teaches nothing.

--- a/packages/agency-lang/stdlib/agents/skills/review/README.md
+++ b/packages/agency-lang/stdlib/agents/skills/review/README.md
@@ -1,0 +1,16 @@
+# Skills for the reviewer
+
+Each file in this directory is one skill: a short markdown document the reviewer
+reads on demand, when the task in front of it calls for that knowledge.
+
+Skills exist so we can teach an agent something without making its system
+prompt longer. A prompt is paid for on every call; a skill is read only when
+the agent decides it is relevant.
+
+Add a skill here when the agent repeatedly gets something wrong that a page
+of instruction would fix, and the knowledge is too specific to justify space
+in every prompt. Name the situation it applies to in the first line, so the
+agent can tell from the listing whether to open it.
+
+Do not add a skill for something a capable model already knows. A skill that
+restates general good practice costs context and teaches nothing.

--- a/packages/agency-lang/stdlib/agents/skills/verifier/README.md
+++ b/packages/agency-lang/stdlib/agents/skills/verifier/README.md
@@ -1,0 +1,16 @@
+# Skills for the verifier
+
+Each file in this directory is one skill: a short markdown document the verifier
+reads on demand, when the task in front of it calls for that knowledge.
+
+Skills exist so we can teach an agent something without making its system
+prompt longer. A prompt is paid for on every call; a skill is read only when
+the agent decides it is relevant.
+
+Add a skill here when the agent repeatedly gets something wrong that a page
+of instruction would fix, and the knowledge is too specific to justify space
+in every prompt. Name the situation it applies to in the first line, so the
+agent can tell from the listing whether to open it.
+
+Do not add a skill for something a capable model already knows. A skill that
+restates general good practice costs context and teaches nothing.

--- a/packages/agency-lang/stdlib/agents/verifier.agency
+++ b/packages/agency-lang/stdlib/agents/verifier.agency
@@ -8,8 +8,7 @@
 import { concurrencyPool } from "std::concurrency"
 import { Feedback, failOpenFeedback } from "std::agents/lib/feedback"
 import { llmOptions } from "std::agents/lib/shared"
-import { readOnlyFileTools } from "std::agents/lib/toolkits"
-import { exec } from "std::shell"
+import { readOnlyFileTools, shellTools } from "std::agents/lib/toolkits"
 import { systemMessage, threadIsNew } from "std::thread"
 
 // One judge per criterion, four at a time: enough concurrency to keep the
@@ -18,10 +17,15 @@ static const POOL_SIZE = 4
 
 export def buildTools(): any[] {
   """
-  Return the verifier's tools. It inspects and measures; it has no write
-  tools, because a verifier that can fix things is no longer a verifier.
+  Return the verifier's tools. It measures with shell pipelines and reads
+  bytes, because a criterion checked by eye is a criterion not checked. It
+  has no write tools: a verifier that can fix things is no longer a verifier.
   """
-  return [...readOnlyFileTools(), exec.partial(useAgentCwd: true)]
+  return [
+    ...readOnlyFileTools(),
+    ...shellTools(),
+    readBinary.partial(useAgentCwd: true),
+  ]
 }
 
 static const systemPrompt = """You verify whether a coding task was completed correctly. You do NOT fix anything. Inspect, COMPUTE, and report.

--- a/packages/agency-lang/stdlib/agents/verifier.agency
+++ b/packages/agency-lang/stdlib/agents/verifier.agency
@@ -43,6 +43,7 @@ export def verifierAgent(
   model: string = "",
   provider: string = "",
   session: string = "",
+  extraTools: any[] = [],
 ): Result<Feedback[]> {
   """
   Verify work on disk against a task: derive measurable success criteria,
@@ -57,6 +58,7 @@ export def verifierAgent(
   @param model - Model override, or "" for the ambient model
   @param provider - Provider for the model override
   @param session - Session name to share a thread across calls, or "" for isolated
+  @param extraTools - Extra tools to offer the LLM, appended to the built-in set
   """
   const captured = guard(cost: maxCost, time: maxTime) {
     let results: Feedback[][] = []
@@ -82,7 +84,7 @@ export def verifierAgent(
 
       const generatedCriteria: string[] = llm(
         generateCriteriaPrompt,
-        llmOptions(model: model, provider: provider),
+        llmOptions(model: model, provider: provider, tools: extraTools),
       )
 
       const allCriteria = criteria.concat(generatedCriteria)
@@ -102,7 +104,11 @@ export def verifierAgent(
 
         const items: Feedback[] = llm(
           prompt,
-          llmOptions(model: model, provider: provider, tools: tools),
+          llmOptions(
+            model: model,
+            provider: provider,
+            tools: tools.concat(extraTools),
+          ),
         )
         return items
       }

--- a/packages/agency-lang/stdlib/agents/verifier.agency
+++ b/packages/agency-lang/stdlib/agents/verifier.agency
@@ -8,20 +8,21 @@
 import { concurrencyPool } from "std::concurrency"
 import { Feedback, failOpenFeedback } from "std::agents/lib/feedback"
 import { llmOptions } from "std::agents/lib/shared"
-import { ls, glob, grep, exec } from "std::shell"
+import { readOnlyFileTools } from "std::agents/lib/toolkits"
+import { exec } from "std::shell"
 import { systemMessage, threadIsNew } from "std::thread"
 
 // One judge per criterion, four at a time: enough concurrency to keep the
 // verification quick without flooding the provider with parallel requests.
 static const POOL_SIZE = 4
 
-static const tools: any[] = [
-  read.partial(useAgentCwd: true),
-  ls.partial(useAgentCwd: true),
-  glob.partial(useAgentCwd: true),
-  grep.partial(useAgentCwd: true),
-  exec.partial(useAgentCwd: true),
-]
+export def buildTools(): any[] {
+  """
+  Return the verifier's tools. It inspects and measures; it has no write
+  tools, because a verifier that can fix things is no longer a verifier.
+  """
+  return [...readOnlyFileTools(), exec.partial(useAgentCwd: true)]
+}
 
 static const systemPrompt = """You verify whether a coding task was completed correctly. You do NOT fix anything. Inspect, COMPUTE, and report.
 
@@ -107,7 +108,7 @@ export def verifierAgent(
           llmOptions(
             model: model,
             provider: provider,
-            tools: tools.concat(extraTools),
+            tools: buildTools().concat(extraTools),
           ),
         )
         return items

--- a/packages/agency-lang/stdlib/agents/verifier.agency
+++ b/packages/agency-lang/stdlib/agents/verifier.agency
@@ -9,11 +9,16 @@ import { concurrencyPool } from "std::concurrency"
 import { Feedback, failOpenFeedback } from "std::agents/lib/feedback"
 import { llmOptions } from "std::agents/lib/shared"
 import { readOnlyFileTools, shellTools } from "std::agents/lib/toolkits"
+import { agentSkill } from "std::skills"
 import { systemMessage, threadIsNew } from "std::thread"
 
 // One judge per criterion, four at a time: enough concurrency to keep the
 // verification quick without flooding the provider with parallel requests.
 static const POOL_SIZE = 4
+
+// Skills we ship for this agent: markdown the model reads on demand,
+// so teaching it something new costs a file rather than prompt length.
+static const skills = agentSkill("verifier")
 
 export def buildTools(): any[] {
   """
@@ -25,6 +30,7 @@ export def buildTools(): any[] {
     ...readOnlyFileTools(),
     ...shellTools(),
     readBinary.partial(useAgentCwd: true),
+    skills,
   ]
 }
 

--- a/packages/agency-lang/stdlib/llm.agency
+++ b/packages/agency-lang/stdlib/llm.agency
@@ -176,6 +176,7 @@ export def modelSupportsInput(model: string, modality: string): boolean | null {
   return _modelSupportsInput(model, modality)
 }
 
+
 // Accumulation details (kept out of the docstring, which is also the LLM tool
 // description): when called more than once, the newly loaded file wins over
 // previously loaded files and over the built-in catalog on provider+name

--- a/packages/agency-lang/stdlib/skills.agency
+++ b/packages/agency-lang/stdlib/skills.agency
@@ -12,7 +12,7 @@ import { frontmatter } from "std::markdown"
 // the interrupt-raising versions have.
 import { _read } from "agency-lang/stdlib-lib/builtins.js"
 import { _glob } from "agency-lang/stdlib-lib/shell.js"
-import { _docsDir } from "agency-lang/stdlib-lib/skills.js"
+import { _docsDir, _agentSkillsDir } from "agency-lang/stdlib-lib/skills.js"
 
 /** @module
   @summary Give an LLM access to a directory of skills, and support Claude-Code-style slash commands.
@@ -258,6 +258,26 @@ export def docsSkill(section: "guide" | "cli" | "diagnostics" | "stdlib") {
   // every read the LLM later performs still raises std::read and goes
   // through handlers/policies exactly like any other read tool.
   return buildSkillsTool(_docsDir(section), "flat", "", true)
+}
+
+export def agentSkill(agent: string) {
+  """
+  Build a skills tool over the skills shipped for one agent. The returned
+  tool lists every skill in its description and lets the model read any one
+  on demand.
+
+  @param agent - Which agent's skills to serve, as a path under the shipped skills directory
+  """
+  // No approval interrupt for the startup scan, matching docsSkill: these
+  // skills ship inside the agency package, so scanning them carries the same
+  // trust as running the stdlib itself. The returned tool is read.partial, so
+  // every read the LLM later performs still raises std::read and goes through
+  // handlers and policies exactly like any other read tool.
+  //
+  // The explicit name matters: the name derived from a directory embeds the
+  // absolute install path, so it differs per machine and gets truncated.
+  const name = "skills_" + agent.replace("/", "_")
+  return buildSkillsTool(_agentSkillsDir(agent), "flat", name)
 }
 
 // ============================================================

--- a/packages/agency-lang/stdlib/supervise.agency
+++ b/packages/agency-lang/stdlib/supervise.agency
@@ -45,10 +45,8 @@ export def supervise(
   if (maxTime < every) {
     return failure("supervise: maxTime is less than the check interval, so no checkpoint would ever be reached")
   }
-  let elapsed = 0m
-  let interval = every
   handle {
-    const captured = guard(time: interval, label: "std::supervise") {
+    const captured = guard(time: every, label: "std::supervise") {
       return block()
     }
     return captured
@@ -56,19 +54,34 @@ export def supervise(
     // Only answer trips from OUR guard. The block's own guards (an agent's
     // cost and time caps) raise the same std::guard effect; without this
     // label gate we would answer an inner trip, extend the wrong guard, and
-    // corrupt our own elapsed-time accounting.
+    // corrupt our own accounting.
     if (intr.effect != "std::guard" || intr.data.label != "std::supervise") {
       return pass()
     }
-    elapsed = elapsed + interval
-    if (elapsed >= maxTime) {
+    // The working time the block has actually consumed. Counting intervals
+    // instead would drift, because a block routinely overshoots its limit
+    // before the trip is answered.
+    const spent = intr.data.spent
+    if (spent >= maxTime) {
       return reject("supervise: maxTime reached")
     }
-    const decision = check(elapsed)
-    interval = Math.min(every, maxTime - elapsed)
+    const decision = check(spent)
+    // The grant is a DELTA added to the tripped budget, and the runtime
+    // refuses an approval that leaves the budget still exceeded. By the time
+    // a trip is answered the block has usually run past the old limit, and on
+    // a loaded machine it can run far past it, so the grant covers that
+    // overshoot before it adds the next interval. Granting a bare interval
+    // fails exactly when the machine is busy, which is the worst time to
+    // discover it.
+    const overshoot = spent - intr.data.limit
+    let nextInterval = every
+    if (maxTime - spent < every) {
+      nextInterval = maxTime - spent
+    }
+    const grant = overshoot + nextInterval
     return match(decision.action) {
-      "continue" => approve({ maxTime: interval })
-      "redirect" => approve({ maxTime: interval, message: decision.message })
+      "continue" => approve({ maxTime: grant })
+      "redirect" => approve({ maxTime: grant, message: decision.message })
       "stop" => reject(decision.message)
     }
   }

--- a/packages/agency-lang/tests/agency/agents/agentSkill.agency
+++ b/packages/agency-lang/tests/agency/agents/agentSkill.agency
@@ -1,0 +1,27 @@
+import { agentSkill } from "std::skills"
+import { buildTools as dataTools } from "std::agents/data"
+
+// The shipped directory must resolve and list what is in it. A path relative
+// to the calling file, or a missing package files entry, breaks this for
+// installed users while working fine in the repo.
+node shippedSkillsResolveAndList(): boolean {
+  const tool = agentSkill("data")
+  return tool.description =~ re/finding-identifiers/
+}
+
+// A nested agent directory resolves too.
+node nestedAgentSkillsResolve(): boolean {
+  const tool = agentSkill("agency/coding")
+  return tool.description.length > 0
+}
+
+// The tool carries a stable name rather than one derived from the absolute
+// install path, which differs per machine.
+node skillToolHasAStableName(): boolean {
+  return agentSkill("data").name == "skills_data"
+}
+
+// Every agent carries its own skills tool.
+node agentsCarryTheirSkills(): boolean {
+  return some(dataTools(), \tool -> tool.name == "skills_data")
+}

--- a/packages/agency-lang/tests/agency/agents/agentSkill.test.json
+++ b/packages/agency-lang/tests/agency/agents/agentSkill.test.json
@@ -1,0 +1,8 @@
+{
+  "tests": [
+    { "nodeName": "shippedSkillsResolveAndList", "description": "a shipped skills directory resolves and lists its files", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "nestedAgentSkillsResolve", "description": "a nested agent skills directory resolves", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "skillToolHasAStableName", "description": "the skills tool name does not embed the install path", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "agentsCarryTheirSkills", "description": "an agent carries its own skills tool", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] }
+  ]
+}

--- a/packages/agency-lang/tests/agency/agents/data.agency
+++ b/packages/agency-lang/tests/agency/agents/data.agency
@@ -1,0 +1,33 @@
+import { dataAgent, buildTools } from "std::agents/data"
+
+node answersFromAMock(): string {
+  const result = dataAgent(task: "what is the current unemployment rate")
+  if (isFailure(result)) { return "failed" }
+  return result.value
+}
+
+// Every connector family must be reachable, and no two tools may share a
+// name: providers reject duplicates and this agent has the longest list.
+node carriesEveryConnectorFamily(): boolean {
+  const names = map(buildTools(), \tool -> tool.name)
+  const required = [
+    "fredSeries",
+    "dbnomicsSeries",
+    "edgarFilings",
+    "gdeltNews",
+    "usaspendingAwards",
+    "wikidataSearch",
+    "littlesisSearch",
+    "hnSearch",
+    "ycBatch",
+  ]
+  const hasAll = every(required, \name -> names.includes(name))
+  return hasAll && unique(names, \name -> name).length == names.length
+}
+
+// It can look up an identifier before querying, which is the failure mode
+// the system prompt warns about.
+node canFindIdentifiersBeforeQuerying(): boolean {
+  const names = map(buildTools(), \tool -> tool.name)
+  return names.includes("fetchMarkdown") && names.includes("wikipedia_search")
+}

--- a/packages/agency-lang/tests/agency/agents/data.test.json
+++ b/packages/agency-lang/tests/agency/agents/data.test.json
@@ -1,0 +1,27 @@
+{
+  "tests": [
+    {
+      "nodeName": "answersFromAMock",
+      "description": "the data agent returns its answer as a success Result",
+      "input": "",
+      "expectedOutput": "\"unemployment was 4.1 percent in the latest month, FRED series UNRATE\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "unemployment was 4.1 percent in the latest month, FRED series UNRATE" }]
+    },
+    {
+      "nodeName": "carriesEveryConnectorFamily",
+      "description": "every connector family is reachable and no tool name repeats",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "canFindIdentifiersBeforeQuerying",
+      "description": "the agent can look up an identifier before querying",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/agents/extraTools.agency
+++ b/packages/agency-lang/tests/agency/agents/extraTools.agency
@@ -1,0 +1,21 @@
+import { reviewAgent } from "std::agents/review"
+import { feedbackHasErrors } from "std::agents/lib/feedback"
+
+let toolWasCalled = false
+
+def markerTool(note: string): string {
+  """Record that the agent was able to call an injected tool."""
+  toolWasCalled = true
+  return "recorded: ${note}"
+}
+
+// A tool passed via extraTools must reach the provider, so the model can
+// call it. The first mock calls the tool; the second returns findings.
+node injectedToolReachesTheAgent(): boolean {
+  const findings = reviewAgent(
+    work: "some work",
+    task: "a task",
+    extraTools: [markerTool],
+  )
+  return toolWasCalled && !feedbackHasErrors(findings)
+}

--- a/packages/agency-lang/tests/agency/agents/extraTools.test.json
+++ b/packages/agency-lang/tests/agency/agents/extraTools.test.json
@@ -1,0 +1,16 @@
+{
+  "tests": [
+    {
+      "nodeName": "injectedToolReachesTheAgent",
+      "description": "a tool passed via extraTools is callable by the agent",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "toolCall": { "name": "markerTool", "args": { "note": "hello" } } },
+        { "return": [] }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/agents/searchTools.agency
+++ b/packages/agency-lang/tests/agency/agents/searchTools.agency
@@ -1,4 +1,4 @@
-import { searchTools, searchProviderNames } from "std::agents/lib/search"
+import { searchTools, searchProviderNames, hostedSearchTools } from "std::agents/lib/search"
 
 // Which keys a developer has set varies, so this pins the invariants that
 // hold either way rather than a specific provider list: every name comes
@@ -11,4 +11,15 @@ node namesComeFromTheCatalog(): boolean {
 
 node oneToolPerAvailableProvider(): boolean {
   return searchTools().length == searchProviderNames().length
+}
+
+// Hosted search is requested from one place rather than hardcoded at each
+// agent. It is deliberately not gated on the model: see the comment in
+// std::agents/lib/search for why a catalog-based gate would answer
+// "unsupported" for every model and silently disable search everywhere.
+node hostedSearchIsRequestedFromOnePlace(): boolean {
+  const capable = hostedSearchTools("gpt-4o-mini")
+  const unknown = hostedSearchTools("some-local-model-nobody-shipped")
+  const ambient = hostedSearchTools()
+  return capable.includes("web_search") && unknown.includes("web_search") && ambient.includes("web_search")
 }

--- a/packages/agency-lang/tests/agency/agents/searchTools.test.json
+++ b/packages/agency-lang/tests/agency/agents/searchTools.test.json
@@ -5,14 +5,33 @@
       "description": "every reported provider comes from the catalog",
       "input": "",
       "expectedOutput": "true",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     },
     {
       "nodeName": "oneToolPerAvailableProvider",
       "description": "each available provider contributes exactly one tool",
       "input": "",
       "expectedOutput": "true",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "hostedSearchIsRequestedFromOnePlace",
+      "description": "hosted search comes from one helper and is not model-gated",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/agents/toolGaps.agency
+++ b/packages/agency-lang/tests/agency/agents/toolGaps.agency
@@ -1,0 +1,71 @@
+import { buildTools as codingTools } from "std::agents/coding"
+import { buildTools as verifierTools } from "std::agents/verifier"
+import { buildTools as reviewTools } from "std::agents/review"
+import { buildTools as agencyVerifierTools } from "std::agents/agency/verifier"
+import { buildTools as agencyCodingTools } from "std::agents/agency/coding"
+import { buildTools as agencyReviewTools } from "std::agents/agency/review"
+
+def hasTool(tools: any[], name: string): boolean {
+  return some(tools, \tool -> tool.name == name)
+}
+
+// The worst gap: the Agency verifier ran a program and judged its return
+// value while unable to see any file the program wrote.
+node agencyVerifierCanSeeFiles(): boolean {
+  const tools = agencyVerifierTools()
+  return hasTool(tools, "read") && hasTool(tools, "bash")
+}
+
+// The verifier is told to compute values and inspect bytes.
+node verifierCanComputeAndReadBytes(): boolean {
+  const tools = verifierTools()
+  return hasTool(tools, "bash") && hasTool(tools, "readBinary")
+}
+
+// The Agency writer could not look up the AG#### codes its own retry prompt
+// quoted at it, nor check a draft before spending an attempt on it.
+node agencyCodingHasDocsAndTypecheck(): boolean {
+  const tools = agencyCodingTools()
+  return hasTool(tools, "agency_diagnostics") && hasTool(tools, "typecheck") && hasTool(tools, "read")
+}
+
+// It gets targeted fetch but deliberately no search: an open-ended search
+// for Agency syntax returns other languages' idioms.
+node agencyCodingFetchesButDoesNotSearch(): boolean {
+  const tools = agencyCodingTools()
+  return hasTool(tools, "fetchMarkdown") && !hasTool(tools, "web_search_brave")
+}
+
+// The coding agent could search the web but not fetch what it found.
+node codingCanFetch(): boolean {
+  return hasTool(codingTools(), "fetchMarkdown")
+}
+
+// Both reviewers can look things up now, and still cannot change anything.
+node reviewersLookUpButCannotWrite(): boolean {
+  const plain = reviewTools()
+  const agency = agencyReviewTools()
+  const canLookUp = hasTool(plain, "fetchMarkdown") && hasTool(agency, "agency_guide")
+  const cannotWrite = !hasTool(plain, "write") && !hasTool(agency, "write") && !hasTool(agency, "bash")
+  return canLookUp && cannotWrite
+}
+
+// No agent may offer two tools with the same name: providers reject that,
+// and .partial() preserves the base name so it is easy to do by accident.
+node noAgentHasDuplicateToolNames(): boolean {
+  const lists = [
+    codingTools(),
+    verifierTools(),
+    reviewTools(),
+    agencyVerifierTools(),
+    agencyCodingTools(),
+    agencyReviewTools(),
+  ]
+  for (list in lists) {
+    const names = map(list, \tool -> tool.name)
+    if (unique(names, \name -> name).length != names.length) {
+      return false
+    }
+  }
+  return true
+}

--- a/packages/agency-lang/tests/agency/agents/toolGaps.test.json
+++ b/packages/agency-lang/tests/agency/agents/toolGaps.test.json
@@ -1,0 +1,81 @@
+{
+  "tests": [
+    {
+      "nodeName": "agencyVerifierCanSeeFiles",
+      "description": "the Agency verifier can inspect files the program wrote",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "verifierCanComputeAndReadBytes",
+      "description": "the verifier can run pipelines and read bytes",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "agencyCodingHasDocsAndTypecheck",
+      "description": "the Agency writer can look up diagnostics and check drafts",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "agencyCodingFetchesButDoesNotSearch",
+      "description": "the Agency writer fetches named pages but does not search",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "codingCanFetch",
+      "description": "the coding agent can fetch what its search finds",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "reviewersLookUpButCannotWrite",
+      "description": "reviewers gained lookups and still cannot change anything",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "noAgentHasDuplicateToolNames",
+      "description": "no agent offers two tools with the same name",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/agents/toolkits.agency
+++ b/packages/agency-lang/tests/agency/agents/toolkits.agency
@@ -28,8 +28,52 @@ node everyBundleHasTools(): boolean {
   return every(allBundles(), \bundle -> bundle.length > 0)
 }
 
+// Membership, not arity: an arity check passes if someone drops grep and
+// adds two unrelated tools, which is exactly the drift this asserts against.
 node writableIsASupersetOfReadOnly(): boolean {
-  return writableFileTools().length == readOnlyFileTools().length + 2
+  const writableNames = map(writableFileTools(), \tool -> tool.name)
+  const coversReadOnly = every(readOnlyFileTools(), \tool -> writableNames.includes(tool.name))
+  return coversReadOnly && writableFileTools().length == readOnlyFileTools().length + 2
+}
+
+/** True when a tool has `useAgentCwd` bound to true by partial application.
+  The bound arguments arrive as parallel indices and values, so the check
+  looks the parameter up by name and then reads the value bound at its
+  position. */
+def isCwdBound(tool: any): boolean {
+  const args = tool.boundArgs
+  if (args == null) {
+    return false
+  }
+  let position = 0
+  let cwdIndex = -1
+  for (param in args.originalParams) {
+    if (param.name == "useAgentCwd") {
+      cwdIndex = position
+    }
+    position = position + 1
+  }
+  if (cwdIndex < 0) {
+    return false
+  }
+  let slot = 0
+  let bound = false
+  for (index in args.indices) {
+    if (index == cwdIndex && args.values[slot] == true) {
+      bound = true
+    }
+    slot = slot + 1
+  }
+  return bound
+}
+
+// Composing from a bundle must not silently move an agent onto the process
+// working directory. This is invisible in CI otherwise, because tests run
+// from the repo root where the two usually coincide: it shows up only as an
+// agent reading or writing outside the directory it was pointed at.
+node fileAndShellToolsAreCwdBound(): boolean {
+  const shouldBeBound = [...writableFileTools(), ...shellTools()]
+  return every(shouldBeBound, isCwdBound)
 }
 
 // Providers reject two tools with the same name, and .partial() preserves the

--- a/packages/agency-lang/tests/agency/agents/toolkits.agency
+++ b/packages/agency-lang/tests/agency/agents/toolkits.agency
@@ -1,0 +1,60 @@
+import {
+  readOnlyFileTools,
+  writableFileTools,
+  shellTools,
+  gitTools,
+  webTools,
+  agencyDocTools,
+  agencyCodeTools,
+  memoryTools,
+  planningTools,
+ } from "std::agents/lib/toolkits"
+
+def allBundles(): any[] {
+  return [
+    readOnlyFileTools(),
+    writableFileTools(),
+    shellTools(),
+    gitTools(),
+    webTools(),
+    agencyDocTools(),
+    agencyCodeTools(),
+    memoryTools(),
+    planningTools(),
+  ]
+}
+
+node everyBundleHasTools(): boolean {
+  return every(allBundles(), \bundle -> bundle.length > 0)
+}
+
+node writableIsASupersetOfReadOnly(): boolean {
+  return writableFileTools().length == readOnlyFileTools().length + 2
+}
+
+// Providers reject two tools with the same name, and .partial() preserves the
+// base name, so a bundle can collide with itself. This is the check that
+// catches it before a provider does.
+node noBundleHasDuplicateNames(): boolean {
+  for (bundle in allBundles()) {
+    const names = map(bundle, \tool -> tool.name)
+    if (unique(names, \name -> name).length != names.length) {
+      return false
+    }
+  }
+  return true
+}
+
+// The wikipedia tools must not advertise a bare `search`, which collides with
+// the web-search providers in std::agents/lib/search.
+node wikipediaToolsAreRenamed(): boolean {
+  const names = map(webTools(), \tool -> tool.name)
+  return names.includes("wikipedia_search") && !names.includes("search")
+}
+
+// The docs tools carry stable names rather than ones derived from the
+// absolute install path, which differs per machine.
+node docsToolsHaveStableNames(): boolean {
+  const names = map(agencyDocTools(), \tool -> tool.name)
+  return names.includes("agency_guide") && names.includes("agency_diagnostics")
+}

--- a/packages/agency-lang/tests/agency/agents/toolkits.test.json
+++ b/packages/agency-lang/tests/agency/agents/toolkits.test.json
@@ -1,9 +1,70 @@
 {
   "tests": [
-    { "nodeName": "everyBundleHasTools", "description": "every bundle returns tools", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "writableIsASupersetOfReadOnly", "description": "writable adds write and edit to read-only", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "noBundleHasDuplicateNames", "description": "no bundle offers two tools with the same name", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "wikipediaToolsAreRenamed", "description": "wikipedia tools do not advertise a bare search", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "docsToolsHaveStableNames", "description": "docs tools carry stable machine-independent names", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] }
+    {
+      "nodeName": "everyBundleHasTools",
+      "description": "every bundle returns tools",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "writableIsASupersetOfReadOnly",
+      "description": "writable adds write and edit to read-only",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "noBundleHasDuplicateNames",
+      "description": "no bundle offers two tools with the same name",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "wikipediaToolsAreRenamed",
+      "description": "wikipedia tools do not advertise a bare search",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "docsToolsHaveStableNames",
+      "description": "docs tools carry stable machine-independent names",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "fileAndShellToolsAreCwdBound",
+      "description": "every file and shell tool in a bundle is bound to the agent working directory",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
   ]
 }

--- a/packages/agency-lang/tests/agency/agents/toolkits.test.json
+++ b/packages/agency-lang/tests/agency/agents/toolkits.test.json
@@ -1,0 +1,9 @@
+{
+  "tests": [
+    { "nodeName": "everyBundleHasTools", "description": "every bundle returns tools", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "writableIsASupersetOfReadOnly", "description": "writable adds write and edit to read-only", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "noBundleHasDuplicateNames", "description": "no bundle offers two tools with the same name", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "wikipediaToolsAreRenamed", "description": "wikipedia tools do not advertise a bare search", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "docsToolsHaveStableNames", "description": "docs tools carry stable machine-independent names", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] }
+  ]
+}

--- a/packages/agency-lang/tests/agency/supervise/supervise.agency
+++ b/packages/agency-lang/tests/agency/supervise/supervise.agency
@@ -101,3 +101,39 @@ node redirectDeliversMessage(): string {
   if (isFailure(r)) { return "unexpected-failure" }
   return r.value
 }
+
+// A block that overshoots its limit by more than the next interval, which is
+// what happens whenever a step runs long, and happens constantly on a loaded
+// machine. approve({maxTime}) grants a DELTA on the tripped budget, and the
+// runtime refuses an approval that leaves the budget still exceeded, so the
+// grant has to cover the overshoot before it adds the interval. Granting a
+// bare interval fails with GuardApproveError and takes the whole supervised
+// run with it.
+//
+// This shipped as an intermittent CI failure that never reproduced locally
+// until the machine was loaded. The tiny interval against a long block makes
+// the overshoot certain instead of load-dependent.
+let slowChecks = 0
+
+def slowCheck(elapsed: number): SuperviseDecision {
+  checks.push("checked")
+  slowChecks = slowChecks + 1
+  // Only the first one is slow. One is enough to push the block well past
+  // the limit it tripped on, and spinning on every trip would make the test
+  // take minutes.
+  if (slowChecks == 1) {
+    spin(3000000)
+  }
+  return { action: "continue", message: "" }
+}
+
+node overshootIsCoveredByTheGrant(): string {
+  const r = supervise(every: 1ms, maxTime: 600000, check: slowCheck) {
+    const s = spin(3000000)
+    return "done:${s}"
+  }
+  if (isFailure(r)) {
+    return "failed:${r.error}"
+  }
+  return r.value
+}

--- a/packages/agency-lang/tests/agency/supervise/supervise.test.json
+++ b/packages/agency-lang/tests/agency/supervise/supervise.test.json
@@ -64,6 +64,17 @@
           "return": "one"
         }
       ]
+    },
+    {
+      "nodeName": "overshootIsCoveredByTheGrant",
+      "description": "a block that overshoots its limit still gets a valid approval",
+      "input": "",
+      "expectedOutput": "\"done:spun\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/verify-agent.agency
+++ b/packages/agency-lang/tests/agency/verify-agent.agency
@@ -1,7 +1,12 @@
 import { verify, renderGaps, unwrapVerdict, Verdict } from "../../lib/agents/agency-agent/subagents/verify.agency"
 
-// verify() end-to-end with scoped LLM mocks (no real API/tools — the
-// mocked phase-1 response has no tool calls, so the tool loop ends).
+// verify() end-to-end with scoped LLM mocks (no real API or tools, since the
+// mocked responses carry no tool calls, so the tool loop ends).
+//
+// The mock scope key is the module where llm() EXECUTES, not where the call
+// is written. Verification lives in std::agents/verifier now, so mocks keyed
+// to the old std::agency location silently match nothing and the verifier
+// reports no findings at all.
 node unsatisfied() {
   const v = verify("Write a regex to /app/regex.txt")
   return "${v.satisfied}|${renderGaps(v.gaps)}"

--- a/packages/agency-lang/tests/agency/verify-agent.test.json
+++ b/packages/agency-lang/tests/agency/verify-agent.test.json
@@ -4,12 +4,27 @@
       "nodeName": "unsatisfied",
       "input": "",
       "expectedOutput": "\"false|- /app/regex.txt was not created\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
       "llmMocks": {
-        "stdlib/agency.agency": [
-          { "return": "The file /app/regex.txt does not exist; not complete." },
-          { "return": [{ "error": true, "feedback": "/app/regex.txt was not created" }] }
+        "stdlib/agents/verifier.agency": [
+          {
+            "return": [
+              "/app/regex.txt exists and contains a regex"
+            ]
+          },
+          {
+            "return": [
+              {
+                "error": true,
+                "feedback": "/app/regex.txt was not created"
+              }
+            ]
+          }
         ]
       }
     },
@@ -17,12 +32,27 @@
       "nodeName": "satisfied",
       "input": "",
       "expectedOutput": "\"true|0\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
       "llmMocks": {
-        "stdlib/agency.agency": [
-          { "return": "Ran the regex against the sample; it matches. Complete." },
-          { "return": [{ "error": false, "feedback": "regex matches the sample" }] }
+        "stdlib/agents/verifier.agency": [
+          {
+            "return": [
+              "/app/regex.txt exists and contains a regex"
+            ]
+          },
+          {
+            "return": [
+              {
+                "error": false,
+                "feedback": "regex matches the sample"
+              }
+            ]
+          }
         ]
       }
     },
@@ -30,7 +60,11 @@
       "nodeName": "unwrapSuccess",
       "input": "",
       "expectedOutput": "\"false|1\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
       "llmMocks": []
     },
@@ -38,7 +72,11 @@
       "nodeName": "unwrapFailure",
       "input": "",
       "expectedOutput": "\"true|- verification could not run: verifier boom\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
       "llmMocks": []
     }


### PR DESCRIPTION
Follow-up to the agents refactor. Implements `docs/superpowers/specs/2026-07-18-agent-tools-and-skills-design.md`.

The last PR fixed the *structure* of the stdlib agents. This one fixes what they can actually **do**.

## Why

Once every agent had the same shape, their tool lists could be compared side by side for the first time, and it turned out nobody had ever chosen them as a set. They had accumulated:

- The **Agency verifier ran a program and judged its return value while blind to any file the program wrote.** A program that returns `"done"` and writes nothing passed. It was verifying the wrong artifact.
- The **researcher had no keyless search.** Provider-hosted `web_search` runs server-side, needs no API key, and works in sandboxes; the expert already used it, and the agent whose whole job is finding things did not. It could also find a Wikipedia page and then not read it, having imported `search` but not `summary` or `article`.
- The **Agency writer could not look up the `AG####` codes its own retry prompt quoted at it**, and could not typecheck a draft before spending a whole attempt on it.
- The **verifier's prompt demanded computed values and byte-level checks** it had no `bash` and no `readBinary` to make.
- The **coding agent could search the web but not fetch what it found.**

## What changed

**Named tool bundles** (`std::agents/lib/toolkits`). Nine functions — `readOnlyFileTools`, `writableFileTools`, `shellTools`, `gitTools`, `webTools`, `agencyDocTools`, `agencyCodeTools`, `memoryTools`, `planningTools`. Every agent now composes its list from these, so a tool list reads as a description of the agent and adding a tool to a category reaches everyone who claimed it. Functions rather than constants, matching `searchTools()`, which must read API keys at call time.

**Every gap above is closed**, plus both reviewers gained web search and fetch so they can check a claim, while still having nothing that changes anything. The boundary is restated in their module docs: **review reads the work and looks things up; the verifier runs the work and measures it.**

One deliberate asymmetry: `agencyCodingAgent` gets targeted fetch but **no** web search. It writes one language whose authoritative docs ship in this package, and an open-ended search returns other languages' idioms — the exact failure its system prompt spends its length fighting. Fetching a page the caller named has no discovery step to go wrong.

**`dataAgent`** (`std::agents/data`) owns the nine data connectors, which no agent could previously reach: FRED, DBnomics, EDGAR, GDELT, LittleSis, Hacker News, YC, USAspending, Wikidata. One agent rather than several by domain — splitting would produce agents differing by tool list rather than by problem, and a caller often can't tell which domain their question falls in. It carries search and fetch too, because querying these APIs means finding an identifier first, and a guessed identifier returns a real answer to the wrong question.

**Packaged skills.** `agentSkill(name)` serves markdown we ship under `stdlib/agents/skills/<agent>/`. A prompt is paid for on every call, which caps how much we can teach an agent; a skill is read only when the model decides it's relevant. These are *ours* — we author them, they ship in the package, no agent takes a skills parameter or scans a user directory. This pass ships the loader, a README per directory, and one worked skill (`data/finding-identifiers.md`), with further content deferred until we have observed failures to write against.

**`extraTools`** on every agent, last in the parameter order. The single seam for anything we don't ship by default: a user's tools, MCP tools, a connector an agent doesn't carry, or another agent wired in deliberately with its own budget. No agent gets another agent by default.

## Two traps this would have hit

**`agentSkill` mirrors `docsSkill`, not `skillsDir` — and not for the reason it looks like.** The approval interrupt lives in `skillsDir`'s body; `docsSkill` skips it by simply not raising it. The `true` that `docsSkill` passes to `buildSkillsTool` is the **`recursive`** flag, not a trust flag. The spec originally said otherwise; reading the source fixed it. Every read the model performs still raises `std::read` through policies.

**Packaged paths must resolve through `getStdlibDir()`.** A relative `"./skills/coding"` resolves against the calling file and breaks once installed into `node_modules` — working perfectly in the repo and failing for every real user. Hence `_agentSkillsDir()` alongside `_docsDir()`. Relatedly, `package.json` shipped markdown only from `./stdlib/docs/**/*.md`, so the skills would have been missing for installed users; `files` is widened and `npm pack --dry-run` confirms all 12 files ship.

## Drive-by fixes

- **`plannerAgent` was never fully on the standard contract**: no `session`, and its drafting call ran bare inside the guard rather than in a thread. Both fixed.
- **Docs skill tool names embedded the absolute install path** (`es_agent_tools_and_skills_..._stdlib_docs_guide`), so they differed per machine and were truncated to 64 chars. They now carry stable names (`agency_guide`, `agency_diagnostics`, ...).

## Verification

- `make` and `make doc` green; `pnpm run lint:structure` clean.
- **8670 unit tests** pass (545 files).
- **76 agency execution tests** pass across 27 files, including 5 new files: `toolkits` (bundle contents, duplicate-name checks), `extraTools` (a tool passed in is actually callable, via a `toolCall` mock), `toolGaps` (one assertion per closed gap, plus no agent offering duplicate tool names), `data`, and `agentSkill` (the test that catches the packaging trap).
- Diff audited against `docs/dev/anti-patterns.md`.

## Known limitations

- **Skill content is one worked example.** The directories are otherwise READMEs. That is the intended follow-up, starting with per-connector skills for `dataAgent`.
- **Tool count grew**: `codingAgent` to ~45, `dataAgent` ~31. No evidence of a selection problem at this size, and `codingAgent` already ran at 38. If one appears, the remedy discussed is trimming the git defaults (17 of those tools are git), not splitting agents — a `gitAgent` that merely proxies git commands would add a round trip and lose the caller's intent.
- **Hosted `web_search` is requested unconditionally, and is not gated on the model.** An earlier version of this PR body claimed these agents "degrade to client-side `searchTools()`" — that was wrong, and there is no such fallback: `hostedTools` passes straight through `llmClient.ts` to smoltalk with nothing gating it. A real gate was built and then removed, because the model catalog keys hosted tools by provider API rather than by model, so it reported "unsupported" for every model and would have silently disabled web search everywhere. The capability is now requested from one place (`hostedSearchTools()` in `std::agents/lib/search`) with that reasoning recorded at the definition. Whether an unsupported `hostedTools` value hard-fails a call on a given provider is still unverified.
- The two pre-existing diagnostics in `lib/agents/review/agent.agency` and `lib/agents/policy/agent.agency` are untouched and identical on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

