### PR TITLE
Type fork block calls as T[] and race as T | null from the block returns

### DIFF
--- a/packages/agency-lang/lib/typeChecker/builtins.ts
+++ b/packages/agency-lang/lib/typeChecker/builtins.ts
@@ -319,10 +319,12 @@ export const BUILTIN_FUNCTION_TYPES: Record<string, BuiltinSignature> = {
 
   // --- Concurrency (language constructs with block arguments) ---
   // `fork` and `race` are special — they take a `string[]` of labels plus a
-  // block, and their return type depends on the block body. We type the
-  // return as `any` for now (no generic-block inference yet) but mark them
-  // `acceptsBlock` so the typechecker doesn't reject the call shape, and
-  // populate `description` so the LSP hover shows useful docs.
+  // block, and their return type depends on the block body. Block-carrying
+  // calls are typed by the synthesizer (BLOCK_CALL_RESULT in synthesizer.ts:
+  // fork -> T[], race -> T | null, T inferred from the block's returns); the
+  // returnType fields below are only the fallback for blockless call shapes.
+  // `acceptsBlock` keeps the call shape legal, and `description` feeds the
+  // LSP hover.
   fork: {
     params: [anyArray],
     returnType: anyArray,

--- a/packages/agency-lang/lib/typeChecker/forkRaceReturnTypes.test.ts
+++ b/packages/agency-lang/lib/typeChecker/forkRaceReturnTypes.test.ts
@@ -225,13 +225,14 @@ describe("degenerate shapes", () => {
     // expr.functionName is user-controlled and BLOCK_CALL_RESULT is a
     // plain object literal, so a bare index would walk the prototype
     // chain: table["toString"] is Object.prototype.toString, and the
-    // dispatch would wrap the block type with it - synthesizing the
-    // string "[object Object]" as a type, silently. The Object.hasOwn
-    // guard keeps inherited keys out; this call must type through the
-    // ordinary user-def path instead.
-    expect(
-      clean(
-        `def toString(xs: number[]): number[] {
+    // dispatch would wrap the block type with it - producing a bogus
+    // type that crashes the diagnostic formatter (probed: "Unknown
+    // variable type" throw). The Object.hasOwn guard keeps inherited
+    // keys out; this call must type through the ordinary user-def
+    // path. Naming a def toString legitimately warns AG4001 (shadows
+    // an imported function) - that one expected code is excluded.
+    const errs = clean(
+      `def toString(xs: number[], func: (any) -> any): number[] {
   return xs
 }
 
@@ -239,8 +240,8 @@ node main() {
   const r: number[] = toString([1, 2]) as x { return x }
   return r
 }`,
-      ),
-    ).toHaveLength(0);
+    ).filter((e) => e.code !== "AG4001");
+    expect(errs).toHaveLength(0);
   });
 
   it("a blockless fork call falls back to the builtin type and does not crash", () => {

--- a/packages/agency-lang/lib/typeChecker/forkRaceReturnTypes.test.ts
+++ b/packages/agency-lang/lib/typeChecker/forkRaceReturnTypes.test.ts
@@ -221,6 +221,28 @@ describe("degenerate shapes", () => {
     ).toHaveLength(0);
   });
 
+  it("a user function named toString with a block does not hit the table", () => {
+    // expr.functionName is user-controlled and BLOCK_CALL_RESULT is a
+    // plain object literal, so a bare index would walk the prototype
+    // chain: table["toString"] is Object.prototype.toString, and the
+    // dispatch would wrap the block type with it - synthesizing the
+    // string "[object Object]" as a type, silently. The Object.hasOwn
+    // guard keeps inherited keys out; this call must type through the
+    // ordinary user-def path instead.
+    expect(
+      clean(
+        `def toString(xs: number[]): number[] {
+  return xs
+}
+
+node main() {
+  const r: number[] = toString([1, 2]) as x { return x }
+  return r
+}`,
+      ),
+    ).toHaveLength(0);
+  });
+
   it("a blockless fork call falls back to the builtin type and does not crash", () => {
     // the table dispatch is gated on blockOf(expr); a blockless call
     // must fall through to BUILTIN_FUNCTION_TYPES (any[]), not reach

--- a/packages/agency-lang/lib/typeChecker/forkRaceReturnTypes.test.ts
+++ b/packages/agency-lang/lib/typeChecker/forkRaceReturnTypes.test.ts
@@ -1,0 +1,343 @@
+import { describe, it, expect } from "vitest";
+import { typecheckSource } from "./testUtils.js";
+
+/** Errors whose message matches. Reject-cases only - accept-cases
+ *  assert the raw list is empty so unrelated diagnostics cannot hide. */
+const matching = (src: string, re: RegExp) =>
+  typecheckSource(src).filter((e) => re.test(e.message));
+
+const clean = (src: string) => typecheckSource(src);
+
+const DOUBLE = `def double(x: number): number {
+  return x * 2
+}
+`;
+
+describe("fork block calls type as T[]", () => {
+  it("infers the element type - consuming an element as the wrong type errors", () => {
+    // Under the old `any` typing this produced nothing; the downstream
+    // mismatch is what distinguishes a working inference from an
+    // absent one.
+    const errs = matching(
+      DOUBLE +
+        `node main() {
+  const xs = fork([1, 2]) as x { return double(x) }
+  const s: string = xs[0]
+  return s
+}`,
+      /not assignable to type 'string'/,
+    );
+    expect(errs.length).toBeGreaterThan(0);
+  });
+
+  it("accepts a T[] annotation with no diagnostics at all", () => {
+    expect(
+      clean(
+        DOUBLE +
+          `node main() {
+  const xs: number[] = fork([1, 2]) as x { return double(x) }
+  return xs
+}`,
+      ),
+    ).toHaveLength(0);
+  });
+
+  it("rejects a scalar annotation", () => {
+    const errs = matching(
+      DOUBLE +
+        `node main() {
+  const n: number = fork([1, 2]) as x { return double(x) }
+  return n
+}`,
+      /not assignable to type 'number'/,
+    );
+    expect(errs.length).toBeGreaterThan(0);
+  });
+
+  it("joins mixed block returns into a union element type", () => {
+    expect(
+      clean(
+        DOUBLE +
+          `node main() {
+  const xs: (number | string)[] = fork([1, 2]) as x {
+    if (x == 1) {
+      return double(x)
+    }
+    return "odd"
+  }
+  return xs
+}`,
+      ),
+    ).toHaveLength(0);
+  });
+
+  it("types a fork nested in a fork block as T[][]", () => {
+    // exercises the shared walk's nested-blockArgument skip against the
+    // new case: the OUTER block's return is the inner fork call, and
+    // the inner block's return must NOT leak into the outer element
+    expect(
+      clean(
+        DOUBLE +
+          `node main() {
+  const grid: number[][] = fork([1]) as x {
+    return fork([2, 3]) as y { return double(y) }
+  }
+  return grid
+}`,
+      ),
+    ).toHaveLength(0);
+  });
+
+  it("keeps isFailure legal on a typed element", () => {
+    // Pins the spec's failures-invisible decision at its dependency:
+    // isFailure takes ANY_T (builtins.ts:245), so a number element is a
+    // legal argument. If isFailure ever gets a narrower signature, this
+    // fails HERE, pointing at the recorded decision, instead of
+    // breaking the merged interrupt execution tests at a distance.
+    expect(
+      clean(
+        DOUBLE +
+          `node main() {
+  const xs: number[] = fork([1, 2]) as x { return double(x) }
+  if (isFailure(xs[1])) {
+    return "failed"
+  }
+  return "ok"
+}`,
+      ),
+    ).toHaveLength(0);
+  });
+});
+
+describe("race block calls type as T | null", () => {
+  it("rejects a T[] annotation - the issue 603 headline case", () => {
+    const errs = matching(
+      DOUBLE +
+        `node main() {
+  const w: number[] = race([1, 2]) as x { return double(x) }
+  return w
+}`,
+      /not assignable to type 'number\[\]'/,
+    );
+    expect(errs.length).toBeGreaterThan(0);
+  });
+
+  it("rejects a bare T annotation - the result is nullable", () => {
+    const errs = matching(
+      DOUBLE +
+        `node main() {
+  const w: number = race([1, 2]) as x { return double(x) }
+  return w
+}`,
+      /not assignable to type 'number'/,
+    );
+    expect(errs.length).toBeGreaterThan(0);
+  });
+
+  it("accepts T | null, and infers T through a nullish coalesce", () => {
+    // the coalesce half both accepts (number survives ??) and consumes
+    // (string binding must error) - see the second block
+    expect(
+      clean(
+        DOUBLE +
+          `node main() {
+  const w: number | null = race([1, 2]) as x { return double(x) }
+  const maybe = race([1, 2]) as x { return double(x) }
+  const n: number = maybe ?? 0
+  return n
+}`,
+      ),
+    ).toHaveLength(0);
+    const errs = matching(
+      DOUBLE +
+        `node main() {
+  const maybe = race([1, 2]) as x { return double(x) }
+  const s: string = maybe ?? 0
+  return s
+}`,
+      /not assignable to type 'string'/,
+    );
+    expect(errs.length).toBeGreaterThan(0);
+  });
+});
+
+describe("fail-open behavior on any-element blocks", () => {
+  it("race collapses to any - the headline mistake is NOT caught here", () => {
+    // `x` is an any-typed block parameter, so the element is any and
+    // race must fail open (any, not any | null). This is the recorded
+    // limitation: the wrong annotation passes when the block returns
+    // any. The PR description states it.
+    expect(
+      clean(
+        `node main() {
+  const w: string[] = race([1, 2]) as x { return x }
+  const s: string = race([1, 2]) as x { return x }
+  return s
+}`,
+      ),
+    ).toHaveLength(0);
+  });
+
+  it("fork keeps the list shape even for any elements - scalar annotations now error", () => {
+    // Deliberate NEW strictness on the fail-open path: any[] is real
+    // information (the list shape), so a scalar annotation errors
+    // where it used to pass. The one shape that can produce sweep
+    // churn in previously-clean code.
+    const errs = matching(
+      `node main() {
+  const s: string = fork([1, 2]) as x { return x }
+  return s
+}`,
+      /not assignable to type 'string'/,
+    );
+    expect(errs.length).toBeGreaterThan(0);
+  });
+
+  it("fork any[] still accepts any array annotation", () => {
+    expect(
+      clean(
+        `node main() {
+  const xs: string[] = fork([1, 2]) as x { return x }
+  return xs
+}`,
+      ),
+    ).toHaveLength(0);
+  });
+});
+
+describe("degenerate shapes", () => {
+  it("a void block produces no diagnostics unannotated", () => {
+    // the synthesized types are void[] / void | null (blockReturnType
+    // folds no-returns to VOID_T); asserted only as absence-of-error
+    // because `void[]` in annotation position is untested grammar
+    expect(
+      clean(
+        `node main() {
+  const a = fork([1, 2]) as x { print("side effect") }
+  const b = race([1, 2]) as x { print("side effect") }
+  return "ok"
+}`,
+      ),
+    ).toHaveLength(0);
+  });
+
+  it("a blockless fork call falls back to the builtin type and does not crash", () => {
+    // the table dispatch is gated on blockOf(expr); a blockless call
+    // must fall through to BUILTIN_FUNCTION_TYPES (any[]), not reach
+    // blockReturnType with undefined
+    expect(
+      clean(
+        `node main() {
+  const r = fork([1, 2])
+  return "ok"
+}`,
+      ),
+    ).toHaveLength(0);
+  });
+
+  it("a fork result returned from a def checks through the return path", () => {
+    expect(
+      clean(
+        DOUBLE +
+          `def spread(xs: number[]): number[] {
+  return fork(xs) as x { return double(x) }
+}
+
+node main() {
+  return spread([1, 2])
+}`,
+      ),
+    ).toHaveLength(0);
+    const errs = matching(
+      DOUBLE +
+        `def wrong(xs: number[]): number {
+  return fork(xs) as x { return double(x) }
+}
+
+node main() {
+  return wrong([1, 2])
+}`,
+      /not assignable/,
+    );
+    expect(errs.length).toBeGreaterThan(0);
+  });
+
+  it("a fork inside a guard composes", () => {
+    // a bare guard legitimately warns AG3009 (may throw interrupts
+    // outside a handler) - that one expected code is excluded so the
+    // assertion stays strict about everything else, in particular that
+    // r.value : number[] binds cleanly
+    const errs = clean(
+      DOUBLE +
+        `node main() {
+  const r = guard(cost: $1) {
+    return fork([1, 2]) as x { return double(x) }
+  }
+  if (isSuccess(r)) {
+    const xs: number[] = r.value
+    return "ok"
+  }
+  return "failed"
+}`,
+    ).filter((e) => e.code !== "AG3009");
+    expect(errs).toHaveLength(0);
+  });
+});
+
+describe("comprehension forms inherit the types", () => {
+  it("race comprehensions reject a list annotation", () => {
+    const errs = matching(
+      DOUBLE +
+        `node main() {
+  const w: number[] = race [double(x) for x in [1, 2]]
+  return w
+}`,
+      /not assignable to type 'number\[\]'/,
+    );
+    expect(errs.length).toBeGreaterThan(0);
+  });
+
+  it("raceShared is nullable too - bare T rejected, T | null accepted", () => {
+    // the fourth #604 prefix, carrying both the shared named argument
+    // and the nullable return
+    const errs = matching(
+      DOUBLE +
+        `node main() {
+  const w: number = raceShared [double(x) for x in [1, 2]]
+  return w
+}`,
+      /not assignable to type 'number'/,
+    );
+    expect(errs.length).toBeGreaterThan(0);
+    expect(
+      clean(
+        DOUBLE +
+          `node main() {
+  const w: number | null = raceShared [double(x) for x in [1, 2]]
+  return "ok"
+}`,
+      ),
+    ).toHaveLength(0);
+  });
+
+  it("fork and forkShared comprehensions accept T[] and reject T", () => {
+    expect(
+      clean(
+        DOUBLE +
+          `node main() {
+  const xs: number[] = forkShared [double(x) for x in [1, 2]]
+  return xs
+}`,
+      ),
+    ).toHaveLength(0);
+    const errs = matching(
+      DOUBLE +
+        `node main() {
+  const n: number = fork [double(x) for x in [1, 2]]
+  return n
+}`,
+      /not assignable to type 'number'/,
+    );
+    expect(errs.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/synthesizer.ts
+++ b/packages/agency-lang/lib/typeChecker/synthesizer.ts
@@ -578,49 +578,82 @@ function synthPipeRhs(
  *  failure side stays `any`, the `try`-expression precedent — the
  *  err-side narrowing users rely on (`isFailure`, `error.type`) is
  *  field-based, not type-based. */
-function synthGuardCall(
+/** The block argument of a call, if it carries one. The single home for
+ *  the block cast - every block-typing consumer reads through this. */
+function blockOf(
   expr: AgencyNode & { type: "functionCall" },
+): { body: AgencyNode[] } | undefined {
+  return (expr as unknown as { block?: { body: AgencyNode[] } }).block;
+}
+
+/** The type a block argument's OWN returns produce. The walk skips
+ *  returns belonging to nested function/node/block definitions, then
+ *  folds: no returns -> void; any return typed `any` -> `any`
+ *  (fail-open); otherwise the union of the distinct return types.
+ *  Every BLOCK_CALL_RESULT row reads through this one walk, so the
+ *  block constructs cannot drift on what counts as a block-level
+ *  return. */
+function blockReturnType(
+  block: { body: AgencyNode[] },
   scope: Scope,
   ctx: TypeCheckerContext,
 ): VariableType {
-  const block = (expr as unknown as { block: { body: AgencyNode[] } }).block;
   const returnTypes: VariableType[] = [];
   for (const { node, ancestors } of walkNodes(block.body)) {
-    if (node.type !== "returnStatement" || !node.value) continue;
+    if (node.type !== "returnStatement" || !node.value) {
+      continue;
+    }
     const nested = ancestors.some(
       (a) =>
         a.type === "function" ||
         a.type === "graphNode" ||
         a.type === "blockArgument",
     );
-    if (!nested) returnTypes.push(synthType(node.value, scope, ctx));
+    if (!nested) {
+      returnTypes.push(synthType(node.value, scope, ctx));
+    }
   }
-  let successType: VariableType;
   if (returnTypes.length === 0) {
-    successType = { type: "primitiveType", value: "void" };
-  } else if (returnTypes.some((t) => isAnyType(t))) {
-    successType = ANY_T;
-  } else {
-    successType = unionTypes(returnTypes);
+    return VOID_T;
   }
-  return { type: "resultType", successType, failureType: ANY_T };
+  if (returnTypes.some((t) => isAnyType(t))) {
+    return ANY_T;
+  }
+  return unionTypes(returnTypes);
 }
+
+/** Reserved calls whose type comes from their block's returns. The walk
+ *  is shared (blockReturnType); only the wrapper differs. Adding
+ *  another block-carrying reserved call is a row. Keying on the call
+ *  name is shadow-proof: every key is in RESERVED_FUNCTION_NAMES. */
+const BLOCK_CALL_RESULT: Record<
+  string,
+  (element: VariableType) => VariableType
+> = {
+  // The guard construct's Result<T> precision. By synth time the
+  // construct has desugared to `_guard(...)` carrying its block
+  // (guardDesugar.ts + the TypeChecker constructor); _guard's own
+  // annotation is the generic Result, so parameterize it from the
+  // block. A direct `_guard` call with a block gets the same, correct,
+  // typing.
+  _guard: (element) => ({
+    type: "resultType",
+    successType: element,
+    failureType: ANY_T,
+  }),
+};
 
 function synthFunctionCall(
   expr: AgencyNode & { type: "functionCall" },
   scope: Scope,
   ctx: TypeCheckerContext,
 ): VariableType {
-  // The guard construct's Result<T> precision. By synth time the
-  // construct has desugared to a `_guard(...)` call carrying its block
-  // (see guardDesugar.ts + the TypeChecker constructor), and _guard's
-  // own annotation is the generic `Result` — so parameterize it here
-  // from the BLOCK's returns, the way an unannotated def body infers.
-  // Keyed on the desugared shape (name + block), which user code only
-  // produces via the construct; a direct `_guard` call with a block
-  // gets the same, correct, typing.
-  if (expr.functionName === "_guard" && (expr as { block?: unknown }).block) {
-    return synthGuardCall(expr, scope, ctx);
+  // Reserved block-carrying calls (guard construct, fork, race) take
+  // their type from the block's returns - see BLOCK_CALL_RESULT.
+  const wrapBlockResult = BLOCK_CALL_RESULT[expr.functionName];
+  const calledBlock = blockOf(expr);
+  if (wrapBlockResult !== undefined && calledBlock !== undefined) {
+    return wrapBlockResult(blockReturnType(calledBlock, scope, ctx));
   }
   // Result constructors: parameterize ResultType from the argument so callers
   // get `Result<T, any>` (success) or `Result<any, T>` (failure). The names

--- a/packages/agency-lang/lib/typeChecker/synthesizer.ts
+++ b/packages/agency-lang/lib/typeChecker/synthesizer.ts
@@ -641,6 +641,19 @@ const BLOCK_CALL_RESULT: Record<
     successType: element,
     failureType: ANY_T,
   }),
+  // fork joins every branch into a list. The list shape is kept even
+  // for an `any` element - any[] still catches scalar annotations.
+  // Failure slots are deliberately invisible (spec: "optimistic about
+  // failures").
+  fork: (element) => ({ type: "arrayType", elementType: element }),
+  // race yields the first-SETTLED branch, or null when zero branches
+  // ran (empty source, or a comprehension filter that matched nothing
+  // - #604). An `any` element collapses to any, NOT any | null:
+  // unionTypes does not absorb any, and fail-open must stay fail-open.
+  // COUPLED to #606: if the empty-race return value or first-success
+  // semantics change there, this row changes with them.
+  race: (element) =>
+    isAnyType(element) ? ANY_T : unionTypes([element, NULL_T]),
 };
 
 function synthFunctionCall(

--- a/packages/agency-lang/lib/typeChecker/synthesizer.ts
+++ b/packages/agency-lang/lib/typeChecker/synthesizer.ts
@@ -572,12 +572,6 @@ function synthPipeRhs(
   return rhsType;
 }
 
-/** `Result<T>` for a guarded block: `T` joins the block's own returns
- *  (returns inside nested functions/blocks excluded, the inference.ts
- *  rule). No returns → the block yields void; any `any` → `any`. The
- *  failure side stays `any`, the `try`-expression precedent — the
- *  err-side narrowing users rely on (`isFailure`, `error.type`) is
- *  field-based, not type-based. */
 /** The block argument of a call, if it carries one. The single home for
  *  the block cast - every block-typing consumer reads through this. */
 function blockOf(
@@ -635,7 +629,9 @@ const BLOCK_CALL_RESULT: Record<
   // (guardDesugar.ts + the TypeChecker constructor); _guard's own
   // annotation is the generic Result, so parameterize it from the
   // block. A direct `_guard` call with a block gets the same, correct,
-  // typing.
+  // typing. The failure side stays `any`, the try-expression
+  // precedent: the err-side narrowing users rely on (`isFailure`,
+  // `error.type`) is field-based, not type-based.
   _guard: (element) => ({
     type: "resultType",
     successType: element,
@@ -662,8 +658,16 @@ function synthFunctionCall(
   ctx: TypeCheckerContext,
 ): VariableType {
   // Reserved block-carrying calls (guard construct, fork, race) take
-  // their type from the block's returns - see BLOCK_CALL_RESULT.
-  const wrapBlockResult = BLOCK_CALL_RESULT[expr.functionName];
+  // their type from the block's returns - see BLOCK_CALL_RESULT. The
+  // Object.hasOwn guard is load-bearing: functionName is user-supplied,
+  // and a bare index on an object literal walks the prototype chain, so
+  // a user function named toString/valueOf/constructor with a block
+  // would get "wrapped" by Object.prototype methods - a silently wrong
+  // type, not a crash. (The sibling tables, CALL_NAME and
+  // COMPREHENSION_PREFIXES, have closed keysets and no such exposure.)
+  const wrapBlockResult = Object.hasOwn(BLOCK_CALL_RESULT, expr.functionName)
+    ? BLOCK_CALL_RESULT[expr.functionName]
+    : undefined;
   const calledBlock = blockOf(expr);
   if (wrapBlockResult !== undefined && calledBlock !== undefined) {
     return wrapBlockResult(blockReturnType(calledBlock, scope, ctx));

--- a/packages/agency-lang/tests/agency/fork-arg-position.agency
+++ b/packages/agency-lang/tests/agency/fork-arg-position.agency
@@ -10,8 +10,10 @@ node main(): string {
   // fork as a function ARGUMENT - this is what currently crashes
   const summed = total(fork([1, 2, 3]) as x { return double(x) })
 
-  // race gets the same fix, and is otherwise untested
-  const first = total([race([5]) as x { return double(x) }])
+  // race gets the same fix, and is otherwise untested. The ?? keeps
+  // race in ARGUMENT POSITION (the coverage this line exists for)
+  // while collapsing the checker's number | null to number
+  const first = total([(race([5]) as x { return double(x) }) ?? 0])
 
   // regression guard: a bare function reference as an argument must
   // still be passed as a reference, not called

--- a/packages/agency-lang/tests/agency/fork/fork-stress.agency
+++ b/packages/agency-lang/tests/agency/fork/fork-stress.agency
@@ -23,7 +23,10 @@ def quickCheck(item: string): string {
     }
     return "${entry.id}: ${item}"
   }
-  return result
+  // race types as string | null (a race over zero branches is null),
+  // but this source list is statically non-empty, so the null arm
+  // cannot occur - collapse it for the string return
+  return result ?? ""
 }
 
 def confirmDelete(item: string): string {

--- a/packages/agency-lang/tests/agency/fork/race-basic.agency
+++ b/packages/agency-lang/tests/agency/fork/race-basic.agency
@@ -7,7 +7,8 @@ node main() {
   let result = race(arr) as item {
     return identity(item)
   }
-  if (arr.includes(result)) {
+  // race types as number | null; the null check narrows it for includes
+  if (result != null && arr.includes(result)) {
     return true
   }
   return false

--- a/packages/agency-lang/tests/agency/fork/race/race-reject-winner.agency
+++ b/packages/agency-lang/tests/agency/fork/race/race-reject-winner.agency
@@ -4,7 +4,12 @@ def confirm(item: number): number {
 }
 
 node main() {
-  let result = race([10, 20, 30]) as item {
+  // Explicitly any: the checker types a race as number | null, but
+  // first-settled semantics can deliver a Failure (pinning that is
+  // this test's whole point), and reading .value/.error off it needs
+  // the checker out of the way. This is the recorded cost of the
+  // failures-invisible typing decision (fork/race spec, #603).
+  let result: any = race([10, 20, 30]) as item {
     return confirm(item)
   }
   if (isSuccess(result)) {


### PR DESCRIPTION
The checker now infers `fork(xs) as x { ... }` as `T[]` and `race(xs) as x { ... }` as `T | null` from the block's returns, so a wrong list/scalar annotation on a race result - `const summaries: string[] = race [...]` - is a type error instead of silently passing as `any`. The comprehension forms (`fork [...]`, `forkShared [...]`, `race [...]`, `raceShared [...]`) inherit the types because they desugar to these calls before the checker runs; they have their own tests anyway.

Closes #603.

Spec: `docs/superpowers/specs/2026-07-19-fork-race-return-types-design.md`. Plan: `docs/superpowers/plans/2026-07-19-fork-race-return-types.md` (rev 2, one review round applied).

## Mechanism

The `_guard` precedent, generalized into data: `synthFunctionCall` now dispatches reserved block-carrying calls through one `BLOCK_CALL_RESULT` table - a shared `blockReturnType` walk (extracted from `synthGuardCall`, which is deleted; its wrapper became the `_guard` row) plus a per-call wrapper lambda. Same table shape as `CALL_NAME` (#599) and `COMPREHENSION_PREFIXES` (#604). Adding another block-typed call is a row. `blockOf` is the single home for the block cast. No parser, desugar, builder, or runtime changes.

## Recorded decisions and limitations (from the spec)

- **Failures are invisible.** A rejected branch really leaves a Failure in a fork slot, and a race can return one (first-settled semantics), but the types are the optimistic `T[]` / `T | null`, not `(T | Failure)[]`. Honest typing would force a guard on every element and needs union narrowing the checker does not have (probed: `Result<T> | null` narrows `.value` through `isSuccess` but not `.error`). A test pins the dependency this rests on: `isFailure` accepts `ANY_T`, so failure checks on typed elements keep compiling.
- **The `any`-element limitation.** When a block's return type is `any` (e.g. it returns a bare block parameter), race collapses to `any` and the #603 headline annotation still passes. The fix bites when the body produces a concrete type - the common case. Fork is different: the builtin fallback already typed blockless-and-block forks as `any[]`, and the new case keeps that list shape, so scalar annotations on any-element forks error (already did, via the builtin).
- **Race is stricter than `arr[i]`.** Index access keeps optimistic plain-`T` typing; the race `| null` reflects the deliberately-introduced empty-race null (#604) that the guide tells callers to handle.
- **Coupled to #606.** The race row encodes empty-race-returns-null. If #606 changes that (Failure instead of null, or first-success semantics), the row changes with it - the coupling is written at the row itself.

## The sweep caught four real pre-existing gaps

`tc` over stdlib and both test corpora, baselined against the behavior-identical refactor commit. stdlib and agency-js: zero new diagnostics (the only two stdlib call sites are any-element). Four catches in `tests/agency`, all fixed:

- `fork/fork-stress.agency`: a race result returned as bare `string`; now `?? ""` with a comment that the statically non-empty source makes the null arm unreachable.
- `fork/race/race-reject-winner.agency`: reads `.value`/`.error` off a race winner that really is a Failure (the test pins first-settled rejection). That access was only ever legal via `any`; the binding is now explicitly `: any` with a comment naming this as the recorded cost of the failures-invisible decision.
- `fork/race-basic.agency`: nullable fed to `.includes(number)`; now behind a `!= null` narrow.
- `fork-arg-position.agency`: `[race(...) as x { ... }]` built a `(number | null)[]` for a `number[]` parameter; fixed with a parenthesized `?? 0` that keeps the race in argument position, which is the coverage that line exists for.

The remaining corpus directories (`lib/agents`, `tests/typescriptGenerator`, `agents`, `examples`) contain no fork/race calls - grep re-verified, including against the #600 files that landed on main after this branch was cut.

## Testing

19 new checker tests. The positive inference cases CONSUME the result (`xs[0]` bound to the wrong type, `?? 0` bound to the wrong type) so they fail when the inference is absent - under the old `any` typing, annotation-accept tests pass identically with or without the feature. Accept-cases assert the unfiltered diagnostic list is empty; reject-cases pin message content. Coverage includes fork-in-fork nesting (`T[][]`), fork-in-guard composition, blockless-call fallback, return-position checking, void blocks, `raceShared`, and the fail-open shapes. Full checker suite: 1628 passing. Structural linter clean. The four touched execution tests re-run green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
