### PR TITLE
Fix CI: anchor skillsDir/commandsDir test fixtures with __dirname

### DIFF
--- a/packages/agency-lang/tests/agency/commands-dir.agency
+++ b/packages/agency-lang/tests/agency/commands-dir.agency
@@ -1,7 +1,7 @@
 import { commandsDir, expandSlash } from "std::skills"
 
 def loadFixture() {
-  return commandsDir("commands-dir-fixture") with approve
+  return commandsDir(__dirname + "/commands-dir-fixture") with approve
 }
 
 // ---------- discovery ----------
@@ -94,7 +94,7 @@ node descriptionOnlyHasEmptyArgHint(): boolean {
 }
 
 node missingDirReturnsEmpty(): boolean {
-  const cmds = commandsDir("commands-dir-fixture-does-not-exist") with approve
+  const cmds = commandsDir(__dirname + "/commands-dir-fixture-does-not-exist") with approve
   return cmds.length == 0
 }
 

--- a/packages/agency-lang/tests/agency/skills-dir.agency
+++ b/packages/agency-lang/tests/agency/skills-dir.agency
@@ -1,17 +1,17 @@
 import { skillsDir } from "std::skills"
 
 def stdDesc(): string {
-  const tool = skillsDir("skills-dir-fixture/std", "standard") with approve
+  const tool = skillsDir(__dirname + "/skills-dir-fixture/std", "standard") with approve
   return tool.description
 }
 
 def flatDesc(): string {
-  const tool = skillsDir("skills-dir-fixture/flat", "flat") with approve
+  const tool = skillsDir(__dirname + "/skills-dir-fixture/flat", "flat") with approve
   return tool.description
 }
 
 def emptyDesc(): string {
-  const tool = skillsDir("skills-dir-fixture/empty", "flat") with approve
+  const tool = skillsDir(__dirname + "/skills-dir-fixture/empty", "flat") with approve
   return tool.description
 }
 
@@ -96,13 +96,13 @@ node siblingDeepPathsStayDistinct(): boolean {
 
 // An explicit name overrides the derived one.
 node explicitNameOverrides(): boolean {
-  const tool = skillsDir("skills-dir-fixture/flat", "flat", "my_docs") with approve
+  const tool = skillsDir(__dirname + "/skills-dir-fixture/flat", "flat", "my_docs") with approve
   return tool.name == "my_docs"
 }
 
 // An explicit name is still sanitized (spaces/punctuation rejected by
 // providers) and capped.
 node explicitNameSanitized(): boolean {
-  const tool = skillsDir("skills-dir-fixture/flat", "flat", "My Cool Skill!") with approve
+  const tool = skillsDir(__dirname + "/skills-dir-fixture/flat", "flat", "My Cool Skill!") with approve
   return tool.name == "My_Cool_Skill"
 }


### PR DESCRIPTION
## Summary

Fixes the CI failures on main introduced by #619 (cwd path anchoring).

`tests/agency/commands-dir.agency` and `tests/agency/skills-dir.agency` load their fixture directories with bare relative paths (`commandsDir("commands-dir-fixture")`, `skillsDir("skills-dir-fixture/std", ...)`), which resolved against the test module's directory before #619 and against the runner's cwd (the package root) after it. The #619 migration audit grepped test files for `read`/`write`/`edit`/`ls`/`grep`/`glob`/`stat`/`exists`/`readSkill` but not `commandsDir`/`skillsDir`, so these two files were missed. Both now anchor their fixtures with `__dirname`; 25/25 and 13/13 pass locally.

The `DEEP_BASE` nodes in skills-dir are left unanchored on purpose: they derive tool names from a nonexistent path string, so resolution never matters.

The third CI failure, `tests/agency/handlers/handler-guard-trip.agency`, is not path-related: it does no file I/O and races a 5ms time guard against a spin loop, and it timed out under the 12-way parallel CI run. It passes locally on this branch. Likely a timing flake under runner contention — same class as the fake-clock work in #618/#575 — so this PR does not touch it.

A repo-wide re-sweep for other unmigrated path-taking calls (`readBinary`/`writeBinary`/`applyPatch`/`multiedit`/`edit`/`stat`/`copy`/`move`/`mkdir`/`commandsDir`/`skillsDir`/`readSkill`) found nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
