### PR TITLE
Add list comprehensions: [expr for x in xs if cond] and fork [...]

### DIFF
--- a/packages/agency-lang/docs/site/.vitepress/config.mts
+++ b/packages/agency-lang/docs/site/.vitepress/config.mts
@@ -62,6 +62,7 @@ export default defineConfig({
           items: [
             { text: "Error Handling", link: "/guide/error-handling" },
             { text: "Blocks", link: "/guide/blocks" },
+            { text: "List Comprehensions", link: "/guide/comprehensions" },
             { text: "Pattern Matching", link: "/guide/pattern-matching" },
             { text: "Concurrency", link: "/guide/concurrency" },
             {

--- a/packages/agency-lang/docs/site/guide/basic-syntax.md
+++ b/packages/agency-lang/docs/site/guide/basic-syntax.md
@@ -151,6 +151,13 @@ for ({ name, age } in people) {
 
 Other loop constructs, such as map, are part of the [agency standard library](/stdlib/array).
 
+To build a new array from an existing one, a
+[list comprehension](/guide/comprehensions) is usually shorter than a loop:
+
+```ts
+const doubled = [x * 2 for x in numbers]
+```
+
 ## Comments
 
 You can have single-line or multi-line comments.

--- a/packages/agency-lang/docs/site/guide/comprehensions.md
+++ b/packages/agency-lang/docs/site/guide/comprehensions.md
@@ -1,0 +1,128 @@
+---
+name: List comprehensions
+description: Build a new list from an existing one in a single expression, either sequentially or concurrently.
+---
+
+# List comprehensions
+
+A list comprehension builds a new array from an existing collection, in one
+expression:
+
+```ts
+const doubled = [x * 2 for x in numbers]
+```
+
+That is the same as writing a loop that appends to an array, but shorter and
+without a mutable variable to get wrong.
+
+## Filtering
+
+Add an `if` clause to keep only some items:
+
+```ts
+const bigNames = [name for name in names if name.length > 5]
+```
+
+## Running the items concurrently
+
+Put `fork` in front and every item runs at the same time:
+
+```ts
+const summaries = fork [llm("Summarize: ${doc}") for doc in docs]
+```
+
+Use this when the body is slow, which for an agent usually means it makes an
+LLM call. Ten documents take about as long as one, instead of ten times as
+long. Results come back in the order of the original list, no matter which
+item finishes first.
+
+The two forms differ in one important way beyond speed. `fork` gives each item
+its own copy of your global variables, and throws those copies away when the
+work joins back up. So a body that changes a global will not have that change
+survive:
+
+```ts
+let count = 0
+
+// count is still 0 afterwards - each branch changed its own copy
+const results = fork [tally(x) for x in xs]
+```
+
+If you need the changes to stick, use the plain form, or read
+[concurrency](/guide/concurrency) for `shared: true`.
+
+The `if` clause runs before the work fans out, so the filter itself is not
+concurrent. Only the body is.
+
+## Binders
+
+The part after `for` works exactly like the one in a
+[`for` loop](/guide/basic-syntax#loops).
+
+A second binder gives you the index when you are iterating an array:
+
+```ts
+const labeled = ["${i}: ${name}" for name, i in names]
+// ["0: Alice", "1: Bob"]
+```
+
+For an object, the second binder is the value at that key instead:
+
+```ts
+const config = { host: "localhost", port: "8080" }
+const lines = ["${k}=${v}" for k, v in config]
+// ["host=localhost", "port=8080"]
+```
+
+The indices are positions in the collection you started with, not in the
+result. So filtering does not renumber them:
+
+```ts
+const xs = ["a", "b", "c", "d"]
+const kept = ["${i}:${x}" for x, i in xs if x != "b"]
+// ["0:a", "2:c", "3:d"] - note the missing 1
+```
+
+You can also pull apart each item as you go:
+
+```ts
+const greetings = ["Hi ${name}" for {name, age} in people]
+const firsts = [a for [a, b] in pairs]
+```
+
+## Things to know
+
+A long comprehension can be broken across lines:
+
+```ts
+const summaries = fork [summarize(doc)
+  for doc in docs
+  if doc.length > 0]
+```
+
+If it is getting long, though, that is usually a sign the body wants to be a
+named function.
+
+Anything that is not a list or an object gives you an empty result rather than
+an error, which matches how `for` loops behave. That includes strings, so
+`[c for c in "abc"]` gives you `[]`, not a list of characters.
+
+## When to use a block instead
+
+The body of a comprehension is a single expression. When you need several
+statements, use the block form, which does the same job:
+
+```ts
+const reports = map(topics) as topic {
+  const notes = research(topic)
+  return summarize(notes)
+}
+```
+
+`fork(topics) as topic { ... }` is the concurrent equivalent.
+
+## References
+
+- [Concurrency](/guide/concurrency) - `fork`, `race`, and shared state
+- [Blocks](/guide/blocks) - the multi-statement form
+- [std::index](/stdlib/) - `map`, `filter`, `reduce`, and friends

--- a/packages/agency-lang/docs/site/guide/partial-results.md
+++ b/packages/agency-lang/docs/site/guide/partial-results.md
@@ -62,6 +62,15 @@ node main() {
 }
 ```
 
+The loop above is deliberate: `saveDraft` has to run after each topic, and a
+comprehension body is a single expression. When you only want the results and
+do not need to save progress between them, a
+[comprehension](/guide/comprehensions) is shorter:
+
+```ts
+const reports = fork [research(topic) for topic in topics]
+```
+
 Things to note:
 
 - The last saved value wins.

--- a/packages/agency-lang/docs/site/stdlib/index.md
+++ b/packages/agency-lang/docs/site/stdlib/index.md
@@ -24,7 +24,7 @@ How an existing file is handled on write:
 export type WriteMode = "overwrite" | "append" | "create-only"
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L50))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L51))
 
 ## Effects
 
@@ -37,7 +37,7 @@ effect std::read {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L34))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L35))
 
 ### std::write
 
@@ -48,7 +48,7 @@ effect std::write {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L38))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L39))
 
 ### std::readImage
 
@@ -59,7 +59,7 @@ effect std::readImage {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L42))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L43))
 
 ## Functions
 
@@ -79,7 +79,7 @@ Print a message to the console.
 |---|---|---|
 | messages | `any[]` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L52))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L53))
 
 ### setAgentCwd
 
@@ -104,7 +104,7 @@ Set the agent working directory. Path-taking tools (read, write, edit,
 |---|---|---|
 | dir | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L81))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L82))
 
 ### getAgentCwd
 
@@ -116,7 +116,7 @@ Return the agent working directory, or an empty string if none is set.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L90))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L91))
 
 ### applyAgentCwd
 
@@ -135,7 +135,7 @@ relative paths against the agent working directory.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L100))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L101))
 
 ### printJSON
 
@@ -155,7 +155,7 @@ Print an object as formatted JSON to the console.
 | obj | `any` |  |
 | highlight | `boolean` | false |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L108))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L109))
 
 ### input
 
@@ -178,7 +178,7 @@ prompt, which surfaces as an AgencyCancelledError.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L125))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L126))
 
 ### sleep
 
@@ -199,7 +199,7 @@ A long sleep wakes immediately on Ctrl-C, race-loser, or time-guard abort.
 |---|---|---|
 | ms | `number` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L136))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L137))
 
 ### saveDraft
 
@@ -226,7 +226,7 @@ Record a best-so-far value for the current function or guarded block. If an
 |---|---|---|
 | value | `any` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L145))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L146))
 
 ### read
 
@@ -262,7 +262,7 @@ Read the contents of a file and return it as a string.
 
 **Throws:** `std::read`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L163))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L164))
 
 ### write
 
@@ -298,7 +298,7 @@ Write content to a file.
 
 **Throws:** `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L191))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L192))
 
 ### writeBinary
 
@@ -335,7 +335,7 @@ Write base64-encoded binary data to a file: images, audio, video, PDFs, or any
 
 **Throws:** `std::writeBinary`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L221))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L222))
 
 ### readBinary
 
@@ -366,7 +366,7 @@ Read a file and return its contents as a Base64-encoded string. Works for any
 
 **Throws:** `std::readBinary`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L251))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L252))
 
 ### range
 
@@ -389,7 +389,7 @@ Generate an array of numbers. With one argument, counts from 0 to start-1;
 
 **Returns:** `number[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L274))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L275))
 
 ### map
 
@@ -411,7 +411,30 @@ Map a function over an array, returning a new array of results.
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L295))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L296))
+
+### mapWithIndex
+
+```ts
+mapWithIndex(arr: any[], func: (any, any) -> any): any[]
+```
+
+Apply a function to each item of an array along with its index, and
+  return a new array of the results.
+
+  @param arr - The array to map over
+  @param func - Called with the item and its zero-based index
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| arr | `any[]` |  |
+| func | `(any, any) => any` |  |
+
+**Returns:** `any[]`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L322))
 
 ### filter
 
@@ -433,7 +456,7 @@ Return a new array containing only the elements for which the function returns t
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L309))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L333))
 
 ### exclude
 
@@ -455,7 +478,7 @@ Return a new array excluding elements for which the function returns true.
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L325))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L349))
 
 ### find
 
@@ -477,7 +500,7 @@ Return the first element for which the function returns true, or null if none ma
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L341))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L365))
 
 ### findIndex
 
@@ -499,7 +522,7 @@ Return the index of the first element for which the function returns true, or -1
 
 **Returns:** `number`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L356))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L380))
 
 ### reduce
 
@@ -523,7 +546,7 @@ Reduce an array to a single value by applying a function to an accumulator and e
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L371))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L395))
 
 ### flatMap
 
@@ -545,7 +568,7 @@ Map a function over an array and flatten the results by one level.
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L386))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L410))
 
 ### flatten
 
@@ -565,7 +588,7 @@ Flatten an array of arrays by one level.
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L403))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L427))
 
 ### every
 
@@ -587,7 +610,7 @@ Return true if the function returns true for every element in the array.
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L418))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L442))
 
 ### some
 
@@ -609,7 +632,7 @@ Return true if the function returns true for at least one element in the array.
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L433))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L457))
 
 ### count
 
@@ -631,7 +654,7 @@ Count the number of elements in the array for which the function returns true.
 
 **Returns:** `number`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L448))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L472))
 
 ### sortBy
 
@@ -653,7 +676,7 @@ Return a new array sorted by the values returned by the function, in ascending o
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L464))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L488))
 
 ### unique
 
@@ -675,7 +698,7 @@ Return a new array with duplicate elements removed, using the function to determ
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L491))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L515))
 
 ### groupBy
 
@@ -697,7 +720,7 @@ Group elements of an array by the value returned by the function. Returns an obj
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L516))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L540))
 
 ### callback
 
@@ -719,4 +742,4 @@ Register a callback for a lifecycle event. A callback registered inside a
 | name | `string` |  |
 | fn | `any` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L536))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L560))

--- a/packages/agency-lang/lib/backends/agencyGenerator.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.ts
@@ -5,6 +5,7 @@ import {
   AgencyNode,
   AgencyProgram,
   Assignment,
+  Comprehension,
   DebuggerStatement,
   InterruptStatement,
   Literal,
@@ -502,6 +503,8 @@ export class AgencyGenerator {
         return this.processFinalizeBlock(node);
       case "guardBlock":
         return this.processGuardBlock(node);
+      case "comprehension":
+        return this.processComprehension(node);
       case "withModifier":
         return `${this.processNode(node.statement)} with ${node.handlerName}`;
       case "staticStatement":
@@ -1704,6 +1707,21 @@ export class AgencyGenerator {
     return this.indentStr(
       `guard${argsStr} {\n${bodyCodeStr}${this.indentStr("}")}`,
     );
+  }
+
+  protected processComprehension(node: Comprehension): string {
+    const prefix = node.parallel ? "fork " : "";
+    const expr = this.processNode(node.expression).trim();
+    const binder =
+      typeof node.itemVar === "string"
+        ? node.itemVar
+        : this.processNode(node.itemVar).trim();
+    const index = node.indexVar ? `, ${node.indexVar}` : "";
+    const iterable = this.processNode(node.iterable).trim();
+    const cond = node.condition
+      ? ` if ${this.processNode(node.condition).trim()}`
+      : "";
+    return `${prefix}[${expr} for ${binder}${index} in ${iterable}${cond}]`;
   }
 
   protected processSkill(node: Skill): string {

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -2810,10 +2810,15 @@ export class TypeScriptBuilder {
     // those), so every argument is positional. processResolvedArgs is the
     // one place that decides reference-vs-call for functionCall arguments;
     // this loop used to be a hand-copy of it and drifted (the fork/race
-    // guard landed in one and not the other).
-    const argNodes = this.processResolvedArgs(
-      args as (Expression | SplatExpression)[],
+    // guard landed in one and not the other). The filter is a checked
+    // narrowing of the branch invariant, not a cast - if a namedArgument
+    // ever reached here it would be dropped by the predicate instead of
+    // silently miscompiled as a positional value.
+    const positionalArgs = args.filter(
+      (arg): arg is Expression | SplatExpression =>
+        arg.type !== "namedArgument",
     );
+    const argNodes = this.processResolvedArgs(positionalArgs);
 
     return ts.obj({
       type: ts.str("positional"),

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -539,6 +539,22 @@ export class TypeScriptBuilder {
     args: (Expression | SplatExpression)[],
   ): TsNode[] {
     return args.map((arg) => {
+      // `fork`/`race` carrying a block is a CALL, not a function
+      // reference, and its lowering lives in processForkCall (reached
+      // via processNode -> processFunctionCall). The "functionArg"
+      // path below treats a functionCall argument as a reference and
+      // emits `__call(fork, ...)`, where `fork` is an undefined
+      // identifier - the ReferenceError this guard prevents. The
+      // presence of a block is the same discriminator
+      // processFunctionCall keys on, so a bare `map(xs, double)`
+      // reference is unaffected.
+      if (
+        arg.type === "functionCall" &&
+        (arg.functionName === "fork" || arg.functionName === "race") &&
+        arg.block
+      ) {
+        return this.processCallArg(arg);
+      }
       if (arg.type === "functionCall") {
         this.functionsUsed.add(arg.functionName);
         return this.generateFunctionCallExpression(
@@ -2790,24 +2806,14 @@ export class TypeScriptBuilder {
       return ts.obj(descriptor);
     }
 
-    const argNodes: TsNode[] = [];
-    for (const arg of args) {
-      if (arg.type === "functionCall") {
-        this.functionsUsed.add(arg.functionName);
-        argNodes.push(
-          this.generateFunctionCallExpression(
-            arg as FunctionCall,
-            "functionArg",
-          ),
-        );
-      } else {
-        argNodes.push(this.processCallArg(arg));
-      }
-    }
-
-    if (node.block) {
-      argNodes.push(this.processBlockArgument(node));
-    }
+    // No named args and no block on this call (the branch above handled
+    // those), so every argument is positional. processResolvedArgs is the
+    // one place that decides reference-vs-call for functionCall arguments;
+    // this loop used to be a hand-copy of it and drifted (the fork/race
+    // guard landed in one and not the other).
+    const argNodes = this.processResolvedArgs(
+      args as (Expression | SplatExpression)[],
+    );
 
     return ts.obj({
       type: ts.str("positional"),

--- a/packages/agency-lang/lib/formatter.comprehension.test.ts
+++ b/packages/agency-lang/lib/formatter.comprehension.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { formatSource } from "./formatter.js";
+
+describe("agency fmt preserves comprehensions", () => {
+  // [source, expected-after-fmt]. Expected differs only where the
+  // formatter's house style normalizes spacing (object patterns print
+  // as `{ name, age }`).
+  const cases: [string, string][] = [
+    ["[f(x) for x in xs]", "[f(x) for x in xs]"],
+    ["[f(x) for x in xs if p(x)]", "[f(x) for x in xs if p(x)]"],
+    ["[f(x, i) for x, i in xs]", "[f(x, i) for x, i in xs]"],
+    [
+      "[name for {name, age} in people]",
+      "[name for { name, age } in people]",
+    ],
+    ["fork [f(x) for x in xs]", "fork [f(x) for x in xs]"],
+    ["fork [f(x) for x in xs if p(x)]", "fork [f(x) for x in xs if p(x)]"],
+  ];
+
+  for (const [expr, expected] of cases) {
+    it(`round-trips ${expr}`, () => {
+      const out = formatSource(`node main() {\n  const r = ${expr}\n}`);
+      expect(out).not.toBeNull();
+      expect(out).toContain(expected);
+      // the whole point: fmt must NOT print the desugared form
+      expect(out).not.toContain("map(");
+      expect(out).not.toContain("_pairsOf(");
+    });
+  }
+});

--- a/packages/agency-lang/lib/lowering/comprehensionDesugar.locations.test.ts
+++ b/packages/agency-lang/lib/lowering/comprehensionDesugar.locations.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { parseAgency } from "../parser.js";
+import { desugarComprehensionsInBody } from "./comprehensionDesugar.js";
+import { typeCheck } from "../typeChecker/index.js";
+
+describe("comprehensionDesugar source locations", () => {
+  it("stamps the comprehension location onto every synthesized node", () => {
+    const src = "node main() {\n  const r = [f(x) for x in xs if p(x)]\n}";
+    const result = parseAgency(src, {}, true, false);
+    if (!(result as any).success) throw new Error("parse failed");
+    const nodes = (result as any).result.nodes;
+    const main = nodes.find((n: any) => n.type === "graphNode");
+
+    const before = main.body[0].value.loc;
+    expect(before).toBeDefined();
+    const { line, col } = before;
+
+    desugarComprehensionsInBody(nodes);
+    const out = main.body[0].value;
+
+    // the outer map, the inner filter, and both blocks must carry the
+    // comprehension's position, not be left undefined
+    expect(out.loc?.line).toBe(line);
+    expect(out.loc?.col).toBe(col);
+    expect(out.arguments[0].loc?.line).toBe(line);
+    expect(out.block.loc?.line).toBe(line);
+  });
+
+  it("reports a type error inside a comprehension body at the user's line", () => {
+    // The error is a wrong-arity call. A wrong-TYPE call would not error:
+    // map's block parameter is `any`, exactly as in a hand-written
+    // `map(xs) as x { ... }`, so element types do not flow (probed).
+    const src = [
+      "def wants(n: number): number {",
+      "  return n",
+      "}",
+      "",
+      "node main() {",
+      '  const xs = ["a", "b"]',
+      "  const r = [wants() for x in xs]",
+      "}",
+    ].join("\n");
+
+    // typeCheck takes a parsed AgencyProgram (lib/typeChecker/index.ts),
+    // not a source string - parse (with lowering, as the real pipeline
+    // does) and then check.
+    const parsed = parseAgency(src);
+    if (!(parsed as any).success) throw new Error("parse failed");
+    const { errors } = typeCheck((parsed as any).result);
+    expect(errors.length).toBeGreaterThan(0);
+
+    // The comprehension is the 7th source line. parseAgency normalizes
+    // loc.line to be 0-INDEXED in the user's source (lib/parser.ts and
+    // docs/dev/locations.md), so the expected line is 6. The column is
+    // the call's own position - the carried node keeps its real loc
+    // through the desugar rather than being restamped.
+    const onComprehensionLine = errors.filter((d) => d.loc?.line === 6);
+    expect(onComprehensionLine.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/agency-lang/lib/lowering/comprehensionDesugar.locations.test.ts
+++ b/packages/agency-lang/lib/lowering/comprehensionDesugar.locations.test.ts
@@ -7,7 +7,9 @@ describe("comprehensionDesugar source locations", () => {
   it("stamps the comprehension location onto every synthesized node", () => {
     const src = "node main() {\n  const r = [f(x) for x in xs if p(x)]\n}";
     const result = parseAgency(src, {}, true, false);
-    if (!(result as any).success) throw new Error("parse failed");
+    if (!(result as any).success) {
+      throw new Error("parse failed");
+    }
     const nodes = (result as any).result.nodes;
     const main = nodes.find((n: any) => n.type === "graphNode");
 
@@ -45,7 +47,9 @@ describe("comprehensionDesugar source locations", () => {
     // not a source string - parse (with lowering, as the real pipeline
     // does) and then check.
     const parsed = parseAgency(src);
-    if (!(parsed as any).success) throw new Error("parse failed");
+    if (!(parsed as any).success) {
+      throw new Error("parse failed");
+    }
     const { errors } = typeCheck((parsed as any).result);
     expect(errors.length).toBeGreaterThan(0);
 

--- a/packages/agency-lang/lib/lowering/comprehensionDesugar.test.ts
+++ b/packages/agency-lang/lib/lowering/comprehensionDesugar.test.ts
@@ -12,11 +12,15 @@ function desugarExpr(src: string): any {
     true,
     false,
   );
-  if (!result.success) throw new Error("parse failed");
+  if (!result.success) {
+    throw new Error("parse failed");
+  }
   const nodes = result.result.nodes as any[];
   desugarComprehensionsInBody(nodes);
   const main = nodes.find((n) => n.type === "graphNode");
-  if (!main) throw new Error("no node definition found");
+  if (!main) {
+    throw new Error("no node definition found");
+  }
   return main.body[0].value;
 }
 

--- a/packages/agency-lang/lib/lowering/comprehensionDesugar.test.ts
+++ b/packages/agency-lang/lib/lowering/comprehensionDesugar.test.ts
@@ -72,6 +72,64 @@ describe("comprehensionDesugar", () => {
     expect(out.block.body[0].value.functionName).toBe("map");
   });
 
+  it("wraps the source in _pairsOf for a two-binder form", () => {
+    const out = desugarExpr("[f(x, i) for x, i in xs]");
+    expect(out.functionName).toBe("map");
+    expect(out.arguments[0].functionName).toBe("_pairsOf");
+    expect(out.block.params[0].name).toBe("__comprehensionItem");
+    // two unpack statements then the return
+    expect(out.block.body).toHaveLength(3);
+  });
+
+  it("pairs BEFORE filtering, so indices are source positions", () => {
+    const out = desugarExpr("[f(x, i) for x, i in xs if p(x)]");
+    // map( filter( _pairsOf(xs) ) ) - _pairsOf must be innermost
+    expect(out.functionName).toBe("map");
+    expect(out.arguments[0].functionName).toBe("filter");
+    expect(out.arguments[0].arguments[0].functionName).toBe("_pairsOf");
+  });
+
+  it("moves a destructuring binder into a pattern const inside the body", () => {
+    const out = desugarExpr("[name for {name, age} in people]");
+    expect(out.block.params[0].name).toBe("__comprehensionItem");
+    expect(out.block.body[0].type).toBe("assignment");
+    // `pattern` is what lowerPatterns keys on; it runs AFTER us
+    expect(out.block.body[0].pattern.type).toBe("objectPattern");
+    expect(out.block.body[0].declKind).toBe("const");
+  });
+
+  it("handles an array-pattern binder", () => {
+    const out = desugarExpr("[a for [a, b] in pairs]");
+    expect(out.block.body[0].pattern.type).toBe("arrayPattern");
+  });
+
+  it("handles a destructuring first binder alongside an index binder", () => {
+    const out = desugarExpr("[f(name, i) for {name}, i in people]");
+    expect(out.arguments[0].functionName).toBe("_pairsOf");
+    // first statement destructures pair[0], second binds pair[1]
+    expect(out.block.body[0].pattern.type).toBe("objectPattern");
+    expect(out.block.body[1].variableName).toBe("i");
+  });
+
+  it("gives the filter block the same unpacking as the map block", () => {
+    const out = desugarExpr("[f(x, i) for x, i in xs if p(x)]");
+    const filterBlock = out.arguments[0].block;
+    // regression guard for the rev-1 ordering hazard: a filter with no
+    // unpacking would reference unbound names
+    expect(filterBlock.body).toHaveLength(3);
+    expect(filterBlock.body[0].type).toBe("assignment");
+  });
+
+  it("gives each block its OWN unpack node instances", () => {
+    // scope resolution stamps scope/blockDepth per enclosing block, so a
+    // node instance shared between the filter block and the map block
+    // would get its stamps overwritten by whichever block runs second
+    const out = desugarExpr("[f(x, i) for x, i in xs if p(x)]");
+    const filterBlock = out.arguments[0].block;
+    expect(filterBlock.body[0]).not.toBe(out.block.body[0]);
+    expect(filterBlock.body[1]).not.toBe(out.block.body[1]);
+  });
+
   it("is idempotent", () => {
     const result = parseAgency(
       "node main() {\n  const r = [f(x) for x in xs]\n}",

--- a/packages/agency-lang/lib/lowering/comprehensionDesugar.test.ts
+++ b/packages/agency-lang/lib/lowering/comprehensionDesugar.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { parseAgency } from "../parser.js";
+import { desugarComprehensionsInBody } from "./comprehensionDesugar.js";
+
+/** `lower: false` keeps the raw comprehension node, since the real
+ *  pipeline would already have desugared it. The prelude import is
+ *  nodes[0], so find the node definition by its runtime tag "graphNode". */
+function desugarExpr(src: string): any {
+  const result = parseAgency(
+    `node main() {\n  const r = ${src}\n}`,
+    {},
+    true,
+    false,
+  );
+  if (!result.success) throw new Error("parse failed");
+  const nodes = result.result.nodes as any[];
+  desugarComprehensionsInBody(nodes);
+  const main = nodes.find((n) => n.type === "graphNode");
+  if (!main) throw new Error("no node definition found");
+  return main.body[0].value;
+}
+
+describe("comprehensionDesugar", () => {
+  it("lowers a plain comprehension to map with a block", () => {
+    const out = desugarExpr("[f(x) for x in xs]");
+    expect(out.type).toBe("functionCall");
+    expect(out.functionName).toBe("map");
+    expect(out.block.params[0].name).toBe("x");
+    expect(out.block.body[0].type).toBe("returnStatement");
+  });
+
+  it("lowers a filter to a nested filter call", () => {
+    const out = desugarExpr("[f(x) for x in xs if p(x)]");
+    expect(out.functionName).toBe("map");
+    expect(out.arguments[0].functionName).toBe("filter");
+    expect(out.arguments[0].block.params[0].name).toBe("x");
+  });
+
+  it("lowers the fork form to a real fork call node", () => {
+    const out = desugarExpr("fork [f(x) for x in xs]");
+    // must be `fork`, not a helper - the builder keys on this name
+    expect(out.functionName).toBe("fork");
+    expect(out.block).toBeDefined();
+  });
+
+  // The rev-1 coverage bug: neither bodySlots nor a hardcoded key list
+  // reaches a call's arguments, so this survived into the builder.
+  it("desugars a comprehension nested in a call argument", () => {
+    const out = desugarExpr("g([f(x) for x in xs])");
+    expect(out.functionName).toBe("g");
+    expect(out.arguments[0].functionName).toBe("map");
+  });
+
+  it("desugars a comprehension in an object literal field", () => {
+    const out = desugarExpr("{ items: [f(x) for x in xs] }");
+    expect(out.type).toBe("agencyObject");
+    // AgencyObject stores fields on `entries` (lib/types/dataStructures.ts:52)
+    const field = out.entries[0];
+    expect(field.value.functionName).toBe("map");
+  });
+
+  it("desugars a comprehension in a binary operand", () => {
+    const out = desugarExpr("g([f(x) for x in xs]) + 1");
+    expect(out.type).toBe("binOpExpression");
+    expect(out.left.arguments[0].functionName).toBe("map");
+  });
+
+  it("desugars nested comprehensions innermost-out", () => {
+    const out = desugarExpr("[[y for y in row] for row in rows]");
+    expect(out.functionName).toBe("map");
+    // the inner one became the outer block's return value
+    expect(out.block.body[0].value.functionName).toBe("map");
+  });
+
+  it("is idempotent", () => {
+    const result = parseAgency(
+      "node main() {\n  const r = [f(x) for x in xs]\n}",
+      {},
+      true,
+      false,
+    );
+    const nodes = (result as any).result.nodes;
+    desugarComprehensionsInBody(nodes);
+    const first = JSON.stringify(nodes);
+    desugarComprehensionsInBody(nodes);
+    expect(JSON.stringify(nodes)).toBe(first);
+  });
+});

--- a/packages/agency-lang/lib/lowering/comprehensionDesugar.ts
+++ b/packages/agency-lang/lib/lowering/comprehensionDesugar.ts
@@ -207,6 +207,23 @@ function comprehensionSource(
   );
 }
 
+/** Copy the comprehension's source location onto a synthesized node and
+ *  everything under it. Without this, a type error inside a comprehension
+ *  body points at generated `map(...)` internals instead of the line the
+ *  user wrote. See docs/dev/locations.md.
+ *
+ *  Only fills a MISSING loc, so nodes carried over from the user's source
+ *  (the body expression, the iterable, the condition) keep their own real
+ *  positions. Uses the same `mapChildren` traversal as `desugarNode` -
+ *  one walking strategy per file. */
+function stampLoc<T>(target: T, loc: Comprehension["loc"]): T {
+  if (!loc || !target || typeof target !== "object") return target;
+  const node = target as any;
+  if (node.type && !node.loc) node.loc = loc;
+  mapChildren(node, (child) => stampLoc(child, loc));
+  return target;
+}
+
 function lower(node: Comprehension): FunctionCall {
   const paramName = paramNameFor(node);
   // unpackStatements is called ONCE PER BLOCK, deliberately. The filter
@@ -218,12 +235,15 @@ function lower(node: Comprehension): FunctionCall {
   // deep-clones to avoid.
   const source = comprehensionSource(node, unpackStatements(node), paramName);
 
-  return call(
-    node.parallel ? "fork" : "map",
-    [source],
-    blockArg(
-      [...unpackStatements(node), returnStmt(node.expression)],
-      paramName,
+  return stampLoc(
+    call(
+      node.parallel ? "fork" : "map",
+      [source],
+      blockArg(
+        [...unpackStatements(node), returnStmt(node.expression)],
+        paramName,
+      ),
     ),
+    node.loc,
   );
 }

--- a/packages/agency-lang/lib/lowering/comprehensionDesugar.ts
+++ b/packages/agency-lang/lib/lowering/comprehensionDesugar.ts
@@ -1,0 +1,129 @@
+import type { AgencyNode, Expression } from "../types.js";
+import type { BlockArgument } from "../types/blockArgument.js";
+import type { Comprehension } from "../types/comprehension.js";
+import type { FunctionCall } from "../types/function.js";
+import type { VariableNameLiteral } from "../types/literals.js";
+
+/**
+ * Rewrite every `comprehension` node into ordinary `map` / `filter` /
+ * `fork` calls carrying block arguments - the exact shape those calls
+ * have when written by hand. After this pass the rest of the compiler
+ * cannot tell the construct existed, so typing, codegen, interrupts,
+ * and fork branch semantics are inherited rather than reimplemented.
+ *
+ * Runs inside parseAgency's `if (lower)` block, BEFORE lowerPatterns, so
+ * a destructuring binder becomes an ordinary pattern assignment that
+ * lowerPatterns then handles with its existing machinery.
+ *
+ * MUTATES IN PLACE, for the same reason guardDesugar does: consumers
+ * hold references to the same node objects, so a copying rewrite would
+ * leave half the pipeline looking at stale bodies. Idempotent - a second
+ * run finds no comprehension nodes.
+ *
+ * The `fork` case emits a real `fork` functionCall node rather than
+ * calling a helper. `fork` is NOT a function: the builder intercepts it
+ * at typescriptBuilder.ts processFunctionCall and compiles the block body
+ * differently, supplying the branch stack and per-branch frames. A helper
+ * receiving an ordinary lifted block would get none of that.
+ * parallelDesugar.ts synthesizes the same shape for `parallel { }`, which
+ * proves it compiles.
+ */
+export function desugarComprehensionsInBody(
+  body: AgencyNode[],
+): AgencyNode[] {
+  body.forEach((node, i) => {
+    body[i] = desugarNode(node);
+  });
+  return body;
+}
+
+/** The generated block parameter. Double underscore is compiler-reserved,
+ *  so it cannot collide with a user binder. */
+const PARAM = "__comprehensionItem";
+
+/**
+ * Apply `fn` to every object-valued child and put the result back.
+ *
+ * Deliberately generic rather than driven by `bodySlots` or
+ * `expressionChildren`. `bodySlots` covers statement bodies only, and
+ * `expressionChildren` is a read view with no writer, so neither alone
+ * reaches every place a comprehension can appear: call arguments, object
+ * literal fields, array items, binary operands, interpolations. A
+ * hardcoded key list develops coverage holes; this cannot.
+ *
+ * `loc` is skipped because it holds plain position data, not nodes.
+ */
+function mapChildren(node: any, fn: (child: any) => any): void {
+  for (const key of Object.keys(node)) {
+    if (key === "loc") continue;
+    const child = node[key];
+    if (Array.isArray(child)) {
+      child.forEach((item, i) => {
+        if (item && typeof item === "object") child[i] = fn(item);
+      });
+    } else if (child && typeof child === "object") {
+      node[key] = fn(child);
+    }
+  }
+}
+
+function desugarNode(node: AgencyNode): AgencyNode {
+  if (!node || typeof node !== "object") return node;
+
+  // Recurse first, so nested comprehensions lower innermost-out.
+  mapChildren(node, desugarNode);
+
+  if (node.type !== "comprehension") return node;
+  return lower(node as Comprehension);
+}
+
+function varRef(name: string): VariableNameLiteral {
+  return { type: "variableName", value: name };
+}
+
+function blockArg(body: AgencyNode[], paramName: string): BlockArgument {
+  return {
+    type: "blockArgument",
+    params: [{ type: "functionParameter", name: paramName }],
+    body,
+  };
+}
+
+function call(
+  functionName: string,
+  args: Expression[],
+  block: BlockArgument,
+): FunctionCall {
+  return { type: "functionCall", functionName, arguments: args, block };
+}
+
+function returnStmt(value: Expression): AgencyNode {
+  return { type: "returnStatement", value } as AgencyNode;
+}
+
+/** The block parameter name. A single-name binder becomes the parameter
+ *  directly, which keeps the user's own name in generated code and in
+ *  diagnostics. Every other shape needs unpacking in the body, so it
+ *  takes the reserved name. */
+function paramNameFor(node: Comprehension): string {
+  return typeof node.itemVar === "string" && !node.indexVar
+    ? node.itemVar
+    : PARAM;
+}
+
+function lower(node: Comprehension): FunctionCall {
+  const paramName = paramNameFor(node);
+  const source = node.condition
+    ? call(
+        "filter",
+        [node.iterable],
+        blockArg([returnStmt(node.condition)], paramName),
+      )
+    : node.iterable;
+
+  return call(
+    node.parallel ? "fork" : "map",
+    [source],
+    blockArg([returnStmt(node.expression)], paramName),
+  );
+}

--- a/packages/agency-lang/lib/lowering/comprehensionDesugar.ts
+++ b/packages/agency-lang/lib/lowering/comprehensionDesugar.ts
@@ -114,11 +114,13 @@ function paramNameFor(node: Comprehension): string {
 /** `__comprehensionItem[n]` - recovers one binder from a pair.
  *  NumberLiteral carries its value as a STRING (lib/types/literals.ts,
  *  and parallelDesugar's numLit helper). */
-function pairIndex(n: number): Expression {
+function pairIndex(position: number): Expression {
   return {
     type: "valueAccess",
     base: varRef(PARAM),
-    chain: [{ kind: "index", index: { type: "number", value: String(n) } }],
+    chain: [
+      { kind: "index", index: { type: "number", value: String(position) } },
+    ],
   } as unknown as Expression;
 }
 

--- a/packages/agency-lang/lib/lowering/comprehensionDesugar.ts
+++ b/packages/agency-lang/lib/lowering/comprehensionDesugar.ts
@@ -111,13 +111,15 @@ function paramNameFor(node: Comprehension): string {
     : PARAM;
 }
 
-/** `__comprehensionItem[n]` - recovers one binder from a pair.
+/** `<paramName>[position]` - recovers one binder from a pair. The block
+ *  parameter name is passed in rather than assuming PARAM, so this cannot
+ *  silently read an out-of-scope name if paramNameFor ever grows a case.
  *  NumberLiteral carries its value as a STRING (lib/types/literals.ts,
  *  and parallelDesugar's numLit helper). */
-function pairIndex(position: number): Expression {
+function pairIndex(paramName: string, position: number): Expression {
   return {
     type: "valueAccess",
-    base: varRef(PARAM),
+    base: varRef(paramName),
     chain: [
       { kind: "index", index: { type: "number", value: String(position) } },
     ],
@@ -167,15 +169,18 @@ function bindTarget(
  *  Empty for a single-name binder, which IS the parameter. A two-binder
  *  form unpacks both halves of a `_pairsOf` pair. A destructuring binder
  *  binds the whole parameter through its pattern. */
-function unpackStatements(node: Comprehension): AgencyNode[] {
+function unpackStatements(
+  node: Comprehension,
+  paramName: string,
+): AgencyNode[] {
   if (node.indexVar) {
     return [
-      bindTarget(node.itemVar, pairIndex(0)),
-      bindName(node.indexVar, pairIndex(1)),
+      bindTarget(node.itemVar, pairIndex(paramName, 0)),
+      bindName(node.indexVar, pairIndex(paramName, 1)),
     ];
   }
   if (typeof node.itemVar !== "string") {
-    return [bindTarget(node.itemVar, varRef(PARAM))];
+    return [bindTarget(node.itemVar, varRef(paramName))];
   }
   return [];
 }
@@ -216,8 +221,11 @@ function comprehensionSource(
  *
  *  Only fills a MISSING loc, so nodes carried over from the user's source
  *  (the body expression, the iterable, the condition) keep their own real
- *  positions. Uses the same `mapChildren` traversal as `desugarNode` -
- *  one walking strategy per file. */
+ *  positions. It DOES descend into those carried subtrees: any node the
+ *  parser left unstamped picks up the comprehension's location, which is
+ *  deliberate - a location on the right line beats no location at all.
+ *  Uses the same `mapChildren` traversal as `desugarNode` - one walking
+ *  strategy per file. */
 function stampLoc<T>(target: T, loc: Comprehension["loc"]): T {
   if (!loc || !target || typeof target !== "object") return target;
   const node = target as any;
@@ -235,14 +243,18 @@ function lower(node: Comprehension): FunctionCall {
   // whichever block is processed second would overwrite the first
   // block's stamps - the same aliasing hazard Assignment.matchSource
   // deep-clones to avoid.
-  const source = comprehensionSource(node, unpackStatements(node), paramName);
+  const source = comprehensionSource(
+    node,
+    unpackStatements(node, paramName),
+    paramName,
+  );
 
   return stampLoc(
     call(
       node.parallel ? "fork" : "map",
       [source],
       blockArg(
-        [...unpackStatements(node), returnStmt(node.expression)],
+        [...unpackStatements(node, paramName), returnStmt(node.expression)],
         paramName,
       ),
     ),

--- a/packages/agency-lang/lib/lowering/comprehensionDesugar.ts
+++ b/packages/agency-lang/lib/lowering/comprehensionDesugar.ts
@@ -1,4 +1,4 @@
-import type { AgencyNode, Expression } from "../types.js";
+import type { AgencyNode, Assignment, Expression } from "../types.js";
 import type { BlockArgument } from "../types/blockArgument.js";
 import type { Comprehension } from "../types/comprehension.js";
 import type { FunctionCall } from "../types/function.js";
@@ -111,19 +111,119 @@ function paramNameFor(node: Comprehension): string {
     : PARAM;
 }
 
+/** `__comprehensionItem[n]` - recovers one binder from a pair.
+ *  NumberLiteral carries its value as a STRING (lib/types/literals.ts,
+ *  and parallelDesugar's numLit helper). */
+function pairIndex(n: number): Expression {
+  return {
+    type: "valueAccess",
+    base: varRef(PARAM),
+    chain: [{ kind: "index", index: { type: "number", value: String(n) } }],
+  } as unknown as Expression;
+}
+
+/** `const <name> = <value>` */
+function bindName(name: string, value: Expression): Assignment {
+  return { type: "assignment", variableName: name, declKind: "const", value };
+}
+
+/** `const <pattern> = <value>` - used for destructuring binders, because
+ *  a destructured BLOCK PARAMETER does not parse (`map(xs) as ([a, b]) { }`
+ *  fails with "expected node body"), while destructuring in a `const`
+ *  works fine.
+ *
+ *  `pattern` is the field lowerPatterns keys on (patternLowering.ts,
+ *  `if (!node.pattern)`). It creates its own temp and calls
+ *  extractBindings, and never reads `variableName` on that path, so the
+ *  empty string is inert rather than a placeholder. */
+function bindPattern(
+  pattern: Comprehension["itemVar"],
+  value: Expression,
+): Assignment {
+  return {
+    type: "assignment",
+    variableName: "",
+    pattern: pattern as Assignment["pattern"],
+    declKind: "const",
+    value,
+  };
+}
+
+/** Bind one binder target, whichever shape it is. */
+function bindTarget(
+  target: Comprehension["itemVar"],
+  value: Expression,
+): Assignment {
+  return typeof target === "string"
+    ? bindName(target, value)
+    : bindPattern(target, value);
+}
+
+/** The statements the block body must run before the user's expression,
+ *  to recover the binders from the block parameter.
+ *
+ *  Empty for a single-name binder, which IS the parameter. A two-binder
+ *  form unpacks both halves of a `_pairsOf` pair. A destructuring binder
+ *  binds the whole parameter through its pattern. */
+function unpackStatements(node: Comprehension): AgencyNode[] {
+  if (node.indexVar) {
+    return [
+      bindTarget(node.itemVar, pairIndex(0)),
+      bindName(node.indexVar, pairIndex(1)),
+    ];
+  }
+  if (typeof node.itemVar !== "string") {
+    return [bindTarget(node.itemVar, varRef(PARAM))];
+  }
+  return [];
+}
+
+/** The collection the map runs over.
+ *
+ *  A two-binder form pairs the items with their indices BEFORE any
+ *  filtering, so the index is the position in the SOURCE, matching
+ *  Python's enumerate-then-filter order. Filtering first would number the
+ *  output instead, which is a silent wrong-answer bug rather than an
+ *  error. Order here is load-bearing: `_pairsOf` must be innermost. */
+function comprehensionSource(
+  node: Comprehension,
+  unpack: AgencyNode[],
+  paramName: string,
+): Expression {
+  const paired: Expression = node.indexVar
+    ? ({
+        type: "functionCall",
+        functionName: "_pairsOf",
+        arguments: [node.iterable],
+      } as FunctionCall)
+    : node.iterable;
+
+  if (!node.condition) return paired;
+
+  return call(
+    "filter",
+    [paired],
+    blockArg([...unpack, returnStmt(node.condition)], paramName),
+  );
+}
+
 function lower(node: Comprehension): FunctionCall {
   const paramName = paramNameFor(node);
-  const source = node.condition
-    ? call(
-        "filter",
-        [node.iterable],
-        blockArg([returnStmt(node.condition)], paramName),
-      )
-    : node.iterable;
+  // unpackStatements is called ONCE PER BLOCK, deliberately. The filter
+  // block and the map block are different scopes, and scope resolution
+  // stamps scope/blockDepth onto assignment and variable nodes per
+  // enclosing block. If the two blocks shared the same node instances,
+  // whichever block is processed second would overwrite the first
+  // block's stamps - the same aliasing hazard Assignment.matchSource
+  // deep-clones to avoid.
+  const source = comprehensionSource(node, unpackStatements(node), paramName);
 
   return call(
     node.parallel ? "fork" : "map",
     [source],
-    blockArg([returnStmt(node.expression)], paramName),
+    blockArg(
+      [...unpackStatements(node), returnStmt(node.expression)],
+      paramName,
+    ),
   );
 }

--- a/packages/agency-lang/lib/parser.ts
+++ b/packages/agency-lang/lib/parser.ts
@@ -21,6 +21,7 @@ import {
 
 import { AgencyConfig } from "./config.js";
 import { lowerPatterns, PatternLoweringError } from "./lowering/patternLowering.js";
+import { desugarComprehensionsInBody } from "./lowering/comprehensionDesugar.js";
 import { LoweringError } from "./lowering/loweringError.js";
 import render from "./templates/backends/agency/template.js";
 import { preludeImportLine } from "./prelude.js";
@@ -273,6 +274,15 @@ export function parseAgency(
     const result = _parseAgency(input, config);
     if (result.success) {
       if (lower) {
+        // Comprehensions desugar FIRST, so a destructuring binder
+        // (`[f(name) for {name} in people]`) becomes an ordinary
+        // pattern assignment that lowerPatterns then handles with its
+        // existing machinery. Running after would leave a pattern no
+        // later stage knows how to read.
+        result.result.nodes = desugarComprehensionsInBody(
+          result.result.nodes,
+        ) as typeof result.result.nodes;
+
         // Apply pattern lowering pass: transforms destructuring/pattern syntax
         // into existing AST constructs. The format path opts out by passing
         // `lower: false` so it can print patterns back as patterns.

--- a/packages/agency-lang/lib/parsers/comprehension.test.ts
+++ b/packages/agency-lang/lib/parsers/comprehension.test.ts
@@ -125,7 +125,8 @@ describe("comprehensionParser", () => {
   // have always parsed as arrays of variable names (probed - this is
   // pre-existing behavior, not something this feature introduced). Pin
   // that they at least never become half-baked comprehension nodes, so
-  // a later improvement (a real diagnostic) shows up as a diff.
+  // a later improvement shows up as a diff. A real diagnostic at the
+  // comprehension is tracked as issue #602.
   it.each([["[x for x in]"], ["[for x in xs]"], ["[x for in xs]"]])(
     "parses the malformed comprehension %s as an array, not a comprehension",
     (src) => {

--- a/packages/agency-lang/lib/parsers/comprehension.test.ts
+++ b/packages/agency-lang/lib/parsers/comprehension.test.ts
@@ -139,4 +139,13 @@ describe("comprehensionParser", () => {
     expect(node.type).toBe("comprehension");
     expect(node.itemVar).toBe("x");
   });
+
+  it("parses line breaks before in and if, not just before for", () => {
+    // the before-keyword whitespace must cross newlines at EVERY
+    // boundary - the naive version only worked before `for`, and only
+    // because a call body happens to eat its own trailing newline
+    const node = parseExpr("[f(x)\n    for x\n    in xs\n    if p(x)]");
+    expect(node.type).toBe("comprehension");
+    expect(node.condition).toBeDefined();
+  });
 });

--- a/packages/agency-lang/lib/parsers/comprehension.test.ts
+++ b/packages/agency-lang/lib/parsers/comprehension.test.ts
@@ -12,10 +12,14 @@ function parseExpr(src: string) {
     true,
     false,
   );
-  if (!result.success) throw new Error("parse failed");
+  if (!result.success) {
+    throw new Error("parse failed");
+  }
   const nodes = result.result.nodes as any[];
   const main = nodes.find((n) => n.type === "graphNode");
-  if (!main) throw new Error("no node definition found");
+  if (!main) {
+    throw new Error("no node definition found");
+  }
   return main.body[0].value;
 }
 

--- a/packages/agency-lang/lib/parsers/comprehension.test.ts
+++ b/packages/agency-lang/lib/parsers/comprehension.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+import { parseAgency } from "../parser.js";
+
+/** Parses with `lower: false` so the raw comprehension node survives.
+ *  The prelude import occupies nodes[0], so the node definition is found
+ *  by type. The runtime tag is "graphNode" - "graphNodeDefinition" is
+ *  only the TypeScript type name and matches nothing at runtime. */
+function parseExpr(src: string) {
+  const result = parseAgency(
+    `node main() {\n  const x = ${src}\n}`,
+    {},
+    true,
+    false,
+  );
+  if (!result.success) throw new Error("parse failed");
+  const nodes = result.result.nodes as any[];
+  const main = nodes.find((n) => n.type === "graphNode");
+  if (!main) throw new Error("no node definition found");
+  return main.body[0].value;
+}
+
+function parseFails(src: string): boolean {
+  const result = parseAgency(
+    `node main() {\n  const x = ${src}\n}`,
+    {},
+    true,
+    false,
+  );
+  return !result.success;
+}
+
+describe("comprehensionParser", () => {
+  it("parses a plain comprehension", () => {
+    const node = parseExpr("[f(x) for x in xs]");
+    expect(node.type).toBe("comprehension");
+    expect(node.itemVar).toBe("x");
+    expect(node.parallel).toBe(false);
+    expect(node.condition).toBeUndefined();
+  });
+
+  it("parses a filter clause", () => {
+    const node = parseExpr("[f(x) for x in xs if p(x)]");
+    expect(node.condition).toBeDefined();
+    expect(node.condition.functionName).toBe("p");
+  });
+
+  it("parses a two-binder comprehension", () => {
+    const node = parseExpr("[f(x, i) for x, i in xs]");
+    expect(node.itemVar).toBe("x");
+    expect(node.indexVar).toBe("i");
+  });
+
+  it("parses an object destructuring binder", () => {
+    const node = parseExpr("[name for {name, age} in people]");
+    expect(node.itemVar.type).toBe("objectPattern");
+  });
+
+  it("parses an array destructuring binder", () => {
+    const node = parseExpr("[a for [a, b] in pairs]");
+    expect(node.itemVar.type).toBe("arrayPattern");
+  });
+
+  it("parses the fork form", () => {
+    const node = parseExpr("fork [f(x) for x in xs]");
+    expect(node.type).toBe("comprehension");
+    expect(node.parallel).toBe(true);
+  });
+
+  it("parses the fork form with a filter", () => {
+    const node = parseExpr("fork [f(x) for x in xs if p(x)]");
+    expect(node.parallel).toBe(true);
+    expect(node.condition).toBeDefined();
+  });
+
+  // Bracket-nesting cases: the inner `]` is a plausible place for the
+  // comprehension parser to terminate early.
+  it("parses an array literal as the iterable", () => {
+    const node = parseExpr("[f(x) for x in [1, 2, 3]]");
+    expect(node.type).toBe("comprehension");
+    expect(node.iterable.type).toBe("agencyArray");
+  });
+
+  it("parses a nested comprehension", () => {
+    const node = parseExpr("[[y for y in row] for row in rows]");
+    expect(node.type).toBe("comprehension");
+    expect(node.expression.type).toBe("comprehension");
+  });
+
+  // Adversarial: the binder is found by scanning for `for`, so a string
+  // containing the word is the obvious way to confuse it.
+  it("parses a body string containing the word for", () => {
+    const node = parseExpr('["waiting for ${x}" for x in xs]');
+    expect(node.type).toBe("comprehension");
+    expect(node.itemVar).toBe("x");
+  });
+
+  // The ambiguity guard: `[` opens both an array literal and a
+  // comprehension. Getting this wrong breaks every array in the language.
+  it("still parses an ordinary array literal", () => {
+    const node = parseExpr("[1, 2, 3]");
+    expect(node.type).toBe("agencyArray");
+    expect(node.items).toHaveLength(3);
+  });
+
+  it("still parses an empty array literal", () => {
+    expect(parseExpr("[]").type).toBe("agencyArray");
+  });
+
+  it("still parses an array whose first item is a call", () => {
+    expect(parseExpr("[f(x), g(y)]").type).toBe("agencyArray");
+  });
+
+  it("still parses an array containing the identifier format", () => {
+    // guards against matching the bare prefix `for` inside a longer name
+    expect(parseExpr("[format, other]").type).toBe("agencyArray");
+  });
+
+  // Half-typed comprehensions are now a thing users and agents will
+  // produce constantly. They do NOT error: the array parser accepts
+  // whitespace-separated items and `in` is a binary operator, so these
+  // have always parsed as arrays of variable names (probed - this is
+  // pre-existing behavior, not something this feature introduced). Pin
+  // that they at least never become half-baked comprehension nodes, so
+  // a later improvement (a real diagnostic) shows up as a diff.
+  it.each([["[x for x in]"], ["[for x in xs]"], ["[x for in xs]"]])(
+    "parses the malformed comprehension %s as an array, not a comprehension",
+    (src) => {
+      expect(parseFails(src)).toBe(false);
+      expect(parseExpr(src).type).toBe("agencyArray");
+    },
+  );
+
+  // tarsec's `spaces` matches newlines too, so a comprehension broken
+  // across lines parses fine. Pinned deliberately: the guide can promise
+  // multi-line works, and a regression here (e.g. swapping in a
+  // same-line-only whitespace parser) is visible as a diff.
+  it("parses a multi-line comprehension", () => {
+    const node = parseExpr("[f(x)\n    for x in xs]");
+    expect(node.type).toBe("comprehension");
+    expect(node.itemVar).toBe("x");
+  });
+});

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -107,6 +107,7 @@ import {
 import { EffectDeclaration } from "../types/effectDeclaration.js";
 import { GraphNodeDefinition } from "../types/graphNode.js";
 import { ForLoop } from "../types/forLoop.js";
+import { Comprehension } from "../types/comprehension.js";
 import { WhileLoop } from "../types/whileLoop.js";
 import { ParallelBlock, SeqBlock } from "../types/parallelBlock.js";
 import { IfElse } from "../types/ifElse.js";
@@ -2713,6 +2714,14 @@ const baseAtom: Parser<Expression> = or(
   schemaAccessParser,
   schemaExpressionParser,
   lazy(() => interruptExprParser),
+  // MUST precede agencyArrayParser, valueAccessParser, and literalParser.
+  // Ahead of agencyArrayParser because that parser would consume `[f(x)`
+  // and then fail at `for`. Ahead of the other two because `fork [...]`
+  // starts with an identifier, which valueAccessParser/literalParser
+  // would happily match as a plain name, leaving the comprehension
+  // unmatched. A future reorder that only preserves the first constraint
+  // breaks the fork form while the sequential form keeps passing.
+  lazy(() => comprehensionParser),
   lazy(() => agencyArrayParser),
   lazy(() => agencyObjectParser),
   lazy(() => booleanParser),
@@ -4613,6 +4622,88 @@ export const destructiveBlockParser: Parser<SeqBlock> = label("a destructive blo
   ),
 )));
 
+/** The iteration binder: an item name or destructuring pattern, plus an
+ *  optional `, index` second binder. Shared between forLoopParser and
+ *  comprehensionParser so `for (x, i in xs)` and `[f(x) for x, i in xs]`
+ *  can never drift apart in what they accept. Captures `itemVar` and
+ *  (optionally) `indexVar`. */
+const iterationBinderFragment: Parser<any>[] = [
+  capture(
+    or(
+      lazy(() => arrayBindingPatternParser),
+      lazy(() => objectBindingPatternParser),
+      many1WithJoin(varNameChar),
+    ),
+    "itemVar",
+  ),
+  optional(
+    captureCaptures(
+      seqC(
+        optionalSpaces,
+        char(","),
+        optionalSpaces,
+        capture(many1WithJoin(varNameChar), "indexVar"),
+      ),
+    ),
+  ),
+];
+
+export const comprehensionParser: Parser<Comprehension> = label(
+  "a list comprehension",
+  withLoc(
+    memo(
+      "comprehensionParser",
+      seqC(
+        set("type", "comprehension"),
+        capture(
+          map(optional(seqR(str("fork"), spaces)), (r) => r !== null),
+          "parallel",
+        ),
+        char("["),
+        optionalSpacesOrNewline,
+        capture(
+          lazy(() => exprParser),
+          "expression",
+        ),
+        // `optionalSpaces` BEFORE each keyword, required `spaces` AFTER.
+        // Before must be optional because exprParser eats trailing
+        // whitespace after a call (`f(x) ` leaves rest `for...`) but not
+        // after a bare name (`x ` leaves rest ` for...`) - requiring
+        // whitespace here broke every call-bodied comprehension. After
+        // must be required so `for` stays a whole word: `[format, other]`
+        // fails at str("for") because exprParser greedily consumed the
+        // full identifier `format`, and `forx` fails the required space.
+        optionalSpaces,
+        str("for"),
+        spaces,
+        ...iterationBinderFragment,
+        optionalSpaces,
+        str("in"),
+        spaces,
+        capture(
+          lazy(() => exprParser),
+          "iterable",
+        ),
+        optional(
+          captureCaptures(
+            seqC(
+              optionalSpaces,
+              str("if"),
+              spaces,
+              capture(
+                lazy(() => exprParser),
+                "condition",
+              ),
+            ),
+          ),
+        ),
+        optionalSpacesOrNewline,
+        char("]"),
+      ),
+    ),
+  ),
+);
+
 export const forLoopParser: Parser<ForLoop> = label("a for loop", withLoc(memo(
   "forLoopParser",
   seqC(
@@ -4626,24 +4717,7 @@ export const forLoopParser: Parser<ForLoop> = label("a for loop", withLoc(memo(
         "expected `(` to open for loop condition",
         optional(or(str("let"), str("const"))),
         optionalSpaces,
-        capture(
-          or(
-            lazy(() => arrayBindingPatternParser),
-            lazy(() => objectBindingPatternParser),
-            many1WithJoin(varNameChar),
-          ),
-          "itemVar",
-        ),
-        optional(
-          captureCaptures(
-            seqC(
-              optionalSpaces,
-              char(","),
-              optionalSpaces,
-              capture(many1WithJoin(varNameChar), "indexVar"),
-            ),
-          ),
-        ),
+        ...iterationBinderFragment,
         optionalSpaces,
         or(str("in"), str("of")),
         spaces,

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -4648,6 +4648,9 @@ const iterationBinderFragment: Parser<any>[] = [
   ),
 ];
 
+// Cast for the same reason as forLoopParser below: the shared
+// iterationBinderFragment is Parser<any>[], so seqC cannot infer the
+// itemVar/indexVar captures through the spread.
 export const comprehensionParser: Parser<Comprehension> = label(
   "a list comprehension",
   withLoc(
@@ -4701,9 +4704,14 @@ export const comprehensionParser: Parser<Comprehension> = label(
         char("]"),
       ),
     ),
-  ),
+  ) as unknown as Parser<Comprehension>,
 );
 
+// The `as unknown as` cast exists because iterationBinderFragment is typed
+// Parser<any>[] (tarsec's seqC cannot infer captures through a spread), so
+// the inferred capture object loses `itemVar`/`indexVar`. The fragment
+// really does capture both - comprehension.test.ts and the for-loop suite
+// pin it at runtime.
 export const forLoopParser: Parser<ForLoop> = label("a for loop", withLoc(memo(
   "forLoopParser",
   seqC(
@@ -4738,7 +4746,7 @@ export const forLoopParser: Parser<ForLoop> = label("a for loop", withLoc(memo(
       ),
     ),
   ),
-)));
+)) as unknown as Parser<ForLoop>);
 
 // Parses: name, name?, name: type, name?: type, name = default, name? = default, name: type = default
 export const functionParameterParser: Parser<FunctionParameter> = memo(

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -4668,19 +4668,22 @@ export const comprehensionParser: Parser<Comprehension> = label(
           lazy(() => exprParser),
           "expression",
         ),
-        // `optionalSpaces` BEFORE each keyword, required `spaces` AFTER.
-        // Before must be optional because exprParser eats trailing
+        // `optionalSpacesOrNewline` BEFORE each keyword, required `spaces`
+        // AFTER. Before must be optional because exprParser eats trailing
         // whitespace after a call (`f(x) ` leaves rest `for...`) but not
         // after a bare name (`x ` leaves rest ` for...`) - requiring
-        // whitespace here broke every call-bodied comprehension. After
-        // must be required so `for` stays a whole word: `[format, other]`
-        // fails at str("for") because exprParser greedily consumed the
-        // full identifier `format`, and `forx` fails the required space.
-        optionalSpaces,
+        // whitespace here broke every call-bodied comprehension. It must
+        // cross newlines (optionalSpaces is spaces/tabs only) or a
+        // comprehension could only break lines after a call, never before
+        // `in`/`if`. After must be required so `for` stays a whole word:
+        // `[format, other]` fails at str("for") because exprParser
+        // greedily consumed the full identifier `format`, and `forx`
+        // fails the required space.
+        optionalSpacesOrNewline,
         str("for"),
         spaces,
         ...iterationBinderFragment,
-        optionalSpaces,
+        optionalSpacesOrNewline,
         str("in"),
         spaces,
         capture(
@@ -4690,7 +4693,7 @@ export const comprehensionParser: Parser<Comprehension> = label(
         optional(
           captureCaptures(
             seqC(
-              optionalSpaces,
+              optionalSpacesOrNewline,
               str("if"),
               spaces,
               capture(

--- a/packages/agency-lang/lib/prelude.ts
+++ b/packages/agency-lang/lib/prelude.ts
@@ -29,6 +29,7 @@ export const PRELUDE_NAMES: readonly string[] = [
   "sleep",
   "saveDraft",
   "_guard",
+  "_pairsOf",
   "read",
   "write",
   "writeBinary",

--- a/packages/agency-lang/lib/prelude.ts
+++ b/packages/agency-lang/lib/prelude.ts
@@ -38,6 +38,7 @@ export const PRELUDE_NAMES: readonly string[] = [
   "callback",
   // Array helpers (moved from std::array into std::index).
   "map",
+  "mapWithIndex",
   "filter",
   "exclude",
   "find",

--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -22,6 +22,7 @@ import {
 import type { ThreadStore } from "./state/threadStore.js";
 import type { HandlerFn } from "./types.js";
 import { matchValName } from "../matchVal.js";
+import { classifyIterable } from "../utils/iteration.js";
 
 /** Options bag for the new `Runner.thread(id, method, opts, callback)`
  *  signature. All fields are optional; emitter passes only the ones
@@ -969,16 +970,21 @@ export class Runner {
 
     this.frame.locals[iterKey] = this.frame.locals[iterKey] ?? 0;
 
-    // Records (plain objects) iterate by key. Arrays iterate by element.
-    // Anything else (null, undefined, primitives) is treated as an empty
-    // iterable, matching how a JS `for...of` over a non-iterable would
-    // simply do nothing rather than crash mid-flow.
+    // Records iterate by key, arrays by element, everything else is empty.
+    // The CLASSIFICATION is shared with `_pairsOf` so comprehensions and
+    // `for` loops cannot disagree about what is iterable
+    // (utils/iteration.ts). The iteration itself stays exactly as it was:
+    // for arrays `iterable` is the caller's own array, and the loop below
+    // re-reads `.length` each step, so a body that appends to the array it
+    // is iterating keeps going. Materializing a snapshot here would break
+    // that (pinned by tests/agency/for-loop-live-iteration.agency).
+    const shape = classifyIterable(items_);
     let iterable: any[];
     let isRecord = false;
-    if (Array.isArray(items_)) {
-      iterable = items_;
-    } else if (items_ != null && typeof items_ === "object") {
-      iterable = Object.keys(items_);
+    if (shape.kind === "array") {
+      iterable = items_ as any[];
+    } else if (shape.kind === "record") {
+      iterable = shape.keys;
       isRecord = true;
     } else {
       iterable = [];

--- a/packages/agency-lang/lib/stdlib/agency.comprehension.test.ts
+++ b/packages/agency-lang/lib/stdlib/agency.comprehension.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { _getNodesOfType } from "./agency.js";
+
+describe("std::agency walks comprehension contents", () => {
+  it("finds a call written inside a comprehension body", () => {
+    const src = [
+      "node main() {",
+      "  const r = [double(x) for x in xs]",
+      "}",
+    ].join("\n");
+
+    const calls = _getNodesOfType(src, ["functionCall"]) as any[];
+    const names = calls.map((c) => c.functionName);
+    expect(names).toContain("double");
+  });
+
+  it("finds a call in the iterable and in the filter", () => {
+    const src = [
+      "node main() {",
+      "  const r = [x for x in getItems() if keep(x)]",
+      "}",
+    ].join("\n");
+
+    const names = (_getNodesOfType(src, ["functionCall"]) as any[]).map(
+      (c) => c.functionName,
+    );
+    expect(names).toContain("getItems");
+    expect(names).toContain("keep");
+  });
+});

--- a/packages/agency-lang/lib/stdlib/builtins.ts
+++ b/packages/agency-lang/lib/stdlib/builtins.ts
@@ -1,6 +1,7 @@
 import * as readline from "readline";
 import process from "process";
 import { readFile, writeFile, appendFile } from "fs/promises";
+import { classifyIterable } from "../utils/iteration.js";
 import { existsSync } from "fs";
 import { execFile } from "child_process";
 import { promisify } from "util";
@@ -324,6 +325,25 @@ export function _values(obj: any): any[] {
 
 export function _entries(obj: any): { key: string; value: any }[] {
   return Object.entries(obj).map(([key, value]) => ({ key, value }));
+}
+
+/** The two-binder comprehension lowering target. Shares its notion of
+ *  "what is iterable" with `Runner.loop` via classifyIterable, so
+ *  `[f(x,i) for x, i in src]` and `for (x, i in src)` cannot disagree.
+ *
+ *  Unlike the loop, this genuinely does build a list: the comprehension
+ *  desugars to `map(_pairsOf(src))`, and `map` needs a real array. Only
+ *  the classification is shared, which is the part that would drift. */
+export function _pairsOf(src: unknown): unknown[][] {
+  const shape = classifyIterable(src);
+  if (shape.kind === "array") {
+    return (src as unknown[]).map((item, index) => [item, index]);
+  }
+  if (shape.kind === "record") {
+    const record = src as Record<string, unknown>;
+    return shape.keys.map((key) => [key, record[key]]);
+  }
+  return [];
 }
 
 export function _range(startOrN: number, end?: number): number[] {

--- a/packages/agency-lang/lib/stdlib/builtins.ts
+++ b/packages/agency-lang/lib/stdlib/builtins.ts
@@ -337,7 +337,15 @@ export function _entries(obj: any): { key: string; value: any }[] {
 export function _pairsOf(src: unknown): unknown[][] {
   const shape = classifyIterable(src);
   if (shape.kind === "array") {
-    return (src as unknown[]).map((item, index) => [item, index]);
+    // Built by index, not Array.prototype.map: map skips sparse-array
+    // holes and leaves holes in its result, while Runner.loop visits
+    // every index up to length (yielding undefined). Index-building
+    // keeps the two agreeing on sparse arrays too.
+    const arr = src as unknown[];
+    return Array.from({ length: arr.length }, (_, index) => [
+      arr[index],
+      index,
+    ]);
   }
   if (shape.kind === "record") {
     const record = src as Record<string, unknown>;

--- a/packages/agency-lang/lib/types.ts
+++ b/packages/agency-lang/lib/types.ts
@@ -100,7 +100,12 @@ export type Expression =
   | InterruptStatement
   | BlockArgument
   | IsExpression
-  | MatchBlock;
+  | MatchBlock
+  // Pre-lowering only: comprehensionDesugar rewrites every Comprehension
+  // into map/filter/fork calls inside parseAgency's `lower` block, so
+  // stages after the parser only meet one on a `lower: false` parse
+  // (formatter, std::agency AST walks).
+  | Comprehension;
 
 /**
  * Runtime set of every `type` string in the `Expression` union above. Kept
@@ -133,6 +138,7 @@ export const EXPRESSION_NODE_TYPES: readonly string[] = [
   "blockArgument",
   "isExpression",
   "matchBlock",
+  "comprehension",
 ];
 
 /** True when `node` is an `Expression` (per `EXPRESSION_NODE_TYPES`). */

--- a/packages/agency-lang/lib/types.ts
+++ b/packages/agency-lang/lib/types.ts
@@ -32,6 +32,7 @@ import { AwaitPending } from "./types/awaitPending.js";
 import { HandleBlock } from "./types/handleBlock.js";
 import { FinalizeBlock } from "./types/finalizeBlock.js";
 import { GuardBlock } from "./types/guardBlock.js";
+import { Comprehension } from "./types/comprehension.js";
 import { DebuggerStatement } from "./types/debuggerStatement.js";
 import { WithModifier } from "./types/withModifier.js";
 import { StaticStatement } from "./types/staticStatement.js";
@@ -72,6 +73,7 @@ export * from "./types/forLoop.js";
 export * from "./types/handleBlock.js";
 export * from "./types/finalizeBlock.js";
 export * from "./types/guardBlock.js";
+export * from "./types/comprehension.js";
 export * from "./types/keyword.js";
 export * from "./types/debuggerStatement.js";
 export * from "./types/blockArgument.js";
@@ -338,6 +340,7 @@ export type AgencyNode =
   | HandleBlock
   | FinalizeBlock
   | GuardBlock
+  | Comprehension
   | WithModifier
   | StaticStatement
   | DebuggerStatement

--- a/packages/agency-lang/lib/types/comprehension.ts
+++ b/packages/agency-lang/lib/types/comprehension.ts
@@ -1,0 +1,28 @@
+import type { Expression } from "../types.js";
+import type { BaseNode } from "./base.js";
+import type { ArrayPattern, ObjectPattern } from "./pattern.js";
+
+/** A list comprehension, `[expr for x in xs if cond]`, or its concurrent
+ *  form `fork [expr for x in xs if cond]` (spec:
+ *  docs/superpowers/specs/2026-07-18-list-comprehensions-design.md).
+ *
+ *  The binder fields mirror ForLoop deliberately: `itemVar` may be a name
+ *  or a destructuring pattern, and `indexVar` is the optional second
+ *  binder, meaning the index for arrays and the value for objects.
+ *  Reusing that shape means the comprehension inherits the loop's
+ *  semantics rather than inventing its own.
+ *
+ *  Lifecycle: the parser and agencyGenerator (for `agency fmt`) see this
+ *  node; comprehensionDesugar rewrites it into map/filter/fork calls
+ *  inside parseAgency's `lower` block, so the checker, the builder, and
+ *  the runtime never see it. */
+export type Comprehension = BaseNode & {
+  type: "comprehension";
+  expression: Expression;
+  itemVar: string | ObjectPattern | ArrayPattern;
+  indexVar?: string;
+  iterable: Expression;
+  condition?: Expression;
+  /** True for `fork [...]`. Selects the desugar target: fork vs map. */
+  parallel: boolean;
+};

--- a/packages/agency-lang/lib/utils/iteration.test.ts
+++ b/packages/agency-lang/lib/utils/iteration.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { classifyIterable } from "./iteration.js";
+
+describe("classifyIterable", () => {
+  it("classifies arrays", () => {
+    expect(classifyIterable(["a", "b"])).toEqual({ kind: "array" });
+    expect(classifyIterable([])).toEqual({ kind: "array" });
+  });
+
+  it("classifies objects and returns their keys", () => {
+    expect(classifyIterable({ h: "1", p: "2" })).toEqual({
+      kind: "record",
+      keys: ["h", "p"],
+    });
+    expect(classifyIterable({})).toEqual({ kind: "record", keys: [] });
+  });
+
+  it.each([[null], [undefined], [42], ["abc"], [true]])(
+    "classifies %p as not iterable",
+    (input) => {
+      expect(classifyIterable(input)).toEqual({ kind: "none" });
+    },
+  );
+
+  it("does not copy the array it classifies", () => {
+    // the classifier must not snapshot - Runner.loop depends on holding
+    // the caller's array by reference so appends mid-loop are seen
+    const xs = [1, 2];
+    const shape = classifyIterable(xs);
+    expect(shape).toEqual({ kind: "array" });
+    expect(Object.keys(shape)).toEqual(["kind"]);
+  });
+});

--- a/packages/agency-lang/lib/utils/iteration.ts
+++ b/packages/agency-lang/lib/utils/iteration.ts
@@ -11,9 +11,10 @@
  * PR #595 collapsed the equivalent hand-copied drift in the prelude list.
  *
  * Arrays iterate by element. Non-null objects iterate by key. Everything
- * else — null, undefined, numbers, STRINGS — iterates nothing, matching
- * how a JS `for...of` over a non-iterable simply does nothing rather than
- * crashing mid-flow.
+ * else — null, undefined, numbers, STRINGS — iterates nothing. That is an
+ * Agency semantic choice (a JS `for...of` over a non-iterable would
+ * throw): agent code frequently feeds an LLM-shaped value into a loop,
+ * and iterating nothing beats crashing mid-flow.
  *
  * This returns a CLASSIFICATION, deliberately, not a built list of pairs.
  * `Runner.loop` holds the caller's array by reference and re-reads its

--- a/packages/agency-lang/lib/utils/iteration.ts
+++ b/packages/agency-lang/lib/utils/iteration.ts
@@ -1,0 +1,41 @@
+/**
+ * classifyIterable — the single source of truth for "what Agency considers
+ * iterable".
+ *
+ * Consumed by:
+ *   - `Runner.loop` (runtime/runner.ts) — the `for (a, b in x)` statement
+ *   - `_pairsOf` (stdlib/builtins.ts) — two-binder list comprehensions
+ *
+ * Both must agree, or `[f(x) for x in src]` behaves differently from
+ * `for (x in src)`. Keeping one implementation is why this file exists;
+ * PR #595 collapsed the equivalent hand-copied drift in the prelude list.
+ *
+ * Arrays iterate by element. Non-null objects iterate by key. Everything
+ * else — null, undefined, numbers, STRINGS — iterates nothing, matching
+ * how a JS `for...of` over a non-iterable simply does nothing rather than
+ * crashing mid-flow.
+ *
+ * This returns a CLASSIFICATION, deliberately, not a built list of pairs.
+ * `Runner.loop` holds the caller's array by reference and re-reads its
+ * length each step, so a loop body that appends to the array it is
+ * iterating keeps going (verified: `xs.push(99)` mid-loop yields
+ * `1,2,3,99`). Returning a materialized snapshot would freeze the length
+ * at entry and quietly break that, and would allocate a pair per item on
+ * every `for` in every program. Sharing only the classification keeps the
+ * anti-drift property — which is the actual goal — at zero behavioral or
+ * allocation cost.
+ */
+export type IterationShape =
+  | { kind: "array" }
+  | { kind: "record"; keys: string[] }
+  | { kind: "none" };
+
+export function classifyIterable(src: unknown): IterationShape {
+  if (Array.isArray(src)) {
+    return { kind: "array" };
+  }
+  if (src != null && typeof src === "object") {
+    return { kind: "record", keys: Object.keys(src) };
+  }
+  return { kind: "none" };
+}

--- a/packages/agency-lang/lib/utils/node.ts
+++ b/packages/agency-lang/lib/utils/node.ts
@@ -63,6 +63,14 @@ export function expressionChildren(node: AgencyNode): AgencyNode[] {
       return [node.condition];
     case "forLoop":
       return [node.iterable];
+    case "comprehension":
+      // The binder is deliberately excluded: it is a binding site, not a
+      // sub-expression, matching how forLoop returns only its iterable.
+      return [
+        node.expression,
+        node.iterable,
+        ...(node.condition ? [node.condition] : []),
+      ];
     case "functionCall":
     case "interruptStatement":
       return node.arguments.map(unwrapCallArg);
@@ -407,6 +415,20 @@ export function* walkNodes(
       yield* walkNodes([node.condition], [...ancestors, node], scopes);
     } else if (node.type === "forLoop") {
       yield* walkNodes([node.iterable as AgencyNode], [...ancestors, node], scopes);
+    } else if (node.type === "comprehension") {
+      // Only reachable on `lower: false` parses (formatter, std::agency's
+      // agent-facing AST walk) — the compile path desugars comprehensions
+      // away before any walk. The binder is a binding site, not a
+      // sub-expression, so it is not descended into, matching forLoop.
+      yield* walkNodes(
+        [
+          node.expression,
+          node.iterable,
+          ...(node.condition ? [node.condition] : []),
+        ],
+        [...ancestors, node],
+        scopes,
+      );
     } else if (node.type === "whileLoop") {
       yield* walkNodes([node.condition], [...ancestors, node], scopes);
     } else if (node.type === "messageThread") {

--- a/packages/agency-lang/stdlib/index.agency
+++ b/packages/agency-lang/stdlib/index.agency
@@ -319,6 +319,17 @@ export def _pairsOf(src: any): any[] {
   return _pairsOfImpl(src)
 }
 
+export def mapWithIndex(arr: any[], func: (any, any) -> any): any[] {
+  """
+  Apply a function to each item of an array along with its index, and
+  return a new array of the results.
+
+  @param arr - The array to map over
+  @param func - Called with the item and its zero-based index
+  """
+  return map(_pairsOf(arr)) as pair { return func(pair[0], pair[1]) }
+}
+
 export def filter(arr: any[], func: (any) -> any): any[] {
   """
   Return a new array containing only the elements for which the function returns true.

--- a/packages/agency-lang/stdlib/index.agency
+++ b/packages/agency-lang/stdlib/index.agency
@@ -14,6 +14,7 @@ import {
   _range,
   _input,
   _sleep,
+  _pairsOf as _pairsOfImpl,
  } from "agency-lang/stdlib-lib/builtins.js"
 import { _resolve } from "agency-lang/stdlib-lib/path.js"
 import {
@@ -304,6 +305,18 @@ export def map(arr: any[], func: (any) -> any): any[] {
     newArr.push(func(item))
   }
   return newArr
+}
+
+export def _pairsOf(src: any): any[] {
+  """
+  Internal: the lowering target for two-binder list comprehensions - use
+  a comprehension, not this function. Returns pairs in binder order,
+  matching the `for` loop: arrays give [item, index], objects give
+  [key, value], and anything else gives an empty array.
+
+  @param src - An array, an object, or anything else
+  """
+  return _pairsOfImpl(src)
 }
 
 export def filter(arr: any[], func: (any) -> any): any[] {

--- a/packages/agency-lang/tests/agency/comprehensions/basic.agency
+++ b/packages/agency-lang/tests/agency/comprehensions/basic.agency
@@ -1,0 +1,43 @@
+def double(x: number): number {
+  return x * 2
+}
+
+def isEven(x: number): boolean {
+  return x % 2 == 0
+}
+
+// a comprehension inside a def, not just a node
+def sumDoubled(xs: number[]): number {
+  return reduce([double(x) for x in xs], 0, \(acc, x) -> acc + x)
+}
+
+node main(): string {
+  const xs = [1, 2, 3, 4]
+
+  const doubled = [double(x) for x in xs]
+  const evens = [double(x) for x in xs if isEven(x)]
+
+  // call-argument position. There is NO length() function in the
+  // language (arrays only have the .length property), so the counting
+  // is done with reduce, which also keeps the comprehension in a real
+  // argument slot - the rev-1 coverage bug this position guards.
+  const nested = reduce([double(x) for x in xs], 0, \(acc, x) -> acc + 1)
+
+  // object literal field
+  const wrapped = { items: [double(x) for x in xs] }
+
+  // inside a block argument body, which exercises the bodySlots path
+  const inBlock = map([1, 2]) as n {
+    const inner = [double(y) for y in xs]
+    return inner.length
+  }
+
+  // nested comprehension
+  const grid = [[double(y) for y in row] for row in [[1, 2], [3]]]
+
+  // empty and degenerate sources
+  const fromEmpty = [double(x) for x in []]
+  const noMatch = [double(x) for x in xs if x > 100]
+
+  return "${doubled[0]},${doubled[3]}|${evens[0]},${evens[1]}|${nested}|${wrapped.items[1]}|${inBlock[0]}|${grid[0][1]}|${fromEmpty.length},${noMatch.length}|${sumDoubled(xs)}"
+}

--- a/packages/agency-lang/tests/agency/comprehensions/basic.test.json
+++ b/packages/agency-lang/tests/agency/comprehensions/basic.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "description": "single-binder comprehensions in every expression position the spec advertises",
+      "expectedOutput": "\"2,8|4,8|4|4|4|4|0,0|20\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/comprehensions/binders.agency
+++ b/packages/agency-lang/tests/agency/comprehensions/binders.agency
@@ -1,0 +1,36 @@
+node main(): string {
+  const xs = ["a", "b", "c", "d"]
+
+  // two-binder over an array: second binder is the INDEX
+  const indexed = ["${i}:${x}" for x, i in xs]
+
+  // the Python-semantics case: indices are positions in the SOURCE,
+  // so filtering out "b" leaves indices 0, 2, 3 - NOT 0, 1, 2
+  const filtered = ["${i}:${x}" for x, i in xs if x != "b"]
+
+  // two-binder over an object: second binder is the VALUE
+  const config = { host: "local", port: "80" }
+  const lines = ["${k}=${v}" for k, v in config]
+
+  // filtering over an object goes through a separate code path
+  const kept = ["${k}" for k, v in config if v != "80"]
+
+  // object destructuring binder
+  const people = [{ name: "Alice", age: 30 }, { name: "Bob", age: 25 }]
+  const greets = ["Hi ${name}" for {name, age} in people]
+
+  // array destructuring binder
+  const pairs = [["x", 1], ["y", 2]]
+  const flat = ["${a}${b}" for [a, b] in pairs]
+
+  // destructuring FIRST binder combined with an index binder
+  const both = ["${name}@${i}" for {name}, i in people]
+
+  // two-binder plus fork
+  const forked = fork ["${i}:${x}" for x, i in xs]
+
+  // non-iterable source gives an empty array, matching for loops
+  const empty = [x for x in null]
+
+  return "${filtered[0]},${filtered[1]},${filtered[2]}|${lines[0]}|${kept[0]},${kept.length}|${greets[1]}|${flat[1]}|${both[1]}|${forked[3]}|${indexed[3]}|${empty.length}"
+}

--- a/packages/agency-lang/tests/agency/comprehensions/binders.test.json
+++ b/packages/agency-lang/tests/agency/comprehensions/binders.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "description": "two-binder, destructuring, object filtering, and fork composition with source-position indices",
+      "expectedOutput": "\"0:a,2:c,3:d|host=local|host,1|Hi Bob|y2|Bob@1|3:d|3:d|0\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/comprehensions/fork-interrupt.agency
+++ b/packages/agency-lang/tests/agency/comprehensions/fork-interrupt.agency
@@ -1,0 +1,19 @@
+def risky(x: number): number {
+  raise interrupt("approve", { value: x })
+  return x * 2
+}
+
+node main(): string {
+  let out = ""
+  handle {
+    const results = fork [risky(x) for x in [1, 2, 3]]
+    const rejected = if isFailure(results[1]) then "fail" else "ok"
+    out = "${results.length}|${results[0]}|${rejected}|${results[2]}"
+  } with (d) {
+    if (d.data.value == 2) {
+      return reject()
+    }
+    return approve()
+  }
+  return out
+}

--- a/packages/agency-lang/tests/agency/comprehensions/fork-interrupt.test.json
+++ b/packages/agency-lang/tests/agency/comprehensions/fork-interrupt.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "description": "interrupts inside a fork comprehension body resume per branch, matching the hand-written baseline",
+      "expectedOutput": "\"3|2|fail|6\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/comprehensions/fork-ordering.agency
+++ b/packages/agency-lang/tests/agency/comprehensions/fork-ordering.agency
@@ -1,0 +1,11 @@
+def slowDouble(x: number): number {
+  // item 1 sleeps longest, item 3 shortest, so completion order is the
+  // REVERSE of source order. Results must still come back by position.
+  sleep((4 - x) * 100)
+  return x * 2
+}
+
+node main(): string {
+  const ordered = fork [slowDouble(x) for x in [1, 2, 3]]
+  return "${ordered[0]},${ordered[1]},${ordered[2]}"
+}

--- a/packages/agency-lang/tests/agency/comprehensions/fork-ordering.test.json
+++ b/packages/agency-lang/tests/agency/comprehensions/fork-ordering.test.json
@@ -1,0 +1,12 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "description": "fork comprehension results arrive in source order, not completion order",
+      "expectedOutput": "\"2,4,6\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "timeoutMs": 30000
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/comprehensions/fork.agency
+++ b/packages/agency-lang/tests/agency/comprehensions/fork.agency
@@ -1,0 +1,35 @@
+let counter = 0
+
+def bump(x: number): number {
+  counter = counter + 1
+  return x * 2
+}
+
+def total(xs: number[]): number {
+  return reduce(xs, 0, \(acc, x) -> acc + x)
+}
+
+node main(): string {
+  const xs = [1, 2, 3]
+
+  const doubled = fork [bump(x) for x in xs]
+
+  // fork isolates globals per branch and discards them at the join, so
+  // the three increments above are thrown away and counter is still 0.
+  // Probed against the hand-written fork form before pinning. This is
+  // the assertion that proves a real fork, not a Promise.all. It is
+  // guarded by asserting `doubled` too, so it cannot pass by the body
+  // never running at all.
+  const afterFork = counter
+
+  // the same body through the explicit construct, for comparison
+  const viaConstruct = fork(xs) as x { return bump(x) }
+
+  // argument position - what Task 1 unblocks
+  const summed = total(fork [bump(x) for x in xs])
+
+  // filter plus fork
+  const filtered = fork [bump(x) for x in xs if x != 2]
+
+  return "${doubled[0]},${doubled[1]},${doubled[2]}|${afterFork}|${viaConstruct[2]}|${summed}|${filtered[0]},${filtered[1]}"
+}

--- a/packages/agency-lang/tests/agency/comprehensions/fork.test.json
+++ b/packages/agency-lang/tests/agency/comprehensions/fork.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "description": "fork comprehensions inherit branch isolation and work in argument position",
+      "expectedOutput": "\"2,4,6|0|6|12|2,6\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/for-loop-live-iteration.agency
+++ b/packages/agency-lang/tests/agency/for-loop-live-iteration.agency
@@ -1,0 +1,17 @@
+node main(): string {
+  const xs = [1, 2, 3]
+  let seen = ""
+  let steps = 0
+  for (x in xs) {
+    seen = seen + "${x},"
+    steps = steps + 1
+    // append once, on the last original element. A snapshotted
+    // iteration stops at 3; a live one picks up 99.
+    if (x == 3) {
+      if (steps < 10) {
+        xs.push(99)
+      }
+    }
+  }
+  return seen
+}

--- a/packages/agency-lang/tests/agency/for-loop-live-iteration.test.json
+++ b/packages/agency-lang/tests/agency/for-loop-live-iteration.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "description": "for loops iterate arrays live, so an append during the loop is visited",
+      "expectedOutput": "\"1,2,3,99,\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/fork-arg-position.agency
+++ b/packages/agency-lang/tests/agency/fork-arg-position.agency
@@ -1,0 +1,21 @@
+def double(x: number): number {
+  return x * 2
+}
+
+def total(xs: number[]): number {
+  return reduce(xs, 0, \(acc, x) -> acc + x)
+}
+
+node main(): string {
+  // fork as a function ARGUMENT - this is what currently crashes
+  const summed = total(fork([1, 2, 3]) as x { return double(x) })
+
+  // race gets the same fix, and is otherwise untested
+  const first = total([race([5]) as x { return double(x) }])
+
+  // regression guard: a bare function reference as an argument must
+  // still be passed as a reference, not called
+  const doubled = map([1, 2, 3], double)
+
+  return "${summed}|${first}|${doubled[0]},${doubled[1]},${doubled[2]}"
+}

--- a/packages/agency-lang/tests/agency/fork-arg-position.test.json
+++ b/packages/agency-lang/tests/agency/fork-arg-position.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "description": "fork and race work in argument position and bare function refs still work",
+      "expectedOutput": "\"12|10|2,4,6\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/fork-interrupt-baseline.agency
+++ b/packages/agency-lang/tests/agency/fork-interrupt-baseline.agency
@@ -1,0 +1,21 @@
+def risky(x: number): number {
+  raise interrupt("approve", { value: x })
+  return x * 2
+}
+
+node main(): string {
+  let out = ""
+  handle {
+    const results = fork([1, 2, 3]) as x {
+      return risky(x)
+    }
+    const rejected = if isFailure(results[1]) then "fail" else "ok"
+    out = "${results.length}|${results[0]}|${rejected}|${results[2]}"
+  } with (d) {
+    if (d.data.value == 2) {
+      return reject()
+    }
+    return approve()
+  }
+  return out
+}

--- a/packages/agency-lang/tests/agency/fork-interrupt-baseline.test.json
+++ b/packages/agency-lang/tests/agency/fork-interrupt-baseline.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "description": "interrupts raised inside a fork block body resume per branch; a rejected branch fails alone",
+      "expectedOutput": "\"3|2|fail|6\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/map-with-index.agency
+++ b/packages/agency-lang/tests/agency/map-with-index.agency
@@ -1,0 +1,14 @@
+node main(): string {
+  const names = ["a", "b", "c"]
+
+  // blocks.md:80 - inline block form
+  const inline = mapWithIndex(names, \(name, index) -> "${index}:${name}")
+
+  // blocks.md:55 - trailing block form. mapWithIndex passes BOTH
+  // arguments, so unlike `map` the second parameter is really bound.
+  const trailing = mapWithIndex(names) as (name, index) {
+    return "${index}-${name}"
+  }
+
+  return "${inline[0]},${inline[2]}|${trailing[0]},${trailing[2]}"
+}

--- a/packages/agency-lang/tests/agency/map-with-index.test.json
+++ b/packages/agency-lang/tests/agency/map-with-index.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "description": "mapWithIndex binds both parameters in inline and trailing block forms",
+      "expectedOutput": "\"0:a,2:c|0-a,2-c\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/pairs-of.agency
+++ b/packages/agency-lang/tests/agency/pairs-of.agency
@@ -1,0 +1,18 @@
+node main(): string {
+  const arrPairs = _pairsOf(["a", "b"])
+  const a0 = "${arrPairs[0][0]}${arrPairs[0][1]}"
+
+  const objPairs = _pairsOf({ host: "local", port: "80" })
+  const o0 = "${objPairs[0][0]}=${objPairs[0][1]}"
+
+  // non-iterables give an empty array, matching Runner.loop, NOT an error.
+  // A string is the interesting one: it falls to the empty branch, so
+  // `[c for c in "abc"]` iterates nothing. Pinned deliberately - someone
+  // will expect characters.
+  const fromNull = _pairsOf(null)
+  const fromNum = _pairsOf(42)
+  const fromStr = _pairsOf("abc")
+  const fromEmpty = _pairsOf([])
+
+  return "${a0}|${o0}|${fromNull.length},${fromNum.length},${fromStr.length},${fromEmpty.length}"
+}

--- a/packages/agency-lang/tests/agency/pairs-of.test.json
+++ b/packages/agency-lang/tests/agency/pairs-of.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "description": "_pairsOf mirrors Runner.loop for arrays, objects, strings, and non-iterables",
+      "expectedOutput": "\"a0|host=local|0,0,0,0\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}


### PR DESCRIPTION
Adds Python-shaped list comprehensions to Agency in two forms: `[expr for x in xs if cond]` (sequential) and `fork [expr for x in xs if cond]` (concurrent).

Plan: `docs/superpowers/plans/2026-07-19-list-comprehensions.md` (rev 4, three review rounds applied). Spec: `docs/superpowers/specs/2026-07-18-list-comprehensions-design.md`.

## How it works

The comprehension parses to its own AST node so `agency fmt` prints back exactly what the author wrote. A desugar pass inside `parseAgency` (before `lowerPatterns`) then rewrites it in place into ordinary `map` / `filter` / `fork` calls carrying block arguments - the exact shape those calls have when written by hand. After that point no later stage can tell the construct existed, so typing, codegen, interrupts, and fork branch semantics are inherited rather than reimplemented. Handler registration is untouched: interrupts raised inside a comprehension body flow through the same block machinery as hand-written fork blocks, and a test pins that the comprehension form behaves character-for-character like the hand-written baseline.

Binders mirror the `for` loop: a second binder is the index for arrays and the value for objects, and destructuring binders work. Two-binder forms pair items with indices BEFORE filtering, so indices are positions in the source (Python's enumerate-then-filter order). The pairing goes through a new `_pairsOf` prelude function whose notion of "what is iterable" is shared with `Runner.loop` via a new `classifyIterable` helper, so comprehensions and `for` loops can never drift apart.

## Also in this PR

- **Bug fix: `fork`/`race` in argument position crashed at runtime.** `total(fork(xs) as x { ... })` emitted `__call(fork, ...)` with `fork` an undefined identifier. The root cause was a hand-copied duplicate of the argument dispatch in `buildCallDescriptor`; the duplicate is collapsed onto `processResolvedArgs`, which now routes block-carrying `fork`/`race` arguments through `processForkCall`.
- **`mapWithIndex`**, which `docs/site/guide/blocks.md` documented but which did not exist. One declarative line over `_pairsOf`.
- **A pin for live `for`-loop iteration**: a body that appends to the array it iterates keeps going. Nothing tested this before, and the `Runner.loop` refactor here is exactly the kind of change that could silently break it.
- **Guide page** at `docs/site/guide/comprehensions.md`, plus cross-references from basic-syntax and partial-results.

## Deviations from the plan, all discovered by probing

- The parser needed `optionalSpacesOrNewline` (not required `spaces`) before the `for`/`in`/`if` keywords: exprParser eats trailing whitespace after a call but not after a bare name, so requiring whitespace broke every call-bodied comprehension.
- Multi-line comprehensions parse fine (the plan expected a single-line v1 limit). Pinned with tests at every keyword boundary and documented in the guide.
- Malformed comprehensions like `[x for x in]` do not error - the array parser has always accepted whitespace-separated items, so they parse as arrays of variable names. Pinned as-is; a real diagnostic is future work.
- `walkNodes` (std::agency's agent-facing AST walk) hand-enumerates its expression descent and needed its own `comprehension` case in addition to `expressionChildren` - without it, calls inside comprehension bodies were invisible to `getNodesOfType`.
- The "type error inside a comprehension body" location test uses a wrong-arity call: wrong-type calls cannot error because map's block parameter is `any`, exactly as in hand-written `map(xs) as x { ... }`.
- `state-isolation.md` was left unchanged: its three `push` sites are single statements demonstrating isolation, not loops a comprehension could replace.
- No docs build ran: VitePress is not installed anywhere in the workspace. All links in the new page were verified against the files on disk instead.

## Deferred

Nested cartesian loops (`for x in xs for y in ys`), record comprehensions, and a concurrency cap on `fork [...]` (`std::concurrency.concurrencyPool` covers the need now).

## Parse-time cost

Measured (review question): the desugar walk costs 2.15ms per pass over the full stdlib corpus (78 files, 545KB) against 763ms of total parse time with lowering on - 0.28%. Warm-make run-to-run variance on the same machine is measured in seconds, so the walk is noise at build level. The atom-chain insertion ahead of agencyArrayParser also adds no meaningful work: the array parser's retry after a failed comprehension attempt hits the memoized exprParser.

## Testing

- Full unit suite: 8735 passed. Structural linter clean. Diff audited against `docs/dev/anti-patterns.md`.
- New unit suites: parser (20 cases including ambiguity guards - every array literal in the language flows through the touched atom chain, and the generator fixtures show zero churn), desugar shape tests, loc stamping, formatter round-trip, `classifyIterable`, and a `std::agency` walk test.
- New execution tests (no LLM calls): every expression position the spec advertises, two-binder and destructuring forms with source-position indices, fork branch isolation (probed against the hand-written form before pinning: globals mutated in branches are discarded at the join), completion-order-inverted sleeps proving source-order results, and per-branch interrupt resumption matching the hand-written baseline exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
