### PR TITLE
Fix duplicate saveDraft tool by removing it from planningTools()

### DIFF
--- a/packages/agency-lang/docs/site/stdlib/agents/lib/toolkits.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/lib/toolkits.md
@@ -22,7 +22,7 @@ An agent's tool list should read as a description of what that agent may
 export static const SAVE_DRAFT_HINT = "\n\nIf you might run low on time or budget, call `saveDraft` with your best answer so far as you work, and update it as you improve. If the run is cut short, the last draft you saved is what the user receives — a run that saved nothing returns nothing."
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/toolkits.agency#L179))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/toolkits.agency#L181))
 
 ## Functions
 
@@ -166,10 +166,9 @@ Return tools that persist and retrieve facts across sessions.
 planningTools(): any[]
 ```
 
-Return tools an agent uses to organize a long run: a todo list, and
-  saveDraft for checkpointing partial work so an aborted run still returns
-  something.
+Return tools an agent uses to organize a long run: writing and reading a
+  todo list.
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/toolkits.agency#L167))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/toolkits.agency#L170))

--- a/packages/agency-lang/lib/agents/agency-agent/tests/toolWiring.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/toolWiring.agency
@@ -20,6 +20,11 @@ import { researchTools } from "../subagents/research.agency"
 // so a duplicate name in either list still breaks this agent.
 import { buildTools as oracleTools } from "std::agents/oracle"
 import { buildTools as explorerTools } from "std::agents/explorer"
+// The two research agents researchAgent routes to. researchTools is handed to
+// whichever one runs as extraTools, so the list that reaches the provider is
+// the agent's own tools plus researchTools plus the saveDraft the agent appends.
+import { buildTools as agencyResearcherOwnTools } from "std::agents/agency/researcher"
+import { buildTools as researcherOwnTools } from "std::agents/researcher"
 
 def pingWith(tools: any[]): string {
   // Reject any interrupt a tool might raise. Under the deterministic
@@ -52,6 +57,17 @@ node codeToolsHaveUniqueNames() {
 
 node researchToolsHaveUniqueNames() {
   return pingWith(researchTools)
+}
+
+// Pinging a list on its own is what let a real duplicate through: researchTools
+// carried saveDraft and so did the agent receiving it, so neither list was wrong
+// by itself. These ping what each research agent actually sends.
+node composedAgencyResearchToolsHaveUniqueNames() {
+  return pingWith([...agencyResearcherOwnTools(), ...researchTools, saveDraft])
+}
+
+node composedResearchToolsHaveUniqueNames() {
+  return pingWith([...researcherOwnTools(), ...researchTools, saveDraft])
 }
 
 node oracleToolsHaveUniqueNames() {

--- a/packages/agency-lang/lib/agents/agency-agent/tests/toolWiring.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/toolWiring.test.json
@@ -15,6 +15,20 @@
       "llmMocks": [{ "return": "pong" }]
     },
     {
+      "nodeName": "composedAgencyResearchToolsHaveUniqueNames",
+      "input": "",
+      "expectedOutput": "\"ok\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "llmMocks": [{ "return": "pong" }]
+    },
+    {
+      "nodeName": "composedResearchToolsHaveUniqueNames",
+      "input": "",
+      "expectedOutput": "\"ok\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "llmMocks": [{ "return": "pong" }]
+    },
+    {
       "nodeName": "oracleToolsHaveUniqueNames",
       "input": "",
       "expectedOutput": "\"ok\"",

--- a/packages/agency-lang/stdlib/agents/coding.agency
+++ b/packages/agency-lang/stdlib/agents/coding.agency
@@ -92,7 +92,7 @@ ${finalizeReminder}
     llmOptions(
     model: model,
     provider: provider,
-    tools: [...buildTools(), ...extraTools],
+    tools: [...buildTools(), ...extraTools, saveDraft],
     hostedTools: hostedSearchTools(model),
   ),
   )

--- a/packages/agency-lang/stdlib/agents/lib/toolkits.agency
+++ b/packages/agency-lang/stdlib/agents/lib/toolkits.agency
@@ -164,13 +164,15 @@ export def memoryTools(): any[] {
   return [remember, recall]
 }
 
+// saveDraft is deliberately not here. Every worker offers saveDraft itself at
+// its own llm call, so a caller can hand this bundle to an agent as extra tools
+// without landing saveDraft in the list twice, which the provider rejects.
 export def planningTools(): any[] {
   """
-  Return tools an agent uses to organize a long run: a todo list, and
-  saveDraft for checkpointing partial work so an aborted run still returns
-  something.
+  Return tools an agent uses to organize a long run: writing and reading a
+  todo list.
   """
-  return [todoWrite, todoList, saveDraft]
+  return [todoWrite, todoList]
 }
 
 // A model-facing instruction, spliced into an agent's prompt when the agent

--- a/packages/agency-lang/tests/agency/agents/toolkits.agency
+++ b/packages/agency-lang/tests/agency/agents/toolkits.agency
@@ -89,6 +89,16 @@ node noBundleHasDuplicateNames(): boolean {
   return true
 }
 
+// Every worker appends its own saveDraft at its llm call, so a bundle a caller
+// hands an agent as extra tools must not carry saveDraft too. When planningTools
+// did, passing it as extraTools put saveDraft in the list twice and the call was
+// rejected before it reached the provider.
+node planningToolsComposesWithAgentSaveDraft(): boolean {
+  const composed = [...planningTools(), saveDraft]
+  const names = map(composed, \tool -> tool.name)
+  return unique(names, \name -> name).length == names.length
+}
+
 // The wikipedia tools must not advertise a bare `search`, which collides with
 // the web-search providers in std::agents/lib/search.
 node wikipediaToolsAreRenamed(): boolean {

--- a/packages/agency-lang/tests/agency/agents/toolkits.test.json
+++ b/packages/agency-lang/tests/agency/agents/toolkits.test.json
@@ -34,6 +34,17 @@
       ]
     },
     {
+      "nodeName": "planningToolsComposesWithAgentSaveDraft",
+      "description": "planningTools does not duplicate the saveDraft an agent appends itself",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
       "nodeName": "wikipediaToolsAreRenamed",
       "description": "wikipedia tools do not advertise a bare search",
       "input": "",


### PR DESCRIPTION
## The bug

Running the Agency agent on an Agency-language question crashed before the request ever reached the provider:

```
Duplicate tool name(s) passed to an LLM call: "saveDraft" (x2). Tool names must be unique.
```

## Root cause

`planningTools()` returned `[todoWrite, todoList, saveDraft]`. The Agency agent spreads that bundle into `researchTools` (`lib/agents/agency-agent/subagents/research.agency`) and hands it to `agencyResearcherAgent` as `extraTools`. That agent builds its list as `buildTools().concat(extraTools).concat([saveDraft])` — so saveDraft came in twice, once from the caller bundle and once from the agent appending its own.

## Audit

This was not specific to the Agency researcher. Every worker ends up with saveDraft in its final list: most append it explicitly at the `llm` call, and the coding agents got it via `planningTools()` inside their own `buildTools()`. So any agent handed `extraTools` containing saveDraft would have failed the same way. `research.agency` was the only caller passing a non-empty `extraTools`, which is why only that path broke — the non-Agency `researcherAgent` route was equally broken and would have failed as soon as a general question went through it.

## The fix

- `planningTools()` returns just `[todoWrite, todoList]`. A bundle meant to be handed to an agent as extra tools must not carry saveDraft, since every worker already offers it.
- `stdlib/agents/coding.agency` was the one agent getting saveDraft only through the bundle, so it now appends saveDraft at its `llm` call like every other agent. Verified in the generated `coding.js` that the tool is still on offer.
- `research.agency` needed no change: it still wants the todo tools and no longer smuggles in a second saveDraft.

## Tests

The existing `toolWiring` tests pinged each tool list **in isolation**, which is exactly why this slipped through — `researchTools` had one saveDraft and the agent had one, so neither list was wrong on its own. Added coverage of the composition that actually reaches the provider:

- `composedAgencyResearchToolsHaveUniqueNames` and `composedResearchToolsHaveUniqueNames` ping the real composed list for both research routes
- `planningToolsComposesWithAgentSaveDraft` asserts the bundle composes with an appended saveDraft

All three were confirmed to have teeth by temporarily reintroducing the duplicate: each failed, the toolWiring ones with the exact error from the report. With the fix in place both suites pass (7/7 and 6/6), and `make` plus `make doc` run clean.

## Not covered

I did not run the full agency suite locally, per the repo guidance. Only `coding.agency` consumed the bundle, so the blast radius should be contained, but CI will confirm the other agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
