### PR TITLE
saveDraft intrinsic survives .rename() via registeredName

### DIFF
--- a/packages/agency-lang/lib/runtime/intrinsicTools.ts
+++ b/packages/agency-lang/lib/runtime/intrinsicTools.ts
@@ -32,8 +32,10 @@ export type IntrinsicTool = {
    *  never object identity — the prelude auto-import means modules
    *  hold their own wrapper objects). */
   matches: (fn: AgencyFunction) => boolean;
-  /** The provider-facing definition, replacing the def's own. */
-  buildDefinition: (ctx: { draftSchema: unknown }) => ToolDefinition;
+  /** The provider-facing definition, replacing the def's own. Receives
+   *  the matched function so a renamed tool advertises its renamed
+   *  name — the name the model calls and dispatch matches against. */
+  buildDefinition: (ctx: { draftSchema: unknown; fn: AgencyFunction }) => ToolDefinition;
   /** Handle one call; the return value is the tool-result text.
    *  Contract note: EVERY call must produce a tool-result message
    *  (providers reject a tool_use with no result), and for now that

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -941,7 +941,7 @@ export async function runPrompt(args: {
     .filter((fn) => fn.toolDefinition)
     .map(
       (fn) =>
-        findIntrinsic(fn)?.buildDefinition({ draftSchema: args.draftSchema }) ??
+        findIntrinsic(fn)?.buildDefinition({ draftSchema: args.draftSchema, fn }) ??
         fn.toolDefinition!,
     );
   // Pre-flight: reject duplicate tool names before they reach the provider,

--- a/packages/agency-lang/lib/runtime/saveDraftTool.test.ts
+++ b/packages/agency-lang/lib/runtime/saveDraftTool.test.ts
@@ -49,11 +49,22 @@ describe("saveDraft intrinsic — recognition", () => {
   it("a stdlib function with another name is NOT recognized", () => {
     expect(findIntrinsic(fakeFn("finalize", "stdlib/index.agency"))).toBeUndefined();
   });
+
+  it("a renamed stdlib saveDraft IS recognized — registeredName survives .rename() (#654)", () => {
+    const renamed = fakeFn("saveDraft", "stdlib/index.agency").rename("save_progress");
+    expect(findIntrinsic(renamed)).toBe(saveDraftIntrinsic);
+  });
+
+  it("a renamed tool advertises its renamed name, so dispatch and the model agree", () => {
+    const renamed = fakeFn("saveDraft", "stdlib/index.agency").rename("save_progress");
+    const def = saveDraftIntrinsic.buildDefinition({ draftSchema: undefined, fn: renamed });
+    expect(def.name).toBe("save_progress");
+  });
 });
 
 describe("saveDraft intrinsic — synthesized definition", () => {
   it("declares exactly one required value param from the threaded schema", () => {
-    const def = saveDraftIntrinsic.buildDefinition({ draftSchema: z.number() });
+    const def = saveDraftIntrinsic.buildDefinition({ draftSchema: z.number(), fn: fakeFn("saveDraft", "stdlib/index.agency") });
     expect(def.name).toBe("saveDraft");
     expect(def.description).toMatch(/best-so-far/);
     const schema = def.schema as z.ZodObject<any>;
@@ -63,7 +74,7 @@ describe("saveDraft intrinsic — synthesized definition", () => {
   });
 
   it("falls back to string when no schema was threaded", () => {
-    const def = saveDraftIntrinsic.buildDefinition({ draftSchema: undefined });
+    const def = saveDraftIntrinsic.buildDefinition({ draftSchema: undefined, fn: fakeFn("saveDraft", "stdlib/index.agency") });
     const schema = def.schema as z.ZodObject<any>;
     expect(schema.shape.value.safeParse("x").success).toBe(true);
     expect(schema.shape.value.safeParse(3).success).toBe(false);

--- a/packages/agency-lang/lib/runtime/saveDraftTool.ts
+++ b/packages/agency-lang/lib/runtime/saveDraftTool.ts
@@ -35,17 +35,20 @@ export function draftCharCount(value: unknown): number {
   }
 }
 
-/** `saveDraft` passed as a tool. Aliases (`const s = saveDraft`) keep
- *  both identity fields, so they recognize; a user's own def named
- *  saveDraft carries its own module id, so it runs as an ordinary
- *  tool. A `.rename()`d stdlib saveDraft changes the name and is NOT
- *  recognized — it falls through to the def path, whose draft files
- *  on the tool branch and is discarded (documented limitation). */
+/** `saveDraft` passed as a tool. Recognition is by `registeredName`
+ *  (the registry key `.rename()` preserves, #653) plus the stdlib
+ *  module id: aliases (`const s = saveDraft`), `.rename()`d copies,
+ *  and derived forms all recognize, while a user's own def named
+ *  saveDraft carries its own module id and runs as an ordinary tool.
+ *  The synthesized definition advertises `fn.name` — the renamed name
+ *  when there is one — because that is what the model calls and what
+ *  tool-call dispatch matches against (#654). */
 export const saveDraftIntrinsic: IntrinsicTool = {
-  matches: (fn) => fn.name === "saveDraft" && fn.module === STDLIB_INDEX_MODULE,
+  matches: (fn) =>
+    fn.registeredName === "saveDraft" && fn.module === STDLIB_INDEX_MODULE,
 
-  buildDefinition: ({ draftSchema }) => ({
-    name: "saveDraft",
+  buildDefinition: ({ draftSchema, fn }) => ({
+    name: fn.name,
     description: DESCRIPTION,
     schema: z.object({ value: (draftSchema as z.ZodTypeAny) ?? z.string() }),
   }),
@@ -54,7 +57,7 @@ export const saveDraftIntrinsic: IntrinsicTool = {
     const callArgs = toolCall.arguments ?? {};
     // Own-property check: the args object comes from the model.
     if (!Object.prototype.hasOwnProperty.call(callArgs, "value")) {
-      return 'Error: saveDraft requires a "value" argument. Nothing was saved.';
+      return `Error: ${toolCall.name} requires a "value" argument. Nothing was saved.`;
     }
     const value = callArgs.value;
     // Save FIRST, validate second. The schema is a best-effort hint

--- a/packages/agency-lang/tests/agency/guards/savedraft-tool-renamed.agency
+++ b/packages/agency-lang/tests/agency/guards/savedraft-tool-renamed.agency
@@ -1,0 +1,13 @@
+// A renamed stdlib saveDraft keeps intrinsic semantics (#654):
+// recognition is by registeredName, which .rename() preserves, and the
+// synthesized tool definition advertises the renamed name — so the
+// model calls save_progress, dispatch matches it, and the draft still
+// lands on the CALLER frame where the guard salvage reads it.
+node main() {
+  const s = saveDraft.rename("save_progress")
+  const result = guard(cost: 0.000001) {
+    return llm("work", tools: [s])
+  }
+  if (isFailure(result)) { return "no-draft" }
+  return result.value
+}

--- a/packages/agency-lang/tests/agency/guards/savedraft-tool-renamed.test.json
+++ b/packages/agency-lang/tests/agency/guards/savedraft-tool-renamed.test.json
@@ -1,0 +1,17 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"model-draft\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "toolCalls": [{ "name": "save_progress", "args": { "value": "model-draft" } }] },
+        { "return": "never-reached" }
+      ],
+      "description": "A renamed saveDraft still intercepts as the intrinsic; the draft files on the caller frame and the guard salvages it.",
+      "interruptHandlers": [{ "action": "reject" }]
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #654.

`saveDraftIntrinsic.matches` compared `fn.name === "saveDraft"`, so a `.rename()`d stdlib saveDraft fell through to the ordinary def path, whose draft files on the tool branch and is discarded — a documented limitation until #653 added `registeredName` (the registry key `.rename()` preserves).

Three small changes:
- `matches` keys on `registeredName` + the stdlib module id, so aliases, `.partial()` forms, and renamed copies all recognize, while a user def named saveDraft is still excluded by module.
- `buildDefinition` receives the matched function and advertises `fn.name` — the renamed name is what the model calls and what tool-call dispatch matches against, so the two now agree (the `IntrinsicTool` contract gains `fn` in the ctx; `prompt.ts` passes it).
- The missing-value error message names `toolCall.name` instead of hardcoding saveDraft.

Tests: two new unit tests (renamed copy recognized; synthesized definition carries the renamed name), the two existing `buildDefinition` tests updated for the widened ctx, and a new execution fixture `savedraft-tool-renamed` mirroring the alias fixture — the mock calls `save_progress` and the guard salvages the draft from the caller frame. Alias and usershadow fixtures still pass; full `lib/runtime` unit suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
