### PR TITLE
Type-check a lone tool passed to a tools: array

### DIFF
--- a/packages/agency-lang/lib/typeChecker/scopes.ts
+++ b/packages/agency-lang/lib/typeChecker/scopes.ts
@@ -401,7 +401,32 @@ export function walkScopeBody(
       case "importStatement":
         for (const importName of node.importedNames) {
           for (const name of getImportedNames(importName)) {
-            scope.declare(name, ANY_T);
+            // A resolved Agency function/node import resolves to its real
+            // function type, not `any`, so passing one where a specific type
+            // is expected — a lone tool where a `tools:` array is required, for
+            // instance — is caught exactly as it is for a locally-defined
+            // `def`. Value references read this scope binding, so without it an
+            // imported tool would silently type as `any` and slip past the
+            // check. A JS import stays `any` (its signature is unknown to the
+            // type checker), and an unresolved Agency import stays `any` too
+            // (absent from importedFunctions), preserving the fail-open
+            // behavior for missing modules.
+            const imported = Object.prototype.hasOwnProperty.call(
+              ctx.importedFunctions,
+              name,
+            )
+              ? ctx.importedFunctions[name]
+              : undefined;
+            const declaredType: VariableType =
+              imported && !ctx.jsImportedNames[name]
+                ? {
+                    type: "functionRefType",
+                    name,
+                    params: imported.parameters,
+                    returnType: imported.returnType ?? null,
+                  }
+                : ANY_T;
+            scope.declare(name, declaredType);
           }
         }
         break;

--- a/packages/agency-lang/lib/typeChecker/scopes.ts
+++ b/packages/agency-lang/lib/typeChecker/scopes.ts
@@ -374,6 +374,38 @@ function checkConstMutations(
   }
 }
 
+const hasOwn = (obj: object, name: string): boolean =>
+  Object.prototype.hasOwnProperty.call(obj, name);
+
+/**
+ * The scope type for an imported name. A resolved Agency function/node import
+ * resolves to its real function type, not `any`, so passing one where a
+ * specific type is expected — a lone tool where a `tools:` array is required,
+ * for instance — is caught exactly as it is for a locally-defined `def`. Value
+ * references read this scope binding, so without it an imported tool would
+ * silently type as `any` and slip past the check.
+ *
+ * A JS import stays `any` (its signature is unknown to the type checker), and
+ * an unresolved Agency import stays `any` too (absent from importedFunctions),
+ * preserving the fail-open behavior for missing modules. Both membership tests
+ * use an own-property check so a name like `toString` is not mistaken for a
+ * prototype method on these plain-object registries.
+ */
+function importedValueType(
+  name: string,
+  ctx: TypeCheckerContext,
+): VariableType {
+  if (hasOwn(ctx.jsImportedNames, name)) return ANY_T;
+  if (!hasOwn(ctx.importedFunctions, name)) return ANY_T;
+  const imported = ctx.importedFunctions[name];
+  return {
+    type: "functionRefType",
+    name,
+    params: imported.parameters,
+    returnType: imported.returnType ?? null,
+  };
+}
+
 /**
  * Walk a body of statements and declare every binding into the given scope.
  * Recurses into nested blocks using the same scope, which preserves today's
@@ -401,32 +433,7 @@ export function walkScopeBody(
       case "importStatement":
         for (const importName of node.importedNames) {
           for (const name of getImportedNames(importName)) {
-            // A resolved Agency function/node import resolves to its real
-            // function type, not `any`, so passing one where a specific type
-            // is expected — a lone tool where a `tools:` array is required, for
-            // instance — is caught exactly as it is for a locally-defined
-            // `def`. Value references read this scope binding, so without it an
-            // imported tool would silently type as `any` and slip past the
-            // check. A JS import stays `any` (its signature is unknown to the
-            // type checker), and an unresolved Agency import stays `any` too
-            // (absent from importedFunctions), preserving the fail-open
-            // behavior for missing modules.
-            const imported = Object.prototype.hasOwnProperty.call(
-              ctx.importedFunctions,
-              name,
-            )
-              ? ctx.importedFunctions[name]
-              : undefined;
-            const declaredType: VariableType =
-              imported && !ctx.jsImportedNames[name]
-                ? {
-                    type: "functionRefType",
-                    name,
-                    params: imported.parameters,
-                    returnType: imported.returnType ?? null,
-                  }
-                : ANY_T;
-            scope.declare(name, declaredType);
+            scope.declare(name, importedValueType(name, ctx));
           }
         }
         break;

--- a/packages/agency-lang/lib/typeChecker/synthesizer.ts
+++ b/packages/agency-lang/lib/typeChecker/synthesizer.ts
@@ -888,6 +888,35 @@ function synthObject(
   };
 }
 
+/**
+ * The type of a tool-method chain element (`fn.partial(...)`,
+ * `fn.describe("…")`, `fn.rename("…")`, `fn.preapprove()`). Each returns a new
+ * tool, which is a function value — so we keep the receiver's functionRefType
+ * rather than collapsing to `any`. That is what makes a single tool ineligible
+ * where a `tools:` array is expected.
+ *
+ * `.partial(name: …)` binds arguments, so it drops those parameters from the
+ * resulting signature — `_matchesFilter(name, filterText).partial(filterText:)`
+ * becomes `(name) -> boolean`, which still satisfies a `(any) -> any` callback.
+ * The other methods leave the signature untouched. When the receiver isn't a
+ * known function we can't prove it's a tool, so we stay `any`.
+ */
+function toolMethodResultType(
+  receiver: VariableType,
+  methodName: string,
+  element: { functionCall: { arguments: any[] } },
+): VariableType {
+  if (receiver.type !== "functionRefType") return ANY_T;
+  if (methodName !== "partial") return receiver;
+  const boundNames = element.functionCall.arguments
+    .filter((a: any) => "type" in a && a.type === "namedArgument")
+    .map((a: any) => a.name);
+  return {
+    ...receiver,
+    params: receiver.params.filter((p) => !boundNames.includes(p.name)),
+  };
+}
+
 function validateAgencyFunctionMethod(
   expr: ValueAccess,
   element: { kind: "methodCall"; functionCall: { type: "functionCall"; functionName: string; arguments: any[] } },
@@ -1048,7 +1077,9 @@ export function synthValueAccess(
       const methodName = element.functionCall.functionName;
       if (methodName === "partial" || methodName in AGENCY_FUNCTION_METHOD_TYPES) {
         validateAgencyFunctionMethod(expr, element, methodName, scope, ctx);
-        currentType = ANY_T;
+        // Chaining still works past this point because the dispatch above keys
+        // on the method name, not the receiver type.
+        currentType = toolMethodResultType(currentType, methodName, element);
         continue;
       }
     }

--- a/packages/agency-lang/lib/typeChecker/toolArgArrayType.test.ts
+++ b/packages/agency-lang/lib/typeChecker/toolArgArrayType.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { parseAgency } from "../parser.js";
+import { SymbolTable } from "../symbolTable.js";
+import { buildCompilationUnit } from "../compilationUnit.js";
+import { typeCheck } from "./index.js";
+
+// A `tools:` argument must be an ARRAY of tools. A lone tool value is not
+// assignable, and the type checker should say so at compile time instead of
+// letting it reach runPrompt, which does `rawTools.map(...)` and crashes with
+// the opaque "rawTools.map is not a function". These tests lock in that a tool
+// value — whether a bare function, a `.partial()`/`.describe()` chain, or an
+// imported function — is caught when passed to `tools:` without brackets, and
+// is accepted once wrapped in an array.
+
+function check(source: string): string[] {
+  const parsed = parseAgency(source);
+  if (!parsed.success) throw new Error(`parse failed: ${parsed.message}`);
+  const info = buildCompilationUnit(parsed.result, undefined, undefined, source);
+  return typeCheck(parsed.result, {}, info).errors.map((e) => e.message);
+}
+
+// Cross-module variant so imported functions resolve to real signatures.
+function checkImporter(files: Record<string, string>, entry: string): string[] {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-toolarg-"));
+  try {
+    for (const [name, src] of Object.entries(files)) {
+      fs.writeFileSync(path.join(dir, name), src);
+    }
+    const entryPath = path.join(dir, entry);
+    const src = files[entry];
+    const parsed = parseAgency(src);
+    if (!parsed.success) throw new Error(`parse failed: ${parsed.message}`);
+    const symbols = SymbolTable.build(entryPath);
+    const info = buildCompilationUnit(parsed.result, symbols, entryPath, src);
+    return typeCheck(parsed.result, {}, info).errors.map((e) => e.message);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+const toolsArrayError = (e: string) =>
+  e.includes("Named argument 'tools'") && e.includes("any[] | null");
+
+describe("tools: argument must be an array — locally-defined tools", () => {
+  it("rejects a lone .partial() result", () => {
+    const errs = check(`
+def weather(city: string, unit: string): string { return city }
+node main() {
+  const r = llm("hi", tools: weather.partial(unit: "C"))
+}
+`);
+    expect(errs.some(toolsArrayError)).toBe(true);
+  });
+
+  it("accepts the same .partial() result inside an array", () => {
+    const errs = check(`
+def weather(city: string, unit: string): string { return city }
+node main() {
+  const r = llm("hi", tools: [weather.partial(unit: "C")])
+}
+`);
+    expect(errs.some(toolsArrayError)).toBe(false);
+  });
+
+  it("rejects a lone .describe() result", () => {
+    const errs = check(`
+def weather(city: string): string { return city }
+node main() {
+  const r = llm("hi", tools: weather.describe("looks up weather"))
+}
+`);
+    expect(errs.some(toolsArrayError)).toBe(true);
+  });
+
+  it("accepts a chained .partial().describe().rename() inside an array", () => {
+    const errs = check(`
+def weather(city: string, unit: string): string { return city }
+node main() {
+  const r = llm("hi", tools: [weather.partial(unit: "C").describe("d").rename("w")])
+}
+`);
+    expect(errs.some(toolsArrayError)).toBe(false);
+  });
+});
+
+describe("tools: argument must be an array — imported tools", () => {
+  const libSrc = "export def weather(city: string, unit: string): string { return city }\n";
+
+  it("rejects a lone imported tool", () => {
+    const errs = checkImporter(
+      {
+        "lib.agency": libSrc,
+        "main.agency":
+          'import { weather } from "./lib.agency"\n' +
+          'node main() {\n  const r = llm("hi", tools: weather)\n}\n',
+      },
+      "main.agency",
+    );
+    expect(errs.some(toolsArrayError)).toBe(true);
+  });
+
+  it("rejects a lone imported .partial() result (the reported crash)", () => {
+    const errs = checkImporter(
+      {
+        "lib.agency": libSrc,
+        "main.agency":
+          'import { weather } from "./lib.agency"\n' +
+          'node main() {\n  const r = llm("hi", tools: weather.partial(unit: "C"))\n}\n',
+      },
+      "main.agency",
+    );
+    expect(errs.some(toolsArrayError)).toBe(true);
+  });
+
+  it("accepts an imported tool inside an array", () => {
+    const errs = checkImporter(
+      {
+        "lib.agency": libSrc,
+        "main.agency":
+          'import { weather } from "./lib.agency"\n' +
+          'node main() {\n  const r = llm("hi", tools: [weather.partial(unit: "C")])\n}\n',
+      },
+      "main.agency",
+    );
+    expect(errs.some(toolsArrayError)).toBe(false);
+  });
+});
+
+describe(".partial() drops bound params so higher-order use still type-checks", () => {
+  // Regression guard: reducing the signature must not break `filter`,
+  // `map`, etc. that expect a `(any) -> any` callback. `_match(name, needle)`
+  // partially applied on `needle` is a `(name) -> boolean`, which satisfies
+  // the one-argument callback — a full two-argument signature would not.
+  it("a .partial() tool with one remaining param satisfies a filter callback", () => {
+    const errs = check(`
+def _match(name: string, needle: string): boolean { return name.includes(needle) }
+def pick(names: string[], needle: string): string[] {
+  return filter(names, _match.partial(needle: needle))
+}
+`);
+    expect(errs.filter((e) => e.includes("not assignable"))).toEqual([]);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/toolArgArrayType.test.ts
+++ b/packages/agency-lang/lib/typeChecker/toolArgArrayType.test.ts
@@ -6,6 +6,7 @@ import { parseAgency } from "../parser.js";
 import { SymbolTable } from "../symbolTable.js";
 import { buildCompilationUnit } from "../compilationUnit.js";
 import { typeCheck } from "./index.js";
+import type { TypeCheckError } from "./types.js";
 
 // A `tools:` argument must be an ARRAY of tools. A lone tool value is not
 // assignable, and the type checker should say so at compile time instead of
@@ -15,15 +16,18 @@ import { typeCheck } from "./index.js";
 // imported function — is caught when passed to `tools:` without brackets, and
 // is accepted once wrapped in an array.
 
-function check(source: string): string[] {
+function check(source: string): TypeCheckError[] {
   const parsed = parseAgency(source);
   if (!parsed.success) throw new Error(`parse failed: ${parsed.message}`);
   const info = buildCompilationUnit(parsed.result, undefined, undefined, source);
-  return typeCheck(parsed.result, {}, info).errors.map((e) => e.message);
+  return typeCheck(parsed.result, {}, info).errors;
 }
 
 // Cross-module variant so imported functions resolve to real signatures.
-function checkImporter(files: Record<string, string>, entry: string): string[] {
+function checkImporter(
+  files: Record<string, string>,
+  entry: string,
+): TypeCheckError[] {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-toolarg-"));
   try {
     for (const [name, src] of Object.entries(files)) {
@@ -35,14 +39,17 @@ function checkImporter(files: Record<string, string>, entry: string): string[] {
     if (!parsed.success) throw new Error(`parse failed: ${parsed.message}`);
     const symbols = SymbolTable.build(entryPath);
     const info = buildCompilationUnit(parsed.result, symbols, entryPath, src);
-    return typeCheck(parsed.result, {}, info).errors.map((e) => e.message);
+    return typeCheck(parsed.result, {}, info).errors;
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }
 }
 
-const toolsArrayError = (e: string) =>
-  e.includes("Named argument 'tools'") && e.includes("any[] | null");
+// AG6014 is the named-argument type mismatch; `params.name` is the argument
+// that failed to type-check. Keying off the code + param is stabler than
+// matching the rendered message text.
+const toolsArrayError = (e: TypeCheckError) =>
+  e.code === "AG6014" && e.params.name === "tools";
 
 describe("tools: argument must be an array — locally-defined tools", () => {
   it("rejects a lone .partial() result", () => {
@@ -141,6 +148,8 @@ def pick(names: string[], needle: string): string[] {
   return filter(names, _match.partial(needle: needle))
 }
 `);
-    expect(errs.filter((e) => e.includes("not assignable"))).toEqual([]);
+    // AG6019 is the call-argument assignability error the full 2-arg
+    // signature would trigger against filter's (any) -> any callback.
+    expect(errs.filter((e) => e.code === "AG6019")).toEqual([]);
   });
 });


### PR DESCRIPTION
## Problem

Passing a **single tool** where `tools:` expects an **array** — for example:

```
llm("...", tools: elapsedTime.partial(since: start))   // no brackets
```

crashed at runtime with the opaque `rawTools.map is not a function`. `runPrompt`
does `.map` on `clientConfig.tools`, so a non-array value blows up.

The type checker types `tools` as `any[] | null` and already rejected a bare
local `tools: add`. But two holes let the value through typed as `any`, which is
freely assignable to `any[]`:

1. **Method-chain hole.** `.partial()`, `.describe()`, `.rename()`, and
   `.preapprove()` collapsed the whole chain to `any`.
2. **Imported-function hole (deeper, pre-existing).** Every imported name was
   declared into scope as `any`, so an imported function typed as `any` when
   used as a *value* — even bare, with no method call. This is why an imported
   `std::` tool slipped through even before any `.partial()`.

## Fix (compile-time only; runtime untouched)

- **`synthesizer.ts`** — a tool-method chain now keeps the receiver's function
  type instead of `any`. `.partial(name: ...)` drops the bound params from the
  resulting signature, so higher-order uses like `filter(xs, fn.partial(a: 1))`
  still type-check (carrying the full signature would break the `filter`/`revise`
  callbacks in `stdlib/ui.agency` and `stdlib/agents/researcher.agency`). When
  the receiver is not a known function we stay `any`.
- **`scopes.ts`** — a resolved Agency function/node import is declared into
  scope with its real function type. JS imports and unresolved imports stay
  `any`, preserving the fail-open behavior for host functions and missing
  modules.

A lone tool now produces a clear `AG6014` at compile time pointing at the
missing brackets. The fix: wrap it — `tools: [elapsedTime.partial(since: start)]`.

## Tests

New `lib/typeChecker/toolArgArrayType.test.ts` (8 tests): lone vs. bracketed
tool for locally-defined and imported functions, chained methods, and a
regression guard that `.partial()`'s arity reduction still satisfies a
`(any) -> any` callback.

- All 1650 type-checker tests pass (including the stdlib fixture typecheck).
- Full `lib/` unit suite: 8888 pass.
- `tsc --noEmit` and the structural linter are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
