### PR TITLE
Fix the genuine tc diagnostics in the agents and test corpus

### DIFF
--- a/packages/agency-lang/lib/agents/policy/agent.agency
+++ b/packages/agency-lang/lib/agents/policy/agent.agency
@@ -82,8 +82,9 @@ def deleteFromPolicy(interruptEffect: InterruptEffect, index: number): boolean {
   Delete the rule at the specified index for the given interrupt effect from the current policy.
   Returns true if the rule was successfully deleted, or false if the index was out of bounds.
   """
-  if (currentPolicy[interruptEffect] && index < currentPolicy[interruptEffect].length) {
-    currentPolicy[interruptEffect].splice(index, 1)
+  const rules = currentPolicy[interruptEffect]
+  if (rules != null && index < rules.length) {
+    rules.splice(index, 1)
     return true
   }
   return false
@@ -158,7 +159,7 @@ What actions would you like to allow?
   Decide the next step. If the user is describing what they want, build or update the policy and use addToPolicy, setPolicy, or deleteFromPolicy. Show the user the policy and get confirmation that it looks good. When you are done, return  { type: "done" }. Otherwise, ask the user a question to clarify what they want, and return { type: "askQuestion", question: "..." }.
   """
 
-  systemMessage(systemPrompt)
+  systemMessage(systemPrompt catch "")
   assistantMessage(contextMessage)
   userMessage(userInput)
 

--- a/packages/agency-lang/lib/agents/review/agent.agency
+++ b/packages/agency-lang/lib/agents/review/agent.agency
@@ -39,7 +39,7 @@ node main() {
   }
   // Have the LLM review the code
   thread {
-    systemMessage(systemPrompt)
+    systemMessage(systemPrompt catch "")
     let typeErrorMessage = "The type checker found no errors."
     if (typeErrors != "") {
       typeErrorMessage = "The type checker reported the following errors:\n${typeErrors}"

--- a/packages/agency-lang/tests/agency-js/data-tech-hackernews/agent.agency
+++ b/packages/agency-lang/tests/agency-js/data-tech-hackernews/agent.agency
@@ -126,12 +126,22 @@ node callSearchBad(): string {
 
 node mockStories(): any {
   const r = hnStories("top", 2) with approve
-  return r catch "FAIL"
+  // sentinel via a guard, not `catch "FAIL"` - the catch default is
+  // checked against the success type, and "FAIL" is deliberately not one
+  if (r is failure(e)) {
+    return "FAIL"
+  }
+  return r.value
 }
 
 node mockItem(): any {
   const r = hnItem(8863) with approve
-  return r catch "FAIL"
+  // sentinel via a guard, not `catch "FAIL"` - the catch default is
+  // checked against the success type, and "FAIL" is deliberately not one
+  if (r is failure(e)) {
+    return "FAIL"
+  }
+  return r.value
 }
 
 node mockItemNull(): string {
@@ -144,5 +154,10 @@ node mockItemNull(): string {
 
 node mockSearch(): any {
   const r = hnSearch("dropbox") with approve
-  return r catch "FAIL"
+  // sentinel via a guard, not `catch "FAIL"` - the catch default is
+  // checked against the success type, and "FAIL" is deliberately not one
+  if (r is failure(e)) {
+    return "FAIL"
+  }
+  return r.value
 }

--- a/packages/agency-lang/tests/agency-js/data-tech-yc/agent.agency
+++ b/packages/agency-lang/tests/agency-js/data-tech-yc/agent.agency
@@ -48,7 +48,11 @@ node tParseMeta(raw: any): any {
 }
 
 node tMetaFinalize(raw: any): any {
-  return metaFinalize(success(raw)) catch {}
+  const r = metaFinalize(success(raw))
+  if (r is failure(e)) {
+    return {}
+  }
+  return r.value
 }
 
 node tCompaniesFinalizeErr(): string {
@@ -109,12 +113,22 @@ node callListBad(): string {
 
 node mockBatch(): any {
   const r = ycBatch("Winter 2012") with approve
-  return r catch "FAIL"
+  // sentinel via a guard, not `catch "FAIL"` - the catch default is
+  // checked against the success type, and "FAIL" is deliberately not one
+  if (r is failure(e)) {
+    return "FAIL"
+  }
+  return r.value
 }
 
 node mockMeta(): any {
   const r = ycMeta() with approve
-  return r catch "FAIL"
+  // sentinel via a guard, not `catch "FAIL"` - the catch default is
+  // checked against the success type, and "FAIL" is deliberately not one
+  if (r is failure(e)) {
+    return "FAIL"
+  }
+  return r.value
 }
 
 node mockBatchBad(): string {

--- a/packages/agency-lang/tests/agency-js/data-usaspending/agent.agency
+++ b/packages/agency-lang/tests/agency-js/data-usaspending/agent.agency
@@ -121,10 +121,20 @@ node callAwardsBad(): string {
 
 node mockAwards(): any {
   const r = usaspendingAwards(recipient: "Lockheed") with approve
-  return r catch "FAIL"
+  // sentinel via a guard, not `catch "FAIL"` - the catch default is
+  // checked against the success type, and "FAIL" is deliberately not one
+  if (r is failure(e)) {
+    return "FAIL"
+  }
+  return r.value
 }
 
 node mockAward(): any {
   const r = usaspendingAward("22834500") with approve
-  return r catch "FAIL"
+  // sentinel via a guard, not `catch "FAIL"` - the catch default is
+  // checked against the success type, and "FAIL" is deliberately not one
+  if (r is failure(e)) {
+    return "FAIL"
+  }
+  return r.value
 }

--- a/packages/agency-lang/tests/agency-js/data-wikidata/agent.agency
+++ b/packages/agency-lang/tests/agency-js/data-wikidata/agent.agency
@@ -96,12 +96,22 @@ node callSearchGoverned(name: string): any {
 
 node mockSearch(): any {
   const r = wikidataSearch("Andreessen Horowitz") with approve
-  return r catch "FAIL"
+  // sentinel via a guard, not `catch "FAIL"` - the catch default is
+  // checked against the success type, and "FAIL" is deliberately not one
+  if (r is failure(e)) {
+    return "FAIL"
+  }
+  return r.value
 }
 
 node mockEntity(): any {
   const r = wikidataEntity("Q42") with approve
-  return r catch "FAIL"
+  // sentinel via a guard, not `catch "FAIL"` - the catch default is
+  // checked against the success type, and "FAIL" is deliberately not one
+  if (r is failure(e)) {
+    return "FAIL"
+  }
+  return r.value
 }
 
 node mockEntityUnknown(): string {
@@ -114,5 +124,10 @@ node mockEntityUnknown(): string {
 
 node mockQuery(): any {
   const r = wikidataQuery("SELECT ?item ?itemLabel WHERE { ?item wdt:P31 wd:Q5 } LIMIT 1") with approve
-  return r catch "FAIL"
+  // sentinel via a guard, not `catch "FAIL"` - the catch default is
+  // checked against the success type, and "FAIL" is deliberately not one
+  if (r is failure(e)) {
+    return "FAIL"
+  }
+  return r.value
 }

--- a/packages/agency-lang/tests/agency-js/policy-prompt-array-data/agent.agency
+++ b/packages/agency-lang/tests/agency-js/policy-prompt-array-data/agent.agency
@@ -16,8 +16,11 @@ node main(args: { policyFile: string }): string {
   const handler = cliPolicyHandler(file: args.policyFile, fields: FIELDS)
   handle {
     interrupt std::edit("apply edits?", {
+      dir: ".",
       filename: "foo.agency",
       edits: [{ oldText: "a", newText: "b", replaceAll: false }],
+      before: "a",
+      after: "b",
     })
   } with (data) {
     return handler(data)

--- a/packages/agency-lang/tests/agency/agents/routing.agency
+++ b/packages/agency-lang/tests/agency/agents/routing.agency
@@ -4,9 +4,9 @@ import { routeFor } from "../../../lib/agents/agency-agent/subagents/code.agency
 // TriageResult, does codeAgent route correctly? "complex" -> plannerAgent,
 // anything else -> the direct loop.
 node complexRoutesToPlanner(): boolean {
-  return routeFor({ path: "complex", plan: "outline" }) == "planner"
+  return routeFor({ path: "complex", plan: ["outline"] }) == "planner"
 }
 
 node simpleRoutesToDirect(): boolean {
-  return routeFor({ path: "simple", plan: "" }) == "direct"
+  return routeFor({ path: "simple", plan: [] }) == "direct"
 }

--- a/packages/agency-lang/tests/agency/guards/guard-in-def.agency
+++ b/packages/agency-lang/tests/agency/guards/guard-in-def.agency
@@ -1,4 +1,6 @@
 
+import { GuardFailureData } from "std::thread"
+
 // Guard inside a `def` function (bare failure shape) instead of a
 // `node` (envelope failure shape). The function-body auto-wrap in
 // codegen differs between def and node; both must re-throw

--- a/packages/agency-lang/tests/agency/raiseStatement.agency
+++ b/packages/agency-lang/tests/agency/raiseStatement.agency
@@ -1,5 +1,8 @@
 def doWrite(): string {
-  raise std::write("confirm?", {})
+  // std::write declares { dir, filename } - the values are immaterial
+  // to this test (it exercises raise mechanics, and the handler
+  // approves/rejects regardless), but the schema is checked (AG3006)
+  raise std::write("confirm?", { dir: ".", filename: "out.txt" })
   return "wrote"
 }
 

--- a/packages/agency-lang/tests/agency/subprocess/pause-then-parent-handler.agency
+++ b/packages/agency-lang/tests/agency/subprocess/pause-then-parent-handler.agency
@@ -29,7 +29,11 @@ node main() {
     if (e.effect == "std::run") {
       return approve()
     }
-    if (e.effect == "std::bash" && e.data.command == "echo phase-two") {
+    // index access, not .command: this handler's inferred data union
+    // only sees the subprocess (std::run) shape - the nested bash
+    // interrupt arrives across the subprocess boundary, which effect
+    // inference cannot see through
+    if (e.effect == "std::bash" && e.data["command"] == "echo phase-two") {
       return approve()
     }
   }


### PR DESCRIPTION
Fixes the genuinely-wrong tc diagnostics that the #608 corpus sweep surfaced. The full corpus had 102 error-severity lines; this PR clears the 22 that are real mistakes and deliberately leaves the rest, because most of them are the point of their tests.

## What was actually wrong, and how each was fixed

Every fix was verified runtime-identical: all affected execution tests and agency-js fixtures pass unchanged (byte-identical fixture matches).

- **`lib/agents/policy/agent.agency`, `lib/agents/review/agent.agency`**: both passed a raw `read(...)` Result into `systemMessage(string)`. Fixed with `catch ""` at the use site - the coordinator's existing idiom for prompt reads. The policy agent also used `currentPolicy[key] && ...` as a condition (array-or-null is not a boolean); now a bound `rules` with a `!= null` guard.
- **`tests/agency/agents/routing.agency`**: passed `plan: "outline"` / `plan: ""` where `TriageResult.plan` is `string[]`. `routeFor` only reads `path`, so the shapes were never exercised - now `["outline"]` / `[]`.
- **`tests/agency/guards/guard-in-def.agency`**: used `GuardFailureData` in an annotation without importing it, so the checker resolved an opaque fieldless type and rejected `.maxCost` - which the real std::thread type has. One import line.
- **`tests/agency/raiseStatement.agency`, `tests/agency-js/policy-prompt-array-data/agent.agency`**: effect-schema drift - `std::write` and `std::edit` declare data fields the raises omitted (AG3006/AG3007). The declared fields are now supplied with immaterial values; the handlers approve/reject regardless and the fixtures only check render/reject outcomes.
- **`tests/agency/subprocess/pause-then-parent-handler.agency`**: `.command` on a handler data union that only sees the std::run shape - the nested bash interrupt crosses the subprocess boundary, which effect inference cannot see through. Index access (`e.data["command"]`) with a comment saying why.
- **The connector sentinel family** (`data-tech-hackernews`, `data-tech-yc`, `data-usaspending`, `data-wikidata`): `return r catch "FAIL"` where the catch default is checked against the Result's success type, and `"FAIL"` is deliberately not one. Rewritten as the `is failure` guard the same files already use elsewhere - sentinel behavior preserved, types honest. (`http-post` keeps its three `catch "FAIL"` sites: its Results are any-success and they typecheck fine.)

## What deliberately stays (80 lines), so nobody re-litigates it

- **`tests/agency/validation/bang*`** (~14): the `!` runtime-validation tests intentionally pass wrong types - the static error is inherent to what they exercise.
- **Failure-path feature tests** (~48): `result/failure-propagation-*` intentionally feed Results into typed params (the propagation IS the feature), `fork/llm-tools/tool-*-failure` intentionally return failures from typed functions, and the interrupt-reject family reads failure fields off success-typed bindings - the same failure-leakage reality recorded in #607.
- **Checker-gap suspects** (~18): `ui-builders-*` property access on `any | null` (arguably should fail open through the `any`), and `pipe-variadic` slot typing. These look like checker improvements, not test bugs - happy to file issues if wanted.

One practical consequence worth stating: a naive tc-over-corpus CI gate is not viable while ~80 deliberate diagnostics exist. If a gate is wanted later it needs either a committed baseline file or a suppression mechanism for intentionally-ill-typed test code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
