### PR TITLE
Teach the coding agent to use the gh CLI

### DIFF
--- a/packages/agency-lang/stdlib/agents/skills/coding/gh-auth.md
+++ b/packages/agency-lang/stdlib/agents/skills/coding/gh-auth.md
@@ -17,7 +17,9 @@ Check the environment first — a token is often already present:
 
 ```bash
 gh auth status
-echo "${GH_TOKEN:-${GITHUB_TOKEN:-no token in env}}"
+# Report whether a token is present without printing its value — never echo a
+# secret, since it would land in logs and transcripts.
+[ -n "${GH_TOKEN:-}${GITHUB_TOKEN:-}" ] && echo "a token is set" || echo "no token in env"
 ```
 
 `gh` reads `GH_TOKEN` and `GITHUB_TOKEN` automatically. If either is set, `gh`

--- a/packages/agency-lang/stdlib/agents/skills/coding/gh-auth.md
+++ b/packages/agency-lang/stdlib/agents/skills/coding/gh-auth.md
@@ -1,0 +1,63 @@
+---
+name: gh: authentication setup
+description: Set up GitHub authentication for the gh CLI when `gh auth status` reports you are not logged in. Covers non-interactive token login, wiring gh's credentials into git, and the GH_TOKEN / GITHUB_TOKEN environment variables.
+---
+
+# Authenticating the `gh` CLI
+
+Read this only when `gh auth status` reports that you are not logged in. If it
+already shows an account, you are authenticated — go back to the task.
+
+You run without a browser, so the interactive `gh auth login` flow that opens a
+web page will not work. Use a token instead.
+
+## Is a token already available?
+
+Check the environment first — a token is often already present:
+
+```bash
+gh auth status
+echo "${GH_TOKEN:-${GITHUB_TOKEN:-no token in env}}"
+```
+
+`gh` reads `GH_TOKEN` and `GITHUB_TOKEN` automatically. If either is set, `gh`
+is effectively authenticated already and `gh auth status` should reflect that.
+If neither is set and you cannot find a token, tell the caller that GitHub
+authentication is missing and stop — you cannot mint a token yourself.
+
+## Log in with a token
+
+If you have a personal access token but `gh` is not using it, pipe it in. Do not
+put the token directly on the command line, where it would be saved in shell
+history:
+
+```bash
+echo "$GITHUB_TOKEN" | gh auth login --with-token
+```
+
+The token needs the `repo` scope for repository work, and `workflow` if you will
+touch GitHub Actions.
+
+## Let git use gh's credentials
+
+So that `git push`, `git pull`, and `git clone` over HTTPS authenticate through
+`gh`:
+
+```bash
+gh auth setup-git
+```
+
+## Verify
+
+```bash
+gh auth status        # should now show your account as logged in
+gh api user --jq '.login'   # prints your GitHub username
+```
+
+## Troubleshooting
+
+| Symptom | Cause and fix |
+|---|---|
+| `gh auth status`: not logged in, but a token is set | The token may be invalid or expired. Confirm with `gh api user`; if it fails, the token is bad. |
+| `git push` still prompts for a password | Run `gh auth setup-git` so git uses gh's credentials over HTTPS. |
+| `HTTP 403` / "Resource not accessible" | The token lacks the needed scope (for example `workflow` for Actions). A new token with the right scopes is required. |

--- a/packages/agency-lang/stdlib/agents/skills/coding/gh-pr-and-issues.md
+++ b/packages/agency-lang/stdlib/agents/skills/coding/gh-pr-and-issues.md
@@ -1,0 +1,150 @@
+---
+name: gh: pull requests, issues & CI
+description: Use the gh (GitHub CLI) for pull requests, issues, and CI. Open, view, diff, and review PRs; read check results and failing CI logs; create, comment on, and search issues; and reach any endpoint with `gh api`. Read this whenever a task involves GitHub.
+---
+
+# Working with GitHub via `gh`
+
+`gh` is the GitHub CLI. It talks to GitHub for you: pull requests, issues, CI
+results, and the raw API. You already have a shell and `git`, so use `gh` for
+anything that lives on GitHub rather than in the local repo.
+
+Run any `gh` command from inside the repository's working tree. `gh` reads the
+`origin` remote to know which repo you are acting on, so you rarely pass the repo
+name yourself.
+
+## First: confirm you are authenticated
+
+```bash
+gh auth status
+```
+
+If this prints an account and "Logged in", you are ready. If it reports you are
+not logged in, read the `gh: authentication setup` skill. If no credentials are
+available at all, say so to the caller and stop — do not guess.
+
+## Multi-line text: always use a file or heredoc
+
+A PR body, issue body, or comment is almost always multi-line Markdown. Passing
+it with `--body "..."` mangles newlines and breaks on quotes. Instead write the
+text to a file and pass `--body-file`, or pipe a heredoc:
+
+```bash
+# Write the body to a temp file first, then reference it.
+cat > /tmp/pr-body.md <<'EOF'
+## Summary
+- Adds retry logic to the upload client
+- Covers the timeout path with a new test
+
+Closes #42
+EOF
+
+gh pr create --title "Add upload retry logic" --body-file /tmp/pr-body.md
+```
+
+The `<<'EOF'` form (quoted delimiter) is important: it stops the shell from
+expanding `$`, backticks, and `!` inside your Markdown.
+
+## Pull requests
+
+### Create a PR
+
+```bash
+# Push your branch first, then open the PR against the default base branch.
+git push -u origin HEAD
+gh pr create --title "Short imperative title" --body-file /tmp/pr-body.md
+```
+
+Useful flags: `--draft` (open as a draft), `--base <branch>` (target a branch
+other than the default), `--reviewer user1,user2`, `--label "bug"`.
+
+To close an issue automatically when the PR merges, put a keyword in the PR
+body: `Closes #42`. Each issue needs its own keyword — `Closes #1, closes #2`
+closes both, but `Closes #1, #2` only closes #1.
+
+### Inspect a PR without changing branches
+
+You can read a PR's metadata and diff without checking it out. This keeps your
+working tree where it is:
+
+```bash
+gh pr view 123               # title, body, state, checks, comments
+gh pr view 123 --comments    # include the full comment thread
+gh pr diff 123               # the full diff
+gh pr diff 123 --name-only   # just the changed file paths
+```
+
+Only run `gh pr checkout 123` if you actually need the PR's code in your working
+tree (for example, to run its tests). It switches your branch.
+
+### Read a PR as structured data
+
+Add `--json` with the fields you want, and `--jq` to pull values out. This is
+the reliable way to feed a PR into your own logic:
+
+```bash
+gh pr view 123 --json title,state,headRefOid,statusCheckRollup
+gh pr view 123 --json headRefOid --jq '.headRefOid'   # the head commit SHA
+```
+
+### Comment on or review a PR
+
+```bash
+gh pr comment 123 --body-file /tmp/comment.md          # a plain comment
+gh pr review 123 --approve --body "LGTM"
+gh pr review 123 --request-changes --body-file /tmp/review.md
+gh pr review 123 --comment --body "A few non-blocking notes"
+```
+
+## CI: reading check results and failures
+
+When a PR's checks fail, find out why before you try to fix anything:
+
+```bash
+gh pr checks 123             # one line per check with pass/fail
+gh pr checks 123 --watch     # block until the checks finish
+
+gh run list --branch "$(git branch --show-current)" --limit 5
+gh run view <run-id>              # summary of jobs in a workflow run
+gh run view <run-id> --log-failed # only the log lines from failed steps
+```
+
+`--log-failed` is the fast path: it skips the passing output and shows just the
+failing step's log, which is usually where the error is.
+
+## Issues
+
+```bash
+gh issue list                                  # open issues in this repo
+gh issue list --state all --label bug --assignee @me
+gh issue view 42                               # body, labels, state
+gh issue view 42 --comments                    # include the discussion
+gh issue view 42 --json title,body,comments,labels,state
+
+gh issue create --title "..." --body-file /tmp/issue.md --label bug
+gh issue comment 42 --body-file /tmp/note.md
+gh issue close 42
+gh issue close 42 --reason "not planned"
+```
+
+Do not trust root-cause analysis written in an issue. Read the code and the
+execution path yourself, then form your own conclusion.
+
+## `gh api`: the escape hatch
+
+Anything the dedicated commands do not cover, you can reach directly. `gh api`
+handles authentication and the base URL for you:
+
+```bash
+# GET — the {owner}/{repo} placeholders are filled from the current repo.
+gh api repos/{owner}/{repo}/pulls/123/files --jq '.[].filename'
+
+# POST with typed fields (-F parses numbers/booleans; -f keeps strings).
+gh api repos/{owner}/{repo}/issues/42/labels -f 'labels[]=priority:high'
+
+# Paginate through every page of a list endpoint.
+gh api --paginate repos/{owner}/{repo}/issues
+```
+
+Reach for `gh api` only when no `gh <command>` fits. The named commands are
+clearer and less error-prone.

--- a/packages/agency-lang/stdlib/agents/skills/coding/gh-repos-and-releases.md
+++ b/packages/agency-lang/stdlib/agents/skills/coding/gh-repos-and-releases.md
@@ -1,0 +1,84 @@
+---
+name: gh: repositories, releases & workflows
+description: Use the gh (GitHub CLI) to manage repositories and releases, beyond day-to-day PR and issue work. Create, clone, fork, and edit repos; cut releases and upload assets; trigger and re-run Actions workflows; set secrets; and create gists.
+---
+
+# Repositories, releases, and workflows via `gh`
+
+This skill covers the GitHub operations you reach for less often than PRs and
+issues. For pull requests, issues, and CI, read the `gh: pull requests, issues
+& CI` skill instead. If `gh auth status` says you are not logged in, read the
+`gh: authentication setup` skill first.
+
+As with all `gh` work, write any multi-line body (release notes, descriptions)
+to a file and pass it with a `--notes-file` / `--body-file` flag rather than
+inlining it with quotes.
+
+## Repositories
+
+```bash
+gh repo clone owner/repo                 # clone (add `-- --depth 1` for shallow)
+gh repo view owner/repo                  # description, default branch, topics
+gh repo create my-project --public --clone
+gh repo create my-project --private --description "..." --license MIT --clone
+gh repo create owner/name --source . --push   # publish the current directory
+
+gh repo fork owner/repo --clone          # fork, clone, and add `upstream`
+gh repo sync owner/repo                   # pull upstream changes into a fork
+
+gh repo edit --description "..." --add-topic "cli,automation"
+gh repo edit --default-branch main --enable-auto-merge
+```
+
+## Releases
+
+```bash
+gh release create v1.2.0 --title "v1.2.0" --generate-notes
+gh release create v1.2.0 --notes-file /tmp/notes.md
+gh release create v2.0.0-rc1 --draft --prerelease --generate-notes
+
+# Attach built artifacts by listing them after the tag.
+gh release create v1.2.0 ./dist/app-linux ./dist/app-macos --generate-notes
+
+gh release list
+gh release view v1.2.0
+gh release download v1.2.0 --dir ./downloads
+```
+
+`--generate-notes` writes the release notes from merged PRs and commits since the
+last release, so you rarely need to write them by hand.
+
+## Actions workflows
+
+```bash
+gh workflow list
+gh workflow run ci.yml --ref main                  # trigger a workflow_dispatch
+gh workflow run deploy.yml -f environment=staging  # pass inputs with -f
+
+gh run list --workflow ci.yml --limit 10
+gh run view <run-id>
+gh run rerun <run-id>            # re-run the whole workflow
+gh run rerun <run-id> --failed   # re-run only the failed jobs
+gh run watch <run-id>            # block until the run finishes
+```
+
+## Secrets
+
+```bash
+gh secret set API_KEY --body "value"
+gh secret set SSH_KEY < ~/.ssh/id_ed25519   # read the value from a file
+gh secret list                               # names only; values are never shown
+gh secret delete API_KEY
+```
+
+`gh secret set` encrypts the value with the repository's public key for you. Set
+repository secrets by default; add `--env <name>` for an environment secret or
+`--org <name>` for an organization secret.
+
+## Gists
+
+```bash
+gh gist create script.py --public --desc "One-off helper"
+gh gist list
+gh gist view <id>
+```

--- a/packages/agency-lang/stdlib/agents/skills/coding/gh-repos-and-releases.md
+++ b/packages/agency-lang/stdlib/agents/skills/coding/gh-repos-and-releases.md
@@ -64,10 +64,13 @@ gh run watch <run-id>            # block until the run finishes
 
 ## Secrets
 
+Pass the value on stdin or from a file, never with `--body "..."` — a value on
+the command line is captured in shell history and visible in process listings.
+
 ```bash
-gh secret set API_KEY --body "value"
-gh secret set SSH_KEY < ~/.ssh/id_ed25519   # read the value from a file
-gh secret list                               # names only; values are never shown
+printf %s "$API_KEY" | gh secret set API_KEY   # value piped in on stdin
+gh secret set SSH_KEY < ~/.ssh/id_ed25519      # value read from a file
+gh secret list                                 # names only; values are never shown
 gh secret delete API_KEY
 ```
 


### PR DESCRIPTION
## What

Teaches the coding agent (`stdlib/agents/coding.agency`) how and when to use the `gh` GitHub CLI, by adding skills to its skills directory. The agent already has `shellTools()` and `gitTools()`, so it *could* run `gh` — it just had no guidance on it. `agentSkill("coding")` globs this directory and lists each skill's description to the model, which reads a file on demand.

## Files

Three flat-layout skills, split so the model reads only what a task needs:

- **`gh-pr-and-issues.md`** — the day-to-day coding loop: open/view/diff/review PRs, read CI check results and failing logs, create/comment/list issues, and the `gh api` escape hatch.
- **`gh-repos-and-releases.md`** — the rest: create/clone/fork/edit repos, releases and assets, Actions workflow dispatch and reruns, secrets, and gists.
- **`gh-auth.md`** — non-interactive token auth (`gh auth login --with-token`, `gh auth setup-git`, `GH_TOKEN`/`GITHUB_TOKEN`), read only when `gh auth status` reports the agent is not logged in.

## Notes

- `gh`-only — no `curl` fallbacks, since the agent has `gh`.
- Emphasizes the practical gotchas: multi-line bodies via `--body-file`/heredoc (never `--body`), inspecting PRs without switching branches, `--json`/`--jq` for structured output, `Closes #N` per-issue.
- Data-only change: these `.md` files are read from source at runtime via `getStdlibDir()`, so no build/compile step is involved. No change to `coding.agency`.

Verified the frontmatter (`name`/`description`, incl. the `gh:` colon in each name) parses correctly through the same tarsec parser the skill loader uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
