### PR TITLE
Run @validate validators through Record values (#630)

### DIFF
--- a/packages/agency-lang/lib/backends/typescriptGenerator/validationDescriptor.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator/validationDescriptor.ts
@@ -464,6 +464,27 @@ function descriptor(
     ]);
   }
 
+  // Record<K, V>: walk entry VALUES against V's descriptor (#630). Built
+  // from the WRITTEN value arg when available so an alias arg keeps its
+  // identity and hits the typeAliasVariable ref branch above — validators
+  // then execute against the descriptor built in the alias-defining module,
+  // never inlined into the consumer's scope. Keys stay schema-checked only
+  // (a transforming key validator would mean rewriting keys — out of scope).
+  if (variableType.type === "genericType" && variableType.name === "Record") {
+    const valueArg = variableType.writtenTypeArgs?.[1] ?? variableType.typeArgs[1];
+    const valueDesc = descriptor(
+      valueArg,
+      typeAliases,
+      typeAliasesFull,
+      seen, pendingAliases);
+    return objEntries([
+      ["kind", ts.str("record")],
+      ["schema", schema],
+      ["validators", validatorsArr],
+      ["value", valueDesc],
+    ]);
+  }
+
   return objEntries([
     ["kind", ts.str("leaf")],
     ["schema", schema],

--- a/packages/agency-lang/lib/backends/typescriptGenerator/validationDescriptor.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator/validationDescriptor.ts
@@ -425,28 +425,15 @@ function descriptor(
   }
 
   if (variableType.type === "unionType") {
-    const branches = variableType.types.map((m) => {
-      const branchSchema = schemaNode(m, typeAliases, typeAliasesFull, pendingAliases);
-      const branchDesc = descriptor(m, typeAliases, typeAliasesFull, seen, pendingAliases);
-      // `(v) => (<branchSchema>).safeParse(v).success`
-      const test = ts.arrowFn(
-        [{ name: "v" }],
-        ts.prop(
-          ts.methodCall(branchSchema, "safeParse", [ts.id("v")]),
-          "success",
-        ),
-      );
-      return ts.obj([
-        ts.set("test", test),
-        ts.set("descriptor", branchDesc),
-      ]);
-    });
-    return objEntries([
-      ["kind", ts.str("union")],
-      ["schema", schema],
-      ["validators", validatorsArr],
-      ["branches", ts.arr(branches)],
-    ]);
+    return unionDescriptor(
+      variableType,
+      schema,
+      validatorsArr,
+      typeAliases,
+      typeAliasesFull,
+      seen,
+      pendingAliases,
+    );
   }
 
   if (variableType.type === "resultType") {
@@ -464,31 +451,90 @@ function descriptor(
     ]);
   }
 
-  // Record<K, V>: walk entry VALUES against V's descriptor (#630). Built
-  // from the WRITTEN value arg when available so an alias arg keeps its
-  // identity and hits the typeAliasVariable ref branch above — validators
-  // then execute against the descriptor built in the alias-defining module,
-  // never inlined into the consumer's scope. Keys stay schema-checked only
-  // (a transforming key validator would mean rewriting keys — out of scope).
   if (variableType.type === "genericType" && variableType.name === "Record") {
-    const valueArg = variableType.writtenTypeArgs?.[1] ?? variableType.typeArgs[1];
-    const valueDesc = descriptor(
-      valueArg,
+    return recordDescriptor(
+      variableType,
+      schema,
+      validatorsArr,
       typeAliases,
       typeAliasesFull,
-      seen, pendingAliases);
-    return objEntries([
-      ["kind", ts.str("record")],
-      ["schema", schema],
-      ["validators", validatorsArr],
-      ["value", valueDesc],
-    ]);
+      seen,
+      pendingAliases,
+    );
   }
 
   return objEntries([
     ["kind", ts.str("leaf")],
     ["schema", schema],
     ["validators", validatorsArr],
+  ]);
+}
+
+/** Union: each branch carries a schema-based membership test plus its own
+ *  descriptor; the walker runs the first branch whose test accepts. */
+function unionDescriptor(
+  variableType: Extract<VariableType, { type: "unionType" }>,
+  schema: TsNode,
+  validatorsArr: TsNode,
+  typeAliases: Record<string, VariableType>,
+  typeAliasesFull: Record<string, TypeAliasEntry>,
+  seen: Set<string>,
+  pendingAliases?: Set<string>,
+): TsNode {
+  const branches = variableType.types.map((m) => {
+    const branchSchema = schemaNode(m, typeAliases, typeAliasesFull, pendingAliases);
+    const branchDesc = descriptor(m, typeAliases, typeAliasesFull, seen, pendingAliases);
+    // `(v) => (<branchSchema>).safeParse(v).success`
+    const test = ts.arrowFn(
+      [{ name: "v" }],
+      ts.prop(
+        ts.methodCall(branchSchema, "safeParse", [ts.id("v")]),
+        "success",
+      ),
+    );
+    return ts.obj([
+      ts.set("test", test),
+      ts.set("descriptor", branchDesc),
+    ]);
+  });
+  return objEntries([
+    ["kind", ts.str("union")],
+    ["schema", schema],
+    ["validators", validatorsArr],
+    ["branches", ts.arr(branches)],
+  ]);
+}
+
+/**
+ * Record<K, V>: walk entry VALUES against V's descriptor (#630). Built from
+ * the WRITTEN value arg when available so an alias arg keeps its identity
+ * and hits the typeAliasVariable ref branch in `descriptor` — validators
+ * then execute against the descriptor built in the alias-defining module,
+ * never inlined into the consumer's scope. Keys stay schema-checked only
+ * (a transforming key validator would mean rewriting keys — out of scope).
+ */
+function recordDescriptor(
+  variableType: Extract<VariableType, { type: "genericType" }>,
+  schema: TsNode,
+  validatorsArr: TsNode,
+  typeAliases: Record<string, VariableType>,
+  typeAliasesFull: Record<string, TypeAliasEntry>,
+  seen: Set<string>,
+  pendingAliases?: Set<string>,
+): TsNode {
+  const valueArg = variableType.writtenTypeArgs?.[1] ?? variableType.typeArgs[1];
+  const valueDesc = descriptor(
+    valueArg,
+    typeAliases,
+    typeAliasesFull,
+    seen,
+    pendingAliases,
+  );
+  return objEntries([
+    ["kind", ts.str("record")],
+    ["schema", schema],
+    ["validators", validatorsArr],
+    ["value", valueDesc],
   ]);
 }
 

--- a/packages/agency-lang/lib/runtime/validateChain.test.ts
+++ b/packages/agency-lang/lib/runtime/validateChain.test.ts
@@ -314,3 +314,24 @@ describe("record descriptor kind (#630)", () => {
     expect(isFailure(await __validateChainRecursive({ a: -1 }, viaRef))).toBe(true);
   });
 });
+
+describe("record walker prototype safety", () => {
+  it("stores a user-supplied __proto__ key as an own entry, never the prototype", async () => {
+    // Zod's z.record drops own __proto__ keys, so reach the walker with a
+    // permissive schema (as a ref-carried descriptor could) to prove the
+    // walker is safe on its own.
+    const permissiveRecord: TypeValidationDescriptor = {
+      kind: "record",
+      schema: z.any(),
+      validators: [],
+      value: { kind: "leaf", schema: z.number(), validators: [] },
+    };
+    const hostile = JSON.parse('{"__proto__": 7, "a": 1}');
+    const r = await __validateChainRecursive(hostile, permissiveRecord);
+    expect(isSuccess(r)).toBe(true);
+    const out = (r as { value: Record<string, unknown> }).value;
+    expect(Object.getPrototypeOf(out)).toBe(Object.prototype);
+    expect(Object.getOwnPropertyNames(out).sort()).toEqual(["__proto__", "a"]);
+    expect(Object.getOwnPropertyDescriptor(out, "__proto__")?.value).toBe(7);
+  });
+});

--- a/packages/agency-lang/lib/runtime/validateChain.test.ts
+++ b/packages/agency-lang/lib/runtime/validateChain.test.ts
@@ -249,3 +249,68 @@ describe("ref descriptors (deferred reads for recursive/forward aliases)", () =>
     expect(isFailure(r)).toBe(true);
   });
 });
+
+describe("record descriptor kind (#630)", () => {
+  const ageDesc: TypeValidationDescriptor = {
+    kind: "leaf",
+    schema: z.number(),
+    validators: [isPos],
+  };
+  const recordDesc: TypeValidationDescriptor = {
+    kind: "record",
+    schema: z.record(z.string(), z.number()),
+    validators: [],
+    value: ageDesc,
+  };
+
+  it("runs the value descriptor validators per entry", async () => {
+    const ok = await __validateChainRecursive({ a: 1, b: 2 }, recordDesc);
+    expect(isSuccess(ok)).toBe(true);
+    const bad = await __validateChainRecursive({ a: 1, b: -5 }, recordDesc);
+    expect(isFailure(bad)).toBe(true);
+  });
+
+  it("writes transformed values back into the result", async () => {
+    const doublingDesc: TypeValidationDescriptor = {
+      kind: "record",
+      schema: z.record(z.string(), z.number()),
+      validators: [],
+      value: { kind: "leaf", schema: z.number(), validators: [doubleIt] },
+    };
+    const r = await __validateChainRecursive({ a: 1, b: 2 }, doublingDesc);
+    expect(isSuccess(r)).toBe(true);
+    expect((r as { value: unknown }).value).toEqual({ a: 2, b: 4 });
+  });
+
+  it("nested records validate through both levels", async () => {
+    const nested: TypeValidationDescriptor = {
+      kind: "record",
+      schema: z.record(z.string(), z.record(z.string(), z.number())),
+      validators: [],
+      value: recordDesc,
+    };
+    expect(isSuccess(await __validateChainRecursive({ x: { a: 1 } }, nested))).toBe(true);
+    expect(isFailure(await __validateChainRecursive({ x: { a: -1 } }, nested))).toBe(true);
+  });
+
+  it("record own validators run before per-entry walks", async () => {
+    const nonEmpty: AgencyValidator = async (v) =>
+      Object.keys(v as object).length > 0 ? success(v) : failure("empty record");
+    const withOwn: TypeValidationDescriptor = {
+      kind: "record",
+      schema: z.record(z.string(), z.number()),
+      validators: [nonEmpty],
+      value: ageDesc,
+    };
+    expect(isFailure(await __validateChainRecursive({}, withOwn))).toBe(true);
+    expect(isSuccess(await __validateChainRecursive({ a: 1 }, withOwn))).toBe(true);
+  });
+
+  it("record inside a ref resolves and validates", async () => {
+    const viaRef: TypeValidationDescriptor = {
+      kind: "ref",
+      get: () => recordDesc,
+    };
+    expect(isFailure(await __validateChainRecursive({ a: -1 }, viaRef))).toBe(true);
+  });
+});

--- a/packages/agency-lang/lib/runtime/validateChain.ts
+++ b/packages/agency-lang/lib/runtime/validateChain.ts
@@ -250,16 +250,22 @@ async function walk(
       if (parsed === null || typeof parsed !== "object") {
         return success(parsed);
       }
+      const entries = parsed as Record<string, unknown>;
       const out: Record<string, unknown> = {};
-      for (const key of Object.keys(parsed as Record<string, unknown>)) {
-        const r = await walk(
-          (parsed as Record<string, unknown>)[key],
-          descriptor.value,
-          depth + 1,
-          maxDepth,
-        );
+      for (const key of Object.keys(entries)) {
+        const r = await walk(entries[key], descriptor.value, depth + 1, maxDepth);
         if (!isSuccess(r)) return r;
-        out[key] = (r as { value: unknown }).value;
+        // defineProperty, not assignment: record keys are user data, and
+        // assigning a key like "__proto__" would rewrite the prototype
+        // instead of storing the entry (prototype pollution). Zod's record
+        // parse drops such keys today, but a ref-carried schema may not —
+        // the walker must be safe on its own.
+        Object.defineProperty(out, key, {
+          value: (r as { value: unknown }).value,
+          enumerable: true,
+          writable: true,
+          configurable: true,
+        });
       }
       return success(out);
     }

--- a/packages/agency-lang/lib/runtime/validateChain.ts
+++ b/packages/agency-lang/lib/runtime/validateChain.ts
@@ -94,6 +94,19 @@ export type TypeValidationDescriptor =
       element: TypeValidationDescriptor;
     }
   | {
+      /**
+       * A Record<K, V>: every entry value walks the same `value` descriptor
+       * (#630 — this is how alias-carried validators on the value type run).
+       * KEYS are schema-checked only: running validators on keys would mean
+       * rewriting keys when a validator transforms, which needs its own
+       * design. Documented in the guide.
+       */
+      kind: "record";
+      schema: z.ZodType;
+      validators: AgencyValidator[];
+      value: TypeValidationDescriptor;
+    }
+  | {
       kind: "union";
       schema: z.ZodType;
       validators: AgencyValidator[];
@@ -224,6 +237,24 @@ async function walk(
         const r = await walk(
           (parsed as Record<string, unknown>)[key],
           childDesc,
+          depth + 1,
+          maxDepth,
+        );
+        if (!isSuccess(r)) return r;
+        out[key] = (r as { value: unknown }).value;
+      }
+      return success(out);
+    }
+
+    case "record": {
+      if (parsed === null || typeof parsed !== "object") {
+        return success(parsed);
+      }
+      const out: Record<string, unknown> = {};
+      for (const key of Object.keys(parsed as Record<string, unknown>)) {
+        const r = await walk(
+          (parsed as Record<string, unknown>)[key],
+          descriptor.value,
           depth + 1,
           maxDepth,
         );

--- a/packages/agency-lang/lib/typeChecker/assignability.ts
+++ b/packages/agency-lang/lib/typeChecker/assignability.ts
@@ -262,7 +262,12 @@ export function resolveTypeDeep(
   t: VariableType,
   typeAliases: Record<string, TypeAliasEntry>,
 ): VariableType {
-  let current = t;
+  // Pure pre-pass, before ANY resolution: stamp Record nodes with their
+  // written args. mapTypes maps children before parents, so by the time the
+  // resolving passes below reach a Record node its typeArgs are already
+  // resolved — the alias identity the validation-descriptor builder needs
+  // (#630) would be gone. Stamping first captures the genuinely-written args.
+  let current = mapTypes(t, stampRecordWrittenArgs);
   // Iterate until a pass produces no change. Generic-alias depth is bounded
   // in practice; MAX_GENERIC_RESOLUTION_PASSES exists only to prevent
   // runaway loops on a bug.
@@ -272,6 +277,15 @@ export function resolveTypeDeep(
     current = next;
   }
   return current;
+}
+
+/** See the pre-pass in resolveTypeDeep. No-op once stamped, so the
+ *  fixpoint iteration stays stable. */
+function stampRecordWrittenArgs(n: VariableType): VariableType {
+  if (n.type === "genericType" && n.name === "Record" && !n.writtenTypeArgs) {
+    return { ...n, writtenTypeArgs: n.typeArgs };
+  }
+  return n;
 }
 
 /**

--- a/packages/agency-lang/lib/typeChecker/assignability.ts
+++ b/packages/agency-lang/lib/typeChecker/assignability.ts
@@ -139,9 +139,10 @@ function resolveTypeWithGuard(
     // types) live in the builtinGenerics.ts registry and evaluate eagerly.
     // The resolver callback carries this call's in-progress guard, so
     // recursive alias arguments degrade gracefully (self-refs stay
-    // nominal). Tag handling is per-entry: utility types merge the
-    // occurrence's tags as the use-site layer; Array/Schema/Record keep
-    // their historical behavior.
+    // nominal). Tag handling is per-entry: utility types and Array merge
+    // the occurrence's tags as the use-site layer; Record keeps them
+    // verbatim on its wrapper; Schema drops them (a schema value is not
+    // validated data). See the registry comment in builtinGenerics.ts.
     if (isBuiltinGenericName(vt.name)) {
       return evalBuiltinGeneric(
         vt.name,

--- a/packages/agency-lang/lib/typeChecker/assignability.ts
+++ b/packages/agency-lang/lib/typeChecker/assignability.ts
@@ -145,7 +145,12 @@ function resolveTypeWithGuard(
     if (isBuiltinGenericName(vt.name)) {
       return evalBuiltinGeneric(
         vt.name,
-        vt.typeArgs,
+        // Prefer the written args when this node has been resolved before
+        // (Record keeps its wrapper, so it can meet the resolver twice).
+        // apply() resolves its args itself, so this is idempotent — and it
+        // keeps writtenTypeArgs genuinely written across passes, which the
+        // validation-descriptor builder relies on for alias identity (#630).
+        vt.writtenTypeArgs ?? vt.typeArgs,
         (t) => resolveTypeWithGuard(t, typeAliases, inProgress),
         vt.tags,
       );

--- a/packages/agency-lang/lib/typeChecker/builtinGenerics.test.ts
+++ b/packages/agency-lang/lib/typeChecker/builtinGenerics.test.ts
@@ -67,6 +67,16 @@ describe("container forms through the registry", () => {
     });
   });
 
+  it("Array merges use-site tags onto the lowered arrayType (#630)", () => {
+    const tag = { type: "tag" as const, name: "validate", arguments: [] };
+    const out = evalBuiltinGeneric("Array", [NUM], id, [tag]);
+    expect(out).toEqual({
+      type: "arrayType",
+      elementType: NUM,
+      tags: [tag],
+    });
+  });
+
   it("Record keeps its genericType wrapper with resolved args, written args, and use-site tags", () => {
     const tag = { type: "tag" as const, name: "validate", arguments: [] };
     const out = evalBuiltinGeneric("Record", [STR, NUM], id, [tag]);

--- a/packages/agency-lang/lib/typeChecker/builtinGenerics.test.ts
+++ b/packages/agency-lang/lib/typeChecker/builtinGenerics.test.ts
@@ -67,13 +67,16 @@ describe("container forms through the registry", () => {
     });
   });
 
-  it("Record keeps its genericType wrapper with resolved args and use-site tags", () => {
+  it("Record keeps its genericType wrapper with resolved args, written args, and use-site tags", () => {
     const tag = { type: "tag" as const, name: "validate", arguments: [] };
     const out = evalBuiltinGeneric("Record", [STR, NUM], id, [tag]);
     expect(out).toEqual({
       type: "genericType",
       name: "Record",
       typeArgs: [STR, NUM],
+      // The written (unresolved) args survive alongside the resolved ones so
+      // the validation-descriptor builder can keep alias identity (#630).
+      writtenTypeArgs: [STR, NUM],
       tags: [tag],
     });
   });

--- a/packages/agency-lang/lib/typeChecker/builtinGenerics.ts
+++ b/packages/agency-lang/lib/typeChecker/builtinGenerics.ts
@@ -136,16 +136,23 @@ export function resolveKeysArg(
 }
 
 const BUILTIN_GENERICS: Record<string, BuiltinGeneric> = {
-  // Container forms. Array/Schema lower to their dedicated type nodes and
-  // (historical behavior, preserved) DROP use-site tags; Record keeps its
-  // genericType wrapper so codegen can emit z.record, and keeps use-site
-  // tags verbatim on that wrapper.
+  // Container forms. Array lowers to its dedicated type node and MERGES
+  // use-site tags (#630 — `@validate(f) Array<T>` used to drop them);
+  // Schema lowers to schemaType and still drops use-site tags (a schema
+  // value is not validated data, so there is nothing for a validator to
+  // run on). Record keeps its genericType wrapper so codegen can emit
+  // z.record, keeps use-site tags verbatim on that wrapper, and stashes
+  // the written args for the validation-descriptor builder.
   Array: {
     arity: 1,
-    apply: ([element], resolve) => ({
-      type: "arrayType",
-      elementType: resolve(element),
-    }),
+    apply: ([element], resolve, useSiteTags) =>
+      withUseSiteTags(
+        {
+          type: "arrayType",
+          elementType: resolve(element),
+        },
+        useSiteTags,
+      ),
   },
   Schema: {
     arity: 1,
@@ -167,6 +174,10 @@ const BUILTIN_GENERICS: Record<string, BuiltinGeneric> = {
         type: "genericType",
         name: "Record",
         typeArgs: [key, resolve(valueArg)],
+        // Written (unresolved) args: the descriptor builder needs the
+        // alias identity of the value type to emit a ref instead of
+        // inlining validators (#630 — see writtenTypeArgs in typeHints.ts).
+        writtenTypeArgs: [keyArg, valueArg],
       };
       if (useSiteTags) {
         node.tags = useSiteTags;

--- a/packages/agency-lang/lib/typeChecker/resolveType.test.ts
+++ b/packages/agency-lang/lib/typeChecker/resolveType.test.ts
@@ -82,7 +82,8 @@ describe("resolveType: built-in generic Record", () => {
       typeArgs: [stringType, numberType],
     };
     const result = resolveType(input, {});
-    expect(result).toEqual(input);
+    // writtenTypeArgs rides along for the validation-descriptor builder (#630).
+    expect(result).toEqual({ ...input, writtenTypeArgs: [stringType, numberType] });
   });
 
   it("resolves aliases inside Record value position", () => {
@@ -101,6 +102,11 @@ describe("resolveType: built-in generic Record", () => {
       type: "genericType",
       name: "Record",
       typeArgs: [stringType, numberType],
+      // Written args keep the alias identity that resolution erases (#630).
+      writtenTypeArgs: [
+        stringType,
+        { type: "typeAliasVariable", aliasName: "N" },
+      ],
     });
   });
 
@@ -280,6 +286,9 @@ describe("resolveType: user-defined generic aliases", () => {
       type: "genericType",
       name: "Record",
       typeArgs: [stringType, anyType],
+      // Written args after param substitution: V has already been replaced
+      // by its default before Record.apply sees the args (#630).
+      writtenTypeArgs: [stringType, anyType],
     });
   });
 
@@ -555,6 +564,16 @@ describe("resolveTypeDeep: nested generic resolution", () => {
         {
           type: "objectType",
           properties: [{ key: "value", value: numberType }],
+        },
+      ],
+      // The written value arg keeps the Container<number> reference so the
+      // descriptor builder can preserve alias identity (#630).
+      writtenTypeArgs: [
+        stringType,
+        {
+          type: "genericType",
+          name: "Container",
+          typeArgs: [numberType],
         },
       ],
     });

--- a/packages/agency-lang/lib/types/typeHints.ts
+++ b/packages/agency-lang/lib/types/typeHints.ts
@@ -57,6 +57,17 @@ export type GenericType = {
   name: string;
   typeArgs: VariableType[];
   /**
+   * The type args exactly as WRITTEN, before alias resolution. Set by the
+   * Record builtin (builtinGenerics.ts) so the validation-descriptor
+   * builder can keep alias identity: a written alias arg routes through
+   * the deferred `__agency_descriptor` ref, so its validators execute in
+   * the defining module where their free identifiers exist — never
+   * inlined into the consuming module (#630). Excluded from typeKey:
+   * resolved args are a function of written args, so type identity is
+   * unaffected.
+   */
+  writtenTypeArgs?: VariableType[];
+  /**
    * Value arguments at the use site of a value-parameterized alias.
    * Example: `BoundedList<string>(3)` — typeArgs is `[string]`, valueArgs is `[3]`.
    * Restricted to the same expression subset accepted by tag arguments.

--- a/packages/agency-lang/tests/agency/record-validators/ages.agency
+++ b/packages/agency-lang/tests/agency/record-validators/ages.agency
@@ -1,0 +1,28 @@
+// Module A: the validator calls a NON-exported helper. If the consumer ever
+// inlines the validator instead of routing through this module's
+// __agency_descriptor, minimumAge does not exist in the consumer scope and
+// validation crashes — that is the #630 regression this directory guards.
+
+def minimumAge(): number {
+  return 18
+}
+
+export def isAdult(v: number): Result<number> {
+  if (v < minimumAge()) {
+    return failure("too young")
+  }
+  return success(v)
+}
+
+export def clampToOne(v: number): Result<number> {
+  if (v < 0) {
+    return success(1)
+  }
+  return success(v)
+}
+
+@validate(isAdult)
+export type Age = number
+
+@validate(clampToOne)
+export type Repaired = number

--- a/packages/agency-lang/tests/agency/record-validators/main.agency
+++ b/packages/agency-lang/tests/agency/record-validators/main.agency
@@ -1,0 +1,53 @@
+// #630: @validate tags must run through Record values, cross-module, via the
+// defining module's descriptor (see ages.agency for why inlining would crash).
+
+import { Age, Repaired } from "./ages.agency"
+
+node rejects() {
+  const ages: Record<string, Age>! = { a: 30, b: 12 }
+  if (ages is failure(err)) {
+    return "rejected:${err}"
+  }
+  return "accepted"
+}
+
+node passes() {
+  const ages: Record<string, Age>! = { a: 30, b: 45 }
+  if (ages is success(v)) {
+    return "ok:${v.a},${v.b}"
+  }
+  return "rejected"
+}
+
+node transforms() {
+  // The record walker must write transformed values back per entry.
+  const fixed: Record<string, Repaired>! = { a: -5, b: 2 }
+  if (fixed is success(v)) {
+    return "fixed:${v.a},${v.b}"
+  }
+  return "rejected"
+}
+
+node patternTest() {
+  // Type patterns ride the same descriptor machinery (tier 2).
+  const good: any = { a: 30 }
+  const bad: any = { a: 12 }
+  let out = ""
+  if (good is Record<string, Age>) {
+    out = "good-yes"
+  }
+  if (bad is Record<string, Age>) {
+    out = "${out},bad-yes"
+  } else {
+    out = "${out},bad-no"
+  }
+  return out
+}
+
+node nested() {
+  const deep: Record<string, Record<string, Age>>! = { x: { a: 12 } }
+  if (deep is failure(err)) {
+    return "deep-rejected"
+  }
+  return "deep-accepted"
+}

--- a/packages/agency-lang/tests/agency/record-validators/main.test.json
+++ b/packages/agency-lang/tests/agency/record-validators/main.test.json
@@ -1,0 +1,39 @@
+{
+  "tests": [
+    {
+      "nodeName": "rejects",
+      "description": "Cross-module Record value validator (calling a module-private helper) rejects a failing entry.",
+      "input": "",
+      "expectedOutput": "\"rejected:too young\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "passes",
+      "description": "Valid entries pass and values are preserved.",
+      "input": "",
+      "expectedOutput": "\"ok:30,45\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "transforms",
+      "description": "A transforming validator on the value type writes repaired values back per entry.",
+      "input": "",
+      "expectedOutput": "\"fixed:1,2\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "patternTest",
+      "description": "is Record<string, Age> runs value validators through the tier-2 type-pattern path.",
+      "input": "",
+      "expectedOutput": "\"good-yes,bad-no\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "nested",
+      "description": "Nested records validate through both levels.",
+      "input": "",
+      "expectedOutput": "\"deep-rejected\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #630: `@validate` tags were silently dropped inside `Record<...>` — the value type validated shape-only.

Design discussed in [the issue thread](https://github.com/egonSchiele/agency-lang/issues/630#issuecomment-5030149584). The one constraint that shaped everything: **validators are never inlined into the consuming module** (they can reference module-private helpers; inlining produces `X is not defined` at runtime). Everything routes through the alias-defining module's `__agency_descriptor`.

## Changes

- **New `record` descriptor kind** (`lib/runtime/validateChain.ts`): walks each entry value against the value-type descriptor, mirrors the `object` kind, writes transformed values back per entry. Keys stay schema-checked only (a transforming key validator would mean rewriting keys — deliberately out of scope, documented on the kind).
- **`descriptor()` Record branch** (`validationDescriptor.ts`): builds the value descriptor from the WRITTEN type arg, so an alias arg hits the existing `typeAliasVariable` ref branch and validators execute in their defining module.
- **`writtenTypeArgs` on Record nodes** (`builtinGenerics.ts`, `typeHints.ts`): the resolver erases alias identity, so Record stashes its pre-resolution args. Two subtleties surfaced during implementation:
  - `resolveTypeDeep` maps children before parents, so by the time the Record node resolves, its args are already resolved — a pure pre-pass now stamps written args before any resolution (`assignability.ts`).
  - Record survives resolution as a `genericType`, so it can meet the resolver twice; the builtin dispatch now prefers `writtenTypeArgs` so re-resolution is idempotent.
  - Excluded from `typeKey` (explicit-field serialization), so type identity is unaffected.
- **`Array` use-site tags** now merge through resolution like `Partial`/`Pick` (previously dropped as "historical behavior"). `Schema` still drops them — a schema value is not validated data.
- Two `descriptor()` branches (union, record) extracted to named helpers — the function crossed the 150-line lint cap.

## Tests

- Runtime walker: per-entry validation, transform write-back, nesting, own-validators-first, ref-wrapped records.
- **Cross-module regression (the headline)**: `tests/agency/record-validators/` — module A defines `Age` whose validator calls a NON-exported module-A helper; module B validates `Record<string, Age>!` and matches `x is Record<string, Age>`. Fails under any inlining approach, passes only via the ref path.
- Transform propagation: `Record<string, Repaired>!` with a clamping validator returns repaired values.
- The exact issue repro now fails with `must be positive`.

3621 unit tests + 5/5 execution tests green locally; agency suite in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
