### PR TITLE
Count cache reads and writes in the token/cost breakdown

### DIFF
--- a/packages/agency-lang/docs/site/stdlib/thread.md
+++ b/packages/agency-lang/docs/site/stdlib/thread.md
@@ -55,6 +55,12 @@ export type ModelCost = {
   model: string;
   inputTokens: number;
   outputTokens: number;
+  // Tokens read back from a cache entry, and tokens written to a new one.
+  // Both are input-side and both are billed, at rates that differ from
+  // `inputTokens` — so a total that leaves them out understates a cached
+  // conversation by most of its size.
+  cachedInputTokens: number;
+  cacheCreationInputTokens: number;
   cost: number
 }
 ```
@@ -74,7 +80,7 @@ export type GuardFailureData = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L214))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L220))
 
 ### ThreadMessage
 
@@ -85,7 +91,7 @@ export type ThreadMessage = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L237))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L243))
 
 ### ThreadInfo
 
@@ -101,7 +107,7 @@ export type ThreadInfo = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L242))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L248))
 
 ## Functions
 
@@ -341,7 +347,7 @@ Unlike the per-branch cost/token accessors, this reads process-wide
 
 **Returns:** `ModelCost[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L205))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L211))
 
 ### listThreads
 
@@ -374,7 +380,7 @@ Summary sourcing: threads opened with `thread(summarize: true)` are
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L314))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L320))
 
 ### currentThreadId
 
@@ -389,7 +395,7 @@ Slug-form id of the active thread (e.g. "t3"), or `""` outside any
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L367))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L373))
 
 ### getThread
 
@@ -421,4 +427,4 @@ Read a slice of a thread's messages. Returns success holding `[]`
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L377))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L383))

--- a/packages/agency-lang/lib/agents/agency-agent/lib/repl.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/repl.agency
@@ -178,8 +178,8 @@ def costSlashCommand(): boolean {
   const byModel = getModelCosts()
   let totalCost = 0.0
   let totalTokens = 0
-  let totalRead = 0
-  let totalWritten = 0
+  let totalCacheRead = 0
+  let totalCacheWrite = 0
   for (m in byModel) {
     totalCost = totalCost + m.cost
     // Cache reads and writes are input tokens too. Counting only
@@ -188,14 +188,14 @@ def costSlashCommand(): boolean {
     totalTokens = totalTokens
       + m.inputTokens + m.outputTokens
       + m.cachedInputTokens + m.cacheCreationInputTokens
-    totalRead = totalRead + m.cachedInputTokens
-    totalWritten = totalWritten + m.cacheCreationInputTokens
+    totalCacheRead = totalCacheRead + m.cachedInputTokens
+    totalCacheWrite = totalCacheWrite + m.cacheCreationInputTokens
   }
   pushMessage("Cost:   $${totalCost.toFixed(4)}")
   pushMessage("Tokens: ${totalTokens}")
-  if (totalRead > 0 || totalWritten > 0) {
+  if (totalCacheRead > 0 || totalCacheWrite > 0) {
     pushMessage(
-      color.dim("        ${totalWritten} written to cache, ${totalRead} read back"),
+      color.dim("        ${totalCacheWrite} written to cache, ${totalCacheRead} read back"),
     )
   }
   if (byModel.length > 0) {

--- a/packages/agency-lang/lib/agents/agency-agent/lib/repl.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/repl.agency
@@ -178,18 +178,33 @@ def costSlashCommand(): boolean {
   const byModel = getModelCosts()
   let totalCost = 0.0
   let totalTokens = 0
+  let totalRead = 0
+  let totalWritten = 0
   for (m in byModel) {
     totalCost = totalCost + m.cost
-    totalTokens = totalTokens + m.inputTokens + m.outputTokens
+    // Cache reads and writes are input tokens too. Counting only
+    // inputTokens + outputTokens reports a fraction of a cached
+    // conversation — on a long agent run, often under a tenth of it.
+    totalTokens = totalTokens
+      + m.inputTokens + m.outputTokens
+      + m.cachedInputTokens + m.cacheCreationInputTokens
+    totalRead = totalRead + m.cachedInputTokens
+    totalWritten = totalWritten + m.cacheCreationInputTokens
   }
   pushMessage("Cost:   $${totalCost.toFixed(4)}")
   pushMessage("Tokens: ${totalTokens}")
+  if (totalRead > 0 || totalWritten > 0) {
+    pushMessage(
+      color.dim("        ${totalWritten} written to cache, ${totalRead} read back"),
+    )
+  }
   if (byModel.length > 0) {
     pushMessage("")
     pushMessage("By model:")
     for (m in byModel) {
+      const up = m.inputTokens + m.cachedInputTokens + m.cacheCreationInputTokens
       pushMessage(
-        "  ${m.model}  ↑${m.inputTokens} ↓${m.outputTokens}  $${m.cost.toFixed(4)}",
+        "  ${m.model}  ↑${up} ↓${m.outputTokens}  $${m.cost.toFixed(4)}",
       )
     }
   }

--- a/packages/agency-lang/lib/runtime/state/globalStore.ts
+++ b/packages/agency-lang/lib/runtime/state/globalStore.ts
@@ -252,15 +252,22 @@ export class GlobalStore {
       // `/cost` (cumulative per-model breakdown). Null-prototype so a
       // provider-supplied model name (e.g. `__proto__`) can't pollute it.
       models: Object.create(null),
+      // Cache reads (`cached*`) and cache writes (`cacheCreation*`) are
+      // counted apart from ordinary input because providers price all three
+      // differently. Reporting only input and output leaves most of an agent
+      // run's spend unexplained.
       usage: {
         inputTokens: 0,
         outputTokens: 0,
         cachedInputTokens: 0,
+        cacheCreationInputTokens: 0,
         totalTokens: 0,
       },
       cost: {
         inputCost: 0,
         outputCost: 0,
+        cachedInputCost: 0,
+        cacheCreationInputCost: 0,
         totalCost: 0,
         currency: "USD",
       },

--- a/packages/agency-lang/lib/runtime/trace/eventLog.test.ts
+++ b/packages/agency-lang/lib/runtime/trace/eventLog.test.ts
@@ -624,10 +624,14 @@ describe("detectLlmCalls", () => {
     });
     const events = detectLlmCalls(prev, curr, 1);
     const llmEvent = events.find((e: any) => e.type === "llm-call") as any;
+    // Neither checkpoint carries `cacheCreationInputTokens` — they stand in
+    // for stats written before that field existed — so its delta must read
+    // zero rather than NaN.
     expect(llmEvent.tokenUsage).toEqual({
       inputTokens: 15,
       outputTokens: 7,
       cachedInputTokens: 3,
+      cacheCreationInputTokens: 0,
       totalTokens: 22,
     });
   });

--- a/packages/agency-lang/lib/runtime/trace/eventLog.ts
+++ b/packages/agency-lang/lib/runtime/trace/eventLog.ts
@@ -50,6 +50,7 @@ export type LlmCallEvent = BaseEvent & {
     inputTokens: number;
     outputTokens: number;
     cachedInputTokens: number;
+    cacheCreationInputTokens: number;
     totalTokens: number;
   } | null;
 };
@@ -177,6 +178,9 @@ function getTokenUsageDiff(
     cachedInputTokens:
       (currStats.usage.cachedInputTokens ?? 0) -
       (prevStats.usage.cachedInputTokens ?? 0),
+    cacheCreationInputTokens:
+      (currStats.usage.cacheCreationInputTokens ?? 0) -
+      (prevStats.usage.cacheCreationInputTokens ?? 0),
     totalTokens:
       (currStats.usage.totalTokens ?? 0) -
       (prevStats.usage.totalTokens ?? 0),

--- a/packages/agency-lang/lib/runtime/utils.test.ts
+++ b/packages/agency-lang/lib/runtime/utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { deepFreeze, extractStructuredResponse, normalizeModelUsage, updateTokenStats } from "./utils.js";
 import { isSuccess, isFailure } from "./result.js";
 import { z } from "zod";
@@ -347,31 +347,78 @@ describe("normalizeModelUsage", () => {
   });
 });
 
-describe("updateTokenStats slot hygiene", () => {
+describe("token-stats counters: missing vs malformed", () => {
+  // A missing counter is ordinary — an older checkpoint, or a provider that
+  // does not cache — so it reads as zero without comment. A malformed one is
+  // a bug, and has to be audible or it hides behind a plausible total.
+  let warn: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+  afterEach(() => warn.mockRestore());
+
+  it("reads a missing counter as zero, silently", () => {
+    const globals = GlobalStore.withTokenStats();
+    delete globals.getTokenStats().usage.cacheCreationInputTokens;
+    updateTokenStats({ globals, usage: usage(10, 5), cost: cost(0.001), model: "opus-4.8" });
+    expect(globals.getTokenStats().usage.cacheCreationInputTokens).toBe(0);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("does not warn about a provider that omits cache counts entirely", () => {
+    const globals = GlobalStore.withTokenStats();
+    updateTokenStats({ globals, usage: usage(10, 5), cost: cost(0.001), model: "gpt-5-mini" });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
   // `tokenStats.cost` holds `currency: "USD"` next to its counters, so the
   // object being accumulated into is not uniformly numeric. Adding must never
-  // touch a non-counter slot, and must not concatenate into one either.
+  // touch a non-counter slot.
   it("leaves the currency field alone", () => {
     const globals = GlobalStore.withTokenStats();
     updateTokenStats({ globals, usage: usage(10, 5), cost: cost(0.001), model: "opus-4.8" });
     expect(globals.getTokenStats().cost.currency).toBe("USD");
+    expect(warn).not.toHaveBeenCalled();
   });
 
-  // A counter that somehow holds NaN (a checkpoint written mid-bug, a
-  // provider returning garbage) must recover rather than stay NaN forever:
-  // NaN + n is NaN, so one bad value would otherwise sink the whole run.
-  it("recovers a counter that is already NaN", () => {
+  // NaN is the signature of an earlier `undefined + n`. Left alone it spreads
+  // to every total it touches, so it recovers to zero — and says why.
+  it("recovers from a NaN counter and warns", () => {
     const globals = GlobalStore.withTokenStats();
     globals.getTokenStats().usage.inputTokens = NaN;
     updateTokenStats({ globals, usage: usage(10, 5), cost: cost(0.001), model: "opus-4.8" });
     expect(globals.getTokenStats().usage.inputTokens).toBe(10);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0][0])).toContain("inputTokens");
   });
 
-  it("recovers a counter holding a non-number", () => {
+  it("restarts a counter holding a string, and warns instead of concatenating", () => {
     const globals = GlobalStore.withTokenStats();
     globals.getTokenStats().usage.outputTokens = "12" as unknown as number;
     updateTokenStats({ globals, usage: usage(10, 5), cost: cost(0.001), model: "opus-4.8" });
-    // 5, not "125" — a string slot restarts the count rather than concatenating.
+    // 5, not "125".
     expect(globals.getTokenStats().usage.outputTokens).toBe(5);
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  // The incoming side matters too: nothing validates a provider's usage
+  // payload at runtime, so a string there would otherwise be counted silently.
+  it("warns when a provider supplies a non-numeric usage value", () => {
+    const globals = GlobalStore.withTokenStats();
+    updateTokenStats({
+      globals,
+      usage: { inputTokens: "900" as unknown as number, outputTokens: 5, totalTokens: 905 },
+      cost: cost(0.001),
+      model: "opus-4.8",
+    });
+    expect(globals.getTokenStats().usage.inputTokens).toBe(0);
+    expect(warn).toHaveBeenCalled();
+    expect(String(warn.mock.calls[0][0])).toContain("incoming");
+  });
+
+  it("warns when a per-model entry holds a malformed counter", () => {
+    normalizeModelUsage({ "opus-4.8": { inputTokens: {}, outputTokens: 5, totalCost: 0.02 } });
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0][0])).toContain("models.opus-4.8.inputTokens");
   });
 });

--- a/packages/agency-lang/lib/runtime/utils.test.ts
+++ b/packages/agency-lang/lib/runtime/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { deepFreeze, extractStructuredResponse, updateTokenStats } from "./utils.js";
+import { deepFreeze, extractStructuredResponse, normalizeModelUsage, updateTokenStats } from "./utils.js";
 import { isSuccess, isFailure } from "./result.js";
 import { z } from "zod";
 import { GlobalStore } from "./state/globalStore.js";
@@ -81,6 +81,8 @@ describe("updateTokenStats per-model breakdown", () => {
     expect(stats.models["opus-4.8"]).toEqual({
       inputTokens: 10,
       outputTokens: 5,
+      cachedInputTokens: 0,
+      cacheCreationInputTokens: 0,
       totalCost: 0.001,
     });
     // The aggregate totals still accumulate independently.
@@ -95,6 +97,8 @@ describe("updateTokenStats per-model breakdown", () => {
     expect(globals.getTokenStats().models["opus-4.8"]).toEqual({
       inputTokens: 12,
       outputTokens: 8,
+      cachedInputTokens: 0,
+      cacheCreationInputTokens: 0,
       totalCost: 0.0015,
     });
   });
@@ -104,8 +108,8 @@ describe("updateTokenStats per-model breakdown", () => {
     updateTokenStats({ globals, usage: usage(10, 5), cost: cost(0.001), model: "gpt-5-mini" });
     updateTokenStats({ globals, usage: usage(20, 10), cost: cost(0.03), model: "opus-4.8" });
     const models = globals.getTokenStats().models;
-    expect(models["gpt-5-mini"]).toEqual({ inputTokens: 10, outputTokens: 5, totalCost: 0.001 });
-    expect(models["opus-4.8"]).toEqual({ inputTokens: 20, outputTokens: 10, totalCost: 0.03 });
+    expect(models["gpt-5-mini"]).toMatchObject({ inputTokens: 10, outputTokens: 5, totalCost: 0.001 });
+    expect(models["opus-4.8"]).toMatchObject({ inputTokens: 20, outputTokens: 10, totalCost: 0.03 });
   });
 
   it("does not record a model entry when no model name is supplied", () => {
@@ -126,7 +130,7 @@ describe("updateTokenStats per-model breakdown", () => {
     expect(stats.usage.inputTokens).toBe(15);
     expect(stats.usage.outputTokens).toBe(7);
     expect(stats.usage.totalTokens).toBe(22);
-    expect(stats.models["smollm2-135m"]).toEqual({
+    expect(stats.models["smollm2-135m"]).toMatchObject({
       inputTokens: 15,
       outputTokens: 7,
       totalCost: 0,
@@ -142,7 +146,7 @@ describe("updateTokenStats per-model breakdown", () => {
     // …and the entry is recorded as a normal own key.
     const models = globals.getTokenStats().models;
     expect(Object.prototype.hasOwnProperty.call(models, "__proto__")).toBe(true);
-    expect(models["__proto__"]).toEqual({ inputTokens: 1, outputTokens: 1, totalCost: 0.001 });
+    expect(models["__proto__"]).toMatchObject({ inputTokens: 1, outputTokens: 1, totalCost: 0.001 });
   });
 
   it("backfills the models slot for token-stats restored from older checkpoints", () => {
@@ -151,7 +155,7 @@ describe("updateTokenStats per-model breakdown", () => {
     const stats = globals.getTokenStats();
     delete stats.models;
     updateTokenStats({ globals, usage: usage(1, 1), cost: cost(0.0002), model: "opus-4.8" });
-    expect(globals.getTokenStats().models["opus-4.8"]).toEqual({
+    expect(globals.getTokenStats().models["opus-4.8"]).toMatchObject({
       inputTokens: 1,
       outputTokens: 1,
       totalCost: 0.0002,
@@ -302,5 +306,43 @@ describe("extractStructuredResponse — markdown code fences (step 2)", () => {
     const r = extractStructuredResponse(s, schema);
     expect(isSuccess(r)).toBe(true);
     if (isSuccess(r)) expect(r.value).toEqual(value);
+  });
+});
+
+describe("normalizeModelUsage", () => {
+  it("carries cache reads and writes through to the per-model view", () => {
+    const globals = GlobalStore.withTokenStats();
+    updateTokenStats({
+      globals,
+      usage: {
+        inputTokens: 2,
+        outputTokens: 100,
+        cachedInputTokens: 5000,
+        cacheCreationInputTokens: 400,
+        totalTokens: 5502,
+      },
+      cost: { inputCost: 0, outputCost: 0, totalCost: 0.004506 },
+      model: "sonnet-5",
+    });
+    const [row] = normalizeModelUsage(globals.getTokenStats().models);
+    expect(row).toEqual({
+      model: "sonnet-5",
+      inputTokens: 2,
+      outputTokens: 100,
+      cachedInputTokens: 5000,
+      cacheCreationInputTokens: 400,
+      cost: 0.004506,
+    });
+  });
+
+  // Entries written before the cache fields existed have no key for them; the
+  // per-model view must read zero rather than undefined, or the `/cost`
+  // totals that add these up become NaN.
+  it("reads zero for a per-model entry missing the cache fields", () => {
+    const [row] = normalizeModelUsage({
+      "opus-4.8": { inputTokens: 10, outputTokens: 5, totalCost: 0.02 },
+    });
+    expect(row.cachedInputTokens).toBe(0);
+    expect(row.cacheCreationInputTokens).toBe(0);
   });
 });

--- a/packages/agency-lang/lib/runtime/utils.test.ts
+++ b/packages/agency-lang/lib/runtime/utils.test.ts
@@ -159,6 +159,81 @@ describe("updateTokenStats per-model breakdown", () => {
   });
 });
 
+describe("updateTokenStats cache accounting", () => {
+  // A prompt-cached call: a few uncached tokens, a block written to the cache,
+  // a block read back from it. Providers price all three differently.
+  const cachedUsage = {
+    inputTokens: 2,
+    outputTokens: 100,
+    cachedInputTokens: 5000,
+    cacheCreationInputTokens: 400,
+    totalTokens: 5502,
+  };
+  const cachedCost = {
+    inputCost: 0.000006,
+    outputCost: 0.0015,
+    cachedInputCost: 0.0015,
+    cacheCreationInputCost: 0.0015,
+    totalCost: 0.004506,
+  };
+
+  it("records cache reads and writes alongside ordinary input", () => {
+    const globals = GlobalStore.withTokenStats();
+    updateTokenStats({ globals, usage: cachedUsage, cost: cachedCost, model: "sonnet-5" });
+    const stats = globals.getTokenStats();
+    expect(stats.usage.cachedInputTokens).toBe(5000);
+    expect(stats.usage.cacheCreationInputTokens).toBe(400);
+    expect(stats.cost.cachedInputCost).toBeCloseTo(0.0015, 10);
+    expect(stats.cost.cacheCreationInputCost).toBeCloseTo(0.0015, 10);
+  });
+
+  // The bug this guards: `totalCost` counted cache spend but the breakdown did
+  // not, so a caller adding up the parts got a number far below the total.
+  it("reports a breakdown that adds up to the total", () => {
+    const globals = GlobalStore.withTokenStats();
+    updateTokenStats({ globals, usage: cachedUsage, cost: cachedCost, model: "sonnet-5" });
+    updateTokenStats({ globals, usage: cachedUsage, cost: cachedCost, model: "sonnet-5" });
+    const { cost: c } = globals.getTokenStats();
+    const parts =
+      c.inputCost + c.outputCost + c.cachedInputCost + c.cacheCreationInputCost;
+    expect(parts).toBeCloseTo(c.totalCost, 10);
+  });
+
+  it("counts every token class in the usage breakdown", () => {
+    const globals = GlobalStore.withTokenStats();
+    updateTokenStats({ globals, usage: cachedUsage, cost: cachedCost, model: "sonnet-5" });
+    const { usage: u } = globals.getTokenStats();
+    const parts =
+      u.inputTokens + u.outputTokens + u.cachedInputTokens + u.cacheCreationInputTokens;
+    expect(parts).toBe(u.totalTokens);
+  });
+
+  // Token-stats restored from a checkpoint written before these fields existed
+  // have `undefined` there. `undefined += n` is NaN, which would then poison
+  // every later total on the run.
+  it("accumulates onto token-stats restored from older checkpoints", () => {
+    const globals = GlobalStore.withTokenStats();
+    const stats = globals.getTokenStats();
+    delete stats.usage.cacheCreationInputTokens;
+    delete stats.cost.cachedInputCost;
+    delete stats.cost.cacheCreationInputCost;
+    updateTokenStats({ globals, usage: cachedUsage, cost: cachedCost, model: "sonnet-5" });
+    const restored = globals.getTokenStats();
+    expect(restored.usage.cacheCreationInputTokens).toBe(400);
+    expect(restored.cost.cachedInputCost).toBeCloseTo(0.0015, 10);
+    expect(restored.cost.cacheCreationInputCost).toBeCloseTo(0.0015, 10);
+  });
+
+  it("leaves the cache fields at zero for a model that does not cache", () => {
+    const globals = GlobalStore.withTokenStats();
+    updateTokenStats({ globals, usage: usage(10, 5), cost: cost(0.001), model: "gpt-5-mini" });
+    const stats = globals.getTokenStats();
+    expect(stats.usage.cacheCreationInputTokens).toBe(0);
+    expect(stats.cost.cacheCreationInputCost).toBe(0);
+    expect(stats.cost.cachedInputCost).toBe(0);
+  });
+});
+
 describe("extractStructuredResponse — wrapper-key unwrapping (step 5)", () => {
   const envelope = z.object({ response: z.number() });
 

--- a/packages/agency-lang/lib/runtime/utils.test.ts
+++ b/packages/agency-lang/lib/runtime/utils.test.ts
@@ -346,3 +346,32 @@ describe("normalizeModelUsage", () => {
     expect(row.cacheCreationInputTokens).toBe(0);
   });
 });
+
+describe("updateTokenStats slot hygiene", () => {
+  // `tokenStats.cost` holds `currency: "USD"` next to its counters, so the
+  // object being accumulated into is not uniformly numeric. Adding must never
+  // touch a non-counter slot, and must not concatenate into one either.
+  it("leaves the currency field alone", () => {
+    const globals = GlobalStore.withTokenStats();
+    updateTokenStats({ globals, usage: usage(10, 5), cost: cost(0.001), model: "opus-4.8" });
+    expect(globals.getTokenStats().cost.currency).toBe("USD");
+  });
+
+  // A counter that somehow holds NaN (a checkpoint written mid-bug, a
+  // provider returning garbage) must recover rather than stay NaN forever:
+  // NaN + n is NaN, so one bad value would otherwise sink the whole run.
+  it("recovers a counter that is already NaN", () => {
+    const globals = GlobalStore.withTokenStats();
+    globals.getTokenStats().usage.inputTokens = NaN;
+    updateTokenStats({ globals, usage: usage(10, 5), cost: cost(0.001), model: "opus-4.8" });
+    expect(globals.getTokenStats().usage.inputTokens).toBe(10);
+  });
+
+  it("recovers a counter holding a non-number", () => {
+    const globals = GlobalStore.withTokenStats();
+    globals.getTokenStats().usage.outputTokens = "12" as unknown as number;
+    updateTokenStats({ globals, usage: usage(10, 5), cost: cost(0.001), model: "opus-4.8" });
+    // 5, not "125" — a string slot restarts the count rather than concatenating.
+    expect(globals.getTokenStats().usage.outputTokens).toBe(5);
+  });
+});

--- a/packages/agency-lang/lib/runtime/utils.ts
+++ b/packages/agency-lang/lib/runtime/utils.ts
@@ -171,6 +171,10 @@ export type ModelUsage = {
   model: string;
   inputTokens: number;
   outputTokens: number;
+  /** Tokens read back from an existing cache entry. */
+  cachedInputTokens: number;
+  /** Tokens written to a new cache entry. */
+  cacheCreationInputTokens: number;
   cost: number;
 };
 
@@ -189,6 +193,12 @@ export function normalizeModelUsage(rawModels: unknown): ModelUsage[] {
       model,
       inputTokens: typeof v?.inputTokens === "number" ? v.inputTokens : 0,
       outputTokens: typeof v?.outputTokens === "number" ? v.outputTokens : 0,
+      cachedInputTokens:
+        typeof v?.cachedInputTokens === "number" ? v.cachedInputTokens : 0,
+      cacheCreationInputTokens:
+        typeof v?.cacheCreationInputTokens === "number"
+          ? v.cacheCreationInputTokens
+          : 0,
       cost: typeof v?.totalCost === "number" ? v.totalCost : 0,
     });
   }
@@ -248,9 +258,11 @@ export function updateTokenStats(args: {
     }
     const m = tokenStats.models[model] ??
       (tokenStats.models[model] = { inputTokens: 0, outputTokens: 0, totalCost: 0 });
-    m.inputTokens += usage.inputTokens || 0;
-    m.outputTokens += usage.outputTokens || 0;
-    m.totalCost += cost.totalCost || 0;
+    addTo(m, "inputTokens", usage.inputTokens);
+    addTo(m, "outputTokens", usage.outputTokens);
+    addTo(m, "cachedInputTokens", usage.cachedInputTokens);
+    addTo(m, "cacheCreationInputTokens", usage.cacheCreationInputTokens);
+    addTo(m, "totalCost", cost.totalCost);
   }
   // Cache reads and cache writes are tracked separately from ordinary input.
   // Without them the breakdown does not reconcile with its own total: on a

--- a/packages/agency-lang/lib/runtime/utils.ts
+++ b/packages/agency-lang/lib/runtime/utils.ts
@@ -223,11 +223,22 @@ type StatCost = {
   totalCost?: number;
 };
 
-/** Add to a counter that may be absent. Token-stats objects restored from a
- *  checkpoint written before a field existed have `undefined` there, and
- *  `undefined += n` is NaN — which then poisons every later total. */
-function addTo(target: Record<string, number>, key: string, amount: number | undefined): void {
-  target[key] = (target[key] || 0) + (amount || 0);
+/** Add to one counter on a token-stats object.
+ *
+ *  The slot may be missing: stats restored from a checkpoint written before
+ *  a field existed have `undefined` there, and `undefined + n` is NaN, which
+ *  then poisons every later total on the run.
+ *
+ *  The slot may also not be a number at all. `tokenStats.cost` holds
+ *  `currency: "USD"` alongside its counters, so the object this walks is not
+ *  uniformly numeric — hence `unknown` values rather than a `Record<string,
+ *  number>` that would claim otherwise. Anything that is not a finite number
+ *  starts from zero, which is the right reading for a counter and keeps a
+ *  stray string from being concatenated into one. */
+function addTo(target: Record<string, unknown>, key: string, amount: number | undefined): void {
+  const current = target[key];
+  const base = typeof current === "number" && Number.isFinite(current) ? current : 0;
+  target[key] = base + (amount || 0);
 }
 
 export function updateTokenStats(args: {

--- a/packages/agency-lang/lib/runtime/utils.ts
+++ b/packages/agency-lang/lib/runtime/utils.ts
@@ -202,13 +202,23 @@ type StatUsage = {
   inputTokens?: number;
   outputTokens?: number;
   cachedInputTokens?: number;
+  cacheCreationInputTokens?: number;
   totalTokens?: number;
 };
 type StatCost = {
   inputCost?: number;
   outputCost?: number;
+  cachedInputCost?: number;
+  cacheCreationInputCost?: number;
   totalCost?: number;
 };
+
+/** Add to a counter that may be absent. Token-stats objects restored from a
+ *  checkpoint written before a field existed have `undefined` there, and
+ *  `undefined += n` is NaN — which then poisons every later total. */
+function addTo(target: Record<string, number>, key: string, amount: number | undefined): void {
+  target[key] = (target[key] || 0) + (amount || 0);
+}
 
 export function updateTokenStats(args: {
   globals: GlobalStore;
@@ -242,12 +252,20 @@ export function updateTokenStats(args: {
     m.outputTokens += usage.outputTokens || 0;
     m.totalCost += cost.totalCost || 0;
   }
-  tokenStats.usage.inputTokens += usage.inputTokens || 0;
-  tokenStats.usage.outputTokens += usage.outputTokens || 0;
-  tokenStats.usage.cachedInputTokens += usage.cachedInputTokens || 0;
-  tokenStats.usage.totalTokens += usage.totalTokens || 0;
+  // Cache reads and cache writes are tracked separately from ordinary input.
+  // Without them the breakdown does not reconcile with its own total: on a
+  // long agent run most of the money goes to cache writes, and most of the
+  // tokens to cache reads, so a report of input + output alone can account
+  // for well under half the bill.
+  addTo(tokenStats.usage, "inputTokens", usage.inputTokens);
+  addTo(tokenStats.usage, "outputTokens", usage.outputTokens);
+  addTo(tokenStats.usage, "cachedInputTokens", usage.cachedInputTokens);
+  addTo(tokenStats.usage, "cacheCreationInputTokens", usage.cacheCreationInputTokens);
+  addTo(tokenStats.usage, "totalTokens", usage.totalTokens);
 
-  tokenStats.cost.inputCost += cost.inputCost || 0;
-  tokenStats.cost.outputCost += cost.outputCost || 0;
-  tokenStats.cost.totalCost += cost.totalCost || 0;
+  addTo(tokenStats.cost, "inputCost", cost.inputCost);
+  addTo(tokenStats.cost, "outputCost", cost.outputCost);
+  addTo(tokenStats.cost, "cachedInputCost", cost.cachedInputCost);
+  addTo(tokenStats.cost, "cacheCreationInputCost", cost.cacheCreationInputCost);
+  addTo(tokenStats.cost, "totalCost", cost.totalCost);
 }

--- a/packages/agency-lang/lib/runtime/utils.ts
+++ b/packages/agency-lang/lib/runtime/utils.ts
@@ -179,6 +179,47 @@ export type ModelUsage = {
 };
 
 /**
+ * Read one counter off a token-stats object. Every place that reads these
+ * slots goes through here, so "what does a missing or broken counter mean"
+ * is answered once.
+ *
+ * There are two ways a slot can fail to hold a number, and they are not the
+ * same thing.
+ *
+ * MISSING (`undefined` / `null`) is ordinary and reads as zero in silence.
+ * Stats restored from a checkpoint written before a field existed have no
+ * key for it, a provider that does not do prompt caching never reports a
+ * cache count, and a fresh per-model entry starts life without the keys that
+ * `updateTokenStats` has not written yet.
+ *
+ * PRESENT BUT NOT A FINITE NUMBER is a bug, and gets said out loud.
+ * `updateTokenStats` is the only writer and only ever writes numbers, so a
+ * string or an object in one of these slots means either the stats object
+ * was corrupted upstream, or a provider returned a non-number in its usage /
+ * cost payload — which nothing enforces at runtime, since the `number |
+ * undefined` parameter types are erased. NaN lands here too: it is the
+ * signature of an earlier `undefined + n`, and it would otherwise spread to
+ * every total it touches.
+ *
+ * Both cases read as zero, because the alternative is throwing, and every
+ * caller of this is a cost display, a REPL footer, or a log line. None of
+ * them is worth taking a run down for. Warning is what keeps the second case
+ * from hiding: the totals will be short by whatever the slot held, and the
+ * message says so.
+ */
+function counterValue(value: unknown, where: string): number {
+  if (value === undefined || value === null) return 0;
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  console.warn(
+    `[agency] token stats: ${where} holds ${String(value)}, which is not a ` +
+      `finite number. Counting it as 0 — the reported totals will be short ` +
+      `by whatever it held. Only updateTokenStats writes these slots, so ` +
+      `this means the stats object or a provider's usage payload is wrong.`,
+  );
+  return 0;
+}
+
+/**
  * Normalize the raw `__tokenStats.models` map into a typed, defensively
  * narrowed array sorted by cost descending (model name as the tiebreak).
  * Single source of truth for reading the per-model breakdown — shared by
@@ -189,17 +230,17 @@ export function normalizeModelUsage(rawModels: unknown): ModelUsage[] {
   if (!rawModels || typeof rawModels !== "object") return [];
   const out: ModelUsage[] = [];
   for (const [model, v] of Object.entries(rawModels as Record<string, any>)) {
+    // The label names the model, so a warning points at the entry to look at
+    // rather than just the field name.
+    const read = (key: keyof ModelUsage | "totalCost") =>
+      counterValue(v?.[key], `models.${model}.${key}`);
     out.push({
       model,
-      inputTokens: typeof v?.inputTokens === "number" ? v.inputTokens : 0,
-      outputTokens: typeof v?.outputTokens === "number" ? v.outputTokens : 0,
-      cachedInputTokens:
-        typeof v?.cachedInputTokens === "number" ? v.cachedInputTokens : 0,
-      cacheCreationInputTokens:
-        typeof v?.cacheCreationInputTokens === "number"
-          ? v.cacheCreationInputTokens
-          : 0,
-      cost: typeof v?.totalCost === "number" ? v.totalCost : 0,
+      inputTokens: read("inputTokens"),
+      outputTokens: read("outputTokens"),
+      cachedInputTokens: read("cachedInputTokens"),
+      cacheCreationInputTokens: read("cacheCreationInputTokens"),
+      cost: read("totalCost"),
     });
   }
   out.sort((a, b) => b.cost - a.cost || (a.model < b.model ? -1 : 1));
@@ -225,20 +266,18 @@ type StatCost = {
 
 /** Add to one counter on a token-stats object.
  *
- *  The slot may be missing: stats restored from a checkpoint written before
- *  a field existed have `undefined` there, and `undefined + n` is NaN, which
- *  then poisons every later total on the run.
+ *  Both sides go through `counterValue`, which is where "missing is fine,
+ *  malformed is a bug worth saying out loud" is decided. The target side
+ *  catches a slot an older checkpoint never wrote; the incoming side catches
+ *  a provider handing back something that is not a number in its usage or
+ *  cost payload.
  *
- *  The slot may also not be a number at all. `tokenStats.cost` holds
- *  `currency: "USD"` alongside its counters, so the object this walks is not
- *  uniformly numeric — hence `unknown` values rather than a `Record<string,
- *  number>` that would claim otherwise. Anything that is not a finite number
- *  starts from zero, which is the right reading for a counter and keeps a
- *  stray string from being concatenated into one. */
-function addTo(target: Record<string, unknown>, key: string, amount: number | undefined): void {
-  const current = target[key];
-  const base = typeof current === "number" && Number.isFinite(current) ? current : 0;
-  target[key] = base + (amount || 0);
+ *  Values are `unknown` rather than `number` because `tokenStats.cost` holds
+ *  `currency: "USD"` next to its counters, so the object this walks is not
+ *  uniformly numeric and a `Record<string, number>` would be claiming
+ *  otherwise. */
+function addTo(target: Record<string, unknown>, key: string, amount: unknown): void {
+  target[key] = counterValue(target[key], key) + counterValue(amount, `${key} (incoming)`);
 }
 
 export function updateTokenStats(args: {

--- a/packages/agency-lang/lib/statelogClient.ts
+++ b/packages/agency-lang/lib/statelogClient.ts
@@ -93,16 +93,24 @@ const DEFAULT_REQUEST_TIMEOUT_MS = 1500;
 
 // === Token / cost types ===
 
+// `cachedInputTokens` are tokens READ from an existing cache entry;
+// `cacheCreationInputTokens` are tokens WRITTEN to a new one. Providers bill
+// them at different rates (a write costs more than ordinary input, a read
+// costs far less), so a breakdown that omits either cannot explain its own
+// total.
 export type TokenUsage = {
   inputTokens?: number;
   outputTokens?: number;
   cachedInputTokens?: number;
+  cacheCreationInputTokens?: number;
   totalTokens?: number;
 };
 
 export type TokenCost = {
   inputCost?: number;
   outputCost?: number;
+  cachedInputCost?: number;
+  cacheCreationInputCost?: number;
   totalCost?: number;
 };
 

--- a/packages/agency-lang/lib/stdlib/cli.ts
+++ b/packages/agency-lang/lib/stdlib/cli.ts
@@ -1128,16 +1128,30 @@ function readTokenSnapshot(): TokenSnapshot {
     // the defensive field-narrowing in `normalizeModelUsage`.
     const models: ModelTotals = {};
     for (const m of normalizeModelUsage((stats as { models?: unknown }).models)) {
-      models[m.model] = { tokens: m.inputTokens + m.outputTokens, cost: m.cost };
+      models[m.model] = {
+        tokens:
+          m.inputTokens +
+          m.outputTokens +
+          m.cachedInputTokens +
+          m.cacheCreationInputTokens,
+        cost: m.cost,
+      };
     }
     const usage = (stats as { usage?: Record<string, unknown> }).usage;
     if (!usage || typeof usage !== "object") {
       return { inputTokens: 0, outputTokens: 0, models };
     }
+    const num = (v: unknown) => (typeof v === "number" ? v : 0);
     return {
-      inputTokens: typeof usage.inputTokens === "number" ? usage.inputTokens : 0,
-      outputTokens:
-        typeof usage.outputTokens === "number" ? usage.outputTokens : 0,
+      // The footer's `↑` is "how much went up the wire this turn", so cache
+      // reads and writes belong in it: both are input the provider billed
+      // for. Counting only uncached input reports a small fraction of a
+      // cached conversation — on a long agent turn, a few percent of it.
+      inputTokens:
+        num(usage.inputTokens) +
+        num(usage.cachedInputTokens) +
+        num(usage.cacheCreationInputTokens),
+      outputTokens: num(usage.outputTokens),
       models,
     };
   } catch {

--- a/packages/agency-lang/stdlib/thread.agency
+++ b/packages/agency-lang/stdlib/thread.agency
@@ -196,6 +196,12 @@ export type ModelCost = {
   model: string;
   inputTokens: number;
   outputTokens: number;
+  // Tokens read back from a cache entry, and tokens written to a new one.
+  // Both are input-side and both are billed, at rates that differ from
+  // `inputTokens` — so a total that leaves them out understates a cached
+  // conversation by most of its size.
+  cachedInputTokens: number;
+  cacheCreationInputTokens: number;
   cost: number
 }
 


### PR DESCRIPTION
## The problem

A cost breakdown that could not explain its own total. From a real
agency-agent run (`agentEnd`):

```
inputCost   0.030525
outputCost  0.122090
totalCost   0.577170     ← input + output = $0.15
```

The missing $0.42 was cache — $0.385 of cache writes and $0.039 of cache
reads — and neither had a field to land in. The token counts were wrong the
same way: `totalTokens: 220170` against 130,008 across the reported fields,
with the missing 90,162 being cache-creation tokens.

On that run, cache accounted for **74% of the money and 94% of the tokens**.
Reporting input and output alone described about a quarter of the bill.

## Why it happened

`StatUsage` and `StatCost` in `lib/runtime/utils.ts` had no fields for cache
reads or cache writes, so `updateTokenStats` had nowhere to put them.

The data was never missing. smoltalk returns `cachedInputTokens`,
`cacheCreationInputTokens`, `cachedInputCost`, and `cacheCreationInputCost`
on every completion, and the per-call `promptCompletion` events in the
statelog already carry all four. Only the aggregation dropped them.

This matters because providers price the three input classes differently. On
Anthropic, derived from the log's own numbers: a Sonnet cache write bills at
$3.75/M against $3.00/M for ordinary input, and a cache read at $0.30/M.
Collapsing them loses exactly the part of the bill that dominates a long
agent run.

## The change

Four fields added to `TokenUsage` / `TokenCost` (`lib/statelogClient.ts`),
matching fields in `StatUsage` / `StatCost`, and zero-initialized in
`GlobalStore.withTokenStats()`.

Accumulation now goes through a small `addTo` helper that treats an absent
counter as zero. That is not decoration: token stats restored from a
checkpoint written before these fields existed have `undefined` there, and
`undefined += n` is `NaN`, which would then poison every later total on the
run.

## Verification

Replaying the original trace's 12 `promptCompletion` events through the
fixed aggregator:

```
cost:  input 0.030525 + output 0.122090 + cachedInput 0.039231
       + cacheCreation 0.385324  =  0.577170   (totalCost 0.577170)

usage: 6,625 + 7,608 + 115,775 + 90,162  =  220,170   (totalTokens 220,170)
```

Both reconcile exactly, where before they were short by $0.42 and 90,162
tokens.

Six new cases in `lib/runtime/utils.test.ts`, including one asserting the
breakdown sums to the total and one covering the restored-from-old-checkpoint
path. `pnpm run typecheck` clean; `lib/runtime/utils.test.ts` 30/30;
`globalStore` / `statelogClient` / `prompt` / `thread` tests 94/94.

## Deliberately not included

`ModelUsage` (the per-model breakdown behind `std::thread`'s `getModelCosts`
and the REPL footer) still reports only `inputTokens` / `outputTokens` /
`cost`. Its `cost` is the full total and so is already correct; adding cache
fields there changes an Agency-visible type and belongs in its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up commit: the display sites

Fixing the aggregate was not enough — every place that shows a token count
to a user was still adding `inputTokens + outputTokens`. On the same run:

| Surface | Reported | Actual |
| --- | --- | --- |
| `/cost` → `Tokens:` | 14,233 | 220,170 |
| REPL footer `↑` | 6,625 | 212,562 |

The cost figures were right the whole time, which is what made it
confusing: the money said one thing and the tokens said something fifteen
times smaller.

Four changes:

- **The per-model accumulator** in `updateTokenStats` did not track cache at
  all, so `ModelUsage` had nothing to report even after the aggregate was
  fixed. It now accumulates both cache fields through the same `addTo`.
- **`normalizeModelUsage`** and the **`ModelCost` type in `std::thread`**
  carry the two new fields, so `getModelCosts()` can report them.
- **The REPL footer** counts cache reads and writes in `↑`. That arrow means
  "how much went up the wire", and both are input the provider billed for.
- **`/cost`** counts them in its total and adds a breakout line:

  ```
  Cost:   $0.5772
  Tokens: 220170
          90162 written to cache, 115775 read back

  By model:
    claude-sonnet-5  ↑165864 ↓6811  $0.4013
    claude-opus-4-8  ↑46698 ↓797  $0.1758
  ```

  That ratio is the useful number: a cache write only pays for itself once
  something reads it. 90k written against 115k read is 1.28 reads per token,
  which is very low — it means contexts are being built and discarded.

The trace event's token delta (`eventLog.getTokenUsageDiff`) gains the same
field, so a cache write shows up in a trace instead of vanishing between two
checkpoints.

### Checked and left alone

- **Node return value** (`createReturnObject`) and **`agentEnd.tokenStats`**
  pass the whole `__tokenStats` object through, so they picked up the new
  fields from the initializer with no change.
- **`getCost()` / `getTokens()`** read the per-branch accumulator, which is
  fed from `completion.cost.totalCost` and `completion.usage.totalTokens` —
  both already whole-value, both already correct.
- **`tokenStatsFromJSON`** and the debugger's stats line return only
  `{totalTokens, totalCost}`, which were correct already.

### Testing

`pnpm run test:agents` 202/202. `lib/runtime/utils.test.ts` 32/32, including
new coverage for `normalizeModelUsage` and for a per-model entry restored
without the cache fields.

The full `vitest run --dir lib` suite is 8,999–9,000 passing with 2–3
failures that differ between runs and all pass in isolation
(`runPolicy.spawn`, `staticInit.crossModule`, `topsortCycleErrors` — all
subprocess-spawning tests, none of which touch token accounting). That looks
like load flakiness in my environment rather than a regression, but I am
flagging it rather than claiming a clean run.
