### PR TITLE
Return subagent failures as Results, not as sentences about failing

### DIFF
--- a/packages/agency-lang/lib/agents/agency-agent/lib/coordinator.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/coordinator.agency
@@ -306,19 +306,48 @@ type AgentTarget =
   | "review"
   | "coordinator"
 
+/* The subagents hand back a Result so that when the coordinator calls one as a
+   tool, the tool loop sees a real failure. `--agent code` and friends bypass
+   the coordinator and print straight to a person, and a person is better
+   served by a sentence than by a Result, so the unwrapping happens here. */
+export def replyOrReason(reply: Result<string>, stopped: string): string {
+  if (isFailure(reply)) {
+    return "${stopped}: ${reply.error}"
+  }
+  return reply.value
+}
+
 export def dispatchAgent(agentName: AgentTarget, userMsg: string): string {
   const expanded = expandSlash(userMsg, projectCommands)
   return match(agentName) {
-    "code" => codeAgent(expanded)
-    "research" => researchAgent(expanded)
-    "oracle" => oracleAgent(expanded)
-    "explorer" => explorerAgent(expanded)
+    "code" => replyOrReason(codeAgent(expanded), "The coding agent stopped")
+    "research" => replyOrReason(researchAgent(expanded), "Research did not finish")
+    "oracle" => replyOrReason(oracleAgent(expanded), "The oracle could not finish")
+    "explorer" => replyOrReason(explorerAgent(expanded), "The explorer could not finish")
     "review" => reviewAgent(expanded)
     _ => {
       const attachments = checkForAttachments(expanded)
       return mainAgent([expanded, ...attachments])
     }
   }
+}
+
+/* Turn a saved draft into the text to show the user. A draft has the type of
+   the function that saved it, so now that the subagents return `Result<string>`
+   their drafts arrive wrapped; deeper workers still save bare strings. Both
+   shapes reach here, and a wrapper printed verbatim would show the user a
+   Result object instead of their answer. */
+export def draftText(partial: any): string {
+  if (partial == null) {
+    return ""
+  }
+  if (isSuccess(partial)) {
+    return "${partial.value}"
+  }
+  if (isFailure(partial)) {
+    return ""
+  }
+  return "${partial}"
 }
 
 export def runTurn(agentName: AgentTarget, userMsg: string): string {
@@ -349,8 +378,8 @@ export def runTurn(agentName: AgentTarget, userMsg: string): string {
         // Show the best-so-far draft the handler kept, if any, rather than
         // only a "stopped" line. The draft is the innermost saveDraft from
         // anywhere in the turn, so it survives the subagents' own guards.
-        const partial = lastTurnPartial()
-        if (partial != null && partial != "") {
+        const partial = draftText(lastTurnPartial())
+        if (partial != "") {
           const header = color.yellow("⏳ Stopped (over the ${dimension} budget). Best answer so far:")
           return "${header}\n\n${partial}"
         }

--- a/packages/agency-lang/lib/agents/agency-agent/subagents/code.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/subagents/code.agency
@@ -141,7 +141,7 @@ export def routeFor(decision: TriageResult): string {
   return if decision.path == "complex" then "planner" else "direct"
 }
 
-def escalate(task: string, reason: string, plan: string): string {
+def escalate(task: string, reason: string, plan: string): Result<string> {
   """
   Switch this task to plan-as-code: writes and runs a purpose-built agent for a
   multi-step task, showing you the plan first. Reach for this ONLY when the task
@@ -152,11 +152,10 @@ def escalate(task: string, reason: string, plan: string): string {
   @param reason - why this task needs a multi-step plan.
   @param plan - your outline of the steps.
   """
-  const planned = supervisedPlan(task: task, reason: reason, plan: plan)
-  if (isFailure(planned)) {
-    return "Planner stopped: ${planned.error}"
-  }
-  return planned.value
+  // A stopped planner is returned as a Result, not as a sentence saying it
+  // stopped: the caller here is a model, and a failure worded as prose looks
+  // to it like an answer worth acting on or retrying verbatim.
+  return supervisedPlan(task: task, reason: reason, plan: plan)
 }
 
 /* The expert consult runs once and sets the whole direction, so it gets the
@@ -294,7 +293,10 @@ def supervisedPlan(task: string, reason: string, plan: string): Result<string> {
   )
 }
 
-export def codeAgent(userMsg: string, agencyTask: boolean = false) {
+export def codeAgent(
+  userMsg: string,
+  agencyTask: boolean = false,
+): Result<string> {
   """
   This agent can help with all coding-related tasks,
   such as reading, writing, or editing code. It can also
@@ -314,7 +316,11 @@ export def codeAgent(userMsg: string, agencyTask: boolean = false) {
   if (_oneShot) {
     return solveUnattended(task: userMsg, agencyTask: agencyTask)
   }
-  return converse(userMsg: userMsg, originalUserMsg: originalUserMsg, agencyTask: agencyTask)
+  // converse holds a conversation rather than running to a verdict, so it has
+  // no failure to report; the other two routes can stop short and say so.
+  return success(
+    converse(userMsg: userMsg, originalUserMsg: originalUserMsg, agencyTask: agencyTask),
+  )
 }
 
 /* A multi-part task acquires domain expertise first, brainstorms several
@@ -324,7 +330,7 @@ export def codeAgent(userMsg: string, agencyTask: boolean = false) {
    so a mid-run redirect can name a specific alternative when the chosen
    path is not working. `escalate`, the mid-flight tool, still uses
    plannerAgent. */
-def escalateToExpert(task: string, agencyTask: boolean): string {
+def escalateToExpert(task: string, agencyTask: boolean): Result<string> {
   const guidance = guidanceOrEmpty(consultExpert(task: task, agencyTask: agencyTask))
   const ideas = brainstormApproaches(task: task, guidance: renderGuidance(guidance))
   const alternatives = renderAlternatives(ideas)
@@ -342,15 +348,22 @@ def escalateToExpert(task: string, agencyTask: boolean): string {
     agencyTask: agencyTask,
     alternatives: alternatives,
   )
+  // `stopped` holds why the solve gave up, and is cleared if the fix round
+  // below rescues the task. It is carried separately from `summary` so the
+  // reason travels back as a failure rather than as prose the coordinator
+  // would read as an answer.
   let summary = ""
+  let stopped = ""
   if (isFailure(solved)) {
-    summary = "Coding agent stopped: ${solved.error}"
+    stopped = "${solved.error}"
   } else {
     summary = solved.value
     // Milestone draft: a completed solve is worth keeping even if the
     // verify or fix round below is cut short by an outer budget guard —
-    // salvage-on-abort then returns this instead of nothing.
-    saveDraft(summary)
+    // salvage-on-abort then returns this instead of nothing. Saved as a
+    // success because salvage returns the draft in place of this function's
+    // return value, so the two must have the same type.
+    saveDraft(success(summary))
   }
   const checked = verifierAgent(
     task: task,
@@ -371,27 +384,31 @@ Fix each problem exactly.
     const fixed = supervisedSolve(task: fixMsg, context: "", agencyTask: agencyTask, alternatives: alternatives)
     if (!isFailure(fixed)) {
       summary = fixed.value
-      saveDraft(summary)
+      stopped = ""
+      saveDraft(success(summary))
     }
   }
-  return summary
+  if (stopped != "") {
+    return failure(stopped)
+  }
+  return success(summary)
 }
 
 /* `agency agent -p`: nobody is here to answer a question and there is no next
    turn, which is what the stdlib coding agent already does. The rules for
    working that way are the whole of ONE_SHOT_NOTE, so they travel as context
    rather than as a second copy of the loop. */
-def solveUnattended(task: string, agencyTask: boolean): string {
+def solveUnattended(task: string, agencyTask: boolean): Result<string> {
   const solved = supervisedSolve(task: task, context: ONE_SHOT_NOTE, agencyTask: agencyTask)
   if (isFailure(solved)) {
-    return "The task did not complete: ${solved.error}"
+    return failure("${solved.error}")
   }
   // Milestone draft: the verify and fix rounds below can be cut short by
   // an outer budget guard; the completed solve must survive that.
-  saveDraft(solved.value)
+  saveDraft(success(solved.value))
   const checked = verifierAgent(task: task, maxCost: $5.00, maxTime: 5m)
   if (!feedbackHasErrors(checked)) {
-    return solved.value
+    return success(solved.value)
   }
   const fixMsg = """
 ${task}
@@ -404,10 +421,10 @@ Fix each one; your work will be re-checked.
 """
   const fixed = supervisedSolve(task: fixMsg, context: ONE_SHOT_NOTE, agencyTask: agencyTask)
   if (isFailure(fixed)) {
-    return solved.value
+    return success(solved.value)
   }
-  saveDraft(fixed.value)
-  return fixed.value
+  saveDraft(success(fixed.value))
+  return success(fixed.value)
 }
 
 /* The interactive turn, which is the part that is genuinely this agent's own:

--- a/packages/agency-lang/lib/agents/agency-agent/subagents/explorer.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/subagents/explorer.agency
@@ -14,7 +14,7 @@ import { explorerAgent as stdExplorerAgent } from "std::agents/explorer"
 
 import { getSlowModel, getSlowProvider } from "../shared.agency"
 
-export def explorerAgent(userMsg: string): string {
+export def explorerAgent(userMsg: string): Result<string> {
   """
   Ask the explorer — a read-only researcher on a stronger
   reasoning model — to produce a broad, synthesizing answer about
@@ -42,14 +42,13 @@ export def explorerAgent(userMsg: string): string {
   @param userMsg - the question, with the scope of coverage you
     want covered
   """
-  const result = stdExplorerAgent(
+  // Returned as a Result rather than a string saying the explorer failed: the
+  // tool loop only recognizes a failure it can see, and a failure worded as
+  // prose invites the coordinator to ask the same question again.
+  return stdExplorerAgent(
     question: userMsg,
     model: getSlowModel(),
     provider: getSlowProvider(),
     session: "explorer",
   )
-  if (isFailure(result)) {
-    return "The explorer could not finish: ${result.error}"
-  }
-  return result.value
 }

--- a/packages/agency-lang/lib/agents/agency-agent/subagents/oracle.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/subagents/oracle.agency
@@ -14,7 +14,7 @@ import { oracleAgent as stdOracleAgent } from "std::agents/oracle"
 
 import { getSlowModel, getSlowProvider } from "../shared.agency"
 
-export def oracleAgent(userMsg: string): string {
+export def oracleAgent(userMsg: string): Result<string> {
   """
   Ask the oracle — a read-only senior reviewer on a stronger
   reasoning model — for a second opinion on a hard problem. Call
@@ -37,14 +37,13 @@ export def oracleAgent(userMsg: string): string {
   @param userMsg - the question, with all the context the oracle
     needs to answer it
   """
-  const result = stdOracleAgent(
+  // Returned as a Result rather than a string saying the oracle failed: the
+  // tool loop only recognizes a failure it can see, and a failure worded as
+  // prose invites the coordinator to ask the same question again.
+  return stdOracleAgent(
     question: userMsg,
     model: getSlowModel(),
     provider: getSlowProvider(),
     session: "oracle",
   )
-  if (isFailure(result)) {
-    return "The oracle could not finish: ${result.error}"
-  }
-  return result.value
 }

--- a/packages/agency-lang/lib/agents/agency-agent/subagents/research.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/subagents/research.agency
@@ -36,7 +36,10 @@ For a question spanning more than two sources, call `todoWrite` first and tick e
 
 Keep replies brief. Cite sources. Show, do not lecture."""
 
-export def researchAgent(userMsg: string, agencyTopic: boolean = false): string {
+export def researchAgent(
+  userMsg: string,
+  agencyTopic: boolean = false,
+): Result<string> {
   """
   Answer a question that needs reading rather than writing: looking something
   up, summarizing a document, gathering background, or recalling a stored
@@ -65,8 +68,10 @@ export def researchAgent(userMsg: string, agencyTopic: boolean = false): string 
       extraTools: researchTools,
     )
   }
-  if (isFailure(result)) {
-    return "Research did not finish: ${result.error}"
-  }
-  return result.value
+  // Returned as a Result, not as a string saying the research failed. A
+  // failure phrased as ordinary prose reads to the coordinator as a normal
+  // answer, so it re-issues the identical call; a Result reaches the tool
+  // loop's failure path, which labels it an error, counts it, and drops the
+  // tool after too many.
+  return result
 }

--- a/packages/agency-lang/lib/agents/agency-agent/tests/subagentFailure.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/subagentFailure.agency
@@ -1,0 +1,49 @@
+/*
+ * The coordinator's subagents return a Result, so a subagent that stops short
+ * reaches the tool loop as a failure rather than as a sentence about failing.
+ * That leaves two places where a Result has to become text again, both of them
+ * pure and both tested here without an LLM:
+ *
+ *   - `replyOrReason`, for `agency agent --agent code` and friends, where the
+ *     reply goes straight to a person with no coordinator in between.
+ *   - `draftText`, for the best-so-far draft shown when a turn runs out of
+ *     budget. Drafts take the type of whatever function saved them, so the
+ *     subagents' drafts now arrive wrapped while deeper workers still save
+ *     bare strings.
+ */
+
+import { draftText, replyOrReason } from "../lib/coordinator.agency"
+
+node replyPassesValueThrough(): boolean {
+  return replyOrReason(success("here is your answer"), "The agent stopped")
+    == "here is your answer"
+}
+
+node replyNamesTheReason(): boolean {
+  const shown = replyOrReason(
+    failure("over the time budget"),
+    "The coding agent stopped",
+  )
+  return shown == "The coding agent stopped: over the time budget"
+}
+
+// A subagent's own draft: saved as a success so it matches the function's
+// return type, and unwrapped before the user sees it.
+node draftUnwrapsSuccess(): boolean {
+  return draftText(success("half an answer")) == "half an answer"
+}
+
+// A deeper stdlib worker still saves a plain string.
+node draftPassesPlainStringThrough(): boolean {
+  return draftText("half an answer") == "half an answer"
+}
+
+node draftOfNothingIsEmpty(): boolean {
+  return draftText(null) == ""
+}
+
+// A failure is not a draft. Showing its error text under "Best answer so far"
+// would present the reason the turn stopped as the work it managed to do.
+node draftIgnoresFailure(): boolean {
+  return draftText(failure("over the time budget")) == ""
+}

--- a/packages/agency-lang/lib/agents/agency-agent/tests/subagentFailure.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/subagentFailure.test.json
@@ -1,0 +1,40 @@
+{
+  "tests": [
+    {
+      "nodeName": "replyPassesValueThrough",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "replyNamesTheReason",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "draftUnwrapsSuccess",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "draftPassesPlainStringThrough",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "draftOfNothingIsEmpty",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "draftIgnoresFailure",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}


### PR DESCRIPTION
## The problem

The agency agent's subagents caught their own failures and returned the reason
as an ordinary string:

```
if (isFailure(result)) {
  return "Research did not finish: ${result.error}"
}
return result.value
```

The coordinator calls these as tools, and to a model a string is an answer.
Nothing in it says that retrying is pointless.

This showed up in a real run. `researchAgent` failed instantly on a duplicate
tool name (since fixed in #648), reported it as prose, and the coordinator
called it again with byte-identical arguments before giving up and trying
something else.

The cost is not just the wasted call. The tool loop has machinery for a failing
tool that none of this reached:

- a `toolError` entry in the statelog, which would have made the duplicate-tool
  bug obvious instead of invisible
- a per-tool failure count, and removal of the tool after `MAX_TOOL_FAILURES`
- a tier suffix that tells the model whether calling again is sensible
  (`neverStarted` -> "Nothing was executed. Correct the arguments and call
  again", and so on)

All of it keys off `isFailure(toolResult)` in `lib/runtime/prompt.ts`, and a
string is not a failure.

## The change

`researchAgent`, `oracleAgent`, `explorerAgent`, `codeAgent`, and the
mid-flight `escalate` tool return `Result<string>` and pass the underlying
failure straight through. Inside `codeAgent`, `escalateToExpert` and
`solveUnattended` do the same; `converse` holds a conversation rather than
running to a verdict, so it has no failure to report and is wrapped in
`success`.

`escalateToExpert` needed one restructuring. It runs a verify-and-fix round
after the solve, and that round can rescue a task whose first solve gave up. So
the reason the solve stopped is now carried in its own local and cleared if the
fix round succeeds, rather than being baked into the summary string.

## Two places that still need text

**`dispatchAgent`.** `agency agent --agent code` (and `--agent research`, and so
on) bypasses the coordinator and prints straight to a person. A person is better
served by a sentence than by a Result, so `replyOrReason` unwraps there, keeping
the previous wording. Output on those paths is unchanged.

**The best-so-far draft.** A saved draft takes the type of the function that
saved it, because salvage returns the draft in place of that function's return
value — so the milestone drafts inside `escalateToExpert` and `solveUnattended`
are now `saveDraft(success(...))`. That means the draft `runTurn` shows when a
turn runs out of budget can now arrive wrapped, while deeper stdlib workers
still save bare strings. `draftText` handles both, and shows nothing for a
failure, since the reason a turn stopped is not the work it managed to do.

## Testing

New `tests/subagentFailure.agency` covers `replyOrReason` and `draftText`
directly — both are pure, so no LLM is involved.

- `pnpm run test:agents`: 208/208 pass (22 files)
- `agency tc lib/agents/agency-agent/`: clean
- `agency lint` on the touched files: 98 AL0001 findings in `coordinator.agency`
  before and after, all pre-existing unused imports

## What this does not fix

The run that prompted this had a second, worse bug that is not addressed here.
When the expert consult's 5-minute guard tripped, the abort unwound out of
`codeAgent` before its `tool_result` was appended, leaving the coordinator's
thread with an orphaned `tool_use`. Every later call to that thread got a 400
from the provider and the agent died. That one is written up separately in
`docs/superpowers/specs/2026-07-22-orphaned-tool-use-on-guard-abort-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
