### PR TITLE
Supervise the planner escalation; partial results at every agent milestone

### DIFF
--- a/packages/agency-lang/docs/site/stdlib/supervise.md
+++ b/packages/agency-lang/docs/site/stdlib/supervise.md
@@ -79,4 +79,4 @@ Run a block, pausing it every interval to check progress and steer it.
 
 **Returns:** `Result<any>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/supervise.agency#L31))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/supervise.agency#L39))

--- a/packages/agency-lang/docs/site/stdlib/supervise.md
+++ b/packages/agency-lang/docs/site/stdlib/supervise.md
@@ -66,7 +66,10 @@ Run a block, pausing it every interval to check progress and steer it.
     whether to continue, redirect, or stop. The draft is the block's own
     account of its progress: a draft that has not changed between checks is
     strong evidence the block is stalled.
-  @param block - The long-running work
+  @param block - The long-running work. Known limitation: do not call
+    supervise() in parallel fork branches — sibling instances can mint
+    colliding guard labels (the instance counter is branch-isolated
+    while the handler chain is shared) and answer each other's trips.
 
 **Parameters:**
 
@@ -79,4 +82,4 @@ Run a block, pausing it every interval to check progress and steer it.
 
 **Returns:** `Result<any>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/supervise.agency#L39))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/supervise.agency#L46))

--- a/packages/agency-lang/lib/agents/agency-agent/subagents/brainstorm.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/subagents/brainstorm.agency
@@ -180,6 +180,12 @@ export def brainstormApproaches(
     const proposals = fork(ANGLES) as angle {
       return proposeApproach(task: task, guidance: guidance, angle: angle)
     }
+    // Partial result: if the budget trips during the judge call below,
+    // the three finished proposals are still worth keeping — the trip
+    // salvages this draft (all proposals as alternatives, none chosen),
+    // the solver proceeds undirected, and the supervisor still gets the
+    // full list for redirects.
+    saveDraft({ chosen: null, alternatives: proposals, rationale: "" })
     const choice = judgeApproaches(task: task, approaches: proposals)
     return splitChoice(
       approaches: proposals,
@@ -187,7 +193,9 @@ export def brainstormApproaches(
       rationale: choice.rationale,
     )
   }
-  // isFailure, not match: this can run inside blocks that pause and resume.
+  // isFailure, not match: this can run inside blocks that pause and
+  // resume. A trip after the draft arrives success-shaped carrying it;
+  // only a run that saved nothing lands here.
   if (isFailure(captured)) {
     return EMPTY_BRAINSTORM
   }

--- a/packages/agency-lang/lib/agents/agency-agent/subagents/code.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/subagents/code.agency
@@ -37,7 +37,11 @@ import {
   renderChosen,
   renderAlternatives,
  } from "./brainstorm.agency"
-import { progressCheck, resetSupervisor } from "./supervisor.agency"
+import {
+  progressCheck,
+  pushSupervisorFrame,
+  popSupervisorFrame,
+ } from "./supervisor.agency"
 
 
 static const superpowersSkill = skillsDir("./skills/superpowers", "flat") with approve
@@ -148,13 +152,7 @@ def escalate(task: string, reason: string, plan: string): string {
   @param reason - why this task needs a multi-step plan.
   @param plan - your outline of the steps.
   """
-  const planned = plannerAgent(
-    task,
-    context: reason,
-    plan: plan,
-    maxCost: ESCALATE_MAX_COST,
-    maxTime: ESCALATE_MAX_TIME,
-  )
+  const planned = supervisedPlan(task: task, reason: reason, plan: plan)
   if (isFailure(planned)) {
     return "Planner stopped: ${planned.error}"
   }
@@ -246,7 +244,7 @@ def supervisedSolve(
   agencyTask: boolean,
   alternatives: string = "",
 ): Result<string> {
-  resetSupervisor(alternatives: alternatives)
+  pushSupervisorFrame(alternatives: alternatives)
   const captured = supervise(
     every: SUPERVISE_EVERY,
     maxTime: ESCALATE_MAX_TIME,
@@ -266,6 +264,42 @@ def supervisedSolve(
       summary: solved.value
     }
   }
+  popSupervisorFrame()
+  return flattenSolveOutcome(captured)
+}
+
+/* The planner escalation, supervised the same way as a solve: it hands
+   plannerAgent the largest budget in the agent and previously ran it
+   with nobody watching. Draft deltas fail open here — the planner's
+   generated program runs in a subprocess, so its drafts live in the
+   child and the delta reads "none" in the parent; the verifier and
+   check history still carry the evidence. */
+def supervisedPlan(task: string, reason: string, plan: string): Result<string> {
+  pushSupervisorFrame()
+  const captured = supervise(
+    every: SUPERVISE_EVERY,
+    maxTime: ESCALATE_MAX_TIME,
+    check: progressCheck.partial(task: task),
+  ) {
+    const planned = plannerAgent(
+      task,
+      context: reason,
+      plan: plan,
+      maxCost: ESCALATE_MAX_COST,
+      maxTime: ESCALATE_MAX_TIME,
+    )
+    if (isFailure(planned)) {
+      return {
+        ok: false,
+        summary: "${planned.error}"
+      }
+    }
+    return {
+      ok: true,
+      summary: planned.value
+    }
+  }
+  popSupervisorFrame()
   return flattenSolveOutcome(captured)
 }
 
@@ -322,6 +356,10 @@ def escalateToExpert(task: string, agencyTask: boolean): string {
     summary = "Coding agent stopped: ${solved.error}"
   } else {
     summary = solved.value
+    // Milestone draft: a completed solve is worth keeping even if the
+    // verify or fix round below is cut short by an outer budget guard —
+    // salvage-on-abort then returns this instead of nothing.
+    saveDraft(summary)
   }
   const checked = verifierAgent(
     task: task,
@@ -342,6 +380,7 @@ Fix each problem exactly.
     const fixed = supervisedSolve(task: fixMsg, context: "", agencyTask: agencyTask, alternatives: alternatives)
     if (!isFailure(fixed)) {
       summary = fixed.value
+      saveDraft(summary)
     }
   }
   return summary
@@ -356,6 +395,9 @@ def solveUnattended(task: string, agencyTask: boolean): string {
   if (isFailure(solved)) {
     return "The task did not complete: ${solved.error}"
   }
+  // Milestone draft: the verify and fix rounds below can be cut short by
+  // an outer budget guard; the completed solve must survive that.
+  saveDraft(solved.value)
   const checked = verifierAgent(task: task, maxCost: $5.00, maxTime: 5m)
   if (!feedbackHasErrors(checked)) {
     return solved.value
@@ -373,6 +415,7 @@ Fix each one; your work will be re-checked.
   if (isFailure(fixed)) {
     return solved.value
   }
+  saveDraft(fixed.value)
   return fixed.value
 }
 

--- a/packages/agency-lang/lib/agents/agency-agent/subagents/code.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/subagents/code.agency
@@ -238,11 +238,19 @@ export def flattenSolveOutcome(captured: Result<any>): Result<string> {
    continue, redirect the paused worker, or stop a run that two checks in a
    row found stalled. This is what turns a 15-minute thrash into a 5-minute
    course correction. */
-def supervisedSolve(
+/* One frame push, one supervised run of `work`, one pop, one flatten.
+   The single home of the outcome-normalization subtleties: the block
+   reads work's Result with isFailure, never match (a match inside a
+   block that pauses and resumes evaluates to null — see
+   tests/agency/supervise/nestedGuardResume.agency), and normalizes to a
+   plain SolveOutcome because a mid-run stop salvages the worker's draft
+   in place of the block's return value. The pop is skipped when an
+   abort unwinds through here; supervisor.agency documents why that
+   leak is accepted and how it is bounded. */
+def supervisedRun(
   task: string,
-  context: string,
-  agencyTask: boolean,
-  alternatives: string = "",
+  alternatives: string,
+  work: () -> Result<string>,
 ): Result<string> {
   pushSupervisorFrame(alternatives: alternatives)
   const captured = supervise(
@@ -250,22 +258,33 @@ def supervisedSolve(
     maxTime: ESCALATE_MAX_TIME,
     check: progressCheck.partial(task: task),
   ) {
-    // isFailure, not match: a match inside a block that pauses and resumes
-    // evaluates to null (see tests/agency/supervise/nestedGuardResume.agency).
-    const solved = solve(task: task, context: context, agencyTask: agencyTask)
-    if (isFailure(solved)) {
+    const worked = work()
+    if (isFailure(worked)) {
       return {
         ok: false,
-        summary: "${solved.error}"
+        summary: "${worked.error}"
       }
     }
     return {
       ok: true,
-      summary: solved.value
+      summary: worked.value
     }
   }
   popSupervisorFrame()
   return flattenSolveOutcome(captured)
+}
+
+def supervisedSolve(
+  task: string,
+  context: string,
+  agencyTask: boolean,
+  alternatives: string = "",
+): Result<string> {
+  return supervisedRun(
+    task: task,
+    alternatives: alternatives,
+    work: \-> solve(task: task, context: context, agencyTask: agencyTask),
+  )
 }
 
 /* The planner escalation, supervised the same way as a solve: it hands
@@ -275,32 +294,17 @@ def supervisedSolve(
    child and the delta reads "none" in the parent; the verifier and
    check history still carry the evidence. */
 def supervisedPlan(task: string, reason: string, plan: string): Result<string> {
-  pushSupervisorFrame()
-  const captured = supervise(
-    every: SUPERVISE_EVERY,
-    maxTime: ESCALATE_MAX_TIME,
-    check: progressCheck.partial(task: task),
-  ) {
-    const planned = plannerAgent(
+  return supervisedRun(
+    task: task,
+    alternatives: "",
+    work: \-> plannerAgent(
       task,
       context: reason,
       plan: plan,
       maxCost: ESCALATE_MAX_COST,
       maxTime: ESCALATE_MAX_TIME,
-    )
-    if (isFailure(planned)) {
-      return {
-        ok: false,
-        summary: "${planned.error}"
-      }
-    }
-    return {
-      ok: true,
-      summary: planned.value
-    }
-  }
-  popSupervisorFrame()
-  return flattenSolveOutcome(captured)
+    ),
+  )
 }
 
 export def codeAgent(userMsg: string, agencyTask: boolean = false) {

--- a/packages/agency-lang/lib/agents/agency-agent/subagents/supervisor.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/subagents/supervisor.agency
@@ -58,26 +58,59 @@ export type CheckRecord = {
   message: string
 }
 
-// History of this run's checks. Reset at the start of each supervised solve;
-// each check appends its own record.
-let _history: CheckRecord[] = []
+/** One supervised run's working state. `history` is this run's checks;
+  `alternatives` is the brainstorm's set-aside approaches rendered as text
+  ("" when no brainstorm ran) so a redirect can steer toward a specific
+  one; `lastDraft` is the solver's draft as of the previous check,
+  stringified for comparison — the draft is the solver's own account of
+  completed progress, and one that has not changed between checks is the
+  sharpest stall evidence available. */
+type SupervisorFrame = {
+  history: CheckRecord[];
+  alternatives: string;
+  lastDraft: string
+}
 
-// The approaches the solver considered and did not pick, rendered as text
-// by the brainstorm step. "" when no brainstorm ran. A redirect can steer
-// toward a specific alternative instead of a vague "try something else".
-let _alternatives: string = ""
+// A STACK of frames, because supervised runs nest: the one-shot
+// coordinator turn is supervised, and it delegates to codeAgent, whose
+// supervisedSolve supervises again. Each supervised run pushes a frame
+// before its supervise() and pops after; progressCheck reads and writes
+// the innermost frame. A single flat state here would let the inner run
+// wipe the outer run's history mid-flight.
+let _frames: SupervisorFrame[] = []
 
-// The solver's draft as of the previous check, stringified for comparison.
-// The draft is the solver's own account of completed progress: a draft
-// that has not changed between checks is the sharpest stall evidence
-// available — a thrashing solver churns the workspace but its "here is
-// what I have finished" statement does not advance.
-let _lastDraft: string = ""
+export def pushSupervisorFrame(alternatives: string = "") {
+  _frames.push(
+    {
+    history: [],
+    alternatives: alternatives,
+    lastDraft: ""
+  },
+  )
+}
 
-export def resetSupervisor(alternatives: string = "") {
-  _history = []
-  _alternatives = alternatives
-  _lastDraft = ""
+export def popSupervisorFrame() {
+  _frames = _frames.slice(0, _frames.length - 1)
+}
+
+/** The innermost frame. Defensive: a progressCheck with no pushed frame
+  (a caller forgot the push) gets a fresh implicit one rather than a
+  crash inside a guard handler. */
+def currentFrame(): SupervisorFrame {
+  if (_frames.length == 0) {
+    pushSupervisorFrame()
+  }
+  const frame = _frames[_frames.length - 1]
+  if (frame == null) {
+    // Unreachable after the push above; satisfies the null-normalized
+    // index type.
+    return {
+      history: [],
+      alternatives: "",
+      lastDraft: ""
+    }
+  }
+  return frame
 }
 
 /** A draft as comparable text: "" for none, the string itself, or JSON for
@@ -114,7 +147,7 @@ export def draftDelta(
 }
 
 export def supervisorHistory(): CheckRecord[] {
-  return _history
+  return currentFrame().history
 }
 
 /** Apply the thrash backstop to the reviewer's verdict. Two ways to a
@@ -266,7 +299,7 @@ Earlier checks this run:
 <history>
 ${history}
 </history>
-${renderAlternativesSection(_alternatives)}
+${renderAlternativesSection(currentFrame().alternatives)}
 Judge the evidence:
 - assessment: "progressing" when the findings show real movement toward the task since the last check; "stalled" when nothing meaningful has changed, or it keeps redoing the same thing. Mid-run gaps are normal — unstarted criteria are only a bad sign when they were also unstarted last check. An unchanged draft is strong stall evidence: a busy workspace with an unadvanced self-report usually means the solver is redoing work.
 - action "continue": on track. The default — pick it unless the evidence clearly says otherwise.
@@ -291,8 +324,9 @@ export def progressCheck(task: string, elapsed: number, draft: any): SuperviseDe
   @param draft - The solver's most recent saveDraft value, or null
   """
   const minutes = Math.round(elapsed / 60000)
+  const frame = currentFrame()
   const draftText = stringifyDraft(draft)
-  const delta = draftDelta(draftText, _lastDraft)
+  const delta = draftDelta(draftText, frame.lastDraft)
   const evidence = verifierEvidence(task: task, minutes: minutes)
   const verdict: SupervisorVerdict = llm(
     reviewPrompt(
@@ -300,12 +334,12 @@ export def progressCheck(task: string, elapsed: number, draft: any): SuperviseDe
     minutes: minutes,
     evidence: evidence.text,
     draftSection: renderDraftSection(draftText, delta),
-    history: renderHistory(_history),
+    history: renderHistory(frame.history),
   ),
   )
-  const decision = applyThrashRule(verdict, _history, delta == "unchanged")
-  _lastDraft = draftText
-  _history.push(
+  const decision = applyThrashRule(verdict, frame.history, delta == "unchanged")
+  frame.lastDraft = draftText
+  frame.history.push(
     {
     minutes: minutes,
     findings: evidence.findings,

--- a/packages/agency-lang/lib/agents/agency-agent/subagents/supervisor.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/subagents/supervisor.agency
@@ -77,9 +77,28 @@ type SupervisorFrame = {
 // before its supervise() and pops after; progressCheck reads and writes
 // the innermost frame. A single flat state here would let the inner run
 // wipe the outer run's history mid-flight.
+//
+// KNOWN LEAK, bounded: the pop is skipped when an abort unwinds through
+// the supervised run (an outer budget trip mid-solve — the very path
+// the milestone drafts exist for). A finalize cannot do the pop: a
+// return-less finalize replaces the aborted scope's salvage value with
+// undefined, clobbering the drafts this feature exists to deliver
+// (probed directly; see PR #614). Leaked frames sit BELOW the next
+// run's frame and are never read — progressCheck only touches the top —
+// so the only costs are growth across a long agent session and stale
+// supervisorHistory() between runs. The clamp below bounds the growth.
 let _frames: SupervisorFrame[] = []
 
+// Legitimate nesting is structurally shallow (a supervised coordinator
+// turn over a supervised solve is depth 2). Anything past this is
+// leaked frames from aborted runs; push drops the oldest to stay
+// bounded.
+static const MAX_SUPERVISOR_FRAMES = 8
+
 export def pushSupervisorFrame(alternatives: string = "") {
+  if (_frames.length >= MAX_SUPERVISOR_FRAMES) {
+    _frames = _frames.slice(_frames.length - MAX_SUPERVISOR_FRAMES + 1)
+  }
   _frames.push(
     {
     history: [],

--- a/packages/agency-lang/lib/agents/agency-agent/tests/brainstorm.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/brainstorm.agency
@@ -61,6 +61,22 @@ node emptyBrainstormRendersEmpty(): string {
   return "solver:${solverBlock.length}|supervisor:${supervisorBlock.length}"
 }
 
+// The salvaged-draft shape (all proposals as alternatives, none chosen)
+// renders correctly at both destinations: nothing for the solver, the
+// full list for the supervisor. This is what a budget trip during the
+// judge call hands back.
+node salvagedDraftShapeRenders(): string {
+  const salvaged: BrainstormResult = {
+    chosen: null,
+    alternatives: [approach("simple"), approach("robust"), approach("reuse")],
+    rationale: ""
+  }
+  const solverBlock = renderChosen(salvaged)
+  const supervisorBlock = renderAlternatives(salvaged)
+  const supervisorHasAll = supervisorBlock.includes("simple") && supervisorBlock.includes("robust") && supervisorBlock.includes("reuse")
+  return "solver:${solverBlock.length}|all:${supervisorHasAll}"
+}
+
 // A real result renders the chosen name for the solver and the set-aside
 // names for the supervisor.
 node renderingsCarryTheNames(): string {

--- a/packages/agency-lang/lib/agents/agency-agent/tests/brainstorm.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/brainstorm.test.json
@@ -43,6 +43,17 @@
           "type": "exact"
         }
       ]
+    },
+    {
+      "nodeName": "salvagedDraftShapeRenders",
+      "description": "the trip-salvaged draft renders nothing for the solver and everything for the supervisor",
+      "input": "",
+      "expectedOutput": "\"solver:0|all:true\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/lib/agents/agency-agent/tests/supervisor.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/supervisor.agency
@@ -9,6 +9,9 @@ import {
   stringifyDraft,
   draftDelta,
   renderDraftSection,
+  pushSupervisorFrame,
+  popSupervisorFrame,
+  supervisorHistory,
  } from "../subagents/supervisor.agency"
 
 def record(assessment: string): CheckRecord {
@@ -77,6 +80,26 @@ node draftSectionFlagsUnchanged(): string {
   const changedNotFlagged = !changedBlock.includes("BYTE-IDENTICAL")
   const noneHasNoDraftTag = !noneBlock.includes("<draft>")
   return "${unchangedFlagged}|${changedNotFlagged}|${noneHasNoDraftTag}"
+}
+
+// Supervised runs nest (a supervised coordinator delegates to a
+// supervised solve), so the working state is a stack of frames: the
+// inner run's history must not touch the outer run's, and popping the
+// inner frame must land back on the outer one intact.
+node nestedFramesAreIsolated(): string {
+  pushSupervisorFrame()
+  supervisorHistory().push(record("progressing"))
+  pushSupervisorFrame()
+  const innerEmpty = supervisorHistory().length
+  supervisorHistory().push(record("stalled"))
+  supervisorHistory().push(record("stalled"))
+  const innerCount = supervisorHistory().length
+  popSupervisorFrame()
+  const outerCount = supervisorHistory().length
+  const outerRecord = supervisorHistory()[0]
+  const outerAssessment = if outerRecord == null then "missing" else outerRecord.assessment
+  popSupervisorFrame()
+  return "innerEmpty:${innerEmpty}|inner:${innerCount}|outer:${outerCount}|outerSaw:${outerAssessment}"
 }
 
 // The first stalled check keeps the reviewer's own action.

--- a/packages/agency-lang/lib/agents/agency-agent/tests/supervisor.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/supervisor.test.json
@@ -153,6 +153,17 @@
           "type": "exact"
         }
       ]
+    },
+    {
+      "nodeName": "nestedFramesAreIsolated",
+      "description": "nested supervisor frames keep isolated histories and pop back intact",
+      "input": "",
+      "expectedOutput": "\"innerEmpty:0|inner:2|outer:1|outerSaw:progressing\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/stdlib/supervise.agency
+++ b/packages/agency-lang/stdlib/supervise.agency
@@ -34,6 +34,13 @@ export type SuperviseDecision = {
 // firing the outer check against the inner guard's numbers and, because
 // guard grants accumulate in the approval merge, extending the inner
 // budget twice.
+//
+// LIMITATION: instances in sibling fork branches can still collide.
+// Module globals are branch-isolated under fork, so two branches that
+// each call supervise() increment isolated copies of this counter from
+// the same base and mint the same label — while the handler chain is
+// shared across branches. Do not call supervise() in parallel fork
+// branches until the label carries branch identity.
 let _instanceCounter = 0
 
 export def supervise(
@@ -52,7 +59,10 @@ export def supervise(
     whether to continue, redirect, or stop. The draft is the block's own
     account of its progress: a draft that has not changed between checks is
     strong evidence the block is stalled.
-  @param block - The long-running work
+  @param block - The long-running work. Known limitation: do not call
+    supervise() in parallel fork branches — sibling instances can mint
+    colliding guard labels (the instance counter is branch-isolated
+    while the handler chain is shared) and answer each other's trips.
   """
   if (maxTime < every) {
     return failure("supervise: maxTime is less than the check interval, so no checkpoint would ever be reached")

--- a/packages/agency-lang/stdlib/supervise.agency
+++ b/packages/agency-lang/stdlib/supervise.agency
@@ -28,6 +28,14 @@ export type SuperviseDecision = {
   message: string
 }
 
+// Each supervise call guards with its own label, so nested supervision
+// works: the chain visits every handler, and with a shared label an
+// inner instance's trip would also be answered by the outer handler —
+// firing the outer check against the inner guard's numbers and, because
+// guard grants accumulate in the approval merge, extending the inner
+// budget twice.
+let _instanceCounter = 0
+
 export def supervise(
   every: number,
   maxTime: number,
@@ -49,17 +57,20 @@ export def supervise(
   if (maxTime < every) {
     return failure("supervise: maxTime is less than the check interval, so no checkpoint would ever be reached")
   }
+  _instanceCounter = _instanceCounter + 1
+  const instanceLabel = "std::supervise#${_instanceCounter}"
   handle {
-    const captured = guard(time: every, label: "std::supervise") {
+    const captured = guard(time: every, label: instanceLabel) {
       return block()
     }
     return captured
   } with (intr) {
-    // Only answer trips from OUR guard. The block's own guards (an agent's
-    // cost and time caps) raise the same std::guard effect; without this
-    // label gate we would answer an inner trip, extend the wrong guard, and
-    // corrupt our own accounting.
-    if (intr.effect != "std::guard" || intr.data.label != "std::supervise") {
+    // Only answer trips from OUR guard — by instance, not by family. The
+    // block's own guards (an agent's cost and time caps) raise the same
+    // std::guard effect, and so does a NESTED supervise; without this
+    // exact-label gate we would answer another instance's trip, extend
+    // the wrong guard, and corrupt our own accounting.
+    if (intr.effect != "std::guard" || intr.data.label != instanceLabel) {
       return pass()
     }
     // The working time the block has actually consumed. Counting intervals

--- a/packages/agency-lang/tests/agency/supervise/supervise.agency
+++ b/packages/agency-lang/tests/agency/supervise/supervise.agency
@@ -177,6 +177,10 @@ def innerCheck(elapsed: number, draft: any): SuperviseDecision {
 }
 
 node nestedSuperviseIsolated(): string {
+  // Self-contained: the counters are file-scope, so reset them here in
+  // case nodes run in a different order or more than once.
+  outerChecks = 0
+  innerChecks = 0
   // The outer interval is huge, so any outerChecks count comes from the
   // outer handler wrongly answering the inner instance's trips.
   const r = supervise(every: 600000, maxTime: 6000000, check: outerCheck) {

--- a/packages/agency-lang/tests/agency/supervise/supervise.agency
+++ b/packages/agency-lang/tests/agency/supervise/supervise.agency
@@ -158,3 +158,35 @@ node checkSeesDraft(): string {
   if (isFailure(r)) { return "unexpected-failure" }
   return "${r.value}|firstDraft:${draftsSeen[0] ?? "none"}"
 }
+
+// Nested supervision: the inner instance's trips must be answered by the
+// INNER handler only. With a shared guard label the outer handler would
+// answer them too — firing the outer check against the inner guard's
+// numbers and double-extending the inner budget via grant accumulation.
+let outerChecks = 0
+let innerChecks = 0
+
+def outerCheck(elapsed: number, draft: any): SuperviseDecision {
+  outerChecks = outerChecks + 1
+  return { action: "continue", message: "" }
+}
+
+def innerCheck(elapsed: number, draft: any): SuperviseDecision {
+  innerChecks = innerChecks + 1
+  return { action: "continue", message: "" }
+}
+
+node nestedSuperviseIsolated(): string {
+  // The outer interval is huge, so any outerChecks count comes from the
+  // outer handler wrongly answering the inner instance's trips.
+  const r = supervise(every: 600000, maxTime: 6000000, check: outerCheck) {
+    const inner = supervise(every: 5ms, maxTime: 600000, check: innerCheck) {
+      const s = spin(300000)
+      return "inner:${s}"
+    }
+    if (isFailure(inner)) { return "inner-failed" }
+    return inner.value
+  }
+  if (isFailure(r)) { return "unexpected-failure" }
+  return "${r.value}|innerChecked:${innerChecks > 0}|outerChecks:${outerChecks}"
+}

--- a/packages/agency-lang/tests/agency/supervise/supervise.test.json
+++ b/packages/agency-lang/tests/agency/supervise/supervise.test.json
@@ -86,6 +86,17 @@
           "type": "exact"
         }
       ]
+    },
+    {
+      "nodeName": "nestedSuperviseIsolated",
+      "description": "a nested supervise instance's trips are answered only by its own handler",
+      "input": "",
+      "expectedOutput": "\"inner:spun|innerChecked:true|outerChecks:0\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Why

Two follow-ups from surveying the agent after #613: the `escalate` → planner path was the last big unsupervised budget in the agent, and the agent consumed partial results everywhere but never computed any of its own.

## Supervise the planner escalation

`escalate` hands `plannerAgent` 15m/$20 — the largest budget in the agent — and ran it with nobody watching. New `supervisedPlan` wraps it with the same `progressCheck` the solves get (verifier evidence, draft deltas, thrash backstop). One documented caveat: the planner's generated program runs in a subprocess, so its drafts stay in the child and the parent's draft delta reads "none" — the fail-open no-signal path, with verifier findings and check history still carrying the evidence.

## Nesting isolation (two fixes)

Supervision now nests — a supervised turn can contain a supervised solve — which surfaced two shared-state collisions:

- **`std::supervise` guards with a per-instance label** (`std::supervise#N`). The handler chain visits every handler, and with the old shared `"std::supervise"` label an outer instance would answer an inner instance's trips: its check would fire against the inner guard's numbers, and because guard grants accumulate in the approval merge, the inner budget would be extended twice per trip. Each handler now gates on its own instance label. `nestedSuperviseIsolated` pins it: the inner instance's checks run, the outer handler answers zero of them.
- **The agent supervisor's working state is a stack of frames** (`pushSupervisorFrame`/`popSupervisorFrame` around each supervised run) instead of flat module state, so an inner run cannot wipe an outer run's history/alternatives/draft mid-flight. `nestedFramesAreIsolated` pins push/push/pop behavior. (`resetSupervisor` is gone; the agent is its only caller.)

## Partial results

Following the partial-results guide, drafts at every point where finished work could still be lost:

- **Brainstorm**: `saveDraft` between the fork and the judge. A budget trip during the judge call now salvages all three finished proposals (as alternatives, none chosen) instead of discarding them for `EMPTY_BRAINSTORM`; the solver proceeds undirected and the supervisor still gets the full list for redirects.
- **Milestone drafts in `escalateToExpert` and `solveUnattended`**: each completed solve (and each successful fix round) is drafted before the verify/fix tail runs, so an outer budget guard tripping mid-verify salvages the finished solve instead of nothing. Limitation stated in the comments: this covers guard-trip aborts, not user cancellation (`AgencyCancelledError` propagates without converting, by design).

The stdlib worker agents already compute partials (coding via prompt, agency/coding per iteration, researcher per grounding round, planner per step, verifier via `finalize`) — these were the agent-side gaps.

## Tests

28 execution tests, no LLM calls: supervise 8 (including `nestedSuperviseIsolated`), agent supervisor 15 (including frame isolation), brainstorm 5 (including the salvaged-draft shape rendering nothing for the solver and everything for the supervisor). One pre-existing flake note: `overshootIsCoveredByTheGrant` timed out once on a loaded machine — the load sensitivity that test itself documents — and passes on rerun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
