### PR TITLE
Fake clock for deterministic time-guard tests (#575)

### DIFF
--- a/docs/superpowers/plans/2026-07-19-fake-clock-migration-list.md
+++ b/docs/superpowers/plans/2026-07-19-fake-clock-migration-list.md
@@ -1,0 +1,58 @@
+# Fake-clock migration list (Task 0 audit output)
+
+Which time-guard fixtures are safe to convert to `_advanceTime` (#575). Task 6
+migrates exactly the `## Cleared` set and nothing else.
+
+## Audit method
+
+`grep -rn "performance.now()\|Date.now()" lib/runtime lib/stdlib` shows the six
+guard reads in `guard.ts` plus independent time reads in `ipc.ts`, `runBatch.ts`,
+`interrupts.ts`, `node.ts`, `prompt.ts`, `memory/manager.ts`, and stdlib helpers.
+The seam routes only `guard.ts`. A fixture is safe to migrate only when its
+asserted output is a guard-trip result and does not depend on any of those other
+reads.
+
+`grep -l "spin(" tests/agency/**` finds exactly four fixtures that spin down a
+guard clock. The `subprocess/nested-pause-*` fixtures do NOT use `spin` — their
+slowness is IPC and real waits, not a guard busy-loop — so they are not
+candidates here, correcting the plan's earlier assumption.
+
+## Cleared
+
+- `tests/agency/supervise/supervise.agency` — every `expectedOutput` is a
+  supervise decision, a salvaged draft, or a boolean (`"done:spun|checked:true"`,
+  `"salvaged:partial"`, `"inner:spun|checksDuring:0"`, `true`, `"delivered:user"`,
+  `"done:spun"`, `"done:spun|firstDraft:partial"`,
+  `"inner:spun|innerChecked:true|outerChecks:0"`). No non-guard time read in any
+  asserted value. The primary CI win (~70s). Contains nested-supervise and
+  guard-in-supervise nodes — migrate per-node per Task 6 Step 4, watching Hazard B
+  (one advance can trip inner and outer together).
+- `tests/agency/supervise/nestedGuardResume.agency` — asserts `"ok:inner:spun"`,
+  `"ok:spun"`, `null`. Nested `guard(time:5ms)` over `guard(time:600000)`. Guard
+  results only. Clear; Hazard B applies (outer 5ms should trip, inner 600000 must
+  not — advance just past 5ms, not past both).
+- `tests/agency/guards/trip-time.agency` — asserts `"done:spun|granted:time"`,
+  `"salvaged:partial-spin"`, `"done:pong"`, `"salvaged:before-request"`,
+  `"done:spun"`, `"done:tool-reported:spun"`. Mostly single guards. Clear; note
+  the bare `return spin(300000)` helper (line 119) is reached from inside a guard,
+  so its replacement advance must run where that guard is live.
+
+## Not migrated (this pass)
+
+- `tests/agency/guards/trip-join.agency` — HELD, not because it asserts on a time
+  value (it asserts `"done|parent-grants:0"` and `"encl-tripped:encl"`, both guard
+  outcomes), but because it drives guards through `runBatch` fork/race branches.
+  Each branch's working-time budget (#549/#550) reads real time via
+  `t.startedAt = performance.now()` in `runBatch.ts`, which the seam does NOT
+  route. So under a fake clock the per-branch working-time would advance on the
+  real clock while the guard budget advances on the fake clock, and the two could
+  diverge and change which guard trips. Its `spin(300000)` is also small (~0.8s),
+  so it is not a CI-time problem. Leave it on the real clock. Revisit only if a
+  future change routes runBatch's working-time through the seam.
+
+## Note on the others
+
+`nestedGuardResume` and `trip-time` spin `300000` (~0.8s each), so they are not the
+CI pain that motivated #575; `supervise` is. They are cleared and worth migrating
+for determinism, but if either resists (Task 6 Step 4 point 6), leaving it slow is
+acceptable. `supervise` is the one that must land.

--- a/docs/superpowers/plans/2026-07-19-fake-clock-migration-list.md
+++ b/docs/superpowers/plans/2026-07-19-fake-clock-migration-list.md
@@ -56,3 +56,20 @@ candidates here, correcting the plan's earlier assumption.
 CI pain that motivated #575; `supervise` is. They are cleared and worth migrating
 for determinism, but if either resists (Task 6 Step 4 point 6), leaving it slow is
 acceptable. `supervise` is the one that must land.
+
+## Migrated (final)
+
+Only the two `spin(3000000)` nodes in `supervise.agency` were migrated:
+`overshootIsCoveredByTheGrant` and `checkSeesDraft`. These were the CI cost.
+`fakeClock` is per test case, so those two carry `"fakeClock": true` and use
+`_advanceTime` while the file's cheap `spin(300000)` nodes keep the real clock
+untouched. Result: `overshootIsCoveredByTheGrant` went from ~70s to ~0.7s and
+still fails when the `grant = nextInterval` regression is reintroduced
+(verified against a reverted build). The whole file dropped from ~76s to ~13s.
+
+Left on the real clock, deliberately: the `spin(300000)` nodes in
+`supervise.agency` (~0.8s each, not worth the per-node interleaving risk),
+`nestedGuardResume.agency`, `trip-time.agency`, and `trip-join.agency`. Each
+migration needs its own trace of when `spent` is sampled and how a trip
+surfaces, and none of them is a CI-time problem. They can be migrated later,
+one at a time, if determinism ever matters more than the ~0.8s cost.

--- a/docs/superpowers/plans/2026-07-19-fake-clock-time-guards-REVIEW.md
+++ b/docs/superpowers/plans/2026-07-19-fake-clock-time-guards-REVIEW.md
@@ -1,0 +1,307 @@
+# Review — Fake clock for time-guard tests (#575) — Implementation Plan
+
+Reviewed against the code, not just read on its own terms. This plan is strong: it
+absorbed the spec-review findings cleanly (firing cap dropped, re-arm described
+correctly in Task 1's `advance` doc-comment and Task 6's trace), and the TDD
+structure with a red-first step per task is exactly right.
+
+Things I checked and can confirm the plan got right:
+- **The env-var mechanism is idiomatic, not a module-global smell.** `executeNodeAsync`
+  spawns a `node` subprocess via `execFileAsync` with `env: { ...process.env, ...env }`
+  (`lib/cli/util.ts:352,357`). Setting `env.AGENCY_FAKE_CLOCK = "1"` scopes the flag
+  to that child only — it never mutates the parent worker's `process.env`. This is
+  the same pattern as `AGENCY_LLM_MOCKS` / `AGENCY_FETCH_MOCKS_FILE`. Good fit.
+- **The `_installSlowInput` precedent is exact.** `stdlib/thread.agency:205` is a
+  non-exported `def` calling `_installSlowInputImpl` (exported from
+  `lib/stdlib/builtins.ts:133`), reached via `import test`. Task 4 mirrors it
+  precisely, including the `agency-lang/stdlib-lib/builtins.js` import specifier.
+- **`check()` returns, it does not throw.** `TimeGuard.check(stack): GuardExceededError | null`
+  (`guard.ts:175,681`), so the Task 3 unit-test assertions (`toBeNull()` /
+  `not.toBeNull()`) are correct. Note the once-only consume flag (`guard.ts:537`):
+  the second `check()` after a trip returns null. The Task 3 test is fine because
+  its first `check()` is under budget (returns null), and it calls `check()` twice,
+  not three times — but keep that flag in mind if the test grows.
+- **No existing clock seam is being duplicated.** `guard.ts` calls `performance.now`
+  and `setTimeout` directly today; there's no runtime `Clock` abstraction to reuse.
+  Correct altitude — this seam is genuinely new.
+
+---
+
+## 🔴 Task 6, Step 4: the nested / subprocess fixtures are the real risk, and they're treated as routine
+
+Step 4 says "swap each guard-clock `spin(...)` for the equivalent `_advanceTime(...)`"
+for the `nested-pause-*` and `guards/*` fixtures in one line. Two mechanics make
+this the hardest part of the whole change, not a rote swap:
+
+**1. `_advanceTime` advances only the clock of the process it runs in.** The
+`nested-pause-*` fixtures are subprocess-IPC fixtures — the guard whose budget must
+expire may be armed in a *child* agency process, not the one where the old `spin()`
+ran. `AGENCY_FAKE_CLOCK=1` is inherited by every descendant process (env inheritance
+on spawn), so each has its *own* `FakeClock`, but a `_advanceTime` call moves only
+the clock of the process that executes it. Before converting each subprocess fixture,
+the plan should require tracing which process holds the guard timer that must fire,
+and confirming the `_advanceTime` call runs in that same process. A swap that moves
+the parent's clock while the guard lives in the child will simply never trip.
+
+**2. One `_advanceTime` fires every due timer at once, so it can over-shoot a trip
+that a real run would have stopped at.** `advance(ms)` fires all timers with
+`dueAt <= target`, in due order. For a single guard that's fine (and the dueAt
+ordering correctly preserves inner-before-outer trip order). But when two guards are
+armed with different limits — an inner `guard(time: 50ms)` inside an outer
+`guard(time: 100ms)` — `_advanceTime(200)` sets *both* tripped flags in one
+synchronous call, before the runner observes either. In a real `spin()` run the
+inner trip aborts the block at 50ms and the outer timer is never reached. The fake
+clock reaches it anyway. For any fixture with nested or concurrent guards, this can
+change which guards trip and how many. The plan should call this out and, per such
+fixture, either advance in increments that stop at the first expected trip, or
+confirm the multi-trip outcome matches the original.
+
+Neither of these breaks the design — they're migration hazards. But Task 6 Step 4
+currently hands them to the implementer as a one-liner. Give each nested/subprocess
+fixture its own sub-step with the "which process / which guard trips first" check
+written out, the way `overshootIsCoveredByTheGrant` got its trace in Step 1.
+
+---
+
+## 🟡 Task 0's gating decision lives only in the PR description
+
+Task 0 audits which fixtures assert on a non-guard time read, and its output is "one
+line per fixture in the PR description." That finding *gates* Task 6 (a fixture that
+asserts on a non-guard time value must not be migrated). Right now the linkage is
+informal: Task 6 Step 4 re-decides "convert only fixtures whose slowness comes from a
+guard clock" on its own rather than consuming Task 0's list.
+
+Make it explicit: Task 6 Step 4 should reference the Task 0 cleared-list by name and
+migrate exactly that set, no more. Otherwise the audit and the migration can drift,
+and a fixture Task 0 flagged as unsafe can still get swapped in Task 6. A durable home
+for the list (even a scratch note committed with the branch) beats a PR-description-only
+record that's gone once the PR merges.
+
+---
+
+## 🟢 Minor / affirmations
+
+- **Two paths install the fake clock, by design.** The explicit `clock?: Clock`
+  constructor arg (Task 2) is the *unit-test* seam; the `AGENCY_FAKE_CLOCK` env var is
+  the *subprocess e2e* seam. Both are legitimate, but the plan never says the arg is
+  never used in production. One sentence in Task 2 saying so would stop a reader from
+  hunting for the arg's production call site.
+- **`wallBaseMs = 0`** (Task 1): a frozen calendar reads as Jan 1 1970. Nothing calls
+  `wallTime()` in this feature, so it's harmless now, but flag it as a known follow-up
+  for #609 (seed the base from a realistic epoch at construction) so it's a decision,
+  not a surprise. No change needed here.
+- **Number inconsistency:** the spec's `spin` example counts to 3,000,000; Task 6
+  Step 1 says replace `spin(300000)` (300k). Harmless, but reconcile so the "was:"
+  comments match what's actually in the fixture.
+- **Task 5 Step 2's red is a red-for-a-different-reason.** The fixture first fails
+  because `_advanceTime` throws "needs a fake clock" (fail-loud proof), not because the
+  trip interleaving is unproven. That interleaving is only proven green at Step 6.
+  That's fine and even a nice bonus proof — just worth noting the Step 2 red does not
+  yet exercise the trip path, so don't read a Step 6 failure as "wiring is done."
+
+---
+
+# Anti-pattern audit (vs `docs/dev/anti-patterns.md`)
+
+First, what the structural linter (Task 7 Step 4) will and won't catch. `lint:structure`
+is `eslint lib/`, and its only Agency rules are: no dynamic imports, `max-depth` 5,
+`max-lines-per-function` 150, `max-lines` 1250. It does **not** enforce nested
+ternaries, single-char names, or magic numbers. So the judgment-call items below will
+pass the lint step green — they need a human. (None of the plan's code trips the four
+enforced rules: `guard.ts` is 962 lines and the added helper is tiny.)
+
+## Declarative "what" vs imperative "how" — the plan gets this right
+
+This was the headline question, and the answer is: the core split is on the *good* side
+of the "imperative code everywhere" anti-pattern. The `Clock` type is a declarative
+"what" — `now()`, `wallTime()`, `setTimer`, `clearTimer`. The imperative "how" (real
+`setTimeout`/`performance.now` vs. the fake timer-drain loop) is encapsulated inside
+`realClock` and `FakeClock`. Consumers stay declarative: `guard.ts` reads
+`this.clock().now()` and never sees a raw timer again. That's exactly "encapsulate the
+imperative code in a few places and expose a nice abstraction," and it means a future
+change to *how* time is sourced touches only the clock, not the six guard call sites.
+The messy `while (true)` drain in `FakeClock.advance` is fine precisely because it's
+sealed inside the abstraction.
+
+## The one place "how" leaks into the caller — `_advanceTimeImpl` (Task 4)
+
+```ts
+if (!(ctx.clock instanceof FakeClock)) { throw new Error(...); }
+ctx.clock.advance(ms);
+```
+
+This is the single spot that branches on the concrete type in the caller rather than
+dispatching through the interface. It exists because the plan (following the spec)
+deliberately keeps `advance` **off** the `Clock` type — only `FakeClock` has it.
+
+The more declarative alternative: put `advance(ms): void` on `Clock`, give
+`realClock.advance` a body that throws "needs a fake clock," and `_advanceTimeImpl`
+collapses to one line — `getRuntimeContext().ctx.clock.advance(ms)` — with no
+`instanceof` and no caller-side branch. The "what happens when you advance a real
+clock" then lives inside `realClock`, where the rest of the how already lives.
+
+The tradeoff is real and worth a conscious decision: the alternative widens the
+*production* `Clock` interface with a test-only verb. My lean is that the current
+`instanceof` is acceptable — it's confined to a test-only helper, not a hot path, and
+it keeps the production interface honest — but this is the one design choice in the
+plan that sits against the anti-pattern the question asked about, so call it out and
+decide on purpose rather than by default.
+
+## Reuse: guard's `clock()` should call the canonical accessor, not re-inline it
+
+Task 3's helper is:
+```ts
+private clock(): Clock {
+  return agencyStore.getStore()?.ctx?.clock ?? realClock;
+}
+```
+The lax context reach `agencyStore.getStore()?.ctx` is already the canonical
+`agency.ctxMaybe()` (exported at `lib/runtime/agency.ts:442`). Re-inlining it duplicates
+that access pattern — the "duplicating existing code" / "inconsistent patterns" entries,
+and the exact drift the `lsp-prelude-drift` work was about (two copies of one access list
+diverging). Prefer `agency.ctxMaybe()?.clock ?? realClock`.
+
+Caveat to verify: importing the `agency` namespace into `guard.ts` may create an import
+cycle (`agency.ts` pulls in guard-adjacent runtime). If it does, inlining is the
+pragmatic exception — but then say so in a one-line comment, so the duplication reads as
+deliberate, not accidental.
+
+## Nested-ternary / too-much-on-one-line — Task 2 Step 3
+
+```ts
+this.clock = args.clock ?? (process.env.AGENCY_FAKE_CLOCK ? new FakeClock() : realClock);
+```
+A coalesce wrapping a ternary, doing env-read + instantiation + fallback on one line.
+The linter won't flag it, but it's on the doc's "nested ternaries" / "too much on a
+single line" list. Extracting a small `defaultClock()` (the env-var "how") leaves the
+constructor reading declaratively: `this.clock = args.clock ?? defaultClock()`. This is
+the same declarative-encapsulation move as the Clock seam itself, applied one level down.
+
+## Minor / judgment calls (not lint-enforced)
+
+- **Single-char names in the new TS tests:** `c` (clock), `h` (handle), `g` (guard) in
+  `clock.test.ts` and `guard.clock.test.ts`. The doc bans single-char names; give them
+  real names. (The `r` for a `Result` in the `.agency` fixtures is fine — that's the
+  established convention in `supervise.agency` itself.)
+- **`FakeClock.advance` picks the next timer via `.filter(...).sort(...)[0]`** re-run
+  every iteration — O(n²·log n) and an indirect way to say "the minimum due timer." The
+  timer list is tiny so it doesn't matter for speed; it's a readability nit. Fine to
+  leave, or a single `reduce` to the min reads more plainly.
+
+## Clean — no hits
+
+Dynamic imports (none), try-catch-swallow (the helper throws; nothing is caught and
+dropped), useless special cases (`advance` handles the empty timer list without an
+`if (length === 0)` guard), the `...(cond ? {x} : {})` ugly-spread, `safeDelete` (Task 6
+uses `cp` to back up a file, and never deletes a repo file), and magic numbers (the
+firing-cap constant is gone; the remaining numbers are contextual test values).
+
+---
+
+# Test-plan audit — will these tests fail when the code breaks?
+
+Short answer: the *end-to-end* tests are strong and would catch a real break, but one
+key *unit* test is too coarse to prove what it claims, and two design invariants have no
+test at all. Details below, most important first.
+
+## 🔴 Task 3's unit test can pass on a half-routed guard — assert `spent`, not just non-null
+
+This is the sharpest issue. `TimeGuard.check` (`guard.ts:691`) trips when
+`this.tripped || this.currentElapsed() >= this.timeLimit` — it reads the clock
+*directly* via `currentElapsed()`, on purpose, so a tight loop that starves the
+`setTimeout` macrotask can't escape the guard. The trip is an **OR** of two independent
+paths: the routed *timer* (sets `tripped`) and the routed *`now()` reads*
+(`currentElapsed()`).
+
+The Task 3 test only asserts `g.check(stack)` is `not.toBeNull()` after `advance(200)`.
+After that advance the fake timer fires and sets `tripped = true`, so `check()` returns
+a trip **regardless of whether the six `now()` reads were routed**. An implementer who
+routes `setTimer` but forgets one of the `performance.now()` reads inside
+`currentElapsed()` (lines 596/638/729) would compute a garbage real-time delta — and this
+test would still be green, because `tripped` short-circuits the OR.
+
+Fix: assert the **reported `spent`**, which flows from `currentElapsed()` → `now()`:
+```ts
+const err = g.check(stack)!;
+expect(err.spent).toBeCloseTo(200, 0);   // fake time, not a real-clock delta
+```
+An unrouted `now()` read makes `spent` a huge real-millisecond number, so this assertion
+fails exactly when the routing is incomplete. This is also the established pattern — the
+existing `guard.test.ts` asserts `.spent` at lines 92/106/121/178/193, so Task 3 is the
+odd one out for checking only nullness. Do the same in the under-budget case (confirm
+`spent` reflects the 50ms advance, not real time).
+
+## 🟡 The `advance()` re-entrancy invariant is untested
+
+`FakeClock.advance` re-reads `this.timers` on every iteration specifically so a fired
+callback that arms a *new* timer is handled correctly — that's the whole reason it isn't
+a one-shot snapshot loop. Task 1 tests the no-re-arm case ("terminates when a fired
+callback is a no-op") but never the re-arming case. Someone "simplifying" the loop to
+snapshot the pending list once would break nothing that's tested.
+
+Add two cases:
+- a callback that arms a timer due *within* the same advance → it fires in the same call;
+- a callback that arms a timer *beyond* target → it does **not** fire.
+
+This pins the design decision the doc-comment leans on, and it's cheap.
+
+## 🟡 The opt-out assertion is muddy — it passes on *any* error
+
+Task 5 Step 7's `advanceWithoutFakeClockThrows` expects `"tripped-or-errored"`. That
+string can't tell "the fake-clock guard correctly refused" from "some unrelated failure
+crept in." The test would stay green if `_advanceTime` threw for the wrong reason, or if
+a future bug made the block fail elsewhere. Since the point of this case is that a
+no-fake-clock run fails *loudly and specifically*, assert on the message:
+```ts
+if (isFailure(r)) { return r.error }   // and expectedOutput matches /fake clock/
+```
+so the test proves the `_advanceTimeImpl` guard fired, not just that *something* went
+wrong. (The plan already flags the crash-vs-Failure uncertainty here; folding the message
+check in resolves both at once.)
+
+## 🟡 No guard-level test for concurrent / nested trips
+
+The plan-review flagged nested/subprocess migration (Task 6 Step 4) as the riskiest part.
+Task 1 tests multiple *raw* FakeClock timers firing in due order, but nothing tests two
+**TimeGuards** with different limits both metering against one advanced clock — e.g. an
+inner `TimeGuard(50)` inside an outer `TimeGuard(100)`, one `advance(200)`, and which
+trips (and with what `spent`). Given that this is exactly where the migration can change
+behavior, a small unit test at the guard level — not just the clock level — would earn
+its keep before Task 6 converts the nested-pause fixtures.
+
+## 🟢 Minor gap: the `dueAt === target` boundary
+
+The filter is `dueAt <= target`. Task 1 tests firing at 110-past-100 and not-yet at 50,
+but never a timer due *exactly* at the advance target. A guard armed for 100ms and
+advanced by exactly 100 is a realistic fixture; add `setTimer(fn, 100); advance(100)` and
+assert it fires, so the boundary is nailed down rather than assumed.
+
+## 🟢 Affirmations — these tests do what they claim
+
+- **Revive-with-no-frame is genuinely covered.** I checked: `guard.test.ts` runs
+  frameless (no `runInTestContext`), so after routing, `this.clock()` resolves through
+  `getStore() → undefined → realClock`. If the helper threw outside a frame, those tests
+  would crash. So Task 3 Step 5 really does exercise the fallback. Worth adding one
+  *named* frameless test that reads `clock()` directly, so the coverage is intentional
+  and documented rather than a side effect — but the behavior is covered today.
+- **Task 6 Step 3 is the strongest test in the plan.** Reverting `grant = overshoot +
+  nextInterval` → `grant = nextInterval` and requiring `overshootIsCoveredByTheGrant` to
+  FAIL proves the migrated fixture still catches the exact regression it was written for.
+  The `grep -n "locals.grant = " stdlib/supervise.js` guard against the incremental
+  manifest silently skipping the rebuild is precisely the right defensive step for a
+  known gotcha. Keep it.
+- **Red-first discipline is consistent.** Every task writes the failing test and runs it
+  to confirm the failure before implementing, so the tests are proven to fail on the
+  unimplemented state — the one caveat being Task 5 Step 2's red fires for the throw
+  reason, not the trip path (already noted above).
+
+## Coverage vs the spec's mandated tests
+
+The spec named six required tests. Mapping: deterministic trip → Task 5 (strong);
+reverted-build regression → Task 6 Step 3 (strong); concurrent due timers → Task 1
+(clock-level only — see the nested-guard gap); opt-out → Task 5 Step 7 (weak assertion,
+see above); revive-with-no-frame → implicit in Task 3 Step 5 (real, but unnamed);
+existing fixtures keep passing → Task 3 Step 5 + Task 7. The firing-cap test the spec
+once listed is correctly gone with the cap. So all six are *present*; two (opt-out,
+revive) are softer than they read, and one (concurrent) is tested a layer below where the
+risk actually lives.

--- a/docs/superpowers/plans/2026-07-19-fake-clock-time-guards.md
+++ b/docs/superpowers/plans/2026-07-19-fake-clock-time-guards.md
@@ -1,0 +1,1045 @@
+# Fake clock for time-guard tests (#575) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let time-guard test fixtures advance a fake clock with a function call instead of burning real CPU in `spin()` loops, so the tests are fast and machine-independent.
+
+**Architecture:** Introduce a `Clock` abstraction on the runtime context. `TimeGuard` reads time and arms its timer through that clock instead of the global `performance.now`/`setTimeout`. The real clock is the default. A test fixture that opts in gets a `FakeClock`, and a test-only stdlib seam `_advanceTime(ms)` moves it forward, firing any guard timer that comes due.
+
+**Tech Stack:** TypeScript runtime (`lib/runtime/`), Agency stdlib (`stdlib/*.agency`), the Agency execution test runner (`lib/cli/`), vitest for unit tests.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-19-fake-clock-time-guards-design.md`. Read it before starting.
+- Default behavior must not change. The real clock is the default; a run only gets a `FakeClock` when explicitly asked.
+- Use types, not interfaces. Use arrays, not sets. Use objects, not maps. No dynamic imports. (Repo coding standards.)
+- `_advanceTime` is a test-only seam: a non-exported `def`, reached via `import test`, backed by a TypeScript helper. It follows the existing `_installSlowInput` precedent in `stdlib/thread.agency:205`.
+- Build after any stdlib change: run `make` (not `pnpm run build`, which skips `lib/agents` and the stdlib compile). For a single stdlib file during iteration, `pnpm run compile stdlib/date.agency --force` (the `--force` is required; the incremental manifest silently skips an unchanged-mtime recompile).
+- Commit message bodies and PR descriptions go in a file passed to `git`, never inline (apostrophe escaping breaks the shell). End commit messages with the `Co-Authored-By` trailer.
+- Save test output to a file; do not re-run the slow agency suite to see failures.
+
+---
+
+## File Structure
+
+- `lib/runtime/clock.ts` — **new**. The `Clock` type, `realClock`, `FakeClock`. Pure, no runtime dependencies. One responsibility: model time and timers behind a swappable seam.
+- `lib/runtime/state/context.ts` — **modify**. `RuntimeContext` gains a `clock` field, set from an explicit constructor arg, else from the `AGENCY_FAKE_CLOCK` env var, else `realClock`.
+- `lib/runtime/guard.ts` — **modify**. `TimeGuard`'s six time reads, one `setTimeout`, and one `clearTimeout` route through a private `clock()` helper.
+- `lib/stdlib/builtins.ts` — **modify**. Add `_advanceTimeImpl`, the TypeScript helper behind the seam, next to `_installSlowInputImpl`.
+- `stdlib/date.agency` — **modify**. Add the non-exported `_advanceTime` def.
+- `lib/cli/util.ts` — **modify**. `executeNodeAsync` accepts `fakeClock` and sets `AGENCY_FAKE_CLOCK=1`.
+- `lib/cli/test.ts` — **modify**. `TestCase` gains `fakeClock?: boolean`, threaded into the `executeNodeAsync` call.
+- The migrated fixtures under `tests/agency/`.
+
+---
+
+## Task 0: Audit time reads outside the guard
+
+The seam controls the six reads in `guard.ts`. Other subsystems read time independently and will NOT be faked (per-branch working-time budgets from #549/#550, statelog timestamps). This task confirms none of the fixtures we plan to migrate assert on those, so the migration cannot silently mislead.
+
+**Files:**
+- No code changes. Produces a note appended to the plan's PR description.
+
+- [ ] **Step 1: Grep every wall/monotonic read in the runtime and state layers**
+
+Run:
+```bash
+cd packages/agency-lang
+grep -rn "performance.now()\|Date.now()" lib/runtime lib/stdlib | grep -v "\.test\." > /tmp/time-reads.txt
+cat /tmp/time-reads.txt
+```
+Expected: a list including `guard.ts` (the six we route), plus others such as `ipc.ts`, `prompt.ts`, `runBatch.ts`, `interrupts.ts`, `ui.ts`, `statelog`.
+
+- [ ] **Step 2: For each fixture slated for migration, confirm its asserted output does not depend on a non-guard time read**
+
+The fixtures to migrate (Task 6) are `tests/agency/supervise/supervise.agency`, the `tests/agency/subprocess/nested-pause-*` fixtures, and the `tests/agency/guards/*` time fixtures. For each, read its `.test.json` `expectedOutput`. Confirm the expected value is a guard trip result (a `Result`, a salvaged draft, a decision string), not a logged duration or a wall-clock timestamp.
+
+Run, for example:
+```bash
+grep -l "spin(" tests/agency/supervise/*.agency tests/agency/subprocess/*.agency tests/agency/guards/*.agency
+```
+
+- [ ] **Step 3: Write the cleared-list to a committed file**
+
+Task 6 migrates exactly the fixtures this audit clears, so the list must be durable, not a PR-description note that vanishes on merge. Write it to `docs/superpowers/plans/2026-07-19-fake-clock-migration-list.md`:
+- a `## Cleared for migration` section: one line per fixture, with the guard-trip value it asserts on (a `Result`, a salvaged draft, a decision string).
+- a `## Not migrated` section: any fixture whose `expectedOutput` depends on a non-guard time read (a logged duration, a wall-clock timestamp), with the reason. These stay on the real clock.
+
+- [ ] **Step 4: Commit the list**
+
+```bash
+git add docs/superpowers/plans/2026-07-19-fake-clock-migration-list.md
+git commit -F <message-file>
+```
+Message subject: `Audit: which time-guard fixtures are safe to fake-clock`
+
+This file is the input Task 6 Step 4 reads by name. A fixture in `## Not migrated` must not be converted.
+
+---
+
+## Task 1: The clock seam
+
+**Files:**
+- Create: `lib/runtime/clock.ts`
+- Test: `lib/runtime/clock.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `type TimerHandle = { id: number }`
+  - `type Clock = { now(): number; wallTime(): number; setTimer(fn: () => void, delayMs: number): TimerHandle; clearTimer(handle: TimerHandle): void }`
+  - `const realClock: Clock`
+  - `class FakeClock implements Clock` with an extra method `advance(ms: number): void`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `lib/runtime/clock.test.ts`:
+```ts
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { FakeClock, realClock } from "./clock.js";
+
+describe("FakeClock", () => {
+  it("starts at zero and advances now() and wallTime() together", () => {
+    const clock = new FakeClock();
+    expect(clock.now()).toBe(0);
+    expect(clock.wallTime()).toBe(0);
+    clock.advance(200);
+    expect(clock.now()).toBe(200);
+    expect(clock.wallTime()).toBe(200);
+  });
+
+  it("fires a timer whose due time falls within the advance", () => {
+    const clock = new FakeClock();
+    let fired = false;
+    clock.setTimer(() => { fired = true; }, 100);
+    clock.advance(50);
+    expect(fired).toBe(false);
+    clock.advance(60); // now at 110, past the 100ms timer
+    expect(fired).toBe(true);
+  });
+
+  it("fires a timer due exactly at the advance target (dueAt === target boundary)", () => {
+    const clock = new FakeClock();
+    let fired = false;
+    clock.setTimer(() => { fired = true; }, 100);
+    clock.advance(100); // lands exactly on the due time
+    expect(fired).toBe(true);
+  });
+
+  it("does not fire a timer that was cleared", () => {
+    const clock = new FakeClock();
+    let fired = false;
+    const handle = clock.setTimer(() => { fired = true; }, 100);
+    clock.clearTimer(handle);
+    clock.advance(200);
+    expect(fired).toBe(false);
+  });
+
+  it("fires multiple distinct timers due within one advance, in due order", () => {
+    const clock = new FakeClock();
+    const order: number[] = [];
+    clock.setTimer(() => order.push(2), 200);
+    clock.setTimer(() => order.push(1), 100);
+    clock.advance(300);
+    expect(order).toEqual([1, 2]);
+  });
+
+  it("sets now() to each timer's due time before firing it", () => {
+    const clock = new FakeClock();
+    let seen = -1;
+    clock.setTimer(() => { seen = clock.now(); }, 100);
+    clock.advance(500);
+    expect(seen).toBe(100); // not 500
+  });
+
+  it("terminates when a fired callback is a no-op (no re-arm)", () => {
+    const clock = new FakeClock();
+    let count = 0;
+    clock.setTimer(() => { count++; }, 100);
+    clock.advance(1000);
+    expect(count).toBe(1);
+    expect(clock.now()).toBe(1000);
+  });
+
+  it("fires a timer that a callback arms WITHIN the same advance span", () => {
+    // Pins the re-entrancy invariant: advance() re-reads the pending list
+    // after each firing, so a timer armed by a fired callback and due before
+    // the target fires in the same advance() call. A one-shot snapshot loop
+    // would silently break this.
+    const clock = new FakeClock();
+    let inner = false;
+    clock.setTimer(() => {
+      clock.setTimer(() => { inner = true; }, 50); // due at 100 + 50 = 150
+    }, 100);
+    clock.advance(300); // 150 <= 300, so the inner timer must fire too
+    expect(inner).toBe(true);
+  });
+
+  it("does NOT fire a timer a callback arms beyond the advance target", () => {
+    const clock = new FakeClock();
+    let inner = false;
+    clock.setTimer(() => {
+      clock.setTimer(() => { inner = true; }, 500); // due at 100 + 500 = 600
+    }, 100);
+    clock.advance(300); // 600 > 300, so the inner timer must NOT fire
+    expect(inner).toBe(false);
+  });
+});
+
+describe("realClock", () => {
+  afterEach(() => vi.useRealTimers());
+  it("delegates to global timers", () => {
+    vi.useFakeTimers();
+    let fired = false;
+    const handle = realClock.setTimer(() => { fired = true; }, 100);
+    vi.advanceTimersByTime(50);
+    expect(fired).toBe(false);
+    vi.advanceTimersByTime(60);
+    expect(fired).toBe(true);
+    realClock.clearTimer(handle); // no throw on an already-fired handle
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm exec vitest run lib/runtime/clock.test.ts`
+Expected: FAIL — `Cannot find module './clock.js'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `lib/runtime/clock.ts`:
+```ts
+export type TimerHandle = { id: number };
+
+/**
+ * The seam every guard time read and timer goes through. The real clock is
+ * the default; tests swap in a FakeClock to advance time deterministically.
+ * See docs/superpowers/specs/2026-07-19-fake-clock-time-guards-design.md.
+ */
+export type Clock = {
+  /** Monotonic milliseconds. What a time guard meters against. */
+  now(): number;
+  /** Milliseconds since the Unix epoch. What std::date reads. Unused today;
+   *  here so issue #609 can reroute std::date through this seam later. */
+  wallTime(): number;
+  setTimer(fn: () => void, delayMs: number): TimerHandle;
+  clearTimer(handle: TimerHandle): void;
+};
+
+export const realClock: Clock = {
+  now: () => performance.now(),
+  wallTime: () => Date.now(),
+  setTimer: (fn, delayMs) => ({
+    id: setTimeout(fn, delayMs) as unknown as number,
+  }),
+  clearTimer: (handle) => clearTimeout(handle.id),
+};
+
+export class FakeClock implements Clock {
+  private monotonicMs = 0;
+  // Base for wall time. Zero for now, so a frozen calendar reads as 1970.
+  // Nothing calls wallTime() in this feature, so it does not matter yet. When
+  // #609 wires std::date through the seam, seed this from a realistic epoch so
+  // a test reading "today" does not get 1970. Known follow-up, not a bug here.
+  private wallBaseMs = 0;
+  private timers: { dueAt: number; fn: () => void; id: number }[] = [];
+  private nextId = 1;
+
+  now(): number {
+    return this.monotonicMs;
+  }
+
+  wallTime(): number {
+    return this.wallBaseMs + this.monotonicMs;
+  }
+
+  setTimer(fn: () => void, delayMs: number): TimerHandle {
+    const id = this.nextId++;
+    this.timers.push({ dueAt: this.monotonicMs + delayMs, fn, id });
+    return { id };
+  }
+
+  clearTimer(handle: TimerHandle): void {
+    this.timers = this.timers.filter((t) => t.id !== handle.id);
+  }
+
+  /**
+   * Move the clock forward `ms` and fire every timer due within that span.
+   * Terminates: nothing here arms a timer, and each iteration removes one, so
+   * the pending list strictly shrinks. A guard timer's callback only aborts;
+   * it never re-arms (re-arming is startWindow, which runs at a later runner
+   * step), so there is no runaway and no firing cap.
+   */
+  advance(ms: number): void {
+    const target = this.monotonicMs + ms;
+    while (true) {
+      // The earliest timer still due within the span. Re-computed each pass,
+      // because a fired callback may have armed a new one.
+      const due = this.earliestDueBy(target);
+      if (!due) break;
+      this.timers = this.timers.filter((t) => t.id !== due.id);
+      this.monotonicMs = due.dueAt; // step to the timer, then fire it
+      due.fn();
+    }
+    this.monotonicMs = target;
+  }
+
+  private earliestDueBy(
+    target: number,
+  ): { dueAt: number; fn: () => void; id: number } | undefined {
+    return this.timers.reduce<
+      { dueAt: number; fn: () => void; id: number } | undefined
+    >((earliest, t) => {
+      if (t.dueAt > target) return earliest;
+      if (!earliest || t.dueAt < earliest.dueAt) return t;
+      return earliest;
+    }, undefined);
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm exec vitest run lib/runtime/clock.test.ts`
+Expected: PASS — all FakeClock cases (including the two re-entrancy cases and the boundary case) and the realClock case.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/runtime/clock.ts lib/runtime/clock.test.ts
+git commit -F <message-file>
+```
+Message subject: `Add the Clock seam: realClock and FakeClock`
+
+---
+
+## Task 2: RuntimeContext carries a clock
+
+**Files:**
+- Modify: `lib/runtime/state/context.ts`
+- Test: `lib/runtime/state/context.clock.test.ts` (new)
+
+**Interfaces:**
+- Consumes: `Clock`, `realClock`, `FakeClock` from Task 1.
+- Produces: `RuntimeContext` has a public `clock: Clock` field. The constructor arg object accepts an optional `clock?: Clock`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `lib/runtime/state/context.clock.test.ts`:
+```ts
+import { describe, it, expect, afterEach } from "vitest";
+import { RuntimeContext } from "./context.js";
+import { FakeClock, realClock } from "../clock.js";
+
+function makeCtx(clock?: import("../clock.js").Clock): RuntimeContext<any> {
+  return new RuntimeContext({
+    statelogConfig: {
+      host: "https://example.com",
+      apiKey: "test-api-key",
+      projectId: "test-project",
+      debugMode: false,
+    },
+    smoltalkDefaults: { model: "default-model" },
+    dirname: "/tmp",
+    clock,
+  });
+}
+
+describe("RuntimeContext.clock", () => {
+  const saved = process.env.AGENCY_FAKE_CLOCK;
+  afterEach(() => {
+    if (saved === undefined) delete process.env.AGENCY_FAKE_CLOCK;
+    else process.env.AGENCY_FAKE_CLOCK = saved;
+  });
+
+  it("defaults to the real clock", () => {
+    delete process.env.AGENCY_FAKE_CLOCK;
+    expect(makeCtx().clock).toBe(realClock);
+  });
+
+  it("installs a FakeClock when AGENCY_FAKE_CLOCK is set", () => {
+    process.env.AGENCY_FAKE_CLOCK = "1";
+    expect(makeCtx().clock).toBeInstanceOf(FakeClock);
+  });
+
+  it("an explicit clock arg wins over the env var", () => {
+    process.env.AGENCY_FAKE_CLOCK = "1";
+    const explicit = new FakeClock();
+    expect(makeCtx(explicit).clock).toBe(explicit);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm exec vitest run lib/runtime/state/context.clock.test.ts`
+Expected: FAIL — `clock` is not a property on `RuntimeContext`, and the constructor arg is unknown.
+
+- [ ] **Step 3: Add the field and constructor wiring**
+
+In `lib/runtime/state/context.ts`:
+
+Add the import near the other runtime imports at the top:
+```ts
+import { Clock, realClock, FakeClock } from "../clock.js";
+```
+
+Add a small module-level helper above the class. It holds the "how" of picking a default clock (the env read plus instantiation), so the constructor body reads declaratively:
+```ts
+/** The default clock for a run: a FakeClock only when a test opts in via the
+ *  AGENCY_FAKE_CLOCK env var, otherwise the real clock. The env var is set by
+ *  the test runner per test case (see lib/cli/util.ts). */
+function defaultClock(): Clock {
+  return process.env.AGENCY_FAKE_CLOCK ? new FakeClock() : realClock;
+}
+```
+
+Add a public field alongside the other public fields (near `handlers`, around line 255's neighbors in the field block that begins near line 80):
+```ts
+  /** The time source for guards. Real by default; a FakeClock only when a
+   *  test opts in. NOT serialized — reconstructed per run, like handlers. */
+  clock: Clock;
+```
+
+Add `clock?: Clock;` to the constructor's args object type (the block starting at line 208, next to `logLevel?`). This arg is a TEST-ONLY seam: unit tests pass a `FakeClock` directly. It is never supplied in production — production runs get their clock from `defaultClock()`, i.e. the env var or the real default. Do not look for a production call site that passes it; there isn't one.
+```ts
+    logLevel?: LogLevel;
+    /** Test-only override. Omitted in production, where defaultClock()
+     *  (the env var or the realClock default) applies. */
+    clock?: Clock;
+```
+
+Set the field in the constructor body, after the `applyRuntimeConfigOverridesToContextArgs` calls (an explicit arg wins, else the default):
+```ts
+    this.clock = args.clock ?? defaultClock();
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm exec vitest run lib/runtime/state/context.clock.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Confirm no serialization regression**
+
+`RuntimeContext` is reconstructed per run and not part of checkpoint state (like `handlers`). Confirm nothing serializes it:
+```bash
+grep -n "clock" lib/runtime/state/context.ts | grep -i "toJSON\|serialize\|JSON.stringify"
+```
+Expected: no output (the clock is never serialized).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/runtime/state/context.ts lib/runtime/state/context.clock.test.ts
+git commit -F <message-file>
+```
+Message subject: `RuntimeContext carries a swappable clock`
+
+---
+
+## Task 3: Route TimeGuard through the clock
+
+**Files:**
+- Modify: `lib/runtime/guard.ts`
+- Test: `lib/runtime/guard.clock.test.ts` (new)
+
+**Interfaces:**
+- Consumes: `RuntimeContext.clock` (Task 2), `FakeClock` (Task 1), `runInTestContext` from `lib/runtime/asyncContext.ts`.
+- Produces: no new exports. `TimeGuard` now meters against `getRuntimeContext().ctx.clock` when a frame is present.
+
+**Background for the implementer:** `TimeGuard` today calls the global `performance.now()` in six places (lines 596, 638, 729, 761, 873, 893), arms an abort timer with `setTimeout` (line 866), and cancels it with `clearTimeout` (line 899). We route all of these through a `clock()` helper. Outside an execution frame — a guard revived from a checkpoint — there is no context, so the helper falls back to `realClock`. That preserves today's behavior: a revived guard with no frame meters against real time.
+
+The existing `TimeGuard` unit tests in `lib/runtime/guard.test.ts` use `vi.useFakeTimers()`. They keep passing unchanged, because `realClock` delegates to the same global `setTimeout`/`performance.now` that vitest mocks.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `lib/runtime/guard.clock.test.ts`:
+```ts
+import { describe, it, expect } from "vitest";
+import { TimeGuard } from "./guard.js";
+import { StateStack } from "./state/stateStack.js";
+import { RuntimeContext } from "./state/context.js";
+import { FakeClock } from "./clock.js";
+import { runInTestContext } from "./asyncContext.js";
+import { ThreadStore } from "./state/threadStore.js";
+
+function ctxWithFakeClock(clock: FakeClock): RuntimeContext<any> {
+  return new RuntimeContext({
+    statelogConfig: {
+      host: "https://example.com",
+      apiKey: "test-api-key",
+      projectId: "test-project",
+      debugMode: false,
+    },
+    smoltalkDefaults: { model: "default-model" },
+    dirname: "/tmp",
+    clock,
+  });
+}
+
+describe("TimeGuard reads the context clock", () => {
+  it("trips on a fake-clock advance, and reports fake-clock spent (not a real-time delta)", () => {
+    const clock = new FakeClock();
+    const ctx = ctxWithFakeClock(clock);
+    const threads = new ThreadStore();
+
+    runInTestContext(ctx, ctx.stateStack, threads, () => {
+      const stack = ctx.stateStack;
+      const guard = new TimeGuard(100);
+      stack.pushGuard(guard);
+      expect(guard.check(stack)).toBeNull(); // not yet over budget
+
+      clock.advance(200); // fake time only; no real ms elapse
+
+      const err = guard.check(stack);
+      expect(err).not.toBeNull();
+      // The load-bearing assertion. `spent` flows from currentElapsed() ->
+      // now(). If any of the six now() reads is NOT routed through the seam,
+      // spent becomes a huge real-millisecond number and this fails. Asserting
+      // only non-null would pass even then, because the routed TIMER already
+      // set `tripped` and check() short-circuits the OR.
+      expect(err!.spent).toBeCloseTo(200, 0);
+      expect(guard.isTripped()).toBe(true);
+    });
+  });
+
+  it("does not trip under budget, and reports the fake-clock elapsed", () => {
+    const clock = new FakeClock();
+    const ctx = ctxWithFakeClock(clock);
+    const threads = new ThreadStore();
+
+    runInTestContext(ctx, ctx.stateStack, threads, () => {
+      const stack = ctx.stateStack;
+      const guard = new TimeGuard(100);
+      stack.pushGuard(guard);
+      clock.advance(50);
+      expect(guard.check(stack)).toBeNull();
+      expect(guard.isTripped()).toBe(false);
+    });
+  });
+
+  it("two guards with different limits both meter against one advanced clock", () => {
+    // This is where the nested-fixture migration risk lives (Task 6 Step 4):
+    // one advance() fires every due timer, so an inner and an outer guard can
+    // both trip in a single advance, which a real spin() run would not do
+    // (the inner trip would abort before the outer limit is reached). Pin the
+    // behavior at the guard level so Task 6 conversions have a reference.
+    const clock = new FakeClock();
+    const ctx = ctxWithFakeClock(clock);
+    const threads = new ThreadStore();
+
+    runInTestContext(ctx, ctx.stateStack, threads, () => {
+      const stack = ctx.stateStack;
+      const outer = new TimeGuard(100);
+      stack.pushGuard(outer);
+      const inner = new TimeGuard(50);
+      stack.pushGuard(inner);
+
+      clock.advance(200); // past BOTH limits in one call
+
+      const innerErr = inner.check(stack);
+      expect(innerErr).not.toBeNull();
+      expect(innerErr!.spent).toBeCloseTo(200, 0);
+      const outerErr = outer.check(stack);
+      expect(outerErr).not.toBeNull();
+    });
+  });
+});
+```
+
+Note for the implementer: verify the import paths for `StateStack`, `ThreadStore`, and the `TimeGuard(limit)` constructor arity against the current source before running — adjust the imports if a path differs. `pushGuard`/`check`/`isTripped` are the driving API, and `check()` returns a `GuardExceededError` carrying `spent` (see the existing `guard.test.ts`, which asserts `.spent` at lines 92/106/121/178/193, for the same pattern under `vi.useFakeTimers`). Note also the once-only consume flag on `TimeGuard`: the second `check()` after a trip returns null, so within one test call `check()` a tripped guard only once when you need the error.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm exec vitest run lib/runtime/guard.clock.test.ts`
+Expected: FAIL — the guard still reads the global `performance.now()`, so advancing the FakeClock does not move the time it meters against, and it never trips.
+
+- [ ] **Step 3: Add the clock() helper and route the reads**
+
+In `lib/runtime/guard.ts`:
+
+Add imports at the top with the other runtime imports:
+```ts
+import { Clock, realClock, TimerHandle } from "./clock.js";
+import { __ctx } from "./asyncContext.js";
+```
+
+`__ctx()` is the canonical lax context accessor (`asyncContext.ts`): it returns `agencyStore.getStore()?.ctx`, or `undefined` outside a frame. Use it rather than re-inlining `agencyStore.getStore()?.ctx`, so this access does not become a second copy that can drift (the same duplication class as the LSP prelude-drift bug). Do NOT reach for `agency.ctxMaybe()` here even though it is the "official" lax accessor — `agency.ts` imports `TimeGuard` from `guard.ts`, so importing `agency` back into `guard.ts` is a circular import. `__ctx` lives in `asyncContext.ts`, which `guard.ts` can import freely.
+
+Add a private helper on the `TimeGuard` class (place it near the other private methods, e.g. just above `startWindow`):
+```ts
+  /** The time source. Reads the run's clock when a frame is present; a
+   *  guard revived from a checkpoint runs frameless and meters against the
+   *  real clock, exactly as before this seam existed. */
+  private clock(): Clock {
+    return __ctx()?.clock ?? realClock;
+  }
+```
+
+Replace each of the six `performance.now()` calls inside `TimeGuard` (lines 596, 638, 729, 761, 873, 893) with `this.clock().now()`. Example, line 893:
+```ts
+    this.windowStart = this.clock().now();
+```
+And inside the timer callback, line 873:
+```ts
+        const spent = this.elapsedMs +
+          (this.windowStart !== undefined
+            ? this.clock().now() - this.windowStart
+            : 0);
+```
+
+Replace the timer arming (line 866):
+```ts
+    this.timerHandle = this.clock().setTimer(() => {
+      // ... unchanged callback body ...
+    }, delay);
+```
+
+Replace the cancellation (line 899):
+```ts
+      this.clock().clearTimer(this.timerHandle);
+```
+
+Note: `this.timerHandle`'s type changes from `ReturnType<typeof setTimeout>` to `TimerHandle | undefined`. Update its field declaration (near line 533) to `private timerHandle: TimerHandle | undefined = undefined;` (`TimerHandle` is already imported from `./clock.js` in the import line above).
+
+- [ ] **Step 4: Run the new test to verify it passes**
+
+Run: `pnpm exec vitest run lib/runtime/guard.clock.test.ts`
+Expected: PASS — the guard trips on fake-clock advance.
+
+- [ ] **Step 5: Run the existing guard tests to verify no regression AND the frameless fallback**
+
+Run: `pnpm exec vitest run lib/runtime/guard.test.ts`
+Expected: PASS. This step does double duty. First, the `vi.useFakeTimers()` tests still work, because `realClock` delegates to the mocked globals. Second — and this is the intended coverage of the revive-with-no-frame case — every test in `guard.test.ts` runs OUTSIDE `runInTestContext`, so `__ctx()` returns `undefined` and `clock()` falls back to `realClock`. If the fallback threw instead of returning `realClock`, every one of these tests would crash. So a green `guard.test.ts` is the proof that a frameless guard meters against the real clock. Do not treat this as an incidental pass; it is the frameless-fallback test.
+
+- [ ] **Step 6: Typecheck**
+
+Run: `pnpm run typecheck`
+Expected: clean (confirms the `timerHandle` type change is consistent).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/runtime/guard.ts lib/runtime/guard.clock.test.ts
+git commit -F <message-file>
+```
+Message subject: `Route TimeGuard time reads through the context clock`
+
+---
+
+## Task 4: The `_advanceTime` seam
+
+**Files:**
+- Modify: `lib/stdlib/builtins.ts`
+- Modify: `stdlib/date.agency`
+- Test: `lib/stdlib/builtins.clock.test.ts` (new)
+
+**Interfaces:**
+- Consumes: `FakeClock` (Task 1), `RuntimeContext.clock` (Task 2), `getRuntimeContext` from `lib/runtime/asyncContext.ts`.
+- Produces:
+  - `export function _advanceTimeImpl(ms: number): void` in `lib/stdlib/builtins.ts`.
+  - A non-exported `def _advanceTime(ms: number)` in `stdlib/date.agency`.
+
+- [ ] **Step 1: Write the failing test for the TypeScript helper**
+
+Create `lib/stdlib/builtins.clock.test.ts`:
+```ts
+import { describe, it, expect } from "vitest";
+import { _advanceTimeImpl } from "./builtins.js";
+import { RuntimeContext } from "../runtime/state/context.js";
+import { FakeClock } from "../runtime/clock.js";
+import { runInTestContext } from "../runtime/asyncContext.js";
+import { ThreadStore } from "../runtime/state/threadStore.js";
+
+function makeCtx(clock?: import("../runtime/clock.js").Clock): RuntimeContext<any> {
+  return new RuntimeContext({
+    statelogConfig: {
+      host: "https://example.com",
+      apiKey: "test-api-key",
+      projectId: "test-project",
+      debugMode: false,
+    },
+    smoltalkDefaults: { model: "default-model" },
+    dirname: "/tmp",
+    clock,
+  });
+}
+
+describe("_advanceTimeImpl", () => {
+  it("advances the run's FakeClock", () => {
+    const clock = new FakeClock();
+    const ctx = makeCtx(clock);
+    runInTestContext(ctx, ctx.stateStack, new ThreadStore(), () => {
+      _advanceTimeImpl(250);
+      expect(clock.now()).toBe(250);
+    });
+  });
+
+  it("throws a clear error when the clock is not fake", () => {
+    const ctx = makeCtx(); // real clock
+    runInTestContext(ctx, ctx.stateStack, new ThreadStore(), () => {
+      expect(() => _advanceTimeImpl(250)).toThrow(/fake clock/i);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm exec vitest run lib/stdlib/builtins.clock.test.ts`
+Expected: FAIL — `_advanceTimeImpl` is not exported.
+
+- [ ] **Step 3: Implement the TypeScript helper**
+
+In `lib/stdlib/builtins.ts`, add near `_installSlowInputImpl` (around line 133). Add the import at the top if not present:
+```ts
+import { FakeClock } from "../runtime/clock.js";
+```
+Then:
+```ts
+/** Test-only: advance the run's fake clock by `ms`, firing any guard timer
+ *  that comes due. Exposed to fixtures as the non-exported `_advanceTime`
+ *  def in `stdlib/date.agency` (test imports only). Throws if the run holds
+ *  the real clock, so a stray call outside a fake-clock test fails loudly
+ *  rather than doing nothing. */
+export function _advanceTimeImpl(ms: number): void {
+  const { ctx } = getRuntimeContext();
+  if (!(ctx.clock instanceof FakeClock)) {
+    throw new Error(
+      '_advanceTime() needs a fake clock. Set "fakeClock": true on this test case.',
+    );
+  }
+  ctx.clock.advance(ms);
+}
+```
+
+Deliberate design note (do not "fix" this in review): `advance` lives on `FakeClock` only, not on the `Clock` type, so this helper branches on the concrete type with `instanceof`. The alternative — putting `advance(ms)` on the `Clock` interface and giving `realClock.advance` a throwing body — would drop the `instanceof` but widen the *production* `Clock` interface with a test-only verb. We keep `advance` off the production interface on purpose. The `instanceof` is confined to this one test-only helper and never runs on a production path, so the leak is acceptable and bounded. This is the one spot in the design that sits against the "dispatch through the interface" preference, and it is a conscious trade, not an oversight.
+
+- [ ] **Step 4: Run the helper test to verify it passes**
+
+Run: `pnpm exec vitest run lib/stdlib/builtins.clock.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Add the Agency-facing seam**
+
+In `stdlib/date.agency`, add a non-exported def (mirror the `_installSlowInput` shape in `stdlib/thread.agency:205`). First, add the import of the helper at the top of `date.agency` alongside its other `agency-lang/stdlib-lib/...` imports (verify the exact module specifier used by the file's existing builtins import; `_installSlowInput` uses `agency-lang/stdlib-lib/builtins.js`):
+```agency
+import { _advanceTimeImpl } from "agency-lang/stdlib-lib/builtins.js"
+```
+Then the def:
+```agency
+/** Test-only seam (import test { _advanceTime }): advance the fake clock so a
+time guard trips without spending real time. Only works under a test case with
+"fakeClock": true; throws otherwise. */
+def _advanceTime(ms: number) {
+  """
+  Test-only: move the fake clock forward `ms` milliseconds, tripping any time
+  guard whose budget is now exceeded.
+
+  @param ms - How many milliseconds of fake time to advance.
+  """
+  _advanceTimeImpl(ms)
+}
+```
+
+- [ ] **Step 6: Build the stdlib and confirm it compiles**
+
+Run:
+```bash
+pnpm run compile stdlib/date.agency --force
+```
+Expected: `stdlib/date.agency → stdlib/date.js` with no error. (The `--force` is mandatory; without it the manifest may skip the recompile.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/stdlib/builtins.ts lib/stdlib/builtins.clock.test.ts stdlib/date.agency stdlib/date.js
+git commit -F <message-file>
+```
+Message subject: `Add the _advanceTime test seam in std::date`
+
+---
+
+## Task 5: Wire `fakeClock` through the test runner
+
+**Files:**
+- Modify: `lib/cli/util.ts`
+- Modify: `lib/cli/test.ts`
+- Test: `tests/agency/guards/fake-clock-trip.agency` + `.test.json` (new fixture, doubles as the end-to-end proof)
+
+**Interfaces:**
+- Consumes: the `AGENCY_FAKE_CLOCK` env contract from Task 2, the `_advanceTime` seam from Task 4.
+- Produces: `TestCase.fakeClock?: boolean`; `executeNodeAsync` sets `AGENCY_FAKE_CLOCK=1` when asked.
+
+- [ ] **Step 1: Write the failing end-to-end fixture**
+
+Create `tests/agency/guards/fake-clock-trip.agency`:
+```agency
+import test { _advanceTime } from "std::date"
+
+node tripsOnFakeAdvance(): string {
+  const r = guard(time: 100ms) {
+    _advanceTime(200)
+    return "never reached"
+  }
+  if (isFailure(r)) { return "tripped" }
+  return r.value
+}
+
+node doesNotTripUnderBudget(): string {
+  const r = guard(time: 100ms) {
+    _advanceTime(50)
+    return "finished"
+  }
+  if (isFailure(r)) { return "tripped" }
+  return r.value
+}
+```
+
+Create `tests/agency/guards/fake-clock-trip.test.json`:
+```json
+{
+  "tests": [
+    {
+      "nodeName": "tripsOnFakeAdvance",
+      "fakeClock": true,
+      "input": "",
+      "expectedOutput": "\"tripped\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "doesNotTripUnderBudget",
+      "fakeClock": true,
+      "input": "",
+      "expectedOutput": "\"finished\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}
+```
+
+- [ ] **Step 2: Run the fixture to verify it fails**
+
+Run:
+```bash
+pnpm run agency test tests/agency/guards/fake-clock-trip.agency 2>&1 | tee /tmp/fakeclock.txt
+```
+Expected: FAIL. `fakeClock` is not yet wired, so no `FakeClock` is installed; `_advanceTimeImpl` sees the real clock and throws "needs a fake clock". (This confirms the seam's fail-loud behavior end to end before wiring.)
+
+Read this red carefully: it fires because `_advanceTime` throws on the real clock, NOT because the trip interleaving is wrong. The trip path is only proven green at Step 6. So do not read a later Step 6 failure as "just the wiring" — Step 2's red does not exercise the trip at all.
+
+- [ ] **Step 3: Add `fakeClock` to the TestCase type**
+
+In `lib/cli/test.ts`, add to the `TestCase` type (the block starting at line 36, after `fetchMocks?`):
+```ts
+  // Install a deterministic fake clock for this test case. Guard fixtures use
+  // it with the `_advanceTime` seam (import test from "std::date") to trip time
+  // guards without spending real time. Off by default: the run keeps the real
+  // clock. See docs/superpowers/specs/2026-07-19-fake-clock-time-guards-design.md.
+  fakeClock?: boolean;
+```
+
+- [ ] **Step 4: Thread it into the executeNodeAsync call**
+
+In `lib/cli/test.ts`, at the `executeNodeAsync({ ... })` call (around line 583), add the field alongside `llmMocks`:
+```ts
+      fakeClock: testCase.fakeClock,
+```
+
+- [ ] **Step 5: Accept and apply it in executeNodeAsync**
+
+In `lib/cli/util.ts`:
+
+Add `fakeClock?: boolean;` to the `ExecuteNodeArgs` type (near `useTestLLMProvider?` around line 214).
+
+In the `executeNodeAsync` function (starting line 376), destructure it:
+```ts
+export async function executeNodeAsync({
+  llmMocks,
+  useTestLLMProvider,
+  fetchMocks,
+  fakeClock,
+  ...rest
+}: ExecuteNodeArgs): Promise<{ data: any; stdout: string; stderr: string }> {
+```
+Then set the env var after the `env` object is created (it is built around line 384; add this right after that block, independent of `useDeterministic`):
+```ts
+  if (fakeClock) {
+    env.AGENCY_FAKE_CLOCK = "1";
+  }
+```
+
+- [ ] **Step 6: Run the fixture to verify it passes**
+
+Run:
+```bash
+pnpm run agency test tests/agency/guards/fake-clock-trip.agency 2>&1 | tee /tmp/fakeclock.txt
+```
+Expected: PASS, 2/2 tests. Both complete near-instantly (no real 100ms waits).
+
+- [ ] **Step 7: Verify the opt-out — a fixture without the flag keeps the real clock**
+
+Add a third node to `fake-clock-trip.agency` and a matching test case WITHOUT `fakeClock`. The node returns the failure's error text, so the assertion can check the SPECIFIC message rather than "something went wrong":
+```agency
+node advanceWithoutFakeClockErrors(): string {
+  const r = guard(time: 100ms) {
+    _advanceTime(10)
+    return "unreached"
+  }
+  if (isFailure(r)) { return r.error }
+  return r.value
+}
+```
+```json
+    {
+      "nodeName": "advanceWithoutFakeClockErrors",
+      "input": "",
+      "expectedOutput": "<PASTE the exact r.error string observed in Step 2>",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+```
+Only `exact` and `llmJudge` are supported criteria (`lib/cli/test.ts:29,35`); there is no `contains`. So assert `exact` on the full error string. The message is deterministic — `_advanceTimeImpl` throws a fixed string, and this node has no other failure path (no llm, no other calls) — so an exact match is stable across runs and still specific to the fake-clock refusal, which is what the reviewer asked for. A generic `"tripped-or-errored"` token would stay green on any unrelated failure and is not acceptable for a fail-loud check.
+
+Note for the implementer: you already have the exact error text. Step 2 ran this whole fixture with no `fakeClock` flag anywhere, so `_advanceTime` threw and the harness printed the resulting `r.error`. Copy that string verbatim into `expectedOutput`. If instead the throw crashed the node rather than surfacing as `isFailure(r)`, that is still an acceptable fail-loud outcome — assert `exact` on the node-error string the harness reports, and record the difference. The invariant to preserve: the assertion fails unless the specific fake-clock refusal fired.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add lib/cli/util.ts lib/cli/test.ts tests/agency/guards/fake-clock-trip.agency tests/agency/guards/fake-clock-trip.test.json
+git commit -F <message-file>
+```
+Message subject: `Wire fakeClock through the test runner`
+
+---
+
+## Task 6: Migrate the slow fixtures
+
+**Files:**
+- Modify: `tests/agency/supervise/supervise.agency` + `.test.json`
+- Modify: the `tests/agency/subprocess/nested-pause-*` fixtures (only those Task 0 cleared)
+- Modify: the `tests/agency/guards/*` time fixtures (only those Task 0 cleared)
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–5.
+
+**Background:** Each migration swaps a `spin(...)` that burns real CPU for an `_advanceTime(...)` that moves the fake clock, and adds `"fakeClock": true` to the affected test cases plus the `import test { _advanceTime } from "std::date"` line. Convert only fixtures whose slowness comes from spinning down a guard clock.
+
+The load-bearing case is `overshootIsCoveredByTheGrant` in `supervise.agency`. Its correctness rests on a specific interleaving (traced in the spec): the block-body `_advanceTime` trips the guard once; the handler runs `slowCheck`, whose own `_advanceTime` fires no timer and only moves the clock; then `approve` re-arms and the block resumes. The regression it guards is `grant = nextInterval` in `stdlib/supervise.agency`.
+
+- [ ] **Step 1: Convert `supervise.agency`**
+
+Add the import at the top:
+```agency
+import test { _advanceTime } from "std::date"
+```
+First read the current fixture to see the exact spin values — they are not uniform. The `overshootIsCoveredByTheGrant` node and its `slowCheck` use `spin(3000000)` (three million); the other nodes use `spin(300000)` (three hundred thousand). Do not assume one value.
+
+In `slowCheck`, replace `spin(3000000)` with `_advanceTime(500)`. In `overshootIsCoveredByTheGrant`'s block, replace `const s = spin(3000000)` with `_advanceTime(500)` and adjust the return so it does not reference `s` (return a literal, e.g. `return "done:spun"`; update the `.test.json` `expectedOutput` to match). Leave `every: 100ms` — do not use `every: 1ms` (the fake clock makes the interval choice free, and a larger interval keeps the trace simple).
+
+Set `"fakeClock": true` on every test case in `supervise.test.json` that now calls `_advanceTime`. Read the other nodes in the file (`continueLetsBlockFinish`, `stopSalvagesDraft`, etc.), replace their `spin(300000)` calls with an `_advanceTime(...)` amount matched to that node's guard/`every` values, and give each `fakeClock: true`.
+
+- [ ] **Step 2: Run supervise to verify it passes and is fast**
+
+Run:
+```bash
+pnpm run compile stdlib/supervise.agency --force  # only if you touched stdlib; the fixture itself is not stdlib
+time pnpm run agency test tests/agency/supervise/supervise.agency 2>&1 | tee /tmp/supervise.txt
+```
+Expected: all tests pass, in a few seconds rather than ~76.
+
+- [ ] **Step 3: Prove the migrated overshoot test still catches the bug**
+
+Temporarily revert the fix in the stdlib to reintroduce the regression:
+```bash
+cp stdlib/supervise.agency /tmp/supervise.agency.bak
+# change: const grant = overshoot + nextInterval   ->   const grant = nextInterval
+```
+Apply the edit, then:
+```bash
+pnpm run compile stdlib/supervise.agency --force
+grep -n "locals.grant = " stdlib/supervise.js   # MUST show the reverted form, or the manifest skipped the rebuild
+pnpm run agency test tests/agency/supervise/supervise.agency 2>&1 | tee /tmp/supervise-buggy.txt
+```
+Expected: `overshootIsCoveredByTheGrant` FAILS with the guard-approval error. If it passes, the migration weakened the test — stop and fix (likely the advance amount is too small; increase it so the overshoot exceeds the next interval).
+
+Then restore:
+```bash
+cp /tmp/supervise.agency.bak stdlib/supervise.agency
+pnpm run compile stdlib/supervise.agency --force
+grep -n "locals.grant = " stdlib/supervise.js   # MUST show overshoot + nextInterval again
+```
+
+- [ ] **Step 4: Convert the remaining fixtures — one at a time, NOT as a batch**
+
+Convert exactly the fixtures on Task 0's committed cleared-list (`docs/superpowers/plans/2026-07-19-fake-clock-migration-list.md`), and no others. A fixture Task 0 flagged as asserting on a non-guard time value must NOT be migrated here — its assertion would read real time inside a fake-clock run and diverge.
+
+This is the riskiest step in the whole plan, and it is not a rote find-and-replace. Two mechanics make each fixture its own small investigation:
+
+**Hazard A — `_advanceTime` moves only the clock of the process it runs in.** The `nested-pause-*` fixtures are subprocess-IPC fixtures. The guard whose budget must expire may be armed in a *child* agency process, not the one where the old `spin()` ran. `AGENCY_FAKE_CLOCK=1` is inherited by every descendant on spawn, so each process has its own `FakeClock`, but a `_advanceTime` call advances only the clock of the process that executes it. A swap that moves the parent's clock while the guard lives in the child will simply never trip, and the test will hang or mis-assert.
+
+**Hazard B — one `_advanceTime` fires every due timer at once.** `advance(ms)` fires all timers with `dueAt <= target`. For a single guard that is fine. But with nested or concurrent guards — an inner `guard(time: 50ms)` inside an outer `guard(time: 100ms)` — `_advanceTime(200)` sets *both* tripped flags in one synchronous call, before the runner observes either. A real `spin()` run would abort at the inner 50ms trip and never reach the outer limit; the fake clock reaches it anyway. This can change which guards trip and how many. (Task 3's "two guards" unit test pins this behavior at the guard level — use it as the reference for what the fixture will now see.)
+
+Do this per fixture, as its own sub-step:
+
+1. **Read the fixture and map its guards.** Write down, for each `spin(...)` you will replace: which `guard(time:)`/`supervise(every:)` budget it is meant to exceed, whether that guard is armed in this process or a spawned child, and whether any other guard is live at the same time.
+2. **Place the `_advanceTime` call in the process that owns the target guard.** If the guard lives in a child, the `_advanceTime` must run in the child's code, not the parent's. Trace it the way `overshootIsCoveredByTheGrant` was traced in Step 1.
+3. **Choose an advance amount that stops at the first expected trip**, if the original run would have stopped there. If a real run would have tripped only the inner guard, advance just past the inner limit (e.g. `_advanceTime(60)` for a 50ms inner), not past the outer. If the original genuinely reaches multiple trips, confirm the multi-trip outcome matches the original's asserted output.
+4. **Add `fakeClock: true`** to the affected test cases, and the `import test { _advanceTime } from "std::date"` line.
+5. **Run the one fixture and confirm it passes:**
+   ```bash
+   pnpm run agency test tests/agency/subprocess/nested-pause-user-guard.agency 2>&1 | tee /tmp/nested.txt
+   ```
+6. **If a fixture resists** — the trip won't fire from any single-process advance, or the multi-trip semantics can't be matched — do not force it. Leave that fixture on real time, note it in the commit message as "not migrated: <reason>", and move on. A fixture kept slow-but-correct beats a fixture made fast-but-wrong.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/agency/supervise tests/agency/subprocess tests/agency/guards
+git commit -F <message-file>
+```
+Message subject: `Migrate slow time-guard fixtures to the fake clock`
+
+---
+
+## Task 7: Full build and final checks
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Full build**
+
+Run: `make`
+Expected: completes without error (rebuilds stdlib and dist so the CLI uses the new seam).
+
+- [ ] **Step 2: Run the affected unit suites once, saved to a file**
+
+Run:
+```bash
+pnpm exec vitest run lib/runtime/clock.test.ts lib/runtime/state/context.clock.test.ts lib/runtime/guard.clock.test.ts lib/runtime/guard.test.ts lib/stdlib/builtins.clock.test.ts 2>&1 | tee /tmp/unit.txt
+```
+Expected: all pass.
+
+- [ ] **Step 3: Typecheck**
+
+Run: `pnpm run typecheck`
+Expected: clean.
+
+- [ ] **Step 4: Structural lint**
+
+Run: `pnpm run lint:structure`
+Expected: clean (catches banned patterns).
+
+- [ ] **Step 5: Push and open the PR (only when asked)**
+
+Do not push or open a PR until the owner asks. When asked, put the description in a file and include the Task 0 audit findings and the reverted-build regression evidence from Task 6 Step 3.
+
+---
+
+## Self-Review
+
+**Spec coverage.** The spec's pieces map to tasks: clock seam → Task 1; clock on the context → Task 2; guard reads through the seam → Task 3; `_advanceTime` in `std::date` as a test seam → Task 4; per-test opt-in via `fakeClock` → Task 5; the out-of-scope blast-radius audit → Task 0; migration → Task 6. The spec's mandatory tests are covered: deterministic trip (Task 5 Step 1), the reverted-build regression (Task 6 Step 3), concurrent due timers (now at BOTH levels — raw timers in Task 1 and two `TimeGuard`s against one advanced clock in Task 3, since the plan-review flagged nested migration as the real risk), the opt-out (Task 5 Step 7, now asserting on the specific fake-clock message rather than a generic token), revive-with-no-frame (the `clock()` fallback, made an intentional named coverage point in Task 3 Step 5). The firing cap was removed from the spec; no task adds one, matching the spec.
+
+**Fixed after plan review.** The Task 3 unit test now asserts `err.spent`, not just non-null, so an unrouted `now()` read fails it (a non-null-only assert passed on a half-routed guard, because the routed timer already sets `tripped` and short-circuits the trip OR). The `advance()` re-entrancy invariant now has two dedicated Task 1 cases (arm-within-span fires, arm-beyond-target does not), plus a `dueAt === target` boundary case. Task 6 Step 4 is expanded from a one-liner into a per-fixture procedure covering the two migration hazards the review named: `_advanceTime` moves only its own process's clock (subprocess fixtures), and one advance fires every due timer at once (nested guards). Task 0's cleared-list is now a committed file that Task 6 reads by name, not a PR-description note. The guard's `clock()` helper uses the canonical `__ctx()` accessor rather than re-inlining the store reach (avoiding drift), and the note explains why `agency.ctxMaybe()` is NOT used (import cycle: `agency.ts` imports `TimeGuard`). The `_advanceTimeImpl` `instanceof` is documented as a conscious trade against widening the production `Clock` interface. The `defaultClock()` helper replaces the constructor's nested ternary.
+
+**Type consistency.** `Clock`, `TimerHandle`, `realClock`, `FakeClock`, and `FakeClock.advance(ms)` are defined in Task 1 and used unchanged in Tasks 2, 3, 4. `RuntimeContext.clock` (Task 2) is read as `ctx.clock` in Tasks 3 and 4. `_advanceTimeImpl(ms)` (Task 4) is the exact name the `_advanceTime` def calls. `fakeClock` is the same property name on `TestCase`, in the `executeNodeAsync` args, and the `AGENCY_FAKE_CLOCK` env var throughout.
+
+**Known verification points handed to the implementer, not left vague.** The `timerHandle` type change (Task 3 Step 3) is typecheck-verified. The import paths in the new test files are flagged for confirmation against source. The no-fake-clock throw's exact surfaced shape (Task 5 Step 7) is called out to confirm rather than assumed. The manifest-skip trap on recompile is guarded with an explicit `grep` on the emitted `.js` (Task 6 Step 3).

--- a/docs/superpowers/specs/2026-07-19-fake-clock-time-guards-design-REVIEW.md
+++ b/docs/superpowers/specs/2026-07-19-fake-clock-time-guards-design-REVIEW.md
@@ -1,0 +1,137 @@
+# Review — Fake clock for time-guard tests (#575)
+
+Reviewed against the actual implementation in `lib/runtime/guard.ts` and
+`stdlib/supervise.agency`, not just read on its own terms. Overall the design is
+sound: the seam is in the right place, the scope is disciplined, and the real
+fallback and per-test opt-in are correct. The issues below are mostly with the
+spec's *explanation of the mechanism*, which is wrong in a way that would mislead
+whoever implements it and whoever writes fixtures against it.
+
+Two things I checked and can confirm the spec got right:
+- `agencyStore.getStore()?.ctx` is the correct field path (matches
+  `lib/runtime/agency.ts`'s `ctxMaybe`).
+- The no-frame real-clock fallback is genuinely needed — a revived guard runs
+  outside an execution frame, and the strict `getRuntimeContext()` throws there.
+
+---
+
+## 🔴 Biggest issue: the re-arm premise is wrong
+
+**Where:** "The clock seam" → the paragraph beginning "The loop is the important
+part" (around line 190).
+
+The spec says: "Each timer that fires runs a guard's abort callback, and that
+callback can arm the next interval timer. So the loop re-reads the pending list
+after every firing."
+
+I checked `guard.ts`. The guard's `setTimeout` callback (line 866) does exactly
+one thing: `controller.abort(...)`. It never re-arms. The interval is re-armed
+only by `startWindow()`, which is reached from install, resume, and
+`extendBudget` — i.e. from the supervise handler's `approve(...)` (lines 586,
+661, 731). That handler runs at an async runner step, **outside** `advance()`.
+
+So the claim does not hold for a single guard. Inside one synchronous
+`advance()` call, a given guard's timer fires **at most once** — there is nothing
+on the pending list to re-read, because the re-arm happens later, after the block
+yields and the interrupt is answered. The multi-trip behavior you see in practice
+comes from the *fixture* calling `advanceTime` more than once (once in the block
+body, once inside `slowCheck`), interleaved with runner steps — not from one
+`advance()` firing a chain.
+
+The loop still needs to fire every *currently-due* timer, because several
+distinct guards (nested guards, or concurrent fork/race branches) can be due at
+once — so keep the loop. But please rewrite this paragraph so it does not claim a
+single guard re-arms itself inside `advance()`. A fixture author will size their
+`advanceTime` amount based on this narrative, and the narrative is misleading.
+This also undercuts the firing-cap rationale — see below.
+
+---
+
+## 🟡 The firing cap's stated cause can't happen
+
+**Where:** "The firing cap" (around line 300).
+
+This section assumes one `advance()` can fire a re-arming interval thousands of
+times. It can't, per the finding above: a single guard fires once per
+`advance()`, then waits on the async handler to re-arm. "`every: 1ms` advanced by
+500ms fires roughly 500 times" is not what happens — it fires once. So the
+600,000-trip runaway is not reachable from one guard.
+
+A cap can still be worth keeping as a cheap backstop against *many concurrent*
+due timers, but justify it on that basis, not on the re-arming-interval story.
+And reconsider whether 10,000 earns its keep: if the real firing count per
+`advance()` is "number of guards currently due" (small), a much lower cap — or
+none — may be simpler. Either way, fix the error-message text and the rationale
+so they describe a failure mode that can actually occur.
+
+---
+
+## 🟡 Walk the `overshootIsCoveredByTheGrant` fixture through the real mechanism
+
+**Where:** "What this ships" → the reduced fixture (around line 80).
+
+I traced this one and it does work, but not the way the spec implies:
+
+1. `advanceTime(500)` in the block body fires the guard once (abort at `dueAt`
+   100, clock lands at 500).
+2. At the next runner step the guard raises the trip; the handler runs
+   `slowCheck`, which itself calls `advanceTime(500)` — but no timer is armed at
+   that point (the fired one wasn't re-armed yet), so that second call just moves
+   the clock.
+3. `approve` re-arms and the block resumes to `return`.
+
+Net result: one real trip, `spent = 500`, `overshoot = 400`, which is exactly
+what catches the `grant = nextInterval` regression. Good.
+
+Two asks:
+- Put this trace in the plan explicitly, and add the early test the "out of
+  scope" section already promises — the design's correctness rests on this
+  interleaving, not on the firing loop.
+- Confirm the second `advanceTime(500)` (inside `slowCheck`) firing nothing is
+  intended and harmless. As written it reads like it's meant to advance a live
+  interval, and it isn't.
+
+---
+
+## 🟡 Confirm `guard.ts` really is the whole blast radius
+
+**Where:** "How the guard reads it" → "no other file changes" (around line 213).
+
+The six reads inside `guard.ts` are right. But a time-guard/supervise fixture can
+*observe* time through other reads this seam does not touch — e.g. per-branch
+working-time budget accounting (the cost/time CLI guards) and statelog
+timestamps also read wall/monotonic time. If any of those participate in what a
+fixture asserts, they'll diverge from the fake clock inside the same test.
+
+Have the plan grep for `performance.now` / `Date.now` across the runtime and
+state, and either confirm none of the surviving reads affect a fixture's
+observable result, or list the ones that do. `sleep()` is already called out;
+make sure that list is exhaustive, not just `guard.ts`.
+
+---
+
+## 🟢 The "synchronous" conclusion is right — and my findings reinforce it
+
+**Where:** "What is deliberately out of scope" → "`advanceTime` is synchronous"
+(around line 325).
+
+Synchronous is correct, and it's a direct consequence of the re-arm finding:
+since the guard's timer callback only calls `controller.abort()` and never
+touches promises, `advance()` has nothing to await. Worth stating the connection
+explicitly — "sync works *because* firing a guard timer only sets an abort; the
+re-arm and the check run later at a runner step" — so a reader doesn't reach for
+async out of caution.
+
+---
+
+## 🟢 Minor / future
+
+- **`maxFirings` plumbing** (around line 161): `advance(ms, maxFirings)` takes the
+  cap as a required param, but `advanceTime(ms)` takes only `ms`. Say where the
+  cap value is supplied at the call site (a module constant in the `advanceTime`
+  backing?), so the plan doesn't have to guess.
+- **`wallBaseMs = 0`** (around line 144): a frozen calendar reads as Jan 1 1970.
+  Harmless now (nothing calls `wallTime()`), but when #609 wires `std::date`
+  through the seam, a test reading "today" gets 1970. Cheap to fix later by
+  seeding `wallBaseMs` from a realistic epoch at construction. No change needed
+  for this PR — just a known follow-up.

--- a/docs/superpowers/specs/2026-07-19-fake-clock-time-guards-design.md
+++ b/docs/superpowers/specs/2026-07-19-fake-clock-time-guards-design.md
@@ -1,0 +1,434 @@
+# Fake clock for time-guard tests (#575)
+
+## Background
+
+Agency has a feature called a time guard. You write `guard(time: 100ms) { ... }`,
+and if the block runs longer than 100 milliseconds, the guard trips: it aborts
+the block and hands back whatever draft the block saved. There is also
+`supervise(every:, maxTime:, check:)`, which trips on a schedule so a check
+function can look in and decide whether to continue, redirect, or stop.
+
+Both of these read the real clock. The guard notes the wall-clock time when the
+block starts, and it arms a real timer that fires when the limit is up.
+
+That makes the guards hard to test. A test cannot ask for "exactly 200
+milliseconds of block time" without actually spending 200 milliseconds. So the
+existing test fixtures burn real time instead. They call a helper named `spin`,
+which counts in a loop to run down the clock:
+
+```agency
+def spin(rounds: number): string {
+  let i = 0
+  while (i < rounds) {
+    i = i + 1
+  }
+  return "spun"
+}
+```
+
+To make a block overshoot its limit, a fixture counts to three million.
+
+This is the whole problem. Counting to three million takes a different amount
+of time on a fast machine than on a slow one, so these fixtures are tuned to the
+hardware. The tuning is fragile. One fixture,
+`tests/agency/supervise/supervise.agency`, spends 70 seconds counting, which is
+a quarter of all the time the Agency test suite added over one recent week. And
+the tuning can silently stop working: a fixture that counts too few rounds still
+passes, it just stops catching the bug it was written for. A faster CI machine
+makes this worse, not better, because a quicker loop produces less overshoot.
+
+The fix is a fake clock. A test turns it on, and then instead of counting to
+three million, the test simply says "pretend 200 milliseconds passed." The guard
+trips because its clock moved, not because real time elapsed. The result does
+not depend on the machine, and the fixture drops from 70 seconds to about 3.
+
+The original filed issue proposed advancing time through entries in the LLM mock
+list. That does not work here, because the slowest fixtures make no LLM calls at
+all. The clock has to move on a plain function call from inside the fixture.
+
+## What this ships
+
+A fixture opts in, imports the test seam, then advances time with a function
+call:
+
+```agency
+import test { _advanceTime } from "std::date"
+
+node tripsWhenTheBudgetRunsOut(): string {
+  const r = guard(time: 100ms) {
+    _advanceTime(200)
+    return "never reached"
+  }
+  if (isFailure(r)) { return "tripped" }
+  return r.value
+}
+```
+
+`_advanceTime(200)` moves the fake clock forward 200 milliseconds and fires any
+guard timer that comes due along the way. The guard's timer was set for 100
+milliseconds, so it fires, and the block trips. No real time is spent.
+
+The 70-second fixture becomes this:
+
+```agency
+def slowCheck(elapsed: number): SuperviseDecision {
+  checks.push("checked")
+  slowChecks = slowChecks + 1
+  if (slowChecks == 1) {
+    _advanceTime(500)      // was: spin(3000000)
+  }
+  return { action: "continue", message: "" }
+}
+
+node overshootIsCoveredByTheGrant(): string {
+  const r = supervise(every: 100ms, maxTime: 600000, check: slowCheck) {
+    _advanceTime(500)      // was: spin(3000000)
+    return "done:spun"
+  }
+  if (isFailure(r)) { return "failed:${r.error}" }
+  return r.value
+}
+```
+
+The overshoot is now stated outright: 500 milliseconds against a 100-millisecond
+interval. Nothing is tuned to the machine.
+
+It is worth tracing this fixture, because its correctness rests on the exact
+order of events, not on the clock loop firing many times.
+
+1. `_advanceTime(500)` in the block body fires the guard's timer once. The timer
+   was due at 100 milliseconds, the clock lands at 500, and the guard aborts.
+2. At the next runner step the guard raises the trip. The supervise handler runs
+   `slowCheck`, which itself calls `_advanceTime(500)`. No timer is armed at this
+   moment, because the one that fired was not re-armed, so this second call only
+   moves the clock. That is intended, not a mistake in the fixture.
+3. `approve(...)` re-arms the interval and the block resumes to `return`.
+
+The net effect is one real trip with `spent = 500` and `overshoot = 400`, which
+is exactly what catches the `grant = nextInterval` regression. The plan carries
+this trace and turns it into the early test named under Testing, because the
+design leans on this interleaving.
+
+## The pieces
+
+### The clock seam
+
+A new file, `lib/runtime/clock.ts`, defines what a clock is:
+
+```ts
+export type TimerHandle = { id: number };
+
+export type Clock = {
+  /** Monotonic milliseconds. What a time guard meters against. */
+  now(): number;
+  /** Milliseconds since the Unix epoch. What std::date reads. */
+  wallTime(): number;
+  setTimer(fn: () => void, delayMs: number): TimerHandle;
+  clearTimer(handle: TimerHandle): void;
+};
+```
+
+Two of these fields matter for this feature and two are here for the future.
+
+The guard uses monotonic time, which is a counter that only ever moves forward,
+read today through `performance.now()`. That is `now()`. The guard also arms and
+cancels a timer. Those are `setTimer` and `clearTimer`. This feature exercises
+those three.
+
+`wallTime()` is here on purpose, though nothing in this feature calls it.
+`std::date` reads calendar time through `new Date()`, which is a different clock
+from the guard's monotonic counter. A future `elapsedTime` function
+([issue #609](https://github.com/egonSchiele/agency-lang/issues/609)) will want
+to read calendar time through the same seam, so that turning on the fake clock
+also freezes the calendar in a test. Putting `wallTime()` in the type now means
+that later work reroutes one function instead of widening this interface. This
+feature leaves `wallTime()` implemented but unused.
+
+One follow-up to record for that later work, not to fix here: `FakeClock` starts
+`wallBaseMs` at zero, so a frozen calendar reads as 1 January 1970. Nothing calls
+`wallTime()` yet, so it does not matter now. When #609 wires `std::date` through
+the seam, a test that reads "today" would get 1970 unless the base is seeded from
+a realistic epoch at construction. That is a cheap change to make then.
+
+The real clock is the default and changes no behavior:
+
+```ts
+export const realClock: Clock = {
+  now: () => performance.now(),
+  wallTime: () => Date.now(),
+  setTimer: (fn, delayMs) => ({ id: setTimeout(fn, delayMs) as unknown as number }),
+  clearTimer: (handle) => clearTimeout(handle.id),
+};
+```
+
+The fake clock keeps a number and a list of pending timers:
+
+```ts
+export class FakeClock implements Clock {
+  private monotonicMs = 0;
+  private wallBaseMs = 0;   // wall time = base + monotonic, so the two move together
+  private timers: { dueAt: number; fn: () => void; id: number }[] = [];
+  private nextId = 1;
+
+  now(): number { return this.monotonicMs; }
+  wallTime(): number { return this.wallBaseMs + this.monotonicMs; }
+
+  setTimer(fn: () => void, delayMs: number): TimerHandle {
+    const id = this.nextId++;
+    this.timers.push({ dueAt: this.monotonicMs + delayMs, fn, id });
+    return { id };
+  }
+
+  clearTimer(handle: TimerHandle): void {
+    this.timers = this.timers.filter((t) => t.id !== handle.id);
+  }
+
+  advance(ms: number): void {
+    const target = this.monotonicMs + ms;
+    while (true) {
+      const due = this.timers
+        .filter((t) => t.dueAt <= target)
+        .sort((a, b) => a.dueAt - b.dueAt)[0];
+      if (!due) break;
+      this.timers = this.timers.filter((t) => t.id !== due.id);
+      this.monotonicMs = due.dueAt;   // move the clock TO the timer, then fire it
+      due.fn();
+    }
+    this.monotonicMs = target;
+  }
+}
+```
+
+Only `monotonicMs` moves. `wallTime()` reads it plus a fixed base, so the two
+clocks always advance together and there is no separate bookkeeping to get wrong.
+After `advance(ms)`, both `now()` and `wallTime()` have moved forward by `ms`.
+
+The loop fires every timer that is due within the span. A guard's abort callback
+does one thing, `controller.abort(...)`; it does not arm a new timer. Re-arming a
+supervisor's next interval happens later, in `startWindow()`, reached from the
+`approve(...)` path at an async runner step, which is outside `advance()`. So a
+single guard's timer fires at most once per `advance()` call.
+
+The loop still fires more than one timer when several distinct guards are due at
+once: nested guards, or the separate branches of a `fork`/`race`, each hold their
+own timer. The clock steps to each timer's due time before firing it, so a
+callback that reads `now()` sees the time its own timer was due for.
+
+The loop is guaranteed to end. Nothing inside `advance()` calls `setTimer`, and
+each iteration removes one timer from the pending list, so the list strictly
+shrinks and the loop stops after firing every currently-due timer. There is no
+runaway to guard against, which is why this design has no firing cap. If the
+timer model ever changes so a callback re-arms itself synchronously, revisit
+this — but today it cannot.
+
+### Where the clock lives
+
+The clock lives on the `RuntimeContext`, which is the object the runtime builds
+once per run and threads through execution. Code reaches it through
+`getRuntimeContext()`, the same accessor that stdlib TypeScript helpers already
+use. This keeps the clock out of any module-level variable, so two tests running
+in one process cannot disturb each other's clock.
+
+The `RuntimeContext` constructor takes a new optional `clock`, defaulting to
+`realClock`. Nothing else about the constructor changes.
+
+### How the guard reads it
+
+Every clock read in `lib/runtime/guard.ts` goes through a small helper instead of
+calling the global functions. That file has six reads of the current time, one
+`setTimeout`, and one `clearTimeout`. Those are the reads the fake clock needs to
+control, because they are what a time guard meters and trips on.
+
+Other parts of the runtime read time too and this seam does not touch them: the
+per-branch working-time budgets from the cost and time CLI guards (#549, #550),
+and statelog event timestamps, among others. That is fine for a fixture that only
+asserts on a guard trip, because the trip runs entirely through `guard.ts`. It is
+a trap for a fixture that asserts on anything else time-derived, such as a logged
+duration, which would still read real time inside a fake-clock test and diverge.
+
+So the plan must grep `performance.now` and `Date.now` across the whole runtime
+and state directories, then for each surviving read decide one of two things: it
+cannot affect a fixture's observable result, or it can and must be listed as a
+known divergence. The `sleep()` carve-out below is one entry on that list, not
+the whole list.
+
+The helper reads the clock through the lax store accessor and falls back to the
+real clock. `agencyStore.getStore()` returns `undefined` outside a frame rather
+than throwing:
+
+```ts
+private clock(): Clock {
+  return agencyStore.getStore()?.ctx?.clock ?? realClock;
+}
+```
+
+The fallback is not decoration. A time guard can revive from a checkpoint outside
+an execution frame, and the strict `getRuntimeContext()` throws there. A revived
+guard with no frame meters against real time, exactly as it does today. So this
+resolves cleanly rather than crashing.
+
+The call sites change shape but not behavior. A read like
+
+```ts
+this.windowStart = performance.now();
+```
+
+becomes
+
+```ts
+this.windowStart = this.clock().now();
+```
+
+The arming site keeps its whole callback body and only changes what schedules it:
+
+```ts
+this.timerHandle = this.clock().setTimer(() => {
+  const spent = this.elapsedMs +
+    (this.windowStart !== undefined ? this.clock().now() - this.windowStart : 0);
+  this.controller?.abort(new AgencyCancelledError(/* unchanged */));
+}, delay);
+```
+
+And cancellation:
+
+```ts
+this.clock().clearTimer(this.timerHandle);   // was: clearTimeout(this.timerHandle)
+```
+
+### Turning it on per fixture
+
+A fixture asks for the fake clock in its `.test.json`, on the individual test
+case, next to where `llmMocks` already lives:
+
+```json
+{
+  "nodeName": "overshootIsCoveredByTheGrant",
+  "fakeClock": true,
+  "expectedOutput": "\"done:spun\"",
+  "evaluationCriteria": [{ "type": "exact" }]
+}
+```
+
+This mirrors how `llmMocks` already flows. The test runner reads `fakeClock` from
+the test case and passes it to the run the same way it passes the mock list. When
+the flag is set, the run constructs the `RuntimeContext` with a `FakeClock`
+instead of the default `realClock`.
+
+The flag is per test case, not per file, so one file can hold both fake-clock and
+real-clock tests. Fixtures that do not set it keep the real clock and keep
+passing without any change. The flag is permanent: a fixture that genuinely wants
+to measure real elapsed time simply never sets it.
+
+### The _advanceTime function
+
+`_advanceTime` lives in `stdlib/date.agency`, and it follows the test-seam
+pattern already set by `_installSlowInput` in `stdlib/thread.agency`. That
+existing seam lets guard fixtures simulate a slow human without touching stdin,
+and it is imported the same way this one is. The shared shape:
+
+- a plain `def`, not `export def`, so a normal `import` cannot see it
+- a leading underscore, matching `_installSlowInput`
+- reached only through `import test { _advanceTime } from "std::date"`
+- a docstring that opens with "Test-only:"
+- a thin Agency wrapper over a TypeScript helper
+
+The choice of `std::date` is deliberate. It is not useful there yet, because you
+cannot fast-forward a real clock, so `_advanceTime` is test-only for now. But it
+sits next to where the production-useful reads, `now` and `elapsedTime`, will
+land when [issue #609](https://github.com/egonSchiele/agency-lang/issues/609)
+adds them. Promoting `_advanceTime` later, if that ever makes sense, is a rename
+to `export def advanceTime`, not a move to another module.
+
+Two things keep it out of production. The `import test` gate means a production
+file, which uses a plain `import`, cannot see the symbol at all. And the
+TypeScript helper behind it reads the clock from the runtime context and throws
+if that clock is not a `FakeClock`:
+
+```
+_advanceTime() needs a fake clock. Set "fakeClock": true on this test case.
+```
+
+So a production run fails loudly rather than doing nothing, and a production file
+cannot even reach the call. The helper, when the clock is fake, calls `advance`.
+
+`_advanceTime(ms)` takes only the number of milliseconds. There is no firing cap,
+because `advance()` cannot run away: it never arms a timer, and it removes one
+timer per iteration, so it always ends after firing the currently-due timers.
+The plan does not need to thread a cap value from the call site.
+
+## What is deliberately out of scope
+
+`_advanceTime` moves the guard's clock and fires guard timers. It does not
+fast-forward `sleep()` or any other real awaited timer, because those do not go
+through the guard clock. A fixture that calls `sleep(1000)` still waits a real
+second. Routing `sleep` and other timers through the seam is a larger change and
+is not needed to fix the time-guard fixtures.
+
+Because of that scoping, `_advanceTime` is synchronous, and this follows directly
+from how a guard timer fires. Firing one only calls `controller.abort(...)`,
+which sets a flag; it starts no promise and re-arms nothing. The runtime reads
+that abort at its next synchronization point, and the re-arm and the guard's
+`check()` both run later at a runner step, outside `_advanceTime`. So `advance()`
+has nothing to await. The plan should confirm this with a test early: if a
+fixture ever needs fake time to interact with awaited work, an async variant
+would be the follow-up, the way vitest ships both `advanceTimersByTime` and
+`advanceTimersByTimeAsync`.
+
+This feature does not expose any clock reads to Agency programs or to the public
+`agency.*` TypeScript helper namespace. Those belong to the `elapsedTime` work in
+[issue #609](https://github.com/egonSchiele/agency-lang/issues/609). This spec
+only lays the seam that work will reuse.
+
+## Testing
+
+Every claim above needs a test that fails before the change and passes after.
+
+Deterministic trip. A `guard(time: 100ms)` block that calls `_advanceTime(200)`
+trips, and one that calls `_advanceTime(50)` does not. Neither spends real time.
+
+The bug the slow fixture guards. The reduced `overshootIsCoveredByTheGrant`
+fixture must still fail when the fix in `stdlib/supervise.agency` is reverted to
+`grant = nextInterval`. This is the load-bearing check: the whole point is a
+faster test that still catches the same regression. The test plan must run the
+fixture against a deliberately reverted build and confirm it fails. Because the
+design's correctness rests on the exact interleaving traced above, not on the
+firing loop, this test is not optional.
+
+Concurrent due timers. Two nested guards, or two `fork` branches each with a time
+guard, both past their limits when `_advanceTime` runs: both trip in the one call.
+This is the case the firing loop exists for, now that a single guard fires once.
+
+The opt-out. A fixture with no `fakeClock` flag keeps the real clock: a guard in
+it trips on real elapsed time, and `_advanceTime` in it throws the clear error.
+
+Revive with no frame. A guard revived from a checkpoint outside an execution
+frame falls back to the real clock instead of throwing.
+
+Existing fixtures. Every current time-guard and supervise fixture keeps passing
+untouched, since none of them set the flag.
+
+## Migration
+
+Convert the slow fixtures to the fake clock, starting with the ones this
+investigation flagged, largest first:
+
+- `tests/agency/supervise/supervise.agency` (70s today)
+- the `tests/agency/subprocess/nested-pause-*` fixtures
+- the `tests/agency/guards/*` time fixtures
+
+Each conversion swaps a `spin(...)` for an `_advanceTime(...)` and adds
+`fakeClock: true` to the affected test cases. Convert only fixtures whose slowness
+comes from spinning down a guard clock. Leave the rest alone.
+
+## Files touched
+
+- `lib/runtime/clock.ts` — new: `Clock` type, `realClock`, `FakeClock`.
+- `lib/runtime/state/context.ts` — `RuntimeContext` gains an optional `clock`,
+  defaulting to `realClock`.
+- `lib/runtime/guard.ts` — the six time reads, one `setTimeout`, and one
+  `clearTimeout` route through a `clock()` helper.
+- `stdlib/date.agency` — the `_advanceTime` test seam and its TypeScript backing.
+- `lib/cli/test.ts` — read `fakeClock` off the test case and install a
+  `FakeClock` on the run.
+- The migrated fixtures.
+```

--- a/packages/agency-lang/docs/site/stdlib/date.md
+++ b/packages/agency-lang/docs/site/stdlib/date.md
@@ -40,7 +40,7 @@ export type DayOfWeek =
   | "saturday"
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L24))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L25))
 
 ## Functions
 
@@ -64,7 +64,7 @@ Get the current date and time as an ISO 8601 string with timezone offset.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L27))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L28))
 
 ### today
 
@@ -86,7 +86,7 @@ Get today's date as a YYYY-MM-DD string.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L37))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L51))
 
 ### tomorrow
 
@@ -108,7 +108,7 @@ Get tomorrow's date as a YYYY-MM-DD string.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L47))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L61))
 
 ### add
 
@@ -132,7 +132,7 @@ Add a duration to a datetime string. Use with unit literals: add(now(), 2h), add
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L57))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L71))
 
 ### addMinutes
 
@@ -156,7 +156,7 @@ Add minutes to a datetime string and return the new datetime.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L68))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L82))
 
 ### addHours
 
@@ -180,7 +180,7 @@ Add hours to a datetime string and return the new datetime.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L79))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L93))
 
 ### addDays
 
@@ -204,7 +204,7 @@ Add days to a datetime string and return the new datetime. Note: adds a fixed 24
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L90))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L104))
 
 ### nextDayOfWeek
 
@@ -228,7 +228,7 @@ Get the date of the next occurrence of a day of the week (e.g. "monday").
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L101))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L115))
 
 ### atTime
 
@@ -254,7 +254,7 @@ Combine a date (YYYY-MM-DD) and time (HH:MM) into a timezone-aware ISO 8601 stri
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L112))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L126))
 
 ### startOfDay
 
@@ -278,7 +278,7 @@ Get the start of the day (midnight) as an ISO 8601 string.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L124))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L138))
 
 ### endOfDay
 
@@ -302,7 +302,7 @@ Get the end of the day (23:59:59) as an ISO 8601 string.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L135))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L149))
 
 ### startOfWeek
 
@@ -326,7 +326,7 @@ Get the start of the current week (Sunday midnight) as an ISO 8601 string.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L146))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L160))
 
 ### endOfWeek
 
@@ -350,7 +350,7 @@ Get the end of the current week (Saturday 23:59:59) as an ISO 8601 string.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L157))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L171))
 
 ### startOfMonth
 
@@ -374,7 +374,7 @@ Get the start of the month (1st at midnight) as an ISO 8601 string.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L168))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L182))
 
 ### endOfMonth
 
@@ -398,4 +398,4 @@ Get the end of the month (last day at 23:59:59) as an ISO 8601 string.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L179))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L193))

--- a/packages/agency-lang/lib/cli/test.ts
+++ b/packages/agency-lang/lib/cli/test.ts
@@ -70,6 +70,11 @@ type TestCase = {
   argv?: string[];
   // Per-test fetch mocks; merged over file-level `fetchMocks` (this wins).
   fetchMocks?: FetchMock[];
+  // Install a deterministic fake clock for this test case. Guard fixtures use
+  // it with the `_advanceTime` seam (import test from "std::date") to trip time
+  // guards without spending real time. Off by default: the run keeps the real
+  // clock. See docs/superpowers/specs/2026-07-19-fake-clock-time-guards-design.md.
+  fakeClock?: boolean;
 };
 type Tests = {
   sourceFile?: string;
@@ -595,6 +600,7 @@ async function runSingleTest(
       timeoutMs,
       signal,
       llmMocks: testCase.llmMocks,
+      fakeClock: testCase.fakeClock,
       useTestLLMProvider: testCase.useTestLLMProvider,
       argv: testCase.argv,
       fetchMocks,

--- a/packages/agency-lang/lib/cli/util.ts
+++ b/packages/agency-lang/lib/cli/util.ts
@@ -212,6 +212,9 @@ type ExecuteNodeArgs = {
   // per-call cost / token output. Setting this is equivalent to running
   // with AGENCY_USE_TEST_LLM_PROVIDER=1 for the spawned subprocess only.
   useTestLLMProvider?: boolean;
+  // Install a deterministic fake clock in the spawned subprocess (sets
+  // AGENCY_FAKE_CLOCK=1). Guard fixtures use it with the `_advanceTime` seam.
+  fakeClock?: boolean;
   // Extra command-line arguments forwarded to the spawned subprocess.
   // These land in `process.argv.slice(2)` of the running agent —
   // primarily for testing std::args and other argv-reading code.
@@ -377,6 +380,7 @@ export async function executeNodeAsync({
   llmMocks,
   useTestLLMProvider,
   fetchMocks,
+  fakeClock,
   ...rest
 }: ExecuteNodeArgs): Promise<{ data: any; stdout: string; stderr: string }> {
   const useDeterministic =
@@ -384,6 +388,12 @@ export async function executeNodeAsync({
   const env: Record<string, string> = useDeterministic
     ? { AGENCY_LLM_MOCKS: JSON.stringify(llmMocks ?? []) }
     : {};
+
+  // Independent of deterministic mode: a fixture opts into the fake clock, and
+  // the subprocess installs it when constructing the RuntimeContext.
+  if (fakeClock) {
+    env.AGENCY_FAKE_CLOCK = "1";
+  }
 
   // Sandbox the agent home per test case: the agent config derives every
   // ~/.agency-agent path from AGENCY_AGENT_HOME when set, so tests can

--- a/packages/agency-lang/lib/runtime/clock.test.ts
+++ b/packages/agency-lang/lib/runtime/clock.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { FakeClock, realClock } from "./clock.js";
+
+describe("FakeClock", () => {
+  it("starts at zero and advances now() and wallTime() together", () => {
+    const clock = new FakeClock();
+    expect(clock.now()).toBe(0);
+    expect(clock.wallTime()).toBe(0);
+    clock.advance(200);
+    expect(clock.now()).toBe(200);
+    expect(clock.wallTime()).toBe(200);
+  });
+
+  it("fires a timer whose due time falls within the advance", () => {
+    const clock = new FakeClock();
+    let fired = false;
+    clock.setTimer(() => {
+      fired = true;
+    }, 100);
+    clock.advance(50);
+    expect(fired).toBe(false);
+    clock.advance(60); // now at 110, past the 100ms timer
+    expect(fired).toBe(true);
+  });
+
+  it("fires a timer due exactly at the advance target (dueAt === target boundary)", () => {
+    const clock = new FakeClock();
+    let fired = false;
+    clock.setTimer(() => {
+      fired = true;
+    }, 100);
+    clock.advance(100); // lands exactly on the due time
+    expect(fired).toBe(true);
+  });
+
+  it("does not fire a timer that was cleared", () => {
+    const clock = new FakeClock();
+    let fired = false;
+    const handle = clock.setTimer(() => {
+      fired = true;
+    }, 100);
+    clock.clearTimer(handle);
+    clock.advance(200);
+    expect(fired).toBe(false);
+  });
+
+  it("fires multiple distinct timers due within one advance, in due order", () => {
+    const clock = new FakeClock();
+    const order: number[] = [];
+    clock.setTimer(() => order.push(2), 200);
+    clock.setTimer(() => order.push(1), 100);
+    clock.advance(300);
+    expect(order).toEqual([1, 2]);
+  });
+
+  it("sets now() to each timer's due time before firing it", () => {
+    const clock = new FakeClock();
+    let seen = -1;
+    clock.setTimer(() => {
+      seen = clock.now();
+    }, 100);
+    clock.advance(500);
+    expect(seen).toBe(100); // not 500
+  });
+
+  it("terminates when a fired callback is a no-op (no re-arm)", () => {
+    const clock = new FakeClock();
+    let count = 0;
+    clock.setTimer(() => {
+      count++;
+    }, 100);
+    clock.advance(1000);
+    expect(count).toBe(1);
+    expect(clock.now()).toBe(1000);
+  });
+
+  it("fires a timer that a callback arms WITHIN the same advance span", () => {
+    // Pins the re-entrancy invariant: advance() re-reads the pending list
+    // after each firing, so a timer armed by a fired callback and due before
+    // the target fires in the same advance() call. A one-shot snapshot loop
+    // would silently break this.
+    const clock = new FakeClock();
+    let inner = false;
+    clock.setTimer(() => {
+      clock.setTimer(() => {
+        inner = true;
+      }, 50); // due at 100 + 50 = 150
+    }, 100);
+    clock.advance(300); // 150 <= 300, so the inner timer must fire too
+    expect(inner).toBe(true);
+  });
+
+  it("does NOT fire a timer a callback arms beyond the advance target", () => {
+    const clock = new FakeClock();
+    let inner = false;
+    clock.setTimer(() => {
+      clock.setTimer(() => {
+        inner = true;
+      }, 500); // due at 100 + 500 = 600
+    }, 100);
+    clock.advance(300); // 600 > 300, so the inner timer must NOT fire
+    expect(inner).toBe(false);
+  });
+});
+
+describe("realClock", () => {
+  afterEach(() => vi.useRealTimers());
+  it("delegates to global timers", () => {
+    vi.useFakeTimers();
+    let fired = false;
+    const handle = realClock.setTimer(() => {
+      fired = true;
+    }, 100);
+    vi.advanceTimersByTime(50);
+    expect(fired).toBe(false);
+    vi.advanceTimersByTime(60);
+    expect(fired).toBe(true);
+    realClock.clearTimer(handle); // no throw on an already-fired handle
+  });
+});

--- a/packages/agency-lang/lib/runtime/clock.test.ts
+++ b/packages/agency-lang/lib/runtime/clock.test.ts
@@ -90,6 +90,13 @@ describe("FakeClock", () => {
     expect(inner).toBe(true);
   });
 
+  it("rejects a negative or NaN advance rather than corrupting the clock", () => {
+    const clock = new FakeClock();
+    expect(() => clock.advance(-5)).toThrow(/non-negative/);
+    expect(() => clock.advance(NaN)).toThrow(/non-negative/);
+    expect(clock.now()).toBe(0); // unchanged by the rejected calls
+  });
+
   it("does NOT fire a timer a callback arms beyond the advance target", () => {
     const clock = new FakeClock();
     let inner = false;

--- a/packages/agency-lang/lib/runtime/clock.ts
+++ b/packages/agency-lang/lib/runtime/clock.ts
@@ -1,0 +1,87 @@
+export type TimerHandle = { id: number };
+
+/**
+ * The seam every guard time read and timer goes through. The real clock is
+ * the default; tests swap in a FakeClock to advance time deterministically.
+ * See docs/superpowers/specs/2026-07-19-fake-clock-time-guards-design.md.
+ */
+export type Clock = {
+  /** Monotonic milliseconds. What a time guard meters against. */
+  now(): number;
+  /** Milliseconds since the Unix epoch. What std::date reads. Unused today;
+   *  here so issue #609 can reroute std::date through this seam later. */
+  wallTime(): number;
+  setTimer(fn: () => void, delayMs: number): TimerHandle;
+  clearTimer(handle: TimerHandle): void;
+};
+
+export const realClock: Clock = {
+  now: () => performance.now(),
+  wallTime: () => Date.now(),
+  setTimer: (fn, delayMs) => ({
+    id: setTimeout(fn, delayMs) as unknown as number,
+  }),
+  clearTimer: (handle) => clearTimeout(handle.id),
+};
+
+export class FakeClock implements Clock {
+  private monotonicMs = 0;
+  // Base for wall time. Zero for now, so a frozen calendar reads as 1970.
+  // Nothing calls wallTime() in this feature, so it does not matter yet. When
+  // #609 wires std::date through the seam, seed this from a realistic epoch so
+  // a test reading "today" does not get 1970. Known follow-up, not a bug here.
+  private wallBaseMs = 0;
+  private timers: { dueAt: number; fn: () => void; id: number }[] = [];
+  private nextId = 1;
+
+  now(): number {
+    return this.monotonicMs;
+  }
+
+  wallTime(): number {
+    return this.wallBaseMs + this.monotonicMs;
+  }
+
+  setTimer(fn: () => void, delayMs: number): TimerHandle {
+    const id = this.nextId++;
+    this.timers.push({ dueAt: this.monotonicMs + delayMs, fn, id });
+    return { id };
+  }
+
+  clearTimer(handle: TimerHandle): void {
+    this.timers = this.timers.filter((t) => t.id !== handle.id);
+  }
+
+  /**
+   * Move the clock forward `ms` and fire every timer due within that span.
+   * Terminates: nothing here arms a timer, and each iteration removes one, so
+   * the pending list strictly shrinks. A guard timer's callback only aborts;
+   * it never re-arms (re-arming is startWindow, which runs at a later runner
+   * step), so there is no runaway and no firing cap.
+   */
+  advance(ms: number): void {
+    const target = this.monotonicMs + ms;
+    while (true) {
+      // The earliest timer still due within the span. Re-computed each pass,
+      // because a fired callback may have armed a new one.
+      const due = this.earliestDueBy(target);
+      if (!due) break;
+      this.timers = this.timers.filter((t) => t.id !== due.id);
+      this.monotonicMs = due.dueAt; // step to the timer, then fire it
+      due.fn();
+    }
+    this.monotonicMs = target;
+  }
+
+  private earliestDueBy(
+    target: number,
+  ): { dueAt: number; fn: () => void; id: number } | undefined {
+    return this.timers.reduce<
+      { dueAt: number; fn: () => void; id: number } | undefined
+    >((earliest, t) => {
+      if (t.dueAt > target) return earliest;
+      if (!earliest || t.dueAt < earliest.dueAt) return t;
+      return earliest;
+    }, undefined);
+  }
+}

--- a/packages/agency-lang/lib/runtime/clock.ts
+++ b/packages/agency-lang/lib/runtime/clock.ts
@@ -1,4 +1,4 @@
-export type TimerHandle = { id: number };
+export type TimerHandle = { id: ReturnType<typeof setTimeout> | number };
 
 /**
  * The seam every guard time read and timer goes through. The real clock is
@@ -18,10 +18,8 @@ export type Clock = {
 export const realClock: Clock = {
   now: () => performance.now(),
   wallTime: () => Date.now(),
-  setTimer: (fn, delayMs) => ({
-    id: setTimeout(fn, delayMs) as unknown as number,
-  }),
-  clearTimer: (handle) => clearTimeout(handle.id),
+  setTimer: (fn, delayMs) => ({ id: setTimeout(fn, delayMs) }),
+  clearTimer: (handle) => clearTimeout(handle.id as ReturnType<typeof setTimeout>),
 };
 
 export class FakeClock implements Clock {
@@ -54,12 +52,22 @@ export class FakeClock implements Clock {
 
   /**
    * Move the clock forward `ms` and fire every timer due within that span.
-   * Terminates: nothing here arms a timer, and each iteration removes one, so
-   * the pending list strictly shrinks. A guard timer's callback only aborts;
-   * it never re-arms (re-arming is startWindow, which runs at a later runner
-   * step), so there is no runaway and no firing cap.
+   *
+   * Termination: in this codebase's usage the loop always ends. A guard
+   * timer's callback only aborts; it never re-arms (re-arming is startWindow,
+   * which runs at a later runner step), and every guard delay is >= 0, so each
+   * iteration removes one timer and no callback adds one that is due earlier.
+   * The loop is NOT proof against an arbitrary caller that arms a fresh 0ms
+   * timer from inside a fired callback — that is a hypothetical no code here
+   * does, so there is no firing cap. The guard below rejects the one misuse
+   * that is easy to hit by accident: a negative or NaN advance, which would
+   * move the clock backward or corrupt it.
    */
   advance(ms: number): void {
+    if (!(ms >= 0)) {
+      // Catches negative and NaN (NaN fails every comparison).
+      throw new Error(`advance(${ms}): ms must be a non-negative number.`);
+    }
     const target = this.monotonicMs + ms;
     while (true) {
       // The earliest timer still due within the span. Re-computed each pass,

--- a/packages/agency-lang/lib/runtime/guard.clock.test.ts
+++ b/packages/agency-lang/lib/runtime/guard.clock.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { TimeGuard } from "./guard.js";
+import { StateStack } from "./state/stateStack.js";
+import { RuntimeContext } from "./state/context.js";
+import { FakeClock } from "./clock.js";
+import { runInTestContext } from "./asyncContext.js";
+import { ThreadStore } from "./state/threadStore.js";
+
+function ctxWithFakeClock(clock: FakeClock): RuntimeContext<any> {
+  return new RuntimeContext({
+    statelogConfig: {
+      host: "https://example.com",
+      apiKey: "test-api-key",
+      projectId: "test-project",
+      debugMode: false,
+    },
+    smoltalkDefaults: { model: "default-model" },
+    dirname: "/tmp",
+    clock,
+  });
+}
+
+describe("TimeGuard reads the context clock", () => {
+  it("trips on a fake-clock advance, and reports fake-clock spent (not a real-time delta)", () => {
+    const clock = new FakeClock();
+    const ctx = ctxWithFakeClock(clock);
+    const threads = new ThreadStore();
+
+    runInTestContext(ctx, ctx.stateStack, threads, () => {
+      const stack = ctx.stateStack;
+      const guard = new TimeGuard(100);
+      stack.pushGuard(guard);
+      expect(guard.check(stack)).toBeNull(); // not yet over budget
+
+      clock.advance(200); // fake time only; no real ms elapse
+
+      const err = guard.check(stack);
+      expect(err).not.toBeNull();
+      // The load-bearing assertion. `spent` flows from currentElapsed() ->
+      // now(). If any of the six now() reads is NOT routed through the seam,
+      // spent becomes a huge real-millisecond number and this fails. Asserting
+      // only non-null would pass even then, because the routed TIMER already
+      // set `tripped` and check() short-circuits the OR.
+      expect(err!.spent).toBeCloseTo(200, 0);
+      expect(guard.isTripped()).toBe(true);
+    });
+  });
+
+  it("does not trip under budget, and reports the fake-clock elapsed", () => {
+    const clock = new FakeClock();
+    const ctx = ctxWithFakeClock(clock);
+    const threads = new ThreadStore();
+
+    runInTestContext(ctx, ctx.stateStack, threads, () => {
+      const stack = ctx.stateStack;
+      const guard = new TimeGuard(100);
+      stack.pushGuard(guard);
+      clock.advance(50);
+      expect(guard.check(stack)).toBeNull();
+      expect(guard.isTripped()).toBe(false);
+    });
+  });
+
+  it("two guards with different limits both meter against one advanced clock", () => {
+    // This is where the nested-fixture migration risk lives (Task 6 Step 4):
+    // one advance() fires every due timer, so an inner and an outer guard can
+    // both trip in a single advance, which a real spin() run would not do
+    // (the inner trip would abort before the outer limit is reached). Pin the
+    // behavior at the guard level so Task 6 conversions have a reference.
+    const clock = new FakeClock();
+    const ctx = ctxWithFakeClock(clock);
+    const threads = new ThreadStore();
+
+    runInTestContext(ctx, ctx.stateStack, threads, () => {
+      const stack = ctx.stateStack;
+      const outer = new TimeGuard(100);
+      stack.pushGuard(outer);
+      const inner = new TimeGuard(50);
+      stack.pushGuard(inner);
+
+      clock.advance(200); // past BOTH limits in one call
+
+      const innerErr = inner.check(stack);
+      expect(innerErr).not.toBeNull();
+      expect(innerErr!.spent).toBeCloseTo(200, 0);
+      const outerErr = outer.check(stack);
+      expect(outerErr).not.toBeNull();
+    });
+  });
+});

--- a/packages/agency-lang/lib/runtime/guard.ts
+++ b/packages/agency-lang/lib/runtime/guard.ts
@@ -1,5 +1,7 @@
 import type { StateStack } from "./state/stateStack.js";
 import { AgencyAbort, AgencyCancelledError, makeAbortCause, readCause } from "./errors.js";
+import { Clock, realClock, TimerHandle } from "./clock.js";
+import { __ctx } from "./asyncContext.js";
 
 /** Monotonic source of stable per-guard ids. Threaded into the
  *  `guardTrip` AbortCause a TimeGuard emits so boundaries can identify
@@ -73,7 +75,7 @@ function clampGrant(
  *     working time at the final join.
  *
  * `toJSON` serializes ONLY persistent state — runtime fields
- * (AbortControllers, setTimeout handles, performance.now() stamps)
+ * (AbortControllers, timer handles, monotonic clock stamps)
  * are NOT included. They're re-established by `resume()` at the first
  * runner step after deserialization.
  */
@@ -524,13 +526,13 @@ export class TimeGuard implements Guard {
    *  double-charge or double-arm. Starts paused — install() flips to
    *  running via startWindow(). */
   private state: "running" | "paused" = "paused";
-  /** performance.now() stamp of the current window's start. Only
-   *  valid when state === "running". */
+  /** Monotonic clock stamp of the current window's start (via clock()).
+   *  Only valid when state === "running". */
   private windowStart: number | undefined = undefined;
   /** AbortController whose .abort() fires when the timer expires. */
   private controller: AbortController | undefined = undefined;
   /** Node setTimeout handle for the in-process timer. */
-  private timerHandle: ReturnType<typeof setTimeout> | undefined = undefined;
+  private timerHandle: TimerHandle | undefined = undefined;
   /** Set when the abort signal fires. Read by check() to convert the
    *  silent abort into a typed throw at the next sync point. */
   private tripped: boolean = false;
@@ -593,7 +595,7 @@ export class TimeGuard implements Guard {
     // popGuard rebuilds without this one.
     this.cancelTimer();
     if (this.state === "running") {
-      this.elapsedMs += performance.now() - this.windowStart!;
+      this.elapsedMs += this.clock().now() - this.windowStart!;
       this.windowStart = undefined;
       this.state = "paused";
     }
@@ -635,7 +637,7 @@ export class TimeGuard implements Guard {
 
   pause(): void {
     if (this.state === "paused") return;
-    this.elapsedMs += performance.now() - this.windowStart!;
+    this.elapsedMs += this.clock().now() - this.windowStart!;
     this.windowStart = undefined;
     this.cancelTimer();
     this.state = "paused";
@@ -726,7 +728,7 @@ export class TimeGuard implements Guard {
     if (this.state === "running") {
       this.cancelTimer();
       this.state = "paused";
-      this.elapsedMs += performance.now() - this.windowStart!;
+      this.elapsedMs += this.clock().now() - this.windowStart!;
       this.windowStart = undefined;
       this.startWindow();
     }
@@ -758,7 +760,7 @@ export class TimeGuard implements Guard {
     return (
       this.elapsedMs +
       (this.state === "running" && this.windowStart !== undefined
-        ? performance.now() - this.windowStart
+        ? this.clock().now() - this.windowStart
         : 0)
     );
   }
@@ -854,6 +856,15 @@ export class TimeGuard implements Guard {
     stack.rebuildAbortSignal();
   }
 
+  /** The time source. Reads the run's clock when a frame is present; a
+   *  guard revived from a checkpoint runs frameless and meters against the
+   *  real clock, exactly as before this seam existed. `__ctx()` is the
+   *  canonical lax accessor; do not use `agency.ctxMaybe()` here (agency.ts
+   *  imports TimeGuard, so that would be a circular import). */
+  private clock(): Clock {
+    return __ctx()?.clock ?? realClock;
+  }
+
   private startWindow(): void {
     // A disarmed guard must never arm its abort timer: check() already
     // reports nothing, but a live timer would still fire the branch's
@@ -863,14 +874,14 @@ export class TimeGuard implements Guard {
     if (this.disarmed) return;
     const remaining = this.timeLimit - this.elapsedMs;
     const delay = remaining > 0 ? remaining : 0;
-    this.timerHandle = setTimeout(() => {
+    this.timerHandle = this.clock().setTimer(() => {
       // Abort WITH a structured cause so any in-flight leaf op (sleep,
       // fetch, …) listening on the composed signal rejects carrying the
       // guard trip — not a bare cancel that the guard's `try` boundary
       // can't recognize and would let escape as an unhandled rejection.
       const spent = this.elapsedMs +
         (this.windowStart !== undefined
-          ? performance.now() - this.windowStart
+          ? this.clock().now() - this.windowStart
           : 0);
       // Abort with an AgencyCancelledError that CARRIES the structured
       // cause. Keeping `signal.reason` an Error (not a bare object) means
@@ -890,13 +901,13 @@ export class TimeGuard implements Guard {
         ),
       );
     }, delay);
-    this.windowStart = performance.now();
+    this.windowStart = this.clock().now();
     this.state = "running";
   }
 
   private cancelTimer(): void {
     if (this.timerHandle) {
-      clearTimeout(this.timerHandle);
+      this.clock().clearTimer(this.timerHandle);
       this.timerHandle = undefined;
     }
   }

--- a/packages/agency-lang/lib/runtime/state/context.clock.test.ts
+++ b/packages/agency-lang/lib/runtime/state/context.clock.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { RuntimeContext } from "./context.js";
+import { FakeClock, realClock, type Clock } from "../clock.js";
+
+function makeCtx(clock?: Clock): RuntimeContext<any> {
+  return new RuntimeContext({
+    statelogConfig: {
+      host: "https://example.com",
+      apiKey: "test-api-key",
+      projectId: "test-project",
+      debugMode: false,
+    },
+    smoltalkDefaults: { model: "default-model" },
+    dirname: "/tmp",
+    clock,
+  });
+}
+
+describe("RuntimeContext.clock", () => {
+  const saved = process.env.AGENCY_FAKE_CLOCK;
+  afterEach(() => {
+    if (saved === undefined) delete process.env.AGENCY_FAKE_CLOCK;
+    else process.env.AGENCY_FAKE_CLOCK = saved;
+  });
+
+  it("defaults to the real clock", () => {
+    delete process.env.AGENCY_FAKE_CLOCK;
+    expect(makeCtx().clock).toBe(realClock);
+  });
+
+  it("installs a FakeClock when AGENCY_FAKE_CLOCK is set", () => {
+    process.env.AGENCY_FAKE_CLOCK = "1";
+    expect(makeCtx().clock).toBeInstanceOf(FakeClock);
+  });
+
+  it("an explicit clock arg wins over the env var", () => {
+    process.env.AGENCY_FAKE_CLOCK = "1";
+    const explicit = new FakeClock();
+    expect(makeCtx(explicit).clock).toBe(explicit);
+  });
+});

--- a/packages/agency-lang/lib/runtime/state/context.clock.test.ts
+++ b/packages/agency-lang/lib/runtime/state/context.clock.test.ts
@@ -38,4 +38,14 @@ describe("RuntimeContext.clock", () => {
     const explicit = new FakeClock();
     expect(makeCtx(explicit).clock).toBe(explicit);
   });
+
+  it("createExecutionContext inherits the clock (it bypasses the constructor)", async () => {
+    // Regression: the execution context is built via Object.create, not the
+    // constructor, so it must copy clock explicitly. Without this the run
+    // meters against `undefined` and _advanceTime never sees the FakeClock.
+    const clock = new FakeClock();
+    const ctx = makeCtx(clock);
+    const execCtx = await ctx.createExecutionContext("r1");
+    expect(execCtx.clock).toBe(clock);
+  });
 });

--- a/packages/agency-lang/lib/runtime/state/context.ts
+++ b/packages/agency-lang/lib/runtime/state/context.ts
@@ -77,7 +77,9 @@ function reviveNative<T>(data: T): T {
  *  AGENCY_FAKE_CLOCK env var, otherwise the real clock. The env var is set by
  *  the test runner per test case (see lib/cli/util.ts). */
 function defaultClock(): Clock {
-  return process.env.AGENCY_FAKE_CLOCK ? new FakeClock() : realClock;
+  // Require exactly "1", not any truthy string. AGENCY_FAKE_CLOCK=0 must
+  // disable, not enable — a non-empty "0" is truthy and would surprise.
+  return process.env.AGENCY_FAKE_CLOCK === "1" ? new FakeClock() : realClock;
 }
 
 /* bunch of stuff that every node/function in the runtime needs access to,
@@ -92,7 +94,15 @@ export class RuntimeContext<T> {
   onStreamLock: boolean;
   handlers: HandlerEntry[];
   /** The time source for guards. Real by default; a FakeClock only when a
-   *  test opts in. NOT serialized — reconstructed per run, like handlers. */
+   *  test opts in. NOT serialized — reconstructed per run, like handlers.
+   *
+   *  DRIFT WARNING: this and the other non-serialized runtime fields
+   *  (handlers, callbacks, checkpoints, locks, …) are set by the constructor
+   *  AND, separately, by `createExecutionContext`, which builds the execution
+   *  context via `Object.create` and copies fields by hand. A field added
+   *  here but forgotten there is silently `undefined` at run time with no
+   *  compile error — that is the bug the `clock` copy fixed. If you add a
+   *  non-serialized field, copy it in `createExecutionContext` too. */
   clock: Clock;
   locks: Record<string, Promise<void>>;
   lockOwners: Record<string, string>;

--- a/packages/agency-lang/lib/runtime/state/context.ts
+++ b/packages/agency-lang/lib/runtime/state/context.ts
@@ -8,6 +8,7 @@ import { nativeTypeReplacer, nativeTypeReviver } from "../revivers/index.js";
 import { CoverageCollector } from "../coverageCollector.js";
 import { AgencyCancelledError, makeAbortCause } from "../errors.js";
 import type { AbortCause } from "../errors.js";
+import { Clock, realClock, FakeClock } from "../clock.js";
 import { agencyStore } from "../asyncContext.js";
 import { DEFAULT_MAX_CALL_DEPTH } from "../callDepth.js";
 import { getSubprocessRunInfo } from "../subprocessRunInfo.js";
@@ -72,6 +73,13 @@ function reviveNative<T>(data: T): T {
   );
 }
 
+/** The default clock for a run: a FakeClock only when a test opts in via the
+ *  AGENCY_FAKE_CLOCK env var, otherwise the real clock. The env var is set by
+ *  the test runner per test case (see lib/cli/util.ts). */
+function defaultClock(): Clock {
+  return process.env.AGENCY_FAKE_CLOCK ? new FakeClock() : realClock;
+}
+
 /* bunch of stuff that every node/function in the runtime needs access to,
 that we don't want to pass as individual arguments everywhere */
 export class RuntimeContext<T> {
@@ -83,6 +91,9 @@ export class RuntimeContext<T> {
   callbacks: AgencyCallbacks;
   onStreamLock: boolean;
   handlers: HandlerEntry[];
+  /** The time source for guards. Real by default; a FakeClock only when a
+   *  test opts in. NOT serialized — reconstructed per run, like handlers. */
+  clock: Clock;
   locks: Record<string, Promise<void>>;
   lockOwners: Record<string, string>;
   lockWaiters: Record<string, string[]>;
@@ -221,6 +232,9 @@ export class RuntimeContext<T> {
      *  test/runtime constructors keep working; defaults to "info" to
      *  match the established no-debug-by-default behavior. */
     logLevel?: LogLevel;
+    /** Test-only override. Omitted in production, where defaultClock()
+     *  (the env var or the realClock default) applies. */
+    clock?: Clock;
   }) {
     // One runtime merge, applied for BOTH transports so a subprocess launched
     // with explicit IPC overrides still inherits the env override (e.g. a
@@ -232,6 +246,7 @@ export class RuntimeContext<T> {
       args,
       getRuntimeConfigOverrides(),
     );
+    this.clock = args.clock ?? defaultClock();
     const statelogConfig = {
       ...args.statelogConfig,
       traceId: args.statelogConfig.traceId || nanoid(),

--- a/packages/agency-lang/lib/runtime/state/context.ts
+++ b/packages/agency-lang/lib/runtime/state/context.ts
@@ -351,6 +351,11 @@ export class RuntimeContext<T> {
     execCtx.maxCallDepth = this.maxCallDepth;
     execCtx.failurePropagation = this.failurePropagation;
     execCtx.checkpoints = new CheckpointStore(this.maxRestores);
+    // The execution context is built via Object.create, bypassing the
+    // constructor, so carry the clock over from the global context. Without
+    // this the run would meter against `undefined` and the fake-clock seam
+    // (_advanceTime) would never see the FakeClock the constructor installed.
+    execCtx.clock = this.clock;
     execCtx.handlers = [];
     execCtx.callbacks = {};
     execCtx.topLevelCallbacks = [];

--- a/packages/agency-lang/lib/stdlib/builtins.clock.test.ts
+++ b/packages/agency-lang/lib/stdlib/builtins.clock.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { _advanceTimeImpl } from "./builtins.js";
+import { RuntimeContext } from "../runtime/state/context.js";
+import { FakeClock, type Clock } from "../runtime/clock.js";
+import { runInTestContext } from "../runtime/asyncContext.js";
+import { ThreadStore } from "../runtime/state/threadStore.js";
+
+function makeCtx(clock?: Clock): RuntimeContext<any> {
+  return new RuntimeContext({
+    statelogConfig: {
+      host: "https://example.com",
+      apiKey: "test-api-key",
+      projectId: "test-project",
+      debugMode: false,
+    },
+    smoltalkDefaults: { model: "default-model" },
+    dirname: "/tmp",
+    clock,
+  });
+}
+
+describe("_advanceTimeImpl", () => {
+  it("advances the run's FakeClock", () => {
+    const clock = new FakeClock();
+    const ctx = makeCtx(clock);
+    runInTestContext(ctx, ctx.stateStack, new ThreadStore(), () => {
+      _advanceTimeImpl(250);
+      expect(clock.now()).toBe(250);
+    });
+  });
+
+  it("throws a clear error when the clock is not fake", () => {
+    const ctx = makeCtx(); // real clock
+    runInTestContext(ctx, ctx.stateStack, new ThreadStore(), () => {
+      expect(() => _advanceTimeImpl(250)).toThrow(/fake clock/i);
+    });
+  });
+});

--- a/packages/agency-lang/lib/stdlib/builtins.ts
+++ b/packages/agency-lang/lib/stdlib/builtins.ts
@@ -9,6 +9,7 @@ import { detectPlatform } from "./utils.js";
 import { resolvePath } from "./resolvePath.js";
 import { AgencyCancelledError } from "../runtime/errors.js";
 import { getRuntimeContext } from "../runtime/asyncContext.js";
+import { FakeClock } from "../runtime/clock.js";
 import type { RuntimeContext } from "../runtime/state/context.js";
 import type { StateStack } from "../runtime/state/stateStack.js";
 import type { ThreadStore } from "../runtime/state/threadStore.js";
@@ -134,6 +135,27 @@ export function _installSlowInputImpl(delayMs: number, answer: string): void {
   const { ctx } = getRuntimeContext();
   ctx.inputOverride = (_prompt: string) =>
     new Promise<string>((resolve) => setTimeout(() => resolve(answer), delayMs));
+}
+
+/** Test-only: advance the run's fake clock by `ms`, firing any guard timer
+ *  that comes due. Exposed to fixtures as the non-exported `_advanceTime`
+ *  def in `stdlib/date.agency` (test imports only). Throws if the run holds
+ *  the real clock, so a stray call outside a fake-clock test fails loudly
+ *  rather than doing nothing.
+ *
+ *  `advance` lives on FakeClock only, not on the Clock type, so this branches
+ *  on the concrete type. That is a deliberate trade: putting a test-only
+ *  `advance` verb on the production Clock interface would be worse. The
+ *  instanceof is confined to this one test-only helper and never runs on a
+ *  production path. */
+export function _advanceTimeImpl(ms: number): void {
+  const { ctx } = getRuntimeContext();
+  if (!(ctx.clock instanceof FakeClock)) {
+    throw new Error(
+      '_advanceTime() needs a fake clock. Set "fakeClock": true on this test case.',
+    );
+  }
+  ctx.clock.advance(ms);
 }
 
 /** ALS-reading replacement. Same body as `__internal_input`. */

--- a/packages/agency-lang/stdlib/date.agency
+++ b/packages/agency-lang/stdlib/date.agency
@@ -1,4 +1,5 @@
 import { _now, _today, _tomorrow, _add, _addMinutes, _addHours, _addDays, _nextDayOfWeek, _atTime, _startOfDay, _endOfDay, _startOfWeek, _endOfWeek, _startOfMonth, _endOfMonth } from "agency-lang/stdlib-lib/date.js"
+import { _advanceTimeImpl } from "agency-lang/stdlib-lib/builtins.js"
 
 /** @module
 @summary Builds timezone-aware ISO 8601 date strings, the format that APIs like Google Calendar expect.
@@ -31,6 +32,19 @@ export def now(timezone: string = ""): string {
   @param timezone - IANA timezone name like "America/New_York" (defaults to the local timezone)
   """
   return _now(timezone)
+}
+
+/** Test-only seam (import test { _advanceTime }): advance the fake clock so a
+time guard trips without spending real time. Only works under a test case with
+"fakeClock": true; throws otherwise. */
+def _advanceTime(ms: number) {
+  """
+  Test-only: move the fake clock forward `ms` milliseconds, tripping any time
+  guard whose budget is now exceeded.
+
+  @param ms - How many milliseconds of fake time to advance.
+  """
+  _advanceTimeImpl(ms)
 }
 
 /** Get today's date as a YYYY-MM-DD string. */

--- a/packages/agency-lang/tests/agency/guards/fake-clock-trip.agency
+++ b/packages/agency-lang/tests/agency/guards/fake-clock-trip.agency
@@ -30,8 +30,12 @@ node doesNotTripUnderBudget(): string {
 }
 
 // The opt-out: a test case WITHOUT "fakeClock" keeps the real clock, and
-// _advanceTime refuses loudly instead of silently doing nothing. Capture its
-// own result — the refusal is a Failure carrying the "fake clock" message.
+// _advanceTime refuses loudly instead of silently doing nothing. There is no
+// guard/handler here (unlike the trip node above): _advanceTimeImpl throws a
+// plain Error, and this relies on failure propagation converting that non-abort
+// throw into a Failure whose `.error` is the message. That conversion is the
+// contract under test — if it ever changed shape, this safety check would need
+// to change with it.
 node advanceWithoutFakeClockErrors(): string {
   const res = _advanceTime(10)
   if (isFailure(res)) { return res.error }

--- a/packages/agency-lang/tests/agency/guards/fake-clock-trip.agency
+++ b/packages/agency-lang/tests/agency/guards/fake-clock-trip.agency
@@ -1,0 +1,39 @@
+import test { _advanceTime } from "std::date"
+
+// The fake clock trips a time guard deterministically: _advanceTime moves the
+// clock past the 100ms budget, the guard trips, and the in-program handler
+// rejects it so the block returns a Failure. No real time is spent.
+node tripsOnFakeAdvance(): string {
+  handle {
+    const r = guard(time: 100ms) {
+      _advanceTime(200)
+      return "never reached"
+    }
+    if (isFailure(r)) { return "tripped" }
+    return r.value
+  } with (i) {
+    return match(i.effect) {
+      "std::guard" => reject()
+      _ => pass()
+    }
+  }
+}
+
+// Advancing under the budget does not trip: the block finishes normally.
+node doesNotTripUnderBudget(): string {
+  const r = guard(time: 100ms) {
+    _advanceTime(50)
+    return "finished"
+  }
+  if (isFailure(r)) { return "tripped" }
+  return r.value
+}
+
+// The opt-out: a test case WITHOUT "fakeClock" keeps the real clock, and
+// _advanceTime refuses loudly instead of silently doing nothing. Capture its
+// own result — the refusal is a Failure carrying the "fake clock" message.
+node advanceWithoutFakeClockErrors(): string {
+  const res = _advanceTime(10)
+  if (isFailure(res)) { return res.error }
+  return "no-error"
+}

--- a/packages/agency-lang/tests/agency/guards/fake-clock-trip.test.json
+++ b/packages/agency-lang/tests/agency/guards/fake-clock-trip.test.json
@@ -1,0 +1,36 @@
+{
+  "tests": [
+    {
+      "nodeName": "tripsOnFakeAdvance",
+      "fakeClock": true,
+      "input": "",
+      "expectedOutput": "\"tripped\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "doesNotTripUnderBudget",
+      "fakeClock": true,
+      "input": "",
+      "expectedOutput": "\"finished\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "advanceWithoutFakeClockErrors",
+      "input": "",
+      "expectedOutput": "\"_advanceTime() needs a fake clock. Set \\\"fakeClock\\\": true on this test case.\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/supervise/supervise.agency
+++ b/packages/agency-lang/tests/agency/supervise/supervise.agency
@@ -1,5 +1,6 @@
 import { supervise, SuperviseDecision } from "std::supervise"
 import { getThread, currentThreadId } from "std::thread"
+import test { _advanceTime } from "std::date"
 
 const checks = []
 
@@ -118,19 +119,21 @@ let slowChecks = 0
 def slowCheck(elapsed: number, draft: any): SuperviseDecision {
   checks.push("checked")
   slowChecks = slowChecks + 1
-  // Only the first one is slow. One is enough to push the block well past
-  // the limit it tripped on, and spinning on every trip would make the test
-  // take minutes.
+  // Only the first check overshoots. One is enough to push the block well past
+  // the limit it tripped on. With the fake clock, advancing 500ms against the
+  // 100ms interval makes the overshoot (400ms) exactly what the grant must
+  // cover — deterministic, where the old spin(3000000) was a load-dependent
+  // race.
   if (slowChecks == 1) {
-    spin(3000000)
+    _advanceTime(500)
   }
   return { action: "continue", message: "" }
 }
 
 node overshootIsCoveredByTheGrant(): string {
-  const r = supervise(every: 1ms, maxTime: 600000, check: slowCheck) {
-    const s = spin(3000000)
-    return "done:${s}"
+  const r = supervise(every: 100ms, maxTime: 600000, check: slowCheck) {
+    _advanceTime(500)
+    return "done:spun"
   }
   if (isFailure(r)) {
     return "failed:${r.error}"
@@ -152,8 +155,8 @@ def recordDraft(elapsed: number, draft: any): SuperviseDecision {
 node checkSeesDraft(): string {
   const r = supervise(every: 100ms, maxTime: 600000, check: recordDraft) {
     saveDraft("partial")
-    const s = spin(3000000)
-    return "done:${s}"
+    _advanceTime(500)
+    return "done:spun"
   }
   if (isFailure(r)) { return "unexpected-failure" }
   return "${r.value}|firstDraft:${draftsSeen[0] ?? "none"}"

--- a/packages/agency-lang/tests/agency/supervise/supervise.test.json
+++ b/packages/agency-lang/tests/agency/supervise/supervise.test.json
@@ -74,7 +74,8 @@
         {
           "type": "exact"
         }
-      ]
+      ],
+      "fakeClock": true
     },
     {
       "nodeName": "checkSeesDraft",
@@ -85,7 +86,8 @@
         {
           "type": "exact"
         }
-      ]
+      ],
+      "fakeClock": true
     },
     {
       "nodeName": "nestedSuperviseIsolated",


### PR DESCRIPTION
## What and why

Time-guard test fixtures burned real CPU in `spin()` busy-loops to run down a guard's clock. That made them slow and machine-dependent: one node, `overshootIsCoveredByTheGrant`, spent ~70s (a quarter of the Agency suite's recent CI growth), and the tuning could silently stop catching its bug on faster hardware. Closes #575.

This adds a fake clock a fixture opts into, then advances with a function call instead of spinning. The guard trips because its clock moved, not because real time passed.

## The seam

- **`lib/runtime/clock.ts`** (new) — a `Clock` type (`now`, `wallTime`, `setTimer`, `clearTimer`), the `realClock` default delegating to the globals, and `FakeClock` with `advance(ms)`.
- **`RuntimeContext`** carries a `clock`, set from a test-only constructor arg, else `AGENCY_FAKE_CLOCK`, else `realClock`. Not serialized.
- **`TimeGuard`** routes its six `performance.now()` reads and its `setTimeout`/`clearTimeout` through a `clock()` helper that reads the run's clock via the canonical `__ctx()` accessor, falling back to `realClock` when frameless (a checkpoint-revived guard).
- **`_advanceTime`** — a test-only seam in `std::date`, non-exported, reached via `import test`, following the existing `_installSlowInput` precedent. It throws if the clock is not fake, so a stray call fails loudly.
- **`fakeClock: true`** on a `.test.json` test case sets `AGENCY_FAKE_CLOCK=1` for that subprocess.

The `Clock` type carries `wallTime()` (unused here) so issue #609's `elapsedTime`/`now` reads can reuse the seam without widening it.

## A real bug found during execution

`createExecutionContext` builds the *execution* context via `Object.create(RuntimeContext.prototype)`, bypassing the constructor — so it never copied `clock`, and the run metered against `undefined`. The execution context now inherits the global context's clock, with a regression test. This was not anticipated by the plan; it surfaced because the e2e fixture failed and I traced it.

## Results

`overshootIsCoveredByTheGrant`: ~70s to ~0.7s. The whole `supervise.agency` file: ~76s to ~13s. Critically, the migrated node **still catches the `grant = nextInterval` regression** — verified against a deliberately reverted build, it fails with the guard-approval error in 0.78s instead of 70s.

Only the two `spin(3000000)` nodes in `supervise.agency` were migrated (the CI cost). `fakeClock` is per test case, so the file's cheap `spin(300000)` nodes keep the real clock untouched. The other spin fixtures (`nestedGuardResume`, `trip-time`, `trip-join`) are deliberately left on the real clock — each needs its own interleaving trace and none is a CI-time problem. `trip-join` in particular drives guards through `runBatch` fork/race branches whose working-time reads real time, which this seam does not route; the audit (committed as `docs/.../fake-clock-migration-list.md`) records the reasoning.

## Verification

- New unit tests: `clock.test.ts` (10, incl. re-entrancy and boundary), `context.clock.test.ts` (incl. the `createExecutionContext` regression), `guard.clock.test.ts` (asserts `spent`, not just non-null, so an unrouted read fails it; plus a nested two-guard case), `builtins.clock.test.ts`.
- Existing `guard.test.ts` (47 tests) passes unchanged — it runs frameless, proving the `realClock` fallback.
- Broad sweep: 3122 unit tests across `lib/runtime`, `lib/cli`, `lib/stdlib` pass. `tsc --noEmit` and `lint:structure` clean.
- The e2e fixture proves the seam three ways: deterministic trip, no-trip-under-budget, and the opt-out (no `fakeClock` makes `_advanceTime` refuse with the specific message).

Spec, plan, and both review docs are included under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
