### PR TITLE
feat(thread): add toolMessage to seed a synthetic tool exchange

### DIFF
--- a/packages/agency-lang/docs/site/stdlib/thread.md
+++ b/packages/agency-lang/docs/site/stdlib/thread.md
@@ -35,7 +35,7 @@ export type AttachmentSource =
   | { kind: "base64"; base64: string; mimeType: string }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L54))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L55))
 
 ### Attachment
 
@@ -46,7 +46,7 @@ export type Attachment =
   | null }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L59))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L60))
 
 ### ModelCost
 
@@ -59,7 +59,7 @@ export type ModelCost = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L173))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L195))
 
 ### GuardFailureData
 
@@ -74,7 +74,7 @@ export type GuardFailureData = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L192))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L214))
 
 ### ThreadMessage
 
@@ -85,7 +85,7 @@ export type ThreadMessage = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L215))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L237))
 
 ### ThreadInfo
 
@@ -101,7 +101,7 @@ export type ThreadInfo = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L220))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L242))
 
 ## Functions
 
@@ -125,7 +125,7 @@ Add a system message to the current thread's message history.
 | msg | `string` |  |
 | label | `string` | "" |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L63))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L64))
 
 ### userMessage
 
@@ -147,7 +147,35 @@ Add a user message to the current thread's message history. Use this
 | msg | `string \| (string \| Attachment)[]` |  |
 | label | `string` | "" |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L75))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L76))
+
+### toolMessage
+
+```ts
+toolMessage(name: string, args: any, result: string, label: string = "")
+```
+
+Add a synthetic tool call and its result to the current thread, as if the
+  model had made the call. Nothing runs; this only shapes the conversation the
+  model reads on its next llm() call. Use it to make the model see work a
+  scaffold did on its behalf. Call it at a clean point in the thread, not in
+  the middle of a tool exchange still waiting for its result.
+
+  @param name - The tool name the model will see it "called"
+  @param args - The call arguments, as an object (serialized to JSON)
+  @param result - The tool response content
+  @param label - Optional debug tag shown in statelog. Never sent to the model.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| name | `string` |  |
+| args | `any` |  |
+| result | `string` |  |
+| label | `string` | "" |
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L88))
 
 ### image
 
@@ -176,7 +204,7 @@ Build an image attachment for a multimodal llm() call. The source is
 
 **Returns:** [Attachment](#attachment)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L87))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L109))
 
 ### file
 
@@ -207,7 +235,7 @@ Build a file (e.g. PDF) attachment for a multimodal llm() call.
 
 **Returns:** [Attachment](#attachment)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L103))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L125))
 
 ### attachToReply
 
@@ -229,7 +257,7 @@ Queue an attachment to be shown to the model after the current tool
 |---|---|---|
 | attachment | [Attachment](#attachment) |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L120))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L142))
 
 ### assistantMessage
 
@@ -251,7 +279,7 @@ Add an assistant message to the current thread's message history.
 | msg | `string` |  |
 | label | `string` | "" |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L133))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L155))
 
 ### getCost
 
@@ -270,7 +298,7 @@ Inside a fork/race branch this includes the parent's accumulated cost
 
 **Returns:** `number`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L150))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L172))
 
 ### threadIsNew
 
@@ -283,7 +311,7 @@ True when the current message thread has no messages yet. Use it inside a
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L158))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L180))
 
 ### getTokens
 
@@ -295,7 +323,7 @@ Return the cumulative token count for the current execution branch.
 
 **Returns:** `number`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L166))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L188))
 
 ### getModelCosts
 
@@ -313,7 +341,7 @@ Unlike the per-branch cost/token accessors, this reads process-wide
 
 **Returns:** `ModelCost[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L183))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L205))
 
 ### listThreads
 
@@ -346,7 +374,7 @@ Summary sourcing: threads opened with `thread(summarize: true)` are
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L292))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L314))
 
 ### currentThreadId
 
@@ -361,7 +389,7 @@ Slug-form id of the active thread (e.g. "t3"), or `""` outside any
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L345))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L367))
 
 ### getThread
 
@@ -393,4 +421,4 @@ Read a slice of a thread's messages. Returns success holding `[]`
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L355))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L377))

--- a/packages/agency-lang/lib/runtime/toolMessageProvider.test.ts
+++ b/packages/agency-lang/lib/runtime/toolMessageProvider.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import type { Result, PromptResult, StreamChunk } from "smoltalk";
+import { agency } from "./agency.js";
+import type {
+  EmbedConfig,
+  EmbedResult,
+  LLMClient,
+  PromptConfig,
+} from "./llmClient.js";
+import { runPrompt } from "./prompt.js";
+import { RuntimeContext } from "./state/context.js";
+import { ThreadStore } from "./state/threadStore.js";
+import { _toolMessage } from "../stdlib/thread.js";
+
+function makeCtx(): RuntimeContext<any> {
+  return new RuntimeContext({
+    statelogConfig: {
+      host: "https://example.com",
+      apiKey: "test-api-key",
+      projectId: "test-project",
+      debugMode: false,
+    },
+    smoltalkDefaults: { model: "default-model" },
+    dirname: "/tmp",
+  });
+}
+
+class RecordingClient implements LLMClient {
+  configs: PromptConfig[] = [];
+  async text(config: PromptConfig): Promise<Result<PromptResult>> {
+    this.configs.push(config);
+    return {
+      success: true,
+      value: {
+        output: "ok",
+        toolCalls: [],
+        model: (config as any).model ?? "unknown",
+        usage: { inputTokens: 1, outputTokens: 1, cachedInputTokens: 0, totalTokens: 2 },
+        cost: { inputCost: 0, outputCost: 0, totalCost: 0, currency: "USD" },
+      },
+    };
+  }
+  async *textStream(config: PromptConfig): AsyncGenerator<StreamChunk> {
+    const r = await this.text(config);
+    if (r.success) yield { type: "text", text: r.value.output } as StreamChunk;
+  }
+  async embed(
+    _input: string | string[],
+    _config?: Partial<EmbedConfig>,
+  ): Promise<Result<EmbedResult>> {
+    throw new Error("not used");
+  }
+}
+
+describe("toolMessage forwarding + wire shape", () => {
+  it("forwards the seeded tool exchange, id-matched, into the provider request", async () => {
+    const ctx = makeCtx();
+    const client = new RecordingClient();
+    ctx.setLLMClient(client);
+    const threads = ThreadStore.withDefaultActive(ctx.statelogClient);
+
+    await agency.withTestContext(
+      { ctx, stack: ctx.stateStack, threads },
+      async () => {
+        await _toolMessage("saveDraft", { value: "hi" }, "Draft saved.");
+        await runPrompt({
+          prompt: "continue",
+          messages: threads.getOrCreateActive(),
+          clientConfig: {} as any,
+        });
+      },
+    );
+
+    expect(client.configs).toHaveLength(1);
+    // PromptConfig.messages (llmClient.ts:25), filled from the thread at
+    // prompt.ts:642. The messages arrive as smoltalk Message instances.
+    const sent = (client.configs[0] as any).messages.map((m: any) =>
+      typeof m.toJSON === "function" ? m.toJSON() : m,
+    );
+
+    const asst = sent.find(
+      (m: any) => m.role === "assistant" && m.toolCalls?.length,
+    );
+    expect(asst).toBeDefined();
+    expect(asst.toolCalls[0].name).toBe("saveDraft");
+
+    const tool = sent.find((m: any) => m.role === "tool");
+    expect(tool).toBeDefined();
+    expect(tool.tool_call_id).toBe(asst.toolCalls[0].id);
+    expect(tool.content).toBe("Draft saved.");
+  });
+});

--- a/packages/agency-lang/lib/stdlib/thread.ts
+++ b/packages/agency-lang/lib/stdlib/thread.ts
@@ -1,4 +1,5 @@
 import * as smoltalk from "smoltalk";
+import { nanoid } from "nanoid";
 import { agencyStore, getRuntimeContext } from "../runtime/asyncContext.js";
 import type { ReplyAttachmentPart } from "../runtime/replyAttachments.js";
 import { __tryCall, type ResultValue } from "../runtime/result.js";
@@ -69,6 +70,48 @@ export async function _userMessage(
 ): Promise<void> {
   const { threads } = getRuntimeContext();
   threads.getOrCreateActive().push(smoltalk.userMessage(msg), label || null);
+}
+
+/** Seed a synthetic tool call and its result onto the active thread, as if
+ *  the model had made the call. Nothing executes: this only shapes the
+ *  conversation. `args` is validated by a JSON round-trip up front, so a
+ *  non-serializable value throws here rather than being rejected by the
+ *  provider on the next `llm()`. Both messages carry `label`, an
+ *  observability-only tag (see `_userMessage`). The id is synthetic — real
+ *  tool-call ids come from the provider, this one is minted with nanoid. */
+export async function _toolMessage(
+  name: string,
+  args: any,
+  result: string,
+  label: string = "",
+): Promise<void> {
+  // Round-trip up front so a non-serializable value throws HERE, not far away
+  // when the provider rejects the thread on the next llm(). One catch covers
+  // both failure shapes: JSON.stringify throws on a circular object, and
+  // returns undefined for a bare function (which then fails in JSON.parse).
+  let argsRecord: Record<string, any>;
+  try {
+    argsRecord = JSON.parse(JSON.stringify(args ?? {}));
+  } catch {
+    throw new Error(
+      `toolMessage: args for "${name}" could not be serialized to JSON`,
+    );
+  }
+
+  const id = nanoid();
+  const { threads } = getRuntimeContext();
+  const thread = threads.getOrCreateActive();
+
+  thread.push(
+    smoltalk.assistantMessage("", {
+      toolCalls: [new smoltalk.ToolCall(id, name, argsRecord)],
+    }),
+    label || null,
+  );
+  thread.push(
+    smoltalk.toolMessage(result, { tool_call_id: id, name }),
+    label || null,
+  );
 }
 
 export async function __internal_assistantMessage(

--- a/packages/agency-lang/lib/stdlib/thread.ts
+++ b/packages/agency-lang/lib/stdlib/thread.ts
@@ -92,9 +92,25 @@ export async function _toolMessage(
   let argsRecord: Record<string, any>;
   try {
     argsRecord = JSON.parse(JSON.stringify(args ?? {}));
-  } catch {
+  } catch (e) {
     throw new Error(
       `toolMessage: args for "${name}" could not be serialized to JSON`,
+      { cause: e },
+    );
+  }
+  // Arguments must be a JSON object (a record), which every real tool call is.
+  // A bare number, string, or array round-trips cleanly but violates that
+  // contract (consumers like dropNullDefaultedArgs expect a record) and a
+  // provider may reject the thread. Enforce it here so the docstring's "as an
+  // object" is real.
+  if (
+    typeof argsRecord !== "object" ||
+    argsRecord === null ||
+    Array.isArray(argsRecord)
+  ) {
+    const got = Array.isArray(argsRecord) ? "array" : typeof argsRecord;
+    throw new Error(
+      `toolMessage: args for "${name}" must be a JSON object, got ${got}`,
     );
   }
 

--- a/packages/agency-lang/lib/stdlib/toolMessage.test.ts
+++ b/packages/agency-lang/lib/stdlib/toolMessage.test.ts
@@ -102,6 +102,24 @@ describe("_toolMessage", () => {
     expect(threads.getOrCreateActive().getMessages()).toHaveLength(2);
   });
 
+  it("throws when args is not a JSON object and pushes nothing", async () => {
+    const ctx = makeCtx();
+    const threads = ThreadStore.withDefaultActive(ctx.statelogClient);
+
+    for (const bad of [5, "raw", [1, 2]]) {
+      await expect(
+        agency.withTestContext(
+          { ctx, stack: ctx.stateStack, threads },
+          async () => {
+            await _toolMessage("t", bad, "r");
+          },
+        ),
+      ).rejects.toThrow(/must be a JSON object/);
+    }
+
+    expect(threads.getOrCreateActive().getMessages()).toHaveLength(0);
+  });
+
   it("throws a clear error on non-serializable args and pushes nothing", async () => {
     const ctx = makeCtx();
     const threads = ThreadStore.withDefaultActive(ctx.statelogClient);

--- a/packages/agency-lang/lib/stdlib/toolMessage.test.ts
+++ b/packages/agency-lang/lib/stdlib/toolMessage.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import { _toolMessage } from "./thread.js";
+import { agency } from "../runtime/agency.js";
+import { RuntimeContext } from "../runtime/state/context.js";
+import { ThreadStore } from "../runtime/state/threadStore.js";
+
+function makeCtx(): RuntimeContext<any> {
+  return new RuntimeContext({
+    statelogConfig: {
+      host: "https://example.com",
+      apiKey: "test-api-key",
+      projectId: "test-project",
+      debugMode: false,
+    },
+    smoltalkDefaults: { model: "default-model" },
+    dirname: "/tmp",
+  });
+}
+
+describe("_toolMessage", () => {
+  it("seeds exactly a matched assistant tool-call + tool-result pair", async () => {
+    const ctx = makeCtx();
+    const threads = ThreadStore.withDefaultActive(ctx.statelogClient);
+    await agency.withTestContext(
+      { ctx, stack: ctx.stateStack, threads },
+      async () => {
+        await _toolMessage("saveDraft", { value: "hi" }, "Draft saved.", "budget");
+      },
+    );
+
+    const msgs = threads
+      .getOrCreateActive()
+      .getMessages()
+      .map((m: any) => m.toJSON());
+
+    // Exactly two messages, nothing stray, in order.
+    expect(msgs).toHaveLength(2);
+    const [asst, tool] = msgs;
+
+    expect(asst.role).toBe("assistant");
+    expect(asst.content).toBe("");
+    expect(asst.toolCalls).toHaveLength(1);
+    expect(asst.toolCalls[0].name).toBe("saveDraft");
+    expect(asst.toolCalls[0].arguments).toEqual({ value: "hi" });
+
+    expect(tool.role).toBe("tool");
+    expect(tool.name).toBe("saveDraft");
+    expect(tool.content).toBe("Draft saved.");
+    expect(tool.tool_call_id).toBe(asst.toolCalls[0].id);
+  });
+
+  it("labels both pushed messages", async () => {
+    const ctx = makeCtx();
+    const threads = ThreadStore.withDefaultActive(ctx.statelogClient);
+    await agency.withTestContext(
+      { ctx, stack: ctx.stateStack, threads },
+      async () => {
+        await _toolMessage("saveDraft", { value: "hi" }, "Draft saved.", "budget");
+      },
+    );
+    const thread = threads.getOrCreateActive();
+    expect(thread.labelAt(0)).toBe("budget");
+    expect(thread.labelAt(1)).toBe("budget");
+  });
+
+  it("leaves both messages unlabeled when no label is given", async () => {
+    const ctx = makeCtx();
+    const threads = ThreadStore.withDefaultActive(ctx.statelogClient);
+    await agency.withTestContext(
+      { ctx, stack: ctx.stateStack, threads },
+      async () => {
+        await _toolMessage("saveDraft", { value: "hi" }, "Draft saved.");
+      },
+    );
+    const thread = threads.getOrCreateActive();
+    expect(thread.labelAt(0)).toBe(null);
+    expect(thread.labelAt(1)).toBe(null);
+  });
+
+  it("defaults null/undefined args to an empty record", async () => {
+    const ctx = makeCtx();
+    const threads = ThreadStore.withDefaultActive(ctx.statelogClient);
+    await agency.withTestContext(
+      { ctx, stack: ctx.stateStack, threads },
+      async () => {
+        await _toolMessage("noArgs", null, "ok");
+      },
+    );
+    const asst: any = threads.getOrCreateActive().getMessages()[0].toJSON();
+    expect(asst.toolCalls[0].arguments).toEqual({});
+  });
+
+  it("creates the active thread when there is none", async () => {
+    const ctx = makeCtx();
+    const threads = new ThreadStore(); // bare: no default active thread
+    await agency.withTestContext(
+      { ctx, stack: ctx.stateStack, threads },
+      async () => {
+        await _toolMessage("saveDraft", { value: "hi" }, "Draft saved.");
+      },
+    );
+    expect(threads.getOrCreateActive().getMessages()).toHaveLength(2);
+  });
+
+  it("throws a clear error on non-serializable args and pushes nothing", async () => {
+    const ctx = makeCtx();
+    const threads = ThreadStore.withDefaultActive(ctx.statelogClient);
+    const circular: any = {};
+    circular.self = circular;
+
+    await expect(
+      agency.withTestContext(
+        { ctx, stack: ctx.stateStack, threads },
+        async () => {
+          await _toolMessage("x", circular, "r");
+        },
+      ),
+    ).rejects.toThrow(/could not be serialized/);
+
+    expect(threads.getOrCreateActive().getMessages()).toHaveLength(0);
+  });
+});

--- a/packages/agency-lang/stdlib/thread.agency
+++ b/packages/agency-lang/stdlib/thread.agency
@@ -27,6 +27,7 @@ primitives, so you can compose your own variants in user code.
 import {
   _systemMessage,
   _userMessage,
+  _toolMessage,
   _assistantMessage,
   _imageAttachment,
   _fileAttachment,
@@ -82,6 +83,27 @@ export def userMessage(msg: string | (string | Attachment)[], label: string = ""
   @param label - Optional debug label shown in statelog. Never sent to the model.
   """
   _userMessage(msg, label)
+}
+
+export def toolMessage(
+  name: string,
+  args: any,
+  result: string,
+  label: string = "",
+) {
+  """
+  Add a synthetic tool call and its result to the current thread, as if the
+  model had made the call. Nothing runs; this only shapes the conversation the
+  model reads on its next llm() call. Use it to make the model see work a
+  scaffold did on its behalf. Call it at a clean point in the thread, not in
+  the middle of a tool exchange still waiting for its result.
+
+  @param name - The tool name the model will see it "called"
+  @param args - The call arguments, as an object (serialized to JSON)
+  @param result - The tool response content
+  @param label - Optional debug tag shown in statelog. Never sent to the model.
+  """
+  _toolMessage(name, args, result, label)
 }
 
 export def image(

--- a/packages/agency-lang/tests/agency/thread/toolmessage-roundtrip.agency
+++ b/packages/agency-lang/tests/agency/thread/toolmessage-roundtrip.agency
@@ -1,0 +1,29 @@
+import { toolMessage, listThreads, getThread } from "std::thread"
+
+node main(): string {
+  toolMessage("saveDraft", { value: "hello" }, "Draft saved.")
+
+  const info = listThreads(false)
+  if (info is failure(_e)) {
+    return "listThreads failed"
+  }
+  const threads = info.value
+  if (threads.length == 0) {
+    return "no threads"
+  }
+
+  const read = getThread(threads[0].id, 0, 50)
+  if (read is failure(_e)) {
+    return "getThread failed"
+  }
+  const msgs = read.value
+  if (msgs.length < 2) {
+    return "too few messages"
+  }
+  // Encode the last TWO roles so a dropped assistant tool-call message (which
+  // would leave an invalid, unmatched tool result) is caught here. getThread
+  // cannot expose tool_call_id, so true pairing is left to the unit test.
+  const prev = msgs[msgs.length - 2]
+  const last = msgs[msgs.length - 1]
+  return "${prev.role}|${last.role}:${last.content}"
+}

--- a/packages/agency-lang/tests/agency/thread/toolmessage-roundtrip.test.json
+++ b/packages/agency-lang/tests/agency/thread/toolmessage-roundtrip.test.json
@@ -1,0 +1,13 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "toolMessage seeds an assistant tool-call followed by its tool result, readable from the thread",
+      "input": "",
+      "expectedOutput": "\"assistant|tool:Draft saved.\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "interruptHandlers": [],
+      "llmMocks": []
+    }
+  ]
+}


### PR DESCRIPTION
## What

Adds `toolMessage(name, args, result, label="")` to `std::thread` — a `userMessage`-style function that seeds a synthetic tool call plus its result into the active thread, as if the model had made the call. Nothing executes; it only shapes the conversation the model reads on its next `llm()`.

```
toolMessage("saveDraft", { value: summary }, "Draft saved.")
// thread now ends with:
//   assistant  tool_call(id, name=saveDraft, arguments={value:…})
//   tool       tool_call_id=id  content="Draft saved."
```

## Why

A scaffold often needs to make the model *see* work it did on the model's behalf — for example, deterministically checkpointing a partial result at a budget threshold rather than hoping the model calls `saveDraft` itself. This is the injection building block for that. It is deliberately small: it does not run anything and knows nothing about budgets or triggers, which are separate pieces to build on top.

## Design

- Runtime `_toolMessage` in `lib/stdlib/thread.ts`, beside `_userMessage`, reusing `getRuntimeContext()` / `getOrCreateActive()` / `thread.push(msg, label || null)` — no new registry or buffer.
- `args` is validated by a JSON round-trip up front, so a non-serializable value throws at the call site instead of being rejected by the provider on the next `llm()`. Stored as a `Record` (smoltalk's `ToolCallJSON.arguments` is a record, not a string).
- The id is synthetic (`nanoid`); real tool-call ids come from the provider.
- `label` rides on both pushed messages, exactly like `_userMessage`. No `onToolCallStart`/`onToolCallEnd` — those are for live executions.

## Scope

- `result` is a plain `string` in v1. Image/file attachments are deferred: the loop's attachment-injection machinery is welded to the live `llm()` call (`runnerState` buffer, minted ids, end-of-round drain) and can't be reused from a thread-seeding primitive. Widening the type later is backward-compatible.

## Tests

- `lib/stdlib/toolMessage.test.ts` (6): exact two-message pair, shared id, `arguments` stored as an object, `name` field, empty assistant content, `label` on both messages, unlabeled default, null-args default, active-thread-created-when-none, and a throw-and-push-nothing case for non-serializable args.
- `tests/agency/thread/toolmessage-roundtrip.agency`: seeds an exchange and reads it back via `getThread`, asserting `assistant|tool:Draft saved.` (catches a dropped assistant message).
- `lib/runtime/toolMessageProvider.test.ts`: proves the seeded exchange is forwarded into the outgoing `PromptConfig`, id-matched. A mock can't prove a real provider accepts an un-redeclared historical tool call; that rests on the documented provider contract and is a CI/manual follow-up.

## Note

`smoltalk.assistantMessage` requires a `ToolCall` **instance** for `toolCalls` (its `toJSON` walks each call), not a plain object — the one implementation detail that differed from the design sketch. Output and all assertions are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
