### PR TITLE
Agent supervisor: stdlib verifier, brainstorm before complex solves, draft deltas

### DIFF
--- a/packages/agency-lang/docs/site/stdlib/supervise.md
+++ b/packages/agency-lang/docs/site/stdlib/supervise.md
@@ -52,7 +52,7 @@ export type SuperviseDecision = {
 supervise(
   every: number,
   maxTime: number,
-  check: (elapsed: number) -> SuperviseDecision,
+  check: (elapsed: number, draft: any) -> SuperviseDecision,
   block: () -> any,
 ): Result<any>
 ```
@@ -61,7 +61,11 @@ Run a block, pausing it every interval to check progress and steer it.
 
   @param every - How often to pause and check
   @param maxTime - Total time budget across all intervals
-  @param check - Called at each pause with elapsed time, and decides whether to continue, redirect, or stop
+  @param check - Called at each pause with elapsed time and the block's most
+    recent saveDraft value (null when none has been saved), and decides
+    whether to continue, redirect, or stop. The draft is the block's own
+    account of its progress: a draft that has not changed between checks is
+    strong evidence the block is stalled.
   @param block - The long-running work
 
 **Parameters:**
@@ -70,7 +74,7 @@ Run a block, pausing it every interval to check progress and steer it.
 |---|---|---|
 | every | `number` |  |
 | maxTime | `number` |  |
-| check | `(elapsed: number) => SuperviseDecision` |  |
+| check | `(elapsed: number, draft: any) => SuperviseDecision` |  |
 | block | `() => any` |  |
 
 **Returns:** `Result<any>`

--- a/packages/agency-lang/lib/agents/agency-agent/subagents/brainstorm.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/subagents/brainstorm.agency
@@ -55,7 +55,9 @@ type Choice = {
 
 /** Split the judge's pick from the rest. Pure, so tests can pin the
   out-of-range behavior: a bad index means no approach was chosen and
-  everything stays an alternative. */
+  everything stays an alternative. The rationale is kept even then — it
+  never renders anywhere when nothing was chosen, and it is the one
+  breadcrumb explaining why the judge went out of range. */
 export def splitChoice(
   approaches: Approach[],
   chosenIndex: number,
@@ -66,7 +68,7 @@ export def splitChoice(
     return {
       chosen: null,
       alternatives: approaches,
-      rationale: ""
+      rationale: rationale
     }
   }
   const alternatives = []

--- a/packages/agency-lang/lib/agents/agency-agent/subagents/brainstorm.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/subagents/brainstorm.agency
@@ -1,0 +1,193 @@
+/*
+ * Brainstorm-before-solving: when a task triages as complex, spend a
+ * moment generating genuinely different directions before committing to
+ * one, instead of running with the first idea.
+ *
+ * Three proposers run in parallel via `fork`, each pushed toward a
+ * different bias (simplest thing, most robust thing, most reuse). A
+ * judge picks the one to pursue. The chosen approach travels into the
+ * solver's context; the rejected ones travel to the supervisor, so a
+ * mid-run redirect can name a specific alternative when the chosen path
+ * is not working.
+ *
+ * Everything fails open: a brainstorm that errors or runs out of budget
+ * returns empty renderings, and the solve proceeds exactly as it would
+ * have without one.
+ */
+import { map } from "std::array"
+
+// Deliberately opinionated biases, so the three proposals differ in kind
+// rather than phrasing.
+static const ANGLES = [
+  "the simplest thing that could possibly work — smallest change, fewest moving parts",
+  "the most robust and thorough approach — handles edge cases, verifiable at every step",
+  "maximum reuse — lean on existing code, tools, and conventions instead of building anything new",
+]
+
+static const BRAINSTORM_MAX_COST = $2.00
+static const BRAINSTORM_MAX_TIME = 3m
+
+/** One proposed direction for the task. */
+export type Approach = {
+  name: string;
+  plan: string;
+  risk: string
+}
+
+/** What a brainstorm produces: the approach to pursue, the ones set
+  aside, and why the judge chose as it did. */
+export type BrainstormResult = {
+  chosen: (Approach | null);
+  alternatives: Approach[];
+  rationale: string
+}
+
+static const EMPTY_BRAINSTORM: BrainstormResult = {
+  chosen: null,
+  alternatives: [],
+  rationale: ""
+}
+
+type Choice = {
+  chosenIndex: number;
+  rationale: string
+}
+
+/** Split the judge's pick from the rest. Pure, so tests can pin the
+  out-of-range behavior: a bad index means no approach was chosen and
+  everything stays an alternative. */
+export def splitChoice(
+  approaches: Approach[],
+  chosenIndex: number,
+  rationale: string,
+): BrainstormResult {
+  const chosen = approaches[chosenIndex]
+  if (chosen == null) {
+    return {
+      chosen: null,
+      alternatives: approaches,
+      rationale: ""
+    }
+  }
+  const alternatives = []
+  let index = 0
+  for (approach in approaches) {
+    if (index != chosenIndex) {
+      alternatives.push(approach)
+    }
+    index = index + 1
+  }
+  return {
+    chosen: chosen,
+    alternatives: alternatives,
+    rationale: rationale
+  }
+}
+
+def renderApproach(approach: Approach): string {
+  return """- ${approach.name}
+  Plan: ${approach.plan}
+  Risk: ${approach.risk}"""
+}
+
+/** The chosen-direction block for the solver's context, or "" when no
+  brainstorm ran (or it failed open). Pure. */
+export def renderChosen(result: BrainstormResult): string {
+  const chosen = result.chosen
+  if (chosen == null) {
+    return ""
+  }
+  return """
+The direction to pursue, chosen after comparing several (${result.rationale}):
+${renderApproach(chosen)}
+
+Follow this direction unless you discover it cannot work; if it fails, say so plainly in your summary rather than silently switching."""
+}
+
+/** The alternatives block for the supervisor, or "" when there are none.
+  Pure. */
+export def renderAlternatives(result: BrainstormResult): string {
+  if (result.alternatives.length == 0) {
+    return ""
+  }
+  return map(result.alternatives, renderApproach).join("\n")
+}
+
+def proposeApproach(task: string, guidance: string, angle: string): Approach {
+  const proposal: Approach = llm(
+    """
+Propose ONE concrete approach to the task below, favoring ${angle}.
+
+<task>
+${task}
+</task>
+
+${guidance}
+
+Return:
+- name: a short label for the approach
+- plan: the concrete steps, 2 to 5 sentences
+- risk: the main way this approach fails
+
+Commit to the bias you were given — do not hedge toward a middle ground.
+""",
+  )
+  return proposal
+}
+
+def judgeApproaches(task: string, approaches: Approach[]): Choice {
+  const rendered = []
+  let index = 0
+  for (approach in approaches) {
+    rendered.push("[${index}] ${renderApproach(approach)}")
+    index = index + 1
+  }
+  const choice: Choice = llm(
+    """
+Pick the best approach for this task.
+
+<task>
+${task}
+</task>
+
+<approaches>
+${rendered.join("\n\n")}
+</approaches>
+
+Return chosenIndex (the [n] of the winner) and rationale (one sentence,
+naming what tipped the decision).
+""",
+  )
+  return choice
+}
+
+export def brainstormApproaches(
+  task: string,
+  guidance: string = "",
+): BrainstormResult {
+  """
+  Generate several genuinely different directions for a complex task in
+  parallel, then pick one to pursue. Returns the chosen approach, the
+  set-aside alternatives, and the judge's rationale. Fails open to an
+  empty result — a solve without a brainstorm is a normal solve.
+
+  @param task - The task to brainstorm directions for
+  @param guidance - Expert guidance to fold into each proposal, or ""
+  """
+  const captured = guard(cost: BRAINSTORM_MAX_COST, time: BRAINSTORM_MAX_TIME) {
+    const proposals = fork(ANGLES) as angle {
+      return proposeApproach(task: task, guidance: guidance, angle: angle)
+    }
+    const choice = judgeApproaches(task: task, approaches: proposals)
+    return splitChoice(
+      approaches: proposals,
+      chosenIndex: choice.chosenIndex,
+      rationale: choice.rationale,
+    )
+  }
+  // isFailure, not match: this can run inside blocks that pause and resume.
+  if (isFailure(captured)) {
+    return EMPTY_BRAINSTORM
+  }
+  return captured.value
+}

--- a/packages/agency-lang/lib/agents/agency-agent/subagents/code.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/subagents/code.agency
@@ -10,6 +10,7 @@
  * (`setAgentCwd`/`getAgentCwd`), which `agent.agency` pins to the user's
  * cwd at startup.
  */
+import { filter } from "std::array"
 import { agencyCodingAgent } from "std::agents/agency/coding"
 import { agencyExpertAgent } from "std::agents/agency/expert"
 import { codingAgent, buildTools as codingAgentTools } from "std::agents/coding"
@@ -302,9 +303,17 @@ def escalateToExpert(task: string, agencyTask: boolean): string {
   const guidance = guidanceOrEmpty(consultExpert(task: task, agencyTask: agencyTask))
   const ideas = brainstormApproaches(task: task, guidance: renderGuidance(guidance))
   const alternatives = renderAlternatives(ideas)
+  // Join only the non-empty parts: both renderings return "" on their
+  // fail-open paths, and a bare "\n" would defeat withContext's
+  // empty-context gate — the solver must run untouched when there is
+  // genuinely no context.
+  const contextParts = filter(
+    [renderGuidance(guidance), renderChosen(ideas)],
+    \part -> part != "",
+  )
   const solved = supervisedSolve(
     task: task,
-    context: "${renderGuidance(guidance)}\n${renderChosen(ideas)}",
+    context: contextParts.join("\n"),
     agencyTask: agencyTask,
     alternatives: alternatives,
   )

--- a/packages/agency-lang/lib/agents/agency-agent/subagents/code.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/subagents/code.agency
@@ -31,6 +31,11 @@ import { oracleAgent } from "./oracle.agency"
 import {
   reviewWrittenFiles,
  } from "./review.agency"
+import {
+  brainstormApproaches,
+  renderChosen,
+  renderAlternatives,
+ } from "./brainstorm.agency"
 import { progressCheck, resetSupervisor } from "./supervisor.agency"
 
 
@@ -238,8 +243,9 @@ def supervisedSolve(
   task: string,
   context: string,
   agencyTask: boolean,
+  alternatives: string = "",
 ): Result<string> {
-  resetSupervisor()
+  resetSupervisor(alternatives: alternatives)
   const captured = supervise(
     every: SUPERVISE_EVERY,
     maxTime: ESCALATE_MAX_TIME,
@@ -285,15 +291,22 @@ export def codeAgent(userMsg: string, agencyTask: boolean = false) {
   return converse(userMsg: userMsg, originalUserMsg: originalUserMsg, agencyTask: agencyTask)
 }
 
-/* A multi-part task acquires domain expertise first, solves with it, then
-   verifies against the expert's checklist and gets one round to fix what
-   failed. `escalate`, the mid-flight tool, still uses plannerAgent. */
+/* A multi-part task acquires domain expertise first, brainstorms several
+   genuinely different directions and commits to one, solves with both in
+   context, then verifies against the expert's checklist and gets one round
+   to fix what failed. The set-aside directions travel to the supervisor,
+   so a mid-run redirect can name a specific alternative when the chosen
+   path is not working. `escalate`, the mid-flight tool, still uses
+   plannerAgent. */
 def escalateToExpert(task: string, agencyTask: boolean): string {
   const guidance = guidanceOrEmpty(consultExpert(task: task, agencyTask: agencyTask))
+  const ideas = brainstormApproaches(task: task, guidance: renderGuidance(guidance))
+  const alternatives = renderAlternatives(ideas)
   const solved = supervisedSolve(
     task: task,
-    context: renderGuidance(guidance),
+    context: "${renderGuidance(guidance)}\n${renderChosen(ideas)}",
     agencyTask: agencyTask,
+    alternatives: alternatives,
   )
   let summary = ""
   if (isFailure(solved)) {
@@ -317,7 +330,7 @@ ${renderFeedback(checked)}
 
 Fix each problem exactly.
 """
-    const fixed = supervisedSolve(task: fixMsg, context: "", agencyTask: agencyTask)
+    const fixed = supervisedSolve(task: fixMsg, context: "", agencyTask: agencyTask, alternatives: alternatives)
     if (!isFailure(fixed)) {
       summary = fixed.value
     }

--- a/packages/agency-lang/lib/agents/agency-agent/subagents/supervisor.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/subagents/supervisor.agency
@@ -2,26 +2,34 @@
  * The supervisor: the reviewer that std::supervise calls while the code
  * subagent's solver is paused at a checkpoint.
  *
- * At each pause it gathers evidence of what the solver has actually done
- * (git status and diff of the agent working directory), shows that evidence
- * plus the history of earlier checks to a reviewer LLM, and turns the
+ * At each pause it sends the stdlib verifier agent into the workspace to
+ * measure what the solver has actually done, shows those findings plus
+ * the history of earlier checks (and the approaches the solver decided
+ * against, when a brainstorm ran) to a reviewer LLM, and turns the
  * reviewer's verdict into a SuperviseDecision: continue, redirect with a
  * course-correction message (injected into the solver's paused
  * conversation), or stop.
  *
- * The check callback runs inside a guard handler, so it stays lean: direct
- * git reads and one tool-free llm() call. Giving the reviewer its own tool
- * loop would raise nested interrupts from inside a handler, which is more
- * machinery than a five-minute pulse check needs.
+ * The check callback runs inside a guard handler. Handlers may raise
+ * interrupts (a handler never hears its own raises), so the verifier
+ * brings its full toolset — shell, file reads, real measurements —
+ * governed by the outer policy like any other tool call. Everything
+ * fails open: a verifier that cannot run (budget refused, policy
+ * rejection) yields no findings, and the reviewer judges from history
+ * alone rather than the check crashing the run.
  */
-import { gitIsRepo, gitStatus, gitDiff } from "std::git"
+import { verifierAgent } from "std::agents/verifier"
+import {
+  Feedback,
+  feedbackHasErrors,
+  renderFeedback,
+ } from "std::agents/lib/feedback"
 import { SuperviseDecision } from "std::supervise"
 
-import { truncate } from "../lib/utils.agency"
-
-// The raw patch can be huge; the reviewer needs the shape of the work, not
-// every hunk.
-static const MAX_PATCH_CHARS = 6000
+// The verifier is a pulse check here, not a final gate: small budgets,
+// because it runs every interval and its findings only steer.
+static const CHECK_MAX_COST = $2.00
+static const CHECK_MAX_TIME = 2m
 
 /** What the reviewer LLM returns for one check. `assessment` is its read of
   the evidence; `action`/`message` are what it wants done about it. */
@@ -34,7 +42,7 @@ export type SupervisorVerdict = {
 /** One earlier check, as the next check sees it. */
 export type CheckRecord = {
   minutes: number;
-  filesChanged: number;
+  findings: number;
   assessment: string;
   action: string;
   message: string
@@ -44,8 +52,14 @@ export type CheckRecord = {
 // each check appends its own record.
 let _history: CheckRecord[] = []
 
-export def resetSupervisor() {
+// The approaches the solver considered and did not pick, rendered as text
+// by the brainstorm step. "" when no brainstorm ran. A redirect can steer
+// toward a specific alternative instead of a vague "try something else".
+let _alternatives: string = ""
+
+export def resetSupervisor(alternatives: string = "") {
   _history = []
+  _alternatives = alternatives
 }
 
 export def supervisorHistory(): CheckRecord[] {
@@ -79,53 +93,33 @@ export def applyThrashRule(
   }
 }
 
-/** What the solver has actually changed on disk, plus how many files that
-  is. Fails open: outside a git repo (or on any git error) there is simply
-  no workspace evidence, and the reviewer is told so rather than the check
-  crashing the run. */
-def workspaceEvidence(): { text: string; filesChanged: number } {
-  // Two distinct ways to end up without evidence: the directory is not a
-  // repo, or git itself failed (an error, or policy rejecting the read).
-  // The reviewer is told which, so it never reasons from "there is no
-  // repo" when there is one.
-  const gitFailed = {
-    text: "(git could not be read — no workspace evidence available; judge from the check history alone)",
-    filesChanged: 0
-  }
-  const isRepo = try gitIsRepo()
-  if (isFailure(isRepo)) {
-    return gitFailed
-  }
-  if (!isRepo.value) {
+/** What the verifier measured in the workspace, plus how many findings it
+  reported. Fails open: a verifier that could not run (budget, policy, any
+  error) yields no evidence, and the reviewer is told so rather than the
+  check crashing the run. */
+def verifierEvidence(task: string, minutes: number): { text: string; findings: number } {
+  const checked = verifierAgent(
+    task: task,
+    context: "This is a MID-RUN progress check at about ${minutes} minutes, not a final verification. The work is expected to be incomplete. Measure what exists so far and report which criteria are already satisfied, which are in visible progress, and which show no sign of being started. Do not pad the report with gaps that are merely not-yet-reached.",
+    maxCost: CHECK_MAX_COST,
+    maxTime: CHECK_MAX_TIME,
+  )
+  if (isFailure(checked)) {
     return {
-      text: "(no git repository — no workspace evidence available; judge from the check history alone)",
-      filesChanged: 0
+      text: "(the verifier could not run: ${checked.error} — judge from the check history alone)",
+      findings: 0
     }
   }
-  const status = try gitStatus()
-  if (isFailure(status)) {
-    return gitFailed
-  }
-  const lines = []
-  for (entry in status.value.entries) {
-    lines.push("${entry.index}${entry.worktree} ${entry.path}")
-  }
-  let text = """
-Changed files (${lines.length}):
-${lines.join("\n")}
-"""
-  const diff = try gitDiff()
-  if (diff is success(d)) {
-    text = """
-${text}
-
-Working-tree diff (truncated):
-${truncate(d.patch, MAX_PATCH_CHARS)}
-"""
+  const findings = checked.value.length
+  if (findings == 0) {
+    return {
+      text: "(the verifier ran and reported no findings)",
+      findings: 0
+    }
   }
   return {
-    text: text,
-    filesChanged: lines.length
+    text: renderFeedback(checked),
+    findings: findings
   }
 }
 
@@ -140,10 +134,26 @@ def renderHistory(history: CheckRecord[]): string {
       note = " — ${record.message}"
     }
     lines.push(
-      "- at ${record.minutes}m: ${record.filesChanged} files changed, assessment ${record.assessment}, action ${record.action}${note}",
+      "- at ${record.minutes}m: ${record.findings} verifier findings, assessment ${record.assessment}, action ${record.action}${note}",
     )
   }
   return lines.join("\n")
+}
+
+/** The alternatives block for the review prompt, or "" when no brainstorm
+  ran. Pure, so tests can pin the shape. */
+export def renderAlternativesSection(alternatives: string): string {
+  if (alternatives == "") {
+    return ""
+  }
+  return """
+
+Approaches the solver considered and did NOT pick:
+<alternatives>
+${alternatives}
+</alternatives>
+If the current approach is failing, a redirect may tell the solver to switch to one of these — name it explicitly.
+"""
 }
 
 def reviewPrompt(
@@ -160,18 +170,18 @@ The task it was given:
 ${task}
 </task>
 
-What it has changed in the workspace so far:
-<workspace>
+What an independent verifier just measured in the workspace:
+<verifier_findings>
 ${evidence}
-</workspace>
+</verifier_findings>
 
 Earlier checks this run:
 <history>
 ${history}
 </history>
-
+${renderAlternativesSection(_alternatives)}
 Judge the evidence:
-- assessment: "progressing" when the workspace shows real movement toward the task since the last check; "stalled" when nothing meaningful has changed, or it keeps redoing the same thing.
+- assessment: "progressing" when the findings show real movement toward the task since the last check; "stalled" when nothing meaningful has changed, or it keeps redoing the same thing. Mid-run gaps are normal — unstarted criteria are only a bad sign when they were also unstarted last check.
 - action "continue": on track. The default — pick it unless the evidence clearly says otherwise.
 - action "redirect": working, but drifting, overbuilding, or looping on a failed approach. Put a short, concrete course correction in `message`, addressed directly to the agent — it is delivered into its conversation as if from the user (e.g. "Stop rewriting the parser; the failing test needs the lexer fixed first").
 - action "stop": continuing is pointless — the approach is destructive, or the task cannot be completed. Put the reason in `message`.
@@ -182,16 +192,17 @@ Set `message` to "" for continue. Never redirect just to say "keep going".
 
 export def progressCheck(task: string, elapsed: number): SuperviseDecision {
   """
-  The check callback for a supervised solve: review the workspace evidence
-  and check history, then continue, redirect, or stop the paused solver.
-  Bind the task first: `progressCheck.partial(task: task)` is the
+  The check callback for a supervised solve: send the verifier into the
+  workspace, review its findings and the check history, then continue,
+  redirect, or stop the paused solver. Bind the task first:
+  `progressCheck.partial(task: task)` is the
   `(elapsed) -> SuperviseDecision` shape std::supervise expects.
 
   @param task - The task the supervised solver is working on
   @param elapsed - Working time the solver has consumed so far, in ms
   """
   const minutes = Math.round(elapsed / 60000)
-  const evidence = workspaceEvidence()
+  const evidence = verifierEvidence(task: task, minutes: minutes)
   const verdict: SupervisorVerdict = llm(
     reviewPrompt(
     task: task,
@@ -204,7 +215,7 @@ export def progressCheck(task: string, elapsed: number): SuperviseDecision {
   _history.push(
     {
     minutes: minutes,
-    filesChanged: evidence.filesChanged,
+    findings: evidence.findings,
     assessment: verdict.assessment,
     action: decision.action,
     message: decision.message

--- a/packages/agency-lang/lib/agents/agency-agent/subagents/supervisor.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/subagents/supervisor.agency
@@ -22,10 +22,16 @@ import { verifierAgent } from "std::agents/verifier"
 import { renderFeedback } from "std::agents/lib/feedback"
 import { SuperviseDecision } from "std::supervise"
 
+import { truncate } from "../lib/utils.agency"
+
 // The verifier is a pulse check here, not a final gate: small budgets,
 // because it runs every interval and its findings only steer.
 static const CHECK_MAX_COST = $2.00
 static const CHECK_MAX_TIME = 2m
+
+// Drafts can be long; the reviewer needs the solver's claim of progress,
+// not every detail of it.
+static const MAX_DRAFT_CHARS = 4000
 
 /** What the reviewer LLM returns for one check. `assessment` is its read of
   the evidence; `action`/`message` are what it wants done about it. */
@@ -39,6 +45,7 @@ export type SupervisorVerdict = {
 export type CheckRecord = {
   minutes: number;
   findings: number;
+  draftStatus: string;
   assessment: string;
   action: string;
   message: string
@@ -53,31 +60,84 @@ let _history: CheckRecord[] = []
 // toward a specific alternative instead of a vague "try something else".
 let _alternatives: string = ""
 
+// The solver's draft as of the previous check, stringified for comparison.
+// The draft is the solver's own account of completed progress: a draft
+// that has not changed between checks is the sharpest stall evidence
+// available — a thrashing solver churns the workspace but its "here is
+// what I have finished" statement does not advance.
+let _lastDraft: string = ""
+
 export def resetSupervisor(alternatives: string = "") {
   _history = []
   _alternatives = alternatives
+  _lastDraft = ""
+}
+
+/** A draft as comparable text: "" for none, the string itself, or JSON for
+  a typed draft object. Pure. */
+export def stringifyDraft(draft: any): string {
+  if (draft == null) {
+    return ""
+  }
+  const asString = "${draft}"
+  if (asString == "[object Object]") {
+    return JSON.stringify(draft)
+  }
+  return asString
+}
+
+/** How the current draft relates to the previous check's. "none": nothing
+  saved yet (no signal). "first": the first draft appeared. "changed":
+  progress in the solver's own words. "unchanged": byte-identical across a
+  whole interval. Pure. */
+export def draftDelta(
+  current: string,
+  previous: string,
+): ("none" | "first" | "changed" | "unchanged") {
+  if (current == "") {
+    return "none"
+  }
+  if (previous == "") {
+    return "first"
+  }
+  if (current == previous) {
+    return "unchanged"
+  }
+  return "changed"
 }
 
 export def supervisorHistory(): CheckRecord[] {
   return _history
 }
 
-/** Apply the thrash backstop to the reviewer's verdict: a second consecutive
-  "stalled" assessment becomes a stop no matter what action the reviewer
-  chose. One stalled check is a judgment call; two in a row means redirection
-  is not working and the run is burning budget. Pure, so tests can pin it. */
+/** Apply the thrash backstop to the reviewer's verdict. Two ways to a
+  forced stop, both pure so tests can pin them:
+
+  - The reviewer says "stalled" AND the solver's draft is byte-identical
+    to the previous check: two independent signals agree, stop now. The
+    draft delta is computed, not judged, which keeps this backstop from
+    depending on how charitable the reviewer feels.
+  - Two consecutive "stalled" assessments, draft or no draft: redirection
+    is not working and the run is burning budget. */
 export def applyThrashRule(
   verdict: SupervisorVerdict,
   history: CheckRecord[],
+  draftUnchanged: boolean = false,
 ): SuperviseDecision {
+  // The reviewer may have left message empty (it only has to fill it for
+  // redirect and stop), so the stop reasons cannot lean on it being there.
+  let observation = ""
+  if (verdict.message != "") {
+    observation = " Last observation: ${verdict.message}"
+  }
+  if (verdict.assessment == "stalled" && draftUnchanged) {
+    return {
+      action: "stop",
+      message: "Stopped by the supervisor: the reviewer found no progress and the solver's own draft has not changed since the last check.${observation}"
+    }
+  }
   const previous = history[history.length - 1]
   if (verdict.assessment == "stalled" && previous != null && previous.assessment == "stalled") {
-    // The reviewer may have left message empty (it only has to fill it for
-    // redirect and stop), so the stop reason cannot lean on it being there.
-    let observation = ""
-    if (verdict.message != "") {
-      observation = " Last observation: ${verdict.message}"
-    }
     return {
       action: "stop",
       message: "Stopped by the supervisor: two checks in a row found no progress.${observation}"
@@ -130,10 +190,30 @@ def renderHistory(history: CheckRecord[]): string {
       note = " — ${record.message}"
     }
     lines.push(
-      "- at ${record.minutes}m: ${record.findings} verifier findings, assessment ${record.assessment}, action ${record.action}${note}",
+      "- at ${record.minutes}m: ${record.findings} verifier findings, draft ${record.draftStatus}, assessment ${record.assessment}, action ${record.action}${note}",
     )
   }
   return lines.join("\n")
+}
+
+/** The draft block for the review prompt. Pure, so tests can pin the
+  shape per delta. */
+export def renderDraftSection(draftText: string, delta: string): string {
+  if (delta == "none") {
+    return "(the solver has not saved a draft yet — no self-report to compare)"
+  }
+  let deltaLine = "This is the solver's FIRST saved draft."
+  if (delta == "changed") {
+    deltaLine = "The draft has changed since the last check."
+  }
+  if (delta == "unchanged") {
+    deltaLine = "The draft is BYTE-IDENTICAL to the last check: the solver's own account of finished work has not advanced in a whole interval."
+  }
+  return """${deltaLine}
+
+<draft>
+${truncate(draftText, MAX_DRAFT_CHARS)}
+</draft>"""
 }
 
 /** The alternatives block for the review prompt, or "" when no brainstorm
@@ -156,6 +236,7 @@ def reviewPrompt(
   task: string,
   minutes: number,
   evidence: string,
+  draftSection: string,
   history: string,
 ): string {
   return """
@@ -171,13 +252,16 @@ What an independent verifier just measured in the workspace:
 ${evidence}
 </verifier_findings>
 
+The solver's own most recent progress report (its saved draft):
+${draftSection}
+
 Earlier checks this run:
 <history>
 ${history}
 </history>
 ${renderAlternativesSection(_alternatives)}
 Judge the evidence:
-- assessment: "progressing" when the findings show real movement toward the task since the last check; "stalled" when nothing meaningful has changed, or it keeps redoing the same thing. Mid-run gaps are normal — unstarted criteria are only a bad sign when they were also unstarted last check.
+- assessment: "progressing" when the findings show real movement toward the task since the last check; "stalled" when nothing meaningful has changed, or it keeps redoing the same thing. Mid-run gaps are normal — unstarted criteria are only a bad sign when they were also unstarted last check. An unchanged draft is strong stall evidence: a busy workspace with an unadvanced self-report usually means the solver is redoing work.
 - action "continue": on track. The default — pick it unless the evidence clearly says otherwise.
 - action "redirect": working, but drifting, overbuilding, or looping on a failed approach. Put a short, concrete course correction in `message`, addressed directly to the agent — it is delivered into its conversation as if from the user (e.g. "Stop rewriting the parser; the failing test needs the lexer fixed first").
 - action "stop": continuing is pointless — the approach is destructive, or the task cannot be completed. Put the reason in `message`.
@@ -186,32 +270,39 @@ Set `message` to "" for continue. Never redirect just to say "keep going".
 """
 }
 
-export def progressCheck(task: string, elapsed: number): SuperviseDecision {
+export def progressCheck(task: string, elapsed: number, draft: any): SuperviseDecision {
   """
   The check callback for a supervised solve: send the verifier into the
-  workspace, review its findings and the check history, then continue,
-  redirect, or stop the paused solver. Bind the task first:
-  `progressCheck.partial(task: task)` is the
-  `(elapsed) -> SuperviseDecision` shape std::supervise expects.
+  workspace, compare the solver's draft against the last check's, review
+  everything with the check history, then continue, redirect, or stop the
+  paused solver. Bind the task first: `progressCheck.partial(task: task)`
+  is the `(elapsed, draft) -> SuperviseDecision` shape std::supervise
+  expects.
 
   @param task - The task the supervised solver is working on
   @param elapsed - Working time the solver has consumed so far, in ms
+  @param draft - The solver's most recent saveDraft value, or null
   """
   const minutes = Math.round(elapsed / 60000)
+  const draftText = stringifyDraft(draft)
+  const delta = draftDelta(draftText, _lastDraft)
   const evidence = verifierEvidence(task: task, minutes: minutes)
   const verdict: SupervisorVerdict = llm(
     reviewPrompt(
     task: task,
     minutes: minutes,
     evidence: evidence.text,
+    draftSection: renderDraftSection(draftText, delta),
     history: renderHistory(_history),
   ),
   )
-  const decision = applyThrashRule(verdict, _history)
+  const decision = applyThrashRule(verdict, _history, delta == "unchanged")
+  _lastDraft = draftText
   _history.push(
     {
     minutes: minutes,
     findings: evidence.findings,
+    draftStatus: delta,
     assessment: verdict.assessment,
     action: decision.action,
     message: decision.message

--- a/packages/agency-lang/lib/agents/agency-agent/subagents/supervisor.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/subagents/supervisor.agency
@@ -25,7 +25,14 @@ import { SuperviseDecision } from "std::supervise"
 import { truncate } from "../lib/utils.agency"
 
 // The verifier is a pulse check here, not a final gate: small budgets,
-// because it runs every interval and its findings only steer.
+// because it runs every interval and its findings only steer. Whose
+// budget it spends: the check runs in the supervise handler, which
+// registered before the solver's own cost guard went live, so that guard
+// is suspended during checks and this spend charges whatever sits ABOVE
+// the solve (the session budget). Supervision overhead is not the
+// solver's work, so that is the right ledger — but it adds up to
+// roughly checks × CHECK_MAX_COST on top of the solve's cap (~6 checks
+// on a 30-minute run).
 static const CHECK_MAX_COST = $2.00
 static const CHECK_MAX_TIME = 2m
 

--- a/packages/agency-lang/lib/agents/agency-agent/subagents/supervisor.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/subagents/supervisor.agency
@@ -19,11 +19,7 @@
  * alone rather than the check crashing the run.
  */
 import { verifierAgent } from "std::agents/verifier"
-import {
-  Feedback,
-  feedbackHasErrors,
-  renderFeedback,
- } from "std::agents/lib/feedback"
+import { renderFeedback } from "std::agents/lib/feedback"
 import { SuperviseDecision } from "std::supervise"
 
 // The verifier is a pulse check here, not a final gate: small budgets,
@@ -104,16 +100,14 @@ def verifierEvidence(task: string, minutes: number): { text: string; findings: n
     maxCost: CHECK_MAX_COST,
     maxTime: CHECK_MAX_TIME,
   )
-  if (isFailure(checked)) {
-    return {
-      text: "(the verifier could not run: ${checked.error} — judge from the check history alone)",
-      findings: 0
-    }
-  }
+  // verifierAgent itself fails open (failOpenFeedback maps any failure to
+  // success([])), so empty findings are ambiguous: a clean run and a
+  // verifier that could not run (budget, policy) look the same here. Say
+  // so, rather than reporting "no findings" as if it were a measurement.
   const findings = checked.value.length
   if (findings == 0) {
     return {
-      text: "(the verifier ran and reported no findings)",
+      text: "(the verifier returned no findings — either nothing was measurable yet or it could not run; judge from the check history alone)",
       findings: 0
     }
   }

--- a/packages/agency-lang/lib/agents/agency-agent/subagents/supervisor.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/subagents/supervisor.agency
@@ -104,7 +104,9 @@ def verifierEvidence(task: string, minutes: number): { text: string; findings: n
   // success([])), so empty findings are ambiguous: a clean run and a
   // verifier that could not run (budget, policy) look the same here. Say
   // so, rather than reporting "no findings" as if it were a measurement.
-  const findings = checked.value.length
+  // The catch fallback is belt-and-braces for the same reason.
+  const items = checked catch []
+  const findings = items.length
   if (findings == 0) {
     return {
       text: "(the verifier returned no findings — either nothing was measurable yet or it could not run; judge from the check history alone)",

--- a/packages/agency-lang/lib/agents/agency-agent/tests/brainstorm.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/brainstorm.agency
@@ -36,7 +36,9 @@ node splitKeepsOrder(): string {
 }
 
 // An out-of-range index means no approach was chosen: everything stays an
-// alternative and the solve proceeds as if no brainstorm ran.
+// alternative and the solve proceeds as if no brainstorm ran. The judge's
+// rationale is kept as a debugging breadcrumb — it renders nowhere when
+// nothing was chosen.
 node splitBadIndexFailsOpen(): string {
   const result = splitChoice(
     approaches: [approach("simple")],
@@ -44,7 +46,7 @@ node splitBadIndexFailsOpen(): string {
     rationale: "confused judge",
   )
   const chosenCount = if result.chosen == null then 0 else 1
-  return "chosen:${chosenCount}|alternatives:${result.alternatives.length}"
+  return "chosen:${chosenCount}|alternatives:${result.alternatives.length}|rationale:${result.rationale}"
 }
 
 // An empty brainstorm renders to nothing everywhere it travels.

--- a/packages/agency-lang/lib/agents/agency-agent/tests/brainstorm.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/brainstorm.agency
@@ -1,0 +1,76 @@
+// The brainstorm seams that need no LLM: the judge-choice splitter and
+// the renderings that travel to the solver and the supervisor.
+import {
+  Approach,
+  BrainstormResult,
+  splitChoice,
+  renderChosen,
+  renderAlternatives,
+ } from "../subagents/brainstorm.agency"
+import { renderAlternativesSection } from "../subagents/supervisor.agency"
+
+def approach(name: string): Approach {
+  return {
+    name: name,
+    plan: "do ${name}",
+    risk: "might not work"
+  }
+}
+
+// The judge's pick becomes chosen; the rest become alternatives, in order.
+node splitKeepsOrder(): string {
+  const result = splitChoice(
+    approaches: [approach("simple"), approach("robust"), approach("reuse")],
+    chosenIndex: 1,
+    rationale: "robust wins",
+  )
+  const chosen = result.chosen
+  if (chosen == null) {
+    return "no-choice"
+  }
+  const names = []
+  for (alternative in result.alternatives) {
+    names.push(alternative.name)
+  }
+  return "${chosen.name}|${names.join(",")}|${result.rationale}"
+}
+
+// An out-of-range index means no approach was chosen: everything stays an
+// alternative and the solve proceeds as if no brainstorm ran.
+node splitBadIndexFailsOpen(): string {
+  const result = splitChoice(
+    approaches: [approach("simple")],
+    chosenIndex: 5,
+    rationale: "confused judge",
+  )
+  const chosenCount = if result.chosen == null then 0 else 1
+  return "chosen:${chosenCount}|alternatives:${result.alternatives.length}"
+}
+
+// An empty brainstorm renders to nothing everywhere it travels.
+node emptyBrainstormRendersEmpty(): string {
+  const empty: BrainstormResult = {
+    chosen: null,
+    alternatives: [],
+    rationale: ""
+  }
+  const solverBlock = renderChosen(empty)
+  const supervisorBlock = renderAlternativesSection(renderAlternatives(empty))
+  return "solver:${solverBlock.length}|supervisor:${supervisorBlock.length}"
+}
+
+// A real result renders the chosen name for the solver and the set-aside
+// names for the supervisor.
+node renderingsCarryTheNames(): string {
+  const result = splitChoice(
+    approaches: [approach("simple"), approach("robust")],
+    chosenIndex: 0,
+    rationale: "simple wins",
+  )
+  const solverBlock = renderChosen(result)
+  const supervisorBlock = renderAlternativesSection(renderAlternatives(result))
+  const solverHasChosen = solverBlock.includes("simple")
+  const supervisorHasAlternative = supervisorBlock.includes("robust")
+  const supervisorLacksChosen = !supervisorBlock.includes("- simple")
+  return "${solverHasChosen}|${supervisorHasAlternative}|${supervisorLacksChosen}"
+}

--- a/packages/agency-lang/lib/agents/agency-agent/tests/brainstorm.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/brainstorm.test.json
@@ -5,28 +5,44 @@
       "description": "the judge's pick becomes chosen; the rest stay alternatives in order",
       "input": "",
       "expectedOutput": "\"robust|simple,reuse|robust wins\"",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     },
     {
       "nodeName": "splitBadIndexFailsOpen",
       "description": "an out-of-range judge index chooses nothing and keeps every approach",
       "input": "",
-      "expectedOutput": "\"chosen:0|alternatives:1\"",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "expectedOutput": "\"chosen:0|alternatives:1|rationale:confused judge\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     },
     {
       "nodeName": "emptyBrainstormRendersEmpty",
       "description": "an empty brainstorm renders to nothing for both solver and supervisor",
       "input": "",
       "expectedOutput": "\"solver:0|supervisor:0\"",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     },
     {
       "nodeName": "renderingsCarryTheNames",
       "description": "chosen goes to the solver block, set-asides go to the supervisor block",
       "input": "",
       "expectedOutput": "\"true|true|true\"",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/lib/agents/agency-agent/tests/brainstorm.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/brainstorm.test.json
@@ -1,0 +1,32 @@
+{
+  "tests": [
+    {
+      "nodeName": "splitKeepsOrder",
+      "description": "the judge's pick becomes chosen; the rest stay alternatives in order",
+      "input": "",
+      "expectedOutput": "\"robust|simple,reuse|robust wins\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "splitBadIndexFailsOpen",
+      "description": "an out-of-range judge index chooses nothing and keeps every approach",
+      "input": "",
+      "expectedOutput": "\"chosen:0|alternatives:1\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "emptyBrainstormRendersEmpty",
+      "description": "an empty brainstorm renders to nothing for both solver and supervisor",
+      "input": "",
+      "expectedOutput": "\"solver:0|supervisor:0\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "renderingsCarryTheNames",
+      "description": "chosen goes to the solver block, set-asides go to the supervisor block",
+      "input": "",
+      "expectedOutput": "\"true|true|true\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/lib/agents/agency-agent/tests/supervisor.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/supervisor.agency
@@ -11,7 +11,7 @@ import {
 def record(assessment: string): CheckRecord {
   return {
     minutes: 5,
-    filesChanged: 1,
+    findings: 1,
     assessment: assessment,
     action: "continue",
     message: ""

--- a/packages/agency-lang/lib/agents/agency-agent/tests/supervisor.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/supervisor.agency
@@ -6,12 +6,16 @@ import {
   applyThrashRule,
   CheckRecord,
   SupervisorVerdict,
+  stringifyDraft,
+  draftDelta,
+  renderDraftSection,
  } from "../subagents/supervisor.agency"
 
 def record(assessment: string): CheckRecord {
   return {
     minutes: 5,
     findings: 1,
+    draftStatus: "changed",
     assessment: assessment,
     action: "continue",
     message: ""
@@ -24,6 +28,55 @@ def stalledVerdict(): SupervisorVerdict {
     action: "redirect",
     message: "same failing test as last time"
   }
+}
+
+// A stalled verdict plus an unchanged draft stops IMMEDIATELY: two
+// independent signals agree, and the draft delta is computed, not judged.
+node stalledWithUnchangedDraftStops(): string {
+  const decision = applyThrashRule(stalledVerdict(), [], true)
+  return decision.action
+}
+
+// An unchanged draft alone does not stop a progressing run — the solver
+// may be mid-step between saves.
+node unchangedDraftAloneIsNotStopped(): string {
+  const verdict: SupervisorVerdict = {
+    assessment: "progressing",
+    action: "continue",
+    message: ""
+  }
+  const decision = applyThrashRule(verdict, [record("stalled")], true)
+  return decision.action
+}
+
+// Draft stringification: null carries no signal, strings pass through,
+// typed drafts compare as JSON.
+node draftStringification(): string {
+  const fromNull = stringifyDraft(null)
+  const fromString = stringifyDraft("half done")
+  const fromObject = stringifyDraft({ step: 2 })
+  return "null:${fromNull.length}|string:${fromString}|object:${fromObject}"
+}
+
+// The delta classification, all four states.
+node draftDeltaStates(): string {
+  const none = draftDelta("", "")
+  const first = draftDelta("a", "")
+  const changed = draftDelta("b", "a")
+  const unchanged = draftDelta("a", "a")
+  return "${none}|${first}|${changed}|${unchanged}"
+}
+
+// The prompt section names the byte-identical case loudly and says so
+// only then.
+node draftSectionFlagsUnchanged(): string {
+  const unchangedBlock = renderDraftSection("half done", "unchanged")
+  const changedBlock = renderDraftSection("half done", "changed")
+  const noneBlock = renderDraftSection("", "none")
+  const unchangedFlagged = unchangedBlock.includes("BYTE-IDENTICAL")
+  const changedNotFlagged = !changedBlock.includes("BYTE-IDENTICAL")
+  const noneHasNoDraftTag = !noneBlock.includes("<draft>")
+  return "${unchangedFlagged}|${changedNotFlagged}|${noneHasNoDraftTag}"
 }
 
 // The first stalled check keeps the reviewer's own action.

--- a/packages/agency-lang/lib/agents/agency-agent/tests/supervisor.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/supervisor.test.json
@@ -5,63 +5,154 @@
       "description": "the first stalled check keeps the reviewer's own action",
       "input": "",
       "expectedOutput": "\"redirect\"",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     },
     {
       "nodeName": "secondConsecutiveStallStops",
       "description": "a second consecutive stalled check becomes a stop",
       "input": "",
       "expectedOutput": "\"stop\"",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     },
     {
       "nodeName": "stallAfterProgressIsNotStopped",
       "description": "a stall after a progressing check is not consecutive",
       "input": "",
       "expectedOutput": "\"redirect\"",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     },
     {
       "nodeName": "emptyObservationStopMessage",
       "description": "a forced stop with an empty reviewer message has no dangling suffix",
       "input": "",
       "expectedOutput": "\"Stopped by the supervisor: two checks in a row found no progress.\"",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     },
     {
       "nodeName": "progressPassesThrough",
       "description": "a progressing verdict passes through untouched",
       "input": "",
       "expectedOutput": "\"continue\"",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     },
     {
       "nodeName": "flattenCompletedSolve",
       "description": "a completed successful solve yields its summary",
       "input": "",
       "expectedOutput": "\"wrote the fix\"",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     },
     {
       "nodeName": "flattenFailedSolve",
       "description": "a completed failed solve yields a failure",
       "input": "",
       "expectedOutput": "\"failure:solver gave up\"",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     },
     {
       "nodeName": "flattenSalvagedDraft",
       "description": "a salvaged draft string surfaces as a success",
       "input": "",
       "expectedOutput": "\"The run was stopped early by the supervisor. Its last saved draft:\\n\\nhalf the files are written\"",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     },
     {
       "nodeName": "flattenSuperviseFailure",
       "description": "a supervise failure passes through as a failure",
       "input": "",
       "expectedOutput": "\"failure:supervise: maxTime reached\"",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "stalledWithUnchangedDraftStops",
+      "description": "a stalled verdict plus an unchanged draft stops immediately",
+      "input": "",
+      "expectedOutput": "\"stop\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "unchangedDraftAloneIsNotStopped",
+      "description": "an unchanged draft alone does not stop a progressing run",
+      "input": "",
+      "expectedOutput": "\"continue\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "draftStringification",
+      "description": "null carries no signal, strings pass through, objects compare as JSON",
+      "input": "",
+      "expectedOutput": "\"null:0|string:half done|object:{\\\"step\\\":2}\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "draftDeltaStates",
+      "description": "the delta classification covers all four states",
+      "input": "",
+      "expectedOutput": "\"none|first|changed|unchanged\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "draftSectionFlagsUnchanged",
+      "description": "the prompt section flags only the byte-identical case",
+      "input": "",
+      "expectedOutput": "\"true|true|true\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/stdlib/supervise.agency
+++ b/packages/agency-lang/stdlib/supervise.agency
@@ -31,7 +31,7 @@ export type SuperviseDecision = {
 export def supervise(
   every: number,
   maxTime: number,
-  check: (elapsed: number) -> SuperviseDecision,
+  check: (elapsed: number, draft: any) -> SuperviseDecision,
   block: () -> any,
 ): Result<any> {
   """
@@ -39,7 +39,11 @@ export def supervise(
 
   @param every - How often to pause and check
   @param maxTime - Total time budget across all intervals
-  @param check - Called at each pause with elapsed time, and decides whether to continue, redirect, or stop
+  @param check - Called at each pause with elapsed time and the block's most
+    recent saveDraft value (null when none has been saved), and decides
+    whether to continue, redirect, or stop. The draft is the block's own
+    account of its progress: a draft that has not changed between checks is
+    strong evidence the block is stalled.
   @param block - The long-running work
   """
   if (maxTime < every) {
@@ -65,7 +69,10 @@ export def supervise(
     if (spent >= maxTime) {
       return reject("supervise: maxTime reached")
     }
-    const decision = check(spent)
+    // The trip already carries a preview of the innermost saved draft
+    // (guardTripInterrupt attaches it as draftValue), so the check gets
+    // the block's own progress report for free.
+    const decision = check(spent, intr.data.draftValue ?? null)
     // The grant is a DELTA added to the tripped budget, and the runtime
     // refuses an approval that leaves the budget still exceeded. By the time
     // a trip is answered the block has usually run past the old limit, and on

--- a/packages/agency-lang/tests/agency/supervise/supervise.agency
+++ b/packages/agency-lang/tests/agency/supervise/supervise.agency
@@ -11,12 +11,12 @@ def spin(rounds: number): string {
   return "spun"
 }
 
-def alwaysContinue(elapsed: number): SuperviseDecision {
+def alwaysContinue(elapsed: number, draft: any): SuperviseDecision {
   checks.push("checked")
   return { action: "continue", message: "" }
 }
 
-def alwaysStop(elapsed: number): SuperviseDecision {
+def alwaysStop(elapsed: number, draft: any): SuperviseDecision {
   return { action: "stop", message: "off the rails" }
 }
 
@@ -77,7 +77,7 @@ node maxTimeBelowIntervalFails(): boolean {
 // next request sees it. The block reads its own thread and reports whether
 // the message landed, mirroring the delivery assertion in
 // tests/agency/subprocess/trip-forward-approve-message.agency.
-def redirectOnce(elapsed: number): SuperviseDecision {
+def redirectOnce(elapsed: number, draft: any): SuperviseDecision {
   checks.push("redirected")
   return { action: "redirect", message: "course-correct: use the other approach" }
 }
@@ -115,7 +115,7 @@ node redirectDeliversMessage(): string {
 // the overshoot certain instead of load-dependent.
 let slowChecks = 0
 
-def slowCheck(elapsed: number): SuperviseDecision {
+def slowCheck(elapsed: number, draft: any): SuperviseDecision {
   checks.push("checked")
   slowChecks = slowChecks + 1
   // Only the first one is slow. One is enough to push the block well past
@@ -136,4 +136,25 @@ node overshootIsCoveredByTheGrant(): string {
     return "failed:${r.error}"
   }
   return r.value
+}
+
+// The check receives the block's most recent saveDraft value: the trip
+// carries a preview of the innermost saved draft, and supervise hands it
+// through. The 100ms interval means the trip fires during the spin, well
+// after saveDraft ran.
+const draftsSeen = []
+
+def recordDraft(elapsed: number, draft: any): SuperviseDecision {
+  draftsSeen.push("${draft}")
+  return { action: "continue", message: "" }
+}
+
+node checkSeesDraft(): string {
+  const r = supervise(every: 100ms, maxTime: 600000, check: recordDraft) {
+    saveDraft("partial")
+    const s = spin(3000000)
+    return "done:${s}"
+  }
+  if (isFailure(r)) { return "unexpected-failure" }
+  return "${r.value}|firstDraft:${draftsSeen[0] ?? "none"}"
 }

--- a/packages/agency-lang/tests/agency/supervise/supervise.test.json
+++ b/packages/agency-lang/tests/agency/supervise/supervise.test.json
@@ -75,6 +75,17 @@
           "type": "exact"
         }
       ]
+    },
+    {
+      "nodeName": "checkSeesDraft",
+      "description": "the check callback receives the block's most recent saved draft",
+      "input": "",
+      "expectedOutput": "\"done:spun|firstDraft:partial\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Why

The supervisor from #600 checks on the code subagent every five minutes, but its reviewer had to be tool-free: nothing inside a handler function could raise an interrupt, so evidence-gathering was limited to direct git reads. #611 removed that restriction. This PR gives the supervisor the standard agent built for exactly this job, adds a think-before-committing step for complex tasks, and teaches the supervisor to read the solver's own progress reports.

## Supervisor uses std::agents/verifier

`progressCheck` now sends `verifierAgent` into the workspace at each pause — full toolset (shell, file reads, real measurements), governed by the outer policy like any other tool call. Its context frames the run as a mid-run check ("the work is expected to be incomplete; report which criteria are satisfied, in progress, or unstarted"), and the reviewer LLM judges those findings plus the check history instead of a raw git diff. Budgets are small ($2 / 2m) because it is a pulse check, and everything fails open — including the ambiguity that `verifierAgent` itself fails open (`failOpenFeedback` maps failures to `success([])`), so empty findings are reported as "either nothing was measurable yet or it could not run", never as a clean measurement.

On the other stdlib agents: `verifierAgent` is the right fit here (it *runs and measures*; `reviewAgent` only reads text; `oracleAgent` is a slow-model second opinion, too heavy for a five-minute cadence). The code subagent already uses the stdlib expert/coding/verifier agents for the solve itself.

## Brainstorm before complex solves

When triage says a task is complex, `escalateToExpert` now brainstorms before solving: three proposers run in parallel via `fork`, each pushed toward a genuinely different bias — simplest thing that could work, most robust, maximum reuse — and a judge picks one with a one-sentence rationale.

- The **chosen** direction goes into the solver's context ("follow this unless you discover it cannot work").
- The **set-aside alternatives** go to the supervisor, which shows them to the reviewer at every check — so a redirect can say "switch to the reuse approach" by name instead of a vague "try something else".

The whole step runs under its own guard ($2 / 3m) and fails open: an errored brainstorm, or a judge that returns an out-of-range index, yields an empty result and the solve proceeds exactly as before.

## Draft deltas

Guard trips already carry a preview of the innermost saved draft (`draftValue`, attached by `guardTripInterrupt` and documented in the guards guide) — nobody consumed it. Now:

- `std::supervise` passes it to the check callback: `check: (elapsed, draft) -> SuperviseDecision`. Signature change to the stdlib; the existing supervise fixtures are updated and a new one (`checkSeesDraft`) pins that a block's `saveDraft` value reaches the check.
- The agent's supervisor stringifies and compares each check's draft against the previous one. The delta is computed, not judged, and it is the sharpest stall signal available for free: a thrashing solver churns the workspace — which git and even the verifier can read as motion — but its own "here is what I have finished" statement does not advance.
- The thrash backstop gains a deterministic input: reviewer-says-stalled **plus** a byte-identical draft stops immediately, instead of waiting for a second stalled check. An unchanged draft alone never stops a progressing run, and a solver that never saves drafts degrades cleanly (delta "none", no signal).

## Tests

25 execution tests across three suites, no LLM calls:

- `tests/agency/supervise/` (7): existing behavior plus `checkSeesDraft`.
- Agent supervisor suite (14): thrash backstop including the two new draft rules, outcome flattening, draft stringification (null/string/typed-object), all four delta states, and the prompt section flagging only the byte-identical case.
- Brainstorm suite (4): the judge-choice splitter keeps order, a bad index fails open, an empty brainstorm renders to nothing, and the renderings carry the right names to the right places.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Breaking change

`std::supervise`'s `check` callback signature changed from `(elapsed) -> SuperviseDecision` to `(elapsed, draft) -> SuperviseDecision`. Every in-repo caller is updated; external check callbacks written to the old shape need the new parameter. Same few-users call as retiring AG3010.
