### PR TITLE
Supervise the code subagent's long-running solves

### DIFF
--- a/packages/agency-lang/lib/agents/agency-agent/subagents/code.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/subagents/code.agency
@@ -22,6 +22,7 @@ import { setAgentCwd, getAgentCwd } from "std::index"
 import { skillsDir } from "std::skills"
 import { setMemoryId } from "std::memory"
 import { exec } from "std::shell"
+import { supervise } from "std::supervise"
 import { systemMessage } from "std::thread"
 
 import { withWebSearch, getSearchBackend } from "../lib/search.agency"
@@ -30,6 +31,7 @@ import { oracleAgent } from "./oracle.agency"
 import {
   reviewWrittenFiles,
  } from "./review.agency"
+import { progressCheck, resetSupervisor } from "./supervisor.agency"
 
 
 static const superpowersSkill = skillsDir("./skills/superpowers", "flat") with approve
@@ -102,6 +104,9 @@ let _first = true
 
 static const ESCALATE_MAX_COST = $20.00
 static const ESCALATE_MAX_TIME = 15m
+
+// How often a supervised solve pauses for the supervisor's progress check.
+static const SUPERVISE_EVERY = 5m
 
 type TriageResult = {
   path: "simple" | "complex";
@@ -194,6 +199,69 @@ def solve(task: string, context: string, agencyTask: boolean): Result<string> {
   )
 }
 
+/* The supervised block cannot hand a Result straight out: a stop mid-run
+   salvages the worker's saveDraft draft in place of the block's return
+   value, so the block normalizes to this plain shape and the flattener
+   sorts out what actually came back. */
+type SolveOutcome = {
+  ok: boolean;
+  summary: string
+}
+
+/** Turn what supervise hands back into the solve Result the callers expect.
+  Three shapes arrive here: a failure (the supervisor stopped a draftless
+  run, or maxTime passed), a SolveOutcome (the block ran to completion), or
+  a salvaged draft (the supervisor stopped the run after the worker saved
+  one — drafts are strings, so anything without a `summary` field is one).
+  Exported for tests. */
+export def flattenSolveOutcome(captured: Result<any>): Result<string> {
+  if (isFailure(captured)) {
+    return failure("${captured.error}")
+  }
+  const value = captured.value
+  if (value.summary == null) {
+    return success(
+      "The run was stopped early by the supervisor. Its last saved draft:\n\n${value}",
+    )
+  }
+  if (!value.ok) {
+    return failure(value.summary)
+  }
+  return success(value.summary)
+}
+
+/* solve, paused every SUPERVISE_EVERY for the supervisor's progress check:
+   continue, redirect the paused worker, or stop a run that two checks in a
+   row found stalled. This is what turns a 15-minute thrash into a 5-minute
+   course correction. */
+def supervisedSolve(
+  task: string,
+  context: string,
+  agencyTask: boolean,
+): Result<string> {
+  resetSupervisor()
+  const captured = supervise(
+    every: SUPERVISE_EVERY,
+    maxTime: ESCALATE_MAX_TIME,
+    check: progressCheck.partial(task: task),
+  ) {
+    // isFailure, not match: a match inside a block that pauses and resumes
+    // evaluates to null (see tests/agency/supervise/nestedGuardResume.agency).
+    const solved = solve(task: task, context: context, agencyTask: agencyTask)
+    if (isFailure(solved)) {
+      return {
+        ok: false,
+        summary: "${solved.error}"
+      }
+    }
+    return {
+      ok: true,
+      summary: solved.value
+    }
+  }
+  return flattenSolveOutcome(captured)
+}
+
 export def codeAgent(userMsg: string, agencyTask: boolean = false) {
   """
   This agent can help with all coding-related tasks,
@@ -222,7 +290,7 @@ export def codeAgent(userMsg: string, agencyTask: boolean = false) {
    failed. `escalate`, the mid-flight tool, still uses plannerAgent. */
 def escalateToExpert(task: string, agencyTask: boolean): string {
   const guidance = guidanceOrEmpty(consultExpert(task: task, agencyTask: agencyTask))
-  const solved = solve(
+  const solved = supervisedSolve(
     task: task,
     context: renderGuidance(guidance),
     agencyTask: agencyTask,
@@ -249,7 +317,7 @@ ${renderFeedback(checked)}
 
 Fix each problem exactly.
 """
-    const fixed = solve(task: fixMsg, context: "", agencyTask: agencyTask)
+    const fixed = supervisedSolve(task: fixMsg, context: "", agencyTask: agencyTask)
     if (!isFailure(fixed)) {
       summary = fixed.value
     }
@@ -262,7 +330,7 @@ Fix each problem exactly.
    working that way are the whole of ONE_SHOT_NOTE, so they travel as context
    rather than as a second copy of the loop. */
 def solveUnattended(task: string, agencyTask: boolean): string {
-  const solved = solve(task: task, context: ONE_SHOT_NOTE, agencyTask: agencyTask)
+  const solved = supervisedSolve(task: task, context: ONE_SHOT_NOTE, agencyTask: agencyTask)
   if (isFailure(solved)) {
     return "The task did not complete: ${solved.error}"
   }
@@ -279,7 +347,7 @@ ${renderFeedback(checked)}
 
 Fix each one; your work will be re-checked.
 """
-  const fixed = solve(task: fixMsg, context: ONE_SHOT_NOTE, agencyTask: agencyTask)
+  const fixed = supervisedSolve(task: fixMsg, context: ONE_SHOT_NOTE, agencyTask: agencyTask)
   if (isFailure(fixed)) {
     return solved.value
   }

--- a/packages/agency-lang/lib/agents/agency-agent/subagents/supervisor.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/subagents/supervisor.agency
@@ -62,9 +62,15 @@ export def applyThrashRule(
 ): SuperviseDecision {
   const previous = history[history.length - 1]
   if (verdict.assessment == "stalled" && previous != null && previous.assessment == "stalled") {
+    // The reviewer may have left message empty (it only has to fill it for
+    // redirect and stop), so the stop reason cannot lean on it being there.
+    let observation = ""
+    if (verdict.message != "") {
+      observation = " Last observation: ${verdict.message}"
+    }
     return {
       action: "stop",
-      message: "Stopped by the supervisor: two checks in a row found no progress. Last observation: ${verdict.message}"
+      message: "Stopped by the supervisor: two checks in a row found no progress.${observation}"
     }
   }
   return {
@@ -78,17 +84,27 @@ export def applyThrashRule(
   no workspace evidence, and the reviewer is told so rather than the check
   crashing the run. */
 def workspaceEvidence(): { text: string; filesChanged: number } {
-  const noEvidence = {
-    text: "(no git repository — no workspace evidence available; judge from the check history alone)",
+  // Two distinct ways to end up without evidence: the directory is not a
+  // repo, or git itself failed (an error, or policy rejecting the read).
+  // The reviewer is told which, so it never reasons from "there is no
+  // repo" when there is one.
+  const gitFailed = {
+    text: "(git could not be read — no workspace evidence available; judge from the check history alone)",
     filesChanged: 0
   }
   const isRepo = try gitIsRepo()
-  if (isFailure(isRepo) || !isRepo.value) {
-    return noEvidence
+  if (isFailure(isRepo)) {
+    return gitFailed
+  }
+  if (!isRepo.value) {
+    return {
+      text: "(no git repository — no workspace evidence available; judge from the check history alone)",
+      filesChanged: 0
+    }
   }
   const status = try gitStatus()
   if (isFailure(status)) {
-    return noEvidence
+    return gitFailed
   }
   const lines = []
   for (entry in status.value.entries) {

--- a/packages/agency-lang/lib/agents/agency-agent/subagents/supervisor.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/subagents/supervisor.agency
@@ -1,0 +1,198 @@
+/*
+ * The supervisor: the reviewer that std::supervise calls while the code
+ * subagent's solver is paused at a checkpoint.
+ *
+ * At each pause it gathers evidence of what the solver has actually done
+ * (git status and diff of the agent working directory), shows that evidence
+ * plus the history of earlier checks to a reviewer LLM, and turns the
+ * reviewer's verdict into a SuperviseDecision: continue, redirect with a
+ * course-correction message (injected into the solver's paused
+ * conversation), or stop.
+ *
+ * The check callback runs inside a guard handler, so it stays lean: direct
+ * git reads and one tool-free llm() call. Giving the reviewer its own tool
+ * loop would raise nested interrupts from inside a handler, which is more
+ * machinery than a five-minute pulse check needs.
+ */
+import { gitIsRepo, gitStatus, gitDiff } from "std::git"
+import { SuperviseDecision } from "std::supervise"
+
+import { truncate } from "../lib/utils.agency"
+
+// The raw patch can be huge; the reviewer needs the shape of the work, not
+// every hunk.
+static const MAX_PATCH_CHARS = 6000
+
+/** What the reviewer LLM returns for one check. `assessment` is its read of
+  the evidence; `action`/`message` are what it wants done about it. */
+export type SupervisorVerdict = {
+  assessment: "progressing" | "stalled";
+  action: "continue" | "redirect" | "stop";
+  message: string
+}
+
+/** One earlier check, as the next check sees it. */
+export type CheckRecord = {
+  minutes: number;
+  filesChanged: number;
+  assessment: string;
+  action: string;
+  message: string
+}
+
+// History of this run's checks. Reset at the start of each supervised solve;
+// each check appends its own record.
+let _history: CheckRecord[] = []
+
+export def resetSupervisor() {
+  _history = []
+}
+
+export def supervisorHistory(): CheckRecord[] {
+  return _history
+}
+
+/** Apply the thrash backstop to the reviewer's verdict: a second consecutive
+  "stalled" assessment becomes a stop no matter what action the reviewer
+  chose. One stalled check is a judgment call; two in a row means redirection
+  is not working and the run is burning budget. Pure, so tests can pin it. */
+export def applyThrashRule(
+  verdict: SupervisorVerdict,
+  history: CheckRecord[],
+): SuperviseDecision {
+  const previous = history[history.length - 1]
+  if (verdict.assessment == "stalled" && previous != null && previous.assessment == "stalled") {
+    return {
+      action: "stop",
+      message: "Stopped by the supervisor: two checks in a row found no progress. Last observation: ${verdict.message}"
+    }
+  }
+  return {
+    action: verdict.action,
+    message: verdict.message
+  }
+}
+
+/** What the solver has actually changed on disk, plus how many files that
+  is. Fails open: outside a git repo (or on any git error) there is simply
+  no workspace evidence, and the reviewer is told so rather than the check
+  crashing the run. */
+def workspaceEvidence(): { text: string; filesChanged: number } {
+  const noEvidence = {
+    text: "(no git repository — no workspace evidence available; judge from the check history alone)",
+    filesChanged: 0
+  }
+  const isRepo = try gitIsRepo()
+  if (isFailure(isRepo) || !isRepo.value) {
+    return noEvidence
+  }
+  const status = try gitStatus()
+  if (isFailure(status)) {
+    return noEvidence
+  }
+  const lines = []
+  for (entry in status.value.entries) {
+    lines.push("${entry.index}${entry.worktree} ${entry.path}")
+  }
+  let text = """
+Changed files (${lines.length}):
+${lines.join("\n")}
+"""
+  const diff = try gitDiff()
+  if (diff is success(d)) {
+    text = """
+${text}
+
+Working-tree diff (truncated):
+${truncate(d.patch, MAX_PATCH_CHARS)}
+"""
+  }
+  return {
+    text: text,
+    filesChanged: lines.length
+  }
+}
+
+def renderHistory(history: CheckRecord[]): string {
+  if (history.length == 0) {
+    return "(this is the first check)"
+  }
+  const lines = []
+  for (record in history) {
+    let note = ""
+    if (record.message != "") {
+      note = " — ${record.message}"
+    }
+    lines.push(
+      "- at ${record.minutes}m: ${record.filesChanged} files changed, assessment ${record.assessment}, action ${record.action}${note}",
+    )
+  }
+  return lines.join("\n")
+}
+
+def reviewPrompt(
+  task: string,
+  minutes: number,
+  evidence: string,
+  history: string,
+): string {
+  return """
+You are supervising a coding agent. It has been working for about ${minutes} minutes and is paused while you review. Decide whether it continues as-is, gets redirected, or stops.
+
+The task it was given:
+<task>
+${task}
+</task>
+
+What it has changed in the workspace so far:
+<workspace>
+${evidence}
+</workspace>
+
+Earlier checks this run:
+<history>
+${history}
+</history>
+
+Judge the evidence:
+- assessment: "progressing" when the workspace shows real movement toward the task since the last check; "stalled" when nothing meaningful has changed, or it keeps redoing the same thing.
+- action "continue": on track. The default — pick it unless the evidence clearly says otherwise.
+- action "redirect": working, but drifting, overbuilding, or looping on a failed approach. Put a short, concrete course correction in `message`, addressed directly to the agent — it is delivered into its conversation as if from the user (e.g. "Stop rewriting the parser; the failing test needs the lexer fixed first").
+- action "stop": continuing is pointless — the approach is destructive, or the task cannot be completed. Put the reason in `message`.
+
+Set `message` to "" for continue. Never redirect just to say "keep going".
+"""
+}
+
+export def progressCheck(task: string, elapsed: number): SuperviseDecision {
+  """
+  The check callback for a supervised solve: review the workspace evidence
+  and check history, then continue, redirect, or stop the paused solver.
+  Bind the task first: `progressCheck.partial(task: task)` is the
+  `(elapsed) -> SuperviseDecision` shape std::supervise expects.
+
+  @param task - The task the supervised solver is working on
+  @param elapsed - Working time the solver has consumed so far, in ms
+  """
+  const minutes = Math.round(elapsed / 60000)
+  const evidence = workspaceEvidence()
+  const verdict: SupervisorVerdict = llm(
+    reviewPrompt(
+    task: task,
+    minutes: minutes,
+    evidence: evidence.text,
+    history: renderHistory(_history),
+  ),
+  )
+  const decision = applyThrashRule(verdict, _history)
+  _history.push(
+    {
+    minutes: minutes,
+    filesChanged: evidence.filesChanged,
+    assessment: verdict.assessment,
+    action: decision.action,
+    message: decision.message
+  },
+  )
+  return decision
+}

--- a/packages/agency-lang/lib/agents/agency-agent/tests/supervisor.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/supervisor.agency
@@ -1,0 +1,109 @@
+// The supervised-solve seams, tested without any LLM: the thrash backstop
+// that turns repeated stalls into a stop, and the flattener that sorts out
+// the three shapes supervise can hand back.
+import { flattenSolveOutcome } from "../subagents/code.agency"
+import {
+  applyThrashRule,
+  CheckRecord,
+  SupervisorVerdict,
+ } from "../subagents/supervisor.agency"
+
+def record(assessment: string): CheckRecord {
+  return {
+    minutes: 5,
+    filesChanged: 1,
+    assessment: assessment,
+    action: "continue",
+    message: ""
+  }
+}
+
+def stalledVerdict(): SupervisorVerdict {
+  return {
+    assessment: "stalled",
+    action: "redirect",
+    message: "same failing test as last time"
+  }
+}
+
+// The first stalled check keeps the reviewer's own action.
+node firstStallIsNotStopped(): string {
+  const decision = applyThrashRule(stalledVerdict(), [])
+  return decision.action
+}
+
+// A second consecutive stalled check becomes a stop, whatever the reviewer chose.
+node secondConsecutiveStallStops(): string {
+  const decision = applyThrashRule(stalledVerdict(), [record("stalled")])
+  return decision.action
+}
+
+// A stall after a progressing check is not consecutive: no stop.
+node stallAfterProgressIsNotStopped(): string {
+  const decision = applyThrashRule(
+    stalledVerdict(),
+    [record("stalled"), record("progressing")],
+  )
+  return decision.action
+}
+
+// A progressing verdict passes through untouched even after a stall.
+node progressPassesThrough(): string {
+  const verdict: SupervisorVerdict = {
+    assessment: "progressing",
+    action: "continue",
+    message: ""
+  }
+  const decision = applyThrashRule(verdict, [record("stalled")])
+  return decision.action
+}
+
+// The block ran to completion and succeeded: the summary comes out.
+node flattenCompletedSolve(): string {
+  const captured: Result<any> = success(
+    {
+    ok: true,
+    summary: "wrote the fix"
+  },
+  )
+  const flat = flattenSolveOutcome(captured)
+  if (isFailure(flat)) {
+    return "unexpected-failure"
+  }
+  return flat.value
+}
+
+// The block ran to completion but the solver failed: a failure comes out.
+node flattenFailedSolve(): string {
+  const captured: Result<any> = success(
+    {
+    ok: false,
+    summary: "solver gave up"
+  },
+  )
+  const flat = flattenSolveOutcome(captured)
+  if (isFailure(flat)) {
+    return "failure:${flat.error}"
+  }
+  return "unexpected-success"
+}
+
+// A stop mid-run salvaged the worker's draft (a string): surfaced as success.
+node flattenSalvagedDraft(): string {
+  const captured: Result<any> = success("half the files are written")
+  const flat = flattenSolveOutcome(captured)
+  if (isFailure(flat)) {
+    return "unexpected-failure"
+  }
+  return flat.value
+}
+
+// supervise itself failed (draftless stop or maxTime): the failure passes through.
+node flattenSuperviseFailure(): string {
+  const captured: Result<any> = failure("supervise: maxTime reached")
+  const flat = flattenSolveOutcome(captured)
+  if (isFailure(flat)) {
+    return "failure:${flat.error}"
+  }
+  return "unexpected-success"
+}

--- a/packages/agency-lang/lib/agents/agency-agent/tests/supervisor.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/supervisor.agency
@@ -47,6 +47,18 @@ node stallAfterProgressIsNotStopped(): string {
   return decision.action
 }
 
+// A forced stop with an empty reviewer message carries no dangling
+// "Last observation:" suffix.
+node emptyObservationStopMessage(): string {
+  const verdict: SupervisorVerdict = {
+    assessment: "stalled",
+    action: "continue",
+    message: ""
+  }
+  const decision = applyThrashRule(verdict, [record("stalled")])
+  return decision.message
+}
+
 // A progressing verdict passes through untouched even after a stall.
 node progressPassesThrough(): string {
   const verdict: SupervisorVerdict = {

--- a/packages/agency-lang/lib/agents/agency-agent/tests/supervisor.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/supervisor.test.json
@@ -22,6 +22,13 @@
       "evaluationCriteria": [{ "type": "exact" }]
     },
     {
+      "nodeName": "emptyObservationStopMessage",
+      "description": "a forced stop with an empty reviewer message has no dangling suffix",
+      "input": "",
+      "expectedOutput": "\"Stopped by the supervisor: two checks in a row found no progress.\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
       "nodeName": "progressPassesThrough",
       "description": "a progressing verdict passes through untouched",
       "input": "",

--- a/packages/agency-lang/lib/agents/agency-agent/tests/supervisor.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/supervisor.test.json
@@ -1,0 +1,60 @@
+{
+  "tests": [
+    {
+      "nodeName": "firstStallIsNotStopped",
+      "description": "the first stalled check keeps the reviewer's own action",
+      "input": "",
+      "expectedOutput": "\"redirect\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "secondConsecutiveStallStops",
+      "description": "a second consecutive stalled check becomes a stop",
+      "input": "",
+      "expectedOutput": "\"stop\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "stallAfterProgressIsNotStopped",
+      "description": "a stall after a progressing check is not consecutive",
+      "input": "",
+      "expectedOutput": "\"redirect\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "progressPassesThrough",
+      "description": "a progressing verdict passes through untouched",
+      "input": "",
+      "expectedOutput": "\"continue\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "flattenCompletedSolve",
+      "description": "a completed successful solve yields its summary",
+      "input": "",
+      "expectedOutput": "\"wrote the fix\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "flattenFailedSolve",
+      "description": "a completed failed solve yields a failure",
+      "input": "",
+      "expectedOutput": "\"failure:solver gave up\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "flattenSalvagedDraft",
+      "description": "a salvaged draft string surfaces as a success",
+      "input": "",
+      "expectedOutput": "\"The run was stopped early by the supervisor. Its last saved draft:\\n\\nhalf the files are written\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "flattenSuperviseFailure",
+      "description": "a supervise failure passes through as a failure",
+      "input": "",
+      "expectedOutput": "\"failure:supervise: maxTime reached\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}


### PR DESCRIPTION
## Why

On hard problems the code subagent thrashes: an escalated or one-shot solve runs its whole 15-minute / $20 budget with nobody checking on it, because the first review (verifierAgent) only happens after solve() returns. std::supervise exists for exactly this, and until now nothing in the agent used it — there was also no reviewer anywhere that could serve as its check callback.

## What

**New `subagents/supervisor.agency`** — the reviewer std::supervise calls at each pause:

- Gathers what the solver actually changed: git status plus a truncated working-tree diff, failing open to "no workspace evidence" outside a git repo.
- Shows that evidence and the history of earlier checks to a reviewer LLM, which returns an assessment ("progressing" / "stalled") and an action: continue, redirect with a course correction (delivered into the paused solver thread as a user message), or stop.
- `applyThrashRule` is a deterministic backstop on top of the reviewer: two consecutive "stalled" assessments become a stop regardless of what the reviewer chose, so a redirect loop that is not working cannot burn the rest of the budget.
- The reviewer call is tool-free because the check runs inside the guard handler; giving it a tool loop would raise nested interrupts from within a handler. Evidence comes from direct std::git reads instead.

**`subagents/code.agency`** — new `supervisedSolve` wraps solve() in `supervise(every: 5m, maxTime: ESCALATE_MAX_TIME, check: progressCheck.partial(task:))`. Both long-running paths use it now: `escalateToExpert` and `solveUnattended`, initial solves and fix rounds alike.

Two shape rules the wrapper honors (both pinned by tests/agency/supervise/nestedGuardResume.agency and the saveDraft salvage rules):

- A supervised block must not `match` a Result — it normalizes to a plain `{ ok, summary }` object inside the block.
- A stop mid-run salvages the worker's saveDraft draft (a string) in place of the block return, so `flattenSolveOutcome` (exported, tested) distinguishes completed solve / salvaged draft / failure and surfaces a draft as a success prefixed "The run was stopped early by the supervisor."

**Left unsupervised on purpose:** `converse` (the user is present and can steer or cancel) and the `escalate` → plannerAgent path (runs in a subprocess; redirect injection there is untested). Both are candidate follow-ups.

## Tests

`lib/agents/agency-agent/tests/supervisor.agency` — 8 execution tests, no LLM calls: the thrash backstop (first stall passes through, second consecutive stall stops, non-consecutive stall does not, progressing passes through) and all three flattener shapes plus the pass-through failure.

Drive-bys found while building: Agency string interpolation cannot contain an inline `if..then..else` (parse error), and std::git FileStatus carries `index`/`worktree` change codes rather than `.status` — the supervisor uses the correct fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
