### PR TITLE
Hoist helper calls into skippable steps so in-process resume cannot desync frames

### DIFF
--- a/packages/agency-lang/docs/dev/hoist-calls.md
+++ b/packages/agency-lang/docs/dev/hoist-calls.md
@@ -1,0 +1,66 @@
+# hoistCalls: resume-safe helper calls
+
+## The invariant
+
+After preprocessing, no statement re-executes a completed frame-pushing call on resume. Every helper call in an unconditionally-evaluated position becomes its own statement:
+
+```agency
+const answer = llm(msg, llmOptions(model: model, tools: tools))
+```
+
+compiles as if the user had written:
+
+```agency
+const __hoist_0 = llmOptions(model: model, tools: tools)
+const answer = llm(msg, __hoist_0)
+```
+
+Each statement is a runner step, and step results live on `__stack.locals`, which serializes into checkpoints. On resume, the temp's step is skipped and its value is read back. The helper never re-runs.
+
+## Why this exists
+
+Resume replay hands saved frames to functions positionally: `StateStack.getNewState()` in deserialize mode shifts the next saved frame to whoever asks. The statement in progress at a pause re-runs its whole body, including helpers that already completed and were not checkpointed. Those helpers consumed frames belonging to still-live functions. The still-live function then got a blank frame, believed it never ran, and re-issued work. The visible symptom was OpenAI rejecting a request whose thread ended with an unanswered tool call: `400 No tool output found for function call`.
+
+Design history and the full position analysis: `docs/superpowers/specs/2026-07-22-hoist-calls-resume-safety-design.md`.
+
+## Where it runs
+
+`TypescriptPreprocessor.preprocess()`, between `collectSkills()` and `addAwaitPendingCalls()`. Guards and parallel blocks are already desugared by then; the await pass and scope resolution see the temps like hand-written statements. The pass lives in `lib/preprocessors/hoistCalls.ts`; the rulings table at the top of that file is the source of truth for what hoists where. Summary:
+
+| Position | Ruling | Why |
+|---|---|---|
+| arguments, literals, interpolations, binary operands | hoist | unconditionally evaluated |
+| statement tail call | stays | it is the pending call itself; also node calls are control flow and throw in value position |
+| `if` conditions, `for` iterables, `match` scrutinees | hoist before the statement | single evaluation either way |
+| `while` conditions with calls | loop rewritten: `while (true) { temps; if (cond) { body } else { break } }` | conditions re-evaluate per iteration; pre-pass they re-ran once per completed iteration on resume |
+| `try` operands, `catch` expressions | opaque | the whole expression compiles into a runtime thunk; moving code out moves the error boundary |
+| short-circuit right sides, if-expression branches | opaque | may never execute |
+| pipe stages | opaque | already memoized per step and failure-gated |
+| pipe input | hoist | evaluated inline at statement level, outside the memoization |
+| `with`/`static` wrapped statements | opaque | hoisting out would cross the approval region; the slot holds exactly one statement |
+| handler (`with (data)`) bodies | never touched | compile to plain JS, cannot pause, safety infrastructure |
+| lifted block bodies (comprehensions, fork branches, `as x { }` blocks) | hoisted within, never across | they own their frame; a temp crossing out would change per-item evaluation to once |
+| module-level initializers | never touched | init-topsort owns them; they cannot pause |
+
+Accepted behavior change: `for (x in async getItems())` used to be rejected by `validateNoAsyncInLoops`; hoisting moves the call above the loop, so it now compiles. A relaxation, not a breakage.
+
+## Temp naming
+
+`__hoist_N`, one counter per frame-owning scope (function, node, lifted block, fork branch), shared across every nested statement list inside it. Frame locals are flat, so per-list numbering would let a loop-body temp overwrite the temp a loop iterable re-reads on resume. Finalize bodies share their container's counter because they run on the container's frame. Seeding scans the scope for existing `__hoist_N` names and numbers above them — that seeding is the collision protection. There is deliberately no lint rule reserving the prefix: no other compiler-reserved prefix (`__block_N`, `__comprehensionItem`, `__substep_`) has one, and the seeding makes collision impossible regardless.
+
+## The tripwire
+
+Residual shapes the pass does not cover (calls nested inside opaque positions, mid-chain method calls inside a hoisted access chain) can still desync. Those now fail loudly instead of corrupting silently: every frame is stamped with its owner's scope name at CLAIM time, and a mismatched claim throws
+
+```
+Resume desync: function "X" tried to claim the saved state of "Y".
+```
+
+plus a statelog `runtimeError` event. Seeing this error always means a toolchain bug, never a bug in the user's program — report it with the program that produced it. The statelog emit is not redundant with the throw: throws convert to Failures at def boundaries and can be laundered by fail-open code; the event survives.
+
+**Which code claims frames, and which merely runs on one.** Claiming (pulling a frame from the stack) and running on a frame are different events, and only claims stamp:
+
+- Claim sites: generated function and node preambles, `blockSetup.mustache`, `forkBlockSetup.mustache` (all emitted by codegen), plus two hand-written TypeScript sites — `runPrompt` and `withResumableScope`.
+- Runs-but-never-claims: the `finalize` closure builds a second Runner named `foo#finalize` on its container's own frame. It must not stamp; a constructor-side check would false-positive on every aborting finalize, which is the salvage path. This is why the Runner constructor knows nothing about stamping.
+
+Empty scope names never stamp (the Runner defaults `scopeName` to `""`; an empty stamp would collide with the real owner later).

--- a/packages/agency-lang/docs/dev/hoist-calls.md
+++ b/packages/agency-lang/docs/dev/hoist-calls.md
@@ -50,7 +50,7 @@ Accepted behavior change: `for (x in async getItems())` used to be rejected by `
 
 ## The tripwire
 
-Residual shapes the pass does not cover (calls nested inside opaque positions, mid-chain method calls inside a hoisted access chain) can still desync. Those now fail loudly instead of corrupting silently: every frame is stamped with its owner's scope name at CLAIM time, and a mismatched claim throws
+Residual shapes the pass does not cover can still desync: calls nested inside opaque positions (short-circuit right sides, catch expressions, try operands, with-modified statements), block bodies nested inside opaque expressions, and mid-chain method calls inside a hoisted access chain (the chain BASE and every argument hoist; a later chain segment re-running an earlier method call is what remains). Those now fail loudly instead of corrupting silently: every frame is stamped with its owner's scope name at CLAIM time, and a mismatched claim throws
 
 ```
 Resume desync: function "X" tried to claim the saved state of "Y".

--- a/packages/agency-lang/docs/dev/interrupts.md
+++ b/packages/agency-lang/docs/dev/interrupts.md
@@ -561,3 +561,18 @@ per-lineage precision, so self-exclusion and the `renderVerdict`
 refusal can tell a handler's OWN raises apart from concurrent sibling
 dispatches on the same branch. The design rationale lives in
 `docs/superpowers/specs/2026-07-19-issue-616-no-pause-inside-handlers-design.md`.
+
+## Replay and helper calls: the hoistCalls pass
+
+Resume replay re-runs the statement that was in progress at the pause.
+Before 2026-07, that replay also re-executed helper calls inside that
+statement which had already completed — `llm(msg, llmOptions(...))`
+re-ran `llmOptions()` — and each re-run consumed a saved frame from the
+positional restore queue that belonged to a still-live function. The
+`hoistCalls` preprocessor pass (docs/dev/hoist-calls.md) rewrites every
+such helper into its own `const __hoist_N = ...` statement, so on
+resume the helper's completed step is skipped and its value read back
+from the frame instead of recomputed. As a backstop, frames are stamped
+with their owner's scope name at claim time, and a mismatched claim on
+replay throws a "Resume desync" error instead of silently corrupting
+state.

--- a/packages/agency-lang/lib/backends/frameClaims.test.ts
+++ b/packages/agency-lang/lib/backends/frameClaims.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { parseAgency } from "../parser.js";
+import { generateTypeScript } from "./typescriptGenerator.js";
+
+/** The tripwire only works if generated code actually claims frames. A
+ *  no-op wiring would pass every claimFrameForScope unit test (they call
+ *  the function directly), so this pins the emission itself: function
+ *  and node preambles, and lifted-block setup, each claim their frame
+ *  under their own scope name. */
+describe("generated code claims frames for the resume tripwire", () => {
+  function compile(src: string): string {
+    const parsed = parseAgency(src, {}, false);
+    if (!parsed.success) throw new Error(parsed.message);
+    return generateTypeScript(parsed.result, undefined, undefined, "claims.agency");
+  }
+
+  it("function and node preambles claim their frames", () => {
+    const out = compile(`
+def helper(): string {
+  return "h"
+}
+
+node main() {
+  const h = helper()
+  return h
+}
+`);
+    expect(out).toContain('claimFrameForScope(__stack, "helper")');
+    expect(out).toContain('claimFrameForScope(__stack, "main")');
+  });
+
+  it("lifted block bodies claim their frames under the block name", () => {
+    const out = compile(`
+def scale(x: number): number {
+  return x + 1
+}
+
+def f(xs: number[]): number[] {
+  return [scale(x) for x in xs]
+}
+`);
+    expect(out).toMatch(/claimFrameForScope\(__bstack, "__block_\d+"\)/);
+  });
+
+  it("finalize closures do NOT claim (they run on the container frame)", () => {
+    const out = compile(`
+def work(): string {
+  return "done"
+
+  finalize {
+    return "salvaged"
+  }
+}
+`);
+    // Exactly one claim: work's own preamble. The finalize closure runs
+    // on work's frame and must not stamp a second name onto it.
+    const claims = out.match(/claimFrameForScope\(/g) ?? [];
+    expect(claims).toHaveLength(1);
+    expect(out).toContain('claimFrameForScope(__stack, "work")');
+  });
+});

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -2195,6 +2195,11 @@ export class TypeScriptBuilder {
         ctx: ts.raw("getRuntimeContext().ctx"),
       }),
 
+      // Claim site: this function just pulled its frame via
+      // setupFunction. A mismatched claim on resume replay is a frame
+      // desync and throws (see claimFrameForScope).
+      ts.raw(`claimFrameForScope(__stack, ${JSON.stringify(functionName)});`),
+
       // Ensure this module's globals are initialized on the
       // current per-scope view. Runs BEFORE this function's own
       // `withAlsFrame` wrap, but the caller's ALS frame is still
@@ -3063,6 +3068,10 @@ export class TypeScriptBuilder {
       // from `stack.threads` JSON (or created fresh). `__threads()`
       // accessors emitted inside step bodies will then resolve to this
       // same store via `Runner.runInScope`.
+      // Claim site: this node just pulled its frame via setupNode. A
+      // mismatched claim on resume replay is a frame desync and throws.
+      ts.raw(`claimFrameForScope(__stack, ${JSON.stringify(nodeName)});`),
+
       ts.raw(
         `const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: ${JSON.stringify(this.moduleId)}, scopeName: ${JSON.stringify(nodeName)}, threads: __setupData.threads });`,
       ),

--- a/packages/agency-lang/lib/cli/bundle.test.ts
+++ b/packages/agency-lang/lib/cli/bundle.test.ts
@@ -40,7 +40,7 @@ describe("createBundle", () => {
         scopeName: "main",
         stepPath: "1",
         stack: {
-          stack: [{ args: {}, locals: { x: 1 }, threads: null, step: 1 }],
+          stack: [{ args: {}, locals: { x: 1 }, threads: null, step: 1, scopeName: null }],
           mode: "serialize",
           other: {},
           deserializeStackLength: 0,
@@ -141,7 +141,7 @@ describe("extractBundle", () => {
         scopeName: "main",
         stepPath: "1",
         stack: {
-          stack: [{ args: {}, locals: { x: 1 }, threads: null, step: 1 }],
+          stack: [{ args: {}, locals: { x: 1 }, threads: null, step: 1, scopeName: null }],
           mode: "serialize",
           other: {},
           deserializeStackLength: 0,

--- a/packages/agency-lang/lib/cli/events.test.ts
+++ b/packages/agency-lang/lib/cli/events.test.ts
@@ -37,7 +37,7 @@ describe("traceLog integration", () => {
         label: null,
         pinned: false,
         stack: {
-          stack: [{ args: {}, locals: {}, threads: null, step: 0 }],
+          stack: [{ args: {}, locals: {}, threads: null, step: 0, scopeName: null }],
           mode: "serialize" as const,
           other: {},
           deserializeStackLength: 0,
@@ -65,6 +65,7 @@ describe("traceLog integration", () => {
               locals: { greeting: "hello" },
               threads: null,
               step: 1,
+              scopeName: null,
             },
           ],
           mode: "serialize" as const,

--- a/packages/agency-lang/lib/debugger/uiState.test.ts
+++ b/packages/agency-lang/lib/debugger/uiState.test.ts
@@ -12,6 +12,7 @@ function makeStackJSON(frames: Partial<StateJSON>[] = []): StateStackJSON {
       locals: f.locals ?? {},
       threads: f.threads ?? null,
       step: f.step ?? 0,
+      scopeName: f.scopeName ?? null,
       ...(f.branches ? { branches: f.branches } : {}),
     })),
     mode: "serialize",

--- a/packages/agency-lang/lib/preprocessors/hoistCalls.test.ts
+++ b/packages/agency-lang/lib/preprocessors/hoistCalls.test.ts
@@ -109,7 +109,7 @@ def f(): number {
   return total
 }`),
     );
-    const names = JSON.stringify(body).match(/__hoist_\d+/g) ?? [];
+    const names: string[] = JSON.stringify(body).match(/__hoist_\d+/g) ?? [];
     expect(names).toContain("__hoist_0");
     expect(names).toContain("__hoist_1");
     const unique = names.filter((n, i) => names.indexOf(n) === i);

--- a/packages/agency-lang/lib/preprocessors/hoistCalls.test.ts
+++ b/packages/agency-lang/lib/preprocessors/hoistCalls.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from "vitest";
+import { parseAgency } from "../parser.js";
+import { hoistCallsInScope } from "./hoistCalls.js";
+import type { AgencyNode } from "../types.js";
+
+function bodyOf(src: string): AgencyNode[] {
+  const parsed = parseAgency(src, {}, true);
+  if (!parsed.success) throw new Error(parsed.message);
+  const fn = (parsed.result.nodes as any[]).find(
+    (n) => n.type === "function" || n.type === "graphNode",
+  );
+  return fn.body;
+}
+
+const stmts = (body: AgencyNode[]) =>
+  body.filter((n: any) => n.type !== "comment" && n.type !== "newLine");
+const temps = (body: AgencyNode[]) =>
+  stmts(body).filter((n: any) => n.variableName?.startsWith("__hoist"));
+
+describe("hoistCallsInScope: statements", () => {
+  it("hoists a call in argument position into a const temp", () => {
+    const body = stmts(
+      hoistCallsInScope(
+        bodyOf(`
+def f(): string {
+  return outer(inner(1))
+}`),
+      ),
+    ) as any[];
+    expect(body.map((n) => n.type)).toEqual(["assignment", "returnStatement"]);
+    expect(body[0].declKind).toBe("const");
+    expect(body[0].variableName).toBe("__hoist_0");
+    expect(body[0].value.type).toBe("functionCall");
+    expect(body[0].value.functionName).toBe("inner");
+    expect(body[1].value.functionName).toBe("outer");
+  });
+
+  it("does not mutate its input", () => {
+    const original = bodyOf(`
+def f(): string {
+  return outer(inner(1))
+}`);
+    const snapshot = JSON.stringify(original);
+    hoistCallsInScope(original);
+    expect(JSON.stringify(original)).toBe(snapshot);
+  });
+
+  it("unrolls nested calls innermost-first, left to right", () => {
+    const body = temps(
+      hoistCallsInScope(
+        bodyOf(`
+def f(): string {
+  return combine(prepare(fetchRaw()), enrich())
+}`),
+      ),
+    ) as any[];
+    expect(body.map((n) => n.value.functionName)).toEqual([
+      "fetchRaw",
+      "prepare",
+      "enrich",
+    ]);
+  });
+
+  it("the statement tail call is not hoisted", () => {
+    const body = hoistCallsInScope(
+      bodyOf(`
+def f(): string {
+  const x = solo(1)
+  return x
+}`),
+    );
+    expect(temps(body)).toHaveLength(0);
+  });
+
+  it("steps over comments between statements", () => {
+    const body = hoistCallsInScope(
+      bodyOf(`
+def f(): string {
+  // a comment sits here
+  return outer(inner(1))
+}`),
+    );
+    expect(temps(body)).toHaveLength(1);
+  });
+
+  it("copies loc onto every synthesized statement", () => {
+    const body = temps(
+      hoistCallsInScope(
+        bodyOf(`
+def f(): string {
+  return outer(inner(1))
+}`),
+      ),
+    ) as any[];
+    expect(body[0].loc).toBeDefined();
+    expect(body[0].loc.line).toBeGreaterThan(0);
+  });
+
+  it("numbering is per frame-owning scope, not per statement list", () => {
+    // The loop body shares the function frame; frame locals are flat, so
+    // a body-level __hoist_0 would clobber the iterable temp the loop
+    // re-reads on resume.
+    const body = hoistCallsInScope(
+      bodyOf(`
+def f(): number {
+  let total = 0
+  for (item in getItems()) { total = total + weigh(item, scale()) }
+  return total
+}`),
+    );
+    const names = JSON.stringify(body).match(/__hoist_\d+/g) ?? [];
+    expect(names).toContain("__hoist_0");
+    expect(names).toContain("__hoist_1");
+    expect(new Set(names).size).toBeGreaterThanOrEqual(2);
+  });
+
+  it("numbering skips user-declared __hoist names (seeding is the guard; no lint rule exists)", () => {
+    const body = hoistCallsInScope(
+      bodyOf(`
+def f(): string {
+  const __hoist_0 = "user owned"
+  return outer(inner(1))
+}`),
+    );
+    const temp = (stmts(body) as any[]).find(
+      (n) => n.value?.functionName === "inner",
+    );
+    expect(temp.variableName).toBe("__hoist_1");
+  });
+
+  it("hoists calls inside object literals, arrays, spreads, and string interpolation", () => {
+    const body = temps(
+      hoistCallsInScope(
+        bodyOf(`
+def f(): string {
+  const opts = { tools: [...searchTools()], label: "x: \${render(1)}" }
+  return llm("q", opts)
+}`),
+      ),
+    ) as any[];
+    expect(body.map((n) => n.value.functionName)).toEqual([
+      "searchTools",
+      "render",
+    ]);
+  });
+
+  it("a temp emitted inside a block body lands in that body, never the enclosing one", () => {
+    // Comprehensions desugar at parse time to map(...) with a block
+    // argument; the per-item call must hoist INSIDE the block body
+    // (evaluated per item), never to the enclosing body (evaluated once).
+    const body = hoistCallsInScope(
+      bodyOf(`
+def f(xs: number[]): number[] {
+  return [scaleBy(perItem(x)) for x in xs]
+}`),
+    );
+    expect(temps(body)).toHaveLength(0);
+    const flat = JSON.stringify(body);
+    expect(flat).toContain("__hoist_0");
+    expect(flat).toContain("perItem");
+  });
+});

--- a/packages/agency-lang/lib/preprocessors/hoistCalls.test.ts
+++ b/packages/agency-lang/lib/preprocessors/hoistCalls.test.ts
@@ -351,6 +351,86 @@ node main() {
     expect(inner).not.toContain("__hoist_");
   });
 
+  it("hoists goto arguments (the node call itself is control flow and stays)", () => {
+    const parsed = parseAgency(`
+node main() {
+  goto second(wrap(side(1)))
+}
+
+node second(x: number) {
+  return x
+}`, {}, true);
+    if (!parsed.success) throw new Error(parsed.message);
+    const main = (parsed.result.nodes as any[]).find(
+      (n) => n.type === "graphNode" && n.nodeName !== "second",
+    );
+    const out = hoistCallsInScope(main.body) as any[];
+    const t = temps(out) as any[];
+    expect(t.map((n) => n.value.functionName)).toEqual(["side", "wrap"]);
+    const g = (stmts(out) as any[]).find((n) => n.type === "gotoStatement");
+    expect(g.nodeCall.functionName).toBe("second");
+    expect(g.nodeCall.arguments[0]).toMatchObject({ type: "variableName" });
+  });
+
+  it("hoists nested calls in match-expression arm values, inside the arm", () => {
+    const body = hoistCallsInScope(
+      bodyOf(`
+def f(x: number): number {
+  const r = match(x) {
+    1 => big(small(1))
+    _ => 0
+  }
+  return r
+}`),
+    );
+    // The temp for small() lands INSIDE the arm body (conditional-
+    // correct), not the enclosing body.
+    expect(temps(body)).toHaveLength(0);
+    const flat = JSON.stringify(body);
+    expect(flat).toContain("__hoist_0");
+    expect(flat).toContain("small");
+  });
+
+  it("hoists thread named-arg calls to before the thread statement", () => {
+    const body = hoistCallsInScope(
+      bodyOf(`
+node main() {
+  thread(label: makeLabel()) {
+    const a = llm("hi")
+  }
+  return "ok"
+}`),
+    );
+    const t = temps(body) as any[];
+    expect(t.map((n) => n.value.functionName)).toEqual(["makeLabel"]);
+    const th = (stmts(body) as any[]).find((n) => n.type === "messageThread");
+    expect(th.label).toMatchObject({ type: "variableName" });
+    // The thread BODY is untouched at this level (llm is its statement
+    // tail inside the same-frame body).
+    expect(JSON.stringify(th.body)).toContain("llm");
+  });
+
+  it("hoists a chain base call, and its arguments, out of an access chain", () => {
+    const body = hoistCallsInScope(
+      bodyOf(`
+def f(): string {
+  const x = outer(mk(inner()).field)
+  return x
+}`),
+    );
+    const t = temps(body) as any[];
+    // inner() extracts first, then the base call mk(...) hoists as its
+    // own step; the chain applies .field to the temp ref.
+    expect(t.map((n) => n.value.functionName ?? n.value.type)).toEqual([
+      "inner",
+      "mk",
+    ]);
+    const assign = (stmts(body) as any[]).find((n) => n.variableName === "x");
+    const chainArg = assign.value.arguments[0];
+    expect(chainArg.type).toBe("valueAccess");
+    expect(chainArg.base).toMatchObject({ type: "variableName" });
+  });
+
   it("is idempotent", () => {
     const once = hoistCallsInScope(
       bodyOf(`

--- a/packages/agency-lang/lib/preprocessors/hoistCalls.test.ts
+++ b/packages/agency-lang/lib/preprocessors/hoistCalls.test.ts
@@ -328,6 +328,29 @@ def f(x: any): any {
     expect(temps(body)).toHaveLength(0);
   });
 
+  it("thread blocks in value position keep their statements inside", () => {
+    // `const msgs = thread { ... }` is a statement-bearing construct in
+    // EXPRESSION position. Hoisting its inner calls out of the thread
+    // body would run them outside the thread (CI caught this: the
+    // thread tests returned []). Bodies of such constructs recurse as
+    // statement lists; nothing crosses the boundary.
+    const body = hoistCallsInScope(
+      bodyOf(`
+node main() {
+  const msgs = thread {
+    const res1: number[] = llm("What are the first 5 prime numbers?")
+    const res2: number = llm("Sum them.")
+  }
+  return msgs
+}`),
+    );
+    expect(temps(body)).toHaveLength(0);
+    const assign = (stmts(body) as any[]).find((n) => n.variableName === "msgs");
+    const inner = JSON.stringify(assign.value);
+    expect(inner).toContain("llm");
+    expect(inner).not.toContain("__hoist_");
+  });
+
   it("is idempotent", () => {
     const once = hoistCallsInScope(
       bodyOf(`

--- a/packages/agency-lang/lib/preprocessors/hoistCalls.test.ts
+++ b/packages/agency-lang/lib/preprocessors/hoistCalls.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
 import { parseAgency } from "../parser.js";
 import { hoistCallsInScope } from "./hoistCalls.js";
 import type { AgencyNode } from "../types.js";
@@ -111,7 +112,8 @@ def f(): number {
     const names = JSON.stringify(body).match(/__hoist_\d+/g) ?? [];
     expect(names).toContain("__hoist_0");
     expect(names).toContain("__hoist_1");
-    expect(new Set(names).size).toBeGreaterThanOrEqual(2);
+    const unique = names.filter((n, i) => names.indexOf(n) === i);
+    expect(unique.length).toBeGreaterThanOrEqual(2);
   });
 
   it("numbering skips user-declared __hoist names (seeding is the guard; no lint rule exists)", () => {
@@ -344,9 +346,8 @@ describe("fixture shape pins (S6): the flagship fixtures exercise hoisted shapes
   // options argument actually becomes a hoisted temp. Pinning that here
   // makes the guarantee permanent — a one-time unwire-and-rerun proves
   // it once, this proves it on every CI run.
-  it("resume-regression-args: the llm options argument is a __hoist temp reference", async () => {
-    const fs = await import("node:fs");
-    const src = fs.readFileSync(
+  it("resume-regression-args: the llm options argument is a __hoist temp reference", () => {
+    const src = readFileSync(
       new URL("../../tests/agency/hoist/resume-regression-args.agency", import.meta.url),
       "utf8",
     );

--- a/packages/agency-lang/lib/preprocessors/hoistCalls.test.ts
+++ b/packages/agency-lang/lib/preprocessors/hoistCalls.test.ts
@@ -160,3 +160,181 @@ def f(xs: number[]): number[] {
     expect(flat).toContain("perItem");
   });
 });
+
+describe("hoistCallsInScope: control flow", () => {
+  it("hoists an if condition call to before the if", () => {
+    const body = stmts(
+      hoistCallsInScope(
+        bodyOf(`
+def f(n: number): number {
+  if (score(n) > 3) { return 1 }
+  return 0
+}`),
+      ),
+    ) as any[];
+    expect(body[0].value.functionName).toBe("score");
+    expect(body[1].type).toBe("ifElse");
+  });
+
+  it("hoists a for iterable call to before the loop", () => {
+    const body = stmts(
+      hoistCallsInScope(
+        bodyOf(`
+def f(): number {
+  let total = 0
+  for (item in getItems()) { total = total + item }
+  return total
+}`),
+      ),
+    ) as any[];
+    const idx = body.findIndex((n) => n.value?.functionName === "getItems");
+    expect(idx).toBeGreaterThanOrEqual(0);
+    expect(idx).toBeLessThan(body.findIndex((n) => n.type === "forLoop"));
+  });
+
+  it("rewrites a while with a condition call into while(true) + if/else-break", () => {
+    const body = hoistCallsInScope(
+      bodyOf(`
+def f(): number {
+  let i = 0
+  while (check(i) < 5) { i = i + 1 }
+  return i
+}`),
+    );
+    const wl = (stmts(body) as any[]).find((n) => n.type === "whileLoop");
+    expect(wl.condition).toMatchObject({ type: "boolean", value: true });
+    const wb = stmts(wl.body) as any[];
+    expect(wb[0].value.functionName).toBe("check");
+    expect(wb[1].type).toBe("ifElse");
+    expect(wb[1].thenBody.length).toBeGreaterThan(0);
+    expect(wb[1].elseBody[0]).toMatchObject({ type: "keyword", value: "break" });
+  });
+
+  it("leaves a call-free while condition untouched", () => {
+    const body = hoistCallsInScope(
+      bodyOf(`
+def f(): number {
+  let i = 0
+  while (i < 5) { i = i + 1 }
+  return i
+}`),
+    );
+    const wl = (stmts(body) as any[]).find((n) => n.type === "whileLoop");
+    expect(wl.condition.type).not.toBe("boolean");
+  });
+});
+
+describe("hoistCallsInScope: boundaries", () => {
+  it("does not descend into a try operand at all", () => {
+    const body = hoistCallsInScope(
+      bodyOf(`
+def f(url: string): any {
+  const t = try parse(fetchBody(url))
+  return t
+}`),
+    );
+    expect(temps(body)).toHaveLength(0);
+  });
+
+  it("hoists the left of a short-circuit but not the right", () => {
+    const body = hoistCallsInScope(
+      bodyOf(`
+def f(): boolean {
+  return probe(1) > 0 && probe(2) > 1
+}`),
+    );
+    expect(temps(body)).toHaveLength(1);
+  });
+
+  it("treats the whole catch expression as opaque", () => {
+    const body = hoistCallsInScope(
+      bodyOf(`
+def f(x: any): any {
+  return risky(deep(x)) catch fallback(x)
+}`),
+    );
+    expect(temps(body)).toHaveLength(0);
+  });
+
+  it("hoists a pipe input but not pipe stages", () => {
+    const body = hoistCallsInScope(
+      bodyOf(`
+def f(x: any): any {
+  return load(x) |> clean |> summarize
+}`),
+    );
+    // load(x) is the deep-left input of the nested |> chain; it is also
+    // non-tail (the tail is the outer pipe), so it hoists. Stages stay.
+    const t = temps(body) as any[];
+    expect(t.map((n) => n.value.functionName)).toEqual(["load"]);
+  });
+
+  it("fork branches: hoists WITHIN the branch body, nothing crosses out", () => {
+    const body = hoistCallsInScope(
+      bodyOf(`
+def f(): any {
+  return fork [expensive(seed(x)) for x in [1, 2]]
+}`),
+    );
+    expect(temps(body)).toHaveLength(0);
+    const flat = JSON.stringify(body);
+    expect(flat).toContain("__hoist_0");
+    expect(flat).toContain("seed");
+  });
+
+  it("skips handler bodies entirely; the handle body still hoists", () => {
+    const src = `
+node main() {
+  handle {
+    return work(prep(1))
+  } with (data) {
+    return match(data.effect) {
+      _ => approve(annotate(data))
+    }
+  }
+}`;
+    const parsed = parseAgency(src, {}, true);
+    if (!parsed.success) throw new Error(parsed.message);
+    const main = (parsed.result.nodes as any[]).find(
+      (n) => n.type === "graphNode",
+    );
+    const out = hoistCallsInScope(main.body);
+    const handle = (stmts(out) as any[]).find((n) => n.type === "handleBlock");
+    expect(handle).toBeDefined();
+    // Positive: the handle BODY hoisted prep into a temp.
+    const handleBodyFlat = JSON.stringify(handle.body);
+    expect(handleBodyFlat).toContain("__hoist_");
+    expect(handleBodyFlat).toContain("prep");
+    // Negative: the with-body subtree is untouched — annotate remains a
+    // call argument and no temp name appears anywhere inside it.
+    const handlerFlat = JSON.stringify(handle.handler);
+    expect(handlerFlat).toContain("annotate");
+    expect(handlerFlat).not.toContain("__hoist_");
+  });
+
+  it("with-modified statements are opaque", () => {
+    // `<stmt> with approve` wraps one statement; hoisting a temp out of
+    // it would move the call outside the modifier's approval region,
+    // and the single-statement slot cannot hold two statements anyway.
+    const body = hoistCallsInScope(
+      bodyOf(`
+def f(x: any): any {
+  const text = dangerous(prep(x)) with approve
+  return text
+}`),
+    );
+    expect(temps(body)).toHaveLength(0);
+  });
+
+  it("is idempotent", () => {
+    const once = hoistCallsInScope(
+      bodyOf(`
+def f(n: number): number {
+  if (score(n) > 3) { return outer(inner(1)) }
+  return 0
+}`),
+    );
+    const twice = hoistCallsInScope(once);
+    expect(JSON.stringify(twice)).toBe(JSON.stringify(once));
+  });
+});

--- a/packages/agency-lang/lib/preprocessors/hoistCalls.test.ts
+++ b/packages/agency-lang/lib/preprocessors/hoistCalls.test.ts
@@ -338,3 +338,29 @@ def f(n: number): number {
     expect(JSON.stringify(twice)).toBe(JSON.stringify(once));
   });
 });
+
+describe("fixture shape pins (S6): the flagship fixtures exercise hoisted shapes", () => {
+  // The resume-regression fixtures only prove anything if their llm
+  // options argument actually becomes a hoisted temp. Pinning that here
+  // makes the guarantee permanent — a one-time unwire-and-rerun proves
+  // it once, this proves it on every CI run.
+  it("resume-regression-args: the llm options argument is a __hoist temp reference", async () => {
+    const fs = await import("node:fs");
+    const src = fs.readFileSync(
+      new URL("../../tests/agency/hoist/resume-regression-args.agency", import.meta.url),
+      "utf8",
+    );
+    const parsed = parseAgency(src, {}, true);
+    if (!parsed.success) throw new Error(parsed.message);
+    const main = (parsed.result.nodes as any[]).find((n) => n.type === "graphNode");
+    const out = hoistCallsInScope(main.body) as any[];
+    const t = temps(out) as any[];
+    expect(t).toHaveLength(1);
+    expect(t[0].value.functionName).toBe("myOptions");
+    const llmStmt = (stmts(out) as any[]).find(
+      (n) => n.value?.functionName === "llm",
+    );
+    const optionsArg = llmStmt.value.arguments[1];
+    expect(optionsArg).toMatchObject({ type: "variableName", value: t[0].variableName });
+  });
+});

--- a/packages/agency-lang/lib/preprocessors/hoistCalls.test.ts
+++ b/packages/agency-lang/lib/preprocessors/hoistCalls.test.ts
@@ -431,11 +431,31 @@ def f(): string {
     expect(chainArg.base).toMatchObject({ type: "variableName" });
   });
 
-  it("is idempotent", () => {
+  it("hoists calls in assignment-target index expressions, before the value temps", () => {
+    // `arr[pick(i)] = compute(i)`: the index evaluates before the
+    // value, so the index temp comes first and the value call stays
+    // as the statement tail.
+    const body = hoistCallsInScope(
+      bodyOf(`
+def f(arr: number[], i: number): number {
+  arr[pick(i)] = compute(i)
+  return arr[0]
+}`),
+    );
+    const t = temps(body) as any[];
+    expect(t.map((n) => n.value.functionName)).toEqual(["pick"]);
+    const assign = (stmts(body) as any[]).find((n) => n.variableName === "arr");
+    expect(assign.accessChain[0].index).toMatchObject({ type: "variableName" });
+    expect(assign.value.functionName).toBe("compute");
+  });
+
+  it("is idempotent, including the while rewrite", () => {
     const once = hoistCallsInScope(
       bodyOf(`
 def f(n: number): number {
   if (score(n) > 3) { return outer(inner(1)) }
+  let i = 0
+  while (check(i) < 5) { i = i + weigh(scale(i)) }
   return 0
 }`),
     );

--- a/packages/agency-lang/lib/preprocessors/hoistCalls.ts
+++ b/packages/agency-lang/lib/preprocessors/hoistCalls.ts
@@ -1,0 +1,408 @@
+/**
+ * hoistCalls — rewrite every statement so helper calls become their own
+ * `const __hoist_N = ...` statements.
+ *
+ * Why: resume replay re-executes the statement that was in progress at a
+ * pause, including helper calls that already completed. Those helpers
+ * re-claim frames from the positional restore queue and desync it (the
+ * still-live owner gets a blank frame and re-issues work). A hoisted
+ * helper is its own runner step: completed steps are skipped on resume
+ * and their value is read back from `__stack.locals`, so the helper
+ * never re-runs. Spec:
+ * docs/superpowers/specs/2026-07-22-hoist-calls-resume-safety-design.md
+ *
+ * The invariant this pass establishes: after preprocessing, a statement
+ * re-executes no completed frame-pushing call on resume — the only call
+ * remaining in unconditionally-evaluated position is the statement's own
+ * tail. Tails stay deliberately: hoisting them uniformly would need a
+ * graph-node-call exclusion (node calls are control flow and THROW in
+ * value position — typescriptBuilder's processNodeCall), while at tail
+ * position they need no rule at all.
+ *
+ * Statement-body recursion is driven by `bodySlots` (the single source
+ * of truth for which fields hold statements); only the expression
+ * interior uses a generic child walk. Rulings are data, not control
+ * flow — see RULINGS / OPERATOR_RULINGS below. Everything copies;
+ * parsed AST is never mutated (in-place mutation burned this repo via
+ * the parse cache clone-on-read fix).
+ *
+ * Temp naming: `__hoist_N`, ONE counter per frame-owning scope
+ * (function, node, lifted block, fork branch), shared by every nested
+ * statement list inside it. Frame locals are flat, so per-list
+ * numbering would let a loop-body temp clobber the temp a loop
+ * iterable re-reads on resume. Blocks own frames (blockSetup.mustache
+ * pushes one), so block bodies restart at 0. Finalize bodies run on
+ * the CONTAINER's frame (bodySlots documents this) and therefore share
+ * the container's counter. Seeding scans the scope for existing
+ * `__hoist_N` names and starts above the max — this seeding is the
+ * collision protection; there is deliberately no lint rule (no other
+ * compiler-reserved prefix has one).
+ *
+ * Known residuals (tripwire territory, not silent corruption): calls
+ * nested inside opaque positions (short-circuit right sides, catch
+ * expressions, try operands, `with`/`static` wrappers, mid-chain method
+ * calls inside a hoisted chain), and block bodies nested inside opaque
+ * expressions.
+ */
+import type { AgencyNode, AgencyProgram } from "../types.js";
+import { bodySlots } from "../utils/bodySlots.js";
+import { createKeyword } from "../types/keyword.js";
+
+type Counter = { n: number };
+
+type Extraction = { temps: AgencyNode[]; expr: any };
+
+/** Expression-node rulings the walker consults before descending.
+ *  "opaque" = never descend, hoist nothing inside (each row says why).
+ *  Unlisted expression node types default to a generic child walk. */
+const NODE_RULINGS: Record<string, "opaque"> = {
+  // The whole operand compiles into the __tryCall thunk; hoisting an
+  // argument out would run it outside the catch boundary and let its
+  // throw escape uncaught.
+  tryExpression: "opaque",
+};
+
+/** binOpExpression rulings by operator.
+ *  - "catch": opaque. The fallback runs only on Failure (__catchResult);
+ *    the left side is excluded too, purely for boundary simplicity — a
+ *    temp for it would be semantically identical.
+ *  - "|>": input-only. Stages are already resume-safe (memoized
+ *    __pipe_result_<path>) AND conditional (__pipeBind skips them on
+ *    Failure); the input is evaluated inline at statement level, outside
+ *    the memoization, so it hoists.
+ *  - "&&" / "||" / "??": left-only. The right side may never execute.
+ *    The first inline call there is resume-aligned by construction
+ *    (nothing before it consumes a frame on replay), so only calls
+ *    NESTED under it remain residual.
+ */
+const OPERATOR_RULINGS: Record<string, "opaque" | "leftOnly"> = {
+  catch: "opaque",
+  "|>": "leftOnly",
+  "&&": "leftOnly",
+  "||": "leftOnly",
+  "??": "leftOnly",
+};
+
+const SKIP_TYPES = ["comment", "newLine"];
+
+export function hoistCallsInProgram(program: AgencyProgram): AgencyProgram {
+  // Only function and graphNode bodies. Module-level initializers are
+  // excluded by construction: they run through the per-variable init
+  // dependency graph (docs/dev/init-topsort.md), cannot pause, and a
+  // synthesized variable would be invisible to the topsort.
+  return {
+    ...program,
+    nodes: program.nodes.map((node) => {
+      if (node.type === "function" || node.type === "graphNode") {
+        return { ...node, body: hoistCallsInScope((node as any).body) } as AgencyNode;
+      }
+      return node;
+    }),
+  };
+}
+
+/** Rewrite one frame-owning scope's statements. Pass `counter` when
+ *  recursing into a nested statement list of the SAME frame (loop and
+ *  if bodies, finalize bodies, thread blocks); omit it at a frame
+ *  boundary (function, node, lifted block, fork branch) so numbering
+ *  restarts against that frame's own flat locals. */
+export function hoistCallsInScope(
+  body: AgencyNode[],
+  counter?: Counter,
+): AgencyNode[] {
+  const c = counter ?? { n: seedCounter(body) };
+  const out: AgencyNode[] = [];
+  for (const stmt of body) {
+    if (!stmt || typeof stmt !== "object" || SKIP_TYPES.includes(stmt.type)) {
+      out.push(stmt);
+      continue;
+    }
+    out.push(...rewriteStatement(stmt, c));
+  }
+  return out;
+}
+
+/** Start numbering above any __hoist_N already present in the scope
+ *  (user-declared or from an earlier run of the pass). This scan is the
+ *  collision protection; it also makes the pass idempotent. */
+function seedCounter(body: AgencyNode[]): number {
+  let max = -1;
+  for (const m of JSON.stringify(body).matchAll(/__hoist_(\d+)/g)) {
+    const n = Number(m[1]);
+    if (n > max) max = n;
+  }
+  return max + 1;
+}
+
+// eslint-disable-next-line max-lines-per-function -- one case per statement kind; splitting would scatter the dispatch
+function rewriteStatement(stmt: any, counter: Counter): AgencyNode[] {
+  switch (stmt.type) {
+    case "assignment": {
+      const value = extractValue(stmt.value, counter);
+      return [...value.temps, { ...stmt, value: value.expr }];
+    }
+    case "returnStatement": {
+      if (!stmt.value) return [stmt];
+      const value = extractValue(stmt.value, counter);
+      return [...value.temps, { ...stmt, value: value.expr }];
+    }
+    case "functionCall":
+    case "interruptStatement": {
+      // A bare call statement: the call itself is the tail; its
+      // arguments (and block body, via the slot recursion inside
+      // walk) still hoist.
+      const walked = walk(stmt, counter, false);
+      return [...walked.temps, walked.expr];
+    }
+    case "ifElse": {
+      // The runtime memoizes the chosen branch (__condbranch_ on the
+      // frame), so the condition already evaluates once; hoisting it
+      // fixes the pause-INSIDE-the-condition replay. Conditions of
+      // `else if` arms are nested ifElse statements inside elseBody,
+      // so their temps land in that conditional list — correct by
+      // construction.
+      const cond = walk(stmt.condition, counter, true);
+      const recursed = recurseSlots({ ...stmt, condition: cond.expr }, counter);
+      return [...cond.temps, recursed];
+    }
+    case "whileLoop": {
+      const cond = walk(stmt.condition, counter, true);
+      if (cond.temps.length === 0) {
+        return [recurseSlots(stmt, counter)];
+      }
+      // while (COND) { BODY } with calls in COND becomes
+      //   while (true) { <temps>; if (COND') { BODY' } else { break } }
+      // No synthesized negation on purpose: the parser cannot even
+      // produce `!(<comparison>)`, and a hand-rolled unary emission
+      // prints `(!h) < 5` silently. The if/else form has no operator
+      // to get wrong. `continue` in BODY still lands on the re-check
+      // (loop top). Why this position matters most: Runner.whileLoop
+      // awaits the condition BEFORE the completed-iteration skip, so
+      // today a condition call re-runs once per completed iteration
+      // on resume.
+      const loc = stmt.condition.loc ?? stmt.loc;
+      const innerBody = hoistCallsInScope(stmt.body, counter);
+      const gate: any = {
+        type: "ifElse",
+        condition: cond.expr,
+        thenBody: innerBody,
+        elseBody: [{ ...createKeyword("break"), loc }],
+        loc,
+      };
+      return [
+        {
+          ...stmt,
+          condition: { type: "boolean", value: true, loc },
+          body: [...cond.temps, gate],
+        },
+      ];
+    }
+    case "forLoop": {
+      // The iterable is materialized once at loop entry (runner.loop),
+      // so a single evaluation before the loop is equivalent — and the
+      // temp's step makes it resume-safe.
+      const iter = walk(stmt.iterable, counter, true);
+      const recursed = recurseSlots({ ...stmt, iterable: iter.expr }, counter);
+      return [...iter.temps, recursed];
+    }
+    case "matchBlock": {
+      // The scrutinee evaluates once; case bodies recurse via slots.
+      const subject = walk(stmt.expression, counter, true);
+      const recursed = recurseSlots(
+        { ...stmt, expression: subject.expr },
+        counter,
+      );
+      return [...subject.temps, recursed];
+    }
+    case "withModifier":
+    case "staticStatement":
+      // Opaque: hoisting out of a `with` region would move the call
+      // outside the modifier's approval scope; `static` initializers
+      // belong to init-topsort. Both wrap exactly one statement
+      // (bodySlots `single`), which a multi-statement rewrite would
+      // break anyway.
+      return [stmt];
+    default:
+      return [recurseSlots(stmt, counter)];
+  }
+}
+
+/** Recurse into a statement's nested statement bodies via bodySlots —
+ *  the drift-proof enumeration of which fields hold statements. Slot
+ *  policy:
+ *  - handleBlock's inline handler body: skipped. Handler bodies compile
+ *    to plain JavaScript without steps and cannot pause (#616), and
+ *    handlers are safety infrastructure this pass has no license to
+ *    restructure.
+ *  - lifted-block slots (a functionCall's block argument, standalone
+ *    blockArgument): a NEW frame-owning scope — fresh counter, and
+ *    temps land inside the block body, never the enclosing one.
+ *  - everything else (if/loop/match/finalize/thread bodies): same
+ *    frame, same counter.
+ */
+function recurseSlots(stmt: any, counter: Counter): AgencyNode {
+  let out: AgencyNode = stmt;
+  for (const slot of bodySlots(out)) {
+    if (stmt.type === "handleBlock" && slot.retargetsReturn) {
+      continue;
+    }
+    const ownFrame =
+      slot.blockAncestor !== undefined || stmt.type === "blockArgument";
+    const newBody = ownFrame
+      ? hoistCallsInScope(slot.body)
+      : hoistCallsInScope(slot.body, counter);
+    out = slot.write(out, newBody);
+  }
+  return out;
+}
+
+/** Extract from a statement's value position: the outermost call (or
+ *  call-bearing access chain) is the statement's tail and stays; every
+ *  other unconditionally-evaluated call hoists. */
+function extractValue(expr: any, counter: Counter): Extraction {
+  if (expr?.type === "functionCall" || expr?.type === "valueAccess") {
+    return walk(expr, counter, false);
+  }
+  return walk(expr, counter, true);
+}
+
+/** The expression walker. Returns fresh nodes; never mutates. `hoistSelf`
+ *  is true everywhere except the single statement-tail node, which the
+ *  statement dispatcher withholds by calling with false. */
+// eslint-disable-next-line max-lines-per-function -- ruling dispatch + one case per expression family
+function walk(node: any, counter: Counter, hoistSelf: boolean): Extraction {
+  if (!node || typeof node !== "object") return { temps: [], expr: node };
+
+  if (NODE_RULINGS[node.type] === "opaque") {
+    return { temps: [], expr: node };
+  }
+
+  if (node.type === "binOpExpression") {
+    const ruling = OPERATOR_RULINGS[node.operator];
+    if (ruling === "opaque") return { temps: [], expr: node };
+    if (ruling === "leftOnly") {
+      const left = walk(node.left, counter, true);
+      return { temps: left.temps, expr: { ...node, left: left.expr } };
+    }
+    const left = walk(node.left, counter, true);
+    const right = walk(node.right, counter, true);
+    return {
+      temps: [...left.temps, ...right.temps],
+      expr: { ...node, left: left.expr, right: right.expr },
+    };
+  }
+
+  if (node.type === "ifElse") {
+    // A value-position if-expression (normally lowered at parse time;
+    // defensive): condition is unconditional, branches are not.
+    const cond = walk(node.condition, counter, true);
+    return { temps: cond.temps, expr: { ...node, condition: cond.expr } };
+  }
+
+  if (node.type === "functionCall") {
+    const temps: AgencyNode[] = [];
+    const args = (node.arguments ?? []).map((arg: any) => {
+      const inner =
+        arg?.type === "namedArgument"
+          ? walk(arg.value, counter, true)
+          : walk(arg, counter, true);
+      temps.push(...inner.temps);
+      return arg?.type === "namedArgument"
+        ? { ...arg, value: inner.expr }
+        : inner.expr;
+    });
+    let call: any = { ...node, arguments: args };
+    if (node.block) {
+      // The block body is a new frame-owning scope; its temps stay
+      // inside it. Recursed here (not via recurseSlots) because in
+      // expression position the call is not a statement.
+      call = {
+        ...call,
+        block: { ...node.block, body: hoistCallsInScope(node.block.body) },
+      };
+    }
+    if (!hoistSelf) return { temps, expr: call };
+    const ref = makeTemp(call, temps, counter);
+    return { temps, expr: ref };
+  }
+
+  if (node.type === "valueAccess") {
+    // Chains hoist as a UNIT when any segment calls: splitting a chain
+    // mid-way would mean rebuilding it across statements. Nested
+    // arguments and index expressions hoist first; a pause inside a
+    // later chain segment re-running an earlier one is a documented
+    // residual (tripwire-covered).
+    const temps: AgencyNode[] = [];
+    let hasCall = node.base?.type === "functionCall";
+    const chain = (node.chain ?? []).map((entry: any) => {
+      if (entry?.kind === "methodCall" && entry.functionCall) {
+        hasCall = true;
+        const inner = walk(
+          { ...entry.functionCall, loc: entry.functionCall.loc ?? node.loc },
+          counter,
+          false,
+        );
+        temps.push(...inner.temps);
+        return { ...entry, functionCall: inner.expr };
+      }
+      if (entry?.kind === "index" && entry.index) {
+        const inner = walk(entry.index, counter, true);
+        temps.push(...inner.temps);
+        if (inner.expr !== entry.index) hasCall = hasCall || false;
+        return { ...entry, index: inner.expr };
+      }
+      return entry;
+    });
+    const rebuilt = { ...node, chain };
+    if (!hoistSelf || !hasCall) return { temps, expr: rebuilt };
+    const ref = makeTemp(rebuilt, temps, counter);
+    return { temps, expr: ref };
+  }
+
+  // Generic descent for every other expression family (arrays, objects,
+  // splats, string interpolations, unary forms, named wrappers). Copies
+  // each object-valued child through the walker; `loc` is data, not a
+  // node. Statement lists never appear under these families — the
+  // constructs that carry them (block arguments, handler bodies) are
+  // handled above or by the statement dispatcher.
+  const temps: AgencyNode[] = [];
+  let expr = node;
+  for (const key of Object.keys(node)) {
+    if (key === "loc") continue;
+    const child = node[key];
+    if (Array.isArray(child)) {
+      let changed = false;
+      const mapped = child.map((item) => {
+        if (item && typeof item === "object") {
+          const inner = walk(item, counter, true);
+          temps.push(...inner.temps);
+          if (inner.expr !== item) changed = true;
+          return inner.expr;
+        }
+        return item;
+      });
+      if (changed) expr = { ...expr, [key]: mapped };
+    } else if (child && typeof child === "object") {
+      const inner = walk(child, counter, true);
+      temps.push(...inner.temps);
+      if (inner.expr !== child) expr = { ...expr, [key]: inner.expr };
+    }
+  }
+  return { temps, expr };
+}
+
+/** Emit `const __hoist_N = <call>` into temps and return the reference
+ *  that replaces the call. loc is copied from the hoisted expression so
+ *  diagnostics, the source map, and the debugger keep pointing at the
+ *  original line (SourceMap.record drops loc-less entries). */
+function makeTemp(call: any, temps: AgencyNode[], counter: Counter): any {
+  const name = `__hoist_${counter.n++}`;
+  temps.push({
+    type: "assignment",
+    declKind: "const",
+    variableName: name,
+    value: call,
+    loc: call.loc,
+  } as unknown as AgencyNode);
+  return { type: "variableName", value: name, loc: call.loc };
+}

--- a/packages/agency-lang/lib/preprocessors/hoistCalls.ts
+++ b/packages/agency-lang/lib/preprocessors/hoistCalls.ts
@@ -152,8 +152,17 @@ function seedCounter(body: AgencyNode[]): number {
 function rewriteStatement(stmt: any, counter: Counter): AgencyNode[] {
   switch (stmt.type) {
     case "assignment": {
+      // Indexed-assignment TARGETS carry expressions too:
+      // `arr[pick(i)] = compute(i)` evaluates the index before the
+      // value, so index temps come first and order is preserved.
+      const chainTemps: AgencyNode[] = [];
+      let out: any = stmt;
+      if (Array.isArray(stmt.accessChain) && stmt.accessChain.length > 0) {
+        const chain = walkChainEntries(stmt.accessChain, chainTemps, counter);
+        out = { ...out, accessChain: chain };
+      }
       const value = extractValue(stmt.value, counter);
-      return [...value.temps, { ...stmt, value: value.expr }];
+      return [...chainTemps, ...value.temps, { ...out, value: value.expr }];
     }
     case "returnStatement": {
       if (!stmt.value) return [stmt];
@@ -388,36 +397,10 @@ function walk(node: any, counter: Counter, hoistSelf: boolean): Extraction {
     const temps: AgencyNode[] = [];
     const base = walk(node.base, counter, true);
     temps.push(...base.temps);
-    let chainHasMethodCall = false;
-    const chain = (node.chain ?? []).map((entry: any) => {
-      if (entry?.kind === "methodCall" && entry.functionCall) {
-        chainHasMethodCall = true;
-        const inner = walk(
-          { ...entry.functionCall, loc: entry.functionCall.loc ?? node.loc },
-          counter,
-          false,
-        );
-        temps.push(...inner.temps);
-        return { ...entry, functionCall: inner.expr };
-      }
-      if (entry?.kind === "index" && entry.index) {
-        const inner = walk(entry.index, counter, true);
-        temps.push(...inner.temps);
-        return { ...entry, index: inner.expr };
-      }
-      if (entry?.kind === "slice") {
-        let e = entry;
-        for (const key of ["start", "end"]) {
-          if (e[key]) {
-            const inner = walk(e[key], counter, true);
-            temps.push(...inner.temps);
-            if (inner.expr !== e[key]) e = { ...e, [key]: inner.expr };
-          }
-        }
-        return e;
-      }
-      return entry;
-    });
+    const chain = walkChainEntries(node.chain ?? [], temps, counter);
+    const chainHasMethodCall = (node.chain ?? []).some(
+      (entry: any) => entry?.kind === "methodCall" && entry.functionCall,
+    );
     const rebuilt = { ...node, base: base.expr, chain };
     if (!hoistSelf || !chainHasMethodCall) return { temps, expr: rebuilt };
     const ref = makeTemp(rebuilt, temps, counter);
@@ -464,6 +447,42 @@ function walk(node: any, counter: Counter, hoistSelf: boolean): Extraction {
     }
   }
   return { temps, expr };
+}
+
+/** Walk the expression operands of an access chain (`a[i]`, `a[i:j]`,
+ *  `a.m(x)`): method-call arguments extract with the call withheld as
+ *  the segment's own operation, index expressions and slice bounds
+ *  extract fully. Shared by valueAccess expressions and indexed
+ *  assignment targets so the two cannot diverge. */
+function walkChainEntries(
+  chain: any[],
+  temps: AgencyNode[],
+  counter: Counter,
+): any[] {
+  return chain.map((entry: any) => {
+    if (entry?.kind === "methodCall" && entry.functionCall) {
+      const inner = walk(entry.functionCall, counter, false);
+      temps.push(...inner.temps);
+      return { ...entry, functionCall: inner.expr };
+    }
+    if (entry?.kind === "index" && entry.index) {
+      const inner = walk(entry.index, counter, true);
+      temps.push(...inner.temps);
+      return { ...entry, index: inner.expr };
+    }
+    if (entry?.kind === "slice") {
+      let e = entry;
+      for (const key of ["start", "end"]) {
+        if (e[key]) {
+          const inner = walk(e[key], counter, true);
+          temps.push(...inner.temps);
+          if (inner.expr !== e[key]) e = { ...e, [key]: inner.expr };
+        }
+      }
+      return e;
+    }
+    return entry;
+  });
 }
 
 /** Emit `const __hoist_N = <call>` into temps and return the reference

--- a/packages/agency-lang/lib/preprocessors/hoistCalls.ts
+++ b/packages/agency-lang/lib/preprocessors/hoistCalls.ts
@@ -359,12 +359,22 @@ function walk(node: any, counter: Counter, hoistSelf: boolean): Extraction {
     return { temps, expr: ref };
   }
 
+  // Statement-bearing constructs in EXPRESSION position (a thread block
+  // as an assignment value is the live case; bodySlots is the
+  // authoritative enumeration). Their bodies recurse as statement
+  // lists — walking them as expressions would hoist inner calls OUT of
+  // the construct and change where they run. Placed after functionCall
+  // (which owns its block-argument slot above) so ordinary calls keep
+  // their argument walking.
+  if (bodySlots(node).length > 0) {
+    return { temps: [], expr: recurseSlots(node, counter) };
+  }
+
   // Generic descent for every other expression family (arrays, objects,
   // splats, string interpolations, unary forms, named wrappers). Copies
   // each object-valued child through the walker; `loc` is data, not a
-  // node. Statement lists never appear under these families — the
-  // constructs that carry them (block arguments, handler bodies) are
-  // handled above or by the statement dispatcher.
+  // node. Statement lists cannot appear below this point: bodySlots
+  // just claimed every construct that carries one.
   const temps: AgencyNode[] = [];
   let expr = node;
   for (const key of Object.keys(node)) {

--- a/packages/agency-lang/lib/preprocessors/hoistCalls.ts
+++ b/packages/agency-lang/lib/preprocessors/hoistCalls.ts
@@ -122,15 +122,29 @@ export function hoistCallsInScope(
   return out;
 }
 
-/** Start numbering above any __hoist_N already present in the scope
+/** Start numbering above any __hoist_N DECLARED in the scope's subtree
  *  (user-declared or from an earlier run of the pass). This scan is the
- *  collision protection; it also makes the pass idempotent. */
+ *  collision protection; it also makes the pass idempotent. Walks the
+ *  tree for assignment declarations rather than regexing serialized
+ *  JSON, so a string literal containing "__hoist_5" cannot bump the
+ *  counter and the cost stays one linear visit per scope. */
 function seedCounter(body: AgencyNode[]): number {
   let max = -1;
-  for (const m of JSON.stringify(body).matchAll(/__hoist_(\d+)/g)) {
-    const n = Number(m[1]);
-    if (n > max) max = n;
-  }
+  const visit = (n: any): void => {
+    if (!n || typeof n !== "object") return;
+    if (Array.isArray(n)) {
+      for (const item of n) visit(item);
+      return;
+    }
+    if (n.type === "assignment" && typeof n.variableName === "string") {
+      const m = n.variableName.match(/^__hoist_(\d+)$/);
+      if (m) max = Math.max(max, Number(m[1]));
+    }
+    for (const key of Object.keys(n)) {
+      if (key !== "loc") visit(n[key]);
+    }
+  };
+  visit(body);
   return max + 1;
 }
 
@@ -153,6 +167,41 @@ function rewriteStatement(stmt: any, counter: Counter): AgencyNode[] {
       // walk) still hoist.
       const walked = walk(stmt, counter, false);
       return [...walked.temps, walked.expr];
+    }
+    case "gotoStatement": {
+      // The node call is control flow (it transfers, and node calls
+      // throw in value position), so it stays; its ARGUMENTS are
+      // ordinary expressions evaluated before the transfer and hoist.
+      const nodeCall = walk(stmt.nodeCall, counter, false);
+      return [...nodeCall.temps, { ...stmt, nodeCall: nodeCall.expr }];
+    }
+    case "matchYield": {
+      // Match-expression arm values (synthesized by lowerPatterns).
+      // Same shape as returnStatement: the value's tail stays, nested
+      // calls hoist — into the arm body, which is conditional-correct
+      // because arms are their own statement lists. typeSource is a
+      // typing-only mirror and stays untouched.
+      if (!stmt.value) return [stmt];
+      const value = extractValue(stmt.value, counter);
+      return [...value.temps, { ...stmt, value: value.expr }];
+    }
+    case "messageThread": {
+      // thread(label: makeLabel()) { ... } — the named-arg expressions
+      // evaluate once at thread open. Hoisted temps sit right before
+      // the statement; on a halted or resume-skipped runner both the
+      // temp steps and the thread step are skipped together, matching
+      // the lazy opts-thunk semantics.
+      const temps: AgencyNode[] = [];
+      let out: any = stmt;
+      for (const key of ["label", "summarize", "continueExpr", "sessionExpr", "hidden"]) {
+        const arg = out[key];
+        if (arg && typeof arg === "object") {
+          const inner = walk(arg, counter, true);
+          temps.push(...inner.temps);
+          if (inner.expr !== arg) out = { ...out, [key]: inner.expr };
+        }
+      }
+      return [...temps, recurseSlots(out, counter)];
     }
     case "ifElse": {
       // The runtime memoizes the chosen branch (__condbranch_ on the
@@ -327,16 +376,22 @@ function walk(node: any, counter: Counter, hoistSelf: boolean): Extraction {
   }
 
   if (node.type === "valueAccess") {
-    // Chains hoist as a UNIT when any segment calls: splitting a chain
-    // mid-way would mean rebuilding it across statements. Nested
-    // arguments and index expressions hoist first; a pause inside a
-    // later chain segment re-running an earlier one is a documented
-    // residual (tripwire-covered).
+    // The BASE walks like any expression, so a call base hoists into
+    // its own step: `getConfig().model` becomes `const __h =
+    // getConfig()` then `__h.model` — the natural boundary, and its
+    // arguments extract with it. Chain segments then hoist as a UNIT
+    // when a method call remains: splitting a chain mid-way would mean
+    // rebuilding it across statements. Method-call arguments, index
+    // expressions, and slice bounds hoist first; a pause inside a
+    // later chain segment re-running an earlier method call is a
+    // documented residual (tripwire-covered).
     const temps: AgencyNode[] = [];
-    let hasCall = node.base?.type === "functionCall";
+    const base = walk(node.base, counter, true);
+    temps.push(...base.temps);
+    let chainHasMethodCall = false;
     const chain = (node.chain ?? []).map((entry: any) => {
       if (entry?.kind === "methodCall" && entry.functionCall) {
-        hasCall = true;
+        chainHasMethodCall = true;
         const inner = walk(
           { ...entry.functionCall, loc: entry.functionCall.loc ?? node.loc },
           counter,
@@ -348,13 +403,23 @@ function walk(node: any, counter: Counter, hoistSelf: boolean): Extraction {
       if (entry?.kind === "index" && entry.index) {
         const inner = walk(entry.index, counter, true);
         temps.push(...inner.temps);
-        if (inner.expr !== entry.index) hasCall = hasCall || false;
         return { ...entry, index: inner.expr };
+      }
+      if (entry?.kind === "slice") {
+        let e = entry;
+        for (const key of ["start", "end"]) {
+          if (e[key]) {
+            const inner = walk(e[key], counter, true);
+            temps.push(...inner.temps);
+            if (inner.expr !== e[key]) e = { ...e, [key]: inner.expr };
+          }
+        }
+        return e;
       }
       return entry;
     });
-    const rebuilt = { ...node, chain };
-    if (!hoistSelf || !hasCall) return { temps, expr: rebuilt };
+    const rebuilt = { ...node, base: base.expr, chain };
+    if (!hoistSelf || !chainHasMethodCall) return { temps, expr: rebuilt };
     const ref = makeTemp(rebuilt, temps, counter);
     return { temps, expr: ref };
   }

--- a/packages/agency-lang/lib/preprocessors/typescriptPreprocessor.ts
+++ b/packages/agency-lang/lib/preprocessors/typescriptPreprocessor.ts
@@ -32,6 +32,7 @@ import {
 } from "@/utils/node.js";
 import { desugarParallelInBody } from "./parallelDesugar.js";
 import { desugarGuardsInBody } from "./guardDesugar.js";
+import { hoistCallsInProgram } from "./hoistCalls.js";
 import { injectSchemaArgsInProgram } from "./injectSchemaArgs.js";
 import { prunePreludeShadows } from "./prunePreludeShadows.js";
 
@@ -344,6 +345,18 @@ export class TypescriptPreprocessor {
       this.importedFunctions,
     );
     this.collectSkills();
+    // Hoist helper calls into their own const steps so resume replay
+    // never re-executes a completed call (frame-queue desync; spec
+    // docs/superpowers/specs/2026-07-22-hoist-calls-resume-safety-design.md).
+    // After collectSkills so skill detection sees original call shapes;
+    // before addAwaitPendingCalls and resolveVariableScopes so the
+    // __hoist temps get awaits and scopes like hand-written statements.
+    //
+    // Accepted behavior change: `for (x in async getItems())` was
+    // rejected by validateNoAsyncInLoops (the async call sat under the
+    // loop node); hoisting moves it above the loop, so it now compiles.
+    // A relaxation, recorded here and in docs/dev/hoist-calls.md.
+    this.program = hoistCallsInProgram(this.program);
     this.addAwaitPendingCalls();
     this.validateNoAsyncInLoops();
 

--- a/packages/agency-lang/lib/runtime/index.ts
+++ b/packages/agency-lang/lib/runtime/index.ts
@@ -27,7 +27,7 @@ export {
   __globals,
   type AgencyStore,
 } from "./asyncContext.js";
-export { StateStack, State } from "./state/stateStack.js";
+export { StateStack, State, claimFrameForScope } from "./state/stateStack.js";
 export { GlobalStore } from "./state/globalStore.js";
 export { MessageThread } from "./state/messageThread.js";
 export { ThreadStore } from "./state/threadStore.js";

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -51,7 +51,7 @@ import {
   MessageThread,
   type MessageThreadJSON,
 } from "./state/messageThread.js";
-import { StateStack } from "./state/stateStack.js";
+import { StateStack, claimFrameForScope } from "./state/stateStack.js";
 import { ThreadStore } from "./state/threadStore.js";
 import { handleStreamingResponse } from "./streaming.js";
 import { GraphState } from "./types.js";
@@ -885,6 +885,10 @@ export async function runPrompt(args: {
 
   // Push a frame onto the state stack — runPrompt participates like any other function
   const { stateStack, stack } = setupFunction();
+  // Hand-written claim (generated code claims in its preambles; runPrompt
+  // is TypeScript). runPrompt's frame was the victim in the motivating
+  // desync: a replayed helper stole it and runPrompt restarted blank.
+  claimFrameForScope(stack, "runPrompt");
   const self = stack.locals;
 
   // Frame-backed locals (survive checkpoint/restore)

--- a/packages/agency-lang/lib/runtime/resumableScope.ts
+++ b/packages/agency-lang/lib/runtime/resumableScope.ts
@@ -50,6 +50,7 @@
 import { agencyStore, getRuntimeContext } from "./asyncContext.js";
 import { setupFunction } from "./node.js";
 import { Runner } from "./runner.js";
+import { claimFrameForScope } from "./state/stateStack.js";
 import { RESULT_ENTRY_LABEL } from "./state/checkpointStore.js";
 
 export type ResumableScopeOpts = {
@@ -120,6 +121,9 @@ export async function withResumableScope<T>(
   // Push a new frame on the active branch's stack (reads `stack` /
   // `threads` from the ALS frame, same as a generated function body).
   const { stateStack, stack, threads } = setupFunction();
+  // Hand-written claim (generated code claims in its preambles; this
+  // helper is TypeScript and pulls a real frame via setupFunction).
+  claimFrameForScope(stack, opts.name);
 
   if (pin) {
     await ctx.checkpoints.createPinned(stateStack, ctx, {

--- a/packages/agency-lang/lib/runtime/state/checkpointStore.test.ts
+++ b/packages/agency-lang/lib/runtime/state/checkpointStore.test.ts
@@ -15,6 +15,7 @@ function makeStackJSON(frames: Partial<StateJSON>[] = []): StateStackJSON {
       locals: f.locals ?? {},
       threads: f.threads ?? null,
       step: f.step ?? 0,
+      scopeName: f.scopeName ?? null,
       ...(f.branches ? { branches: f.branches } : {}),
     })),
     mode: "serialize",

--- a/packages/agency-lang/lib/runtime/state/schemas.ts
+++ b/packages/agency-lang/lib/runtime/state/schemas.ts
@@ -27,6 +27,9 @@ export const stateJSONSchema = z.object({
   locals: z.record(z.string(), z.any()),
   threads: threadStoreJSONSchema.nullable(),
   step: z.number(),
+  // Accepts absent (external payloads validated pre-tripwire) and
+  // normalizes to null so the parsed shape satisfies StateJSON.
+  scopeName: z.string().nullable().optional().default(null),
   branches: z.record(z.string(), branchStateJSONSchema).optional(),
 });
 

--- a/packages/agency-lang/lib/runtime/state/stateStack.tripwire.test.ts
+++ b/packages/agency-lang/lib/runtime/state/stateStack.tripwire.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { StateStack, claimFrameForScope } from "./stateStack.js";
+
+describe("frame scope-name tripwire", () => {
+  it("stamps an unstamped frame and accepts a matching re-claim", () => {
+    const stack = new StateStack();
+    const frame = stack.getNewState();
+    claimFrameForScope(frame, "myFunc");
+    expect(frame.scopeName).toBe("myFunc");
+    expect(() => claimFrameForScope(frame, "myFunc")).not.toThrow();
+  });
+
+  it("throws a named error when a frame is claimed by a different scope", () => {
+    const stack = new StateStack();
+    const frame = stack.getNewState();
+    claimFrameForScope(frame, "runPrompt");
+    expect(() => claimFrameForScope(frame, "searchTools")).toThrow(
+      /Resume desync.*searchTools.*runPrompt/s,
+    );
+  });
+
+  it("refuses to stamp an empty scope name", () => {
+    // Not a legacy accommodation: guards the next hand-written claim
+    // site whose author forgets a name (Runner defaults scopeName to "",
+    // runner.ts — an empty stamp would collide with the real owner).
+    const stack = new StateStack();
+    const frame = stack.getNewState();
+    claimFrameForScope(frame, "");
+    expect(frame.scopeName).toBeNull();
+  });
+
+  it("scopeName is always serialized and survives a round trip", () => {
+    const stack = new StateStack();
+    const claimed = stack.getNewState();
+    claimFrameForScope(claimed, "myFunc");
+    stack.getNewState(); // second frame, never claimed
+    const json = JSON.parse(JSON.stringify(stack.toJSON()));
+    expect(json.stack[0].scopeName).toBe("myFunc");
+    expect(json.stack[1].scopeName).toBeNull();
+    const restored = StateStack.fromJSON(json);
+    expect(restored.stack[0].scopeName).toBe("myFunc");
+    expect(restored.stack[1].scopeName).toBeNull();
+  });
+
+  it("two Runners on one frame do not conflict, because running is not claiming", () => {
+    // The finalize shape: the container claimed the frame; the finalize
+    // Runner merely runs on it and never calls claimFrameForScope. The
+    // design invariant this pins: only claim sites stamp.
+    const stack = new StateStack();
+    const frame = stack.getNewState();
+    claimFrameForScope(frame, "foo");
+    expect(frame.scopeName).toBe("foo");
+  });
+});

--- a/packages/agency-lang/lib/runtime/state/stateStack.ts
+++ b/packages/agency-lang/lib/runtime/state/stateStack.ts
@@ -6,6 +6,7 @@ import { sendCostTelemetryToParent } from "../costTelemetry.js";
 import { Checkpoint } from "../index.js";
 import { MemoryFrame } from "../memory/frame.js";
 import { deepClone } from "../utils.js";
+import { agencyStore } from "../asyncContext.js";
 import type { GlobalStoreJSON } from "./globalStore.js";
 import { ThreadStoreJSON } from "./threadStore.js";
 
@@ -81,6 +82,15 @@ export class State {
    *  interrupt/resume. Read only by this frame's own catch rung (the
    *  carry-on-abort level rule); no other code walks it. */
   savedDraft?: { value: any };
+  /** The scope that CLAIMED this frame (pulled it from the stack via
+   *  setupFunction/setupNode), stamped by claimFrameForScope at the
+   *  claim sites: generated function/node/block preambles, runPrompt,
+   *  and withResumableScope. Null means never claimed. Claiming and
+   *  RUNNING are different events — a finalize Runner runs on its
+   *  container's frame and must not stamp — so the Runner constructor
+   *  never touches this. Always serialized; a mismatched claim on
+   *  resume replay is state corruption and throws. */
+  scopeName: string | null = null;
 
   constructor(
     opts: {
@@ -222,6 +232,7 @@ export class State {
       locals: deepClone(this.locals),
       threads: this.threads ? deepClone(this.threads) : null,
       step: this.step,
+      scopeName: this.scopeName,
     };
     if (this.scopedCallbacks && this.scopedCallbacks.length > 0) {
       // Pass `fn` through as a reference — the outer serializer (with
@@ -275,6 +286,7 @@ export class State {
       threads: json.threads,
       step: json.step,
     });
+    state.scopeName = json.scopeName ?? null;
     if (json.scopedCallbacks && json.scopedCallbacks.length > 0) {
       state.scopedCallbacks = json.scopedCallbacks.map((cb) => ({
         name: cb.name,
@@ -315,10 +327,43 @@ export type StateJSON = {
   locals: Record<string, any>;
   threads: ThreadStoreJSON | null;
   step: number;
+  scopeName: string | null;
   branches?: Record<string, BranchStateJSON>;
   scopedCallbacks?: Array<{ name: string; fn: any }>;
   savedDraft?: { value: any };
 };
+
+/** Stamp-or-check a frame claim. First claim stamps; a mismatched later
+ *  claim means resume replay handed this frame to the wrong function —
+ *  state corruption, so throw (house precedent: the guard-stack drift
+ *  throw in cloneForBranch below). Claiming and RUNNING are different
+ *  events — finalize Runners run on their container's frame and must
+ *  not stamp — so this is called from frame-claim sites only, never
+ *  the Runner constructor. Empty names never stamp: they mean a claim
+ *  site forgot its name (Runner defaults scopeName to "").
+ *  The statelog emit is not redundant with the throw: throws convert
+ *  to Failures at def boundaries and can be laundered downstream; the
+ *  event is the signal that survives. Best-effort via the ALS pattern
+ *  (no store in bare unit tests means no emit; the throw still fires). */
+export function claimFrameForScope(frame: State, scopeName: string): void {
+  if (!scopeName) return;
+  if (frame.scopeName === null || frame.scopeName === undefined) {
+    frame.scopeName = scopeName;
+    return;
+  }
+  if (frame.scopeName !== scopeName) {
+    const msg =
+      `Resume desync: function "${scopeName}" tried to claim the saved ` +
+      `state of "${frame.scopeName}". This is a compiler/runtime bug — ` +
+      `please report it with the program that produced it.`;
+    agencyStore.getStore()?.ctx?.statelogClient?.error?.({
+      errorType: "runtimeError",
+      message: msg,
+      functionName: scopeName,
+    });
+    throw new Error(msg);
+  }
+}
 
 export type StateStackJSON = {
   stack: StateJSON[];

--- a/packages/agency-lang/lib/runtime/trace/eventLog.test.ts
+++ b/packages/agency-lang/lib/runtime/trace/eventLog.test.ts
@@ -21,7 +21,7 @@ function makeCheckpoint(overrides: Record<string, any> = {}): Checkpoint {
     label: null,
     pinned: false,
     stack: {
-      stack: [{ args: {}, locals: {}, threads: null, step: 0 }],
+      stack: [{ args: {}, locals: {}, threads: null, step: 0, scopeName: null }],
       mode: "serialize" as const,
       other: {},
       deserializeStackLength: 0,
@@ -95,7 +95,7 @@ describe("detectStackChanges", () => {
     const prev = makeCheckpoint({
       stepPath: "1",
       stack: {
-        stack: [{ args: {}, locals: {}, threads: null, step: 1 }],
+        stack: [{ args: {}, locals: {}, threads: null, step: 1, scopeName: null }],
         mode: "serialize",
         other: {},
         deserializeStackLength: 0,
@@ -107,7 +107,7 @@ describe("detectStackChanges", () => {
       stepPath: "0",
       stack: {
         stack: [
-          { args: {}, locals: {}, threads: null, step: 1 },
+          { args: {}, locals: {}, threads: null, step: 1, scopeName: null },
           {
             args: { name: "Alice" },
             locals: { name: "Alice" },
@@ -134,7 +134,7 @@ describe("detectStackChanges", () => {
       stepPath: "2",
       stack: {
         stack: [
-          { args: {}, locals: {}, threads: null, step: 1 },
+          { args: {}, locals: {}, threads: null, step: 1, scopeName: null },
           {
             args: { name: "Alice" },
             locals: { name: "Alice" },
@@ -179,7 +179,7 @@ describe("detectStackChanges", () => {
       stepPath: "2",
       stack: {
         stack: [
-          { args: {}, locals: { x: 1 }, threads: null, step: 1 },
+          { args: {}, locals: { x: 1 }, threads: null, step: 1, scopeName: null },
           {
             args: { name: "Alice" },
             locals: { name: "Alice" },
@@ -198,7 +198,7 @@ describe("detectStackChanges", () => {
       stepPath: "2",
       stack: {
         stack: [
-          { args: {}, locals: { x: 1 }, threads: null, step: 2 },
+          { args: {}, locals: { x: 1 }, threads: null, step: 2, scopeName: null },
         ],
         mode: "serialize",
         other: {},
@@ -216,7 +216,7 @@ describe("detectStackChanges", () => {
     const prev = makeCheckpoint({
       stepPath: "1",
       stack: {
-        stack: [{ args: {}, locals: {}, threads: null, step: 1 }],
+        stack: [{ args: {}, locals: {}, threads: null, step: 1, scopeName: null }],
         mode: "serialize",
         other: {},
         deserializeStackLength: 0,
@@ -228,9 +228,9 @@ describe("detectStackChanges", () => {
       stepPath: "0",
       stack: {
         stack: [
-          { args: {}, locals: {}, threads: null, step: 1 },
-          { args: { a: 1 }, locals: { a: 1 }, threads: null, step: 0 },
-          { args: { b: 2 }, locals: { b: 2 }, threads: null, step: 0 },
+          { args: {}, locals: {}, threads: null, step: 1, scopeName: null },
+          { args: { a: 1 }, locals: { a: 1 }, threads: null, step: 0, scopeName: null },
+          { args: { b: 2 }, locals: { b: 2 }, threads: null, step: 0, scopeName: null },
         ],
         mode: "serialize",
         other: {},
@@ -250,9 +250,9 @@ describe("detectStackChanges", () => {
       stepPath: "1",
       stack: {
         stack: [
-          { args: {}, locals: {}, threads: null, step: 1 },
-          { args: {}, locals: {}, threads: null, step: 1 },
-          { args: {}, locals: {}, threads: null, step: 1 },
+          { args: {}, locals: {}, threads: null, step: 1, scopeName: null },
+          { args: {}, locals: {}, threads: null, step: 1, scopeName: null },
+          { args: {}, locals: {}, threads: null, step: 1, scopeName: null },
         ],
         mode: "serialize",
         other: {},
@@ -265,7 +265,7 @@ describe("detectStackChanges", () => {
       stepPath: "2",
       stack: {
         stack: [
-          { args: {}, locals: {}, threads: null, step: 2 },
+          { args: {}, locals: {}, threads: null, step: 2, scopeName: null },
         ],
         mode: "serialize",
         other: {},
@@ -292,7 +292,7 @@ describe("detectVariableChanges", () => {
     const prev = makeCheckpoint({
       stepPath: "0",
       stack: {
-        stack: [{ args: {}, locals: {}, threads: null, step: 0 }],
+        stack: [{ args: {}, locals: {}, threads: null, step: 0, scopeName: null }],
         mode: "serialize",
         other: {},
         deserializeStackLength: 0,
@@ -303,7 +303,7 @@ describe("detectVariableChanges", () => {
       stepPath: "1",
       stack: {
         stack: [
-          { args: {}, locals: { name: "Alice" }, threads: null, step: 1 },
+          { args: {}, locals: { name: "Alice" }, threads: null, step: 1, scopeName: null },
         ],
         mode: "serialize",
         other: {},
@@ -326,7 +326,7 @@ describe("detectVariableChanges", () => {
     const prev = makeCheckpoint({
       stepPath: "1",
       stack: {
-        stack: [{ args: {}, locals: { x: 1 }, threads: null, step: 1 }],
+        stack: [{ args: {}, locals: { x: 1 }, threads: null, step: 1, scopeName: null }],
         mode: "serialize",
         other: {},
         deserializeStackLength: 0,
@@ -336,7 +336,7 @@ describe("detectVariableChanges", () => {
     const curr = makeCheckpoint({
       stepPath: "2",
       stack: {
-        stack: [{ args: {}, locals: { x: 2 }, threads: null, step: 2 }],
+        stack: [{ args: {}, locals: { x: 2 }, threads: null, step: 2, scopeName: null }],
         mode: "serialize",
         other: {},
         deserializeStackLength: 0,
@@ -385,7 +385,7 @@ describe("detectVariableChanges", () => {
       stepPath: "1",
       stack: {
         stack: [
-          { args: {}, locals: { x: 42, y: "hello" }, threads: null, step: 1 },
+          { args: {}, locals: { x: 42, y: "hello" }, threads: null, step: 1, scopeName: null },
         ],
         mode: "serialize",
         other: {},
@@ -397,7 +397,7 @@ describe("detectVariableChanges", () => {
       stepPath: "2",
       stack: {
         stack: [
-          { args: {}, locals: { x: 42, y: "hello" }, threads: null, step: 2 },
+          { args: {}, locals: { x: 42, y: "hello" }, threads: null, step: 2, scopeName: null },
         ],
         mode: "serialize",
         other: {},
@@ -413,7 +413,7 @@ describe("detectVariableChanges", () => {
     const prev = makeCheckpoint({
       stepPath: "0",
       stack: {
-        stack: [{ args: {}, locals: {}, threads: null, step: 0 }],
+        stack: [{ args: {}, locals: {}, threads: null, step: 0, scopeName: null }],
         mode: "serialize",
         other: {},
         deserializeStackLength: 0,
@@ -846,7 +846,7 @@ describe("detectBranches", () => {
     const prev = makeCheckpoint({
       stepPath: "1",
       stack: {
-        stack: [{ args: {}, locals: {}, threads: null, step: 1 }],
+        stack: [{ args: {}, locals: {}, threads: null, step: 1, scopeName: null }],
         mode: "serialize",
         other: {},
         deserializeStackLength: 0,
@@ -879,7 +879,7 @@ describe("detectBranches", () => {
     const prev = makeCheckpoint({
       stepPath: "1",
       stack: {
-        stack: [{ args: {}, locals: {}, threads: null, step: 1 }],
+        stack: [{ args: {}, locals: {}, threads: null, step: 1, scopeName: null }],
         mode: "serialize",
         other: {},
         deserializeStackLength: 0,
@@ -912,7 +912,7 @@ describe("detectBranches", () => {
     const prev = makeCheckpoint({
       stepPath: "2",
       stack: {
-        stack: [{ args: {}, locals: {}, threads: null, step: 2 }],
+        stack: [{ args: {}, locals: {}, threads: null, step: 2, scopeName: null }],
         mode: "serialize",
         other: {},
         deserializeStackLength: 0,
@@ -976,7 +976,7 @@ describe("generateEventLog", () => {
       stepPath: "1",
       stack: {
         stack: [
-          { args: {}, locals: { x: 42 }, threads: null, step: 1 },
+          { args: {}, locals: { x: 42 }, threads: null, step: 1, scopeName: null },
         ],
         mode: "serialize",
         other: {},

--- a/packages/agency-lang/lib/runtime/trace/traceReader.test.ts
+++ b/packages/agency-lang/lib/runtime/trace/traceReader.test.ts
@@ -35,7 +35,7 @@ describe("TraceReader", () => {
           scopeName: "myNode",
           stepPath: String(i),
           stack: {
-            stack: [{ args: {}, locals: { x: i }, threads: null, step: i }],
+            stack: [{ args: {}, locals: { x: i }, threads: null, step: i, scopeName: null }],
             mode: "serialize",
             other: {},
             deserializeStackLength: 0,
@@ -88,8 +88,9 @@ describe("TraceReader", () => {
             locals: { result: "hello" },
             threads: null,
             step: 3,
+            scopeName: null,
           },
-          { args: {}, locals: {}, threads: null, step: 0 },
+          { args: {}, locals: {}, threads: null, step: 0, scopeName: null },
         ],
         mode: "serialize",
         other: { foo: "bar" },
@@ -242,7 +243,7 @@ describe("TraceReader", () => {
         scopeName: "main",
         stepPath: "0",
         stack: {
-          stack: [{ args: {}, locals: {}, threads: null, step: 0 }],
+          stack: [{ args: {}, locals: {}, threads: null, step: 0, scopeName: null }],
           mode: "serialize",
           other: {},
           deserializeStackLength: 0,

--- a/packages/agency-lang/lib/runtime/trace/traceWriter.test.ts
+++ b/packages/agency-lang/lib/runtime/trace/traceWriter.test.ts
@@ -29,7 +29,7 @@ function makeCheckpoint(
     label: null,
     pinned: false,
     stack: {
-      stack: [{ args: {}, locals: {}, threads: null, step: 0 }],
+      stack: [{ args: {}, locals: {}, threads: null, step: 0, scopeName: null }],
       mode: "serialize",
       other: {},
       deserializeStackLength: 0,
@@ -98,7 +98,7 @@ describe("TraceWriter", () => {
         id: 1,
         stepPath: "1",
         stack: {
-          stack: [{ args: {}, locals: { x: 99 }, threads: null, step: 1 }],
+          stack: [{ args: {}, locals: { x: 99 }, threads: null, step: 1, scopeName: null }],
           mode: "serialize",
           other: {},
           deserializeStackLength: 0,

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/blockSetup.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/blockSetup.mustache
@@ -2,6 +2,9 @@ const __bsetup = setupFunction();
 const __bstack = __bsetup.stack;
 const __self = __bstack.locals;
 const {{{frameVar}}} = __bstack;
+// Claim site: this block just pulled its frame via setupFunction. A
+// mismatched claim on resume replay is a frame desync and throws.
+claimFrameForScope(__bstack, {{{scopeName}}});
 {{#params}}
 __bstack.args[{{{this.paramNameQuoted}}}] = {{{this.paramName}}};
 {{/params}}

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/blockSetup.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/blockSetup.ts
@@ -7,6 +7,9 @@ export const template = `const __bsetup = setupFunction();
 const __bstack = __bsetup.stack;
 const __self = __bstack.locals;
 const {{{frameVar}}} = __bstack;
+// Claim site: this block just pulled its frame via setupFunction. A
+// mismatched claim on resume replay is a frame desync and throws.
+claimFrameForScope(__bstack, {{{scopeName}}});
 {{#params}}
 __bstack.args[{{{this.paramNameQuoted}}}] = {{{this.paramName}}};
 {{/params}}
@@ -38,12 +41,12 @@ __bsetup.stateStack.pop();
 
 export type TemplateType = {
   frameVar: string | boolean | number;
+  scopeName: string | boolean | number;
   params: {
     paramNameQuoted: string | boolean | number;
     paramName: string | boolean | number;
   }[];
   moduleId: string | boolean | number;
-  scopeName: string | boolean | number;
   finalizeDecl: string | boolean | number;
   body: string | boolean | number;
   abortReturn: string | boolean | number;

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/forkBlockSetup.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/forkBlockSetup.mustache
@@ -8,6 +8,9 @@ const __parentForkArgs = __bstack.args;
 const __bstack = __forkBranchStack.getNewState();
 const __self = __bstack.locals;
 const {{{frameVar}}} = __bstack;
+// Claim site: this branch just pulled its frame from the branch stack.
+// A mismatched claim on resume replay is a frame desync and throws.
+claimFrameForScope(__bstack, {{{scopeName}}});
 // `__stateStack` is read from ALS via the `__stateStack()` accessor.
 // The branch ALS frame seeded by `runBatch.runInBranchAlsFrame`
 // (lib/runtime/runBatch.ts) already carries `stack: __forkBranchStack`,

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/forkBlockSetup.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/forkBlockSetup.ts
@@ -13,6 +13,9 @@ const __parentForkArgs = __bstack.args;
 const __bstack = __forkBranchStack.getNewState();
 const __self = __bstack.locals;
 const {{{frameVar}}} = __bstack;
+// Claim site: this branch just pulled its frame from the branch stack.
+// A mismatched claim on resume replay is a frame desync and throws.
+claimFrameForScope(__bstack, {{{scopeName}}});
 // \`__stateStack\` is read from ALS via the \`__stateStack()\` accessor.
 // The branch ALS frame seeded by \`runBatch.runInBranchAlsFrame\`
 // (lib/runtime/runBatch.ts) already carries \`stack: __forkBranchStack\`,
@@ -42,10 +45,10 @@ __forkBranchStack.pop();
 export type TemplateType = {
   isNested: boolean;
   frameVar: string | boolean | number;
+  scopeName: string | boolean | number;
   paramName: string;
   paramNameQuoted: string | boolean | number;
   moduleId: string | boolean | number;
-  scopeName: string | boolean | number;
   body: string | boolean | number;
 };
 

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
@@ -14,7 +14,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,

--- a/packages/agency-lang/tests/agency/hoist/eval-order.agency
+++ b/packages/agency-lang/tests/agency/hoist/eval-order.agency
@@ -1,0 +1,27 @@
+// Pins evaluation order under hoisting: argument order, binary-op
+// order, short-circuit skip (right absent), try operand untouched, and
+// a pattern-binding condition. The order recorded here must be
+// identical with the pass unwired — verified once manually during
+// development; this fixture pins it for CI.
+let order: string[] = []
+
+def mark(tag: string, v: number): number {
+  order = [...order, tag]
+  return v
+}
+
+def add2(a: number, b: number): number {
+  return a + b
+}
+
+node main() {
+  const sum = add2(mark("a", 1), mark("b", 2))
+  const gated = mark("left", 0) > 0 && mark("right", 1) > 0
+  const combo = mark("l1", 1) + mark("l2", 2)
+  const t = try add2(mark("t1", 1), mark("t2", 2))
+  const pv = add2(mark("c", 3), 4)
+  if (pv is number) {
+    order = [...order, "pat"]
+  }
+  return "${order}"
+}

--- a/packages/agency-lang/tests/agency/hoist/eval-order.test.json
+++ b/packages/agency-lang/tests/agency/hoist/eval-order.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"a,b,left,l1,l2,t1,t2,c,pat\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Helper execution order is unchanged by hoisting; the short-circuited right side never runs."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/hoist/failure-through-temp.agency
+++ b/packages/agency-lang/tests/agency/hoist/failure-through-temp.agency
@@ -1,0 +1,18 @@
+// Failure propagation through a hoisted temp: the Failure lands in the
+// temp, and the consuming call's argument-propagation rules apply
+// unchanged (the body is skipped, the failure flows out).
+def failing(): number {
+  return failure("boom")
+}
+
+def wants(n: number): string {
+  return "got ${n}"
+}
+
+node main() {
+  const out = wants(failing())
+  if (out is failure(e)) {
+    return "propagated:${e}"
+  }
+  return "unexpected:${out}"
+}

--- a/packages/agency-lang/tests/agency/hoist/failure-through-temp.test.json
+++ b/packages/agency-lang/tests/agency/hoist/failure-through-temp.test.json
@@ -1,0 +1,10 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"propagated:boom\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/hoist/finalize-no-tripwire.agency
+++ b/packages/agency-lang/tests/agency/hoist/finalize-no-tripwire.agency
@@ -1,0 +1,21 @@
+// Tripwire regression (frame claim/run distinction): a finalize block
+// constructs a SECOND Runner on its container's frame with scopeName
+// "<container>#finalize". Stamping at CLAIM sites (not the Runner
+// constructor) means that reuse must never trip "Resume desync" on the
+// abort path — the salvage path saveDraft depends on.
+def work(): string {
+  const reply = llm("Reply with: pong")
+  return reply
+
+  finalize {
+    return "salvaged"
+  }
+}
+
+node main() {
+  const result = guard(cost: 0.000001) {
+    return work()
+  }
+  if (isFailure(result)) { return "guard-failure" }
+  return result.value
+}

--- a/packages/agency-lang/tests/agency/hoist/finalize-no-tripwire.test.json
+++ b/packages/agency-lang/tests/agency/hoist/finalize-no-tripwire.test.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"salvaged\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "pong" }],
+      "description": "A function-level finalize on the abort path runs on the container frame without tripping the scope-name tripwire.",
+      "interruptHandlers": [{ "action": "reject" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/hoist/loop-body-pause.agency
+++ b/packages/agency-lang/tests/agency/hoist/loop-body-pause.agency
@@ -1,0 +1,23 @@
+// A pause inside a loop body statement that also hoists a helper: the
+// loop machinery clears __substep_/__condbranch_ per iteration but
+// never __hoist_ locals; this pins that interaction end to end.
+effect mytest::step { i: number }
+
+def double(x: number): number {
+  return x * 2
+}
+
+def confirm(i: number): number {
+  const ok = interrupt mytest::step("Go?", { i: i })
+  return i
+}
+
+node main() {
+  let total = 0
+  let i = 0
+  while (i < 3) {
+    total = total + double(confirm(i))
+    i = i + 1
+  }
+  return total
+}

--- a/packages/agency-lang/tests/agency/hoist/loop-body-pause.test.json
+++ b/packages/agency-lang/tests/agency/hoist/loop-body-pause.test.json
@@ -1,0 +1,25 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "6",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "interruptHandlers": [
+        {
+          "action": "approve"
+        },
+        {
+          "action": "approve"
+        },
+        {
+          "action": "approve"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/hoist/nested-arg-interrupt-double.agency
+++ b/packages/agency-lang/tests/agency/hoist/nested-arg-interrupt-double.agency
@@ -1,0 +1,28 @@
+// f(g(x), h(y)) where BOTH arguments raise interrupts: after hoisting
+// they are two sequential temp steps, so the run pauses twice, in
+// left-to-right order, and each helper runs exactly once. The order
+// list pins both properties.
+effect mytest::gtwo { tag: string }
+
+let order: string[] = []
+
+def gLeft(x: number): number {
+  order = [...order, "g"]
+  const ok = interrupt mytest::gtwo("left?", { tag: "g" })
+  return x + 1
+}
+
+def hRight(y: number): number {
+  order = [...order, "h"]
+  const ok = interrupt mytest::gtwo("right?", { tag: "h" })
+  return y + 2
+}
+
+def combine(a: number, b: number): number {
+  return a * 100 + b
+}
+
+node main() {
+  const result = combine(gLeft(1), hRight(3))
+  return "${result}|${order}"
+}

--- a/packages/agency-lang/tests/agency/hoist/nested-arg-interrupt-double.test.json
+++ b/packages/agency-lang/tests/agency/hoist/nested-arg-interrupt-double.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"205|g,h\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "interruptHandlers": [{ "action": "approve" }, { "action": "approve" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/hoist/nested-arg-interrupt.agency
+++ b/packages/agency-lang/tests/agency/hoist/nested-arg-interrupt.agency
@@ -1,0 +1,17 @@
+// The question this answers: f(g(x)) where g raises an interrupt — the
+// hoisted temp step carries the pause, and f still receives the value
+// after resume. Both plain defs, no llm involved.
+effect mytest::gone { x: number }
+
+def gatekeeper(x: number): number {
+  const ok = interrupt mytest::gone("Let it through?", { x: x })
+  return x + 1
+}
+
+def tenfold(a: number): number {
+  return a * 10
+}
+
+node main() {
+  return tenfold(gatekeeper(2))
+}

--- a/packages/agency-lang/tests/agency/hoist/nested-arg-interrupt.test.json
+++ b/packages/agency-lang/tests/agency/hoist/nested-arg-interrupt.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "30",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "interruptHandlers": [{ "action": "approve" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/hoist/resume-regression-args.agency
+++ b/packages/agency-lang/tests/agency/hoist/resume-regression-args.agency
@@ -1,0 +1,22 @@
+// THE flagship regression: the reported bug shape, a helper call in
+// argument position of llm(). Replay of the paused statement used to
+// re-execute myOptions(), which stole the next queued frame; the pass
+// hoists it into a skippable step. Resumes through respondToInterrupts,
+// the same entry point the interactive CLI (run -i) uses, where
+// bisect-a.agency reproduced the original 400.
+effect mytest::greet { name: string }
+
+def greetTool(name: string): string {
+  """Greets a person."""
+  const ok = interrupt mytest::greet("Approve greeting?", { name: name })
+  return "greeted ${name}"
+}
+
+def myOptions(): any {
+  return { tools: [greetTool] }
+}
+
+node main() {
+  const answer = llm("Greet Ada using the tool.", myOptions())
+  return answer
+}

--- a/packages/agency-lang/tests/agency/hoist/resume-regression-args.test.json
+++ b/packages/agency-lang/tests/agency/hoist/resume-regression-args.test.json
@@ -1,0 +1,16 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"done Ada\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "toolCalls": [{ "name": "greetTool", "args": { "name": "Ada" } }] },
+        { "return": "done Ada" }
+      ],
+      "interruptHandlers": [{ "action": "approve" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/hoist/resume-regression-spread.agency
+++ b/packages/agency-lang/tests/agency/hoist/resume-regression-spread.agency
@@ -1,0 +1,18 @@
+// Same regression as resume-regression-args, with the helper call in a
+// spread inside the options literal.
+effect mytest::greet2 { name: string }
+
+def greetTool(name: string): string {
+  """Greets a person."""
+  const ok = interrupt mytest::greet2("Approve greeting?", { name: name })
+  return "greeted ${name}"
+}
+
+def buildTools(): any[] {
+  return [greetTool]
+}
+
+node main() {
+  const answer = llm("Greet Ada using the tool.", { tools: [...buildTools()] })
+  return answer
+}

--- a/packages/agency-lang/tests/agency/hoist/resume-regression-spread.test.json
+++ b/packages/agency-lang/tests/agency/hoist/resume-regression-spread.test.json
@@ -1,0 +1,16 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"done Ada\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "toolCalls": [{ "name": "greetTool", "args": { "name": "Ada" } }] },
+        { "return": "done Ada" }
+      ],
+      "interruptHandlers": [{ "action": "approve" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/hoist/roundtrip-tools.agency
+++ b/packages/agency-lang/tests/agency/hoist/roundtrip-tools.agency
@@ -1,0 +1,27 @@
+// FunctionRef round-trips with the derivation chain in the pausing
+// frame: the hoisted temp holds a partial-bound tool and a renamed tool
+// when the gate pauses. After resume the mock calls the RENAMED tool,
+// which only works if the revived ref kept its rename (PR #653,
+// registeredName).
+effect mytest::gate { x: number }
+
+def add(a: number, b: number): number {
+  """Adds two numbers."""
+  return a + b
+}
+
+def hello(name: string): string {
+  """Says hello."""
+  return "hello ${name}"
+}
+
+def gateTool(x: number): number {
+  """Waits for approval."""
+  const ok = interrupt mytest::gate("Proceed?", { x: x })
+  return x
+}
+
+node main() {
+  const answer = llm("Use the gate, then greet Ada.", { tools: [add.partial(a: 5), hello.rename("greet_tool"), gateTool] })
+  return answer
+}

--- a/packages/agency-lang/tests/agency/hoist/roundtrip-tools.test.json
+++ b/packages/agency-lang/tests/agency/hoist/roundtrip-tools.test.json
@@ -1,0 +1,17 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"hello Ada done\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "toolCalls": [{ "name": "gateTool", "args": { "x": 1 } }] },
+        { "toolCalls": [{ "name": "greet_tool", "args": { "name": "Ada" } }] },
+        { "return": "hello Ada done" }
+      ],
+      "interruptHandlers": [{ "action": "approve" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/hoist/temp-step-pause.agency
+++ b/packages/agency-lang/tests/agency/hoist/temp-step-pause.agency
@@ -1,0 +1,17 @@
+// A pause inside a hoisted temp's OWN step: the helper that builds the
+// llm options raises the interrupt. The temp is an assignment step and
+// must carry the interrupt; `built` pins single execution.
+effect mytest::opts { tag: string }
+
+let built = 0
+
+def needsApproval(): any {
+  const ok = interrupt mytest::opts("Build options?", { tag: "opts" })
+  built = built + 1
+  return {}
+}
+
+node main() {
+  const answer = llm("Say READY.", needsApproval())
+  return "${answer}|${built}"
+}

--- a/packages/agency-lang/tests/agency/hoist/temp-step-pause.test.json
+++ b/packages/agency-lang/tests/agency/hoist/temp-step-pause.test.json
@@ -1,0 +1,13 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"READY|1\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "READY" }],
+      "interruptHandlers": [{ "action": "approve" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/hoist/while-cond-pause.agency
+++ b/packages/agency-lang/tests/agency/hoist/while-cond-pause.agency
@@ -1,0 +1,22 @@
+// A pause INSIDE a while condition, resumed. This is the worst-behaved
+// position pre-pass: Runner.whileLoop awaits the condition before the
+// completed-iteration skip, so a condition call re-ran once per
+// completed iteration on resume. The calls counter pins single
+// execution per iteration.
+effect mytest::tick { i: number }
+
+let calls = 0
+
+def gate(i: number): number {
+  calls = calls + 1
+  const ok = interrupt mytest::tick("Continue?", { i: i })
+  return i
+}
+
+node main() {
+  let i = 0
+  while (gate(i) < 2) {
+    i = i + 1
+  }
+  return "i=${i} calls=${calls}"
+}

--- a/packages/agency-lang/tests/agency/hoist/while-cond-pause.test.json
+++ b/packages/agency-lang/tests/agency/hoist/while-cond-pause.test.json
@@ -1,0 +1,25 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"i=2 calls=3\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "interruptHandlers": [
+        {
+          "action": "approve"
+        },
+        {
+          "action": "approve"
+        },
+        {
+          "action": "approve"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/hoist/while-rewrite-break-continue.agency
+++ b/packages/agency-lang/tests/agency/hoist/while-rewrite-break-continue.agency
@@ -1,0 +1,19 @@
+// A rewritten while whose body carries a user break AND a user
+// continue: the rewrite injects its own break, so two exit paths flow
+// through one construct. continue must land on the hoisted condition
+// re-check at the loop top.
+def below(i: number): boolean {
+  return i < 10
+}
+
+node main() {
+  let i = 0
+  let sum = 0
+  while (below(i)) {
+    i = i + 1
+    if (i == 7) { break }
+    if (i == 2 || i == 4 || i == 6) { continue }
+    sum = sum + i
+  }
+  return "i=${i} sum=${sum}"
+}

--- a/packages/agency-lang/tests/agency/hoist/while-rewrite-break-continue.test.json
+++ b/packages/agency-lang/tests/agency/hoist/while-rewrite-break-continue.test.json
@@ -1,0 +1,10 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"i=7 sum=9\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/hoist/while-rewrite.agency
+++ b/packages/agency-lang/tests/agency/hoist/while-rewrite.agency
@@ -1,0 +1,14 @@
+// The while rewrite at runtime, with a COMPARISON in the condition (a
+// bare boolean call could not distinguish a correct emission from a
+// broken one). Compiles to while(true) + if/else-break.
+def count(i: number): number {
+  return i
+}
+
+node main() {
+  let i = 0
+  while (count(i) < 3) {
+    i = i + 1
+  }
+  return "done ${i}"
+}

--- a/packages/agency-lang/tests/agency/hoist/while-rewrite.test.json
+++ b/packages/agency-lang/tests/agency/hoist/while-rewrite.test.json
@@ -1,0 +1,10 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"done 3\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -189,6 +189,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "assignment.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptBuilder/simple.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/simple.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -189,6 +189,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "simple.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/array.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/array.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -189,6 +189,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "array.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,

--- a/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -189,6 +189,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "assignment.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -187,6 +187,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "compute");
   if (!__globals()!.isInitialized("asyncAssigned.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -352,6 +353,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "asyncAssigned.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -189,6 +189,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "asyncLlm.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -187,6 +187,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "append");
   if (!__globals()!.isInitialized("asyncUnassigned.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -360,6 +361,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "asyncUnassigned.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -187,6 +187,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "process");
   if (!__globals()!.isInitialized("bangParams.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -357,6 +358,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "bangParams.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -187,6 +187,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "process");
   if (!__globals()!.isInitialized("bangReturnType.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -337,6 +338,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "bangReturnType.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -191,6 +191,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "bangValidation.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -187,6 +187,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "twice");
   if (!__globals()!.isInitialized("blockBasic.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -367,6 +368,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "blockBasic.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({
@@ -393,6 +395,9 @@ __stack.locals.results = await __call(twice, {
 const __bstack = __bsetup.stack;
 const __self = __bstack.locals;
 const __bframe___block_0 = __bstack;
+// Claim site: this block just pulled its frame via setupFunction. A
+// mismatched claim on resume replay is a frame desync and throws.
+claimFrameForScope(__bstack, "__block_0");
 
 const runner = new Runner(__ctx, __bstack, { state: __bstack, moduleId: "blockBasic.agency", scopeName: "__block_0" });
 try {

--- a/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -187,6 +187,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "mapItems");
   if (!__globals()!.isInitialized("blockParams.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -385,6 +386,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "blockParams.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({
@@ -414,6 +416,9 @@ __stack.locals.doubled = await __call(mapItems, {
 const __bstack = __bsetup.stack;
 const __self = __bstack.locals;
 const __bframe___block_0 = __bstack;
+// Claim site: this block just pulled its frame via setupFunction. A
+// mismatched claim on resume replay is a frame desync and throws.
+claimFrameForScope(__bstack, "__block_0");
 
 __bstack.args["x"] = x;
 

--- a/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -189,6 +189,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "checkpoint-restore.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/comments.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comments.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -195,6 +195,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "greet");
   if (!__globals()!.isInitialized("comments.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -338,6 +339,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "comments.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -195,6 +195,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "greet");
   if (!__globals()!.isInitialized("defaultValues.agency")) {
     await __initializeGlobals(__ctx)
   }

--- a/packages/agency-lang/tests/typescriptGenerator/destructiveBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/destructiveBlock.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -187,6 +187,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "prep");
   if (!__globals()!.isInitialized("destructiveBlock.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -335,6 +336,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "_doWrite");
   if (!__globals()!.isInitialized("destructiveBlock.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -483,6 +485,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "writeThing");
   if (!__globals()!.isInitialized("destructiveBlock.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -657,6 +660,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "destructiveBlock.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/destructiveNested.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/destructiveNested.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -187,6 +187,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "f");
   if (!__globals()!.isInitialized("destructiveNested.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -329,6 +330,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "destructiveNested.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -190,6 +190,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "add");
   if (!__globals()!.isInitialized("docstrings.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -347,6 +348,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "greet");
   if (!__globals()!.isInitialized("docstrings.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -490,6 +492,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "calculateArea");
   if (!__globals()!.isInitialized("docstrings.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -652,6 +655,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "processData");
   if (!__globals()!.isInitialized("docstrings.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -781,6 +785,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "versionedTool");
   if (!__globals()!.isInitialized("docstrings.agency")) {
     await __initializeGlobals(__ctx)
   }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -191,6 +191,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "euler-0001.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
@@ -211,7 +211,24 @@ await callHook({
       await runner.step(1, async (runner) => {
 __stack.locals.sum = 0;
       });
-      await runner.loop(2, async () => (Array.from({length: 1000 - 1}, (_, __i) => __i + 1)), async (i, _, runner) => {
+      await runner.step(2, async (runner) => {
+__stack.locals.__hoist_0 = await __call(range, {
+          type: "positional",
+          args: [1, 1000]
+        });
+if (hasInterrupts(__stack.locals.__hoist_0)) {
+          await getRuntimeContext().ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __stack.locals.__hoist_0
+          })
+          return;
+        }
+if (isAborted(__stack.locals.__hoist_0)) {
+          throw __stack.locals.__hoist_0.toError()
+        }
+      });
+      await runner.loop(3, async () => (__stack.locals.__hoist_0), async (i, _, runner) => {
 await runner.ifElse(0, [
 
   {
@@ -225,7 +242,7 @@ __stack.locals.sum = __stack.locals.sum + i;
 
 ]);
       });
-      await runner.step(3, async (runner) => {
+      await runner.step(4, async (runner) => {
 runner.halt({
           messages: __threads(),
           data: __stack.locals.sum
@@ -234,7 +251,7 @@ return;
       });
     })
     if (runner.halted) return runner.haltResult;
-    await runner.hook(4, async () => {
+    await runner.hook(5, async () => {
 await callHook({
         name: "onNodeEnd",
         data: {
@@ -299,4 +316,4 @@ Agent crashed: ${__error.message}`)
   }
 }
 export default graph
-export const __sourceMap = {"euler-0001.agency:main":{"1":{"line":4,"col":2},"2":{"line":5,"col":2},"3":{"line":10,"col":2},"2.0.0":{"line":7,"col":6},"2.0":{"line":6,"col":4}}};
+export const __sourceMap = {"euler-0001.agency:main":{"1":{"line":4,"col":2},"2":{"line":5,"col":12},"3":{"line":5,"col":2},"4":{"line":10,"col":2},"3.0.0":{"line":7,"col":6},"3.0":{"line":6,"col":4}}};

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -191,6 +191,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "euler-0002.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -191,6 +191,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "euler-0003.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -189,6 +189,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "isPalindrome");
   if (!__globals()!.isInitialized("euler-0004.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -370,6 +371,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "euler-0004.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
@@ -425,11 +425,23 @@ await callHook({
         })
       });
       await runner.step(1, async (runner) => {
-__functionCompleted = true;
-runner.halt(__stack.args.a / await __call(gcd, {
+__stack.locals.__hoist_0 = await __call(gcd, {
           type: "positional",
           args: [__stack.args.a, __stack.args.b]
-        }) * __stack.args.b)
+        });
+if (hasInterrupts(__stack.locals.__hoist_0)) {
+          await getRuntimeContext().ctx.pendingPromises.awaitAll()
+          runner.halt(__stack.locals.__hoist_0)
+          return;
+        }
+if (isAborted(__stack.locals.__hoist_0)) {
+          runner.halt(__stack.locals.__hoist_0.carryThrough(__stack, "lcm"))
+          return;
+        }
+      });
+      await runner.step(2, async (runner) => {
+__functionCompleted = true;
+runner.halt(__stack.args.a / __stack.locals.__hoist_0 * __stack.args.b)
 return;
       });
     })
@@ -555,7 +567,24 @@ await callHook({
       await runner.step(1, async (runner) => {
 __stack.locals.result = 1;
       });
-      await runner.loop(2, async () => (Array.from({length: 21 - 2}, (_, __i) => __i + 2)), async (i, _, runner) => {
+      await runner.step(2, async (runner) => {
+__stack.locals.__hoist_0 = await __call(range, {
+          type: "positional",
+          args: [2, 21]
+        });
+if (hasInterrupts(__stack.locals.__hoist_0)) {
+          await getRuntimeContext().ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __stack.locals.__hoist_0
+          })
+          return;
+        }
+if (isAborted(__stack.locals.__hoist_0)) {
+          throw __stack.locals.__hoist_0.toError()
+        }
+      });
+      await runner.loop(3, async () => (__stack.locals.__hoist_0), async (i, _, runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.result = await __call(lcm, {
             type: "positional",
@@ -574,7 +603,7 @@ if (isAborted(__stack.locals.result)) {
           }
         });
       });
-      await runner.step(3, async (runner) => {
+      await runner.step(4, async (runner) => {
 runner.halt({
           messages: __threads(),
           data: __stack.locals.result
@@ -583,7 +612,7 @@ return;
       });
     })
     if (runner.halted) return runner.haltResult;
-    await runner.hook(4, async () => {
+    await runner.hook(5, async () => {
 await callHook({
         name: "onNodeEnd",
         data: {
@@ -648,4 +677,4 @@ Agent crashed: ${__error.message}`)
   }
 }
 export default graph
-export const __sourceMap = {"euler-0005.agency:gcd":{"1":{"line":4,"col":2},"2":{"line":5,"col":2},"3":{"line":6,"col":2},"4":{"line":11,"col":2},"3.0":{"line":7,"col":4},"3.1":{"line":8,"col":4},"3.2":{"line":9,"col":4}},"euler-0005.agency:lcm":{"1":{"line":15,"col":2}},"euler-0005.agency:main":{"1":{"line":19,"col":2},"2":{"line":20,"col":2},"3":{"line":23,"col":2},"2.0":{"line":21,"col":4}}};
+export const __sourceMap = {"euler-0005.agency:gcd":{"1":{"line":4,"col":2},"2":{"line":5,"col":2},"3":{"line":6,"col":2},"4":{"line":11,"col":2},"3.0":{"line":7,"col":4},"3.1":{"line":8,"col":4},"3.2":{"line":9,"col":4}},"euler-0005.agency:lcm":{"1":{"line":15,"col":14},"2":{"line":15,"col":2}},"euler-0005.agency:main":{"1":{"line":19,"col":2},"2":{"line":20,"col":12},"3":{"line":20,"col":2},"4":{"line":23,"col":2},"3.0":{"line":21,"col":4}}};

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -189,6 +189,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "gcd");
   if (!__globals()!.isInitialized("euler-0005.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -367,6 +368,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "lcm");
   if (!__globals()!.isInitialized("euler-0005.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -533,6 +535,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "euler-0005.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
@@ -215,7 +215,24 @@ __stack.locals.sumOfSquares = 0;
       await runner.step(2, async (runner) => {
 __stack.locals.sum = 0;
       });
-      await runner.loop(3, async () => (Array.from({length: 101 - 1}, (_, __i) => __i + 1)), async (i, _, runner) => {
+      await runner.step(3, async (runner) => {
+__stack.locals.__hoist_0 = await __call(range, {
+          type: "positional",
+          args: [1, 101]
+        });
+if (hasInterrupts(__stack.locals.__hoist_0)) {
+          await getRuntimeContext().ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __stack.locals.__hoist_0
+          })
+          return;
+        }
+if (isAborted(__stack.locals.__hoist_0)) {
+          throw __stack.locals.__hoist_0.toError()
+        }
+      });
+      await runner.loop(4, async () => (__stack.locals.__hoist_0), async (i, _, runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.sumOfSquares = __stack.locals.sumOfSquares + i * i;
         });
@@ -223,10 +240,10 @@ await runner.step(1, async (runner) => {
 __stack.locals.sum = __stack.locals.sum + i;
         });
       });
-      await runner.step(4, async (runner) => {
+      await runner.step(5, async (runner) => {
 __stack.locals.squareOfSum = __stack.locals.sum * __stack.locals.sum;
       });
-      await runner.step(5, async (runner) => {
+      await runner.step(6, async (runner) => {
 runner.halt({
           messages: __threads(),
           data: __stack.locals.squareOfSum - __stack.locals.sumOfSquares
@@ -235,7 +252,7 @@ return;
       });
     })
     if (runner.halted) return runner.haltResult;
-    await runner.hook(6, async () => {
+    await runner.hook(7, async () => {
 await callHook({
         name: "onNodeEnd",
         data: {
@@ -300,4 +317,4 @@ Agent crashed: ${__error.message}`)
   }
 }
 export default graph
-export const __sourceMap = {"euler-0006.agency:main":{"1":{"line":5,"col":2},"2":{"line":6,"col":2},"3":{"line":7,"col":2},"4":{"line":11,"col":2},"5":{"line":12,"col":2},"3.0":{"line":8,"col":4},"3.1":{"line":9,"col":4}}};
+export const __sourceMap = {"euler-0006.agency:main":{"1":{"line":5,"col":2},"2":{"line":6,"col":2},"3":{"line":7,"col":12},"4":{"line":7,"col":2},"5":{"line":11,"col":2},"6":{"line":12,"col":2},"4.0":{"line":8,"col":4},"4.1":{"line":9,"col":4}}};

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -192,6 +192,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "euler-0006.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
@@ -431,13 +431,27 @@ __stack.locals.num = 1;
 await runner.step(0, async (runner) => {
 __stack.locals.num = __stack.locals.num + 1;
         });
-await runner.ifElse(1, [
+await runner.step(1, async (runner) => {
+__stack.locals.__hoist_0 = await __call(isPrime, {
+            type: "positional",
+            args: [__stack.locals.num]
+          });
+if (hasInterrupts(__stack.locals.__hoist_0)) {
+            await getRuntimeContext().ctx.pendingPromises.awaitAll()
+            runner.halt({
+              ...__state,
+              data: __stack.locals.__hoist_0
+            })
+            return;
+          }
+if (isAborted(__stack.locals.__hoist_0)) {
+            throw __stack.locals.__hoist_0.toError()
+          }
+        });
+await runner.ifElse(2, [
 
   {
-    condition: async () => await __call(isPrime, {
-              type: "positional",
-              args: [__stack.locals.num]
-            }),
+    condition: async () => __stack.locals.__hoist_0,
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.count = __stack.locals.count + 1;
@@ -521,4 +535,4 @@ Agent crashed: ${__error.message}`)
   }
 }
 export default graph
-export const __sourceMap = {"euler-0007.agency:isPrime":{"1":{"line":4,"col":2},"2":{"line":5,"col":2},"3":{"line":6,"col":2},"4":{"line":7,"col":2},"5":{"line":8,"col":2},"6":{"line":12,"col":2},"1.0":{"line":4,"col":15},"2.0":{"line":5,"col":15},"3.0":{"line":6,"col":34},"5.0.0":{"line":9,"col":42},"5.0":{"line":9,"col":4},"5.1":{"line":10,"col":4}},"euler-0007.agency:main":{"1":{"line":16,"col":2},"2":{"line":17,"col":2},"3":{"line":18,"col":2},"4":{"line":24,"col":2},"3.0":{"line":19,"col":4},"3.1.0":{"line":21,"col":6},"3.1":{"line":20,"col":4}}};
+export const __sourceMap = {"euler-0007.agency:isPrime":{"1":{"line":4,"col":2},"2":{"line":5,"col":2},"3":{"line":6,"col":2},"4":{"line":7,"col":2},"5":{"line":8,"col":2},"6":{"line":12,"col":2},"1.0":{"line":4,"col":15},"2.0":{"line":5,"col":15},"3.0":{"line":6,"col":34},"5.0.0":{"line":9,"col":42},"5.0":{"line":9,"col":4},"5.1":{"line":10,"col":4}},"euler-0007.agency:main":{"1":{"line":16,"col":2},"2":{"line":17,"col":2},"3":{"line":18,"col":2},"4":{"line":24,"col":2},"3.0":{"line":19,"col":4},"3.1":{"line":20,"col":8},"3.2.0":{"line":21,"col":6},"3.2":{"line":20,"col":4}}};

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -189,6 +189,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "isPrime");
   if (!__globals()!.isInitialized("euler-0007.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -403,6 +404,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "euler-0007.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
@@ -502,12 +502,26 @@ __stack.locals.j = 0;
         });
 await runner.whileLoop(2, async () => __stack.locals.j < 13, async (runner) => {
 await runner.step(0, async (runner) => {
-__stack.locals.product = __stack.locals.product * await __call(toDigit, {
+__stack.locals.__hoist_0 = await __call(toDigit, {
               type: "positional",
               args: [__nn(__stack.locals.digits[__stack.locals.i + __stack.locals.j])]
             });
+if (hasInterrupts(__stack.locals.__hoist_0)) {
+              await getRuntimeContext().ctx.pendingPromises.awaitAll()
+              runner.halt({
+                ...__state,
+                data: __stack.locals.__hoist_0
+              })
+              return;
+            }
+if (isAborted(__stack.locals.__hoist_0)) {
+              throw __stack.locals.__hoist_0.toError()
+            }
           });
 await runner.step(1, async (runner) => {
+__stack.locals.product = __stack.locals.product * __stack.locals.__hoist_0;
+          });
+await runner.step(2, async (runner) => {
 __stack.locals.j = __stack.locals.j + 1;
           });
         });
@@ -601,4 +615,4 @@ Agent crashed: ${__error.message}`)
   }
 }
 export default graph
-export const __sourceMap = {"euler-0008.agency:toDigit":{"1":{"line":5,"col":2},"2":{"line":6,"col":2},"3":{"line":7,"col":2},"4":{"line":8,"col":2},"5":{"line":9,"col":2},"6":{"line":10,"col":2},"7":{"line":11,"col":2},"8":{"line":12,"col":2},"9":{"line":13,"col":2},"10":{"line":14,"col":2},"1.0":{"line":5,"col":18},"2.0":{"line":6,"col":18},"3.0":{"line":7,"col":18},"4.0":{"line":8,"col":18},"5.0":{"line":9,"col":18},"6.0":{"line":10,"col":18},"7.0":{"line":11,"col":18},"8.0":{"line":12,"col":18},"9.0":{"line":13,"col":18}},"euler-0008.agency:main":{"1":{"line":18,"col":2},"2":{"line":19,"col":2},"3":{"line":20,"col":2},"4":{"line":21,"col":2},"5":{"line":33,"col":2},"4.0":{"line":22,"col":4},"4.1":{"line":23,"col":4},"4.2.0":{"line":25,"col":6},"4.2.1":{"line":26,"col":6},"4.2":{"line":24,"col":4},"4.3.0":{"line":29,"col":6},"4.3":{"line":28,"col":4},"4.4":{"line":31,"col":4}}};
+export const __sourceMap = {"euler-0008.agency:toDigit":{"1":{"line":5,"col":2},"2":{"line":6,"col":2},"3":{"line":7,"col":2},"4":{"line":8,"col":2},"5":{"line":9,"col":2},"6":{"line":10,"col":2},"7":{"line":11,"col":2},"8":{"line":12,"col":2},"9":{"line":13,"col":2},"10":{"line":14,"col":2},"1.0":{"line":5,"col":18},"2.0":{"line":6,"col":18},"3.0":{"line":7,"col":18},"4.0":{"line":8,"col":18},"5.0":{"line":9,"col":18},"6.0":{"line":10,"col":18},"7.0":{"line":11,"col":18},"8.0":{"line":12,"col":18},"9.0":{"line":13,"col":18}},"euler-0008.agency:main":{"1":{"line":18,"col":2},"2":{"line":19,"col":2},"3":{"line":20,"col":2},"4":{"line":21,"col":2},"5":{"line":33,"col":2},"4.0":{"line":22,"col":4},"4.1":{"line":23,"col":4},"4.2.0":{"line":25,"col":26},"4.2.1":{"line":25,"col":6},"4.2.2":{"line":26,"col":6},"4.2":{"line":24,"col":4},"4.3.0":{"line":29,"col":6},"4.3":{"line":28,"col":4},"4.4":{"line":31,"col":4}}};

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -190,6 +190,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "toDigit");
   if (!__globals()!.isInitialized("euler-0008.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -466,6 +467,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "euler-0008.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -191,6 +191,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "euler-0009.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -189,6 +189,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "isPrime");
   if (!__globals()!.isInitialized("euler-0010.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -403,6 +404,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "euler-0010.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
@@ -428,13 +428,27 @@ __stack.locals.sum = 2;
 __stack.locals.n = 3;
       });
       await runner.whileLoop(3, async () => __stack.locals.n < 2000000, async (runner) => {
-await runner.ifElse(0, [
+await runner.step(0, async (runner) => {
+__stack.locals.__hoist_0 = await __call(isPrime, {
+            type: "positional",
+            args: [__stack.locals.n]
+          });
+if (hasInterrupts(__stack.locals.__hoist_0)) {
+            await getRuntimeContext().ctx.pendingPromises.awaitAll()
+            runner.halt({
+              ...__state,
+              data: __stack.locals.__hoist_0
+            })
+            return;
+          }
+if (isAborted(__stack.locals.__hoist_0)) {
+            throw __stack.locals.__hoist_0.toError()
+          }
+        });
+await runner.ifElse(1, [
 
   {
-    condition: async () => await __call(isPrime, {
-              type: "positional",
-              args: [__stack.locals.n]
-            }),
+    condition: async () => __stack.locals.__hoist_0,
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.sum = __stack.locals.sum + __stack.locals.n;
@@ -443,7 +457,7 @@ __stack.locals.sum = __stack.locals.sum + __stack.locals.n;
   },
 
 ]);
-await runner.step(1, async (runner) => {
+await runner.step(2, async (runner) => {
 __stack.locals.n = __stack.locals.n + 2;
         });
       });
@@ -521,4 +535,4 @@ Agent crashed: ${__error.message}`)
   }
 }
 export default graph
-export const __sourceMap = {"euler-0010.agency:isPrime":{"1":{"line":4,"col":2},"2":{"line":5,"col":2},"3":{"line":6,"col":2},"4":{"line":7,"col":2},"5":{"line":8,"col":2},"6":{"line":12,"col":2},"1.0":{"line":4,"col":15},"2.0":{"line":5,"col":15},"3.0":{"line":6,"col":34},"5.0.0":{"line":9,"col":42},"5.0":{"line":9,"col":4},"5.1":{"line":10,"col":4}},"euler-0010.agency:main":{"1":{"line":16,"col":2},"2":{"line":17,"col":2},"3":{"line":18,"col":2},"4":{"line":24,"col":2},"3.0.0":{"line":20,"col":6},"3.0":{"line":19,"col":4},"3.1":{"line":22,"col":4}}};
+export const __sourceMap = {"euler-0010.agency:isPrime":{"1":{"line":4,"col":2},"2":{"line":5,"col":2},"3":{"line":6,"col":2},"4":{"line":7,"col":2},"5":{"line":8,"col":2},"6":{"line":12,"col":2},"1.0":{"line":4,"col":15},"2.0":{"line":5,"col":15},"3.0":{"line":6,"col":34},"5.0.0":{"line":9,"col":42},"5.0":{"line":9,"col":4},"5.1":{"line":10,"col":4}},"euler-0010.agency:main":{"1":{"line":16,"col":2},"2":{"line":17,"col":2},"3":{"line":18,"col":2},"4":{"line":24,"col":2},"3.0":{"line":19,"col":8},"3.1.0":{"line":20,"col":6},"3.1":{"line":19,"col":4},"3.2":{"line":22,"col":4}}};

--- a/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -189,6 +189,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "forLoop.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
@@ -234,7 +234,24 @@ if (isAborted(__funcResult)) {
       await runner.step(4, async (runner) => {
 //  Range-based for loop
       });
-      await runner.loop(5, async () => (Array.from({length: 5 - 0}, (_, __i) => __i + 0)), async (i, _, runner) => {
+      await runner.step(5, async (runner) => {
+__stack.locals.__hoist_0 = await __call(range, {
+          type: "positional",
+          args: [0, 5]
+        });
+if (hasInterrupts(__stack.locals.__hoist_0)) {
+          await getRuntimeContext().ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __stack.locals.__hoist_0
+          })
+          return;
+        }
+if (isAborted(__stack.locals.__hoist_0)) {
+          throw __stack.locals.__hoist_0.toError()
+        }
+      });
+      await runner.loop(6, async () => (__stack.locals.__hoist_0), async (i, _, runner) => {
 await runner.step(0, async (runner) => {
 const __funcResult = await __call(print, {
             type: "positional",
@@ -253,13 +270,13 @@ if (isAborted(__funcResult)) {
           }
         });
       });
-      await runner.step(6, async (runner) => {
+      await runner.step(7, async (runner) => {
 //  Indexed for loop
       });
-      await runner.step(7, async (runner) => {
+      await runner.step(8, async (runner) => {
 __stack.locals.names = [`alice`, `bob`];
       });
-      await runner.loop(8, async () => (__stack.locals.names), async (name, index, runner) => {
+      await runner.loop(9, async () => (__stack.locals.names), async (name, index, runner) => {
 await runner.step(0, async (runner) => {
 const __funcResult = await __call(print, {
             type: "positional",
@@ -297,7 +314,7 @@ if (isAborted(__funcResult)) {
       });
     })
     if (runner.halted) return runner.haltResult;
-    await runner.hook(9, async () => {
+    await runner.hook(10, async () => {
 await callHook({
         name: "onNodeEnd",
         data: {
@@ -362,4 +379,4 @@ Agent crashed: ${__error.message}`)
   }
 }
 export default graph
-export const __sourceMap = {"forLoop.agency:main":{"2":{"line":2,"col":2},"3":{"line":3,"col":2},"5":{"line":8,"col":2},"7":{"line":13,"col":2},"8":{"line":14,"col":2},"3.0":{"line":4,"col":4},"5.0":{"line":9,"col":4},"8.0":{"line":15,"col":4},"8.1":{"line":16,"col":4}}};
+export const __sourceMap = {"forLoop.agency:main":{"2":{"line":2,"col":2},"3":{"line":3,"col":2},"5":{"line":8,"col":12},"6":{"line":8,"col":2},"8":{"line":13,"col":2},"9":{"line":14,"col":2},"3.0":{"line":4,"col":4},"6.0":{"line":9,"col":4},"9.0":{"line":15,"col":4},"9.1":{"line":16,"col":4}}};

--- a/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -187,6 +187,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "add");
   if (!__globals()!.isInitialized("function-with-types.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -369,6 +370,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "greet");
   if (!__globals()!.isInitialized("function-with-types.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -535,6 +537,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "mixed");
   if (!__globals()!.isInitialized("function-with-types.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -714,6 +717,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "processArray");
   if (!__globals()!.isInitialized("function-with-types.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -880,6 +884,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "flexible");
   if (!__globals()!.isInitialized("function-with-types.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -1048,6 +1053,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "foo");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "function-with-types.agency", scopeName: "foo", threads: __setupData.threads });
   try {
     await agencyStore.run({
@@ -1138,6 +1144,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "function-with-types.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function.mjs
@@ -500,12 +500,26 @@ await callHook({
         })
       });
       await runner.step(1, async (runner) => {
+__stack.locals.__hoist_0 = await __call(test, {
+          type: "positional",
+          args: []
+        });
+if (hasInterrupts(__stack.locals.__hoist_0)) {
+          await getRuntimeContext().ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __stack.locals.__hoist_0
+          })
+          return;
+        }
+if (isAborted(__stack.locals.__hoist_0)) {
+          throw __stack.locals.__hoist_0.toError()
+        }
+      });
+      await runner.step(2, async (runner) => {
 const __funcResult = await __call(print, {
           type: "positional",
-          args: [await __call(test, {
-            type: "positional",
-            args: []
-          })]
+          args: [__stack.locals.__hoist_0]
         });
 if (hasInterrupts(__funcResult)) {
           await getRuntimeContext().ctx.pendingPromises.awaitAll()
@@ -521,7 +535,7 @@ if (isAborted(__funcResult)) {
       });
     })
     if (runner.halted) return runner.haltResult;
-    await runner.hook(2, async () => {
+    await runner.hook(3, async () => {
 await callHook({
         name: "onNodeEnd",
         data: {
@@ -586,4 +600,4 @@ Agent crashed: ${__error.message}`)
   }
 }
 export default graph
-export const __sourceMap = {"function.agency:test":{"1":{"line":1,"col":2}},"function.agency:add":{},"function.agency:main":{"1":{"line":9,"col":2}}};
+export const __sourceMap = {"function.agency:test":{"1":{"line":1,"col":2}},"function.agency:add":{},"function.agency:main":{"1":{"line":9,"col":8},"2":{"line":9,"col":2}}};

--- a/packages/agency-lang/tests/typescriptGenerator/function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -187,6 +187,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "test");
   if (!__globals()!.isInitialized("function.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -319,6 +320,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "add");
   if (!__globals()!.isInitialized("function.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -480,6 +482,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "function.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -187,6 +187,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "greet");
   if (!__globals()!.isInitialized("functionRef.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -335,6 +336,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "double");
   if (!__globals()!.isInitialized("functionRef.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -483,6 +485,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "applyToAll");
   if (!__globals()!.isInitialized("functionRef.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -660,6 +663,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "functionRef.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
@@ -395,10 +395,24 @@ if (isAborted(__stack.locals.c)) {
           throw __stack.locals.c.toError()
         }
       });
-      await runner.ifElse(2, [
+      await runner.step(2, async (runner) => {
+__stack.locals.__hoist_0 = await isSuccess(__stack.locals.c);
+if (hasInterrupts(__stack.locals.__hoist_0)) {
+          await getRuntimeContext().ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __stack.locals.__hoist_0
+          })
+          return;
+        }
+if (isAborted(__stack.locals.__hoist_0)) {
+          throw __stack.locals.__hoist_0.toError()
+        }
+      });
+      await runner.ifElse(3, [
 
   {
-    condition: async () => await isSuccess(__stack.locals.c),
+    condition: async () => __stack.locals.__hoist_0,
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 const __funcResult = await __call(print, {
@@ -423,7 +437,7 @@ if (isAborted(__funcResult)) {
 ]);
     })
     if (runner.halted) return runner.haltResult;
-    await runner.hook(3, async () => {
+    await runner.hook(4, async () => {
 await callHook({
         name: "onNodeEnd",
         data: {
@@ -488,4 +502,4 @@ Agent crashed: ${__error.message}`)
   }
 }
 export default graph
-export const __sourceMap = {"genericAliasValidation.agency:process":{"1":{"line":3,"col":2},"2":{"line":4,"col":2}},"genericAliasValidation.agency:main":{"1":{"line":8,"col":2},"2":{"line":9,"col":2},"2.0":{"line":10,"col":4}}};
+export const __sourceMap = {"genericAliasValidation.agency:process":{"1":{"line":3,"col":2},"2":{"line":4,"col":2}},"genericAliasValidation.agency:main":{"1":{"line":8,"col":2},"2":{"line":9,"col":6},"3":{"line":9,"col":2},"3.0":{"line":10,"col":4}}};

--- a/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -188,6 +188,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "process");
   if (!__globals()!.isInitialized("genericAliasValidation.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -358,6 +359,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "genericAliasValidation.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/goto.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/goto.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -189,6 +189,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "foo");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "goto.agency", scopeName: "foo", threads: __setupData.threads });
   try {
     await agencyStore.run({
@@ -272,6 +273,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "goto.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -189,6 +189,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "greet");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "gotoWithArgs.agency", scopeName: "greet", threads: __setupData.threads });
   if (!__state.isResume) {
     __stack.args["name"] = __state.data.name;
@@ -275,6 +276,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "gotoWithArgs.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -190,6 +190,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "greet");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "graph-node-with-types.agency", scopeName: "greet", threads: __setupData.threads });
   if (!__state.isResume) {
     __stack.args["name"] = __state.data.name;

--- a/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -189,6 +189,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "ifElse.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
@@ -224,13 +224,27 @@ __stack.locals.result = `condition was true`;
   },
 
 ]);
-      await runner.ifElse(4, [
+      await runner.step(4, async (runner) => {
+__stack.locals.__hoist_0 = await __call(isReady, {
+          type: "positional",
+          args: []
+        });
+if (hasInterrupts(__stack.locals.__hoist_0)) {
+          await getRuntimeContext().ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __stack.locals.__hoist_0
+          })
+          return;
+        }
+if (isAborted(__stack.locals.__hoist_0)) {
+          throw __stack.locals.__hoist_0.toError()
+        }
+      });
+      await runner.ifElse(5, [
 
   {
-    condition: async () => await __call(isReady, {
-            type: "positional",
-            args: []
-          }),
+    condition: async () => __stack.locals.__hoist_0,
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.status = `ready`;
@@ -239,15 +253,15 @@ __stack.locals.status = `ready`;
   },
 
 ]);
-      await runner.step(5, async (runner) => {
+      await runner.step(6, async (runner) => {
 //  If statement with property access
       });
-      await runner.step(6, async (runner) => {
+      await runner.step(7, async (runner) => {
 __stack.locals.obj = {
           "active": true
         };
       });
-      await runner.ifElse(7, [
+      await runner.ifElse(8, [
 
   {
     condition: async () => __stack.locals.obj.active,
@@ -259,13 +273,13 @@ __stack.locals.message = `object is active`;
   },
 
 ]);
-      await runner.step(8, async (runner) => {
+      await runner.step(9, async (runner) => {
 //  Nested if statements
       });
-      await runner.step(9, async (runner) => {
+      await runner.step(10, async (runner) => {
 __stack.locals.outer = true;
       });
-      await runner.ifElse(10, [
+      await runner.ifElse(11, [
 
   {
     condition: async () => __stack.locals.outer,
@@ -289,7 +303,7 @@ __stack.locals.nested = `both true`;
   },
 
 ]);
-      await runner.step(11, async (runner) => {
+      await runner.step(12, async (runner) => {
 //  TODO fix
 //  If with index access
 //  arr = [1, 2, 3]
@@ -298,10 +312,10 @@ __stack.locals.nested = `both true`;
 //  }
 //  Multiple statements in then body
       });
-      await runner.step(12, async (runner) => {
+      await runner.step(13, async (runner) => {
 __stack.locals.condition = true;
       });
-      await runner.ifElse(13, [
+      await runner.ifElse(14, [
 
   {
     condition: async () => __stack.locals.condition,
@@ -319,13 +333,13 @@ __stack.locals.c = 3;
   },
 
 ]);
-      await runner.step(14, async (runner) => {
+      await runner.step(15, async (runner) => {
 //  Multiple statements in both then and else bodies
       });
-      await runner.step(15, async (runner) => {
+      await runner.step(16, async (runner) => {
 __stack.locals.value = false;
       });
-      await runner.ifElse(16, [
+      await runner.ifElse(17, [
 
   {
     condition: async () => __stack.locals.value,
@@ -340,10 +354,10 @@ __stack.locals.y = 20;
   },
 
 ]);
-      await runner.step(17, async (runner) => {
+      await runner.step(18, async (runner) => {
 //  Basic else
       });
-      await runner.ifElse(18, [
+      await runner.ifElse(19, [
 
   {
     condition: async () => __stack.locals.flag,
@@ -359,10 +373,10 @@ await runner.step(1, async (runner) => {
 __stack.locals.result = `no`;
           });
 });
-      await runner.step(19, async (runner) => {
+      await runner.step(20, async (runner) => {
 //  else if chain
       });
-      await runner.ifElse(20, [
+      await runner.ifElse(21, [
 
   {
     condition: async () => __eq(__stack.locals.a, 1),
@@ -389,7 +403,7 @@ __stack.locals.result = `other`;
 });
     })
     if (runner.halted) return runner.haltResult;
-    await runner.hook(21, async () => {
+    await runner.hook(22, async () => {
 await callHook({
         name: "onNodeEnd",
         data: {
@@ -454,4 +468,4 @@ Agent crashed: ${__error.message}`)
   }
 }
 export default graph
-export const __sourceMap = {"ifElse.agency:main":{"2":{"line":2,"col":2},"3":{"line":3,"col":2},"4":{"line":7,"col":2},"6":{"line":12,"col":2},"7":{"line":15,"col":2},"9":{"line":20,"col":2},"10":{"line":21,"col":2},"12":{"line":35,"col":2},"13":{"line":36,"col":2},"15":{"line":43,"col":2},"16":{"line":44,"col":2},"18":{"line":50,"col":2},"20":{"line":57,"col":2},"3.0":{"line":4,"col":4},"4.0":{"line":8,"col":4},"7.0":{"line":16,"col":4},"10.0":{"line":22,"col":4},"10.1.0":{"line":24,"col":6},"10.1":{"line":23,"col":4},"13.0":{"line":37,"col":4},"13.1":{"line":38,"col":4},"13.2":{"line":39,"col":4},"16.0":{"line":45,"col":4},"16.1":{"line":46,"col":4},"18.0":{"line":51,"col":4},"18.1":{"line":53,"col":4},"20.0":{"line":58,"col":4},"20.1":{"line":60,"col":4},"20.2":{"line":62,"col":4}}};
+export const __sourceMap = {"ifElse.agency:main":{"2":{"line":2,"col":2},"3":{"line":3,"col":2},"4":{"line":7,"col":6},"5":{"line":7,"col":2},"7":{"line":12,"col":2},"8":{"line":15,"col":2},"10":{"line":20,"col":2},"11":{"line":21,"col":2},"13":{"line":35,"col":2},"14":{"line":36,"col":2},"16":{"line":43,"col":2},"17":{"line":44,"col":2},"19":{"line":50,"col":2},"21":{"line":57,"col":2},"3.0":{"line":4,"col":4},"5.0":{"line":8,"col":4},"8.0":{"line":16,"col":4},"11.0":{"line":22,"col":4},"11.1.0":{"line":24,"col":6},"11.1":{"line":23,"col":4},"14.0":{"line":37,"col":4},"14.1":{"line":38,"col":4},"14.2":{"line":39,"col":4},"17.0":{"line":45,"col":4},"17.1":{"line":46,"col":4},"19.0":{"line":51,"col":4},"19.1":{"line":53,"col":4},"21.0":{"line":58,"col":4},"21.1":{"line":60,"col":4},"21.2":{"line":62,"col":4}}};

--- a/packages/agency-lang/tests/typescriptGenerator/imports.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/imports.mjs
@@ -24,7 +24,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -187,6 +187,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "twice");
   if (!__globals()!.isInitialized("inlineBlockBasic.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -367,6 +368,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "inlineBlockBasic.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({
@@ -393,6 +395,9 @@ __stack.locals.results = await __call(twice, {
 const __bstack = __bsetup.stack;
 const __self = __bstack.locals;
 const __bframe___block_0 = __bstack;
+// Claim site: this block just pulled its frame via setupFunction. A
+// mismatched claim on resume replay is a frame desync and throws.
+claimFrameForScope(__bstack, "__block_0");
 
 const runner = new Runner(__ctx, __bstack, { state: __bstack, moduleId: "inlineBlockBasic.agency", scopeName: "__block_0" });
 try {

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -187,6 +187,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "mapItems");
   if (!__globals()!.isInitialized("inlineBlockParams.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -376,6 +377,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "inlineBlockParams.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({
@@ -405,6 +407,9 @@ __stack.locals.doubled = await __call(mapItems, {
 const __bstack = __bsetup.stack;
 const __self = __bstack.locals;
 const __bframe___block_0 = __bstack;
+// Claim site: this block just pulled its frame via setupFunction. A
+// mismatched claim on resume replay is a frame desync and throws.
+claimFrameForScope(__bstack, "__block_0");
 
 __bstack.args["x"] = x;
 

--- a/packages/agency-lang/tests/typescriptGenerator/input.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/input.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -189,6 +189,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "input.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -189,6 +189,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "interpolation.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -187,6 +187,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "greet");
   if (!__globals()!.isInitialized("interrupt-2-deep-in-function.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -389,6 +390,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "foo2");
   if (!__globals()!.isInitialized("interrupt-2-deep-in-function.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -591,6 +593,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "sayHi");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "interrupt-2-deep-in-function.agency", scopeName: "sayHi", threads: __setupData.threads });
   if (!__state.isResume) {
     __stack.args["name"] = __state.data.name;

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -189,6 +189,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "interrupt-assignment.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -187,6 +187,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "greet");
   if (!__globals()!.isInitialized("interrupt-in-node.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -391,6 +392,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "foo2");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "interrupt-in-node.agency", scopeName: "foo2", threads: __setupData.threads });
   if (!__state.isResume) {
     __stack.args["name"] = __state.data.name;
@@ -512,6 +514,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "sayHi");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "interrupt-in-node.agency", scopeName: "sayHi", threads: __setupData.threads });
   if (!__state.isResume) {
     __stack.args["name"] = __state.data.name;

--- a/packages/agency-lang/tests/typescriptGenerator/intersectionTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/intersectionTypes.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -195,6 +195,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "intersectionTypes.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -192,6 +192,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "llmConfigParam.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -189,6 +189,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "matchBlock.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlockBlockArms.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlockBlockArms.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -189,6 +189,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "matchBlockBlockArms.agency", scopeName: "main", threads: __setupData.threads });
   if (!__state.isResume) {
     __stack.args["x"] = __state.data.x;

--- a/packages/agency-lang/tests/typescriptGenerator/matchExpression.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchExpression.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -189,6 +189,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "matchExpression.agency", scopeName: "main", threads: __setupData.threads });
   if (!__state.isResume) {
     __stack.args["x"] = __state.data.x;

--- a/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -190,6 +190,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "greet");
   if (!__globals()!.isInitialized("multiLineComment.agency")) {
     await __initializeGlobals(__ctx)
   }

--- a/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -189,6 +189,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "greet");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "multipleNodes.agency", scopeName: "greet", threads: __setupData.threads });
   try {
     await agencyStore.run({
@@ -288,6 +289,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "processGreeting");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "multipleNodes.agency", scopeName: "processGreeting", threads: __setupData.threads });
   if (!__state.isResume) {
     __stack.args["msg"] = __state.data.msg;
@@ -395,6 +397,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "multipleNodes.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -202,6 +202,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "greet");
   if (!__globals()!.isInitialized("namedArgs.agency")) {
     await __initializeGlobals(__ctx)
   }

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -187,6 +187,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "greet");
   if (!__globals()!.isInitialized("namedArgsReorder.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -363,6 +364,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "namedArgsReorder.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -189,6 +189,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "noResponseFormat.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -189,6 +189,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "objectDescription.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -195,6 +195,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "greet");
   if (!__globals()!.isInitialized("optionalParams.agency")) {
     await __initializeGlobals(__ctx)
   }

--- a/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -187,6 +187,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "double");
   if (!__globals()!.isInitialized("pipe-operator.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -335,6 +336,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "multiply");
   if (!__globals()!.isInitialized("pipe-operator.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -496,6 +498,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "safeDivide");
   if (!__globals()!.isInitialized("pipe-operator.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -673,6 +676,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "pipe-operator.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
@@ -694,16 +694,44 @@ await callHook({
         })
       });
       await runner.step(1, async (runner) => {
-__stack.locals.__pipe_0 = await success(5);
+__stack.locals.__hoist_0 = await success(5);
+if (hasInterrupts(__stack.locals.__hoist_0)) {
+          await getRuntimeContext().ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __stack.locals.__hoist_0
+          })
+          return;
+        }
+if (isAborted(__stack.locals.__hoist_0)) {
+          throw __stack.locals.__hoist_0.toError()
+        }
       });
-      __stack.locals.r1 = await runner.pipe(2, __stack.locals.__pipe_0, async (__pipeArg) => await __call(double, {
+      await runner.step(2, async (runner) => {
+__stack.locals.__pipe_0 = __stack.locals.__hoist_0;
+      });
+      __stack.locals.r1 = await runner.pipe(3, __stack.locals.__pipe_0, async (__pipeArg) => await __call(double, {
         type: "positional",
         args: [__pipeArg]
       }));
-      await runner.step(3, async (runner) => {
-__stack.locals.__pipe_1 = await success(5);
+      await runner.step(4, async (runner) => {
+__stack.locals.__hoist_1 = await success(5);
+if (hasInterrupts(__stack.locals.__hoist_1)) {
+          await getRuntimeContext().ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __stack.locals.__hoist_1
+          })
+          return;
+        }
+if (isAborted(__stack.locals.__hoist_1)) {
+          throw __stack.locals.__hoist_1.toError()
+        }
       });
-      __stack.locals.r2 = await runner.pipe(4, __stack.locals.__pipe_1, async (__pipeArg) => await __call(await __callMethod(multiply, "partial", {
+      await runner.step(5, async (runner) => {
+__stack.locals.__pipe_1 = __stack.locals.__hoist_1;
+      });
+      __stack.locals.r2 = await runner.pipe(6, __stack.locals.__pipe_1, async (__pipeArg) => await __call(await __callMethod(multiply, "partial", {
         type: "named",
         positionalArgs: [],
         namedArgs: {
@@ -713,14 +741,28 @@ __stack.locals.__pipe_1 = await success(5);
         type: "positional",
         args: [__pipeArg]
       }));
-      await runner.step(5, async (runner) => {
-__stack.locals.__pipe_2 = await success(10);
+      await runner.step(7, async (runner) => {
+__stack.locals.__hoist_2 = await success(10);
+if (hasInterrupts(__stack.locals.__hoist_2)) {
+          await getRuntimeContext().ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __stack.locals.__hoist_2
+          })
+          return;
+        }
+if (isAborted(__stack.locals.__hoist_2)) {
+          throw __stack.locals.__hoist_2.toError()
+        }
       });
-      __stack.locals.__pipe_2 = await runner.pipe(6, __stack.locals.__pipe_2, async (__pipeArg) => await __call(double, {
+      await runner.step(8, async (runner) => {
+__stack.locals.__pipe_2 = __stack.locals.__hoist_2;
+      });
+      __stack.locals.__pipe_2 = await runner.pipe(9, __stack.locals.__pipe_2, async (__pipeArg) => await __call(double, {
         type: "positional",
         args: [__pipeArg]
       }));
-      __stack.locals.r3 = await runner.pipe(7, __stack.locals.__pipe_2, async (__pipeArg) => await __call(await __callMethod(multiply, "partial", {
+      __stack.locals.r3 = await runner.pipe(10, __stack.locals.__pipe_2, async (__pipeArg) => await __call(await __callMethod(multiply, "partial", {
         type: "named",
         positionalArgs: [],
         namedArgs: {
@@ -730,17 +772,45 @@ __stack.locals.__pipe_2 = await success(10);
         type: "positional",
         args: [__pipeArg]
       }));
-      await runner.step(8, async (runner) => {
-__stack.locals.__pipe_3 = await failure(`nope`);
+      await runner.step(11, async (runner) => {
+__stack.locals.__hoist_3 = await failure(`nope`);
+if (hasInterrupts(__stack.locals.__hoist_3)) {
+          await getRuntimeContext().ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __stack.locals.__hoist_3
+          })
+          return;
+        }
+if (isAborted(__stack.locals.__hoist_3)) {
+          throw __stack.locals.__hoist_3.toError()
+        }
       });
-      __stack.locals.r4 = await runner.pipe(9, __stack.locals.__pipe_3, async (__pipeArg) => await __call(double, {
+      await runner.step(12, async (runner) => {
+__stack.locals.__pipe_3 = __stack.locals.__hoist_3;
+      });
+      __stack.locals.r4 = await runner.pipe(13, __stack.locals.__pipe_3, async (__pipeArg) => await __call(double, {
         type: "positional",
         args: [__pipeArg]
       }));
-      await runner.step(10, async (runner) => {
-__stack.locals.__pipe_4 = await success(10);
+      await runner.step(14, async (runner) => {
+__stack.locals.__hoist_4 = await success(10);
+if (hasInterrupts(__stack.locals.__hoist_4)) {
+          await getRuntimeContext().ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __stack.locals.__hoist_4
+          })
+          return;
+        }
+if (isAborted(__stack.locals.__hoist_4)) {
+          throw __stack.locals.__hoist_4.toError()
+        }
       });
-      __stack.locals.r5 = await runner.pipe(11, __stack.locals.__pipe_4, async (__pipeArg) => await __call(await __callMethod(safeDivide, "partial", {
+      await runner.step(15, async (runner) => {
+__stack.locals.__pipe_4 = __stack.locals.__hoist_4;
+      });
+      __stack.locals.r5 = await runner.pipe(16, __stack.locals.__pipe_4, async (__pipeArg) => await __call(await __callMethod(safeDivide, "partial", {
         type: "named",
         positionalArgs: [],
         namedArgs: {
@@ -752,7 +822,7 @@ __stack.locals.__pipe_4 = await success(10);
       }));
     })
     if (runner.halted) return runner.haltResult;
-    await runner.hook(12, async () => {
+    await runner.hook(17, async () => {
 await callHook({
         name: "onNodeEnd",
         data: {
@@ -817,4 +887,4 @@ Agent crashed: ${__error.message}`)
   }
 }
 export default graph
-export const __sourceMap = {"pipe-operator.agency:double":{"1":{"line":1,"col":2}},"pipe-operator.agency:multiply":{"1":{"line":5,"col":2}},"pipe-operator.agency:safeDivide":{"1":{"line":9,"col":2},"2":{"line":12,"col":2},"1.0":{"line":10,"col":4}},"pipe-operator.agency:main":{"1":{"line":16,"col":2},"2":{"line":16,"col":2},"3":{"line":17,"col":2},"4":{"line":17,"col":2},"5":{"line":18,"col":2},"6":{"line":18,"col":2},"7":{"line":18,"col":2},"8":{"line":19,"col":2},"9":{"line":19,"col":2},"10":{"line":20,"col":2},"11":{"line":20,"col":2}}};
+export const __sourceMap = {"pipe-operator.agency:double":{"1":{"line":1,"col":2}},"pipe-operator.agency:multiply":{"1":{"line":5,"col":2}},"pipe-operator.agency:safeDivide":{"1":{"line":9,"col":2},"2":{"line":12,"col":2},"1.0":{"line":10,"col":4}},"pipe-operator.agency:main":{"1":{"line":16,"col":11},"2":{"line":16,"col":2},"3":{"line":16,"col":2},"4":{"line":17,"col":11},"5":{"line":17,"col":2},"6":{"line":17,"col":2},"7":{"line":18,"col":11},"8":{"line":18,"col":2},"9":{"line":18,"col":2},"10":{"line":18,"col":2},"11":{"line":19,"col":11},"12":{"line":19,"col":2},"13":{"line":19,"col":2},"14":{"line":20,"col":11},"15":{"line":20,"col":2},"16":{"line":20,"col":2}}};

--- a/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -190,6 +190,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "recordIndex.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/recursiveTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recursiveTypes.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -203,6 +203,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "recursiveTypes.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({
@@ -282,6 +283,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "llmTree");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "recursiveTypes.agency", scopeName: "llmTree", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -187,6 +187,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "checkAge");
   if (!__globals()!.isInitialized("result-basic.agency")) {
     await __initializeGlobals(__ctx)
   }

--- a/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -187,6 +187,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "checkValue");
   if (!__globals()!.isInitialized("result-guards.agency")) {
     await __initializeGlobals(__ctx)
   }

--- a/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
@@ -237,10 +237,22 @@ await callHook({
           }
         })
       });
-      await runner.ifElse(1, [
+      await runner.step(1, async (runner) => {
+__stack.locals.__hoist_0 = await isSuccess(__stack.args.r);
+if (hasInterrupts(__stack.locals.__hoist_0)) {
+          await getRuntimeContext().ctx.pendingPromises.awaitAll()
+          runner.halt(__stack.locals.__hoist_0)
+          return;
+        }
+if (isAborted(__stack.locals.__hoist_0)) {
+          runner.halt(__stack.locals.__hoist_0.carryThrough(__stack, "checkValue"))
+          return;
+        }
+      });
+      await runner.ifElse(2, [
 
   {
-    condition: async () => await isSuccess(__stack.args.r),
+    condition: async () => __stack.locals.__hoist_0,
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __functionCompleted = true;
@@ -251,7 +263,7 @@ return;
   },
 
 ]);
-      await runner.step(2, async (runner) => {
+      await runner.step(3, async (runner) => {
 __functionCompleted = true;
 runner.halt(`error`)
 return;
@@ -343,4 +355,4 @@ export const checkValue = __AgencyFunction.create({
   exported: false
 }, __toolRegistry);
 export default graph
-export const __sourceMap = {"result-guards.agency:checkValue":{"1":{"line":1,"col":2},"2":{"line":4,"col":2},"1.0":{"line":2,"col":4}}};
+export const __sourceMap = {"result-guards.agency:checkValue":{"1":{"line":1,"col":6},"2":{"line":1,"col":2},"3":{"line":4,"col":2},"2.0":{"line":2,"col":4}}};

--- a/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -189,6 +189,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "returnValue.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -189,6 +189,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "rewindCheckpoint.agency", scopeName: "main", threads: __setupData.threads });
   if (!__state.isResume) {
     __stack.args["message"] = __state.data.message;

--- a/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -191,6 +191,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "schemaAccess.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/schemaChaining.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaChaining.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -189,6 +189,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "schemaChaining.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -192,6 +192,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "parseValue");
   if (!__globals()!.isInitialized("schemaParamInjection.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -356,6 +357,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "wrapper");
   if (!__globals()!.isInitialized("schemaParamInjection.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -501,6 +503,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "schemaParamInjection.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
@@ -10,7 +10,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -196,6 +196,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "setLLMClient.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/simple.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/simple.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -189,6 +189,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "simple.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/skill.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/skill.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -189,6 +189,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "analyzeData");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "skill.agency", scopeName: "analyzeData", threads: __setupData.threads });
   if (!__state.isResume) {
     __stack.args["input"] = __state.data.input;

--- a/packages/agency-lang/tests/typescriptGenerator/slice.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/slice.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -189,6 +189,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "slice.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -189,6 +189,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "sliceAssign.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -187,6 +187,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "greet");
   if (!__globals()!.isInitialized("sourceMap.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -355,6 +356,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "sourceMap.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/splat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/splat.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,

--- a/packages/agency-lang/tests/typescriptGenerator/static.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/static.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -209,6 +209,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "static.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -189,6 +189,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "foo");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "streaming.agency", scopeName: "foo", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -189,6 +189,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "string-interpolation.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -189,6 +189,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "foo");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "stringConcat.agency", scopeName: "foo", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -187,6 +187,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "foo");
   if (!__globals()!.isInitialized("threadsAndSubthreads.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -508,6 +509,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "threadsAndSubthreads.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/type-patterns.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/type-patterns.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -189,6 +189,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "describe");
   if (!__globals()!.isInitialized("type-patterns.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -461,6 +462,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "type-patterns.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/type-patterns.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/type-patterns.mjs
@@ -480,12 +480,26 @@ await callHook({
         })
       });
       await runner.step(1, async (runner) => {
+__stack.locals.__hoist_0 = await __call(describe, {
+          type: "positional",
+          args: [`hi`]
+        });
+if (hasInterrupts(__stack.locals.__hoist_0)) {
+          await getRuntimeContext().ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __stack.locals.__hoist_0
+          })
+          return;
+        }
+if (isAborted(__stack.locals.__hoist_0)) {
+          throw __stack.locals.__hoist_0.toError()
+        }
+      });
+      await runner.step(2, async (runner) => {
 const __funcResult = await __call(print, {
           type: "positional",
-          args: [await __call(describe, {
-            type: "positional",
-            args: [`hi`]
-          })]
+          args: [__stack.locals.__hoist_0]
         });
 if (hasInterrupts(__funcResult)) {
           await getRuntimeContext().ctx.pendingPromises.awaitAll()
@@ -501,7 +515,7 @@ if (isAborted(__funcResult)) {
       });
     })
     if (runner.halted) return runner.haltResult;
-    await runner.hook(2, async () => {
+    await runner.hook(3, async () => {
 await callHook({
         name: "onNodeEnd",
         data: {
@@ -566,4 +580,4 @@ Agent crashed: ${__error.message}`)
   }
 }
 export default graph
-export const __sourceMap = {"type-patterns.agency:describe":{"1":{"line":6,"col":2},"2":{"line":9,"col":2},"3":{"line":12,"col":2},"4":{"line":15,"col":9},"5":{"line":15,"col":9},"6":{"line":15,"col":2},"1.0":{"line":7,"col":4},"2.0":{"line":10,"col":4},"3.0":{"line":13,"col":4},"5.2":{"line":15,"col":9},"5.5":{"line":15,"col":9},"5.8":{"line":15,"col":9}},"type-patterns.agency:main":{"1":{"line":25,"col":2}}};
+export const __sourceMap = {"type-patterns.agency:describe":{"1":{"line":6,"col":2},"2":{"line":9,"col":2},"3":{"line":12,"col":2},"4":{"line":15,"col":9},"5":{"line":15,"col":9},"6":{"line":15,"col":2},"1.0":{"line":7,"col":4},"2.0":{"line":10,"col":4},"3.0":{"line":13,"col":4},"5.2":{"line":15,"col":9},"5.5":{"line":15,"col":9},"5.8":{"line":15,"col":9}},"type-patterns.agency:main":{"1":{"line":25,"col":8},"2":{"line":25,"col":2}}};

--- a/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -189,6 +189,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "typeHints.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/typeOperators.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeOperators.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -195,6 +195,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "typeOperators.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -191,6 +191,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "exportedTypeAlias.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -189,6 +189,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "literal.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -193,6 +193,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "nestedTypeAlias.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -191,6 +191,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "typeAlias.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -189,6 +189,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "unitLiterals.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/utilityTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/utilityTypes.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -193,6 +193,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "patch");
   if (!__globals()!.isInitialized("utilityTypes.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -343,6 +344,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "utilityTypes.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({
@@ -430,6 +432,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "llmPatch");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "utilityTypes.agency", scopeName: "llmPatch", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -189,6 +189,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "valueAccessInterpolation.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -189,6 +189,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "varTypes.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -191,6 +191,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "log");
   if (!__globals()!.isInitialized("variadic.agency")) {
     await __initializeGlobals(__ctx)
   }

--- a/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -187,6 +187,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "foo");
   if (!__globals()!.isInitialized("withModifier.agency")) {
     await __initializeGlobals(__ctx)
   }
@@ -359,6 +360,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "withModifier.agency", scopeName: "main", threads: __setupData.threads });
   try {
     await agencyStore.run({

--- a/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
@@ -9,7 +9,7 @@ import os from "os";
 import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
-  setupNode, setupFunction, runNode, runPrompt, callHook,
+  setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
@@ -189,6 +189,7 @@ const __self = __setupData.self;
 const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
+  claimFrameForScope(__stack, "main");
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "withParam.agency", scopeName: "main", threads: __setupData.threads });
   if (!__state.isResume) {
     __stack.args["input"] = __state.data.input;


### PR DESCRIPTION
Fixes the in-process resume frame desync: interactively approving a tool interrupt could corrupt the resume and end in `400 No tool output found for function call` (reproduced with `bisect-a.agency` under `run -i`).

## The bug

Resume replay hands saved frames to functions positionally (`StateStack.getNewState()` in deserialize mode is a bare `shift()`). The statement in progress at a pause re-runs its whole body, including helper calls that had already completed and were therefore not in the checkpoint — `llm(msg, llmOptions(...))` re-ran `llmOptions()`. Each such re-run consumed a saved frame belonging to a still-live function. The victim (`runPrompt` in the reported case) then got a blank frame, restarted from its first request, and sent a thread that still ended with an unanswered tool call. The test suite never saw it because tests pass tools as literals (`tools: [myTool]`), while every stdlib agent uses the helper-call shape.

## The fix, two independent halves

**1. The `hoistCalls` preprocessor pass** (`lib/preprocessors/hoistCalls.ts`): every helper call in an unconditionally-evaluated position becomes its own `const __hoist_N = ...` statement. Statements are steps, step results serialize on `__stack.locals`, so on resume the helper's completed step is skipped and its value read back — it never re-runs and the frame queue stays aligned. Zero builder changes: a new statement is automatically a new step.

Position rulings are data (a table the traversal consults), statement recursion rides `bodySlots`/house walkers, and everything copies (no AST mutation). Highlights:
- `while` conditions with calls rewrite to `while (true) { temps; if (cond) { body } else { break } }` — the worst pre-pass position, since `Runner.whileLoop` re-evaluated the condition once per completed iteration on resume.
- Opaque boundaries: `try` operands and `catch` expressions (thunk boundaries), short-circuit right sides and if-expression branches (conditional), pipe stages (already memoized + failure-gated; the pipe input hoists), `with`-modified statements, handler bodies (plain JS, cannot pause), module-level initializers (init-topsort).
- Lifted blocks (comprehensions, fork branches) hoist within, never across; temp counters are per frame-owning scope because frame locals are flat.
- One accepted relaxation: `for (x in async getItems())` now compiles (the async call hoists above the loop), where `validateNoAsyncInLoops` used to reject it. Recorded in `docs/dev/hoist-calls.md`.

**2. The scope-name tripwire** (runtime + codegen): frames are stamped with their owner at CLAIM time — generated function/node/block preambles plus hand-written claims in `runPrompt` and `withResumableScope` — and a mismatched claim on replay throws `Resume desync: function "X" tried to claim the saved state of "Y"` plus a statelog event (throws convert to Failures at def boundaries and can be laundered; the event survives). Claiming and running are distinct events by design: `finalize` closures build a second Runner on their container's frame and must not stamp, which is why the check does NOT live in the Runner constructor. Residual shapes the pass cannot cover (calls nested inside conditional positions, mid-chain method calls) now fail loudly instead of silently.

## Verified both directions

With the pass unwired (one-time manual check): the flagship regression fixture fails with exactly the predicted theft —

```
Resume desync: function "myOptions" tried to claim the saved state of "runPrompt".
```

— and the eval-order fixture prints the identical sequence wired and unwired (the neutrality evidence). With the pass wired, all fixtures pass. A permanent unit test pins that the flagship fixture's llm options argument really is a hoisted temp, so the fixture cannot silently stop exercising the bug.

## Tests

- 23 unit tests on the pass (positions, boundaries, ordering, per-scope numbering, idempotency, purity, the fixture shape pin) + 5 on the tripwire + 3 pinning claim emission in generated code (including "finalize closures do NOT claim").
- 11 agency execution fixtures under `tests/agency/hoist/`: both resume-regression shapes (argument-position and spread), eval-order neutrality (short-circuit skip included), while rewrite at runtime with a comparison condition, user break/continue inside a rewritten while, a pause inside a while condition (single-execution-per-iteration pinned), a pause inside a hoisted temp's own step, failure propagation through a temp, FunctionRef round-trips with `.partial()` + `.rename()` tools live in the pausing frame (depends on #653, already merged), a pause inside a loop body, and finalize-no-tripwire.
- Full unit suite: 9064 passed, 0 failed. `lint:structure` clean.

## Commit structure

Mechanical fixture regenerations are isolated in their own commits (one for the claim emission, one for the pass's statement shapes) so the code commits stay readable. Note the fixture suite string-compares generated output and never executes it; the execution fixtures and CI agency suite are the real gates.

Spec: `docs/superpowers/specs/2026-07-22-hoist-calls-resume-safety-design.md` (in the repo root docs, untracked). Docs added: `docs/dev/hoist-calls.md` + a paragraph in `docs/dev/interrupts.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
