### PR TITLE
Add agency lint with an unused-imports rule (AL0001), editor gray-out, and remove-on-save

### DIFF
--- a/packages/agency-lang/lib/cli/explain.test.ts
+++ b/packages/agency-lang/lib/cli/explain.test.ts
@@ -53,3 +53,16 @@ describe("renderDiagnosticList", () => {
     }
   });
 });
+
+describe("lint code fallthrough", () => {
+  it("explains a lint code (AL0001)", () => {
+    const result = renderDiagnosticText("AL0001");
+    expect(result.found).toBe(true);
+    expect(result.text).toContain("AL0001");
+    expect(result.text.toLowerCase()).toContain("import");
+  });
+
+  it("still rejects unknown codes", () => {
+    expect(renderDiagnosticText("AL9999").found).toBe(false);
+  });
+});

--- a/packages/agency-lang/lib/cli/explain.ts
+++ b/packages/agency-lang/lib/cli/explain.ts
@@ -5,6 +5,11 @@ import {
   type DiagnosticName,
 } from "@/typeChecker/diagnostics.js";
 import { DIAGNOSTIC_EXPLANATIONS } from "@/typeChecker/diagnosticExplanations.js";
+import {
+  LINT_DIAGNOSTICS,
+  type LintDiagnosticName,
+} from "@/linter/diagnostics.js";
+import { LINT_EXPLANATIONS } from "@/linter/diagnosticExplanations.js";
 import { color } from "@/utils/termcolors.js";
 
 function lookup(codeOrName: string): DiagnosticName | undefined {
@@ -20,6 +25,17 @@ function lookup(codeOrName: string): DiagnosticName | undefined {
   return undefined;
 }
 
+/** Same lookup for lint codes/names, tried after the AG#### registry misses. */
+function lookupLint(codeOrName: string): LintDiagnosticName | undefined {
+  const q = codeOrName.trim();
+  if (Object.hasOwn(LINT_DIAGNOSTICS, q)) return q as LintDiagnosticName;
+  const upper = q.toUpperCase();
+  for (const [name, entry] of Object.entries(LINT_DIAGNOSTICS)) {
+    if (entry.code.toUpperCase() === upper) return name as LintDiagnosticName;
+  }
+  return undefined;
+}
+
 /** Rendered detail for one diagnostic. `found:false` carries the not-found
  *  message with a suggestion; the caller prints it and exits 1. */
 export function renderDiagnosticText(codeOrName: string): {
@@ -28,6 +44,19 @@ export function renderDiagnosticText(codeOrName: string): {
 } {
   const name = lookup(codeOrName);
   if (!name) {
+    const lintName = lookupLint(codeOrName);
+    if (lintName) {
+      const entry = LINT_DIAGNOSTICS[lintName];
+      const lines = [
+        `${color.bold(entry.code)} ${color.dim(lintName)}`,
+        `${color.dim("severity:")} ${entry.severity} ${color.dim("(lint)")}`,
+        "",
+        entry.message,
+        "",
+        LINT_EXPLANATIONS[lintName],
+      ];
+      return { found: true, text: lines.join("\n") };
+    }
     return {
       found: false,
       text: `Unknown diagnostic code '${codeOrName}'. Run 'agency explain --list' to see all codes.`,

--- a/packages/agency-lang/lib/cli/lint.test.ts
+++ b/packages/agency-lang/lib/cli/lint.test.ts
@@ -1,0 +1,20 @@
+import { it, expect } from "vitest";
+import { lintSource } from "../linter/registry.js";
+import { formatFindings } from "./lint.js";
+
+it("formats a finding 1-indexed with its code", () => {
+  const source = `import { now } from "std::date"\nnode main() { return 1 }\n`;
+  const findings = lintSource(source, "/main.agency", {});
+  expect(findings).toHaveLength(1);
+  const out = formatFindings("/main.agency", findings);
+  // 'now' starts at 0-indexed column 9 ("import { " is 9 chars), so the
+  // 1-indexed display position is 1:10.
+  expect(out).toContain("1:10");
+  expect(out).toContain("AL0001");
+  expect(out).toContain("now");
+});
+
+it("reports nothing for a clean file", () => {
+  const source = `import { now } from "std::date"\nnode main() { return now() }\n`;
+  expect(lintSource(source, "/main.agency", {})).toEqual([]);
+});

--- a/packages/agency-lang/lib/cli/lint.ts
+++ b/packages/agency-lang/lib/cli/lint.ts
@@ -1,0 +1,13 @@
+import type { LintFinding } from "../linter/types.js";
+import { color } from "../utils/termcolors.js";
+
+/** Render one file's findings, 1-indexed, one line per finding. Callers only
+ *  invoke this when there is at least one finding. */
+export function formatFindings(filePath: string, findings: LintFinding[]): string {
+  const lines = [color.bold(filePath)];
+  for (const f of findings) {
+    const pos = `${f.loc.line + 1}:${f.loc.col + 1}`;
+    lines.push(`  ${color.dim(pos)}  ${color.yellow(f.code)}  ${f.message}`);
+  }
+  return lines.join("\n");
+}

--- a/packages/agency-lang/lib/linter/diagnosticExplanations.ts
+++ b/packages/agency-lang/lib/linter/diagnosticExplanations.ts
@@ -1,0 +1,10 @@
+import type { LintDiagnosticName } from "./diagnostics.js";
+
+/** Long-form explanations for `agency explain <code>`, keyed by rule name. */
+export const LINT_EXPLANATIONS: Record<LintDiagnosticName, string> = {
+  unusedImport: `An import brings in a name the file never references. Unused
+imports add noise and can hide a mistake (an import you meant to use). This is a
+hint, not an error — the program still compiles and runs. The editor grays the
+name out and offers "Remove unused import"; \`agency lint\` reports it. Names
+imported from \`std::index\` and \`import test { … }\` imports are not reported.`,
+};

--- a/packages/agency-lang/lib/linter/diagnostics.test.ts
+++ b/packages/agency-lang/lib/linter/diagnostics.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { LINT_DIAGNOSTICS, lintDiagnostic } from "./diagnostics.js";
+
+describe("lint diagnostics registry", () => {
+  it("assigns a unique code to every entry", () => {
+    const codes = Object.values(LINT_DIAGNOSTICS).map((e) => e.code);
+    expect(new Set(codes).size).toBe(codes.length);
+  });
+
+  it("every code matches the AL#### shape", () => {
+    for (const entry of Object.values(LINT_DIAGNOSTICS)) {
+      expect(entry.code).toMatch(/^AL\d{4}$/);
+    }
+  });
+
+  it("lintDiagnostic stamps the code and renders the message", () => {
+    const loc = { line: 0, col: 0, start: 0, end: 3 };
+    const finding = lintDiagnostic("unusedImport", { name: "foo" }, loc);
+    expect(finding.code).toBe("AL0001");
+    expect(finding.name).toBe("unusedImport");
+    expect(finding.severity).toBe("hint");
+    expect(finding.message).toBe("'foo' is imported but never used.");
+    expect(finding.loc).toBe(loc);
+    expect(finding.fix).toBeUndefined();
+  });
+});

--- a/packages/agency-lang/lib/linter/diagnostics.ts
+++ b/packages/agency-lang/lib/linter/diagnostics.ts
@@ -1,0 +1,44 @@
+import type { SourceLocation } from "../types/base.js";
+import { renderMessage } from "../typeChecker/diagnostics.js";
+import type { LintFinding, LintFix } from "./types.js";
+
+/**
+ * The single source of truth for every lint finding the linter can emit.
+ *
+ * APPEND-ONLY: a shipped code is never renumbered or reused. A retired rule
+ * keeps its entry with `retired: true` so the code stays reserved. Codes are
+ * numbered sequentially (AL0001, AL0002, …) in the order rules are added.
+ * This deliberately diverges from the type checker's prefix-range category
+ * scheme (AG1xxx = types, AG4xxx = names, …): lint rules are few and flat,
+ * so the code number carries no category meaning here.
+ *
+ * Message templates use {param} placeholders. Params are structured data
+ * (a name, a count), never sentence fragments.
+ */
+export const LINT_DIAGNOSTICS = {
+  unusedImport: {
+    code: "AL0001",
+    severity: "hint",
+    message: "'{name}' is imported but never used.",
+  },
+} as const;
+
+export type LintDiagnosticName = keyof typeof LINT_DIAGNOSTICS;
+
+/** Build a fully-formed finding from a registry entry, stamping the code. */
+export function lintDiagnostic(
+  name: LintDiagnosticName,
+  params: Record<string, string | number>,
+  loc: SourceLocation,
+  fix?: LintFix,
+): LintFinding {
+  const entry = LINT_DIAGNOSTICS[name];
+  return {
+    code: entry.code,
+    name,
+    message: renderMessage(entry.message, params),
+    severity: entry.severity,
+    loc,
+    fix,
+  };
+}

--- a/packages/agency-lang/lib/linter/registry.test.ts
+++ b/packages/agency-lang/lib/linter/registry.test.ts
@@ -1,0 +1,26 @@
+import { it, expect } from "vitest";
+import { runLinter, lintSource, LINT_RULES } from "./registry.js";
+import { parseAgency } from "../parser.js";
+
+it("registry includes the unused-imports rule", () => {
+  expect(LINT_RULES.map((r) => r.name)).toContain("unusedImport");
+});
+
+it("lintSource parses and reports findings", () => {
+  const source = `import { now } from "std::date"\nnode main() { return 1 }\n`;
+  const findings = lintSource(source, "/test.agency", {});
+  expect(findings).toHaveLength(1);
+  expect(findings[0].code).toBe("AL0001");
+});
+
+it("lintSource returns [] for source that does not parse", () => {
+  expect(lintSource("def foo( {", "/bad.agency", {})).toEqual([]);
+});
+
+it("runLinter accepts an already-parsed context", () => {
+  const source = `import { now } from "std::date"\nnode main() { return now() }\n`;
+  const parsed = parseAgency(source, {}, false);
+  if (!parsed.success) throw new Error("did not parse");
+  const findings = runLinter({ program: parsed.result, source, filePath: "/t.agency" });
+  expect(findings).toEqual([]);
+});

--- a/packages/agency-lang/lib/linter/registry.ts
+++ b/packages/agency-lang/lib/linter/registry.ts
@@ -1,0 +1,31 @@
+import { parseAgency } from "../parser.js";
+import type { AgencyConfig } from "../config.js";
+import type { LintContext, LintFinding, LintRule } from "./types.js";
+import { unusedImportsRule } from "./rules/unusedImports.js";
+
+/** Every enabled rule. Append a rule here to enable it. */
+export const LINT_RULES: LintRule[] = [unusedImportsRule];
+
+/** Run every rule over the context and concatenate their findings. */
+export function runLinter(ctx: LintContext): LintFinding[] {
+  return LINT_RULES.flatMap((rule) => rule.run(ctx));
+}
+
+/**
+ * Parse `source` and lint it. Parses with the template OFF so every finding's
+ * offsets index into `source` (docs/dev/locations.md). A file that does not
+ * parse has no lint findings — the parser's own error is the user's problem
+ * to fix first, and every caller of this function surfaces parse errors
+ * through its own channel (CLI compile errors, LSP parse diagnostics).
+ */
+export function lintSource(
+  source: string,
+  filePath: string,
+  config: AgencyConfig,
+): LintFinding[] {
+  const parsed = parseAgency(source, config, false);
+  if (!parsed.success) {
+    return [];
+  }
+  return runLinter({ program: parsed.result, source, filePath });
+}

--- a/packages/agency-lang/lib/linter/rules/unusedImports.fix.test.ts
+++ b/packages/agency-lang/lib/linter/rules/unusedImports.fix.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { parseAgency } from "../../parser.js";
+import type { LintContext, LintEdit, LintFinding } from "../types.js";
+import { unusedImportsRule, unusedImportsBatchEdits } from "./unusedImports.js";
+
+function ctxFor(source: string): LintContext {
+  const parsed = parseAgency(source, {}, false);
+  if (!parsed.success) throw new Error("did not parse");
+  return { program: parsed.result, source, filePath: "/test.agency" };
+}
+
+function applyEdits(source: string, edits: LintEdit[]): string {
+  let out = source;
+  for (const e of [...edits].sort((a, b) => b.start - a.start)) {
+    out = out.slice(0, e.start) + e.newText + out.slice(e.end);
+  }
+  return out;
+}
+
+function applied(source: string, f: LintFinding): string {
+  return applyEdits(source, f.fix?.edits ?? []);
+}
+
+describe("unused-imports rule: per-finding fix", () => {
+  it("regenerates the statement without the unused name", () => {
+    const src = `import { a, b } from "./x.agency"\nnode main() { return a() }\n`;
+    const f = unusedImportsRule.run(ctxFor(src))[0];
+    expect(applied(src, f)).toContain(`import { a } from "./x.agency"`);
+    expect(applied(src, f)).not.toContain("b");
+  });
+
+  it("deletes the whole statement when the only name is unused", () => {
+    const src = `import { a } from "./x.agency"\nnode main() { return 1 }\n`;
+    const f = unusedImportsRule.run(ctxFor(src))[0];
+    expect(applied(src, f)).toBe(`node main() { return 1 }\n`);
+  });
+
+  it("keeps aliases on surviving names and removes the unused alias", () => {
+    const src = `import { a as x, b as y } from "./m.agency"\nnode main() { return x() }\n`;
+    const f = unusedImportsRule.run(ctxFor(src))[0]; // y is unused
+    const out = applied(src, f);
+    expect(out).toContain("a as x");
+    expect(out).not.toContain("as y");
+  });
+
+  it("removes an unused import node via regeneration", () => {
+    const src = `import node { greet } from "./o.agency"\nnode main() { return 1 }\n`;
+    const f = unusedImportsRule.run(ctxFor(src))[0];
+    expect(applied(src, f)).toBe(`node main() { return 1 }\n`);
+  });
+});
+
+describe("unused-imports rule: batch edits", () => {
+  it("regenerates a statement once when it has two unused names", () => {
+    const src = `import { a, b, c } from "./x.agency"\nnode main() { return a() }\n`;
+    const ctx = ctxFor(src);
+    const edits = unusedImportsBatchEdits(ctx);
+    expect(edits).toHaveLength(1); // one edit per statement, never per name
+    expect(applyEdits(src, edits)).toContain(`import { a } from "./x.agency"`);
+  });
+
+  it("deletes a statement whose names are all unused, and trims another", () => {
+    const src = [
+      `import { a } from "./x.agency"`,
+      `import { b, c } from "./y.agency"`,
+      `node main() { return c() }`,
+      ``,
+    ].join("\n");
+    const out = applyEdits(src, unusedImportsBatchEdits(ctxFor(src)));
+    expect(out).not.toContain("x.agency");
+    expect(out).toContain(`import { c } from "./y.agency"`);
+    expect(out).not.toContain("b,");
+  });
+
+  it("returns no edits for a clean file", () => {
+    const src = `import { a } from "./x.agency"\nnode main() { return a() }\n`;
+    expect(unusedImportsBatchEdits(ctxFor(src))).toEqual([]);
+  });
+});

--- a/packages/agency-lang/lib/linter/rules/unusedImports.fix.test.ts
+++ b/packages/agency-lang/lib/linter/rules/unusedImports.fix.test.ts
@@ -77,3 +77,22 @@ describe("unused-imports rule: batch edits", () => {
     expect(unusedImportsBatchEdits(ctxFor(src))).toEqual([]);
   });
 });
+
+describe("unused-imports rule: whole-line deletion edges", () => {
+  it("preserves a blank line that follows a deleted import", () => {
+    const src = [
+      `import { a } from "./x.agency"`,
+      ``,
+      `node main() { return 1 }`,
+      ``,
+    ].join("\n");
+    const f = unusedImportsRule.run(ctxFor(src))[0];
+    expect(applied(src, f)).toBe(`\nnode main() { return 1 }\n`);
+  });
+
+  it("deletes a statement at EOF with no trailing newline", () => {
+    const src = `node main() { return 1 }\nimport { a } from "./x.agency"`;
+    const f = unusedImportsRule.run(ctxFor(src))[0];
+    expect(applied(src, f)).toBe(`node main() { return 1 }\n`);
+  });
+});

--- a/packages/agency-lang/lib/linter/rules/unusedImports.test.ts
+++ b/packages/agency-lang/lib/linter/rules/unusedImports.test.ts
@@ -88,3 +88,32 @@ describe("unused-imports rule: detection", () => {
     expect(findings[0].loc.start).toBeGreaterThan(source.indexOf("ab") + 1);
   });
 });
+
+describe("unused-imports rule: at-risk used positions are kept", () => {
+  it("keeps an import used only as a named handler (functionRef, no type field)", () => {
+    const src = [
+      `import { myHandler } from "./handlers.agency"`,
+      `node main() {`,
+      `  handle { print(1) } with myHandler`,
+      `}`,
+      ``,
+    ].join("\n");
+    expect(names(src)).toEqual([]);
+  });
+
+  it("keeps an import node used only as a goto target", () => {
+    const src = [
+      `import node { second } from "./other.agency"`,
+      `node main() {`,
+      `  goto second()`,
+      `}`,
+      ``,
+    ].join("\n");
+    expect(names(src)).toEqual([]);
+  });
+
+  it("flags an unused import named after an Object.prototype key", () => {
+    expect(names(`import { constructor } from "./x.agency"\nnode main() { return 1 }\n`))
+      .toEqual(["constructor"]);
+  });
+});

--- a/packages/agency-lang/lib/linter/rules/unusedImports.test.ts
+++ b/packages/agency-lang/lib/linter/rules/unusedImports.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { parseAgency } from "../../parser.js";
+import type { LintContext } from "../types.js";
+import { unusedImportsRule } from "./unusedImports.js";
+
+// Parse WITHOUT the template so offsets index `source` (docs/dev/locations.md).
+function ctxFor(source: string): LintContext {
+  const parsed = parseAgency(source, {}, false);
+  if (!parsed.success) throw new Error("test source did not parse");
+  return { program: parsed.result, source, filePath: "/test.agency" };
+}
+
+function names(source: string): string[] {
+  return unusedImportsRule.run(ctxFor(source)).map((f) => {
+    const m = f.message.match(/'(\w+)'/);
+    return m ? m[1] : "";
+  });
+}
+
+describe("unused-imports rule: detection", () => {
+  it("flags an import that is never referenced", () => {
+    expect(names(`import { now } from "std::date"\nnode main() { return 1 }\n`))
+      .toEqual(["now"]);
+  });
+
+  it("does not flag an import used in a call", () => {
+    expect(names(`import { now } from "std::date"\nnode main() { return now() }\n`))
+      .toEqual([]);
+  });
+
+  it("does not flag an import used as a value", () => {
+    expect(names(`import { now } from "std::date"\nnode main() { const f = now\n  return f() }\n`))
+      .toEqual([]);
+  });
+
+  it("does not flag an import used only as a bare type annotation (typeAliasVariable)", () => {
+    expect(names(`import { Config } from "./types.agency"\ndef f(x: Config): number { return 1 }\n`))
+      .toEqual([]);
+  });
+
+  it("does not flag an import used only as a parameterized type (genericType)", () => {
+    expect(names(`import { Box } from "./types.agency"\ndef f(x: Box<number>): number { return 1 }\n`))
+      .toEqual([]);
+  });
+
+  it("does not flag an aliased import that is used by its local name", () => {
+    expect(names(`import { now as clock } from "std::date"\nnode main() { return clock() }\n`))
+      .toEqual([]);
+  });
+
+  it("flags an aliased import that is never used", () => {
+    expect(names(`import { now as clock } from "std::date"\nnode main() { return 1 }\n`))
+      .toEqual(["clock"]);
+  });
+
+  it("keeps an import when a local of the same name is present (conservative)", () => {
+    expect(names(`import { now } from "std::date"\nnode main() { const now = 5\n  return now }\n`))
+      .toEqual([]);
+  });
+
+  it("never flags std::index imports (the injected prelude)", () => {
+    expect(names(`import { map } from "std::index"\nnode main() { return 1 }\n`))
+      .toEqual([]);
+  });
+
+  it("never flags a testOnly import", () => {
+    expect(names(`import test { secret } from "./helpers.agency"\nnode main() { return 1 }\n`))
+      .toEqual([]);
+  });
+
+  it("flags an unused import node", () => {
+    expect(names(`import node { greet } from "./other.agency"\nnode main() { return 1 }\n`))
+      .toEqual(["greet"]);
+  });
+
+  it("flags every unused name when a statement has more than one", () => {
+    expect(names(`import { a, b, c } from "./x.agency"\nnode main() { return a() }\n`))
+      .toEqual(["b", "c"]);
+  });
+
+  it("reports each finding at its own source range, even for names that are substrings of other names", () => {
+    const source = `import { ab, b } from "./x.agency"\nnode main() { return ab() }\n`;
+    const findings = unusedImportsRule.run(ctxFor(source));
+    expect(findings).toHaveLength(1);
+    // Word-boundary matching: the range must be the standalone `b`, not the
+    // `b` inside `ab`.
+    expect(source.slice(findings[0].loc.start, findings[0].loc.end)).toBe("b");
+    expect(findings[0].loc.start).toBeGreaterThan(source.indexOf("ab") + 1);
+  });
+});

--- a/packages/agency-lang/lib/linter/rules/unusedImports.ts
+++ b/packages/agency-lang/lib/linter/rules/unusedImports.ts
@@ -1,0 +1,158 @@
+import type { SourceLocation } from "../../types/base.js";
+import type { AgencyProgram } from "../../types.js";
+import type {
+  ImportStatement,
+  ImportNodeStatement,
+} from "../../types/importStatement.js";
+import { getImportedNames } from "../../types/importStatement.js";
+import type { LintContext, LintFinding, LintRule } from "../types.js";
+import { lintDiagnostic } from "../diagnostics.js";
+
+/** Names referenced anywhere in the file body. Conservative: an imported name
+ *  found here is treated as used, so the rule never removes a used import.
+ *  The reference positions and their node shapes (verified via pnpm run ast):
+ *    - value reference / access-chain base → `variableName` (.value)
+ *    - direct call                         → `functionCall` (.functionName)
+ *    - bare type annotation                → `typeAliasVariable` (.aliasName)
+ *    - parameterized type                  → `genericType` (.name)
+ *  This is a generic structural walk, NOT walkNodes: walkNodes visits
+ *  statement-level AgencyNodes and does not descend into type hints or tag
+ *  arguments, which are exactly the positions that would cause a false
+ *  "unused" (and a deleted needed import) if missed. Import statements are
+ *  excluded so an import does not count as its own use. */
+export function collectReferencedNames(program: AgencyProgram): Record<string, true> {
+  const used: Record<string, true> = {};
+  const visit = (value: unknown): void => {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        visit(item);
+      }
+      return;
+    }
+    if (value && typeof value === "object") {
+      const node = value as Record<string, unknown>;
+      if (node.type === "variableName" && typeof node.value === "string") {
+        used[node.value] = true;
+      } else if (node.type === "functionCall" && typeof node.functionName === "string") {
+        used[node.functionName] = true;
+      } else if (node.type === "typeAliasVariable" && typeof node.aliasName === "string") {
+        used[node.aliasName] = true;
+      } else if (node.type === "genericType" && typeof node.name === "string") {
+        used[node.name] = true;
+      }
+      for (const key of Object.keys(node)) {
+        visit(node[key]);
+      }
+    }
+  };
+  for (const node of program.nodes) {
+    if (node.type === "importStatement" || node.type === "importNodeStatement") {
+      continue;
+    }
+    visit(node);
+  }
+  return used;
+}
+
+/** 0-indexed line/col plus offsets, matching the codebase's SourceLocation. */
+export function locFromOffsets(source: string, start: number, end: number): SourceLocation {
+  let line = 0;
+  let lastNewline = -1;
+  for (let i = 0; i < start; i++) {
+    if (source[i] === "\n") {
+      line++;
+      lastNewline = i;
+    }
+  }
+  return { line, col: start - lastNewline - 1, start, end };
+}
+
+const escapeForRegex = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+/** The local name's character range within a statement's source span, matched
+ *  on word boundaries so `b` never matches inside `ab` or inside the module
+ *  path. Falls back to the whole statement span if the token is somehow not
+ *  found (dimming the whole statement is honest; pointing at the wrong
+ *  character is not). */
+function nameRange(
+  source: string,
+  stmtStart: number,
+  stmtEnd: number,
+  localName: string,
+): SourceLocation {
+  const span = source.slice(stmtStart, stmtEnd);
+  const match = new RegExp(
+    `(?<![A-Za-z0-9_])${escapeForRegex(localName)}(?![A-Za-z0-9_])`,
+  ).exec(span);
+  if (!match) {
+    return locFromOffsets(source, stmtStart, stmtEnd);
+  }
+  const start = stmtStart + match.index;
+  return locFromOffsets(source, start, start + localName.length);
+}
+
+/** The statement's span with trailing whitespace trimmed off: the parser's
+ *  span includes the optional trailing newline it consumed, which is not part
+ *  of the statement text we match names in or replace on regeneration. */
+function statementSpan(
+  source: string,
+  stmt: ImportStatement | ImportNodeStatement,
+): { start: number; end: number } {
+  const loc = stmt.loc ?? { line: 0, col: 0, start: 0, end: 0 };
+  let end = loc.end;
+  while (end > loc.start && /\s/.test(source[end - 1])) {
+    end--;
+  }
+  return { start: loc.start, end };
+}
+
+function findingFor(
+  ctx: LintContext,
+  stmt: ImportStatement | ImportNodeStatement,
+  localName: string,
+): LintFinding {
+  const span = statementSpan(ctx.source, stmt);
+  const range = nameRange(ctx.source, span.start, span.end, localName);
+  return lintDiagnostic("unusedImport", { name: localName }, range);
+}
+
+/** Each lintable statement paired with its unused local names. Shared by the
+ *  per-name findings (below) and the grouped batch fix. */
+function unusedByStatement(
+  ctx: LintContext,
+): { stmt: ImportStatement | ImportNodeStatement; unusedNames: string[] }[] {
+  const used = collectReferencedNames(ctx.program);
+  const groups: { stmt: ImportStatement | ImportNodeStatement; unusedNames: string[] }[] = [];
+  for (const node of ctx.program.nodes) {
+    if (node.type === "importStatement") {
+      if (node.modulePath === "std::index") {
+        continue; // injected prelude
+      }
+      if (node.testOnly) {
+        continue; // test-only wiring
+      }
+      const unusedNames = node.importedNames
+        .filter((nameType) => nameType.type === "namedImport") // namespace/default deferred
+        .flatMap((nameType) => getImportedNames(nameType))
+        .filter((localName) => !used[localName]);
+      if (unusedNames.length > 0) {
+        groups.push({ stmt: node, unusedNames });
+      }
+    } else if (node.type === "importNodeStatement") {
+      const unusedNames = node.importedNodes.filter((localName) => !used[localName]);
+      if (unusedNames.length > 0) {
+        groups.push({ stmt: node, unusedNames });
+      }
+    }
+  }
+  return groups;
+}
+
+export const unusedImportsRule: LintRule = {
+  name: "unusedImport",
+  run(ctx: LintContext): LintFinding[] {
+    return unusedByStatement(ctx).flatMap(({ stmt, unusedNames }) =>
+      unusedNames.map((localName) => findingFor(ctx, stmt, localName)),
+    );
+  },
+};

--- a/packages/agency-lang/lib/linter/rules/unusedImports.ts
+++ b/packages/agency-lang/lib/linter/rules/unusedImports.ts
@@ -3,9 +3,11 @@ import type { AgencyProgram } from "../../types.js";
 import type {
   ImportStatement,
   ImportNodeStatement,
+  NamedImport,
 } from "../../types/importStatement.js";
 import { getImportedNames } from "../../types/importStatement.js";
-import type { LintContext, LintFinding, LintRule } from "../types.js";
+import { AgencyGenerator } from "../../backends/agencyGenerator.js";
+import type { LintContext, LintEdit, LintFinding, LintFix, LintRule } from "../types.js";
 import { lintDiagnostic } from "../diagnostics.js";
 
 /** Names referenced anywhere in the file body. Conservative: an imported name
@@ -106,6 +108,94 @@ function statementSpan(
   return { start: loc.start, end };
 }
 
+/** Print a single import statement back to Agency source. `preserveOrder` is
+ *  required: without it the generator buffers imports and returns "". */
+function printImport(node: ImportStatement | ImportNodeStatement): string {
+  return new AgencyGenerator({ preserveOrder: true }).processNode(node).trim();
+}
+
+/** A copy of a NamedImport with the given local names removed (dropping their
+ *  aliases and retry-safety markers). Returns null if that empties the group. */
+function namedImportWithout(nameType: NamedImport, localNames: string[]): NamedImport | null {
+  // Map each local name back to its original imported name (alias-aware).
+  const originals = localNames.map(
+    (localName) =>
+      Object.keys(nameType.aliases).find((o) => nameType.aliases[o] === localName) ??
+      localName,
+  );
+  const importedNames = nameType.importedNames.filter((n) => !originals.includes(n));
+  if (importedNames.length === 0) {
+    return null;
+  }
+  const aliases = { ...nameType.aliases };
+  for (const original of originals) {
+    delete aliases[original];
+  }
+  const next: NamedImport = { type: "namedImport", importedNames, aliases };
+  const destructive = nameType.destructiveNames?.filter((n) => !originals.includes(n));
+  const idempotent = nameType.idempotentNames?.filter((n) => !originals.includes(n));
+  if (destructive && destructive.length > 0) {
+    next.destructiveNames = destructive;
+  }
+  if (idempotent && idempotent.length > 0) {
+    next.idempotentNames = idempotent;
+  }
+  return next;
+}
+
+/** A copy of the statement with the local names removed, or null if the whole
+ *  statement should be deleted. */
+function rebuildWithout(
+  stmt: ImportStatement | ImportNodeStatement,
+  localNames: string[],
+): ImportStatement | ImportNodeStatement | null {
+  if (stmt.type === "importNodeStatement") {
+    const importedNodes = stmt.importedNodes.filter((n) => !localNames.includes(n));
+    if (importedNodes.length === 0) {
+      return null;
+    }
+    return { ...stmt, importedNodes };
+  }
+  const importedNames = stmt.importedNames
+    .map((nameType) =>
+      nameType.type === "namedImport" ? namedImportWithout(nameType, localNames) : nameType,
+    )
+    .filter((nameType): nameType is NonNullable<typeof nameType> => nameType !== null);
+  if (importedNames.length === 0) {
+    return null;
+  }
+  return { ...stmt, importedNames };
+}
+
+/** The single edit that removes `localNames` from `stmt`: either the statement
+ *  regenerated without them, or (when nothing survives) a deletion of the
+ *  whole statement including its trailing newline, so no blank line is left
+ *  behind. The parser's span already includes the trailing newline it
+ *  consumed; the regeneration path replaces only the trimmed statement text. */
+function removalEdit(
+  source: string,
+  stmt: ImportStatement | ImportNodeStatement,
+  localNames: string[],
+): LintEdit {
+  const loc = stmt.loc ?? { line: 0, col: 0, start: 0, end: 0 };
+  const span = statementSpan(source, stmt);
+  const rebuilt = rebuildWithout(stmt, localNames);
+  if (rebuilt === null) {
+    const end = source[loc.end] === "\n" ? loc.end + 1 : loc.end;
+    return { start: loc.start, end, newText: "" };
+  }
+  return { start: span.start, end: span.end, newText: printImport(rebuilt) };
+}
+
+/** One edit per statement, each regenerated with ALL of its unused names
+ *  removed. Used by "Remove all unused imports" and remove-on-save. Never
+ *  produces overlapping edits, because a statement appears at most once. */
+export function unusedImportsBatchEdits(ctx: LintContext): LintEdit[] {
+  return unusedByStatement(ctx).map(({ stmt, unusedNames }) =>
+    removalEdit(ctx.source, stmt, unusedNames),
+  );
+}
+
 function findingFor(
   ctx: LintContext,
   stmt: ImportStatement | ImportNodeStatement,
@@ -113,7 +203,11 @@ function findingFor(
 ): LintFinding {
   const span = statementSpan(ctx.source, stmt);
   const range = nameRange(ctx.source, span.start, span.end, localName);
-  return lintDiagnostic("unusedImport", { name: localName }, range);
+  const fix: LintFix = {
+    title: `Remove unused import '${localName}'`,
+    edits: [removalEdit(ctx.source, stmt, [localName])],
+  };
+  return lintDiagnostic("unusedImport", { name: localName }, range, fix);
 }
 
 /** Each lintable statement paired with its unused local names. Shared by the

--- a/packages/agency-lang/lib/linter/rules/unusedImports.ts
+++ b/packages/agency-lang/lib/linter/rules/unusedImports.ts
@@ -12,18 +12,28 @@ import { lintDiagnostic } from "../diagnostics.js";
 
 /** Names referenced anywhere in the file body. Conservative: an imported name
  *  found here is treated as used, so the rule never removes a used import.
- *  The reference positions and their node shapes (verified via pnpm run ast):
- *    - value reference / access-chain base → `variableName` (.value)
- *    - direct call                         → `functionCall` (.functionName)
- *    - bare type annotation                → `typeAliasVariable` (.aliasName)
- *    - parameterized type                  → `genericType` (.name)
+ *
+ *  Collection is conservative BY CONSTRUCTION, not by enumerating node types:
+ *  any object carrying a name-bearing field (`functionName`, `aliasName`,
+ *  `handlerName`) contributes that name, regardless of its `type`/`kind`
+ *  discriminant. Over-collection only makes the rule keep an import (safe,
+ *  possibly a missed detection); an allow-list of discriminants risks
+ *  under-collection, which deletes a used import — a `handle { } with fn`
+ *  handler reference is `{ kind: "functionRef", functionName }` with no
+ *  `type` field at all, and removing a handler's import silently unregisters
+ *  the handler (CLAUDE.md-critical). Two fields stay discriminated because
+ *  their names are too generic to collect blindly: `value` (string literals
+ *  also have one) and `name` (parameters also have one).
+ *
  *  This is a generic structural walk, NOT walkNodes: walkNodes visits
  *  statement-level AgencyNodes and does not descend into type hints or tag
  *  arguments, which are exactly the positions that would cause a false
  *  "unused" (and a deleted needed import) if missed. Import statements are
  *  excluded so an import does not count as its own use. */
 export function collectReferencedNames(program: AgencyProgram): Record<string, true> {
-  const used: Record<string, true> = {};
+  // Null prototype: identifiers are user-controlled, and on a plain object a
+  // key like "__proto__" or "constructor" would hit the prototype chain.
+  const used: Record<string, true> = Object.create(null);
   const visit = (value: unknown): void => {
     if (Array.isArray(value)) {
       for (const item of value) {
@@ -33,13 +43,19 @@ export function collectReferencedNames(program: AgencyProgram): Record<string, t
     }
     if (value && typeof value === "object") {
       const node = value as Record<string, unknown>;
+      if (typeof node.functionName === "string") {
+        used[node.functionName] = true;
+      }
+      if (typeof node.aliasName === "string") {
+        used[node.aliasName] = true;
+      }
+      if (typeof node.handlerName === "string") {
+        used[node.handlerName] = true;
+      }
       if (node.type === "variableName" && typeof node.value === "string") {
         used[node.value] = true;
-      } else if (node.type === "functionCall" && typeof node.functionName === "string") {
-        used[node.functionName] = true;
-      } else if (node.type === "typeAliasVariable" && typeof node.aliasName === "string") {
-        used[node.aliasName] = true;
-      } else if (node.type === "genericType" && typeof node.name === "string") {
+      }
+      if (node.type === "genericType" && typeof node.name === "string") {
         used[node.name] = true;
       }
       for (const key of Object.keys(node)) {
@@ -181,7 +197,13 @@ function removalEdit(
   const span = statementSpan(source, stmt);
   const rebuilt = rebuildWithout(stmt, localNames);
   if (rebuilt === null) {
-    const end = source[loc.end] === "\n" ? loc.end + 1 : loc.end;
+    // The parser's span usually already consumed the statement's trailing
+    // newline. Only extend past one when it did not (statement at EOF or
+    // followed by `;`); extending unconditionally would eat the NEXT line's
+    // newline and collapse an intentional blank line between imports.
+    const spanEndsWithNewline = source[loc.end - 1] === "\n";
+    const end =
+      !spanEndsWithNewline && source[loc.end] === "\n" ? loc.end + 1 : loc.end;
     return { start: loc.start, end, newText: "" };
   }
   return { start: span.start, end: span.end, newText: printImport(rebuilt) };

--- a/packages/agency-lang/lib/linter/types.ts
+++ b/packages/agency-lang/lib/linter/types.ts
@@ -1,0 +1,40 @@
+import type { SourceLocation } from "../types/base.js";
+import type { AgencyProgram } from "../types.js";
+import type { LintDiagnosticName } from "./diagnostics.js";
+
+/** The linter owns its own severity vocabulary. v1 only emits "hint". */
+export type LintSeverity = "hint" | "info" | "warning";
+
+/** A single text edit, as a half-open [start, end) offset range into the
+ *  file's source. Deleting text is newText: "". */
+export type LintEdit = { start: number; end: number; newText: string };
+
+/** The automatic fix for a finding: a titled set of edits. */
+export type LintFix = { title: string; edits: LintEdit[] };
+
+/** One thing the linter noticed. Always carries a code (via the factory). */
+export type LintFinding = {
+  code: string;
+  name: LintDiagnosticName;
+  message: string;
+  severity: LintSeverity;
+  loc: SourceLocation;
+  fix?: LintFix;
+};
+
+/** What a rule is given. `program` is parsed with the template OFF, so its
+ *  `loc.start`/`loc.end` index into `source` and its import statements retain
+ *  their locations. Rules that need scope or symbol information do not exist
+ *  yet; when one does, extend this type in the same PR. */
+export type LintContext = {
+  program: AgencyProgram;
+  source: string;
+  filePath: string;
+};
+
+/** A rule: a pure function from context to findings, tied to its registry
+ *  entry by `name`. */
+export type LintRule = {
+  name: LintDiagnosticName;
+  run: (ctx: LintContext) => LintFinding[];
+};

--- a/packages/agency-lang/lib/lsp/codeAction.test.ts
+++ b/packages/agency-lang/lib/lsp/codeAction.test.ts
@@ -168,3 +168,35 @@ describe("unused-import code actions", () => {
     expect(actions.filter((a) => a.title.startsWith("Remove"))).toEqual([]);
   });
 });
+
+describe("code-action kind filtering (context.only)", () => {
+  it("returns only the batch action when the client asks for source.fixAll", () => {
+    const source = `import { a, b } from "./x.agency"\nnode main() { return 1 }\n`;
+    const doc = makeDoc(source);
+    const actions = getCodeActions(
+      {
+        textDocument: { uri: doc.uri },
+        range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
+        context: { diagnostics: [], only: ["source.fixAll"] },
+      },
+      doc,
+      new SymbolTable(),
+    );
+    expect(actions.map((a) => a.kind)).toEqual(["source.fixAll"]);
+  });
+
+  it("returns nothing lint-related when the client asks for refactor kinds", () => {
+    const source = `import { a } from "./x.agency"\nnode main() { return 1 }\n`;
+    const doc = makeDoc(source);
+    const actions = getCodeActions(
+      {
+        textDocument: { uri: doc.uri },
+        range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
+        context: { diagnostics: [], only: ["refactor"] },
+      },
+      doc,
+      new SymbolTable(),
+    );
+    expect(actions).toEqual([]);
+  });
+});

--- a/packages/agency-lang/lib/lsp/codeAction.test.ts
+++ b/packages/agency-lang/lib/lsp/codeAction.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { DiagnosticSeverity } from "vscode-languageserver-protocol";
+import { DiagnosticSeverity, type TextEdit } from "vscode-languageserver-protocol";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { getCodeActions } from "./codeAction.js";
 import { SymbolTable } from "../symbolTable.js";
@@ -104,5 +104,67 @@ describe("getCodeActions", () => {
     };
     const actions = getCodeActions(params, doc, symbolTable);
     expect(actions).toHaveLength(0);
+  });
+});
+
+describe("unused-import code actions", () => {
+  function applyLspEdits(source: string, doc: TextDocument, edits: TextEdit[]): string {
+    let out = source;
+    for (const e of [...edits].sort(
+      (a, b) => doc.offsetAt(b.range.start) - doc.offsetAt(a.range.start),
+    )) {
+      out = out.slice(0, doc.offsetAt(e.range.start)) + e.newText + out.slice(doc.offsetAt(e.range.end));
+    }
+    return out;
+  }
+
+  function actionsFor(source: string) {
+    const doc = makeDoc(source);
+    const actions = getCodeActions(
+      {
+        textDocument: { uri: doc.uri },
+        range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
+        context: { diagnostics: [] },
+      },
+      doc,
+      new SymbolTable(),
+    );
+    return { doc, actions };
+  }
+
+  it("offers a Remove unused import quick fix", () => {
+    const source = `import { now } from "std::date"\nnode main() { return 1 }\n`;
+    const { doc, actions } = actionsFor(source);
+    const remove = actions.find((a) => a.title === "Remove unused import 'now'");
+    expect(remove).toBeDefined();
+    const out = applyLspEdits(source, doc, remove!.edit!.changes![doc.uri]);
+    expect(out).toBe(`node main() { return 1 }\n`);
+  });
+
+  it("batch-removes multiple unused names in one statement without overlapping edits", () => {
+    const source = `import { a, b, c } from "./x.agency"\nnode main() { return a() }\n`;
+    const { doc, actions } = actionsFor(source);
+    const batch = actions.find((a) => a.title === "Remove all unused imports");
+    expect(batch).toBeDefined();
+    const edits = batch!.edit!.changes![doc.uri];
+    expect(edits).toHaveLength(1); // one edit per statement
+    const out = applyLspEdits(source, doc, edits);
+    expect(out).toContain(`import { a } from "./x.agency"`);
+  });
+
+  it("offers the batch under both source kinds", () => {
+    const source = `import { a } from "./x.agency"\nnode main() { return 1 }\n`;
+    const { actions } = actionsFor(source);
+    const kinds = actions
+      .filter((a) => a.title === "Remove all unused imports")
+      .map((a) => a.kind);
+    expect(kinds).toContain("source.fixAll");
+    expect(kinds).toContain("source.removeUnusedImports");
+  });
+
+  it("offers no lint actions for a clean file", () => {
+    const source = `import { a } from "./x.agency"\nnode main() { return a() }\n`;
+    const { actions } = actionsFor(source);
+    expect(actions.filter((a) => a.title.startsWith("Remove"))).toEqual([]);
   });
 });

--- a/packages/agency-lang/lib/lsp/codeAction.ts
+++ b/packages/agency-lang/lib/lsp/codeAction.ts
@@ -60,25 +60,44 @@ export function getCodeActions(
     if (stdlibAction) actions.push(stdlibAction);
   }
 
+  // `context.only` is the client's kind filter (e.g. `["source.fixAll"]` on
+  // save). Kinds are hierarchical: a filter matches a kind that equals it or
+  // extends it with a `.` segment. Honoring it skips the parse + lint below
+  // entirely when the client asked for kinds we do not produce.
+  const only = params.context.only;
+  const wantsKind = (kind: string): boolean =>
+    !only || only.some((o) => kind === o || kind.startsWith(`${o}.`));
+  const wantsQuickFix = wantsKind(CodeActionKind.QuickFix);
+  const wantsBatch =
+    wantsKind(CodeActionKind.SourceFixAll) || wantsKind(REMOVE_UNUSED_IMPORTS_KIND);
+  if (!wantsQuickFix && !wantsBatch) {
+    return actions;
+  }
+
   const source = doc.getText();
   const parsed = parseAgency(source, {}, false);
   if (parsed.success) {
     const ctx: LintContext = { program: parsed.result, source, filePath: uriToPath(doc.uri) };
     const findings = runLinter(ctx).filter((f) => f.fix);
-    for (const f of findings) {
-      actions.push({
-        title: f.fix!.title,
-        kind: CodeActionKind.QuickFix,
-        edit: { changes: { [doc.uri]: f.fix!.edits.map((e) => lintEditToTextEdit(doc, e)) } },
-      });
+    if (wantsQuickFix) {
+      for (const f of findings) {
+        actions.push({
+          title: f.fix!.title,
+          kind: CodeActionKind.QuickFix,
+          edit: { changes: { [doc.uri]: f.fix!.edits.map((e) => lintEditToTextEdit(doc, e)) } },
+        });
+      }
     }
-    if (findings.length > 0) {
+    if (wantsBatch && findings.length > 0) {
       // The batch regenerates each statement ONCE with all of its unused
       // names removed (one edit per statement) — concatenating the
       // per-finding fixes instead would produce overlapping edits whenever
       // one statement has two unused names, which VS Code rejects.
       const batchEdits = unusedImportsBatchEdits(ctx).map((e) => lintEditToTextEdit(doc, e));
       for (const kind of [CodeActionKind.SourceFixAll, REMOVE_UNUSED_IMPORTS_KIND]) {
+        if (!wantsKind(kind)) {
+          continue;
+        }
         actions.push({
           title: "Remove all unused imports",
           kind,

--- a/packages/agency-lang/lib/lsp/codeAction.ts
+++ b/packages/agency-lang/lib/lsp/codeAction.ts
@@ -11,6 +11,22 @@ import { TextDocument } from "vscode-languageserver-textdocument";
 import type { SymbolTable } from "../symbolTable.js";
 import { uriToPath } from "./uri.js";
 import { getStdlibFiles, stdlibModuleName } from "../importPaths.js";
+import { parseAgency } from "../parser.js";
+import { runLinter } from "../linter/registry.js";
+import { unusedImportsBatchEdits } from "../linter/rules/unusedImports.js";
+import type { LintContext, LintEdit } from "../linter/types.js";
+
+/** Dedicated source-action kind for remove-on-save. Offered alongside the
+ *  generic SourceFixAll so either `editor.codeActionsOnSave` configuration
+ *  triggers the removal. */
+export const REMOVE_UNUSED_IMPORTS_KIND = "source.removeUnusedImports";
+
+function lintEditToTextEdit(doc: TextDocument, e: LintEdit): TextEdit {
+  return {
+    range: { start: doc.positionAt(e.start), end: doc.positionAt(e.end) },
+    newText: e.newText,
+  };
+}
 
 // Lazily built index: symbol name → "std::module"
 let stdlibIndex: Record<string, string> | null = null;
@@ -42,6 +58,34 @@ export function getCodeActions(
     if (importAction) actions.push(importAction);
     const stdlibAction = suggestStdlibImport(diagnostic, doc);
     if (stdlibAction) actions.push(stdlibAction);
+  }
+
+  const source = doc.getText();
+  const parsed = parseAgency(source, {}, false);
+  if (parsed.success) {
+    const ctx: LintContext = { program: parsed.result, source, filePath: uriToPath(doc.uri) };
+    const findings = runLinter(ctx).filter((f) => f.fix);
+    for (const f of findings) {
+      actions.push({
+        title: f.fix!.title,
+        kind: CodeActionKind.QuickFix,
+        edit: { changes: { [doc.uri]: f.fix!.edits.map((e) => lintEditToTextEdit(doc, e)) } },
+      });
+    }
+    if (findings.length > 0) {
+      // The batch regenerates each statement ONCE with all of its unused
+      // names removed (one edit per statement) — concatenating the
+      // per-finding fixes instead would produce overlapping edits whenever
+      // one statement has two unused names, which VS Code rejects.
+      const batchEdits = unusedImportsBatchEdits(ctx).map((e) => lintEditToTextEdit(doc, e));
+      for (const kind of [CodeActionKind.SourceFixAll, REMOVE_UNUSED_IMPORTS_KIND]) {
+        actions.push({
+          title: "Remove all unused imports",
+          kind,
+          edit: { changes: { [doc.uri]: batchEdits } },
+        });
+      }
+    }
   }
 
   return actions;

--- a/packages/agency-lang/lib/lsp/diagnostics.test.ts
+++ b/packages/agency-lang/lib/lsp/diagnostics.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { TextDocument } from "vscode-languageserver-textdocument";
+import { DiagnosticSeverity, DiagnosticTag } from "vscode-languageserver-protocol";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
@@ -350,5 +351,29 @@ describe("runDiagnostics — test-only imports", () => {
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("lint diagnostics", () => {
+  it("emits a Hint diagnostic tagged Unnecessary for an unused import", () => {
+    const source = `import { now } from "std::date"\nnode main() { return 1 }\n`;
+    const doc = makeDoc(source);
+    const { diagnostics } = runDiagnostics(doc, "/test.agency", {}, emptySymbolTable);
+    const lint = diagnostics.find((d) => d.code === "AL0001");
+    expect(lint).toBeDefined();
+    expect(lint!.severity).toBe(DiagnosticSeverity.Hint);
+    expect(lint!.tags).toContain(DiagnosticTag.Unnecessary);
+    // The grayed range covers only the name 'now'.
+    expect(source.slice(
+      doc.offsetAt(lint!.range.start),
+      doc.offsetAt(lint!.range.end),
+    )).toBe("now");
+  });
+
+  it("does not gray out the injected prelude names", () => {
+    const source = `node main() { return 1 }\n`;
+    const doc = makeDoc(source);
+    const { diagnostics } = runDiagnostics(doc, "/test.agency", {}, emptySymbolTable);
+    expect(diagnostics.filter((d) => d.code === "AL0001")).toEqual([]);
   });
 });

--- a/packages/agency-lang/lib/lsp/diagnostics.ts
+++ b/packages/agency-lang/lib/lsp/diagnostics.ts
@@ -1,7 +1,9 @@
 import {
   Diagnostic,
   DiagnosticSeverity,
+  DiagnosticTag,
 } from "vscode-languageserver-protocol";
+import { runLinter } from "../linter/registry.js";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { parseAgency } from "../parser.js";
 import { resolveImports } from "../preprocessors/importResolver.js";
@@ -102,6 +104,12 @@ export function runDiagnostics(
   }
 
   let program = parseResult.result;
+  // The linter needs the pristine parse: later passes (resolveReExports,
+  // resolveImports) return rewritten programs whose import statements are
+  // replaced or dropped. The pipeline below reassigns `program`, so this
+  // alias keeps pointing at the original. Parsed with applyTemplate=false,
+  // so finding offsets index straight into `source`.
+  const lintProgram = parseResult.result;
 
   // The CLI parses source through a template that auto-injects an
   // `import { ... } from "std::index"` statement. The LSP path uses
@@ -180,6 +188,21 @@ export function runDiagnostics(
       severity: DiagnosticSeverity.Error,
       range,
       message: err.message,
+      source: "agency",
+    });
+  }
+
+  const lintFindings = runLinter({ program: lintProgram, source, filePath: fsPath });
+  for (const f of lintFindings) {
+    diagnostics.push({
+      // v1: every lint finding is a hint. When the first warning-severity
+      // rule ships, replace this with a severity map — do not let it
+      // silently render warnings as hints.
+      severity: DiagnosticSeverity.Hint,
+      tags: [DiagnosticTag.Unnecessary],
+      code: f.code,
+      range: { start: doc.positionAt(f.loc.start), end: doc.positionAt(f.loc.end) },
+      message: f.message,
       source: "agency",
     });
   }

--- a/packages/agency-lang/lib/lsp/server.ts
+++ b/packages/agency-lang/lib/lsp/server.ts
@@ -8,6 +8,7 @@ import {
   InitializeResult,
   InitializeParams,
   CompletionList,
+  CodeActionKind,
   DidChangeWatchedFilesNotification,
 } from "vscode-languageserver/node.js";
 import { TextDocument } from "vscode-languageserver-textdocument";
@@ -29,7 +30,7 @@ import { handleSignatureHelp } from "./signatureHelp.js";
 import { handleReferences } from "./references.js";
 import { handleRename, handlePrepareRename } from "./rename.js";
 import { handleTypeDefinition } from "./typeDefinition.js";
-import { getCodeActions } from "./codeAction.js";
+import { getCodeActions, REMOVE_UNUSED_IMPORTS_KIND } from "./codeAction.js";
 import { getWorkspaceSymbols } from "./workspaceSymbol.js";
 import type { DocumentState } from "./documentState.js";
 
@@ -71,7 +72,13 @@ export function startServer(): void {
         renameProvider: { prepareProvider: true },
         documentHighlightProvider: true,
         foldingRangeProvider: true,
-        codeActionProvider: true,
+        codeActionProvider: {
+          codeActionKinds: [
+            CodeActionKind.QuickFix,
+            CodeActionKind.SourceFixAll,
+            REMOVE_UNUSED_IMPORTS_KIND,
+          ],
+        },
         workspaceSymbolProvider: true,
         documentLinkProvider: {},
       },

--- a/packages/agency-lang/lib/parser.test.ts
+++ b/packages/agency-lang/lib/parser.test.ts
@@ -253,7 +253,10 @@ describe("parseAgency loc.line invariant", () => {
   const collectLines = (program: AgencyProgram): number[] => {
     const lines: number[] = [];
     for (const { node } of walkNodes(program.nodes)) {
-      if (node.loc) lines.push(node.loc.line);
+      // A negative line marks a template-injected node (the prelude import
+      // sits on the wrapper's lines, above line 0 of the user's source). The
+      // invariant is about user-source nodes, which only exist at line >= 0.
+      if (node.loc && node.loc.line >= 0) lines.push(node.loc.line);
     }
     return lines;
   };

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -3535,7 +3535,7 @@ const quotedPath: Parser<string> = map(
   (res) => res.path,
 );
 
-export const importNodeStatmentParser: Parser<ImportNodeStatement> = memo(
+export const importNodeStatmentParser: Parser<ImportNodeStatement> = withLoc(memo(
   "importNodeStatement",
   seqC(
     set("type", "importNodeStatement"),
@@ -3560,7 +3560,7 @@ export const importNodeStatmentParser: Parser<ImportNodeStatement> = memo(
       ),
     ),
   ),
-);
+));
 
 const nameWithOptionalAlias = or(
   map(
@@ -3676,7 +3676,7 @@ const importNameTypeParser: Parser<ImportNameType[]> = sepBy(
   or(namedImportParser, namespaceImportParser, defaultImportParser),
 );
 
-export const importStatmentParser: Parser<ImportStatement> = map(
+export const importStatmentParser: Parser<ImportStatement> = withLoc(map(
   memo(
     "importStatement",
     seqC(
@@ -3722,7 +3722,7 @@ export const importStatmentParser: Parser<ImportStatement> = map(
     }
     return out;
   },
-);
+));
 
 // =============================================================================
 // exportFromStatement.ts — `export { x } from "..."` and `export * from "..."`

--- a/packages/agency-lang/lib/types/importStatement.ts
+++ b/packages/agency-lang/lib/types/importStatement.ts
@@ -40,8 +40,11 @@ export type DefaultImport = {
 export function getImportedNames(importNameType: ImportNameType): string[] {
   switch (importNameType.type) {
     case "namedImport":
-      return importNameType.importedNames.map(
-        (n) => importNameType.aliases[n] ?? n,
+      // Own-property check: names are user identifiers, and a plain lookup
+      // for a name like "constructor" would return the inherited prototype
+      // member instead of the (absent) alias.
+      return importNameType.importedNames.map((n) =>
+        Object.hasOwn(importNameType.aliases, n) ? importNameType.aliases[n] : n,
       );
     case "namespaceImport":
       return [importNameType.importedNames];

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -17,6 +17,8 @@ import {
   installDirFromUrl,
 } from "@/cli/installLocation.js";
 import { pack } from "@/cli/pack.js";
+import { lintSource } from "@/linter/registry.js";
+import { formatFindings } from "@/cli/lint.js";
 import { resolveBudget } from "@/cli/budget.js";
 import { fixtures, test, testTs, SlowTest, parseShardSpec } from "@/cli/test.js";
 import { generateReport, cleanCoverage } from "@/cli/coverage.js";
@@ -959,6 +961,32 @@ export function createProgram(deps: CliDependencies = {}): Command {
         console.error(text);
         process.exit(1);
       }
+    });
+
+  program
+    .command("lint")
+    .description("Lint .agency file(s) for style issues (reads from stdin if no input)")
+    .argument("[inputs...]", "Paths to .agency input files")
+    .action(async (inputs: string[]) => {
+      const config = getConfig();
+      let anyFindings = false;
+      await forEachSource(inputs, (contents, src) => {
+        const filePath = src.kind === "file" ? src.path : "<stdin>";
+        const findings = lintSource(contents, filePath, config);
+        if (findings.length > 0) {
+          anyFindings = true;
+          console.log(formatFindings(filePath, findings));
+          console.log("");
+        }
+      });
+      if (!anyFindings) {
+        console.log("No lint findings.");
+      } else {
+        console.log("Run `agency explain <code>` for details.");
+      }
+      // All v1 findings are hints; hints never fail CI, so the exit code
+      // stays 0. The PR that adds the first warning-severity rule adds the
+      // non-zero path.
     });
 
   program

--- a/packages/agency-lang/tests/typescriptPreprocessor/tools.json
+++ b/packages/agency-lang/tests/typescriptPreprocessor/tools.json
@@ -13,7 +13,13 @@
         }
       ],
       "modulePath": "std::http",
-      "isAgencyImport": true
+      "isAgencyImport": true,
+      "loc": {
+        "line": 0,
+        "col": 0,
+        "start": 0,
+        "end": 34
+      }
     },
     {
       "type": "function",


### PR DESCRIPTION
## What this adds

A linter subsystem (`lib/linter/`) with one rule, surfaced three ways:

- **`agency lint <files|dirs>`** prints findings with stable `AL####` codes:

  ```
  main.agency
    1:10  AL0001  'now' is imported but never used.

  Run `agency explain <code>` for details.
  ```

- **VS Code grays out unused imports** (Hint severity + the `Unnecessary` tag) and offers a "Remove unused import" quick fix, a "Remove all unused imports" batch action, and remove-on-save via `source.fixAll` or the dedicated `source.removeUnusedImports` kind.

- **`agency explain AL0001`** falls through from the type checker registry to the lint registry.

The first rule, `unused-imports` (AL0001), covers named imports (`import { a, b }`) and `import node { x }`. It is deliberately **conservative**: an imported name that appears anywhere in the file counts as used, even if a shadowing local is the real target. A missed detection costs nothing; a false positive would delete a needed import, so the rule is built to never produce one.

## Design notes

- The linter is a consumer of a parsed program, not a new analysis: rules are pure functions from `{ program, source, filePath }` to findings-as-data, and both the CLI and the LSP run the identical rules on the identical parse mode (template off, so offsets index the raw file).
- The reference walk collects `variableName`, `functionCall`, `typeAliasVariable`, and `genericType` nodes. The `typeAliasVariable` arm matters: a bare annotation like `x: Config` parses as `typeAliasVariable`, not `genericType`, and missing it would falsely flag type-only imports.
- Removal fixes **regenerate the whole import statement** from the AST via the `AgencyGenerator` instead of splicing name tokens, which handles aliases (`a as b`), `destructive`/`idempotent` markers, and trailing commas for free. The batch action regenerates each statement once with all of its unused names removed, so it never emits overlapping edits.
- The injected `std::index` prelude import and `import test { }` imports are skipped entirely.
- Lint codes are append-only from day one (`AL0001`, sequential numbering, category-free by design — documented divergence from the type checker's prefix-range scheme).
- `agency lint` always exits 0 for now: the only rule is a hint, and hints should not fail CI. The PR that adds the first warning-severity rule adds the non-zero path.

## One parser change

Import statements previously carried no `loc` at all, so there was nothing to anchor a finding or a fix to. `importStatmentParser` and `importNodeStatmentParser` are now wrapped in `withLoc`, like most other statement parsers. Fallout was small and is included:

- The `parseAgency` loc.line invariant tests now skip template-injected nodes (the prelude import sits above line 0 of the user source, so its `loc.line` is negative by construction).
- One preprocessor fixture (`tests/typescriptPreprocessor/tools.json`) regenerated to include the new `loc` field.

## Testing

- 39 new tests across the linter (registry integrity, 13 detection cases, 7 fix cases, entry points), CLI formatting, `explain` fallthrough, LSP diagnostics mapping, and LSP code actions (including the two-unused-names-in-one-statement batch case).
- Full parser/preprocessor sweep (1864 tests) green after the `withLoc` change; structural linter clean; `agency lint` smoke-tested by hand.

Spec and reviews: `docs/superpowers/specs/2026-07-21-agency-lint-command-design.md` and siblings (in the worktree-lint-command worktree, not part of this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
