### PR TITLE
Promote the oracle and the explorer into the standard library

### DIFF
--- a/packages/agency-lang/docs/site/.vitepress/config.mts
+++ b/packages/agency-lang/docs/site/.vitepress/config.mts
@@ -269,6 +269,8 @@ export default defineConfig({
                 { text: "agents/coding", link: "/stdlib/agents/coding" },
                 { text: "agents/data", link: "/stdlib/agents/data" },
                 { text: "agents/expert", link: "/stdlib/agents/expert" },
+                { text: "agents/explorer", link: "/stdlib/agents/explorer" },
+                { text: "agents/oracle", link: "/stdlib/agents/oracle" },
                 { text: "agents/planner", link: "/stdlib/agents/planner" },
                 { text: "agents/researcher", link: "/stdlib/agents/researcher" },
                 { text: "agents/review", link: "/stdlib/agents/review" },

--- a/packages/agency-lang/docs/site/stdlib/agents/explorer.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/explorer.md
@@ -1,0 +1,79 @@
+---
+name: "explorer"
+description: "A read-only surveyor: give it a broad question about a codebase or"
+---
+
+# explorer
+
+a body of docs and it reads widely, then synthesizes an organized answer.
+
+  Reach for it when the answer needs many files read and pulled together:
+  summarize these docs, tour this module, explain how this works across the
+  codebase. It reads and organizes; it never changes anything.
+
+  Broad and descriptive, where oracleAgent is sharp and narrow. Ask the
+  explorer to survey many things; ask the oracle to judge one.
+
+## Functions
+
+### buildTools
+
+```ts
+buildTools(): any[]
+```
+
+Return the explorer's tools. Read-only by design: it surveys and
+  describes, and a surveyor that can edit is no longer a surveyor.
+
+**Returns:** `any[]`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/explorer.agency#L107))
+
+### explorerAgent
+
+```ts
+explorerAgent(
+  question: string,
+  context: string = "",
+  maxCost: number = $20.00,
+  maxTime: number = 15m,
+  model: string = "",
+  provider: string = "",
+  session: string = "",
+  extraTools: any[] = [],
+): Result<string>
+```
+
+Survey a codebase or a body of documentation and return an organized
+  answer: a summary, a tour, or an explanation of how something works across
+  many files. Reads widely before synthesizing, and cites what it read. It
+  never changes anything.
+
+  Pass a self-contained question and say how much ground to cover: this agent
+  starts fresh and cannot see your conversation.
+
+  @param question - The question, and the scope you want covered
+  @param context - Extra material folded into the prompt, or ""
+  @param maxCost - Hard spend cap
+  @param maxTime - Hard wall-clock cap
+  @param model - Model override, or "" for the ambient model
+  @param provider - Provider for the model override
+  @param session - Session name to share a thread across calls, or "" for isolated
+  @param extraTools - Extra tools to offer the LLM, appended to the built-in set
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| question | `string` |  |
+| context | `string` | "" |
+| maxCost | `number` | $20.00 |
+| maxTime | `number` | 15m |
+| model | `string` | "" |
+| provider | `string` | "" |
+| session | `string` | "" |
+| extraTools | `any[]` | [] |
+
+**Returns:** `Result<string>`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/explorer.agency#L144))

--- a/packages/agency-lang/docs/site/stdlib/agents/lib/shared.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/lib/shared.md
@@ -40,6 +40,8 @@ llmOptions(
   provider: string,
   tools: any[] = [],
   hostedTools: string[] = [],
+  reasoningEffort: string = "",
+  thinking: boolean = false,
 ): any
 ```
 
@@ -52,6 +54,8 @@ Build an llm options object with an optional model override. Returns a
   @param provider - Provider for the model, or "" to auto-resolve
   @param tools - Tools to offer the LLM
   @param hostedTools - Provider-hosted tools to enable
+  @param reasoningEffort - "low", "medium", or "high", or "" to leave it to the model
+  @param thinking - Whether to ask the model to think before answering
 
 **Parameters:**
 
@@ -61,6 +65,8 @@ Build an llm options object with an optional model override. Returns a
 | provider | `string` |  |
 | tools | `any[]` | [] |
 | hostedTools | `string[]` | [] |
+| reasoningEffort | `string` | "" |
+| thinking | `boolean` | false |
 
 **Returns:** `any`
 

--- a/packages/agency-lang/docs/site/stdlib/agents/oracle.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/oracle.md
@@ -1,0 +1,81 @@
+---
+name: "oracle"
+description: "A read-only senior reviewer: give it a hard problem and it reads"
+---
+
+# oracle
+
+the code, thinks, and returns a direct verdict.
+
+  Reach for it before acting, when a second opinion is worth more than
+  another attempt: is this plan sound, does this already exist, why does this
+  bug persist, what is wrong with this design. It reads and reasons; it never
+  changes anything.
+
+  Sharp and narrow, where explorerAgent is broad and descriptive. Ask the
+  oracle to judge one thing; ask the explorer to survey many.
+
+## Functions
+
+### buildTools
+
+```ts
+buildTools(): any[]
+```
+
+Return the oracle's tools. Read-only by design: it inspects, consults, and
+  judges, and a reviewer that can edit is no longer a reviewer.
+
+**Returns:** `any[]`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/oracle.agency#L86))
+
+### oracleAgent
+
+```ts
+oracleAgent(
+  question: string,
+  context: string = "",
+  maxCost: number = $20.00,
+  maxTime: number = 15m,
+  model: string = "",
+  provider: string = "",
+  session: string = "",
+  extraTools: any[] = [],
+): Result<string>
+```
+
+Ask for a second opinion on a hard problem: whether a plan is sound,
+  whether the code already exists, why a bug persists, what is wrong with a
+  design. Reads the code and returns a written analysis ending in a concrete
+  recommendation. It never changes anything.
+
+  Pass a self-contained question: this agent starts fresh and cannot see your
+  conversation. Include the plan, the relevant file paths, and what you have
+  already tried.
+
+  @param question - The question, with all the context needed to answer it
+  @param context - Extra material folded into the prompt, or ""
+  @param maxCost - Hard spend cap
+  @param maxTime - Hard wall-clock cap
+  @param model - Model override, or "" for the ambient model
+  @param provider - Provider for the model override
+  @param session - Session name to share a thread across calls, or "" for isolated
+  @param extraTools - Extra tools to offer the LLM, appended to the built-in set
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| question | `string` |  |
+| context | `string` | "" |
+| maxCost | `number` | $20.00 |
+| maxTime | `number` | 15m |
+| model | `string` | "" |
+| provider | `string` | "" |
+| session | `string` | "" |
+| extraTools | `any[]` | [] |
+
+**Returns:** `Result<string>`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/oracle.agency#L124))

--- a/packages/agency-lang/lib/agents/agency-agent/subagents/explorer.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/subagents/explorer.agency
@@ -1,124 +1,18 @@
 /*
- * explorer subagent — a read-only breadth-first researcher.
+ * The explorer, as the agency agent's coordinator sees it.
  *
- * Called by other agents when the user asks a broad, synthesizing
- * question about the codebase or the bundled Agency docs:
- * "summarize the docs", "what are the main features of X", "how
- * does Y work across the codebase", "give me a tour of module Z".
+ * The agent itself lives in std::agents/explorer, so users get the same
+ * surveyor in their own agents. This wrapper supplies the two things that
+ * are the agency agent's business and not the stdlib's: the slow-model slot
+ * the user selected, and a shared session so repeated surveys in one run
+ * continue a conversation rather than starting cold.
  *
- * Explorer's job is COVERAGE, not critique. It reads widely, then
- * synthesizes. Oracle is sharp and narrow; explorer is thorough
- * and broad. Read-only — no write/edit/bash tools.
+ * The docstring below is what the coordinator reads when deciding whether to
+ * call this, so it is written for routing, not for the agent's own behavior.
  */
-import { ls, glob, grep } from "std::shell"
-import { docsSkill } from "std::skills"
-import { systemMessage } from "std::thread"
+import { explorerAgent as stdExplorerAgent } from "std::agents/explorer"
 
-import { withWebSearch } from "../lib/search.agency"
 import { getSlowModel, getSlowProvider } from "../shared.agency"
-
-// explorer gets a read-only view of the project via the raw read tools.
-// Relative paths resolve against the agent working directory (set by
-// `agent.agency` at startup), so no per-tool anchoring is needed.
-
-static const docSkill = docsSkill("guide")
-static const cliSkill = docsSkill("cli")
-static const diagnosticsSkill = docsSkill("diagnostics")
-static const stdlibSkill = docsSkill("stdlib")
-
-export static const explorerSysPrompt = """
-You are the **explorer** — a read-only researcher called by other
-agents when they need a broad, synthesizing answer about the
-codebase or the bundled Agency docs. Your job is **coverage and
-synthesis**, not action and not critique.
-
-You are different from the oracle. The oracle is sharp, narrow, and
-gives a verdict on a specific plan or bug. You are broad, patient,
-and produce structured overviews. Typical questions you answer:
-
-1. **Doc summarization** — "Summarize the Agency docs", "What are
-   the main features of the language?"
-2. **Codebase tours** — "Give me a tour of `lib/parsers/`",
-   "What modules make up the runtime?"
-3. **Cross-cutting how-it-works questions** — "How does the
-   typechecker interact with the preprocessor?", "Walk me through
-   the compilation pipeline."
-4. **Feature comparison** — "What's different about Agency vs
-   TypeScript?", "How does Agency handle X compared to Y?"
-
-## How to respond
-
-- **Cast a wide net first.** Before answering anything, `glob` /
-  `ls` the relevant directories and **list every file that could
-  be relevant**. For "summarize the docs", that means globbing the
-  whole `docs/` tree — not picking three files to start.
-- **Use the standard-library reference.** For any question about what
-  `std::` modules exist or what they do, call `stdlibSkill` — it lists
-  every module with a one-line summary, then lets you read any page.
-- **Read in parallel batches.** When you have many independent
-  files to read, emit the `read` calls in a single turn. The
-  runtime executes them concurrently when they arrive together;
-  if you read, wait, then read again, you've serialized work that
-  didn't need to be serial. The same goes for `grep` and `glob`.
-- **Do not summarize until you've read.** Premature summarization
-  is the #1 failure mode. If your plan is "read 12 files", read
-  all 12 before writing a single sentence of synthesis. The most
-  important files are often not the first ones you'd guess.
-- **Structure the synthesis by theme, not by file.** The caller
-  wants "here are the 5 key ideas in Agency", not "here's what
-  file 1 said, here's what file 2 said". Group related findings
-  together; identify cross-cutting patterns.
-- **Cite sources.** Every substantive claim should point to a
-  file path (and line number when useful) so the caller can
-  verify or follow up. Don't paraphrase without attribution.
-- **Lead with the answer.** Start with a one-paragraph TL;DR,
-  then the structured body. The caller may stop reading after
-  the first paragraph — make it carry weight.
-- **Be honest about gaps.** If you couldn't find information on
-  something the caller asked about, say so explicitly. Don't
-  paper over absence with plausible-sounding generalities.
-- **Use ASCII diagrams for structural answers.** Pipelines,
-  module graphs, data flow, layered architectures — draw them in
-  a fenced ```text block. A small diagram is often the single
-  most valuable thing in a "how does X work" answer, worth more
-  than several paragraphs of prose. Example:
-
-  ```text
-  parse → SymbolTable.build → preprocess → TypeScriptBuilder → printTs
-  ```
-
-  Keep diagrams small (fit on screen without scrolling) and skip
-  them when the answer is purely conceptual rather than structural.
-
-## What NOT to do
-
-- Don't write or modify any code. You have no write/edit/bash tools.
-- Don't critique or recommend changes — that's the oracle's job.
-  You describe what exists; you don't judge it.
-- Don't ask clarifying questions for broad asks. If the user
-  said "summarize the docs", interpret that generously — read
-  widely, organize the result, deliver. Ask only if the request
-  is genuinely under-specified.
-- Don't stop early because the answer "feels good enough" after
-  reading three files. Coverage is the point. If you set out to
-  read 12, read 12.
-- Don't pad the synthesis with restatements of the caller's
-  question or apologies for length. Get to the substance.
-"""
-
-export static const explorerTools: any[] = [
-  read.partial(useAgentCwd: true),
-  ls.partial(useAgentCwd: true),
-  glob.partial(useAgentCwd: true),
-  grep.partial(useAgentCwd: true),
-  docSkill,
-  cliSkill,
-  diagnosticsSkill,
-  stdlibSkill,
-]
-
-// only add system message the first time
-let first = true
 
 export def explorerAgent(userMsg: string): string {
   """
@@ -148,25 +42,14 @@ export def explorerAgent(userMsg: string): string {
   @param userMsg - the question, with the scope of coverage you
     want covered
   """
-  thread(label: "explorer", summarize: true, session: "explorer") {
-    if (first) {
-      systemMessage(explorerSysPrompt)
-      first = false
-    }
-    reply = llm(
-      userMsg,
-      withWebSearch(
-      {
-      tools: explorerTools,
-      model: getSlowModel(),
-      provider: getSlowProvider(),
-      reasoningEffort: "high",
-      thinking: {
-        enabled: true
-      }
-    },
-    ),
-    )
+  const result = stdExplorerAgent(
+    question: userMsg,
+    model: getSlowModel(),
+    provider: getSlowProvider(),
+    session: "explorer",
+  )
+  if (isFailure(result)) {
+    return "The explorer could not finish: ${result.error}"
   }
-  return reply
+  return result.value
 }

--- a/packages/agency-lang/lib/agents/agency-agent/subagents/oracle.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/subagents/oracle.agency
@@ -1,87 +1,18 @@
-import { typecheck } from "std::agency"
-import { ls, glob, grep } from "std::shell"
-import { docsSkill } from "std::skills"
-import { systemMessage } from "std::thread"
+/*
+ * The oracle, as the agency agent's coordinator sees it.
+ *
+ * The agent itself lives in std::agents/oracle, so users get the same
+ * reviewer in their own agents. This wrapper supplies the two things that
+ * are the agency agent's business and not the stdlib's: the slow-model slot
+ * the user selected, and a shared session so repeated consults in one run
+ * continue a conversation rather than starting cold.
+ *
+ * The docstring below is what the coordinator reads when deciding whether to
+ * call this, so it is written for routing, not for the agent's own behavior.
+ */
+import { oracleAgent as stdOracleAgent } from "std::agents/oracle"
 
-import { withWebSearch } from "../lib/search.agency"
 import { getSlowModel, getSlowProvider } from "../shared.agency"
-
-// Oracle gets a read-only view of the project via the raw read tools.
-// Relative paths resolve against the agent working directory (set by
-// `agent.agency` at startup), so no per-tool anchoring is needed.
-
-static const docSkill = docsSkill("guide")
-static const cliSkill = docsSkill("cli")
-static const diagnosticsSkill = docsSkill("diagnostics")
-
-export static const oracleSysPrompt = """
-You are the **oracle** — a senior reviewer called by other agents
-when they want a second opinion on a hard problem. You think
-carefully, you read the codebase, and you give a direct, honest
-analysis. You do not write or edit files. You do not run commands.
-Your job is to **think**, not to act.
-
-## What you're asked to do
-
-You are typically asked one of:
-
-1. **Plan review** — "Here's what I'm about to do. Is this a good
-   plan? Will it work? Is there a simpler way?"
-2. **Codebase reconnaissance** — "Is there existing code in this
-   repo that already solves X, before I write something new?"
-3. **Hard debugging** — "I've tried A, B, C and the bug persists.
-   What's actually going on?"
-4. **Design critique** — "Review this diff / function / module and
-   tell me what's wrong with it."
-
-## How to respond
-
-- **Read before you reason.** Use `grep`, `glob`, `ls`, `read` to
-  ground every claim in actual code. Run searches in parallel when
-  the lookups are independent. Never speculate about what a file
-  contains — read it.
-- **Look for existing solutions first.** When asked about a new
-  feature or helper, grep the codebase for prior art before
-  evaluating the proposed approach. If a helper, type, or pattern
-  already exists, say so and point to it (file path + line).
-- **Be specific.** Cite file paths and line numbers. Quote the
-  relevant lines. Vague advice is worse than no advice.
-- **Be direct.** If the plan is flawed, say it's flawed and explain
-  why in one or two sentences. Don't soften with "you might want
-  to consider" — say "this won't work because X". If the plan is
-  fine, say it's fine and stop. No flattery, no hedging.
-- **Surface what the caller missed.** The most valuable thing you
-  do is point out the constraint, edge case, or existing code that
-  the caller didn't know about. Volunteer this — don't wait to be
-  asked.
-- **End with a concrete recommendation.** Either "proceed with the
-  plan", "proceed but change X", or "don't proceed — do Y instead".
-  No "it depends" without specifying what it depends on.
-
-## What NOT to do
-
-- Don't write or modify any code. You have no write/edit/bash tools.
-- Don't echo back the caller's plan as if confirming receipt —
-  start with the analysis.
-- Don't pad with summaries of what you read. The caller wants your
-  conclusion and the evidence behind it, not a tour of the codebase.
-- Don't ask clarifying questions unless the request is genuinely
-  ambiguous — make a reasonable assumption, state it, and answer.
-"""
-
-export static const oracleTools: any[] = [
-  read.partial(useAgentCwd: true),
-  ls.partial(useAgentCwd: true),
-  glob.partial(useAgentCwd: true),
-  grep.partial(useAgentCwd: true),
-  typecheck,
-  docSkill,
-  cliSkill,
-  diagnosticsSkill,
-]
-
-// only add system message the first time
-let first = true
 
 export def oracleAgent(userMsg: string): string {
   """
@@ -106,25 +37,14 @@ export def oracleAgent(userMsg: string): string {
   @param userMsg - the question, with all the context the oracle
     needs to answer it
   """
-  thread(label: "oracle", summarize: true, session: "oracle") {
-    if (first) {
-      systemMessage(oracleSysPrompt)
-      first = false
-    }
-    reply = llm(
-      userMsg,
-      withWebSearch(
-      {
-      tools: oracleTools,
-      model: getSlowModel(),
-      provider: getSlowProvider(),
-      reasoningEffort: "high",
-      thinking: {
-        enabled: true
-      }
-    },
-    ),
-    )
+  const result = stdOracleAgent(
+    question: userMsg,
+    model: getSlowModel(),
+    provider: getSlowProvider(),
+    session: "oracle",
+  )
+  if (isFailure(result)) {
+    return "The oracle could not finish: ${result.error}"
   }
-  return reply
+  return result.value
 }

--- a/packages/agency-lang/lib/agents/agency-agent/tests/toolWiring.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/toolWiring.agency
@@ -15,8 +15,11 @@
  */
 import { codeTools } from "../subagents/code.agency"
 import { researchTools } from "../subagents/research.agency"
-import { oracleTools } from "../subagents/oracle.agency"
-import { explorerTools } from "../subagents/explorer.agency"
+// The oracle and the explorer live in the stdlib now, so their tool lists
+// come from there. The check is the same: the agency agent still offers them,
+// so a duplicate name in either list still breaks this agent.
+import { buildTools as oracleTools } from "std::agents/oracle"
+import { buildTools as explorerTools } from "std::agents/explorer"
 
 def pingWith(tools: any[]): string {
   // Reject any interrupt a tool might raise. Under the deterministic
@@ -52,9 +55,9 @@ node researchToolsHaveUniqueNames() {
 }
 
 node oracleToolsHaveUniqueNames() {
-  return pingWith(oracleTools)
+  return pingWith(oracleTools())
 }
 
 node explorerToolsHaveUniqueNames() {
-  return pingWith(explorerTools)
+  return pingWith(explorerTools())
 }

--- a/packages/agency-lang/stdlib/agents/explorer.agency
+++ b/packages/agency-lang/stdlib/agents/explorer.agency
@@ -1,0 +1,187 @@
+/** @module
+  @summary A read-only surveyor: give it a broad question about a codebase or
+  a body of docs and it reads widely, then synthesizes an organized answer.
+
+  Reach for it when the answer needs many files read and pulled together:
+  summarize these docs, tour this module, explain how this works across the
+  codebase. It reads and organizes; it never changes anything.
+
+  Broad and descriptive, where oracleAgent is sharp and narrow. Ask the
+  explorer to survey many things; ask the oracle to judge one.
+*/
+import { hostedSearchTools, searchTools } from "std::agents/lib/search"
+import { llmOptions, withContext } from "std::agents/lib/shared"
+import {
+  readOnlyFileTools,
+  agencyDocTools,
+  webTools,
+ } from "std::agents/lib/toolkits"
+import { agentSkill } from "std::skills"
+import { systemMessage, threadIsNew } from "std::thread"
+
+// Skills we ship for this agent: markdown the model reads on demand, so
+// teaching it something new costs a file rather than prompt length.
+static const skills = agentSkill("explorer")
+
+static const systemPrompt = """
+You are the **explorer** — a read-only researcher called when someone
+needs a broad, synthesizing answer about a codebase or a body of
+documentation. Your job is **coverage and synthesis**, not action and
+not critique.
+
+You are different from the oracle. The oracle is sharp, narrow, and
+gives a verdict on a specific plan or bug. You are broad, patient,
+and produce structured overviews. Typical questions you answer:
+
+1. **Doc summarization** — "Summarize these docs", "What are the
+   main features of this library?"
+2. **Codebase tours** — "Give me a tour of `lib/parsers/`",
+   "What modules make up the runtime?"
+3. **Cross-cutting how-it-works questions** — "How does the
+   typechecker interact with the preprocessor?", "Walk me through
+   the compilation pipeline."
+4. **Feature comparison** — "What's different about X vs Y?"
+
+## How to respond
+
+- **Cast a wide net first.** Before answering anything, `glob` /
+  `ls` the relevant directories and **list every file that could
+  be relevant**. For "summarize the docs", that means globbing the
+  whole `docs/` tree — not picking three files to start.
+- **Read in parallel batches.** When you have many independent
+  files to read, emit the `read` calls in a single turn. The
+  runtime executes them concurrently when they arrive together;
+  if you read, wait, then read again, you've serialized work that
+  didn't need to be serial. The same goes for `grep` and `glob`.
+- **Do not summarize until you've read.** Premature summarization
+  is the #1 failure mode. If your plan is "read 12 files", read
+  all 12 before writing a single sentence of synthesis. The most
+  important files are often not the first ones you'd guess.
+- **Structure the synthesis by theme, not by file.** The caller
+  wants "here are the 5 key ideas", not "here's what file 1 said,
+  here's what file 2 said". Group related findings together;
+  identify cross-cutting patterns.
+- **Cite sources.** Every substantive claim should point to a
+  file path (and line number when useful) so the caller can
+  verify or follow up. Don't paraphrase without attribution.
+- **Lead with the answer.** Start with a one-paragraph TL;DR,
+  then the structured body. The caller may stop reading after
+  the first paragraph — make it carry weight.
+- **Be honest about gaps.** If you couldn't find information on
+  something the caller asked about, say so explicitly. Don't
+  paper over absence with plausible-sounding generalities.
+- **Use ASCII diagrams for structural answers.** Pipelines,
+  module graphs, data flow, layered architectures — draw them in
+  a fenced ```text block. A small diagram is often the single
+  most valuable thing in a "how does X work" answer, worth more
+  than several paragraphs of prose. Example:
+
+  ```text
+  parse → SymbolTable.build → preprocess → TypeScriptBuilder → printTs
+  ```
+
+  Keep diagrams small (fit on screen without scrolling) and skip
+  them when the answer is purely conceptual rather than structural.
+
+For questions about the Agency language itself, the bundled docs tools
+(`agency_guide`, `agency_cli`, `agency_diagnostics`, `agency_stdlib`) are
+authoritative. `agency_stdlib` lists every std:: module with a one-line
+summary, which is the fastest way to answer "what exists".
+
+## What NOT to do
+
+- Don't write or modify any code. You have no write, edit, or shell tools.
+- Don't critique or recommend changes — that's the oracle's job.
+  You describe what exists; you don't judge it.
+- Don't ask clarifying questions for broad asks. If the caller
+  said "summarize the docs", interpret that generously — read
+  widely, organize the result, deliver. Ask only if the request
+  is genuinely under-specified.
+- Don't stop early because the answer "feels good enough" after
+  reading three files. Coverage is the point. If you set out to
+  read 12, read 12.
+- Don't pad the synthesis with restatements of the caller's
+  question or apologies for length. Get to the substance.
+"""
+
+export def buildTools(): any[] {
+  """
+  Return the explorer's tools. Read-only by design: it surveys and
+  describes, and a surveyor that can edit is no longer a surveyor.
+  """
+  return [
+    ...readOnlyFileTools(),
+    ...agencyDocTools(),
+    ...webTools(),
+    ...searchTools(),
+    skills,
+  ]
+}
+
+def survey(
+  question: string,
+  context: string,
+  model: string,
+  provider: string,
+  extraTools: any[],
+): string {
+  if (threadIsNew()) {
+    systemMessage(systemPrompt)
+  }
+  return llm(
+    withContext(task: question, context: context),
+    llmOptions(
+      model: model,
+      provider: provider,
+      tools: buildTools().concat(extraTools),
+      hostedTools: hostedSearchTools(model),
+      reasoningEffort: "high",
+      thinking: true,
+    ),
+  )
+}
+
+export def explorerAgent(
+  question: string,
+  context: string = "",
+  maxCost: number = $20.00,
+  maxTime: number = 15m,
+  model: string = "",
+  provider: string = "",
+  session: string = "",
+  extraTools: any[] = [],
+): Result<string> {
+  """
+  Survey a codebase or a body of documentation and return an organized
+  answer: a summary, a tour, or an explanation of how something works across
+  many files. Reads widely before synthesizing, and cites what it read. It
+  never changes anything.
+
+  Pass a self-contained question and say how much ground to cover: this agent
+  starts fresh and cannot see your conversation.
+
+  @param question - The question, and the scope you want covered
+  @param context - Extra material folded into the prompt, or ""
+  @param maxCost - Hard spend cap
+  @param maxTime - Hard wall-clock cap
+  @param model - Model override, or "" for the ambient model
+  @param provider - Provider for the model override
+  @param session - Session name to share a thread across calls, or "" for isolated
+  @param extraTools - Extra tools to offer the LLM, appended to the built-in set
+  """
+  // The guard Result is the return value: a success carries the survey, a
+  // failure carries whatever actually went wrong.
+  return guard(cost: maxCost, time: maxTime) {
+    let reply = ""
+    thread(label: "explorerAgent", session: session, summarize: true) {
+      reply = survey(
+        question: question,
+        context: context,
+        model: model,
+        provider: provider,
+        extraTools: extraTools,
+      )
+    }
+    return reply
+  }
+}

--- a/packages/agency-lang/stdlib/agents/lib/shared.agency
+++ b/packages/agency-lang/stdlib/agents/lib/shared.agency
@@ -19,6 +19,8 @@ export def llmOptions(
   provider: string,
   tools: any[] = [],
   hostedTools: string[] = [],
+  reasoningEffort: string = "",
+  thinking: boolean = false,
 ): any {
   """
   Build an llm options object with an optional model override. Returns a
@@ -30,6 +32,8 @@ export def llmOptions(
   @param provider - Provider for the model, or "" to auto-resolve
   @param tools - Tools to offer the LLM
   @param hostedTools - Provider-hosted tools to enable
+  @param reasoningEffort - "low", "medium", or "high", or "" to leave it to the model
+  @param thinking - Whether to ask the model to think before answering
   """
   const options: any = { tools: tools }
   if (hostedTools.length > 0) {
@@ -38,6 +42,12 @@ export def llmOptions(
   if (model != "") {
     options.model = model
     options.provider = provider
+  }
+  if (reasoningEffort != "") {
+    options.reasoningEffort = reasoningEffort
+  }
+  if (thinking) {
+    options.thinking = { enabled: true }
   }
   return options
 }

--- a/packages/agency-lang/stdlib/agents/oracle.agency
+++ b/packages/agency-lang/stdlib/agents/oracle.agency
@@ -1,0 +1,168 @@
+/** @module
+  @summary A read-only senior reviewer: give it a hard problem and it reads
+  the code, thinks, and returns a direct verdict.
+
+  Reach for it before acting, when a second opinion is worth more than
+  another attempt: is this plan sound, does this already exist, why does this
+  bug persist, what is wrong with this design. It reads and reasons; it never
+  changes anything.
+
+  Sharp and narrow, where explorerAgent is broad and descriptive. Ask the
+  oracle to judge one thing; ask the explorer to survey many.
+*/
+import { hostedSearchTools, searchTools } from "std::agents/lib/search"
+import { llmOptions, withContext } from "std::agents/lib/shared"
+import {
+  readOnlyFileTools,
+  agencyCodeTools,
+  agencyDocTools,
+  webTools,
+ } from "std::agents/lib/toolkits"
+import { agentSkill } from "std::skills"
+import { systemMessage, threadIsNew } from "std::thread"
+
+// Skills we ship for this agent: markdown the model reads on demand, so
+// teaching it something new costs a file rather than prompt length.
+static const skills = agentSkill("oracle")
+
+static const systemPrompt = """
+You are the **oracle** — a senior reviewer called when someone wants a
+second opinion on a hard problem. You think carefully, you read the
+code, and you give a direct, honest analysis. You do not write or edit
+files. You do not run commands. Your job is to **think**, not to act.
+
+## What you're asked to do
+
+You are typically asked one of:
+
+1. **Plan review** — "Here's what I'm about to do. Is this a good
+   plan? Will it work? Is there a simpler way?"
+2. **Codebase reconnaissance** — "Is there existing code in this
+   repo that already solves X, before I write something new?"
+3. **Hard debugging** — "I've tried A, B, C and the bug persists.
+   What's actually going on?"
+4. **Design critique** — "Review this diff / function / module and
+   tell me what's wrong with it."
+
+## How to respond
+
+- **Read before you reason.** Use `grep`, `glob`, `ls`, `read` to
+  ground every claim in actual code. Run searches in parallel when
+  the lookups are independent. Never speculate about what a file
+  contains — read it.
+- **Look for existing solutions first.** When asked about a new
+  feature or helper, grep the codebase for prior art before
+  evaluating the proposed approach. If a helper, type, or pattern
+  already exists, say so and point to it (file path + line).
+- **Be specific.** Cite file paths and line numbers. Quote the
+  relevant lines. Vague advice is worse than no advice.
+- **Be direct.** If the plan is flawed, say it's flawed and explain
+  why in one or two sentences. Don't soften with "you might want
+  to consider" — say "this won't work because X". If the plan is
+  fine, say it's fine and stop. No flattery, no hedging.
+- **Surface what the caller missed.** The most valuable thing you
+  do is point out the constraint, edge case, or existing code that
+  the caller didn't know about. Volunteer this — don't wait to be
+  asked.
+- **End with a concrete recommendation.** Either "proceed with the
+  plan", "proceed but change X", or "don't proceed — do Y instead".
+  No "it depends" without specifying what it depends on.
+
+For questions about the Agency language itself, the bundled docs tools
+(`agency_guide`, `agency_cli`, `agency_diagnostics`, `agency_stdlib`) are
+authoritative — consult them rather than recalling.
+
+## What NOT to do
+
+- Don't write or modify any code. You have no write, edit, or shell tools.
+- Don't echo back the caller's plan as if confirming receipt —
+  start with the analysis.
+- Don't pad with summaries of what you read. The caller wants your
+  conclusion and the evidence behind it, not a tour of the codebase.
+- Don't ask clarifying questions unless the request is genuinely
+  ambiguous — make a reasonable assumption, state it, and answer.
+"""
+
+export def buildTools(): any[] {
+  """
+  Return the oracle's tools. Read-only by design: it inspects, consults, and
+  judges, and a reviewer that can edit is no longer a reviewer.
+  """
+  return [
+    ...readOnlyFileTools(),
+    ...agencyCodeTools(),
+    ...agencyDocTools(),
+    ...webTools(),
+    ...searchTools(),
+    skills,
+  ]
+}
+
+def consider(
+  question: string,
+  context: string,
+  model: string,
+  provider: string,
+  extraTools: any[],
+): string {
+  if (threadIsNew()) {
+    systemMessage(systemPrompt)
+  }
+  return llm(
+    withContext(task: question, context: context),
+    llmOptions(
+      model: model,
+      provider: provider,
+      tools: buildTools().concat(extraTools),
+      hostedTools: hostedSearchTools(model),
+      reasoningEffort: "high",
+      thinking: true,
+    ),
+  )
+}
+
+export def oracleAgent(
+  question: string,
+  context: string = "",
+  maxCost: number = $20.00,
+  maxTime: number = 15m,
+  model: string = "",
+  provider: string = "",
+  session: string = "",
+  extraTools: any[] = [],
+): Result<string> {
+  """
+  Ask for a second opinion on a hard problem: whether a plan is sound,
+  whether the code already exists, why a bug persists, what is wrong with a
+  design. Reads the code and returns a written analysis ending in a concrete
+  recommendation. It never changes anything.
+
+  Pass a self-contained question: this agent starts fresh and cannot see your
+  conversation. Include the plan, the relevant file paths, and what you have
+  already tried.
+
+  @param question - The question, with all the context needed to answer it
+  @param context - Extra material folded into the prompt, or ""
+  @param maxCost - Hard spend cap
+  @param maxTime - Hard wall-clock cap
+  @param model - Model override, or "" for the ambient model
+  @param provider - Provider for the model override
+  @param session - Session name to share a thread across calls, or "" for isolated
+  @param extraTools - Extra tools to offer the LLM, appended to the built-in set
+  """
+  // The guard Result is the return value: a success carries the analysis, a
+  // failure carries whatever actually went wrong.
+  return guard(cost: maxCost, time: maxTime) {
+    let reply = ""
+    thread(label: "oracleAgent", session: session, summarize: true) {
+      reply = consider(
+        question: question,
+        context: context,
+        model: model,
+        provider: provider,
+        extraTools: extraTools,
+      )
+    }
+    return reply
+  }
+}

--- a/packages/agency-lang/stdlib/agents/skills/explorer/README.md
+++ b/packages/agency-lang/stdlib/agents/skills/explorer/README.md
@@ -1,0 +1,16 @@
+# Skills for the explorer
+
+Each file in this directory is one skill: a short markdown document the explorer
+reads on demand, when the task in front of it calls for that knowledge.
+
+Skills exist so we can teach an agent something without making its system
+prompt longer. A prompt is paid for on every call; a skill is read only when
+the agent decides it is relevant.
+
+Add a skill here when the agent repeatedly gets something wrong that a page
+of instruction would fix, and the knowledge is too specific to justify space
+in every prompt. Name the situation it applies to in the first line, so the
+agent can tell from the listing whether to open it.
+
+Do not add a skill for something a capable model already knows. A skill that
+restates general good practice costs context and teaches nothing.

--- a/packages/agency-lang/stdlib/agents/skills/oracle/README.md
+++ b/packages/agency-lang/stdlib/agents/skills/oracle/README.md
@@ -1,0 +1,16 @@
+# Skills for the oracle
+
+Each file in this directory is one skill: a short markdown document the oracle
+reads on demand, when the task in front of it calls for that knowledge.
+
+Skills exist so we can teach an agent something without making its system
+prompt longer. A prompt is paid for on every call; a skill is read only when
+the agent decides it is relevant.
+
+Add a skill here when the agent repeatedly gets something wrong that a page
+of instruction would fix, and the knowledge is too specific to justify space
+in every prompt. Name the situation it applies to in the first line, so the
+agent can tell from the listing whether to open it.
+
+Do not add a skill for something a capable model already knows. A skill that
+restates general good practice costs context and teaches nothing.

--- a/packages/agency-lang/tests/agency/agents/oracleExplorer.agency
+++ b/packages/agency-lang/tests/agency/agents/oracleExplorer.agency
@@ -1,0 +1,46 @@
+import { oracleAgent, buildTools as oracleTools } from "std::agents/oracle"
+import { explorerAgent, buildTools as explorerTools } from "std::agents/explorer"
+
+def hasTool(tools: any[], name: string): boolean {
+  return some(tools, \tool -> tool.name == name)
+}
+
+node oracleAnswers(): string {
+  const result = oracleAgent(question: "is this plan sound")
+  if (isFailure(result)) { return "failed" }
+  return result.value
+}
+
+node explorerAnswers(): string {
+  const result = explorerAgent(question: "summarize the parsers")
+  if (isFailure(result)) { return "failed" }
+  return result.value
+}
+
+// Both are read-only, which is the property that distinguishes them from
+// the coding agent. A reviewer or surveyor that can edit is neither.
+node bothAreReadOnly(): boolean {
+  const forbidden = ["write", "edit", "bash", "exec"]
+  const oracleClean = every(forbidden, \name -> !hasTool(oracleTools(), name))
+  const explorerClean = every(forbidden, \name -> !hasTool(explorerTools(), name))
+  return oracleClean && explorerClean
+}
+
+// Both read files and consult the bundled docs; the oracle additionally
+// inspects Agency source, which the explorer has no need of.
+node toolsMatchTheirJobs(): boolean {
+  const oracleReads = hasTool(oracleTools(), "read") && hasTool(oracleTools(), "agency_guide")
+  const oracleChecks = hasTool(oracleTools(), "typecheck")
+  const explorerReads = hasTool(explorerTools(), "glob") && hasTool(explorerTools(), "agency_stdlib")
+  return oracleReads && oracleChecks && explorerReads
+}
+
+node neitherHasDuplicateToolNames(): boolean {
+  for (list in [oracleTools(), explorerTools()]) {
+    const names = map(list, \tool -> tool.name)
+    if (unique(names, \name -> name).length != names.length) {
+      return false
+    }
+  }
+  return true
+}

--- a/packages/agency-lang/tests/agency/agents/oracleExplorer.test.json
+++ b/packages/agency-lang/tests/agency/agents/oracleExplorer.test.json
@@ -1,0 +1,9 @@
+{
+  "tests": [
+    { "nodeName": "oracleAnswers", "description": "the oracle returns its analysis as a success Result", "input": "", "expectedOutput": "\"the plan is sound, proceed\"", "evaluationCriteria": [{ "type": "exact" }], "useTestLLMProvider": true, "llmMocks": [{ "return": "the plan is sound, proceed" }] },
+    { "nodeName": "explorerAnswers", "description": "the explorer returns its survey as a success Result", "input": "", "expectedOutput": "\"the parsers are combinator-based\"", "evaluationCriteria": [{ "type": "exact" }], "useTestLLMProvider": true, "llmMocks": [{ "return": "the parsers are combinator-based" }] },
+    { "nodeName": "bothAreReadOnly", "description": "neither agent carries a tool that changes anything", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "toolsMatchTheirJobs", "description": "each carries the tools its job needs", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "neitherHasDuplicateToolNames", "description": "no duplicate tool names in either agent", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] }
+  ]
+}


### PR DESCRIPTION
Piece **B** of the agency-agent decomposition: move the two subagents that are useful to everyone into the standard library.

## Why these two

The oracle and the explorer were agency-agent subagents, but neither is specific to that agent. "Read the code and tell me whether this plan holds up" and "read this whole corpus and organize what's in it" are things any user's agent wants. Meanwhile `verify` and `review` are already thin wrappers over stdlib agents, and `research` largely duplicates `researcherAgent` — those are a separate cleanup. These two were the ones where capability actually moves *out* to users rather than just getting rewired.

## What they are

| Agent | Job |
|---|---|
| `oracleAgent` (`std::agents/oracle`) | Sharp and narrow. Judge one thing: is this plan sound, does this already exist, why does this bug persist, what is wrong with this design. Returns an analysis ending in a concrete recommendation. |
| `explorerAgent` (`std::agents/explorer`) | Broad and descriptive. Survey many things: summarize these docs, tour this module, explain how this works across the codebase. Reads widely before synthesizing, and cites what it read. |

Both take the standard contract (`question, context, maxCost, maxTime, model, provider, session, extraTools`), return `Result<string>`, compose their tools from the shared bundles, and ship a skills directory.

**Both are read-only by construction** — no write, edit, or shell tools. That is the property separating them from the coding agent, and a test pins it rather than trusting the tool list to stay right.

## What stayed in the agency agent

The subagent files remain, as thin wrappers, because two things there are the agent's business and not the stdlib's:

- the **slow-model slot** the user selected through `/model`, passed as `model:` / `provider:`
- a **shared session**, so repeated consults within one run continue a conversation instead of starting cold

Their docstrings also stay, because those are what the coordinator reads when deciding where to route a turn — they are written for routing, not for describing the agents' own behavior, and the stdlib versions have their own.

That is the shape I would expect for most of this migration: the capability lives in the stdlib, and the agent supplies its own configuration and routing language.

## Incidental change

`llmOptions` gains `reasoningEffort` and `thinking`. Both agents ran with `reasoningEffort: "high"` and thinking enabled, which is much of what makes them worth calling, and the shared options builder had no way to express it. No existing caller passes either, so the defaults leave every other agent unchanged.

## One thing worth a look in review

The prompts moved almost verbatim, with one class of edit: they referred to the docs tools as `docSkill`, `cliSkill`, `stdlibSkill`. Those tools are named `agency_guide`, `agency_cli`, `agency_stdlib`, `agency_diagnostics` since the last PR gave them stable names. The prompts now use the real names, since telling a model to call a tool that does not exist under that name is worse than not mentioning it.

## Verification

- `make`, `make doc`, `pnpm run lint:structure` all green.
- **8676 unit tests** pass.
- **All agency execution test files** pass, including a new `oracleExplorer` file covering both agents answering, the read-only property, the tools matching their jobs, and no duplicate tool names.
- The agency agent's own suites pass unchanged: `toolWiring` (4), `agentTurn` (29), `oneShotRounds` (4). `toolWiring` now pulls the tool lists from the stdlib, so it still catches a duplicate name in either agent.
- `npm pack --dry-run` confirms both new skills directories ship.

## Not in this PR

The rest of the decomposition: collapsing `verify` / `review` / `research` onto their stdlib equivalents (A), splitting `codeAgent` interactive from autonomous (C), separating CLI from UX from agent logic in `agent.agency` (D), and deciding what happens to the model-selection stack (E).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
