### PR TITLE
In-handler guard trips reject instead of pausing; loss-proof handler mark on StateStack (#616)

### DIFF
--- a/packages/agency-lang/docs/dev/checkpointing.md
+++ b/packages/agency-lang/docs/dev/checkpointing.md
@@ -235,3 +235,21 @@ node main() {
 
 - **Unit tests**: `lib/runtime/checkpoint.test.ts`, `lib/runtime/state/checkpointStore.test.ts`
 - **Generator fixture**: `tests/typescriptGenerator/checkpoint-restore.agency` + `.mjs`
+
+---
+
+## Checkpoints and executing handlers (issue #616)
+
+Not every checkpoint is a pause: guard scopes create pinned checkpoints
+during normal execution, including inside handler functions. But the
+interrupt-pause kind — where the run exits and hands a checkpoint to
+the user — must never capture a stack with a handler mid-flight,
+because handlers have no step address to resume into. The four
+interrupt-pause creation sites (`raiseGuardTripsAtStep`, the TS-raise
+surface path in `agencyInterrupt.ts`, the prompt-step bailout in
+`promptRunner.ts`, and the shared batch checkpoint in `runBatch.ts`)
+each call `StateStack.assertNoExecutingHandlers()` first. The list it
+checks is maintained by the interrupt dispatcher, is inherited by
+branch stacks, and is deliberately never serialized: since no pause can
+exist while it is non-empty, a deserialized stack correctly starts with
+it empty.

--- a/packages/agency-lang/docs/dev/interrupts.md
+++ b/packages/agency-lang/docs/dev/interrupts.md
@@ -537,3 +537,24 @@ runtime.
   `grantedMs` and propagates up nested joins one at a time. Grants
   never cross budgets (decision 16): only clones sharing the parent's
   guardId are read.
+
+## No pause inside handlers (issue #616)
+
+Handler functions compile to plain callbacks with no step counters, so
+there is no step address inside a handler for a resume to replay back
+to. That makes one rule absolute: an interrupt-pause checkpoint must
+never capture a moment when a handler is mid-flight, because that
+checkpoint could never be resumed. The enforcement has two carriers.
+`StateStack.executingHandlerEntries` is the loss-proof one: the
+dispatcher mirrors each executing handler entry onto the raising
+branch's stack, branch stacks inherit a snapshot of it through
+`runBatch`, and the guard-trip machinery refuses to surface (it throws
+the original trip error instead) while the list is non-empty. Every
+interrupt-pause checkpoint site calls
+`stack.assertNoExecutingHandlers()`, which walks the branch subtree and
+fails loudly if the impossible happens. The `executingHandlers.ts`
+AsyncLocalStorage remains, but only for what the stack cannot express:
+per-lineage precision, so self-exclusion and the `renderVerdict`
+refusal can tell a handler's OWN raises apart from concurrent sibling
+dispatches on the same branch. The design rationale lives in
+`docs/superpowers/specs/2026-07-19-issue-616-no-pause-inside-handlers-design.md`.

--- a/packages/agency-lang/docs/site/guide/handlers.md
+++ b/packages/agency-lang/docs/site/guide/handlers.md
@@ -214,7 +214,7 @@ Why this is safe: a skipped handler contributes nothing — not an approve — s
 
 Three caveats:
 
-1. **A raise nothing settles cannot ask the user.** Handler functions cannot pause, so where ordinary code would propagate to you for a decision, a handler's raise is rejected with an explanatory message. In practice: if your outer handlers propagate an effect, a handler raising that effect gets a failure Result, not a prompt.
+1. **A raise nothing settles cannot ask the user.** Handler functions cannot pause, so where ordinary code would propagate to you for a decision, a handler's raise is rejected with an explanatory message. This covers guard trips too: a `guard` block inside a handler whose trip no outer handler answers fails with the trip error instead of pausing. In practice: if your outer handlers propagate an effect, a handler raising that effect gets a failure Result, not a prompt.
 2. **Propagation beats approval.** If an outer handler propagates the effect, even a `with approve` inside the handler does not save the raise — it is rejected as in caveat 1.
 3. **The skip is per activation, not per source handler.** A recursive function containing a handle block registers one handler entry per activation, and only the executing activation is skipped. Sibling activations still hear the raise; the chain-depth limit backstops that shape.
 

--- a/packages/agency-lang/docs/site/guide/handlers.md
+++ b/packages/agency-lang/docs/site/guide/handlers.md
@@ -214,7 +214,7 @@ Why this is safe: a skipped handler contributes nothing — not an approve — s
 
 Three caveats:
 
-1. **A raise nothing settles cannot ask the user.** Handler functions cannot pause, so where ordinary code would propagate to you for a decision, a handler's raise is rejected with an explanatory message. This covers guard trips too: a `guard` block inside a handler whose trip no outer handler answers fails with the trip error instead of pausing. In practice: if your outer handlers propagate an effect, a handler raising that effect gets a failure Result, not a prompt.
+1. **A raise nothing settles cannot ask the user.** Handler functions cannot pause, so where ordinary code would propagate to you for a decision, a handler's raise is rejected with an explanatory message. In practice: if your outer handlers propagate an effect, a handler raising that effect gets a failure Result, not a prompt.
 2. **Propagation beats approval.** If an outer handler propagates the effect, even a `with approve` inside the handler does not save the raise — it is rejected as in caveat 1.
 3. **The skip is per activation, not per source handler.** A recursive function containing a handle block registers one handler entry per activation, and only the executing activation is skipped. Sibling activations still hear the raise; the chain-depth limit backstops that shape.
 

--- a/packages/agency-lang/lib/runtime/agencyInterrupt.ts
+++ b/packages/agency-lang/lib/runtime/agencyInterrupt.ts
@@ -186,6 +186,7 @@ export async function interrupt<T = unknown>(
   // resume, the replay sees the id and short-circuits via the lookup
   // above.
   frame.locals[key] = intr.interruptId;
+  stack.assertNoExecutingHandlers();
   const checkpointId = ctx.checkpoints.create(stack, ctx, {
     moduleId: callsite.moduleId,
     scopeName: callsite.scopeName,

--- a/packages/agency-lang/lib/runtime/effectMerge.test.ts
+++ b/packages/agency-lang/lib/runtime/effectMerge.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { mergeFor, mergeForIpc } from "./effectMerge.js";
 import { interruptWithHandlers, mergeChainOutcomes, pass } from "./interrupts.js";
 import { RuntimeContext } from "./state/context.js";
+import { StateStack } from "./state/stateStack.js";
 
 describe("mergeFor — the table is total", () => {
   it("an unregistered effect keeps the historical overwrite, including a valueless outer clobbering an inner value", () => {
@@ -62,7 +63,7 @@ describe("the chain merges approvals through the effect table", () => {
       async () => ({ type: "approve", value: { maxCost: 0.5, message: "outer says go" } }),
       async () => ({ type: "approve", value: { maxCost: 0.5 } }),
     ]);
-    const verdict = await interruptWithHandlers("std::guard", "m", {}, "o", ctx);
+    const verdict = await interruptWithHandlers("std::guard", "m", {}, "o", ctx, new StateStack());
     expect(verdict).toEqual({
       type: "approve",
       value: {
@@ -79,7 +80,7 @@ describe("the chain merges approvals through the effect table", () => {
       async () => ({ type: "approve", value: undefined }),
       async () => ({ type: "approve", value: 42 }),
     ]);
-    const verdict = await interruptWithHandlers("std::bash", "m", {}, "o", ctx);
+    const verdict = await interruptWithHandlers("std::bash", "m", {}, "o", ctx, new StateStack());
     expect(verdict).toEqual({ type: "approve", value: undefined });
   });
 
@@ -90,7 +91,7 @@ describe("the chain merges approvals through the effect table", () => {
       async () => ({ type: "approve", value: { maxCost: 0.75 } }),
     ]);
     const verdict = (await interruptWithHandlers(
-      "std::guard", "m", {}, "o", ctx,
+      "std::guard", "m", {}, "o", ctx, new StateStack(),
     )) as any;
     expect(verdict.value.maxCost).toBe(1.0);
   });

--- a/packages/agency-lang/lib/runtime/executingHandlers.ts
+++ b/packages/agency-lang/lib/runtime/executingHandlers.ts
@@ -22,10 +22,16 @@ import type { HandlerEntry } from "./types.js";
  * activation is skipped. Sibling activations of the same source handler
  * still hear the raise; MAX_HANDLER_CHAIN_DEPTH backstops that shape.
  *
- * This state never needs checkpointing. Checkpoints capture a paused run,
- * and no interrupt raised inside a handler ever surfaces to pause one
- * (renderVerdict refuses those as rejections), so a checkpoint can never
- * observe this stack non-empty on the paused lineage.
+ * This ALS is NOT what keeps pauses out of handlers, and it is never
+ * checkpointed. The pause guarantee lives on the stack instead:
+ * runHandlerChain mirrors each executing entry into
+ * `StateStack.executingHandlerEntries`, the guard-trip machinery refuses
+ * to surface while that list is non-empty, and every interrupt-pause
+ * checkpoint site asserts it empty (issue #616). The ALS carries only
+ * the per-lineage precision that the stack mark cannot: which raises
+ * are a handler's OWN. If this ALS ever loses a read, exclusion can
+ * misfire (bounded by MAX_HANDLER_CHAIN_DEPTH) — but the run still
+ * cannot pause mid-handler, because the pause refusals read the stack.
  */
 const executingHandlersALS = new AsyncLocalStorage<HandlerEntry[]>();
 

--- a/packages/agency-lang/lib/runtime/guardTripInterrupt.inHandler.test.ts
+++ b/packages/agency-lang/lib/runtime/guardTripInterrupt.inHandler.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { TimeGuard, GuardExceededError } from "./guard.js";
+import { raiseGuardTripsUntilClear } from "./guardTripInterrupt.js";
+import { RuntimeContext } from "./state/context.js";
+import { StateStack } from "./state/stateStack.js";
+import type { HandlerEntry } from "./types.js";
+
+const makeCtx = (): RuntimeContext<any> => {
+  const ctx = new RuntimeContext({
+    statelogConfig: { host: "", apiKey: "", projectId: "", debugMode: false, observability: false },
+    smoltalkDefaults: {},
+    dirname: process.cwd(),
+  });
+  ctx.runId = "test-run";
+  return ctx;
+};
+
+const entry = (): HandlerEntry => ({ fn: async () => undefined, liveGuardIds: [] });
+
+/** A tripped single-member time scope on a marked stack, plus its error —
+ *  the state a guard gate sees when a 5ms guard inside a handler is blown. */
+function arrangeTrippedInHandler() {
+  const ctx = makeCtx();
+  const stack = new StateStack();
+  const time = new TimeGuard(5);
+  stack.pushGuard(time);
+  time.scopeIds = [time.guardId];
+  const err = new GuardExceededError("time", 5, 12, time.guardId, "in-handler");
+  stack.executingHandlerEntries.push(entry());
+  return { ctx, stack, time, err };
+}
+
+const guardTripKeys = (stack: StateStack): string[] =>
+  Object.keys(stack.other).filter((k) => k.startsWith("__guardTrip_"));
+
+describe("in-handler guard trips refuse to surface", () => {
+  it("persisted open question: throws the trip error instead of re-surfacing", async () => {
+    const { ctx, stack, time, err } = arrangeTrippedInHandler();
+    const key = `__guardTrip_${time.guardId}#time@${time.currentLimit()}`;
+    stack.other[key] = "stale-interrupt-id"; // open question, no recorded answer
+    await expect(
+      raiseGuardTripsUntilClear(ctx, stack, () => err),
+    ).rejects.toBe(err);
+    expect(guardTripKeys(stack)).toEqual([]); // stale key dropped, nothing new persisted
+  });
+
+  it("unanswered dispatch: throws the trip error, persists nothing, checkpoints nothing", async () => {
+    const { ctx, stack, err } = arrangeTrippedInHandler();
+    ctx.handlers = []; // nobody can answer
+    // The stack is marked but there is deliberately no ALS scope: this is
+    // the lost-ALS shape from the issue-616 investigation. The stack-read
+    // refusal must hold on its own.
+    await expect(
+      raiseGuardTripsUntilClear(ctx, stack, () => err),
+    ).rejects.toBe(err);
+    expect(guardTripKeys(stack)).toEqual([]);
+    expect(ctx.checkpoints.getSorted()).toEqual([]);
+  });
+});

--- a/packages/agency-lang/lib/runtime/guardTripInterrupt.ts
+++ b/packages/agency-lang/lib/runtime/guardTripInterrupt.ts
@@ -83,6 +83,10 @@ async function raiseOneTrip(
 ): Promise<Interrupt[] | undefined> {
   const scope = GuardScope.resolve(stack, tripped)!;
   const key = guardTripKey(tripped);
+  // Reads the STACK mark, not the executing-handlers ALS: the pause
+  // refusals must survive the ALS coming up empty (issue #616), and the
+  // stack is reachable here as a plain parameter.
+  const inHandler = stack.executingHandlerEntries.length > 0;
 
   // Resume path FIRST: an answered question must never re-ask. The key
   // is derived from guard state (see guardTripKey), so a replay of THIS
@@ -95,6 +99,15 @@ async function raiseOneTrip(
       delete stack.other[key];
       applyVerdict(recorded, scope, tripped, err, stack);
       return undefined;
+    }
+    // A persisted open question must not re-surface from inside a
+    // handler: re-surfacing pauses, and a handler cannot pause. The
+    // trip stands as a rejection; the guard boundary converts it. The
+    // stale key is dropped so a later out-of-handler replay does not
+    // resurrect a question whose trip already resolved as a rejection.
+    if (inHandler) {
+      delete stack.other[key];
+      throw err;
     }
     // The question is already OPEN (persisted, no answer yet — e.g. a
     // resume triggered by answering a DIFFERENT interrupt in the same
@@ -150,6 +163,14 @@ async function raiseOneTrip(
       // then hand the batch to the PromptRunner step for its snapshot +
       // checkpoint + bailout machinery.
       const interrupts = verdict as Interrupt[];
+      // Inside a handler, renderVerdict already refuses unanswered
+      // raises when its ALS is intact — this stack-read check is the
+      // one that holds when the ALS is not. Reaching it means a pause
+      // was about to be persisted from inside a handler; fail as the
+      // rejection it must be, never as serialized state.
+      if (inHandler) {
+        throw err;
+      }
       stack.other[key] = interrupts[0].interruptId;
       return interrupts;
     } finally {
@@ -319,6 +340,7 @@ export async function raiseGuardTripsAtStep(args: {
   // at this step so the resumed replay re-enters HERE, re-detects, and
   // applies the recorded answer before the step body ever runs — which
   // is what makes this raise point replay-safe by construction.
+  stack.assertNoExecutingHandlers();
   const checkpointId = ctx.checkpoints.create(stack, ctx, args.location);
   const checkpoint = ctx.checkpoints.get(checkpointId);
   outcome.forEach((intr) => {

--- a/packages/agency-lang/lib/runtime/interrupts.executingHandlers.test.ts
+++ b/packages/agency-lang/lib/runtime/interrupts.executingHandlers.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest";
+import { interruptWithHandlers, isRejected } from "./interrupts.js";
+import { RuntimeContext } from "./state/context.js";
+import { StateStack } from "./state/stateStack.js";
+import type { HandlerEntry } from "./types.js";
+
+const makeCtx = (): RuntimeContext<any> =>
+  new RuntimeContext({
+    statelogConfig: { host: "", apiKey: "", projectId: "", debugMode: false, observability: false },
+    smoltalkDefaults: {},
+    dirname: process.cwd(),
+  });
+
+describe("stack-carried handler execution mark", () => {
+  it("throws when handlers are registered but no stack is passed", async () => {
+    const ctx = makeCtx();
+    ctx.handlers = [{ fn: async () => ({ type: "approve" }), liveGuardIds: [] }];
+    await expect(
+      interruptWithHandlers("std::x", "m", {}, "o", ctx, undefined),
+    ).rejects.toThrow(/no StateStack/);
+  });
+
+  it("marks the stack for the duration of a handler body", async () => {
+    const ctx = makeCtx();
+    const stack = new StateStack();
+    let seenDuring = -1;
+    ctx.handlers = [
+      {
+        fn: async () => {
+          seenDuring = stack.executingHandlerEntries.length;
+          return { type: "approve" };
+        },
+        liveGuardIds: [],
+      },
+    ];
+    await interruptWithHandlers("std::x", "m", {}, "o", ctx, stack);
+    expect(seenDuring).toBe(1);
+    expect(stack.executingHandlerEntries).toEqual([]);
+  });
+
+  it("a handler never hears a raise made from its own body (exclusion via the stack)", async () => {
+    const ctx = makeCtx();
+    const stack = new StateStack();
+    let selfHeard = 0;
+    let outerHeard = 0;
+    const inner: HandlerEntry = {
+      fn: async (intr: any) => {
+        if (intr.effect === "inner::raise") {
+          selfHeard++;
+          return { type: "approve" };
+        }
+        const verdict = await interruptWithHandlers("inner::raise", "m", {}, "o", ctx, stack);
+        return { type: "approve", value: verdict };
+      },
+      liveGuardIds: [],
+    };
+    const outer: HandlerEntry = {
+      fn: async (intr: any) => {
+        if (intr.effect === "inner::raise") outerHeard++;
+        return { type: "approve" };
+      },
+      liveGuardIds: [],
+    };
+    ctx.handlers = [outer, inner]; // chain walks last-registered first, so `inner` runs first
+    await interruptWithHandlers("kickoff", "m", {}, "o", ctx, stack);
+    expect(selfHeard).toBe(0);
+    expect(outerHeard).toBe(1);
+  });
+
+  it("an unanswered raise from inside a handler is refused as a rejection", async () => {
+    const ctx = makeCtx();
+    const stack = new StateStack();
+    let refusal: any = null;
+    ctx.handlers = [
+      {
+        fn: async (intr: any) => {
+          if (intr.effect === "kickoff") {
+            refusal = await interruptWithHandlers("nobody::answers", "m", {}, "o", ctx, stack);
+          }
+          return { type: "approve" };
+        },
+        liveGuardIds: [],
+      },
+    ];
+    await interruptWithHandlers("kickoff", "m", {}, "o", ctx, stack);
+    expect(isRejected(refusal)).toBe(true);
+    expect(refusal.value).toMatch(/inside a handler/);
+  });
+
+  it("handler exit awaits promises the handler launched, while the mark is still set", async () => {
+    const ctx = makeCtx();
+    const stack = new StateStack();
+    let markAtStragglerEnd = -1;
+    ctx.handlers = [
+      {
+        fn: async () => {
+          ctx.pendingPromises.add(
+            (async () => {
+              await new Promise((r) => setTimeout(r, 10));
+              markAtStragglerEnd = stack.executingHandlerEntries.length;
+            })(),
+          );
+          return { type: "approve" }; // handler returns while the straggler still runs
+        },
+        liveGuardIds: [],
+      },
+    ];
+    await interruptWithHandlers("kickoff", "m", {}, "o", ctx, stack);
+    expect(markAtStragglerEnd).toBe(1); // straggler finished BEFORE the pop
+    expect(stack.executingHandlerEntries).toEqual([]);
+  });
+
+  it("handler exit does not await promises launched before the handler began", async () => {
+    const ctx = makeCtx();
+    const stack = new StateStack();
+    let preSettled = false;
+    ctx.pendingPromises.add(
+      new Promise<void>((r) => setTimeout(() => { preSettled = true; r(); }, 30)),
+    );
+    ctx.handlers = [{ fn: async () => ({ type: "approve" }), liveGuardIds: [] }];
+    await interruptWithHandlers("kickoff", "m", {}, "o", ctx, stack);
+    expect(preSettled).toBe(false); // the deadlock-shaped promise was left alone
+  });
+});

--- a/packages/agency-lang/lib/runtime/interrupts.executingHandlers.test.ts
+++ b/packages/agency-lang/lib/runtime/interrupts.executingHandlers.test.ts
@@ -38,7 +38,9 @@ describe("stack-carried handler execution mark", () => {
     expect(stack.executingHandlerEntries).toEqual([]);
   });
 
-  it("a handler never hears a raise made from its own body (exclusion via the stack)", async () => {
+  // Exclusion is decided by the executingHandlers ALS, not the stack
+  // mark; this pins that the carrier work did not disturb it.
+  it("a handler never hears a raise made from its own body", async () => {
     const ctx = makeCtx();
     const stack = new StateStack();
     let selfHeard = 0;

--- a/packages/agency-lang/lib/runtime/interrupts.test.ts
+++ b/packages/agency-lang/lib/runtime/interrupts.test.ts
@@ -9,6 +9,7 @@ import {
   pass,
 } from "./interrupts.js";
 import { RuntimeContext } from "./state/context.js";
+import { StateStack } from "./state/stateStack.js";
 
 describe("interruptWithHandlers resolvedBy attribution (IPC mode)", () => {
   const originalSend = process.send;
@@ -54,7 +55,7 @@ describe("interruptWithHandlers resolvedBy attribution (IPC mode)", () => {
     const ctx = makeCtx([async () => ({ type: "approve", value: "ok" })]);
     const resolved = vi.spyOn(ctx.statelogClient, "interruptResolved");
 
-    const verdict = await interruptWithHandlers("std::bash", "m", {}, "o", ctx);
+    const verdict = await interruptWithHandlers("std::bash", "m", {}, "o", ctx, new StateStack());
     expect(verdict).toEqual({ type: "approve", value: "ok" });
     expect(resolved).toHaveBeenCalledWith(
       expect.objectContaining({ outcome: "approved", resolvedBy: "handler" }),
@@ -67,7 +68,7 @@ describe("interruptWithHandlers resolvedBy attribution (IPC mode)", () => {
     const ctx = makeCtx([]);
     const resolved = vi.spyOn(ctx.statelogClient, "interruptResolved");
 
-    const verdict = await interruptWithHandlers("std::bash", "m", {}, "o", ctx);
+    const verdict = await interruptWithHandlers("std::bash", "m", {}, "o", ctx, new StateStack());
     expect(verdict).toEqual({ type: "approve", value: "parent-ok" });
     expect(resolved).toHaveBeenCalledWith(
       expect.objectContaining({ outcome: "approved", resolvedBy: "ipc" }),
@@ -81,7 +82,7 @@ describe("interruptWithHandlers resolvedBy attribution (IPC mode)", () => {
     const ctx = makeCtx([async () => ({ type: "reject", value: "no" })]);
     const resolved = vi.spyOn(ctx.statelogClient, "interruptResolved");
 
-    const verdict = await interruptWithHandlers("std::bash", "m", {}, "o", ctx);
+    const verdict = await interruptWithHandlers("std::bash", "m", {}, "o", ctx, new StateStack());
     expect(verdict).toEqual({ type: "reject", value: "no" });
     expect(send).not.toHaveBeenCalled();
     expect(resolved).toHaveBeenCalledTimes(1);
@@ -100,7 +101,7 @@ describe("interruptWithHandlers resolvedBy attribution (IPC mode)", () => {
     const { outcome } = await gatherChainOutcome(
       { effect: "std::bash", message: "m", data: {}, origin: "o" },
       ctx,
-      undefined,
+      new StateStack(),
       "child-intr-1",
     );
     expect(outcome).toEqual({ kind: "rejected", value: "no" });
@@ -148,7 +149,7 @@ describe("interruptWithHandlers expectsValue", () => {
       },
     ]);
     const verdict = await interruptWithHandlers(
-      "unknown", "Question for user", {}, "o", ctx, undefined,
+      "unknown", "Question for user", {}, "o", ctx, new StateStack(),
       { expectsValue: true },
     );
     expect(verdict).toEqual({ type: "approve", value: "Adit" });
@@ -308,7 +309,7 @@ describe("pass()", () => {
       async () => ({ type: "approve", value: "outer" }), // outer (walked last)
       async () => pass(),                                // inner (walked first)
     ]);
-    const verdict = await interruptWithHandlers("std::bash", "m", {}, "o", ctx);
+    const verdict = await interruptWithHandlers("std::bash", "m", {}, "o", ctx, new StateStack());
     expect(verdict).toEqual({ type: "approve", value: "outer" });
   });
 
@@ -317,7 +318,7 @@ describe("pass()", () => {
       async () => ({ type: "approve", value: "outer" }),
       async () => undefined,
     ]);
-    const verdict = await interruptWithHandlers("std::bash", "m", {}, "o", ctx);
+    const verdict = await interruptWithHandlers("std::bash", "m", {}, "o", ctx, new StateStack());
     expect(verdict).toEqual({ type: "approve", value: "outer" });
   });
 
@@ -328,14 +329,14 @@ describe("pass()", () => {
       async () => pass(),
     ]);
     const decisions = vi.spyOn(ctx.statelogClient, "handlerDecision");
-    await interruptWithHandlers("std::bash", "m", {}, "o", ctx);
+    await interruptWithHandlers("std::bash", "m", {}, "o", ctx, new StateStack());
     const kinds = decisions.mock.calls.map((c) => c[0].decision);
     expect(kinds).toEqual(["pass", "pass", "approve"]);
   });
 
   it("every handler passing surfaces the interrupt", async () => {
     const ctx = makeCtx([async () => pass(), async () => pass()]);
-    const verdict = await interruptWithHandlers("std::bash", "m", {}, "o", ctx);
+    const verdict = await interruptWithHandlers("std::bash", "m", {}, "o", ctx, new StateStack());
     expect(Array.isArray(verdict)).toBe(true);
     expect((verdict as any)[0].effect).toBe("std::bash");
   });

--- a/packages/agency-lang/lib/runtime/interrupts.ts
+++ b/packages/agency-lang/lib/runtime/interrupts.ts
@@ -238,10 +238,13 @@ async function runHandlerChain(
   // below and climbs the depth.
   if ((ctx.handlers ?? []).length > 0 && !stack) {
     throw new Error(
-      "Interrupt dispatch reached runHandlerChain with handlers registered but no StateStack. " +
-        "The executing-handler mark lives on the stack; dispatching without one would silently " +
-        "disable self-exclusion and the in-handler pause refusal. Pass the raising branch " +
-        "stack to interruptWithHandlers / gatherChainOutcome.",
+      "Cannot run interrupt handlers: no StateStack was passed in. " +
+        "While a handler runs, the runtime records it on the StateStack. " +
+        "That record is what stops a guard trip inside the handler from " +
+        "pausing the run. With no stack there is nowhere to record the " +
+        "handler, so that protection would silently turn off. To fix " +
+        "this, pass the current StateStack when calling " +
+        "interruptWithHandlers or gatherChainOutcome.",
     );
   }
   const depth = (handlerChainDepthALS.getStore() ?? 0) + 1;
@@ -308,6 +311,7 @@ async function runHandlerChain(
             // right now, which cannot settle until this chain returns.
             await ctx.pendingPromises.awaitPending(
               ctx.pendingPromises.keysSince(promiseWatermark),
+              { rejectInterrupts: true },
             );
           } finally {
             const idx = stack!.executingHandlerEntries.lastIndexOf(entry);

--- a/packages/agency-lang/lib/runtime/interrupts.ts
+++ b/packages/agency-lang/lib/runtime/interrupts.ts
@@ -311,7 +311,9 @@ async function runHandlerChain(
             );
           } finally {
             const idx = stack!.executingHandlerEntries.lastIndexOf(entry);
-            if (idx !== -1) stack!.executingHandlerEntries.splice(idx, 1);
+            if (idx !== -1) {
+              stack!.executingHandlerEntries.splice(idx, 1);
+            }
             ctx.exitToolCall();
             if (suspensionToken !== undefined) {
               stack!.endSuspension(suspensionToken);

--- a/packages/agency-lang/lib/runtime/interrupts.ts
+++ b/packages/agency-lang/lib/runtime/interrupts.ts
@@ -236,6 +236,14 @@ async function runHandlerChain(
   // inherited parent depth, so fan-out breadth never accumulates; only a
   // handler whose body re-enters the chain nests inside the `run(...)` scope
   // below and climbs the depth.
+  if ((ctx.handlers ?? []).length > 0 && !stack) {
+    throw new Error(
+      "Interrupt dispatch reached runHandlerChain with handlers registered but no StateStack. " +
+        "The executing-handler mark lives on the stack; dispatching without one would silently " +
+        "disable self-exclusion and the in-handler pause refusal. Pass the raising branch " +
+        "stack to interruptWithHandlers / gatherChainOutcome.",
+    );
+  }
   const depth = (handlerChainDepthALS.getStore() ?? 0) + 1;
   if (depth > MAX_HANDLER_CHAIN_DEPTH) {
     throw new HandlerRecursionError(interruptObj.effect, MAX_HANDLER_CHAIN_DEPTH);
@@ -259,7 +267,12 @@ async function runHandlerChain(
         if (eligible && !eligible(entry)) continue;
         // A handler never hears its own raises: an entry currently
         // executing in this lineage is skipped and the rest of the chain
-        // decides. Re-entering the raiser was the only source of the
+        // decides. Per-LINEAGE (the ALS), not the per-branch stack mark:
+        // concurrent sibling dispatches on one branch must still reach a
+        // handler that another dispatch is executing — only a raise from
+        // within the handler's own body is its own. The stack mark below
+        // serves the pause refusals, which want the coarser fact.
+        // Re-entering the raiser was the only source of the
         // handler recursion, and the raiser's vote was never load-bearing
         // — the same author writes the raise and the handler. Safety is
         // fail-closed: an excluded entry contributes nothing, so the raise
@@ -278,15 +291,31 @@ async function runHandlerChain(
         const suspensionToken = stack
           ? stack.beginSuspension(entry.liveGuardIds)
           : undefined;
+        stack!.executingHandlerEntries.push(entry);
+        const promiseWatermark = ctx.pendingPromises.watermark();
         // Treat handler execution as atomic for the debugger — same as LLM tool calls.
         ctx.enterToolCall();
         let result: any;
         try {
           result = await runAsHandler(entry, () => entry.fn(interruptObj));
         } finally {
-          ctx.exitToolCall();
-          if (suspensionToken !== undefined) {
-            stack!.endSuspension(suspensionToken);
+          try {
+            // Handler exit is an await boundary for the promises the
+            // handler launched: an async call that outlived the body
+            // would otherwise keep running un-marked. Scoped by the
+            // watermark, not awaitAll — the full pending set can
+            // contain the async call whose raise is being dispatched
+            // right now, which cannot settle until this chain returns.
+            await ctx.pendingPromises.awaitPending(
+              ctx.pendingPromises.keysSince(promiseWatermark),
+            );
+          } finally {
+            const idx = stack!.executingHandlerEntries.lastIndexOf(entry);
+            if (idx !== -1) stack!.executingHandlerEntries.splice(idx, 1);
+            ctx.exitToolCall();
+            if (suspensionToken !== undefined) {
+              stack!.endSuspension(suspensionToken);
+            }
           }
         }
         // A handler that is a compiled def returns an AbortedResult when

--- a/packages/agency-lang/lib/runtime/promptRunner.test.ts
+++ b/packages/agency-lang/lib/runtime/promptRunner.test.ts
@@ -161,7 +161,7 @@ describe("PromptRunner.step interrupt handling", () => {
     const runner = new PromptRunner({
       self,
       ctx,
-      stateStack: {} as any,
+      stateStack: new StateStack(),
       checkpointInfo: { moduleId: "m", scopeName: "s", stepPath: "p" },
       snapshotMessages: () => {
         snapshots.push("snapshot");
@@ -194,7 +194,7 @@ describe("PromptRunner.step interrupt handling", () => {
     const runner = new PromptRunner({
       self: {},
       ctx,
-      stateStack: {} as any,
+      stateStack: new StateStack(),
       checkpointInfo: undefined,
       snapshotMessages: () => [],
     });
@@ -218,7 +218,7 @@ describe("PromptRunner.step interrupt handling", () => {
     const runner = new PromptRunner({
       self: {},
       ctx,
-      stateStack: {} as any,
+      stateStack: new StateStack(),
       checkpointInfo: { moduleId: "m", scopeName: "s", stepPath: "p" },
       snapshotMessages: () => [],
     });

--- a/packages/agency-lang/lib/runtime/promptRunner.ts
+++ b/packages/agency-lang/lib/runtime/promptRunner.ts
@@ -109,6 +109,7 @@ export class PromptRunner {
       this.opts.self.messagesJSON = this.opts.snapshotMessages();
       const basePath = this.opts.checkpointInfo?.stepPath ?? "";
       const stepPath = basePath ? `${basePath}/${key}` : key;
+      this.opts.stateStack.assertNoExecutingHandlers();
       const cpId = this.opts.ctx.checkpoints.create(
         this.opts.stateStack,
         this.opts.ctx,

--- a/packages/agency-lang/lib/runtime/runBatch.ts
+++ b/packages/agency-lang/lib/runtime/runBatch.ts
@@ -318,6 +318,11 @@ function rehydrateInheritedGuards(
   branch: BranchState,
   parentStack: StateStack,
 ): void {
+  // Before the rehydration flag: the executing-handler snapshot must
+  // track the parent's CURRENT list on every entry, not the list from
+  // the branch's first rehydration. A branch started inside a handler
+  // inherits its exclusion identity and the no-pause refusal (#616).
+  branch.stack.adoptExecutingHandlersFrom(parentStack);
   if (branch.guardsRehydrated) return;
   branch.stack.rehydrateInheritedGuardsFrom(parentStack);
   branch.guardsRehydrated = true;
@@ -526,6 +531,7 @@ function stampSharedCheckpoint<T>(
   // snapshot the per-tool `messages.push(...)`es that happened during
   // the batch into `self.messagesJSON` before the deep-clone fires.
   hooks?.beforeCheckpoint?.();
+  parentStack.assertNoExecutingHandlers();
   const cpId = ctx.checkpoints.create(parentStack, ctx, checkpointLocation);
   const cp = ctx.checkpoints.get(cpId)!;
   for (const intr of interrupts) {

--- a/packages/agency-lang/lib/runtime/state/pendingPromiseStore.test.ts
+++ b/packages/agency-lang/lib/runtime/state/pendingPromiseStore.test.ts
@@ -145,3 +145,24 @@ describe("PendingPromiseStore watermark", () => {
     expect(preSettled).toBe(false); // the slow pre-mark promise was not awaited
   });
 });
+
+describe("awaitPending rejectInterrupts", () => {
+  it("throws ConcurrentInterruptError for an interrupt-shaped result when opted in", async () => {
+    const store = new PendingPromiseStore();
+    const k = store.add(Promise.resolve([{ type: "interrupt", interruptId: "x" }]));
+    await expect(
+      store.awaitPending([k], { rejectInterrupts: true }),
+    ).rejects.toBeInstanceOf(ConcurrentInterruptError);
+  });
+
+  it("passes interrupt-shaped results through when not opted in", async () => {
+    const store = new PendingPromiseStore();
+    let resolved: any = null;
+    const k = store.add(
+      Promise.resolve([{ type: "interrupt", interruptId: "x" }]),
+      (v) => { resolved = v; },
+    );
+    await store.awaitPending([k]);
+    expect(resolved).toEqual([{ type: "interrupt", interruptId: "x" }]);
+  });
+});

--- a/packages/agency-lang/lib/runtime/state/pendingPromiseStore.test.ts
+++ b/packages/agency-lang/lib/runtime/state/pendingPromiseStore.test.ts
@@ -115,3 +115,33 @@ describe("PendingPromiseStore", () => {
     });
   });
 });
+
+describe("PendingPromiseStore watermark", () => {
+  it("keysSince returns only keys registered at or after the mark", () => {
+    const store = new PendingPromiseStore();
+    store.add(Promise.resolve(1));
+    const mark = store.watermark();
+    const k1 = store.add(Promise.resolve(2));
+    const k2 = store.add(Promise.resolve(3));
+    expect(store.keysSince(mark).sort()).toEqual([k1, k2].sort());
+  });
+
+  it("keysSince skips keys that were already awaited", async () => {
+    const store = new PendingPromiseStore();
+    const mark = store.watermark();
+    const k1 = store.add(Promise.resolve("a"));
+    await store.awaitPending([k1]);
+    const k2 = store.add(Promise.resolve("b"));
+    expect(store.keysSince(mark)).toEqual([k2]);
+  });
+
+  it("awaitPending(keysSince(mark)) leaves pre-mark promises alone", async () => {
+    const store = new PendingPromiseStore();
+    let preSettled = false;
+    store.add(new Promise<void>((r) => setTimeout(() => { preSettled = true; r(); }, 5)));
+    const mark = store.watermark();
+    store.add(Promise.resolve("post"));
+    await store.awaitPending(store.keysSince(mark));
+    expect(preSettled).toBe(false); // the slow pre-mark promise was not awaited
+  });
+});

--- a/packages/agency-lang/lib/runtime/state/pendingPromiseStore.ts
+++ b/packages/agency-lang/lib/runtime/state/pendingPromiseStore.ts
@@ -68,4 +68,19 @@ export class PendingPromiseStore {
   clear(): void {
     this.pending = {};
   }
+
+  /** Position marker for keysSince. Handler dispatch records this
+   *  before running a handler body so handler exit can await exactly
+   *  the promises the handler launched — awaiting the full set would
+   *  deadlock on the async call whose raise is being dispatched. */
+  watermark(): number {
+    return this.counter;
+  }
+
+  /** Still-pending keys registered at or after the given watermark. */
+  keysSince(mark: number): string[] {
+    return Object.keys(this.pending).filter(
+      (k) => Number(k.slice("__pending_".length)) >= mark,
+    );
+  }
 }

--- a/packages/agency-lang/lib/runtime/state/pendingPromiseStore.ts
+++ b/packages/agency-lang/lib/runtime/state/pendingPromiseStore.ts
@@ -16,7 +16,10 @@ export class PendingPromiseStore {
     return key;
   }
 
-  async awaitPending(keys: string[]): Promise<void> {
+  async awaitPending(
+    keys: string[],
+    opts?: { rejectInterrupts?: boolean },
+  ): Promise<void> {
     const entries = keys
       .map((k) => ({ key: k, entry: this.pending[k] }))
       .filter((e) => e.entry !== undefined);
@@ -27,6 +30,20 @@ export class PendingPromiseStore {
 
     for (let i = 0; i < entries.length; i++) {
       const { key, entry } = entries[i];
+      // Same guard awaitAll applies: a result that IS an interrupt
+      // means an async function paused while we were awaiting it, which
+      // this code path cannot transport. The handler-exit await opts in
+      // so an in-handler straggler cannot be silently consumed here.
+      if (
+        opts?.rejectInterrupts &&
+        (hasInterrupts(results[i]) || isInterrupt(results[i]))
+      ) {
+        throw new ConcurrentInterruptError(
+          "An async function launched inside a handler returned an interrupt. " +
+            "Handlers cannot pause, so this interrupt cannot be delivered. " +
+            "Await the async call inside the handler body, or move it outside the handler.",
+        );
+      }
       if (entry!.resolve) {
         entry!.resolve(results[i]);
       }

--- a/packages/agency-lang/lib/runtime/state/stateStack.executingHandlers.test.ts
+++ b/packages/agency-lang/lib/runtime/state/stateStack.executingHandlers.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { StateStack, State } from "./stateStack.js";
+import type { HandlerEntry } from "../types.js";
+
+const entry = (): HandlerEntry => ({ fn: async () => undefined, liveGuardIds: [] });
+
+describe("StateStack.executingHandlerEntries", () => {
+  it("starts empty and is not serialized", () => {
+    const stack = new StateStack();
+    expect(stack.executingHandlerEntries).toEqual([]);
+    stack.executingHandlerEntries.push(entry());
+    expect("executingHandlerEntries" in stack.toJSON()).toBe(false);
+    const revived = StateStack.fromJSON(stack.toJSON());
+    expect(revived.executingHandlerEntries).toEqual([]);
+  });
+
+  it("adoptExecutingHandlersFrom copies a snapshot, not an alias", () => {
+    const parent = new StateStack();
+    const e = entry();
+    parent.executingHandlerEntries.push(e);
+    const child = new StateStack();
+    child.adoptExecutingHandlersFrom(parent);
+    expect(child.executingHandlerEntries).toEqual([e]);
+    expect(child.executingHandlerEntries[0]).toBe(e); // same entry OBJECT: exclusion is identity-based
+    parent.executingHandlerEntries.pop();
+    expect(child.executingHandlerEntries).toEqual([e]); // parent pop does not reach the child
+  });
+
+  it("assertNoExecutingHandlers passes on a clean stack with frames", () => {
+    const stack = new StateStack();
+    stack.stack.push(new State());
+    expect(() => stack.assertNoExecutingHandlers()).not.toThrow();
+  });
+
+  it("assertNoExecutingHandlers throws when the top-level list is non-empty", () => {
+    const stack = new StateStack();
+    stack.executingHandlerEntries.push(entry());
+    expect(() => stack.assertNoExecutingHandlers()).toThrow(/handler function is executing/);
+  });
+
+  it("assertNoExecutingHandlers finds a mark on a nested branch under an unmarked parent", () => {
+    const stack = new StateStack();
+    const frame = new State();
+    stack.stack.push(frame);
+    const branch = frame.newBranch("tool_x");
+    branch.stack.executingHandlerEntries.push(entry());
+    expect(() => stack.assertNoExecutingHandlers()).toThrow(/handler function is executing/);
+  });
+});

--- a/packages/agency-lang/lib/runtime/state/stateStack.executingHandlers.test.ts
+++ b/packages/agency-lang/lib/runtime/state/stateStack.executingHandlers.test.ts
@@ -21,7 +21,7 @@ describe("StateStack.executingHandlerEntries", () => {
     const child = new StateStack();
     child.adoptExecutingHandlersFrom(parent);
     expect(child.executingHandlerEntries).toEqual([e]);
-    expect(child.executingHandlerEntries[0]).toBe(e); // same entry OBJECT: exclusion is identity-based
+    expect(child.executingHandlerEntries[0]).toBe(e); // entry objects are copied by reference, not cloned
     parent.executingHandlerEntries.pop();
     expect(child.executingHandlerEntries).toEqual([e]); // parent pop does not reach the child
   });

--- a/packages/agency-lang/lib/runtime/state/stateStack.ts
+++ b/packages/agency-lang/lib/runtime/state/stateStack.ts
@@ -385,13 +385,19 @@ export class StateStack {
 
   /** Handler entries executing on this branch, innermost last. The
    *  dispatcher (runHandlerChain) pushes before a handler body runs and
-   *  pops after; self-exclusion and the in-handler pause refusals read
-   *  this list. Lives on the stack rather than an AsyncLocalStorage so
-   *  every reader reaches it through a plain object reference it
-   *  already holds — there is no ambient lookup to lose. Never
-   *  serialized: no interrupt-pause checkpoint may exist while it is
-   *  non-empty (assertNoExecutingHandlers), so a deserialized stack
-   *  correctly starts empty.
+   *  pops after. This list serves the PAUSE side of issue #616 only:
+   *  the guard-trip refusals and the interrupt-pause checkpoint
+   *  assertions read it. Self-exclusion (a handler never hears its own
+   *  raises) does NOT read it — that stays on the executingHandlers.ts
+   *  ALS, because exclusion needs per-lineage precision this per-branch
+   *  list cannot give (a concurrent sibling dispatch must still reach a
+   *  handler another dispatch is executing). Lives on the stack rather
+   *  than an AsyncLocalStorage so every pause-side reader reaches it
+   *  through a plain object reference it already holds — there is no
+   *  ambient lookup to lose. Never serialized: no interrupt-pause
+   *  checkpoint may exist while it is non-empty
+   *  (assertNoExecutingHandlers), so a deserialized stack correctly
+   *  starts empty.
    *  See docs/superpowers/specs/2026-07-19-issue-616-no-pause-inside-handlers-design.md */
   executingHandlerEntries: HandlerEntry[] = [];
 

--- a/packages/agency-lang/lib/runtime/state/stateStack.ts
+++ b/packages/agency-lang/lib/runtime/state/stateStack.ts
@@ -205,6 +205,17 @@ export class State {
     }
   }
 
+  /** Visit every branch stack hanging off this frame. Branches are
+   *  private; this is the read path for walks that must cover the whole
+   *  branch subtree (StateStack.assertNoExecutingHandlers). */
+  forEachBranchStack(fn: (stack: StateStack) => void): void {
+    if (this.branches) {
+      for (const branch of Object.values(this.branches)) {
+        fn(branch.stack);
+      }
+    }
+  }
+
   toJSON(): StateJSON {
     const json: StateJSON = {
       args: deepClone(this.args),
@@ -371,6 +382,51 @@ export class StateStack {
   // currently not serialized, but used to track if we've hit an interrupt in the current branch
   interrupted: boolean = false;
   hasChildInterrupts: boolean = false;
+
+  /** Handler entries executing on this branch, innermost last. The
+   *  dispatcher (runHandlerChain) pushes before a handler body runs and
+   *  pops after; self-exclusion and the in-handler pause refusals read
+   *  this list. Lives on the stack rather than an AsyncLocalStorage so
+   *  every reader reaches it through a plain object reference it
+   *  already holds — there is no ambient lookup to lose. Never
+   *  serialized: no interrupt-pause checkpoint may exist while it is
+   *  non-empty (assertNoExecutingHandlers), so a deserialized stack
+   *  correctly starts empty.
+   *  See docs/superpowers/specs/2026-07-19-issue-616-no-pause-inside-handlers-design.md */
+  executingHandlerEntries: HandlerEntry[] = [];
+
+  /** Snapshot the parent mark into this branch stack. runBatch calls
+   *  this alongside guard rehydration for every branch it starts: a
+   *  branch created while a handler executes runs while that handler
+   *  executes (all runBatch modes join before returning), so it
+   *  inherits the exclusion identity and the no-pause refusal. A
+   *  snapshot, not a shared reference — the parent pops its entries on
+   *  handler exit and the branch must not observe that mid-flight. */
+  adoptExecutingHandlersFrom(parent: StateStack): void {
+    this.executingHandlerEntries = [...parent.executingHandlerEntries];
+  }
+
+  /** Throw if any handler is executing on this stack or any branch
+   *  under it. Called at the interrupt-pause checkpoint sites: handlers
+   *  have no step address, so a pause taken mid-handler could never be
+   *  resumed. Walks branches because a mark can live on a branch stack
+   *  whose parent is unmarked (a tool-call branch created inside a
+   *  handler). */
+  assertNoExecutingHandlers(): void {
+    if (this.executingHandlerEntries.length > 0) {
+      throw new Error(
+        "Cannot pause the run while a handler function is executing: " +
+          "handlers have no step address, so this checkpoint could never " +
+          "be resumed. This is a runtime bug — an in-handler pause path " +
+          "was reached. See issue #616.",
+      );
+    }
+    for (const frame of this.stack) {
+      frame.forEachBranchStack((branchStack) =>
+        branchStack.assertNoExecutingHandlers(),
+      );
+    }
+  }
 
   // Per-branch abort signal. Set by Runner.runRace / Runner.runForkAll on each
   // branch's stack. When the parent fork/race aborts a losing branch, this

--- a/packages/agency-lang/tests/agency/handlers/handler-guard-trip-propagate.agency
+++ b/packages/agency-lang/tests/agency/handlers/handler-guard-trip-propagate.agency
@@ -1,18 +1,13 @@
+import test { _advanceTime } from "std::date"
+
 // A guard INSIDE the handler body trips, and the outer handler
 // PROPAGATES std::guard instead of answering. A propagated in-handler
 // trip cannot ask the user (handlers cannot pause), so it is refused:
 // the guard block fails with the trip error, the handler completes
 // degraded, and the run never pauses. This is the issue-616 refusal
-// path; the answered path lives in handler-guard-trip.agency.
+// path; the answered path lives in handler-guard-trip.agency. The fake
+// clock drives the trip, same as the sibling fixture.
 let sawFailure = false
-
-def spin(rounds: number): string {
-  let count = 0
-  while (count < rounds) {
-    count = count + 1
-  }
-  return "spun"
-}
 
 def inner(): string {
   handle {
@@ -20,8 +15,8 @@ def inner(): string {
     return "work done"
   } with (data) {
     const guarded = guard(time: 5ms, label: "in-handler") {
-      const spun = spin(3000000)
-      return "guarded:${spun}"
+      _advanceTime(20)
+      return "guarded:done"
     }
     if (isFailure(guarded)) {
       sawFailure = true

--- a/packages/agency-lang/tests/agency/handlers/handler-guard-trip-propagate.agency
+++ b/packages/agency-lang/tests/agency/handlers/handler-guard-trip-propagate.agency
@@ -1,0 +1,44 @@
+// A guard INSIDE the handler body trips, and the outer handler
+// PROPAGATES std::guard instead of answering. A propagated in-handler
+// trip cannot ask the user (handlers cannot pause), so it is refused:
+// the guard block fails with the trip error, the handler completes
+// degraded, and the run never pauses. This is the issue-616 refusal
+// path; the answered path lives in handler-guard-trip.agency.
+let sawFailure = false
+
+def spin(rounds: number): string {
+  let count = 0
+  while (count < rounds) {
+    count = count + 1
+  }
+  return "spun"
+}
+
+def inner(): string {
+  handle {
+    interrupt("please review")
+    return "work done"
+  } with (data) {
+    const guarded = guard(time: 5ms, label: "in-handler") {
+      const spun = spin(3000000)
+      return "guarded:${spun}"
+    }
+    if (isFailure(guarded)) {
+      sawFailure = true
+    }
+    return approve()
+  }
+}
+
+node main() {
+  let result = ""
+  handle {
+    result = inner()
+  } with (data) {
+    if (data.effect == "std::guard") {
+      return propagate()
+    }
+    return approve()
+  }
+  return "${result}|failed:${sawFailure}"
+}

--- a/packages/agency-lang/tests/agency/handlers/handler-guard-trip-propagate.test.json
+++ b/packages/agency-lang/tests/agency/handlers/handler-guard-trip-propagate.test.json
@@ -1,0 +1,13 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "An in-handler guard trip that the outer chain propagates is refused as a rejection: the guard block fails, the handler completes, the run never pauses. failed:false means the trip either paused the run or was silently approved.",
+      "input": "",
+      "expectedOutput": "\"work done|failed:true\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "interruptHandlers": [],
+      "llmMocks": []
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/handlers/handler-guard-trip-propagate.test.json
+++ b/packages/agency-lang/tests/agency/handlers/handler-guard-trip-propagate.test.json
@@ -2,6 +2,7 @@
   "tests": [
     {
       "nodeName": "main",
+      "fakeClock": true,
       "description": "An in-handler guard trip that the outer chain propagates is refused as a rejection: the guard block fails, the handler completes, the run never pauses. failed:false means the trip either paused the run or was silently approved.",
       "input": "",
       "expectedOutput": "\"work done|failed:true\"",

--- a/packages/agency-lang/tests/agency/handlers/handler-guard-trip-unhandled.agency
+++ b/packages/agency-lang/tests/agency/handlers/handler-guard-trip-unhandled.agency
@@ -1,0 +1,34 @@
+// Same shape as handler-guard-trip-propagate, with NO outer handler:
+// the in-handler trip has nobody to answer it. The refusal must
+// convert it to a failed guard Result instead of pausing a run that
+// nobody could resume.
+let sawFailure = false
+
+def spin(rounds: number): string {
+  let count = 0
+  while (count < rounds) {
+    count = count + 1
+  }
+  return "spun"
+}
+
+def inner(): string {
+  handle {
+    interrupt("please review")
+    return "work done"
+  } with (data) {
+    const guarded = guard(time: 5ms, label: "in-handler") {
+      const spun = spin(3000000)
+      return "guarded:${spun}"
+    }
+    if (isFailure(guarded)) {
+      sawFailure = true
+    }
+    return approve()
+  }
+}
+
+node main() {
+  const result = inner()
+  return "${result}|failed:${sawFailure}"
+}

--- a/packages/agency-lang/tests/agency/handlers/handler-guard-trip-unhandled.agency
+++ b/packages/agency-lang/tests/agency/handlers/handler-guard-trip-unhandled.agency
@@ -1,16 +1,11 @@
+import test { _advanceTime } from "std::date"
+
 // Same shape as handler-guard-trip-propagate, with NO outer handler:
 // the in-handler trip has nobody to answer it. The refusal must
 // convert it to a failed guard Result instead of pausing a run that
-// nobody could resume.
+// nobody could resume. The fake clock drives the trip, same as the
+// sibling fixtures.
 let sawFailure = false
-
-def spin(rounds: number): string {
-  let count = 0
-  while (count < rounds) {
-    count = count + 1
-  }
-  return "spun"
-}
 
 def inner(): string {
   handle {
@@ -18,8 +13,8 @@ def inner(): string {
     return "work done"
   } with (data) {
     const guarded = guard(time: 5ms, label: "in-handler") {
-      const spun = spin(3000000)
-      return "guarded:${spun}"
+      _advanceTime(20)
+      return "guarded:done"
     }
     if (isFailure(guarded)) {
       sawFailure = true

--- a/packages/agency-lang/tests/agency/handlers/handler-guard-trip-unhandled.test.json
+++ b/packages/agency-lang/tests/agency/handlers/handler-guard-trip-unhandled.test.json
@@ -2,6 +2,7 @@
   "tests": [
     {
       "nodeName": "main",
+      "fakeClock": true,
       "description": "An in-handler guard trip with no outer handler registered is refused as a rejection rather than pausing a run nobody can resume. The guard block fails, the handler completes, the run finishes.",
       "input": "",
       "expectedOutput": "\"work done|failed:true\"",

--- a/packages/agency-lang/tests/agency/handlers/handler-guard-trip-unhandled.test.json
+++ b/packages/agency-lang/tests/agency/handlers/handler-guard-trip-unhandled.test.json
@@ -1,0 +1,13 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "An in-handler guard trip with no outer handler registered is refused as a rejection rather than pausing a run nobody can resume. The guard block fails, the handler completes, the run finishes.",
+      "input": "",
+      "expectedOutput": "\"work done|failed:true\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "interruptHandlers": [],
+      "llmMocks": []
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/handlers/handler-guard-trip.agency
+++ b/packages/agency-lang/tests/agency/handlers/handler-guard-trip.agency
@@ -1,19 +1,14 @@
+import test { _advanceTime } from "std::date"
+
 // A guard INSIDE the handler body trips. The trip (std::guard) skips the
 // executing handler and is answered by the OUTER handler, which extends
 // the budget. This is the supervise shape — an expensive check running
-// inside a guard handler — reduced to a fixture. The grant is a DELTA
-// that must cover the overshoot the block ran past its limit before the
-// trip was answered (see the overshoot lesson in stdlib/supervise.agency),
-// so it is granted generously.
+// inside a guard handler — reduced to a fixture. The fake clock drives
+// the trip: _advanceTime jumps past the 5ms budget, the gate at the next
+// step raises the trip, and after the outer grant the block completes.
+// (The original wall-clock spin could not finish inside CI's per-test
+// cap: its 3M loop iterations compile to 3M awaited runner steps.)
 let tripsSeen = 0
-
-def spin(rounds: number): string {
-  let count = 0
-  while (count < rounds) {
-    count = count + 1
-  }
-  return "spun"
-}
 
 def inner(): string {
   handle {
@@ -21,8 +16,8 @@ def inner(): string {
     return "work done"
   } with (data) {
     const guarded = guard(time: 5ms, label: "in-handler") {
-      const spun = spin(3000000)
-      return "guarded:${spun}"
+      _advanceTime(20)
+      return "guarded:done"
     }
     // isFailure, not match: guard Results are read with isFailure by
     // convention in code that may pause and resume.

--- a/packages/agency-lang/tests/agency/handlers/handler-guard-trip.test.json
+++ b/packages/agency-lang/tests/agency/handlers/handler-guard-trip.test.json
@@ -2,7 +2,8 @@
   "tests": [
     {
       "nodeName": "main",
-      "description": "A guard trip raised while a handler executes routes past the excluded handler to the outer chain, which extends the budget. trips:0 means mid-handler guard trips are not reaching outer handlers.",
+      "fakeClock": true,
+      "description": "A guard trip raised while a handler executes routes past the excluded handler to the outer chain, which extends the budget. trips:0 means mid-handler guard trips are not reaching outer handlers. Driven by the fake clock so the trip is deterministic and cheap enough for CI.",
       "input": "",
       "expectedOutput": "\"work done|trips:1\"",
       "evaluationCriteria": [{ "type": "exact" }],


### PR DESCRIPTION
Fixes #616.

Design spec: `docs/superpowers/specs/2026-07-19-issue-616-no-pause-inside-handlers-design.md` (in the repo, at the workspace root docs). Implementation plan: `docs/superpowers/plans/2026-07-20-issue-616-no-pause-inside-handlers.md`.

## What this fixes

Handlers compile to plain callbacks with no step counters, so a run can never resume into the middle of one. That makes one rule absolute: an interrupt-pause checkpoint must never be created while a handler is executing. Issue #616 found two holes in that rule. First, the resume branch at the top of `raiseOneTrip` re-surfaces a persisted open guard question without running the handler chain, so it skips the `renderVerdict` refusal entirely — one bad surface poisons every later resume through serialized state. Second, both existing defenses (self-exclusion and the renderVerdict refusal) read the same `AsyncLocalStorage`, and the `handler-guard-trip` CI failure (trips:9, depth-10 recursion) is best explained by that read coming up empty under load, which disables both at once.

## The change, in three layers

**1. The guard-trip machinery refuses to pause inside a handler.** `raiseOneTrip` now checks the stack mark at three doors: the persisted-id resume branch throws the original `GuardExceededError` instead of re-surfacing; the unanswered-dispatch branch throws instead of persisting a question id; and `raiseGuardTripsAtStep` asserts before creating its checkpoint. A refused trip rides the existing rejection rails — the guard block fails, draft salvage and the failure conversion run unchanged, and the handler completes degraded. The unit test for the unanswered door deliberately marks the stack with no ALS scope: it is the lost-ALS shape from the investigation, and it passes on the stack read alone.

**2. A loss-proof carrier: `StateStack.executingHandlerEntries`.** The dispatcher mirrors each executing handler entry onto the raising branch stack (push before the body, pop in a finally). Every reader reaches the stack through a plain object field or explicit parameter, so there is no ambient lookup to lose. Branch stacks inherit a snapshot through `rehydrateInheritedGuards` in `runBatch`, which covers fork, race, parallel tool calls, and the subprocess path. The list is never serialized, which is now safe by construction rather than by an assumed invariant. Handler exit additionally becomes a scoped await boundary: promises the handler launched (`async foo()`) are awaited before the entry pops, so a straggler cannot keep running on an unmarked stack. The await is scoped by a watermark on `PendingPromiseStore` rather than `awaitAll()`, because the full pending set can contain the very async call whose raise is being dispatched — awaiting it would deadlock on the chain returning.

**3. Loud assertions at all four interrupt-pause sites.** `raiseGuardTripsAtStep`, the TS-raise surface path (`agencyInterrupt.ts`), the prompt-step bailout (`promptRunner.ts`), and the shared batch checkpoint (`runBatch.ts`) each call `stack.assertNoExecutingHandlers()` before creating their checkpoint. It walks the branch subtree, because a mark can live on a tool-call branch whose parent stack is unmarked. With layers 1 and 2 these are unreachable; the assertion exists because "unreachable" claims silently rotting is exactly how this bug happened.

## One deviation from the spec, found during execution

The spec called for retiring the ALS entirely and reading exclusion from the stack. Executing that broke two #611 regression tests (`agencyInterrupt.test.ts`, the concurrent-dispatch suite): with 15 parallel raises from a handle body, dispatch B on the same stack saw the handler mid-flight for dispatch A and wrongly skipped it. Exclusion needs per-lineage precision — "did this raise come from within this handler's own body" — and only the async-call-tree carrier can answer that. So the final shape is a hybrid:

- **ALS (kept):** self-exclusion in the chain walk and the renderVerdict refusal, exactly as #611 shipped them. Per-lineage, semantically precise.
- **Stack mark (new):** everything pause-related — the guard-trip refusal doors and the four assertions. Per-branch, coarser, and immune to the loss mode.

If the ALS ever drops a read again, the worst case regresses to bounded #611-style recursion, but the run still cannot pause mid-handler, which is the safety property this issue is about. The misleading comment in `executingHandlers.ts` — whose "can never observe this non-empty" claim was the thing that did not hold — is rewritten to state this split.

Also found during execution: the assertion cannot live inside `CheckpointStore.create`, because guard scopes create pinned checkpoints during healthy in-handler execution (`resumableScope.ts` — the supervise shape). Hence the four-site placement.

## Tests

- `lib/runtime/guardTripInterrupt.inHandler.test.ts` — the two refusal doors, including the persisted-id bypass reproduced as a failing test first (it surfaced an `Interrupt[]` from inside a handler before the fix).
- `lib/runtime/interrupts.executingHandlers.test.ts` — mark lifetime, exclusion, refusal, the no-stack throw, and both watermark-await behaviors (straggler awaited while marked; pre-existing promise left alone).
- `lib/runtime/state/stateStack.executingHandlers.test.ts` — snapshot semantics, non-serialization, and the branch-subtree walk.
- `tests/agency/handlers/handler-guard-trip-propagate.agency` and `-unhandled.agency` — the end-to-end refusal path that previously had zero coverage: an in-handler trip that nobody answers fails the guard block and the run completes without pausing. These are the tests that pin #616.
- Regression: the full #611 handler fleet, the guards fleet, fork/pause-path agency tests, and all 1512 runtime unit tests pass.

Note: the fake-clock work in #575 makes the flaky `handler-guard-trip` test deterministic but must not close #616 — the new propagate/unhandled fixtures are the ones that cover this gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
