### PR TITLE
Add forkShared, race, and raceShared comprehension prefixes; fix race over an empty list

### DIFF
--- a/packages/agency-lang/docs/site/guide/comprehensions.md
+++ b/packages/agency-lang/docs/site/guide/comprehensions.md
@@ -48,11 +48,49 @@ let count = 0
 const results = fork [tally(x) for x in xs]
 ```
 
-If you need the changes to stick, use the plain form, or read
-[concurrency](/guide/concurrency) for `shared: true`.
+If you need the changes to stick, use `forkShared`:
+
+```ts
+let total = 0
+
+def tally(x: number): number {
+  total = total + x
+  return x
+}
+
+// every branch adds into the SAME total - it really accumulates
+const seen = forkShared [tally(x) for x in xs]
+```
+
+Two things to know about `forkShared`. First, sharing only matters when the body
+*changes* something: a body that only reads a global behaves the same either way,
+so `forkShared [total + x for x in xs]` gains nothing over `fork`. Second, the
+branches run at the same time, so the order of their writes is unpredictable.
+Adding to a total works because addition lands the same in any order; building an
+ordered string or overwriting one field does not. See
+[concurrency](/guide/concurrency) for the full story on shared state.
 
 The `if` clause runs before the work fans out, so the filter itself is not
 concurrent. Only the body is.
+
+## Taking the first result
+
+Put `race` in front and you get the first item to finish - one value, **not a
+list**:
+
+```ts
+// whichever summary comes back first wins; the other branches are cancelled
+const fastest = race [summarize(doc) for doc in docs]
+```
+
+Two edges to know. If nothing runs at all - the source is empty, or the `if`
+clause filters everything out - the result is `null`. And "first to finish"
+includes finishing badly: if the quickest branch fails, that failure is what you
+get back, so check with `isFailure` when the body can fail.
+
+`raceShared` combines racing with shared globals. One caveat comes with it: a
+losing branch that already changed a global before it was cancelled leaves that
+change behind. There is no undo - that is what sharing means.
 
 ## Binders
 

--- a/packages/agency-lang/docs/site/guide/concurrency.md
+++ b/packages/agency-lang/docs/site/guide/concurrency.md
@@ -106,3 +106,7 @@ print(globalVar)
 ```
 
 The same option works on `race` and `parallel` too.
+
+The comprehension forms spell this as a prefix:
+[`forkShared [...]` and `raceShared [...]`](/guide/comprehensions). A `race` over
+an empty list resolves to `null`.

--- a/packages/agency-lang/lib/backends/agencyGenerator.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.ts
@@ -24,6 +24,7 @@ import {
 } from "../types.js";
 
 import { AccessChainElement, ValueAccess } from "../types/access.js";
+import { comprehensionPrefixString } from "../types/comprehension.js";
 import { BlockArgument } from "../types/blockArgument.js";
 import {
   AgencyArray,
@@ -1710,7 +1711,7 @@ export class AgencyGenerator {
   }
 
   protected processComprehension(node: Comprehension): string {
-    const prefix = node.parallel ? "fork " : "";
+    const prefix = comprehensionPrefixString(node);
     const expr = this.processNode(node.expression).trim();
     const binder =
       typeof node.itemVar === "string"

--- a/packages/agency-lang/lib/formatter.comprehension.test.ts
+++ b/packages/agency-lang/lib/formatter.comprehension.test.ts
@@ -15,6 +15,12 @@ describe("agency fmt preserves comprehensions", () => {
     ],
     ["fork [f(x) for x in xs]", "fork [f(x) for x in xs]"],
     ["fork [f(x) for x in xs if p(x)]", "fork [f(x) for x in xs if p(x)]"],
+    ["forkShared [f(x) for x in xs]", "forkShared [f(x) for x in xs]"],
+    ["race [f(x) for x in xs]", "race [f(x) for x in xs]"],
+    [
+      "raceShared [f(x) for x in xs if p(x)]",
+      "raceShared [f(x) for x in xs if p(x)]",
+    ],
   ];
 
   for (const [expr, expected] of cases) {

--- a/packages/agency-lang/lib/lowering/comprehensionDesugar.test.ts
+++ b/packages/agency-lang/lib/lowering/comprehensionDesugar.test.ts
@@ -24,6 +24,11 @@ function desugarExpr(src: string): any {
   return main.body[0].value;
 }
 
+/** The shared: true named argument of a desugared call, if present. */
+function namedArg(callNode: any): any {
+  return callNode.arguments.find((a: any) => a.type === "namedArgument");
+}
+
 describe("comprehensionDesugar", () => {
   it("lowers a plain comprehension to map with a block", () => {
     const out = desugarExpr("[f(x) for x in xs]");
@@ -132,6 +137,55 @@ describe("comprehensionDesugar", () => {
     const filterBlock = out.arguments[0].block;
     expect(filterBlock.body[0]).not.toBe(out.block.body[0]);
     expect(filterBlock.body[1]).not.toBe(out.block.body[1]);
+  });
+
+  it("lowers forkShared to a fork call carrying shared: true", () => {
+    const out = desugarExpr("forkShared [f(x) for x in xs]");
+    expect(out.functionName).toBe("fork");
+    expect(namedArg(out).name).toBe("shared");
+    // stampLoc fills the synthesized literal's loc too (deliberate), so
+    // match the semantic fields rather than deep-equality
+    expect(namedArg(out).value.type).toBe("boolean");
+    expect(namedArg(out).value.value).toBe(true);
+  });
+
+  it("lowers a plain fork with NO shared argument", () => {
+    const out = desugarExpr("fork [f(x) for x in xs]");
+    expect(namedArg(out)).toBeUndefined();
+  });
+
+  it("lowers race to a call named exactly race", () => {
+    // the builder keys on this name to reach processForkCall
+    const out = desugarExpr("race [f(x) for x in xs]");
+    expect(out.functionName).toBe("race");
+    expect(out.block).toBeDefined();
+  });
+
+  it("lowers raceShared to race plus the shared argument", () => {
+    const out = desugarExpr("raceShared [f(x) for x in xs]");
+    expect(out.functionName).toBe("race");
+    expect(namedArg(out).name).toBe("shared");
+  });
+
+  it("keeps the shared argument outside the filter nesting", () => {
+    // filter runs sequentially BEFORE the fan-out; shared belongs to the
+    // outer concurrent call only
+    const out = desugarExpr("forkShared [f(x) for x in xs if p(x)]");
+    expect(out.functionName).toBe("fork");
+    expect(namedArg(out)).toBeDefined();
+    const filter = out.arguments[0];
+    expect(filter.functionName).toBe("filter");
+    expect(namedArg(filter)).toBeUndefined();
+  });
+
+  it("puts the shared argument beside a _pairsOf-wrapped source", () => {
+    // two binders wrap the source in _pairsOf; an implementation that
+    // appended shared BEFORE wrapping, or assumed arguments[0] is the
+    // raw iterable, passes every other test and fails this one
+    const out = desugarExpr("forkShared [f(x, i) for x, i in xs]");
+    expect(out.functionName).toBe("fork");
+    expect(out.arguments[0].functionName).toBe("_pairsOf");
+    expect(namedArg(out).name).toBe("shared");
   });
 
   it("is idempotent", () => {

--- a/packages/agency-lang/lib/lowering/comprehensionDesugar.ts
+++ b/packages/agency-lang/lib/lowering/comprehensionDesugar.ts
@@ -1,4 +1,9 @@
-import type { AgencyNode, Assignment, Expression } from "../types.js";
+import type {
+  AgencyNode,
+  Assignment,
+  Expression,
+  NamedArgument,
+} from "../types.js";
 import type { BlockArgument } from "../types/blockArgument.js";
 import type { Comprehension } from "../types/comprehension.js";
 import type { FunctionCall } from "../types/function.js";
@@ -91,10 +96,30 @@ function blockArg(body: AgencyNode[], paramName: string): BlockArgument {
 
 function call(
   functionName: string,
-  args: Expression[],
+  args: (Expression | NamedArgument)[],
   block: BlockArgument,
 ): FunctionCall {
   return { type: "functionCall", functionName, arguments: args, block };
+}
+
+/** mode -> the call the comprehension lowers to. Keyed on the type, so
+ *  a new mode is a compile error here rather than a silent fallthrough. */
+const CALL_NAME: Record<Comprehension["mode"], string> = {
+  seq: "map",
+  fork: "fork",
+  race: "race",
+};
+
+/** The `shared: true` named argument, in exactly the shape the parser
+ *  produces for hand-written `fork(xs, shared: true)` and the builder
+ *  pulls off in processForkCall. BooleanLiteral value is a real boolean
+ *  (unlike NumberLiteral, whose value is a string). */
+function sharedArg(): NamedArgument {
+  return {
+    type: "namedArgument",
+    name: "shared",
+    value: { type: "boolean", value: true },
+  };
 }
 
 function returnStmt(value: Expression): AgencyNode {
@@ -251,8 +276,10 @@ function lower(node: Comprehension): FunctionCall {
 
   return stampLoc(
     call(
-      node.parallel ? "fork" : "map",
-      [source],
+      CALL_NAME[node.mode],
+      // named argument AFTER the positional source, matching how a user
+      // writes fork(xs, shared: true)
+      node.shared ? [source, sharedArg()] : [source],
       blockArg(
         [...unpackStatements(node, paramName), returnStmt(node.expression)],
         paramName,

--- a/packages/agency-lang/lib/parsers/comprehension.test.ts
+++ b/packages/agency-lang/lib/parsers/comprehension.test.ts
@@ -38,7 +38,8 @@ describe("comprehensionParser", () => {
     const node = parseExpr("[f(x) for x in xs]");
     expect(node.type).toBe("comprehension");
     expect(node.itemVar).toBe("x");
-    expect(node.parallel).toBe(false);
+    expect(node.mode).toBe("seq");
+    expect(node.shared).toBe(false);
     expect(node.condition).toBeUndefined();
   });
 
@@ -67,13 +68,95 @@ describe("comprehensionParser", () => {
   it("parses the fork form", () => {
     const node = parseExpr("fork [f(x) for x in xs]");
     expect(node.type).toBe("comprehension");
-    expect(node.parallel).toBe(true);
+    expect(node.mode).toBe("fork");
+    expect(node.shared).toBe(false);
   });
 
   it("parses the fork form with a filter", () => {
     const node = parseExpr("fork [f(x) for x in xs if p(x)]");
-    expect(node.parallel).toBe(true);
+    expect(node.mode).toBe("fork");
+    expect(node.shared).toBe(false);
     expect(node.condition).toBeDefined();
+  });
+
+  it("parses the forkShared form", () => {
+    // also the ordering pin: if the or() tried str("fork") before
+    // str("forkShared"), fork would match, die on the S where required
+    // whitespace should be, and this test would fail
+    const node = parseExpr("forkShared [f(x) for x in xs]");
+    expect(node.type).toBe("comprehension");
+    expect(node.mode).toBe("fork");
+    expect(node.shared).toBe(true);
+  });
+
+  it("parses the race form", () => {
+    const node = parseExpr("race [f(x) for x in xs]");
+    expect(node.mode).toBe("race");
+    expect(node.shared).toBe(false);
+  });
+
+  it("parses the raceShared form", () => {
+    const node = parseExpr("raceShared [f(x) for x in xs]");
+    expect(node.mode).toBe("race");
+    expect(node.shared).toBe(true);
+  });
+
+  it("composes a shared prefix with a filter and two binders", () => {
+    const node = parseExpr("forkShared [f(x, i) for x, i in xs if p(x)]");
+    expect(node.mode).toBe("fork");
+    expect(node.shared).toBe(true);
+    expect(node.indexVar).toBe("i");
+    expect(node.condition).toBeDefined();
+  });
+
+  it("parses a multi-line comprehension behind a new prefix", () => {
+    // tarsec spaces cross newlines; the merged suite pins this at every
+    // keyword boundary, and the prefix is a fourth boundary with the
+    // same exposure
+    const node = parseExpr("forkShared [f(x)\n    for x in xs]");
+    expect(node.mode).toBe("fork");
+    expect(node.shared).toBe(true);
+  });
+
+  // Not a prefix without required whitespace after the keyword. Probed
+  // against the pre-change grammar as failing; the new grammar reaches
+  // the same conclusion by a different path (forkShared matches then
+  // dies on the space, fork matches then dies on the S) - this test IS
+  // the re-verification the plan calls for.
+  it("does not treat forkSharedx as a prefix", () => {
+    expect(parseFails("forkSharedx [x for x in xs]")).toBe(true);
+  });
+
+  // forkShared is not reserved. No-space indexing parses as value
+  // access (the comprehension parser needs whitespace after the
+  // keyword, so it never engages); WITH a space it fails to parse -
+  // matching `somearr [0]`, because spaced indexing is not legal
+  // Agency for ANY identifier (probed).
+  it("still parses forkShared[0] as indexing", () => {
+    const node = parseExpr("forkShared[0]");
+    expect(node.type).toBe("valueAccess");
+  });
+
+  it("rejects forkShared [0] the same as any spaced indexing", () => {
+    expect(parseFails("forkShared [0]")).toBe(true);
+    expect(parseFails("somearr [0]")).toBe(true);
+  });
+
+  // race was already a callable (race(items, shared: true) as x { } is
+  // documented in the concurrency guide) and this plan promotes the
+  // word to a prefix keyword. Pin that existing call uses survive: the
+  // prefix rule needs whitespace-then-bracket, so a paren falls through.
+  it("still parses race(xs) as x {} as a function call", () => {
+    const node = parseExpr("race(xs) as x { return x }");
+    expect(node.type).toBe("functionCall");
+    expect(node.functionName).toBe("race");
+    expect(node.block).toBeDefined();
+  });
+
+  it("still rejects race (xs) like any spaced call", () => {
+    // spaced calls are not legal Agency for any identifier (probed
+    // pre-change with the same input); the prefix must not change that
+    expect(parseFails("race (xs) as x { return x }")).toBe(true);
   });
 
   // Bracket-nesting cases: the inner `]` is a plausible place for the

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -107,7 +107,11 @@ import {
 import { EffectDeclaration } from "../types/effectDeclaration.js";
 import { GraphNodeDefinition } from "../types/graphNode.js";
 import { ForLoop } from "../types/forLoop.js";
-import { Comprehension } from "../types/comprehension.js";
+import {
+  Comprehension,
+  COMPREHENSION_PREFIXES,
+  SEQ_PREFIX,
+} from "../types/comprehension.js";
 import { WhileLoop } from "../types/whileLoop.js";
 import { ParallelBlock, SeqBlock } from "../types/parallelBlock.js";
 import { IfElse } from "../types/ifElse.js";
@@ -4656,11 +4660,31 @@ export const comprehensionParser: Parser<Comprehension> = label(
   withLoc(
     memo(
       "comprehensionParser",
-      seqC(
+      map(
+        seqC(
         set("type", "comprehension"),
+        // The concurrency prefix, as a raw keyword; the map() below this
+        // seqC converts it to mode/shared via COMPREHENSION_PREFIXES.
+        // Ordering in the or() is load-bearing: LONGEST FIRST, or
+        // str("fork") would half-match the fork in forkShared and then
+        // die on the required whitespace.
         capture(
-          map(optional(seqR(str("fork"), spaces)), (r) => r !== null),
-          "parallel",
+          map(
+            optional(
+              seqR(
+                or(
+                  str("forkShared"),
+                  str("raceShared"),
+                  str("fork"),
+                  str("race"),
+                ),
+                spaces,
+              ),
+            ),
+            // seqR returns ALL results as an array; the keyword is [0]
+            (r) => (r === null ? null : (r as unknown[])[0]),
+          ),
+          "prefix",
         ),
         char("["),
         optionalSpacesOrNewline,
@@ -4705,6 +4729,19 @@ export const comprehensionParser: Parser<Comprehension> = label(
         ),
         optionalSpacesOrNewline,
         char("]"),
+        ),
+        // Convert the raw prefix keyword into mode/shared by table
+        // lookup - one branch, the sequential case being a table row
+        // (SEQ_PREFIX) rather than a special case. The return annotation
+        // is the node's one construction-site type check, since the
+        // trailing cast below erases inference.
+        (result: any): Comprehension => {
+          const { prefix, ...rest } = result;
+          const fields = prefix
+            ? COMPREHENSION_PREFIXES[prefix as string]
+            : SEQ_PREFIX;
+          return { ...rest, ...fields };
+        },
       ),
     ),
   ) as unknown as Parser<Comprehension>,

--- a/packages/agency-lang/lib/runtime/runBatch.test.ts
+++ b/packages/agency-lang/lib/runtime/runBatch.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { TimeGuard } from "./guard.js";
 import { getRuntimeContext, runInTestContext } from "./asyncContext.js";
 import { readCause } from "./errors.js";
 import type { Interrupt } from "./interrupts.js";
@@ -463,6 +464,37 @@ describe("runBatch — mode 'sequential'", () => {
 
 describe("runBatch — mode 'race'", () => {
   const WINNER_KEY = "__race_winner_test";
+
+  it("empty race resolves to null and resumes the parent time guards", async () => {
+    const { ctx } = makeCtx();
+    const { parentStack, parentFrame } = makeParent();
+    // A real TimeGuard so the charge-and-resume instanceof filter sees
+    // it, with stubbed methods so no real timers arm inside the test.
+    const guard = new TimeGuard(60_000);
+    guard.pause = vi.fn();
+    guard.resume = vi.fn();
+    parentStack.guards.push(guard);
+
+    const result = await runBatch<number>({
+      ctx,
+      parentStack,
+      parentFrame,
+      checkpointLocation: cpLoc,
+      mode: "race",
+      raceWinnerLocalKey: WINNER_KEY,
+      children: [],
+    });
+
+    // no branch can win: null, matching how absent lookups normalize
+    expect(result).toEqual({ kind: "values", values: [null] });
+    // no winner index persisted - a resume re-runs the empty guard
+    expect(parentFrame.locals[WINNER_KEY]).toBeUndefined();
+    // runBatch pauses the parent clock before dispatching to the race;
+    // the empty exit must resume it like every other value exit, or the
+    // parent's time budget stays paused forever after the region
+    expect(guard.pause).toHaveBeenCalled();
+    expect(guard.resume).toHaveBeenCalled();
+  });
 
   it("first to settle wins; losers are aborted and their branches deleted", async () => {
     const { ctx } = makeCtx();

--- a/packages/agency-lang/lib/runtime/runBatch.ts
+++ b/packages/agency-lang/lib/runtime/runBatch.ts
@@ -725,6 +725,11 @@ async function runRaceFirstTime<T>(
   // index is persisted - a resume of a zero-branch race re-runs this
   // same guard.
   if (tasks.length === 0) {
+    // runBatch paused the parent's TimeGuards before dispatching here,
+    // and every VALUE exit must charge-and-resume them or the parent's
+    // clock stays paused forever after the region. Zero branches charge
+    // zero time; the call is only the resume.
+    chargeAndResumeParentTimeGuards(opts.parentStack, [], "max");
     return { kind: "values", values: [null as T] };
   }
 

--- a/packages/agency-lang/lib/runtime/runBatch.ts
+++ b/packages/agency-lang/lib/runtime/runBatch.ts
@@ -716,6 +716,18 @@ async function runRaceFirstTime<T>(
   const { parentFrame, hooks } = opts;
   const raceKey = opts.raceWinnerLocalKey;
 
+  // Promise.race([]) never settles, so a race over zero branches used to
+  // hang the whole program (unsettled top-level await, exit 13) with no
+  // diagnostic. Zero branches means nothing can win: resolve to null,
+  // matching how absent lookups normalize (obj[missingKey], unmatched
+  // match -> null). Reachable from user code via a comprehension filter
+  // that matches nothing: `race [f(x) for x in xs if p(x)]`. No winner
+  // index is persisted - a resume of a zero-branch race re-runs this
+  // same guard.
+  if (tasks.length === 0) {
+    return { kind: "values", values: [null as T] };
+  }
+
   // Tag promises with their index so we can identify the winner / first
   // failure regardless of resolution order.
   const tagged = tasks.map((t, i) =>

--- a/packages/agency-lang/lib/types/comprehension.ts
+++ b/packages/agency-lang/lib/types/comprehension.ts
@@ -23,6 +23,58 @@ export type Comprehension = BaseNode & {
   indexVar?: string;
   iterable: Expression;
   condition?: Expression;
-  /** True for `fork [...]`. Selects the desugar target: fork vs map. */
-  parallel: boolean;
+  /** Which call the comprehension desugars to: "seq" lowers to `map`,
+   *  the other two lower to the call of the same name. */
+  mode: "seq" | "fork" | "race";
+  /** True for the `forkShared`/`raceShared` prefixes. Non-optional so
+   *  the invariant "seq is never shared" is carried by the prefix table
+   *  (SEQ_PREFIX below) rather than by a comment. Lowers to a
+   *  `shared: true` named argument on the desugared call, which
+   *  processForkCall already understands. */
+  shared: boolean;
 };
+
+/** Comprehension concurrency prefixes: keyword -> node fields. The
+ *  parser matches these keywords; the formatter prints them back via
+ *  comprehensionPrefixString, a reverse lookup over this SAME table.
+ *  Adding a prefix is one row here plus one str(...) in the parser's
+ *  or(...) (longest keyword first). Neither word is reserved - they are
+ *  only special immediately before a comprehension bracket. */
+export const COMPREHENSION_PREFIXES: Record<
+  string,
+  { mode: "fork" | "race"; shared: boolean }
+> = {
+  fork: { mode: "fork", shared: false },
+  forkShared: { mode: "fork", shared: true },
+  race: { mode: "race", shared: false },
+  raceShared: { mode: "race", shared: true },
+};
+
+/** The no-prefix (sequential) fields. A table row, not a special case in
+ *  the parser: seq carries shared: false because this says so. */
+export const SEQ_PREFIX: { mode: "seq"; shared: boolean } = {
+  mode: "seq",
+  shared: false,
+};
+
+/** fields -> keyword, for the formatter. Reverse lookup over
+ *  COMPREHENSION_PREFIXES so a prefix that parses always prints back as
+ *  itself. Throws on an unprintable combination rather than emitting
+ *  source text that would not re-parse. */
+export function comprehensionPrefixString(
+  node: Pick<Comprehension, "mode" | "shared">,
+): string {
+  if (node.mode === "seq") {
+    return "";
+  }
+  const entry = Object.entries(COMPREHENSION_PREFIXES).find(
+    ([, fields]) =>
+      fields.mode === node.mode && fields.shared === node.shared,
+  );
+  if (entry === undefined) {
+    throw new Error(
+      `no comprehension prefix spells mode=${node.mode} shared=${node.shared}`,
+    );
+  }
+  return `${entry[0]} `;
+}

--- a/packages/agency-lang/tests/agency/comprehensions/fork-shared-interrupt.agency
+++ b/packages/agency-lang/tests/agency/comprehensions/fork-shared-interrupt.agency
@@ -1,0 +1,22 @@
+let approvals = 0
+
+def risky(x: number): number {
+  raise interrupt("approve", { value: x })
+  approvals = approvals + 1
+  return x * 2
+}
+
+node main(): string {
+  let out = ""
+  handle {
+    const results = forkShared [risky(x) for x in [1, 2, 3]]
+    const rejected = if isFailure(results[1]) then "fail" else "ok"
+    out = "${results.length}|${results[0]}|${rejected}|${results[2]}|${approvals}"
+  } with (d) {
+    if (d.data.value == 2) {
+      return reject()
+    }
+    return approve()
+  }
+  return out
+}

--- a/packages/agency-lang/tests/agency/comprehensions/fork-shared-interrupt.test.json
+++ b/packages/agency-lang/tests/agency/comprehensions/fork-shared-interrupt.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "description": "interrupts in a forkShared body resume per branch and post-resume shared mutations persist; the rejected branch contributes nothing",
+      "expectedOutput": "\"3|2|fail|6|2\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/comprehensions/fork-shared.agency
+++ b/packages/agency-lang/tests/agency/comprehensions/fork-shared.agency
@@ -1,0 +1,39 @@
+let counter = 0
+
+def bump(x: number): number {
+  // no await between reading and writing counter, so each increment is
+  // atomic within its microtask - THAT is why exactly-3 is safe to
+  // assert even though shared write ORDER is nondeterministic (the
+  // guide says so in the same PR). Adding an await inside this
+  // function would make the count racy; do not.
+  counter = counter + 1
+  return x * 2
+}
+
+def slowDouble(x: number): number {
+  // inverted: item 1 sleeps longest, so completion order reverses
+  // source order and an implementation returning completion order
+  // prints 6,4,2
+  sleep((4 - x) * 100)
+  return x * 2
+}
+
+node main(): string {
+  const xs = [1, 2, 3]
+
+  // forkShared branches mutate the SAME globals - the mirror of
+  // fork.agency, where the identical body leaves counter at 0. Probed
+  // against the hand-written fork(xs, shared: true) form before pinning.
+  const doubled = forkShared [bump(x) for x in xs]
+  const afterShared = counter
+
+  // filter composes: only two branches run, only two increments land
+  const filtered = forkShared [bump(x) for x in xs if x != 2]
+  const afterFiltered = counter
+
+  // results keep SOURCE order on the shared path too - shareGlobals
+  // changes which GlobalStore branches point at, not how results join
+  const ordered = forkShared [slowDouble(x) for x in xs]
+
+  return "${doubled[0]},${doubled[1]},${doubled[2]}|${afterShared}|${filtered[0]},${filtered[1]}|${afterFiltered}|${ordered[0]},${ordered[1]},${ordered[2]}"
+}

--- a/packages/agency-lang/tests/agency/comprehensions/fork-shared.test.json
+++ b/packages/agency-lang/tests/agency/comprehensions/fork-shared.test.json
@@ -1,0 +1,12 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "description": "forkShared mutations survive the join, filters compose, and results keep source order",
+      "expectedOutput": "\"2,4,6|3|2,6|5|2,4,6\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "timeoutMs": 30000
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/comprehensions/race-interrupt.agency
+++ b/packages/agency-lang/tests/agency/comprehensions/race-interrupt.agency
@@ -1,0 +1,37 @@
+def risky(x: number): number {
+  raise interrupt("approve", { value: x })
+  sleep((4 - x) * 100)
+  return x * 2
+}
+
+node allApproved(): string {
+  let out = ""
+  handle {
+    // every branch raises, every branch is approved; the shortest
+    // sleep (item 3) wins. Losers holding nothing - their interrupts
+    // were resolved before the sleeps began.
+    const winner = race [risky(x) for x in [1, 2, 3]]
+    out = "${winner}"
+  } with (d) {
+    return approve()
+  }
+  return out
+}
+
+node fastestRejected(): string {
+  let out = ""
+  handle {
+    // race is first-SETTLED: the rejected branch fails before any
+    // sibling wakes from its sleep, so the race returns the FAILURE,
+    // not the next-fastest success (probed against the block form)
+    const winner = race [risky(x) for x in [1, 2, 3]]
+    const failed = if isFailure(winner) then "fail" else "ok"
+    out = "${failed}"
+  } with (d) {
+    if (d.data.value == 3) {
+      return reject()
+    }
+    return approve()
+  }
+  return out
+}

--- a/packages/agency-lang/tests/agency/comprehensions/race-interrupt.test.json
+++ b/packages/agency-lang/tests/agency/comprehensions/race-interrupt.test.json
@@ -1,0 +1,20 @@
+{
+  "tests": [
+    {
+      "nodeName": "allApproved",
+      "input": "",
+      "description": "interrupts in a race body resume per branch and the fastest approved branch wins",
+      "expectedOutput": "\"6\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "timeoutMs": 30000
+    },
+    {
+      "nodeName": "fastestRejected",
+      "input": "",
+      "description": "race is first-settled: a rejected branch that settles first wins the race with its Failure",
+      "expectedOutput": "\"fail\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "timeoutMs": 30000
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/comprehensions/race-shared.agency
+++ b/packages/agency-lang/tests/agency/comprehensions/race-shared.agency
@@ -1,0 +1,19 @@
+let log = ""
+
+def probe(x: number): number {
+  // synchronous shared write BEFORE the first await, so every branch
+  // logs regardless of who wins
+  log = log + "${x},"
+  sleep((4 - x) * 100)
+  return x * 10
+}
+
+node main(): string {
+  const winner = raceShared [probe(x) for x in [1, 2, 3]]
+
+  // all three pre-sleep writes persist, including the losing branches -
+  // raceShared does not roll back. Assert length, not order: which
+  // branch wrote first is a scheduler property, how many characters
+  // survived is the rollback property under test.
+  return "${winner}|${log.length}"
+}

--- a/packages/agency-lang/tests/agency/comprehensions/race-shared.test.json
+++ b/packages/agency-lang/tests/agency/comprehensions/race-shared.test.json
@@ -1,0 +1,12 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "description": "raceShared returns the winner and losing branches shared writes persist without rollback",
+      "expectedOutput": "\"30|6\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "timeoutMs": 30000
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/comprehensions/race.agency
+++ b/packages/agency-lang/tests/agency/comprehensions/race.agency
@@ -1,0 +1,23 @@
+def slowDouble(x: number): number {
+  // item 1 sleeps longest, item 3 shortest - the winner is deterministic
+  sleep((4 - x) * 100)
+  return x * 2
+}
+
+node main(): string {
+  // race returns ONE value, not a list - the first branch to finish
+  const winner = race [slowDouble(x) for x in [1, 2, 3]]
+
+  // filter composes: excluding 3 changes who wins
+  const winnerFiltered = race [slowDouble(x) for x in [1, 2, 3] if x != 3]
+
+  // one branch: still a scalar, not a one-element list
+  const single = race [slowDouble(x) for x in [7]]
+
+  // a filter matching NOTHING used to hang the program; the empty race
+  // now resolves to null at the block level, and the comprehension
+  // inherits it
+  const none = race [slowDouble(x) for x in [1, 2, 3] if x > 100]
+
+  return "${winner}|${winnerFiltered}|${single}|${none == null}"
+}

--- a/packages/agency-lang/tests/agency/comprehensions/race.test.json
+++ b/packages/agency-lang/tests/agency/comprehensions/race.test.json
@@ -1,0 +1,12 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "description": "race comprehensions return the first finisher as a scalar; filters, single items, and empty results compose",
+      "expectedOutput": "\"6|4|14|true\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "timeoutMs": 30000
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/race-empty.agency
+++ b/packages/agency-lang/tests/agency/race-empty.agency
@@ -1,0 +1,12 @@
+node main(): string {
+  // race over nothing: no branch can win, so the result is null -
+  // matching how absent lookups normalize (obj[missing], unmatched
+  // match). Before this fix the program HUNG (unsettled top-level
+  // await, exit 13), which a filter matching nothing made easy to hit.
+  const winner = race([]) as x { return x * 2 }
+
+  // fork over nothing already worked; pin the pair together
+  const empty = fork([]) as x { return x * 2 }
+
+  return "${winner == null}|${empty.length}"
+}

--- a/packages/agency-lang/tests/agency/race-empty.test.json
+++ b/packages/agency-lang/tests/agency/race-empty.test.json
@@ -1,0 +1,12 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "description": "race over an empty list returns null instead of hanging; fork over an empty list returns []",
+      "expectedOutput": "\"true|0\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "timeoutMs": 30000
+    }
+  ]
+}


### PR DESCRIPTION
Adds three concurrency prefixes to list comprehensions - `forkShared [...]`, `race [...]`, and `raceShared [...]` - as pure sugar over the existing block forms, and fixes a runtime hole the feature would otherwise inherit: a `race` over an empty list used to hang the program.

Spec: `docs/superpowers/specs/2026-07-19-shared-and-race-comprehensions-design.md`. Plan: `docs/superpowers/plans/2026-07-19-shared-and-race-comprehensions.md` (rev 2, one review round applied). Follows #599.

## The empty-race fix (Task 0, could have been its own PR)

`race([]) as x { ... }` never resolved: `runRaceFirstTime` awaits `Promise.race(tagged)`, and `Promise.race([])` never settles, so the program died with `Warning: Detected unsettled top-level await` and exit 13 - no value, no error, no diagnostic. The comprehension form makes this easy to reach (`race [f(x) for x in xs if p(x)]` with a filter matching nothing). A race over zero branches now resolves to `null`, matching how absent lookups normalize (`obj[missingKey]`, unmatched `match`). Pinned at the block level (`tests/agency/race-empty.agency`) and through the comprehension (the empty-filter case in `race.agency`).

## How the prefixes work

Each desugars to the call a user could write by hand, before any later compiler stage runs:

| Written | Desugars to |
|---|---|
| `forkShared [f(x) for x in xs]` | `fork(xs, shared: true) as x { return f(x) }` |
| `race [f(x) for x in xs]` | `race(xs) as x { return f(x) }` |
| `raceShared [f(x) for x in xs]` | `race(xs, shared: true) as x { return f(x) }` |

The builder and runtime needed zero changes for the prefixes themselves - `processForkCall` already handles `race` and pulls off `shared: true`. The `Comprehension` node's `parallel: boolean` became `mode: "seq" | "fork" | "race"` plus a non-optional `shared: boolean`, and one exported table (`COMPREHENSION_PREFIXES` in `lib/types/comprehension.ts`) is read by BOTH the parser (keyword to fields) and the formatter (fields to keyword, reverse lookup) - so `agency fmt` structurally cannot disagree with the parser about how a prefix is spelled, and adding a prefix is one table row plus one `str(...)`.

Neither new word is reserved: they are only special immediately before a bracket that actually parses as a comprehension. Pinned: `forkShared[0]` still indexes a variable of that name, `race(xs) as x { }` still parses as the existing call form, and the spaced variants (`forkShared [0]`, `race (xs)`) fail to parse exactly as they do for any identifier (spaced indexing and spaced calls were never legal Agency - probed before pinning).

## Probe-verified semantics (all inherited, all pinned by execution tests, no LLM calls)

Every expected value was probed against the hand-written block form before being pinned:

- **`forkShared` mutations survive the join**: the exact mirror of the merged isolation test - the same body that leaves a counter at 0 under `fork` leaves it at 3 under `forkShared`. The test states why exactly-3 is deterministic (no await between read and write) even though shared write ORDER is not, which the guide says in the same PR.
- **Results keep source order on the shared path** (inverted-sleep test - the merged suite's ordering test, repeated through `shareGlobals`).
- **`race` returns a scalar**, including over a single item; filters compose; empty-after-filter gives `null`.
- **Race is first-SETTLED, not first-success**: a branch whose interrupt is rejected settles as a Failure before slower siblings wake, and that Failure wins the race. Surprising, real, now pinned and documented ("finishing badly still counts as finishing").
- **`raceShared` does not roll back**: losing branches' pre-await shared writes persist. Asserted by membership (`log.length`), not write order - which branch writes first is a scheduler property.
- **Interrupts resume per branch through BOTH new paths** (`forkShared` and `race`), matching the hand-written baselines character for character, including post-resume shared mutations persisting with the rejected branch contributing nothing. Handlers are safety infrastructure; both new execution differences (shared globals, loser cancellation) got their own pins.

## Known limitations, stated rather than discovered later

- The checker types a race result as `any`, so `const summaries: string[] = race [...]` typechecks despite being wrong. Guide says "one value, not a list" in prose; the structural fix is filed as #603 (block-form scope).
- `Comprehension.parallel` becoming `mode`/`shared` is visible to `agency ast` and `std::agency` AST consumers. #599 merged earlier today, so the blast radius is approximately zero.
- Half-typed comprehension diagnostics remain #602; nested cartesian loops, record comprehensions, and concurrency caps remain deferred as in #599.

## Testing

Unit: 3704 tests across `lib/parsers`, `lib/lowering`, `lib/backends` (includes the generator fixture drivers - zero churn), `lib/runtime`, and both formatter suites, all green. Full baseline suite was green before work began. Execution: all ten comprehension files pass (five merged + five new) plus the block-form empty-race pin. `agency tc` clean on `race.agency`. Structural linter clean; diff audited against `docs/dev/anti-patterns.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
