### PR TITLE
Fix phantom LSP errors by giving the prelude one definition

### DIFF
--- a/packages/agency-lang/lib/lsp/diagnostics.test.ts
+++ b/packages/agency-lang/lib/lsp/diagnostics.test.ts
@@ -83,6 +83,46 @@ describe("runDiagnostics — stdlib auto-import parity with CLI", () => {
   });
 });
 
+describe("runDiagnostics — every prelude name resolves", () => {
+  // Regression: the LSP used to keep its own hand-copied list of the names
+  // the CLI parser template auto-imports. The copy drifted — `_guard`,
+  // `saveDraft`, and `flatten` were added to the template but never to the
+  // LSP's list — so a file using the `guard` construct lit up with a phantom
+  // "Function '_guard' is not defined" in the editor while
+  // `agency typecheck` on the same file reported nothing. Both paths now
+  // render the same PRELUDE_NAMES, so this asserts the drifted names in
+  // particular resolve through the LSP.
+  it("reports no undefined-name errors for guard, saveDraft, or flatten", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-lsp-prelude-"));
+    try {
+      const mainFile = path.join(tmpDir, "main.agency");
+      const source = [
+        "node main() {",
+        "  const captured = guard(cost: 1.0) {",
+        "    saveDraft([1, 2])",
+        "    return [1, 2]",
+        "  }",
+        "  const flat = flatten([[1], [2]])",
+        "  return flat",
+        "}",
+        "",
+      ].join("\n");
+      fs.writeFileSync(mainFile, source);
+
+      const doc = makeDoc(source, `file://${mainFile}`);
+      const symbolTable = SymbolTable.build(mainFile, {});
+      const { diagnostics } = runDiagnostics(doc, mainFile, {}, symbolTable);
+
+      const undefinedNames = diagnostics.filter((d) =>
+        /is not defined/.test(d.message),
+      );
+      expect(undefinedNames.map((d) => d.message)).toEqual([]);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("runDiagnostics — test-only imports", () => {
   // The LSP is an analysis-only path: it must honor `import test` so
   // migrated test files keep full editor support instead of dying on a

--- a/packages/agency-lang/lib/lsp/diagnostics.test.ts
+++ b/packages/agency-lang/lib/lsp/diagnostics.test.ts
@@ -111,12 +111,85 @@ describe("runDiagnostics — every prelude name resolves", () => {
 
       const doc = makeDoc(source, `file://${mainFile}`);
       const symbolTable = SymbolTable.build(mainFile, {});
-      const { diagnostics } = runDiagnostics(doc, mainFile, {}, symbolTable);
+      const { diagnostics, program } = runDiagnostics(doc, mainFile, {}, symbolTable);
 
+      // Without this, a grammar change that stopped the snippet parsing
+      // would leave zero name-resolution diagnostics and the assertion
+      // below would pass while checking nothing.
+      expect(program).not.toBeNull();
       const undefinedNames = diagnostics.filter((d) =>
         /is not defined/.test(d.message),
       );
       expect(undefinedNames.map((d) => d.message)).toEqual([]);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("runDiagnostics — shadowing a prelude name", () => {
+  // Agency treats the prelude as overridable: a user's own `def map` wins,
+  // and the compile path realizes that by dropping `map` from the injected
+  // import (prunePreludeShadows). The LSP has to run the same pass or it
+  // still sees the import and warns about a shadow the compiler resolved.
+  it("does not warn when a user def shadows a prelude name", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-lsp-shadow-"));
+    try {
+      const mainFile = path.join(tmpDir, "main.agency");
+      const source = [
+        "def map(xs: number[]): number[] {",
+        "  return xs",
+        "}",
+        "node main() {",
+        "  return map([1])",
+        "}",
+        "",
+      ].join("\n");
+      fs.writeFileSync(mainFile, source);
+
+      const doc = makeDoc(source, `file://${mainFile}`);
+      const symbolTable = SymbolTable.build(mainFile, {});
+      const { diagnostics, program } = runDiagnostics(doc, mainFile, {}, symbolTable);
+
+      expect(program).not.toBeNull();
+      const shadowWarnings = diagnostics.filter((d) => /shadows an imported/.test(d.message));
+      expect(shadowWarnings.map((d) => d.message)).toEqual([]);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  // `_guard` is exempt from pruning (UNPRUNABLE_PRELUDE_NAMES): letting a
+  // user `_guard` displace the real one would silently rebind every
+  // `guard(...) { }` in the file and bypass budget metering. The editor
+  // must keep reporting that, not go quiet along with the shadow warnings.
+  it("still reports a user def named _guard", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-lsp-guardshadow-"));
+    try {
+      const mainFile = path.join(tmpDir, "main.agency");
+      const source = [
+        "def _guard(x: number): number {",
+        "  return x",
+        "}",
+        "node main() {",
+        "  return _guard(1)",
+        "}",
+        "",
+      ].join("\n");
+      fs.writeFileSync(mainFile, source);
+
+      const doc = makeDoc(source, `file://${mainFile}`);
+      const symbolTable = SymbolTable.build(mainFile, {});
+      const { diagnostics, program } = runDiagnostics(doc, mainFile, {}, symbolTable);
+
+      expect(program).not.toBeNull();
+      const messages = diagnostics.map((d) => d.message);
+      // The shadow warning must survive the pruning pass for this name
+      // specifically, and the reserved-name error rides alongside it.
+      expect(messages).toContain("'_guard' shadows an imported function.");
+      expect(messages).toContain(
+        "'_guard' is a reserved built-in; cannot be redefined.",
+      );
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }

--- a/packages/agency-lang/lib/lsp/diagnostics.ts
+++ b/packages/agency-lang/lib/lsp/diagnostics.ts
@@ -17,6 +17,7 @@ import type { ScopeInfo } from "../typeChecker/types.js";
 import { ImportStatement } from "../types/importStatement.js";
 import { resolveAgencyImportPath } from "../importPaths.js";
 import { PRELUDE_NAMES } from "../prelude.js";
+import { prunePreludeShadows } from "../preprocessors/prunePreludeShadows.js";
 
 /**
  * Inject a synthetic `import { ... } from "std::index"` so the LSP sees the
@@ -49,7 +50,7 @@ function ensureStdlibImport(
     importedNames: [
       {
         type: "namedImport",
-        importedNames: PRELUDE_NAMES,
+        importedNames: [...PRELUDE_NAMES],
         aliases: {},
       },
     ],
@@ -109,6 +110,12 @@ export function runDiagnostics(
   // undefined here. Synthesize the same import so they resolve through
   // `importedFunctions` like in the CLI flow.
   program = ensureStdlibImport(program, symbolTable, fsPath);
+  // Agency treats the prelude as overridable, and the compile path realizes
+  // that by dropping a shadowed name from the injected import
+  // (typescriptPreprocessor.ts). The LSP has to run the same pass or it
+  // warns about shadows the compiler already resolved. Pure AST mutation,
+  // no codegen dependency, so it is safe on this analysis-only path.
+  prunePreludeShadows(program);
 
   try {
     program = resolveReExports(program, symbolTable, fsPath);

--- a/packages/agency-lang/lib/lsp/diagnostics.ts
+++ b/packages/agency-lang/lib/lsp/diagnostics.ts
@@ -16,21 +16,13 @@ import { buildSemanticIndex, type SemanticIndex } from "./semantics.js";
 import type { ScopeInfo } from "../typeChecker/types.js";
 import { ImportStatement } from "../types/importStatement.js";
 import { resolveAgencyImportPath } from "../importPaths.js";
-
-// Names auto-imported from std::index by the parser template. Kept in sync
-// with lib/templates/backends/agency/template.mustache.
-const STDLIB_AUTO_IMPORTS: string[] = [
-  "print", "printJSON", "input", "sleep", "read", "write",
-  "writeBinary", "readBinary", "range", "callback",
-  // Array helpers (moved from std::array into std::index).
-  "map", "filter", "exclude", "find", "findIndex", "reduce", "flatMap",
-  "every", "some", "count", "sortBy", "unique", "groupBy",
-];
+import { PRELUDE_NAMES } from "../prelude.js";
 
 /**
  * Inject a synthetic `import { ... } from "std::index"` so the LSP sees the
- * same auto-imports the CLI parser template prepends — see
- * lib/templates/backends/agency/template.mustache. The synthetic is added
+ * same auto-imports the CLI parser template prepends. Both render the same
+ * PRELUDE_NAMES (lib/prelude.ts) so the editor and the compiler cannot
+ * disagree about what is in scope. The synthetic is added
  * unconditionally (alongside any user `import … from "std::index"`) so a
  * user who imports a *subset* like `import { range } from "std::index"`
  * still gets `print`, `read`, etc. from the auto-imports — matching CLI
@@ -57,7 +49,7 @@ function ensureStdlibImport(
     importedNames: [
       {
         type: "namedImport",
-        importedNames: STDLIB_AUTO_IMPORTS,
+        importedNames: PRELUDE_NAMES,
         aliases: {},
       },
     ],

--- a/packages/agency-lang/lib/parser.ts
+++ b/packages/agency-lang/lib/parser.ts
@@ -23,6 +23,7 @@ import { AgencyConfig } from "./config.js";
 import { lowerPatterns, PatternLoweringError } from "./lowering/patternLowering.js";
 import { LoweringError } from "./lowering/loweringError.js";
 import render from "./templates/backends/agency/template.js";
+import { preludeImportLine } from "./prelude.js";
 import {
   assignmentParser,
   binOpParser,
@@ -260,7 +261,7 @@ export function parseAgency(
   lower: boolean = true,
 ): ParseAgencyResult {
   if (applyTemplate) {
-    input = render({ body: input });
+    input = render({ preludeImport: preludeImportLine(), body: input });
   }
   // The parser adds locs by subtracting `currentTemplateOffset` from
   // tarsec spans. When the template was applied, spans are shifted by

--- a/packages/agency-lang/lib/prelude.test.ts
+++ b/packages/agency-lang/lib/prelude.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { PRELUDE_NAMES, preludeImportLine } from "./prelude.js";
+import { SymbolTable } from "./symbolTable.js";
+import { resolveAgencyImportPath } from "./importPaths.js";
+
+describe("the prelude", () => {
+  // Collapsing the parser template and the LSP onto one list stops those two
+  // from disagreeing, but it can't stop the list from disagreeing with the
+  // stdlib. Rename an export in stdlib/index.agency and the prelude would
+  // still ask for the old name — breaking every Agency file at once. This
+  // catches that at unit-test speed.
+  it("only names things std::index actually exports", () => {
+    const stdlibPath = resolveAgencyImportPath("std::index", process.cwd());
+    const symbolTable = SymbolTable.build(stdlibPath, {});
+    const symbols = symbolTable.getFile(stdlibPath);
+    expect(symbols).toBeDefined();
+
+    const exportedNames = Object.keys(symbols!).filter(
+      (name) => symbols![name].exported,
+    );
+    const missing = PRELUDE_NAMES.filter((n) => !exportedNames.includes(n));
+    expect(missing).toEqual([]);
+  });
+
+  // The prelude is deliberately a *subset* of what std::index exports:
+  // setAgentCwd and friends are importable but intentionally not in scope
+  // everywhere. So the check above runs in one direction only — this
+  // records why, so nobody "fixes" it into a two-way equality check and
+  // drags those names into every file.
+  it("is a subset, not a mirror, of the std::index exports", () => {
+    expect(PRELUDE_NAMES).not.toContain("setAgentCwd");
+    expect(PRELUDE_NAMES).not.toContain("getAgentCwd");
+    expect(PRELUDE_NAMES).not.toContain("applyAgentCwd");
+  });
+
+  // AGENCY_TEMPLATE_OFFSET (lib/parsers/parsers.ts) hardcodes how many lines
+  // the parser template adds, and every diagnostic's line number is computed
+  // by subtracting it. A prelude import that wrapped onto a second line
+  // would silently shift every error in the editor down a row.
+  it("renders as a single line", () => {
+    expect(preludeImportLine()).not.toContain("\n");
+  });
+});

--- a/packages/agency-lang/lib/prelude.ts
+++ b/packages/agency-lang/lib/prelude.ts
@@ -22,7 +22,7 @@
  * import must stay on one line. prelude.test.ts enforces both and explains
  * why each matters.
  */
-export const PRELUDE_NAMES: string[] = [
+export const PRELUDE_NAMES: readonly string[] = [
   "print",
   "printJSON",
   "input",

--- a/packages/agency-lang/lib/prelude.ts
+++ b/packages/agency-lang/lib/prelude.ts
@@ -1,0 +1,58 @@
+/**
+ * The prelude: names every Agency file gets without importing them.
+ *
+ * This array is the only definition of that list. Two places render it:
+ *
+ *  - `parseAgency` wraps user source in the parser template
+ *    (lib/templates/backends/agency/template.mustache), which turns these
+ *    names into a real `import { … } from "std::index"` line.
+ *  - The LSP can't use that template — wrapping the source would shift
+ *    every line and land the editor's squiggles on the wrong row — so
+ *    `runDiagnostics` synthesizes an equivalent import statement instead
+ *    (lib/lsp/diagnostics.ts).
+ *
+ * Both read this array, so the compiler and the editor cannot disagree
+ * about what is in scope. They used to keep separate hand-copied lists,
+ * which drifted: `_guard`, `saveDraft`, and `flatten` reached the template
+ * but not the LSP, so any file using the `guard` construct showed a
+ * phantom "Function '_guard' is not defined" in the editor that
+ * `agency typecheck` never reported.
+ *
+ * Every name here must be exported by stdlib/index.agency, and the rendered
+ * import must stay on one line. prelude.test.ts enforces both and explains
+ * why each matters.
+ */
+export const PRELUDE_NAMES: string[] = [
+  "print",
+  "printJSON",
+  "input",
+  "sleep",
+  "saveDraft",
+  "_guard",
+  "read",
+  "write",
+  "writeBinary",
+  "readBinary",
+  "range",
+  "callback",
+  // Array helpers (moved from std::array into std::index).
+  "map",
+  "filter",
+  "exclude",
+  "find",
+  "findIndex",
+  "reduce",
+  "flatMap",
+  "every",
+  "some",
+  "count",
+  "sortBy",
+  "unique",
+  "groupBy",
+  "flatten",
+];
+
+/** The prelude as a single-line `import { … } from "std::index"` statement. */
+export function preludeImportLine(): string {
+  return `import { ${PRELUDE_NAMES.join(", ")} } from "std::index";`;
+}

--- a/packages/agency-lang/lib/templates/backends/agency/template.mustache
+++ b/packages/agency-lang/lib/templates/backends/agency/template.mustache
@@ -1,3 +1,3 @@
-import { print, printJSON, input, sleep, saveDraft, _guard, read, write, writeBinary, readBinary, range, callback, map, filter, exclude, find, findIndex, reduce, flatMap, every, some, count, sortBy, unique, groupBy, flatten } from "std::index";
+{{{preludeImport:string}}}
 
 {{{body:string}}}

--- a/packages/agency-lang/lib/templates/backends/agency/template.ts
+++ b/packages/agency-lang/lib/templates/backends/agency/template.ts
@@ -3,11 +3,12 @@
 // Any manual changes will be lost.
 import { apply } from "typestache";
 
-export const template = `import { print, printJSON, input, sleep, saveDraft, _guard, read, write, writeBinary, readBinary, range, callback, map, filter, exclude, find, findIndex, reduce, flatMap, every, some, count, sortBy, unique, groupBy, flatten } from "std::index";
+export const template = `{{{preludeImport:string}}}
 
 {{{body:string}}}`;
 
 export type TemplateType = {
+  preludeImport: string;
   body: string;
 };
 


### PR DESCRIPTION
## The bug

The editor showed `Function '_guard' is not defined` on files that `agency typecheck` accepted. Same file, two different answers.

Root cause: the compiler and the LSP each kept their own hand-copied list of the names auto-imported from `std::index`, and the LSP copy had drifted. Three names reached the parser template but never the LSP list:

- `_guard`
- `saveDraft`
- `flatten`

The `guard` construct desugars to a `_guard(...)` call before type checking, so any file using `guard` lit up with a phantom error the compiler never saw. Files using `saveDraft` or `flatten` had the same problem.

The LSP cannot just use the parser template: wrapping the source shifts every line and lands the squiggles on the wrong row. So it synthesizes an equivalent import instead. That is fine. Keeping a second copy of the list is what broke.

## The fix

`lib/prelude.ts` is now the only definition of the prelude. The parser template renders it, and the LSP builds its synthetic import from it, so the editor and the compiler cannot disagree about what is in scope.

Collapsing the two lists does not stop that list from disagreeing with the stdlib, so `prelude.test.ts` also checks every prelude name against the real `std::index` exports. That check runs one way only. The prelude is deliberately a subset: `setAgentCwd`, `getAgentCwd`, and `applyAgentCwd` are exported without being in scope everywhere, and a two-way equality check would drag them into every file.

A third test pins the rendered import to a single line. `AGENCY_TEMPLATE_OFFSET` hardcodes how many lines the template adds, and every diagnostic line number is computed by subtracting it, so wrapping the import at 80 columns would silently shift every editor error down a row.

## Verification

- Wrote the failing test first. It failed naming exactly `_guard`, `saveDraft`, and `flatten`, no more and no less, which is what confirmed the root cause instead of assuming it.
- The stdlib-drift test passed on first run, which proves nothing, so I injected a fake name and watched it fail before reverting.
- Ran the reported file, `stdlib/agents/verifier.agency`, through the real LSP path: zero diagnostics.
- `preludeImportLine()` renders byte-identical to the old hardcoded template line, so no Agency file compiles differently.
- `tsc --noEmit` clean. Parser, prelude, and LSP diagnostics tests all pass.

## Note for the reviewer

The full unit suite reports 72 failures across 16 files in a fresh worktree, all `Cannot find package 'agency-lang/...'` from an unbuilt checkout. These are not from this change: stashing the diff and re-running the same 16 files reproduces the identical 72 failures. Leaving them alone as out of scope. CI runs on a built tree and should be clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
