### PR TITLE
Fix FunctionRefReviver: renamed tools now round-trip, and registry misses no longer crash checkpoint writes

### DIFF
--- a/packages/agency-lang/foo.agency
+++ b/packages/agency-lang/foo.agency
@@ -1,6 +1,15 @@
+import { researcherAgent } from "std::agents/researcher"
 import { now } from "std::date"
 node main() {
-  const start = now()
-  sleep(4)
-  print(elapsedTime(since: start))
+  handle {
+    const prompt = "What are the top news stories today?"
+    const result = researcherAgent(task: prompt)
+    print(result)
+    return result
+  } with (data) {
+    return match(data.effect) {
+      "std::search" => approve()
+      _ => reject()
+    }
+  }
 }

--- a/packages/agency-lang/foo.agency
+++ b/packages/agency-lang/foo.agency
@@ -1,15 +1,6 @@
-import { researcherAgent } from "std::agents/researcher"
 import { now } from "std::date"
 node main() {
-  handle {
-    const prompt = "What are the top news stories today?"
-    const result = researcherAgent(task: prompt)
-    print(result)
-    return result
-  } with (data) {
-    return match(data.effect) {
-      "std::search" => approve()
-      _ => reject()
-    }
-  }
+  const start = now()
+  sleep(4)
+  print(elapsedTime(since: start))
 }

--- a/packages/agency-lang/lib/runtime/agencyFunction.ts
+++ b/packages/agency-lang/lib/runtime/agencyFunction.ts
@@ -81,6 +81,7 @@ export type AgencyFunctionOpts = {
   exported?: boolean;
   markers?: ToolMarkers;
   isPreapproved?: boolean;
+  originalName?: string;
 };
 
 export class AgencyFunction {
@@ -98,10 +99,17 @@ export class AgencyFunction {
   readonly exported: boolean;
   readonly markers: ToolMarkers;
   private readonly _isPreapproved: boolean;
+  /** The name this function's registered ancestor carries in the function
+   *  registry. `.rename()` changes `name` but not this, and every other
+   *  derivation (`.partial()`, `.describe()`, `.preapprove()`) carries it
+   *  forward — so a serialized ref to any derived copy can find its
+   *  registry entry again. Equal to `name` for functions never renamed. */
+  readonly originalName: string;
 
   constructor(opts: AgencyFunctionOpts) {
     this.name = opts.name;
     this.module = opts.module;
+    this.originalName = opts.originalName ?? opts.name;
     this._fn = opts.fn;
     this.params = opts.params;
     this.toolDefinition = opts.toolDefinition;
@@ -146,6 +154,7 @@ export class AgencyFunction {
       exported: this.exported,
       markers: this.markers,
       isPreapproved: this._isPreapproved,
+      originalName: this.originalName,
     });
   }
 
@@ -249,6 +258,7 @@ export class AgencyFunction {
       exported: this.exported,
       markers: this.markers,
       isPreapproved: this._isPreapproved,
+      originalName: this.originalName,
     });
   }
 
@@ -295,6 +305,7 @@ export class AgencyFunction {
       exported: this.exported,
       markers: this.markers,
       isPreapproved: true,
+      originalName: this.originalName,
     });
   }
 
@@ -331,6 +342,9 @@ export class AgencyFunction {
       exported: this.exported,
       markers: this.markers,
       isPreapproved: this._isPreapproved,
+      // The registry never learns the new name, so serialization keeps the
+      // registered name for revival (see FunctionRefReviver).
+      originalName: this.originalName,
     });
   }
 

--- a/packages/agency-lang/lib/runtime/agencyFunction.ts
+++ b/packages/agency-lang/lib/runtime/agencyFunction.ts
@@ -81,7 +81,7 @@ export type AgencyFunctionOpts = {
   exported?: boolean;
   markers?: ToolMarkers;
   isPreapproved?: boolean;
-  originalName?: string;
+  registeredName?: string;
 };
 
 export class AgencyFunction {
@@ -99,17 +99,18 @@ export class AgencyFunction {
   readonly exported: boolean;
   readonly markers: ToolMarkers;
   private readonly _isPreapproved: boolean;
-  /** The name this function's registered ancestor carries in the function
-   *  registry. `.rename()` changes `name` but not this, and every other
-   *  derivation (`.partial()`, `.describe()`, `.preapprove()`) carries it
-   *  forward — so a serialized ref to any derived copy can find its
-   *  registry entry again. Equal to `name` for functions never renamed. */
-  readonly originalName: string;
+  /** The key this function's registered ancestor is stored under in the
+   *  function registry. `.rename()` changes `name` but not this, and the
+   *  other derivations carry it forward — `.partial()` and `.preapprove()`
+   *  directly, `.describe()` via `withToolDefinition()` — so a serialized
+   *  ref to any derived copy can find its registry entry again. Equal to
+   *  `name` for functions never renamed. */
+  readonly registeredName: string;
 
   constructor(opts: AgencyFunctionOpts) {
     this.name = opts.name;
     this.module = opts.module;
-    this.originalName = opts.originalName ?? opts.name;
+    this.registeredName = opts.registeredName ?? opts.name;
     this._fn = opts.fn;
     this.params = opts.params;
     this.toolDefinition = opts.toolDefinition;
@@ -154,7 +155,7 @@ export class AgencyFunction {
       exported: this.exported,
       markers: this.markers,
       isPreapproved: this._isPreapproved,
-      originalName: this.originalName,
+      registeredName: this.registeredName,
     });
   }
 
@@ -258,7 +259,7 @@ export class AgencyFunction {
       exported: this.exported,
       markers: this.markers,
       isPreapproved: this._isPreapproved,
-      originalName: this.originalName,
+      registeredName: this.registeredName,
     });
   }
 
@@ -305,7 +306,7 @@ export class AgencyFunction {
       exported: this.exported,
       markers: this.markers,
       isPreapproved: true,
-      originalName: this.originalName,
+      registeredName: this.registeredName,
     });
   }
 
@@ -344,7 +345,7 @@ export class AgencyFunction {
       isPreapproved: this._isPreapproved,
       // The registry never learns the new name, so serialization keeps the
       // registered name for revival (see FunctionRefReviver).
-      originalName: this.originalName,
+      registeredName: this.registeredName,
     });
   }
 

--- a/packages/agency-lang/lib/runtime/revivers/functionRefReviver.test.ts
+++ b/packages/agency-lang/lib/runtime/revivers/functionRefReviver.test.ts
@@ -125,15 +125,15 @@ describe("FunctionRefReviver", () => {
     });
 
     it("near-miss block names revive to the generic stub, not the block stub", async () => {
+      // Pins the STRICT block-name predicate: these two must not match
+      // isBlockName, and the generic-stub message (vs "before replay
+      // rebound it") proves which branch they took.
       reviver.registry = {};
       for (const name of ["__blockish", "__block_"]) {
         const stub = reviver.revive({ name, module: "test.agency" });
-        const outcome = await stub
-          .invoke({ type: "positional", args: [] })
-          .then((v: unknown) => v, (e: unknown) => e);
-        const msg =
-          outcome instanceof Error ? outcome.message : JSON.stringify(outcome);
-        expect(msg).toContain("never loaded its module");
+        await expect(
+          stub.invoke({ type: "positional", args: [] }),
+        ).rejects.toThrow(/never loaded its module/);
       }
     });
 
@@ -579,16 +579,16 @@ describe("renamed functions round-trip (#652)", () => {
       __nativeType: "FunctionRef",
       name: "wikipedia_search",
       module: "stdlib/wikipedia.agency",
-      originalName: "search",
+      registeredName: "search",
       toolDescription: "Search Wikipedia",
     });
   });
 
-  it("serialize omits originalName for never-renamed functions", () => {
+  it("serialize omits registeredName for never-renamed functions", () => {
     const reviver = new FunctionRefReviver();
     const registry: Record<string, AgencyFunction> = {};
     const fn = makeRegistered(registry);
-    expect(reviver.serialize(fn)).not.toHaveProperty("originalName");
+    expect(reviver.serialize(fn)).not.toHaveProperty("registeredName");
   });
 
   it("a renamed function revives via the registered name and keeps the new name", async () => {
@@ -635,7 +635,7 @@ describe("renamed functions round-trip (#652)", () => {
       __nativeType: "FunctionRef",
       name: "wikipedia_search",
       module: "stdlib/wikipedia.agency",
-      originalName: "search",
+      registeredName: "search",
       toolDescription: "Search Wikipedia",
     };
     const stub = reviver.revive(serialized) as AgencyFunction;

--- a/packages/agency-lang/lib/runtime/revivers/functionRefReviver.test.ts
+++ b/packages/agency-lang/lib/runtime/revivers/functionRefReviver.test.ts
@@ -83,10 +83,17 @@ describe("FunctionRefReviver", () => {
         .toThrow("no registry set");
     });
 
-    it("throws when function is not found", () => {
+    it("revives a missing ordinary function to a tripwire stub (#652)", async () => {
+      // revive() also runs during SERIALIZATION (deepClone in State.toJSON),
+      // so a miss must never throw eagerly — it would crash checkpoint
+      // writes. The stub throws only when invoked.
       reviver.registry = {};
-      expect(() => reviver.revive({ name: "missing", module: "test.agency" }))
-        .toThrow("not found in registry");
+      const stub = reviver.revive({ name: "missing", module: "test.agency" });
+      expect(AgencyFunction.isAgencyFunction(stub)).toBe(true);
+      expect(stub.name).toBe("missing");
+      await expect(
+        stub.invoke({ type: "positional", args: [] }),
+      ).rejects.toThrow(/never loaded its module/);
     });
 
     it("revives an unregistered block ref to a stub instead of throwing", () => {
@@ -117,14 +124,17 @@ describe("FunctionRefReviver", () => {
       expect(msg).toContain("before replay rebound it");
     });
 
-    it("non-block names still throw eagerly on a registry miss", () => {
+    it("near-miss block names revive to the generic stub, not the block stub", async () => {
       reviver.registry = {};
-      expect(() =>
-        reviver.revive({ name: "__blockish", module: "test.agency" }),
-      ).toThrow("not found in registry");
-      expect(() =>
-        reviver.revive({ name: "__block_", module: "test.agency" }),
-      ).toThrow("not found in registry");
+      for (const name of ["__blockish", "__block_"]) {
+        const stub = reviver.revive({ name, module: "test.agency" });
+        const outcome = await stub
+          .invoke({ type: "positional", args: [] })
+          .then((v: unknown) => v, (e: unknown) => e);
+        const msg =
+          outcome instanceof Error ? outcome.message : JSON.stringify(outcome);
+        expect(msg).toContain("never loaded its module");
+      }
     });
 
     it("a REGISTERED block name resolves to the real function, not a stub", () => {
@@ -446,16 +456,18 @@ describe("lazy callback refs (#544)", () => {
     expect(ref.module).toBe("agency_abc");
   });
 
-  it("still throws for ordinary missing names", () => {
+  it("ordinary missing names get the generic stub, not the callback lazy ref", async () => {
     const reviver = new FunctionRefReviver();
     reviver.registry = {};
-    expect(() => reviveRef(reviver, "myHelper", "app.agency")).toThrow(/not found in registry/);
-  });
-
-  it("still throws for near-miss names (strict predicate)", () => {
-    const reviver = new FunctionRefReviver();
-    reviver.registry = {};
-    expect(() => reviveRef(reviver, "__cb_helper", "app.agency")).toThrow(/not found in registry/);
+    for (const name of ["myHelper", "__cb_helper"]) {
+      const stub = reviveRef(reviver, name, "app.agency") as AgencyFunction;
+      // The generic stub is a tripwire: unlike the callback lazy ref, it
+      // does NOT re-check the registry at invoke time.
+      reviver.registry[`app.agency:${name}`] = makeAgencyFunction(name, "app.agency");
+      await expect(
+        stub.invoke({ type: "positional", args: [] }),
+      ).rejects.toThrow(/never loaded its module/);
+    }
   });
 
   it("does not self-register the lazy ref under the real key", () => {
@@ -541,6 +553,110 @@ describe("lazy callback refs (#544)", () => {
     await expect(ref.invoke({ type: "positional", args: [{}] })).rejects.toThrow(
       /__cb_main_0.*agency_abc/s,
     );
+  });
+});
+
+describe("renamed functions round-trip (#652)", () => {
+  function makeRegistered(
+    registry: Record<string, AgencyFunction>,
+  ): AgencyFunction {
+    return AgencyFunction.create({
+      name: "search",
+      module: "stdlib/wikipedia.agency",
+      fn: (query: string) => `results for ${query}`,
+      params: [
+        { name: "query", hasDefault: false, defaultValue: undefined, variadic: false },
+      ],
+      toolDefinition: { name: "search", description: "Search Wikipedia", schema: null },
+    }, registry);
+  }
+
+  it("serialize records the registered name when the function was renamed", () => {
+    const reviver = new FunctionRefReviver();
+    const registry: Record<string, AgencyFunction> = {};
+    const renamed = makeRegistered(registry).rename("wikipedia_search");
+    expect(reviver.serialize(renamed)).toEqual({
+      __nativeType: "FunctionRef",
+      name: "wikipedia_search",
+      module: "stdlib/wikipedia.agency",
+      originalName: "search",
+      toolDescription: "Search Wikipedia",
+    });
+  });
+
+  it("serialize omits originalName for never-renamed functions", () => {
+    const reviver = new FunctionRefReviver();
+    const registry: Record<string, AgencyFunction> = {};
+    const fn = makeRegistered(registry);
+    expect(reviver.serialize(fn)).not.toHaveProperty("originalName");
+  });
+
+  it("a renamed function revives via the registered name and keeps the new name", async () => {
+    const registry: Record<string, AgencyFunction> = {};
+    const renamed = makeRegistered(registry).rename("wikipedia_search");
+    functionRefReviver.registry = registry;
+
+    const json = JSON.stringify({ tool: renamed }, nativeTypeReplacer);
+    const restored = JSON.parse(json, nativeTypeReviver);
+
+    expect(restored.tool.name).toBe("wikipedia_search");
+    expect(restored.tool.toolDefinition.name).toBe("wikipedia_search");
+    const result = await restored.tool.invoke({ type: "positional", args: ["cats"] });
+    expect(result).toBe("results for cats");
+
+    functionRefReviver.registry = null;
+  });
+
+  it("rename composed with partial round-trips", async () => {
+    const registry: Record<string, AgencyFunction> = {};
+    const composed = makeRegistered(registry)
+      .rename("wikipedia_search")
+      .partial({ query: "dogs" });
+    functionRefReviver.registry = registry;
+
+    const json = JSON.stringify({ tool: composed }, nativeTypeReplacer);
+    const restored = JSON.parse(json, nativeTypeReviver);
+
+    expect(restored.tool.name).toBe("wikipedia_search");
+    expect(restored.tool.getUnboundParams()).toHaveLength(0);
+    const result = await restored.tool.invoke({ type: "positional", args: [] });
+    expect(result).toBe("results for dogs");
+
+    functionRefReviver.registry = null;
+  });
+
+  it("deepClone-style round-trip of a renamed ref survives a registry miss intact", () => {
+    // The #652 crash shape: State.toJSON deepClones state holding a renamed
+    // ref in a process whose registry lacks the module. The clone must
+    // reproduce the ref byte-for-byte so the checkpoint stays correct.
+    const reviver = new FunctionRefReviver();
+    reviver.registry = {};
+    const serialized = {
+      __nativeType: "FunctionRef",
+      name: "wikipedia_search",
+      module: "stdlib/wikipedia.agency",
+      originalName: "search",
+      toolDescription: "Search Wikipedia",
+    };
+    const stub = reviver.revive(serialized) as AgencyFunction;
+    expect(reviver.serialize(stub)).toEqual(serialized);
+  });
+
+  it("the miss stub preserves bound params and preapproval through re-serialization", () => {
+    const reviver = new FunctionRefReviver();
+    reviver.registry = {};
+    const serialized = {
+      __nativeType: "FunctionRef",
+      name: "read",
+      module: "stdlib/shell.agency",
+      params: [
+        { name: "useAgentCwd", hasDefault: false, defaultValue: undefined, variadic: false, isBound: true, boundValue: true },
+        { name: "path", hasDefault: false, defaultValue: undefined, variadic: false },
+      ],
+      isPreapproved: true,
+    };
+    const stub = reviver.revive(serialized) as AgencyFunction;
+    expect(reviver.serialize(stub)).toEqual(serialized);
   });
 });
 

--- a/packages/agency-lang/lib/runtime/revivers/functionRefReviver.ts
+++ b/packages/agency-lang/lib/runtime/revivers/functionRefReviver.ts
@@ -23,6 +23,12 @@ export class FunctionRefReviver implements BaseReviver<AgencyFunction> {
       name: value.name,
       module: value.module,
     };
+    // A renamed function is not in the registry under its new name, so the
+    // ref must carry the name its registered ancestor was created under —
+    // revive() looks that up and re-applies the rename.
+    if (value.originalName !== value.name) {
+      result.originalName = value.originalName;
+    }
     // Serialize params with bound values inline
     if (value.params.some(p => p.isBound)) {
       result.params = value.params;
@@ -49,8 +55,16 @@ export class FunctionRefReviver implements BaseReviver<AgencyFunction> {
     }
     const name = value.name as string;
     const module = value.module as string;
+    const lookupName =
+      typeof value.originalName === "string" ? value.originalName : name;
 
-    const original = this.findInRegistry(name, module);
+    const found = lookupInRegistry(this.registry, lookupName, module);
+    if (!found) {
+      return this.reviveMiss(name, module, value);
+    }
+    // Re-apply the rename so the revived function keeps the name tool-call
+    // dispatch and the LLM saw when the state was serialized.
+    const original = name === lookupName ? found : found.rename(name);
 
     let result: AgencyFunction;
 
@@ -93,10 +107,17 @@ export class FunctionRefReviver implements BaseReviver<AgencyFunction> {
     return result;
   }
 
-  private findInRegistry(name: string, module: string): AgencyFunction {
-    const found = lookupInRegistry(this.registry!, name, module);
-    if (found) return found;
-
+  /** A registry miss must never throw here: revive() also runs during
+   *  SERIALIZATION (`deepClone` inside `State.toJSON` round-trips through
+   *  `JSON.parse` with revivers), so an eager throw crashes checkpoint
+   *  writes — including the guard-trip checkpoint that salvages drafts
+   *  (#652). Every miss maps to a stub that survives re-serialization and
+   *  fails, precisely, only if something actually invokes it. */
+  private reviveMiss(
+    name: string,
+    module: string,
+    value: Record<string, unknown>,
+  ): AgencyFunction {
     // Compiler-generated blocks register themselves only when their creating
     // line executes. A fresh process restoring a checkpoint has executed
     // nothing yet, so a miss here is EXPECTED for blocks — replay rebinds
@@ -114,10 +135,12 @@ export class FunctionRefReviver implements BaseReviver<AgencyFunction> {
     if (isLiftedCallbackName(name)) {
       return makeLazyCallbackRef(name, module, this);
     }
-    throw new Error(
-      `FunctionRefReviver: function "${name}" from module "${module}" not found in registry. ` +
-      `The function may have been renamed or removed since this state was serialized.`
-    );
+    // Anything else: an ordinary function whose module this process never
+    // loaded — the same embedded-child-checkpoint shape as callbacks, but
+    // nothing spontaneously fires these, so a tripwire is honest. The stub
+    // is built from the serialized fields so serialize(revive(x)) === x and
+    // the ref rides through this process undamaged.
+    return makeUnresolvedFunctionStub(name, module, value);
   }
 }
 
@@ -214,7 +237,7 @@ function makeLazyCallbackRef(
           `Callback "${name}" from module "${module}" crossed a process ` +
           `boundary and was fired before its module was loaded (or the ` +
           `callback was removed since this state was serialized).`;
-        emitLazyCallbackMissError(name, msg);
+        emitFunctionRefMissError(name, msg);
         throw new Error(msg);
       }
       return real.invoke({ type: "positional", args });
@@ -224,13 +247,50 @@ function makeLazyCallbackRef(
   });
 }
 
+/** A serialization-preserving tripwire for a ref whose function is in no
+ *  loaded module: params, tool description, preapproval, and originalName
+ *  are rebuilt from the serialized fields so serialize(revive(x)) === x —
+ *  the ref can ride through this process (a parent holding an embedded
+ *  child checkpoint, #652) and revive intact in the process that owns the
+ *  module. Unlike callbacks, nothing fires these spontaneously, so the
+ *  body throws instead of resolving lazily: if the direct lookup missed,
+ *  the module genuinely is not loaded here, and a call must surface that.
+ *  Plain `new` on purpose — must NOT self-register under the real name. */
+function makeUnresolvedFunctionStub(
+  name: string,
+  module: string,
+  value: Record<string, unknown>,
+): AgencyFunction {
+  return new AgencyFunction({
+    name,
+    module,
+    originalName:
+      typeof value.originalName === "string" ? value.originalName : name,
+    fn: () => {
+      const msg =
+        `Function "${name}" from module "${module}" crossed a serialization ` +
+        `boundary into a process that never loaded its module, and was ` +
+        `invoked there (or the function was removed since this state was ` +
+        `serialized).`;
+      emitFunctionRefMissError(name, msg);
+      throw new Error(msg);
+    },
+    params: Array.isArray(value.params) ? (value.params as FuncParam[]) : [],
+    toolDefinition:
+      typeof value.toolDescription === "string"
+        ? { name, description: value.toolDescription, schema: null }
+        : null,
+    isPreapproved: value.isPreapproved === true,
+  });
+}
+
 /** Surface an unresolvable fire in the trace, not only the terminal.
  *  fireWithGuard catches the throw and console.errors it, which is
  *  invisible after the fact; the Statelog error event makes the dropped
  *  callback findable. Best-effort: `agencyStore.getStore()` is undefined
  *  outside any runtime frame (e.g. a bare unit test), and no client means
  *  nothing to emit to — the caller throws the real error either way. */
-function emitLazyCallbackMissError(name: string, msg: string): void {
+function emitFunctionRefMissError(name: string, msg: string): void {
   agencyStore.getStore()?.ctx?.statelogClient?.error?.({
     errorType: "runtimeError",
     message: msg,

--- a/packages/agency-lang/lib/runtime/revivers/functionRefReviver.ts
+++ b/packages/agency-lang/lib/runtime/revivers/functionRefReviver.ts
@@ -26,8 +26,8 @@ export class FunctionRefReviver implements BaseReviver<AgencyFunction> {
     // A renamed function is not in the registry under its new name, so the
     // ref must carry the name its registered ancestor was created under —
     // revive() looks that up and re-applies the rename.
-    if (value.originalName !== value.name) {
-      result.originalName = value.originalName;
+    if (value.registeredName !== value.name) {
+      result.registeredName = value.registeredName;
     }
     // Serialize params with bound values inline
     if (value.params.some(p => p.isBound)) {
@@ -56,7 +56,7 @@ export class FunctionRefReviver implements BaseReviver<AgencyFunction> {
     const name = value.name as string;
     const module = value.module as string;
     const lookupName =
-      typeof value.originalName === "string" ? value.originalName : name;
+      typeof value.registeredName === "string" ? value.registeredName : name;
 
     const found = lookupInRegistry(this.registry, lookupName, module);
     if (!found) {
@@ -140,6 +140,20 @@ export class FunctionRefReviver implements BaseReviver<AgencyFunction> {
     // nothing spontaneously fires these, so a tripwire is honest. The stub
     // is built from the serialized fields so serialize(revive(x)) === x and
     // the ref rides through this process undamaged.
+    //
+    // Unlike the block and callback branches, a miss HERE is never
+    // expected, so it must be findable even if the stub is never invoked
+    // (a stale checkpoint after a refactor would otherwise restore clean
+    // and only fail — or silently not fail — much later). Emit at revive
+    // time; the invoke-time emit inside the stub still fires on top of
+    // this if something actually calls it.
+    emitFunctionRefMissError(
+      name,
+      `FunctionRefReviver: function "${name}" from module "${module}" not ` +
+        `found in registry; revived to a stub that will throw if invoked. ` +
+        `The function may have been renamed or removed since this state ` +
+        `was serialized.`,
+    );
     return makeUnresolvedFunctionStub(name, module, value);
   }
 }
@@ -248,14 +262,20 @@ function makeLazyCallbackRef(
 }
 
 /** A serialization-preserving tripwire for a ref whose function is in no
- *  loaded module: params, tool description, preapproval, and originalName
+ *  loaded module: params, tool description, preapproval, and registeredName
  *  are rebuilt from the serialized fields so serialize(revive(x)) === x —
  *  the ref can ride through this process (a parent holding an embedded
  *  child checkpoint, #652) and revive intact in the process that owns the
  *  module. Unlike callbacks, nothing fires these spontaneously, so the
  *  body throws instead of resolving lazily: if the direct lookup missed,
  *  the module genuinely is not loaded here, and a call must surface that.
- *  Plain `new` on purpose — must NOT self-register under the real name. */
+ *  Plain `new` on purpose — must NOT self-register under the real name.
+ *
+ *  The rebuilt fields mirror EXACTLY what serialize() writes — no more
+ *  (`exported` and `markers` are absent because serialize() never emits
+ *  them). If a field is ever added to serialize(), it must be added here
+ *  and to the round-trip tests in the same change, or the stub silently
+ *  drops it on re-serialization. */
 function makeUnresolvedFunctionStub(
   name: string,
   module: string,
@@ -264,8 +284,8 @@ function makeUnresolvedFunctionStub(
   return new AgencyFunction({
     name,
     module,
-    originalName:
-      typeof value.originalName === "string" ? value.originalName : name,
+    registeredName:
+      typeof value.registeredName === "string" ? value.registeredName : name,
     fn: () => {
       const msg =
         `Function "${name}" from module "${module}" crossed a serialization ` +

--- a/packages/agency-lang/tests/agency/renamed-ref-checkpoint.agency
+++ b/packages/agency-lang/tests/agency/renamed-ref-checkpoint.agency
@@ -1,0 +1,22 @@
+import { bash } from "std::shell"
+
+// Integration regression for #652: a renamed tool held in frame state must
+// survive a checkpoint WRITE. State.toJSON deep-clones locals through
+// JSON.parse with revivers installed, so the renamed ref is revived during
+// the write; before the fix that threw ("greet_tool" not in registry) and
+// killed the checkpoint. The bash() interrupt below forces the write while
+// the renamed and partial-bound refs are live locals, and the calls after
+// resume prove the revived refs still work.
+
+def hello(name: string): string {
+  return "hello ${name}"
+}
+
+node main() {
+  const greet = hello.rename("greet_tool")
+  const bob = hello.partial(name: "Bob")
+  const r = bash("echo go")
+  const a = greet(name: "Ada")
+  const b = bob()
+  return "${a}|${b}"
+}

--- a/packages/agency-lang/tests/agency/renamed-ref-checkpoint.test.json
+++ b/packages/agency-lang/tests/agency/renamed-ref-checkpoint.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"hello Ada|hello Bob\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "interruptHandlers": [{ "action": "approve" }]
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #652.

## The bug

A renamed function could never survive serialization. `.rename()` returns a copy with the new name but never re-registers it, and `FunctionRefReviver.serialize()` recorded only `name` + `module`. So a serialized ref to `wikipediaSearch.rename("wikipedia_search")` looked up `wikipedia_search` in a registry that only knows `search`, and the reviver threw.

Worse, the throw fired during checkpoint **writes**, not just restores: `State.toJSON` clones state via `deepClone`, which round-trips through `JSON.parse` with the revivers installed. In the run that surfaced this, a guard-trip checkpoint crashed while salvaging a draft, converting a working `judgeWork` salvage into a runtime error (and `failOpenFeedback` then laundered that error into a review pass).

## The fix, two parts

**1. Renames round-trip.** `AgencyFunction` now carries `originalName` — the name its registered ancestor has in the registry. All four derivations (`rename`, `partial`, `withToolDefinition`, `preapprove`) thread it through. `serialize()` records it when it differs from `name`; `revive()` looks up the original and re-applies `.rename()`, the same reconstruction pattern already used for `.partial()` and `.describe()`.

**2. A genuine registry miss no longer crashes serialization.** A miss that is not a block or lifted callback now revives to a stub built from the serialized fields, so `serialize(revive(x)) === x` and the ref rides through a process that does not own the module undamaged. The stub throws a precise error (plus a statelog event) only if something actually invokes it. Unlike the callback lazy ref it does not re-check the registry at invoke time: nothing fires these spontaneously, so a call after a miss is a real error worth surfacing.

## Tests

Six new tests (rename serialization, rename round-trip, rename+partial, the exact #652 clone-through-a-miss shape, stub fidelity with bound params and preapproval) and three updated pins for the changed miss behavior. Full `lib/` unit suite and structural linter pass.

## Note

`foo.agency` also changed in this PR — it now contains the researcher news demo that surfaced the bug. Drop that commit hunk if you want the scratch file kept out of history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
