### PR TITLE
Require commas between literal items; targeted parse errors for half-typed comprehensions

### DIFF
--- a/packages/agency-lang/lib/parsers/comprehension.test.ts
+++ b/packages/agency-lang/lib/parsers/comprehension.test.ts
@@ -228,6 +228,36 @@ describe("comprehensionParser", () => {
     expect(parseFailsWith("[x for x in]", /iterable/)).toBe(true);
   });
 
+  it("reports a missing binder even with no space before the bracket", () => {
+    // an editor auto-closing the bracket turns a half-typed `[x for`
+    // into `[x for]` - the commit must not be gated on the user having
+    // typed a trailing space
+    expect(parseFailsWith("[x for]", /binder/)).toBe(true);
+    expect(parseFailsWith("[x for ]", /binder/)).toBe(true);
+  });
+
+  // in/if inside the commit points are word-bounded, so a fused token
+  // reports the missing KEYWORD rather than blaming the next clause
+  it("does not let insomething match as in", () => {
+    expect(
+      parseFailsWith("[x for x insomething]", /expected `in`/),
+    ).toBe(true);
+  });
+
+  it("does not let iffy match as a filter if", () => {
+    // iffy is not a filter keyword; with the boundary the optional
+    // filter backtracks and the close-bracket commit reports instead
+    expect(parseFailsWith("[x for x in xs iffy]", /close/)).toBe(true);
+  });
+
+  it("still treats forever as an identifier, not a for prefix", () => {
+    // the word boundary after `for` replaces the old required-space
+    // rule; a longer identifier must still fail BEFORE the commit and
+    // fall through to the array comma rule
+    expect(parseFails("[x forever]")).toBe(true);
+    expect(parseFailsWith("[x forever]", /comprehension/)).toBe(false);
+  });
+
   it("reports a missing in keyword", () => {
     // the binder greedily reads the word `in` as its name, so the
     // commit fires at the missing `in` position (over `xs`)

--- a/packages/agency-lang/lib/parsers/comprehension.test.ts
+++ b/packages/agency-lang/lib/parsers/comprehension.test.ts
@@ -33,6 +33,21 @@ function parseFails(src: string): boolean {
   return !result.success;
 }
 
+/** True when the source fails to parse AND the failure message matches -
+ *  the targeted-diagnostic contract from #602. */
+function parseFailsWith(src: string, re: RegExp): boolean {
+  const result = parseAgency(
+    `node main() {\n  const x = ${src}\n}`,
+    {},
+    true,
+    false,
+  );
+  if (result.success) {
+    return false;
+  }
+  return re.test((result as { message?: string }).message ?? "");
+}
+
 describe("comprehensionParser", () => {
   it("parses a plain comprehension", () => {
     const node = parseExpr("[f(x) for x in xs]");
@@ -202,21 +217,39 @@ describe("comprehensionParser", () => {
     expect(parseExpr("[format, other]").type).toBe("agencyArray");
   });
 
-  // Half-typed comprehensions are now a thing users and agents will
-  // produce constantly. They do NOT error: the array parser accepts
-  // whitespace-separated items and `in` is a binary operator, so these
-  // have always parsed as arrays of variable names (probed - this is
-  // pre-existing behavior, not something this feature introduced). Pin
-  // that they at least never become half-baked comprehension nodes, so
-  // a later improvement shows up as a diff. A real diagnostic at the
-  // comprehension is tracked as issue #602.
-  it.each([["[x for x in]"], ["[for x in xs]"], ["[x for in xs]"]])(
-    "parses the malformed comprehension %s as an array, not a comprehension",
-    (src) => {
-      expect(parseFails(src)).toBe(false);
-      expect(parseExpr(src).type).toBe("agencyArray");
-    },
-  );
+  // Half-typed comprehensions now ERROR at the comprehension (#602).
+  // Two mechanisms combine: literal items require commas between them
+  // again (the 2026-07-04 comma-optional regression is fixed, so these
+  // can no longer fall back to whitespace-separated arrays of variable
+  // names), and the comprehension parser COMMITS once `[ expr for ` has
+  // matched, turning later failures into targeted messages instead of
+  // a silent backtrack.
+  it("reports a missing iterable", () => {
+    expect(parseFailsWith("[x for x in]", /iterable/)).toBe(true);
+  });
+
+  it("reports a missing in keyword", () => {
+    // the binder greedily reads the word `in` as its name, so the
+    // commit fires at the missing `in` position (over `xs`)
+    expect(parseFailsWith("[x for in xs]", /expected `in`/)).toBe(true);
+  });
+
+  it("reports a missing filter condition", () => {
+    expect(parseFailsWith("[x for x in xs if]", /condition/)).toBe(true);
+  });
+
+  it("reports an unclosed comprehension", () => {
+    expect(parseFailsWith("[x for x in xs", /close/)).toBe(true);
+  });
+
+  it("rejects a missing body expression, via the array comma rule", () => {
+    // `[for x in xs]` parses `for` as the body expression, so the
+    // comprehension never reaches its commit point (the keyword is
+    // consumed as a name and ` x` is not `for `). It fails as an
+    // array missing its commas instead - a generic error, but at the
+    // right position
+    expect(parseFails("[for x in xs]")).toBe(true);
+  });
 
   // tarsec's `spaces` matches newlines too, so a comprehension broken
   // across lines parses fine. Pinned deliberately: the guide can promise

--- a/packages/agency-lang/lib/parsers/literalDelimiter.test.ts
+++ b/packages/agency-lang/lib/parsers/literalDelimiter.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { agencyArrayParser, agencyObjectParser } from "./parsers.js";
+
+/** Whole-input parse helpers: success means the parser consumed the
+ *  entire literal, matching how these parsers are driven in tests
+ *  elsewhere in this directory. */
+const arrayOk = (src: string) => {
+  const r = agencyArrayParser(src);
+  return r.success && r.rest === "";
+};
+const objectOk = (src: string) => {
+  const r = agencyObjectParser(src);
+  return r.success && r.rest === "";
+};
+
+describe("literal items require commas between them", () => {
+  it("parses ordinary comma-separated arrays and objects", () => {
+    expect(arrayOk("[1, 2, 3]")).toBe(true);
+    expect(arrayOk("[]")).toBe(true);
+    expect(objectOk(`{ "a": 1, "b": 2 }`)).toBe(true);
+    expect(objectOk("{}")).toBe(true);
+  });
+
+  it("keeps trailing commas", () => {
+    expect(arrayOk("[1, 2, 3,]")).toBe(true);
+    expect(objectOk(`{ "a": 1, "b": 2, }`)).toBe(true);
+  });
+
+  it("keeps multi-line literals with commas", () => {
+    expect(arrayOk("[\n  1,\n  2,\n  3\n]")).toBe(true);
+    expect(objectOk(`{\n  "a": 1,\n  "b": 2\n}`)).toBe(true);
+  });
+
+  it("keeps splats", () => {
+    expect(arrayOk("[...xs, 1]")).toBe(true);
+  });
+
+  // The 2026-07-04 comments-between-entries rewrite made the comma
+  // optional EVERYWHERE, so any whitespace separated items and
+  // `[x for x in]` parsed as a four-item array of variable names
+  // (#602). These pin the restoration of the required comma.
+  it("rejects whitespace-separated array items", () => {
+    expect(arrayOk("[1 2 3]")).toBe(false);
+    expect(arrayOk("[x for x in]")).toBe(false);
+    expect(arrayOk("[\n  1\n  2\n]")).toBe(false);
+  });
+
+  it("rejects whitespace-separated object entries", () => {
+    expect(objectOk(`{ "a": 1 "b": 2 }`)).toBe(false);
+  });
+
+  it("rejects a comment interposed between comma-less items", () => {
+    // the trailing-position lookahead only accepts trivia followed by
+    // the CLOSER - a comment cannot smuggle in a missing comma
+    expect(arrayOk("[1 // note\n 2]")).toBe(false);
+  });
+
+  // The comment placements the rewrite legitimately added, all pinned
+  // in dataStructures.test.ts too - re-asserted here beside the
+  // rejections so the whole delimiter contract reads in one place.
+  it("keeps comments after a comma", () => {
+    expect(arrayOk("[\n  1,\n  // keep me\n  2\n]")).toBe(true);
+    expect(objectOk(`{\n  "a": 1,\n  // keep me\n  "b": 2\n}`)).toBe(true);
+  });
+
+  it("keeps trailing comments without a trailing comma", () => {
+    expect(objectOk(`{\n  // lead\n  "a": 1\n  // trail\n}`)).toBe(true);
+    expect(arrayOk("[\n  1\n  // trail\n]")).toBe(true);
+  });
+});

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -1303,9 +1303,14 @@ type InterleavedEntry<T> = ItemEntry<T> | TriviaEntry;
 // so `partitionTrivia` can distinguish it — no manual result unwrapping.
 // `multiLineCommentParser` does NOT eat its trailing newline, which the
 // trailing `optionalSpacesOrNewline` handles so `many(...)` keeps progressing.
+/** One comment/blank-line unit, shared between triviaEntry (which
+ *  captures it) and literalDelimiter's trailing-position lookahead
+ *  (which only scans past it). */
+const literalTrivia = or(blankLineParser, commentParser, multiLineCommentParser);
+
 const triviaEntry: Parser<TriviaEntry> = seqC(
   set("kind", "trivia"),
-  capture(or(blankLineParser, commentParser, multiLineCommentParser), "node"),
+  capture(literalTrivia, "node"),
   optionalSpacesOrNewline,
 ) as Parser<TriviaEntry>;
 
@@ -2148,14 +2153,30 @@ export const splatParser: Parser<SplatExpression> = seqC(
   capture(lazy(() => exprParser), "value"),
 );
 
-// The delimiter between literal items: whitespace/newlines may sit on either
-// side of the separating comma (matching the old `commaWithNewline`), and the
-// comma itself is optional so a trailing comma before `}`/`]` is allowed.
-const literalDelimiter = seqR(
-  optionalSpacesOrNewline,
-  optional(char(",")),
-  optionalSpacesOrNewline,
-);
+// The delimiter after each literal item: a comma is REQUIRED between
+// items (whitespace/newlines may surround it, matching the old
+// `commaWithNewline`). The alternative branch is a LOOKAHEAD accepting
+// only trailing position - optional comments/blank lines followed by
+// the closing bracket - which covers the final item, trailing commas
+// (a comma whose next item never arrives), and trailing comments
+// without a comma, while rejecting whitespace-separated items. The
+// 2026-07-04 rewrite made the comma optional EVERYWHERE, so any
+// whitespace separated items and `[x for x in]` parsed as a four-item
+// array of variable names (#602).
+const literalDelimiter = (closer: string) =>
+  seqR(
+    optionalSpacesOrNewline,
+    or(
+      char(","),
+      peek(
+        seqR(
+          many(seqR(literalTrivia, optionalSpacesOrNewline)),
+          char(closer),
+        ),
+      ),
+    ),
+    optionalSpacesOrNewline,
+  );
 
 export const agencyArrayParser: Parser<AgencyArray> = trace(
   "agencyArrayParser",
@@ -2167,7 +2188,7 @@ export const agencyArrayParser: Parser<AgencyArray> = trace(
         many(
           or(
             triviaEntry,
-            itemEntry(or(splatParser, lazy(() => exprParser)), literalDelimiter),
+            itemEntry(or(splatParser, lazy(() => exprParser)), literalDelimiter("]")),
           ),
         ),
         "entries",
@@ -2237,7 +2258,7 @@ export const agencyObjectParser: Parser<AgencyObject> = map(
       many(
         or(
           triviaEntry,
-          itemEntry(or(splatParser, agencyObjectKVParser), literalDelimiter),
+          itemEntry(or(splatParser, agencyObjectKVParser), literalDelimiter("}")),
         ),
       ),
       "entries",
@@ -4706,29 +4727,64 @@ export const comprehensionParser: Parser<Comprehension> = label(
         optionalSpacesOrNewline,
         str("for"),
         spaces,
-        ...iterationBinderFragment,
-        optionalSpacesOrNewline,
-        str("in"),
-        spaces,
-        capture(
-          lazy(() => exprParser),
-          "iterable",
+        // COMMIT POINT (#602). Once `[ expr for ` has matched, nothing
+        // but a comprehension attempt can be on the wire - arrays,
+        // strings containing the word for, and format-style identifiers
+        // all diverge earlier (pinned in comprehension.test.ts). So
+        // from here failures are hard, targeted parseError throws
+        // instead of a silent backtrack into the array parser, which
+        // used to swallow half-typed comprehensions.
+        captureCaptures(
+          parseError(
+            "expected a binder name or pattern after `for` in this list comprehension",
+            ...iterationBinderFragment,
+          ),
+        ),
+        captureCaptures(
+          parseError(
+            "expected `in` after the list comprehension binder",
+            optionalSpacesOrNewline,
+            str("in"),
+          ),
+        ),
+        // the required whitespace after `in` lives with the iterable,
+        // so `[x for x in]` reports a missing iterable rather than
+        // blaming the `in` it already has
+        captureCaptures(
+          parseError(
+            "expected an iterable expression after `in` in this list comprehension",
+            spaces,
+            capture(
+              lazy(() => exprParser),
+              "iterable",
+            ),
+          ),
         ),
         optional(
           captureCaptures(
             seqC(
               optionalSpacesOrNewline,
               str("if"),
-              spaces,
-              capture(
-                lazy(() => exprParser),
-                "condition",
+              // committed once `if` matched: a filter keyword with no
+              // condition is a broken comprehension, not an array
+              captureCaptures(
+                parseError(
+                  "expected a filter condition after `if` in this list comprehension",
+                  spaces,
+                  capture(
+                    lazy(() => exprParser),
+                    "condition",
+                  ),
+                ),
               ),
             ),
           ),
         ),
-        optionalSpacesOrNewline,
-        char("]"),
+        parseError(
+          "expected `]` to close this list comprehension",
+          optionalSpacesOrNewline,
+          char("]"),
+        ),
         ),
         // Convert the raw prefix keyword into mode/shared by table
         // lookup - one branch, the sequential case being a table row

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -4720,23 +4720,29 @@ export const comprehensionParser: Parser<Comprehension> = label(
         // whitespace here broke every call-bodied comprehension. It must
         // cross newlines (optionalSpaces is spaces/tabs only) or a
         // comprehension could only break lines after a call, never before
-        // `in`/`if`. After must be required so `for` stays a whole word:
-        // `[format, other]` fails at str("for") because exprParser
-        // greedily consumed the full identifier `format`, and `forx`
-        // fails the required space.
+        // `in`/`if`. `for` stays a whole word via the not(varNameChar)
+        // boundary below: `[format, other]` fails at str("for") because
+        // exprParser greedily consumed the full identifier `format`, and
+        // `forx` fails the boundary.
         optionalSpacesOrNewline,
         str("for"),
-        spaces,
-        // COMMIT POINT (#602). Once `[ expr for ` has matched, nothing
-        // but a comprehension attempt can be on the wire - arrays,
-        // strings containing the word for, and format-style identifiers
-        // all diverge earlier (pinned in comprehension.test.ts). So
-        // from here failures are hard, targeted parseError throws
-        // instead of a silent backtrack into the array parser, which
-        // used to swallow half-typed comprehensions.
+        // word boundary, not required whitespace: `[x for]` (an editor
+        // auto-closing a half-typed comprehension) must still reach the
+        // commit and get the binder message, while `forever` must fail
+        // here, BEFORE the commit, and fall through to the array rule
+        not(varNameChar),
+        // COMMIT POINT (#602). Once `[ expr for` has matched as a whole
+        // word, nothing but a comprehension attempt can be on the wire -
+        // arrays, strings containing the word for, and format-style
+        // identifiers all diverge earlier (pinned in
+        // comprehension.test.ts). So from here failures are hard,
+        // targeted parseError throws instead of a silent backtrack into
+        // the array parser, which used to swallow half-typed
+        // comprehensions.
         captureCaptures(
           parseError(
             "expected a binder name or pattern after `for` in this list comprehension",
+            spaces,
             ...iterationBinderFragment,
           ),
         ),
@@ -4745,6 +4751,10 @@ export const comprehensionParser: Parser<Comprehension> = label(
             "expected `in` after the list comprehension binder",
             optionalSpacesOrNewline,
             str("in"),
+            // word-bounded (the ifExpressionParser precedent), so
+            // `insomething` reports the missing `in` here instead of
+            // committing past it and blaming the iterable
+            not(varNameChar),
           ),
         ),
         // the required whitespace after `in` lives with the iterable,
@@ -4765,8 +4775,13 @@ export const comprehensionParser: Parser<Comprehension> = label(
             seqC(
               optionalSpacesOrNewline,
               str("if"),
-              // committed once `if` matched: a filter keyword with no
-              // condition is a broken comprehension, not an array
+              // word boundary: `iffy` is an identifier, not a filter
+              // keyword - it must fail here so the optional backtracks
+              // and the close-bracket commit reports instead
+              not(varNameChar),
+              // committed once `if` matched as a whole word: a filter
+              // keyword with no condition is a broken comprehension,
+              // not an array
               captureCaptures(
                 parseError(
                   "expected a filter condition after `if` in this list comprehension",


### PR DESCRIPTION
Half-typed comprehensions like `[x for x in]` now fail with a targeted parse error at the comprehension, instead of silently parsing as a four-item array of variable names and surfacing later as `x is not defined` on the wrong line.

Closes #602.

Two mechanisms, because the investigation found the array fallback was itself a bug:

## 1. Literal items require commas between them again

The 2026-07-04 comments-between-entries rewrite (0b3233d67) replaced `sepBy(commaWithNewline, ...)` with a delimiter whose comma was optional EVERYWHERE - justified in its comment only by trailing commas - so any whitespace separated array/object items. `[1 2 3]` was a three-item array; `[x for x in]` was `[x, for, x, in]`. Two weeks old, accidental, and the reason half-typed comprehensions had somewhere silent to fall.

The delimiter now requires the comma between items, with one alternative branch: a LOOKAHEAD accepting only trailing position (optional comments/blank lines, then the closing bracket). That single formulation keeps everything the rewrite legitimately added - trailing commas, comments after a comma, trailing comments without a trailing comma (all pinned in dataStructures.test.ts and re-asserted beside the new rejections in literalDelimiter.test.ts) - and closes even the comment-interposed leak: `[1 // note\n 2]` fails, because the lookahead finds an item where the closer should be. The new grammar is strictly narrower, so no accepted parse changes shape; things either parse exactly as before or now error.

## 2. The comprehension parser commits after `[ expr for `

Past that prefix nothing but a comprehension attempt can be on the wire (#599 pinned the divergences: arrays fail at `str("for")` on a comma, `[format, other]` never sees a bare `for`, `forx` fails the required whitespace). Failures after the commit are now hard `parseError` throws with targeted messages - the same idiom `forLoopParser` uses:

- `[x for x in]` -> expected an iterable expression after `in`
- `[x for in xs]` -> expected `in` after the list comprehension binder (the binder greedily reads the word `in` as its name; the error lands on `xs`)
- `[x for x in xs if]` -> expected a filter condition after `if`
- `[x for x in xs` -> expected `]` to close this list comprehension

One placement subtlety: the required whitespace after `in` lives inside the ITERABLE commit, not the `in` commit, so `[x for x in]` blames the missing iterable rather than the `in` it already has. `[for x in xs]` never reaches the commit (the leading `for` parses as the body expression), so it fails through the comma rule instead - a generic message, but at the right position.

The three merged pins that asserted the malformed inputs parse as arrays now assert the specific messages - the diff those pins were built to make visible.

## Verification

- Full parser suite (1641), backends + lowering + formatter + checker suites (2212), zero fixture churn.
- `tc` sweep across `stdlib/`, `tests/agency`, `tests/agency-js`, and `lib/agents`: zero parse failures - nothing in the corpus relied on comma-less literals in the two weeks the regression existed. (A narrower grammar cannot reshape accepted parses, so type-level output is untouched by construction.)
- Full `make` recompiles the entire stdlib under the new grammar - the strongest parse gate available - and all ten comprehension execution tests plus the literal-heavy execution tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
