### PR TITLE
Repair abandoned dangling tool calls on thread reopen

### DIFF
--- a/packages/agency-lang/docs/dev/checkpointing.md
+++ b/packages/agency-lang/docs/dev/checkpointing.md
@@ -108,6 +108,11 @@ This allows injecting messages into the restored state, useful for providing con
 
 The fact that shared variables persist across restores is what makes retry loops work — a shared counter can track how many times a checkpoint has been restored even though local variables reset.
 
+A checkpoint whose thread has since been repaired (see "Reopen repair" in
+threads.md) is stale: `restoreThreadForResume` throws rather than letting
+the old snapshot overwrite the repaired thread. `MessageThread.repairs` is
+the generation both sides compare; `markRepaired()` is its only writer.
+
 ---
 
 ## Configuration

--- a/packages/agency-lang/docs/dev/threads.md
+++ b/packages/agency-lang/docs/dev/threads.md
@@ -99,6 +99,34 @@ Key distinction: **thread = blank slate; subthread = fork of parent's conversati
 
 ---
 
+## Reopen repair: abandoned turns cannot poison a session
+
+A turn that parks on an unanswered interrupt leaves its thread ending on an
+assistant message with unanswered tool calls. If the turn is resumed, the
+gap closes naturally. If it is abandoned — the user starts a new turn on
+the same session instead of answering — the gap would make the provider
+reject every later request (`tool_use` ids without `tool_result` blocks),
+killing the session permanently.
+
+So reopening a thread for new work repairs it first. The seam is the
+first-execution branch of `Runner.thread()`: on a `session:` second+ entry
+or a `thread(continue: id)`, `repairReopenedThread`
+(`lib/runtime/threadRepair.ts`) appends a synthetic tool result per
+dangling call plus a breadcrumb assistant message, and fires a
+`threadRepaired` statelog event. A checkpoint resume never travels through
+that branch (the frame-locals guard skips the open side effect), so repair
+cannot fire while a parked turn can still be resumed.
+
+Each repair advances the thread's generation (`MessageThread.markRepaired`).
+The prompt restore path (`restoreThreadForResume`) refuses a checkpoint
+taken before a repair — a late answer to an abandoned turn would otherwise
+overwrite the repaired thread and every newer turn, because the restore
+writes the snapshot INTO the live aliased thread.
+
+Design history: `docs/superpowers/specs/2026-07-22-orphaned-tool-use-on-guard-abort-design.md`.
+
+---
+
 ## How are threads passed into prompts?
 
 In `typescriptGenerator.ts` lines 741-748, when generating a prompt function call, the generator determines the thread expression:

--- a/packages/agency-lang/lib/agents/agency-agent/lib/budget.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/budget.agency
@@ -12,7 +12,9 @@
     fallback) to the guard `coordinator.runTurn` wraps around the turn.
   - `turnBudgetHandler` is the top-level handler for that guard. When the
     budget trips it asks the user whether to grant more, and either extends
-    the guard in place or stops.
+    the guard in place or stops. It also rejects any OTHER guard trip that
+    reaches it — an unowned budget cap is honored as a hard stop rather
+    than parking the turn on a question nobody answers.
 
   Why a guard and not a "check the clock" tool: a tool the model must choose
   to call has no forcing function, and the model is suspended inside slow
@@ -135,13 +137,33 @@ def parseMoreBudget(reply: string): MoreBudget {
 
 export def turnBudgetHandler(intr: any): any {
   """
-  Top-level handler for the per-turn budget guard. Answers only this turn's
-  trip (matched by label) and passes every other interrupt through: subagent
-  budget caps keep bubbling to their own owners, and tool-approval
-  interrupts keep reaching the policy handler.
+  Top-level handler for the per-turn budget guard. Answers every guard trip
+  that reaches it: this turn's trip (matched by label) can be granted more
+  budget; any other guard trip has no owner by the time it gets here and is
+  rejected, so the budget is a hard stop instead of a question nobody
+  answers. Non-guard interrupts pass through to the policy handler.
   """
-  if (intr.effect != "std::guard" || intr.data.label != TURN_BUDGET_LABEL) {
+  if (intr.effect != "std::guard") {
     return pass()
+  }
+  if (intr.data.label != TURN_BUDGET_LABEL) {
+    // A guard trip that reaches this handler has no owner: handlers below
+    // us had their chance, and nothing above us answers guards. Passing
+    // would park the whole turn at a checkpoint nobody will ever resume
+    // (the orphaned tool_use incident, 2026-07-22 design doc). Honor the
+    // budget as a hard stop: reject converts the trip to a Failure at the
+    // guard site, where the caller salvages via finalize or draftValue.
+    // _lastPartial is deliberately NOT set here — that slot is the
+    // TURN's best-so-far for runTurn to show when the turn stops, and
+    // this turn is continuing; the inner guard's own salvage carries its
+    // partial back through the Result.
+    if (isInteractive()) {
+      const who = intr.data.label ?? "a subagent"
+      print(color.yellow(
+        "⏳ The ${intr.data.dimension} budget for ${who} ran out; stopping that step with its best result so far.",
+      ))
+    }
+    return reject()
   }
 
   // One-shot / piped runs: nobody is here to answer, so honor the budget as

--- a/packages/agency-lang/lib/runtime/__tests__/testHelpers.ts
+++ b/packages/agency-lang/lib/runtime/__tests__/testHelpers.ts
@@ -76,6 +76,7 @@ export function makeMockCtx(opts: {
       handlerDecision: () => {},
       threadCreated: () => {},
       threadResumed: () => {},
+      threadRepaired: () => {},
       agentStart: () => {},
       agentEnd: () => {},
     },

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -28,6 +28,7 @@ import type { NormalizedLLMError } from "./llmClient.js";
 import {
   markThreadCancelled,
   needsThreadRepair,
+  restoreThreadForResume,
 } from "./threadRepair.js";
 import { isGuardExceededError } from "./guard.js";
 import { callHook, invokeCallbacks } from "./hooks.js";
@@ -1043,23 +1044,11 @@ export async function runPrompt(args: {
   // stale snapshot from the original interrupt time, missing everything
   // that was appended after resume.
   //
-  // To keep the alias on resume, we write the saved JSON contents INTO
-  // args.messages rather than constructing a fresh MessageThread. The
-  // saved JSON and args.messages are equivalent on resume (both were
-  // captured in the same checkpoint), so this is effectively a no-op
-  // overwrite — but it preserves the alias for the rest of the run.
+  // See restoreThreadForResume for how the alias is preserved and when a
+  // restore is refused (a snapshot that predates a thread repair).
   let messages: MessageThread;
   if (self.messagesJSON) {
-    const restored = MessageThread.fromJSON(self.messagesJSON);
-    if (args.messages) {
-      // adoptFrom, not setMessages(restored.getMessages()): the latter
-      // takes only the messages and would drop the labels fromJSON just
-      // restored. The alias is still preserved.
-      args.messages.adoptFrom(restored);
-      messages = args.messages;
-    } else {
-      messages = restored;
-    }
+    messages = restoreThreadForResume(self.messagesJSON, args.messages);
   } else if (clientConfig.messages) {
     messages = MessageThread.fromJSON(clientConfig.messages);
   } else if (args.messages) {

--- a/packages/agency-lang/lib/runtime/runner.test.ts
+++ b/packages/agency-lang/lib/runtime/runner.test.ts
@@ -7,6 +7,9 @@ import { getRuntimeContext, runInTestContext } from "./asyncContext.js";
 import { makeMockCtx } from "./__tests__/testHelpers.js";
 import { TimeGuard } from "./guard.js";
 import { readCause } from "./errors.js";
+import * as smoltalk from "smoltalk";
+import { ABANDONED_TURN_TEXT } from "./threadRepair.js";
+import type { MessageThread } from "./state/messageThread.js";
 
 function makeFrame(): State {
   return new State({ args: {}, locals: {}, step: 0 });
@@ -1122,5 +1125,104 @@ describe("stripSlug", () => {
     expect(stripSlug("t")).toBe("t");
     expect(stripSlug("t1a")).toBe("t1a");
     expect(stripSlug("")).toBe("");
+  });
+});
+
+describe("thread() — abandoned-turn repair on reopen", () => {
+  // The shape a parked-then-abandoned turn leaves behind: trailing
+  // assistant with two tool calls, only one answered. Mirrors the trace
+  // in the orphaned-tool-use design doc.
+  const damage = (t: MessageThread) => {
+    t.push(smoltalk.userMessage("go"));
+    t.push(
+      smoltalk.assistantMessage("", {
+        toolCalls: [
+          new smoltalk.ToolCall("a", "whatIAmDoing", {}),
+          new smoltalk.ToolCall("b", "codeAgent", {}),
+        ],
+      }),
+    );
+    t.push(smoltalk.toolMessage("ok", { tool_call_id: "a", name: "whatIAmDoing" }));
+  };
+
+  // One thread() entry with its own fresh frame — the shape of a NEW
+  // turn. Returns the opened thread id.
+  async function openFresh(
+    threads: ThreadStore,
+    opts: Record<string, unknown>,
+  ): Promise<string> {
+    let tid = "";
+    const runner = new Runner(makeMockCtx(), makeFrame(), { threads });
+    await runner.thread(0, "create", opts, async () => {
+      tid = threads.activeId()!;
+    });
+    return tid;
+  }
+
+  it("session reopen repairs the dangling tail before new work lands", async () => {
+    const threads = new ThreadStore();
+    const tid = await openFresh(threads, { session: "main" });
+    damage(threads.get(tid)!);
+
+    await openFresh(threads, { session: "main" });
+
+    const thread = threads.get(tid)!;
+    const toolIds = thread
+      .getMessages()
+      .filter((m): m is smoltalk.ToolMessage => m instanceof smoltalk.ToolMessage)
+      .map((m) => m.tool_call_id);
+    expect(toolIds).toEqual(["a", "b"]);
+    expect((thread.getMessages().at(-1) as smoltalk.AssistantMessage).content).toBe(
+      ABANDONED_TURN_TEXT,
+    );
+    expect(thread.repairs).toBe(1);
+  });
+
+  it("thread(continue: id) reopen repairs too", async () => {
+    const threads = new ThreadStore();
+    const tid = await openFresh(threads, {});
+    damage(threads.get(tid)!);
+
+    await openFresh(threads, { continueId: tid });
+
+    expect(threads.get(tid)!.repairs).toBe(1);
+  });
+
+  it("valid thread reopens byte-identical, generation stays 0", async () => {
+    const threads = new ThreadStore();
+    const tid = await openFresh(threads, { session: "main" });
+    const thread = threads.get(tid)!;
+    thread.push(smoltalk.userMessage("hi"));
+    thread.push(smoltalk.assistantMessage("hello"));
+    const before = JSON.stringify(thread.toJSON());
+
+    await openFresh(threads, { session: "main" });
+
+    expect(JSON.stringify(thread.toJSON())).toBe(before);
+    expect(thread.repairs).toBe(0);
+  });
+
+  it("a checkpoint-resume re-entry does NOT repair — the frame-locals guard is load-bearing", async () => {
+    const threads = new ThreadStore();
+    const frame = makeFrame();
+    let tid = "";
+    const r1 = new Runner(makeMockCtx(), frame, { threads });
+    await r1.thread(0, "create", { session: "main" }, async () => {
+      tid = threads.activeId()!;
+    });
+    damage(threads.get(tid)!);
+
+    // Resume shape: locals carried over (they hold __thread_<path>), step
+    // counter back at the re-executing step — thread() re-enters its body
+    // WITHOUT re-running the open side effect, so no repair may fire.
+    const resumedFrame = new State({ args: {}, locals: { ...frame.locals }, step: 0 });
+    let reEntered = false;
+    const r2 = new Runner(makeMockCtx(), resumedFrame, { threads });
+    await r2.thread(0, "create", { session: "main" }, async () => {
+      reEntered = true;
+    });
+
+    expect(reEntered).toBe(true); // proves we exercised the guard branch, not a step skip
+    expect(threads.get(tid)!.repairs).toBe(0);
   });
 });

--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -11,6 +11,7 @@ import { makeRedactReplacer, REDACTED } from "./redactForStatelog.js";
 import { __pipeBind } from "./result.js";
 import { nativeTypeReplacer, nativeTypeReviver } from "./revivers/index.js";
 import { runBatch } from "./runBatch.js";
+import { repairReopenedThread } from "./threadRepair.js";
 import type { SourceLocationOpts } from "./state/checkpointStore.js";
 import type { RuntimeContext } from "./state/context.js";
 import type { BranchState, State } from "./state/stateStack.js";
@@ -702,6 +703,13 @@ export class Runner {
         tid = threads.createSubthread(createMeta);
       } else {
         tid = threads.create(createMeta);
+      }
+      if (isResumption) {
+        // Reopened threads are repaired before new work lands; a
+        // checkpoint resume never reaches this branch (the frame-locals
+        // guard above skips the whole open side effect). The full safety
+        // argument lives on repairReopenedThread.
+        repairReopenedThread(threads.get(tid), this.ctx.statelogClient, tid);
       }
       this.frame.locals[threadKey] = tid;
       this.frame.locals[resumptionKey] = isResumption;

--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -709,6 +709,13 @@ export class Runner {
         // checkpoint resume never reaches this branch (the frame-locals
         // guard above skips the whole open side effect). The full safety
         // argument lives on repairReopenedThread.
+        //
+        // The createSubthread branch below needs no repair even though it
+        // clones the parent's messages: a dangling tail only ever exists
+        // on a thread whose turn parked and bailed out of the whole run,
+        // so no code is left executing that could take a subthread off it
+        // — and a later run must reopen the parent (through this branch)
+        // before it can be active again.
         repairReopenedThread(threads.get(tid), this.ctx.statelogClient, tid);
       }
       this.frame.locals[threadKey] = tid;

--- a/packages/agency-lang/lib/runtime/state/messageThread.test.ts
+++ b/packages/agency-lang/lib/runtime/state/messageThread.test.ts
@@ -287,3 +287,41 @@ describe("queueMessage validation and copy semantics (PR 651 review)", () => {
     expect(revived.hasQueuedMessages()).toBe(false);
   });
 });
+
+describe("repair generation — markRepaired / isNewerThan", () => {
+  it("defaults to 0 and stays out of JSON until incremented", () => {
+    const t = new MessageThread([smoltalk.userMessage("hi")]);
+    expect(t.repairs).toBe(0);
+    expect("repairs" in t.toJSON()).toBe(false);
+  });
+
+  it("markRepaired is monotonic and round-trips through JSON", () => {
+    const t = new MessageThread([smoltalk.userMessage("hi")]);
+    t.markRepaired();
+    t.markRepaired();
+    expect(t.repairs).toBe(2);
+    expect(MessageThread.fromJSON(t.toJSON()).repairs).toBe(2);
+  });
+
+  it("legacy JSON without the field revives as 0", () => {
+    expect(MessageThread.fromJSON({ messages: [] }).repairs).toBe(0);
+  });
+
+  it("adoptFrom copies the counter with the content", () => {
+    const a = new MessageThread();
+    const b = new MessageThread([smoltalk.userMessage("hi")]);
+    b.markRepaired();
+    a.adoptFrom(b);
+    expect(a.repairs).toBe(1);
+  });
+
+  it("isNewerThan orders live thread against a snapshot", () => {
+    const live = new MessageThread();
+    const snapshot = new MessageThread();
+    expect(live.isNewerThan(snapshot)).toBe(false); // equal → restorable
+    live.markRepaired();
+    expect(live.isNewerThan(snapshot)).toBe(true); // repaired after → stale
+    snapshot.markRepaired();
+    expect(live.isNewerThan(snapshot)).toBe(false); // snapshot post-repair → fine
+  });
+});

--- a/packages/agency-lang/lib/runtime/state/messageThread.ts
+++ b/packages/agency-lang/lib/runtime/state/messageThread.ts
@@ -79,7 +79,8 @@ export class MessageThread {
    *  Nothing else touches `this.messages`. A desync does not degrade
    *  gracefully — it shifts every later label onto the wrong message — so
    *  keep it that way. A rewrite via `setMessages` with no labels
-   *  (summarization, repair) drops them; that is intended. */
+   *  (summarization) drops them; that is intended. (Thread repair
+   *  appends via `push`, so it keeps them.) */
   messageLabels: (string | null)[];
   /** Messages queued by `queueMessage`, waiting for the thread's next
    *  request-turn. Drained by the turn-boundary machinery in the tool

--- a/packages/agency-lang/lib/runtime/state/messageThread.ts
+++ b/packages/agency-lang/lib/runtime/state/messageThread.ts
@@ -17,6 +17,7 @@ export type MessageThreadJSON = {
   label?: string | null;
   summary?: string | null;
   queuedMessages?: QueuedMessage[];
+  repairs?: number;
 };
 
 /** A message waiting on a thread for delivery at the thread's next
@@ -62,6 +63,16 @@ export class MessageThread {
    *  module-level state in TS. `null` until the summary is computed.
    *  Round-tripped through `toJSON`/`fromJSON`. */
   summary: string | null = null;
+  /** Repair generation: how many times `repairAbandonedTurn`
+   *  (threadRepair.ts) has rewritten this thread. A repair answers tool
+   *  calls a parked-then-abandoned turn left dangling, so any checkpoint
+   *  snapshot taken BEFORE it is stale — restoring one would overwrite
+   *  the repair and everything appended since. `isNewerThan` is that
+   *  comparison; `markRepaired` is the ONLY writer outside the
+   *  serialization paths (fromJSON / adoptFrom). Never assign directly.
+   *  Round-tripped through `toJSON`/`fromJSON` so checkpoints record the
+   *  generation they captured. */
+  repairs: number = 0;
   /** Per-message debug labels, aligned with `messages` BY INDEX
    *  (`messageLabels[i]` labels `messages[i]`; the lengths always match).
    *  Observability only: shown in statelog, never sent to the provider.
@@ -151,6 +162,21 @@ export class MessageThread {
     // adoptFrom (its args.messages alias), and a queue that survived
     // toJSON but not adoptFrom would be dropped exactly on resume.
     this.queuedMessages = cloneQueue(other.queuedMessages);
+    this.repairs = other.repairs;
+  }
+
+  /** Record that this thread was repaired. Monotonic on purpose — the
+   *  stale-checkpoint check reads `repairs` as a generation number, so it
+   *  must only ever go up. */
+  markRepaired(): void {
+    this.repairs += 1;
+  }
+
+  /** True when this thread has been repaired since `snapshot` was
+   *  captured — which makes restoring `snapshot` a write over newer
+   *  history. See restoreThreadForResume in threadRepair.ts. */
+  isNewerThan(snapshot: MessageThread): boolean {
+    return this.repairs > snapshot.repairs;
   }
 
   /** The ONLY append. Everything that adds a message goes through here,
@@ -255,6 +281,9 @@ export class MessageThread {
     if (this.queuedMessages.length > 0) {
       json.queuedMessages = cloneQueue(this.queuedMessages);
     }
+    if (this.repairs > 0) {
+      json.repairs = this.repairs;
+    }
     return json;
   }
 
@@ -274,6 +303,7 @@ export class MessageThread {
     let _hidden = false;
     let _label: string | null = null;
     let _summary: string | null = null;
+    let _repairs = 0;
     if (Array.isArray(json)) {
       _messages = json;
     } else if ("messages" in json) {
@@ -292,6 +322,9 @@ export class MessageThread {
       }
       if ("summary" in json && json.summary !== undefined) {
         _summary = json.summary;
+      }
+      if ("repairs" in json && typeof json.repairs === "number") {
+        _repairs = json.repairs;
       }
     } else {
       throw new Error("Invalid input for MessageThread.fromJSON");
@@ -314,6 +347,7 @@ export class MessageThread {
     thread.hidden = _hidden;
     thread.label = _label;
     thread.summary = _summary;
+    thread.repairs = _repairs;
     // Accept only a real array: persisted JSON containing
     // `queuedMessages: null` (or any non-array) must not throw during
     // resume — it revives as an empty queue, same as the absent key.

--- a/packages/agency-lang/lib/runtime/threadRepair.test.ts
+++ b/packages/agency-lang/lib/runtime/threadRepair.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect } from "vitest";
 import * as smoltalk from "smoltalk";
 import { makeAbortCause } from "./errors.js";
+import { runInTestContext } from "./asyncContext.js";
+import { makeMockCtx } from "./__tests__/testHelpers.js";
 import { MessageThread } from "./state/messageThread.js";
+import { StateStack } from "./state/stateStack.js";
+import { ThreadStore } from "./state/threadStore.js";
 import {
   ABANDONED_CALL_TEXT,
   ABANDONED_TURN_TEXT,
@@ -218,7 +222,7 @@ describe("repairAbandonedTurn", () => {
 });
 
 describe("repairReopenedThread — the seam helper", () => {
-  it("repairs and emits threadRepaired with the slugged id and the call ids", () => {
+  it("repairs and emits threadRepaired with the raw thread id and the call ids", () => {
     const t = new MessageThread([
       smoltalk.userMessage("go"),
       asst("", [
@@ -229,7 +233,8 @@ describe("repairReopenedThread — the seam helper", () => {
     ]);
     const events: Array<{ threadId: string; toolCallIds: string[] }> = [];
     repairReopenedThread(t, { threadRepaired: (e) => { events.push(e); } }, "7");
-    expect(events).toEqual([{ threadId: "t7", toolCallIds: ["b"] }]);
+    // Raw id, matching threadCreated/threadResumed — consumers join on it.
+    expect(events).toEqual([{ threadId: "7", toolCallIds: ["b"] }]);
     expect(t.repairs).toBe(1);
   });
 
@@ -282,5 +287,28 @@ describe("restoreThreadForResume", () => {
     const live = new MessageThread([smoltalk.userMessage("hi")]);
     live.markRepaired();
     expect(restoreThreadForResume(live.toJSON(), live)).toBe(live);
+  });
+
+  it("emits a statelog runtimeError alongside the refusal throw", () => {
+    // The emit exists so the refusal survives Failure laundering — if it
+    // silently stops firing, that is the exact failure mode it defends
+    // against, so the wiring gets its own assertion (mirrors the
+    // threadRepaired test above).
+    const ctx = makeMockCtx();
+    const errors: Array<Record<string, unknown>> = [];
+    ctx.statelogClient.error = (e: Record<string, unknown>) => {
+      errors.push(e);
+    };
+    const live = new MessageThread([smoltalk.userMessage("hi")]);
+    const snap = live.toJSON();
+    live.markRepaired();
+    runInTestContext(ctx, new StateStack(), new ThreadStore(), () => {
+      expect(() => restoreThreadForResume(snap, live)).toThrow(
+        /repaired after this checkpoint/,
+      );
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0].errorType).toBe("runtimeError");
+    expect(errors[0].functionName).toBe("restoreThreadForResume");
   });
 });

--- a/packages/agency-lang/lib/runtime/threadRepair.test.ts
+++ b/packages/agency-lang/lib/runtime/threadRepair.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect } from "vitest";
 import * as smoltalk from "smoltalk";
 import { makeAbortCause } from "./errors.js";
 import { MessageThread } from "./state/messageThread.js";
-import { markThreadCancelled, needsThreadRepair } from "./threadRepair.js";
+import {
+  markThreadCancelled,
+  needsThreadRepair,
+  unansweredToolCalls,
+} from "./threadRepair.js";
 
 /** Convenience builders for the markThreadCancelled repair-shape tests. */
 const asst = (text: string, toolCalls?: Array<{ id: string; name: string }>) =>
@@ -100,5 +104,59 @@ describe("needsThreadRepair — repair policy", () => {
     ).toBe(false);
     expect(needsThreadRepair(makeAbortCause({ kind: "raceLoser" }))).toBe(false);
     expect(needsThreadRepair(makeAbortCause({ kind: "cleanup" }))).toBe(false);
+  });
+});
+
+describe("unansweredToolCalls", () => {
+  it("returns only the trailing assistant turn's unanswered calls", () => {
+    const t = new MessageThread([
+      smoltalk.userMessage("go"),
+      asst("", [{ id: "x", name: "f" }]),
+      tool("x"),
+      asst("", [
+        { id: "a", name: "whatIAmDoing" },
+        { id: "b", name: "codeAgent" },
+      ]),
+      tool("a"),
+    ]);
+    expect(unansweredToolCalls(t).map((c) => c.id)).toEqual(["b"]);
+  });
+
+  it("ignores unanswered calls on EARLIER assistant turns — the contract is trailing-turn only", () => {
+    const t = new MessageThread([
+      smoltalk.userMessage("go"),
+      asst("", [{ id: "old", name: "f" }]), // never answered, but not trailing
+      asst("", [{ id: "new", name: "f" }]),
+    ]);
+    expect(unansweredToolCalls(t).map((c) => c.id)).toEqual(["new"]);
+  });
+
+  it("trailing assistant with no tool calls (an ordinary reply) reports empty", () => {
+    const t = new MessageThread([smoltalk.userMessage("hi"), asst("hello")]);
+    expect(unansweredToolCalls(t)).toEqual([]);
+  });
+
+  it("valid tail and no-assistant threads both report empty", () => {
+    const valid = new MessageThread([
+      smoltalk.userMessage("go"),
+      asst("", [{ id: "x", name: "f" }]),
+      tool("x"),
+    ]);
+    expect(unansweredToolCalls(valid)).toEqual([]);
+    expect(unansweredToolCalls(new MessageThread([smoltalk.userMessage("hi")]))).toEqual([]);
+  });
+});
+
+describe("markThreadCancelled — label preservation (push, not setMessages)", () => {
+  it("keeps per-message debug labels on the right messages and stays aligned", () => {
+    const t = new MessageThread();
+    t.push(smoltalk.userMessage("go"), "the-user-msg");
+    t.push(asst("", [{ id: "y", name: "f" }]), "the-tool-round");
+    markThreadCancelled(t);
+    expect(t.labelAt(0)).toBe("the-user-msg");
+    expect(t.labelAt(1)).toBe("the-tool-round");
+    expect(roles(t)).toEqual(["user", "assistant", "tool", "assistant"]);
+    // The alignment invariant messageThread.ts warns about: lengths match.
+    expect(t.messageLabels.length).toBe(t.getMessages().length);
   });
 });

--- a/packages/agency-lang/lib/runtime/threadRepair.test.ts
+++ b/packages/agency-lang/lib/runtime/threadRepair.test.ts
@@ -9,6 +9,7 @@ import {
   needsThreadRepair,
   repairAbandonedTurn,
   repairReopenedThread,
+  restoreThreadForResume,
   unansweredToolCalls,
 } from "./threadRepair.js";
 
@@ -242,5 +243,44 @@ describe("repairReopenedThread — the seam helper", () => {
 
   it("tolerates a missing thread and a missing statelog client", () => {
     expect(() => repairReopenedThread(undefined, undefined, "7")).not.toThrow();
+  });
+});
+
+describe("restoreThreadForResume", () => {
+  it("adopts into the live thread and preserves the alias", () => {
+    const live = new MessageThread([smoltalk.userMessage("hi")]);
+    const out = restoreThreadForResume(live.toJSON(), live);
+    expect(out).toBe(live); // same object — the caller's alias survives
+    expect(roles(out)).toEqual(["user"]);
+  });
+
+  it("no live thread: revives the snapshot", () => {
+    const snap = new MessageThread([smoltalk.userMessage("hi")]).toJSON();
+    expect(roles(restoreThreadForResume(snap, undefined))).toEqual(["user"]);
+  });
+
+  it("refuses a snapshot taken before a repair", () => {
+    const live = new MessageThread([smoltalk.userMessage("hi")]);
+    const snap = live.toJSON(); // generation 0
+    live.markRepaired();
+    expect(() => restoreThreadForResume(snap, live)).toThrow(
+      /repaired after this checkpoint/,
+    );
+    expect(live.repairs).toBe(1); // refusal must not have adopted anything
+  });
+
+  it("legacy bare-array snapshots (implicit generation 0) are refused after a repair", () => {
+    const live = new MessageThread([smoltalk.userMessage("hi")]);
+    live.markRepaired();
+    const legacy = [smoltalk.userMessage("hi").toJSON()];
+    expect(() => restoreThreadForResume(legacy, live)).toThrow(
+      /repaired after this checkpoint/,
+    );
+  });
+
+  it("a snapshot taken AFTER the repair restores fine", () => {
+    const live = new MessageThread([smoltalk.userMessage("hi")]);
+    live.markRepaired();
+    expect(restoreThreadForResume(live.toJSON(), live)).toBe(live);
   });
 });

--- a/packages/agency-lang/lib/runtime/threadRepair.test.ts
+++ b/packages/agency-lang/lib/runtime/threadRepair.test.ts
@@ -12,12 +12,14 @@ import {
   unansweredToolCalls,
 } from "./threadRepair.js";
 
-/** Convenience builders for the markThreadCancelled repair-shape tests. */
+/** Convenience builders for the repair-shape tests. Real ToolCall
+ *  instances, not plain objects — AssistantMessage.toJSON calls
+ *  tc.toJSON() on each, so the byte-identical assertions need them. */
 const asst = (text: string, toolCalls?: Array<{ id: string; name: string }>) =>
   smoltalk.assistantMessage(
     text,
     toolCalls
-      ? { toolCalls: toolCalls.map((c) => ({ id: c.id, name: c.name, arguments: {} })) }
+      ? { toolCalls: toolCalls.map((c) => new smoltalk.ToolCall(c.id, c.name, {})) }
       : undefined,
   );
 const tool = (id: string) =>

--- a/packages/agency-lang/lib/runtime/threadRepair.test.ts
+++ b/packages/agency-lang/lib/runtime/threadRepair.test.ts
@@ -3,8 +3,12 @@ import * as smoltalk from "smoltalk";
 import { makeAbortCause } from "./errors.js";
 import { MessageThread } from "./state/messageThread.js";
 import {
+  ABANDONED_CALL_TEXT,
+  ABANDONED_TURN_TEXT,
   markThreadCancelled,
   needsThreadRepair,
+  repairAbandonedTurn,
+  repairReopenedThread,
   unansweredToolCalls,
 } from "./threadRepair.js";
 
@@ -158,5 +162,83 @@ describe("markThreadCancelled — label preservation (push, not setMessages)", (
     expect(roles(t)).toEqual(["user", "assistant", "tool", "assistant"]);
     // The alignment invariant messageThread.ts warns about: lengths match.
     expect(t.messageLabels.length).toBe(t.getMessages().length);
+  });
+});
+
+describe("repairAbandonedTurn", () => {
+  const damaged = () =>
+    new MessageThread([
+      smoltalk.userMessage("go"),
+      asst("", [
+        { id: "a", name: "whatIAmDoing" },
+        { id: "b", name: "codeAgent" },
+        { id: "c", name: "readDocs" },
+      ]),
+      tool("a"),
+    ]);
+
+  it("answers EVERY dangling call, appends the breadcrumb, bumps the generation", () => {
+    const t = damaged();
+    const repaired = repairAbandonedTurn(t);
+    expect(repaired.map((c) => c.id)).toEqual(["b", "c"]);
+    expect(roles(t)).toEqual(["user", "assistant", "tool", "tool", "tool", "assistant"]);
+    const stubs = t
+      .getMessages()
+      .filter((m): m is smoltalk.ToolMessage => m instanceof smoltalk.ToolMessage);
+    expect(stubs.map((m) => m.tool_call_id)).toEqual(["a", "b", "c"]);
+    expect(stubs[1].content).toBe(ABANDONED_CALL_TEXT);
+    expect((t.getMessages().at(-1) as smoltalk.AssistantMessage).content).toBe(
+      ABANDONED_TURN_TEXT,
+    );
+    expect(t.repairs).toBe(1);
+  });
+
+  it("valid thread: byte-identical no-op, generation untouched", () => {
+    const t = new MessageThread([
+      smoltalk.userMessage("go"),
+      asst("", [{ id: "x", name: "f" }]),
+      tool("x"),
+    ]);
+    const before = JSON.stringify(t.toJSON());
+    expect(repairAbandonedTurn(t)).toEqual([]);
+    expect(JSON.stringify(t.toJSON())).toBe(before);
+    expect(t.repairs).toBe(0);
+  });
+
+  it("repairing twice counts twice — the generation is a counter, not a flag", () => {
+    const t = damaged();
+    repairAbandonedTurn(t);
+    t.push(asst("", [{ id: "z", name: "f" }])); // a second abandoned round
+    repairAbandonedTurn(t);
+    expect(t.repairs).toBe(2);
+  });
+});
+
+describe("repairReopenedThread — the seam helper", () => {
+  it("repairs and emits threadRepaired with the slugged id and the call ids", () => {
+    const t = new MessageThread([
+      smoltalk.userMessage("go"),
+      asst("", [
+        { id: "a", name: "whatIAmDoing" },
+        { id: "b", name: "codeAgent" },
+      ]),
+      tool("a"),
+    ]);
+    const events: Array<{ threadId: string; toolCallIds: string[] }> = [];
+    repairReopenedThread(t, { threadRepaired: (e) => { events.push(e); } }, "7");
+    expect(events).toEqual([{ threadId: "t7", toolCallIds: ["b"] }]);
+    expect(t.repairs).toBe(1);
+  });
+
+  it("healthy thread: NO event, no changes", () => {
+    const t = new MessageThread([smoltalk.userMessage("hi"), asst("hello")]);
+    const events: unknown[] = [];
+    repairReopenedThread(t, { threadRepaired: (e) => { events.push(e); } }, "7");
+    expect(events).toEqual([]);
+    expect(t.repairs).toBe(0);
+  });
+
+  it("tolerates a missing thread and a missing statelog client", () => {
+    expect(() => repairReopenedThread(undefined, undefined, "7")).not.toThrow();
   });
 });

--- a/packages/agency-lang/lib/runtime/threadRepair.ts
+++ b/packages/agency-lang/lib/runtime/threadRepair.ts
@@ -22,6 +22,65 @@ export function needsThreadRepair(cause: AbortCause | undefined): boolean {
   return cause.kind === "userInterrupt" || cause.kind === "userKill";
 }
 
+export type DanglingToolCall = { id: string; name: string };
+
+/** The trailing assistant turn's tool calls that have no ToolMessage
+ *  answering them — the only structurally invalid shape a mid-round stop
+ *  can leave (every earlier round is complete, or the tool loop would not
+ *  have advanced past it). Deliberately NOT a whole-thread validity check;
+ *  do not reach for it as one. Empty when the tail is valid or there is
+ *  no assistant turn at all. */
+export function unansweredToolCalls(
+  messages: MessageThread,
+): DanglingToolCall[] {
+  const all = messages.getMessages();
+  const lastAssistant = all.findLastIndex(
+    (m) => m instanceof smoltalk.AssistantMessage,
+  );
+  if (lastAssistant === -1) return [];
+  const calls =
+    (all[lastAssistant] as smoltalk.AssistantMessage).toolCalls ?? [];
+  const answeredIds = all
+    .slice(lastAssistant + 1)
+    .filter(
+      (m): m is smoltalk.ToolMessage => m instanceof smoltalk.ToolMessage,
+    )
+    .map((m) => m.tool_call_id);
+  return calls.filter((c) => !answeredIds.includes(c.id));
+}
+
+function hasAssistantTurn(messages: MessageThread): boolean {
+  return messages
+    .getMessages()
+    .some((m) => m instanceof smoltalk.AssistantMessage);
+}
+
+type RepairWording = { perCall: string; breadcrumb: string };
+
+/** The one append procedure every repair shares: stub each dangling call,
+ *  then leave a breadcrumb assistant message. Appends via `push`, so
+ *  per-message debug labels on existing messages survive. Only the
+ *  wording varies between repairs; the policy of WHEN to run lives in the
+ *  named repair functions. */
+function appendRepair(
+  messages: MessageThread,
+  dangling: DanglingToolCall[],
+  wording: RepairWording,
+): void {
+  for (const call of dangling) {
+    // Synthetic response — the model sees WHICH tool was cut off (not a
+    // mysterious gap), AND the thread becomes structurally valid for the
+    // next provider call, which requires a `tool` reply per `tool_call`.
+    messages.push(
+      smoltalk.toolMessage(wording.perCall, {
+        tool_call_id: call.id,
+        name: call.name,
+      }),
+    );
+  }
+  messages.push(smoltalk.assistantMessage(wording.breadcrumb));
+}
+
 /**
  * Leave a thread in a role-valid state after a hard cancellation
  * (AgencyCancelledError / abort). A cancel can land mid-tool-round, so the
@@ -34,45 +93,21 @@ export function needsThreadRepair(cause: AbortCause | undefined): boolean {
  * runPrompt loop would not have advanced past it), so we synthesize ONLY the
  * specific `tool` messages the trailing assistant is missing — preserving
  * earlier complete rounds, the dangling assistant's text body, and any tool
- * responses that did return in a partial batch. (The previous implementation
- * truncated back to the last user message, discarding all of that.) A neutral
+ * responses that did return in a partial batch. A neutral
  * `[Response cancelled.]` breadcrumb is appended so the next turn's model sees
  * the interruption. `messages` is the live, persisted MessageThread (see
- * agencyLlm.llm), so this repair sticks for the next turn.
+ * agencyLlm.llm), so this repair sticks for the next turn. Appends via
+ * `push`, so per-message debug labels survive. Returns the calls it stubbed
+ * (its sibling `repairAbandonedTurn` shares the contract).
  */
-export function markThreadCancelled(messages: MessageThread): void {
-  const all = messages.getMessages();
-  let lastAssistant = -1;
-  for (let i = all.length - 1; i >= 0; i--) {
-    if (all[i] instanceof smoltalk.AssistantMessage) {
-      lastAssistant = i;
-      break;
-    }
-  }
-  if (lastAssistant === -1) return; // no assistant turn — thread already valid
-
-  const calls = (all[lastAssistant] as smoltalk.AssistantMessage).toolCalls ?? [];
-  const answered = new Set(
-    all
-      .slice(lastAssistant + 1)
-      .filter((m): m is smoltalk.ToolMessage => m instanceof smoltalk.ToolMessage)
-      .map((m) => m.tool_call_id),
-  );
-
-  const repaired = [...all];
-  for (const call of calls) {
-    if (!answered.has(call.id)) {
-      // Synthetic response — the model sees WHICH tool was cancelled (not a
-      // mysterious gap), AND the thread becomes structurally valid for the
-      // next provider call, which requires a `tool` reply per `tool_call`.
-      repaired.push(
-        smoltalk.toolMessage("[Tool call cancelled before completion.]", {
-          tool_call_id: call.id,
-          name: call.name,
-        }),
-      );
-    }
-  }
-  repaired.push(smoltalk.assistantMessage("[Response cancelled.]"));
-  messages.setMessages(repaired);
+export function markThreadCancelled(
+  messages: MessageThread,
+): DanglingToolCall[] {
+  if (!hasAssistantTurn(messages)) return []; // nothing sent yet — already valid
+  const dangling = unansweredToolCalls(messages);
+  appendRepair(messages, dangling, {
+    perCall: "[Tool call cancelled before completion.]",
+    breadcrumb: "[Response cancelled.]",
+  });
+  return dangling;
 }

--- a/packages/agency-lang/lib/runtime/threadRepair.ts
+++ b/packages/agency-lang/lib/runtime/threadRepair.ts
@@ -1,6 +1,8 @@
 import * as smoltalk from "smoltalk";
+import { agencyStore } from "./asyncContext.js";
 import type { AbortCause } from "./errors.js";
-import type { MessageThread } from "./state/messageThread.js";
+import { MessageThread } from "./state/messageThread.js";
+import type { MessageThreadJSON } from "./state/messageThread.js";
 
 /**
  * Thread repair after a hard cancellation, extracted from prompt.ts so the
@@ -177,4 +179,50 @@ export function repairReopenedThread(
     threadId: `t${tid}`,
     toolCallIds: repaired.map((c) => c.id),
   });
+}
+
+/** Rebuild the message thread when resuming from a checkpoint.
+ *
+ *  On resume the caller's `live` thread must stay ALIASED — mutations
+ *  during the resumed run (tool responses, the final assistant message)
+ *  must propagate to every other holder of the thread. So the restored
+ *  JSON is written INTO `live` via `adoptFrom` rather than swapping in a
+ *  fresh object (and adoptFrom, not setMessages: setMessages takes only
+ *  the messages and would drop the labels fromJSON just restored). On a
+ *  normal resume this is a no-op overwrite: both sides were captured in
+ *  the same checkpoint.
+ *
+ *  The exception is a checkpoint that predates a repair of the live
+ *  thread. Once `repairAbandonedTurn` has run, the parked turn that took
+ *  this snapshot was abandoned and newer turns may exist; restoring would
+ *  overwrite all of it. Refusing loudly is correct. The generation check
+ *  MUST run before `adoptFrom` — adoptFrom copies the snapshot's (lower)
+ *  generation onto the live thread, so checking after would always pass.
+ *  The ordering is pinned by tests. */
+export function restoreThreadForResume(
+  snapshot: MessageThreadJSON | smoltalk.MessageJSON[],
+  live: MessageThread | undefined,
+): MessageThread {
+  const restored = MessageThread.fromJSON(snapshot);
+  if (!live) return restored;
+  if (live.isNewerThan(restored)) {
+    const msg =
+      "Cannot resume this turn: its conversation thread was repaired after " +
+      "this checkpoint was taken (the parked turn was abandoned and newer " +
+      "turns have run since). Restoring would overwrite the newer " +
+      "conversation, so it is refused.";
+    // Best-effort statelog BEFORE the throw: a throw converts to a Failure
+    // at the next def boundary, and Failures can get laundered into prose
+    // by the time a model or user sees them — the refusal must stay
+    // findable in the trace regardless. Same rationale and shape as
+    // claimFrameForScope in state/stateStack.ts.
+    agencyStore.getStore()?.ctx?.statelogClient?.error?.({
+      errorType: "runtimeError",
+      message: msg,
+      functionName: "restoreThreadForResume",
+    });
+    throw new Error(msg);
+  }
+  live.adoptFrom(restored);
+  return live;
 }

--- a/packages/agency-lang/lib/runtime/threadRepair.ts
+++ b/packages/agency-lang/lib/runtime/threadRepair.ts
@@ -175,8 +175,10 @@ export function repairReopenedThread(
   if (!thread) return;
   const repaired = repairAbandonedTurn(thread);
   if (repaired.length === 0) return;
+  // Raw registry id, not the `t`-slug: the other thread lifecycle events
+  // (threadCreated, threadResumed) emit raw ids, and consumers join on it.
   void statelog?.threadRepaired?.({
-    threadId: `t${tid}`,
+    threadId: tid,
     toolCallIds: repaired.map((c) => c.id),
   });
 }
@@ -206,11 +208,15 @@ export function restoreThreadForResume(
   const restored = MessageThread.fromJSON(snapshot);
   if (!live) return restored;
   if (live.isNewerThan(restored)) {
+    // State the observed fact; offer the usual cause only as a hint. The
+    // check cannot actually know WHY the thread is ahead of the snapshot —
+    // abandonment is the common case, but a concurrent branch reopening a
+    // shared session while this turn was parked produces the same refusal.
     const msg =
       "Cannot resume this turn: its conversation thread was repaired after " +
-      "this checkpoint was taken (the parked turn was abandoned and newer " +
-      "turns have run since). Restoring would overwrite the newer " +
-      "conversation, so it is refused.";
+      "this checkpoint was taken, so restoring would overwrite the newer " +
+      "conversation. This usually means the parked turn was abandoned and " +
+      "the session continued without it.";
     // Best-effort statelog BEFORE the throw: a throw converts to a Failure
     // at the next def boundary, and Failures can get laundered into prose
     // by the time a model or user sees them — the refusal must stay

--- a/packages/agency-lang/lib/runtime/threadRepair.ts
+++ b/packages/agency-lang/lib/runtime/threadRepair.ts
@@ -111,3 +111,70 @@ export function markThreadCancelled(
   });
   return dangling;
 }
+
+export const ABANDONED_CALL_TEXT =
+  "[Tool call interrupted; the turn was never resumed.]";
+export const ABANDONED_TURN_TEXT =
+  "[The previous turn was interrupted before it finished.]";
+
+/** Repair a thread whose previous turn parked on an unanswered interrupt
+ *  and was then abandoned (the user started a new turn instead of
+ *  answering). Distinct wording from `markThreadCancelled` on purpose:
+ *  nobody cancelled anything, so the breadcrumb tells the next turn's
+ *  model the work was interrupted — it can offer to pick it back up.
+ *  Bumps the thread's repair generation so a late restore of the
+ *  abandoned turn's checkpoint is refused instead of clobbering the
+ *  thread — see `restoreThreadForResume`. Total no-op on a valid
+ *  thread. */
+export function repairAbandonedTurn(
+  messages: MessageThread,
+): DanglingToolCall[] {
+  const dangling = unansweredToolCalls(messages);
+  if (dangling.length === 0) return [];
+  appendRepair(messages, dangling, {
+    perCall: ABANDONED_CALL_TEXT,
+    breadcrumb: ABANDONED_TURN_TEXT,
+  });
+  messages.markRepaired();
+  return dangling;
+}
+
+export type ThreadRepairedSink = {
+  threadRepaired?: (event: {
+    threadId: string;
+    toolCallIds: string[];
+  }) => Promise<void> | void;
+};
+
+/** Everything the reopen seam needs, so `Runner.thread()` stays one line.
+ *
+ *  A reopen (session second+ entry, or `thread(continue: id)`) means the
+ *  previous turn on this thread stopped mattering — at least for the
+ *  REPL, where a parked turn blocks the loop, so a reopen implies
+ *  abandonment. (Within a single run a reopen from a second step path is
+ *  also possible; it is harmless here because a healthy in-run thread
+ *  has no dangling tail.) If the abandoned turn parked mid-tool-round,
+ *  the thread still ends on an assistant message with unanswered tool
+ *  calls — a shape the provider rejects outright, which would otherwise
+ *  poison every later request on this session.
+ *
+ *  Safe at the reopen seam and ONLY there: a checkpoint resume of a
+ *  parked turn never reaches it — `Runner.thread()` guards the open side
+ *  effect behind `frame.locals[threadKey]`, which is restored with the
+ *  checkpoint, and `restoreBranchView` reinstates the active stack by
+ *  direct assignment. If either mechanism changes, this repair would
+ *  start firing mid-resume; the resume-re-entry test in runner.test.ts
+ *  exists to catch exactly that. */
+export function repairReopenedThread(
+  thread: MessageThread | undefined,
+  statelog: ThreadRepairedSink | undefined,
+  tid: string,
+): void {
+  if (!thread) return;
+  const repaired = repairAbandonedTurn(thread);
+  if (repaired.length === 0) return;
+  void statelog?.threadRepaired?.({
+    threadId: `t${tid}`,
+    toolCallIds: repaired.map((c) => c.id),
+  });
+}

--- a/packages/agency-lang/lib/statelogClient.ts
+++ b/packages/agency-lang/lib/statelogClient.ts
@@ -1207,6 +1207,26 @@ export class StatelogClient {
     });
   }
 
+  /** Fired when a reopened thread (session second+ entry or
+   *  `thread(continue: id)`) was found structurally invalid — its trailing
+   *  assistant message had tool calls with no results — and
+   *  `repairAbandonedTurn` synthesized the missing results before new work
+   *  was appended. A repair means a previous turn parked on an interrupt
+   *  and was abandoned; that is worth being able to find in a trace. */
+  async threadRepaired({
+    threadId,
+    toolCallIds,
+  }: {
+    threadId: string;
+    toolCallIds: string[];
+  }): Promise<void> {
+    await this.post({
+      type: "threadRepaired",
+      threadId,
+      toolCallIds,
+    });
+  }
+
   /** Fired when the `onThreadEnd` callback dispatcher itself throws
    *  inside the `Runner.thread` finally block. Individual callback
    *  errors are caught and logged by `fireWithGuard`; this event

--- a/packages/agency-lang/stdlib/agents/agency/coding.agency
+++ b/packages/agency-lang/stdlib/agents/agency/coding.agency
@@ -272,7 +272,7 @@ export def agencyCodingAgent(
   @param session - Session name to share a thread across calls, or "" for isolated
   @param extraTools - Extra tools to offer the LLM, appended to the built-in set
   """
-  const captured = guard(cost: maxCost, time: maxTime) {
+  const captured = guard(cost: maxCost, time: maxTime, label: "agencyCodingAgent") {
     let outcome: WriteOutcome = { valid: false, source: "", problems: ["generation never ran"] }
     thread(label: "agencyCodingAgent", session: session) {
       outcome = generateLoop(

--- a/packages/agency-lang/stdlib/agents/agency/expert.agency
+++ b/packages/agency-lang/stdlib/agents/agency/expert.agency
@@ -77,7 +77,7 @@ export def agencyExpertAgent(
   @param session - Session name to share a thread across calls, or "" for isolated
   @param extraTools - Extra tools to offer the LLM, appended to the built-in set
   """
-  return guard(cost: maxCost, time: maxTime) {
+  return guard(cost: maxCost, time: maxTime, label: "agencyExpertAgent") {
     let guidance: ExpertGuidance = emptyGuidance
     thread(label: "agencyExpertAgent", session: session) {
       guidance = consult(

--- a/packages/agency-lang/stdlib/agents/agency/researcher.agency
+++ b/packages/agency-lang/stdlib/agents/agency/researcher.agency
@@ -87,7 +87,7 @@ export def agencyResearcherAgent(
   @param session - Session name to share a thread across calls, or "" for isolated
   @param extraTools - Extra tools to offer the LLM, appended to the built-in set
   """
-  return guard(cost: maxCost, time: maxTime) {
+  return guard(cost: maxCost, time: maxTime, label: "agencyResearcherAgent") {
     let reply = ""
     thread(label: "agencyResearcherAgent", session: session, summarize: true) {
       reply = answer(

--- a/packages/agency-lang/stdlib/agents/agency/review.agency
+++ b/packages/agency-lang/stdlib/agents/agency/review.agency
@@ -121,7 +121,7 @@ export def agencyReviewAgent(
   if (task == "") {
     return feedback
   }
-  const captured = guard(cost: maxCost, time: maxTime) {
+  const captured = guard(cost: maxCost, time: maxTime, label: "agencyReviewAgent") {
     let judged: Feedback[] = []
     thread(label: "agencyReviewAgent", session: session) {
       judged = judgeAgainstTask(

--- a/packages/agency-lang/stdlib/agents/agency/verifier.agency
+++ b/packages/agency-lang/stdlib/agents/agency/verifier.agency
@@ -117,7 +117,7 @@ export def agencyVerifierAgent(
   @param session - Session name to share a thread across calls, or "" for isolated
   @param extraTools - Extra tools to offer the LLM, appended to the built-in set
   """
-  const captured = guard(cost: maxCost, time: maxTime) {
+  const captured = guard(cost: maxCost, time: maxTime, label: "agencyVerifierAgent") {
     return runAndJudge(
       source: source,
       task: task,

--- a/packages/agency-lang/stdlib/agents/coding.agency
+++ b/packages/agency-lang/stdlib/agents/coding.agency
@@ -122,7 +122,7 @@ export def codingAgent(
   @param extraTools - Extra tools to offer the LLM, appended to the built-in set
   """
 
-  return guard(cost: maxCost, time: maxTime) {
+  return guard(cost: maxCost, time: maxTime, label: "codingAgent") {
     let reply = ""
     thread(label: "codingAgent", session: session) {
       reply = solve(

--- a/packages/agency-lang/stdlib/agents/data.agency
+++ b/packages/agency-lang/stdlib/agents/data.agency
@@ -128,7 +128,7 @@ export def dataAgent(
   @param extraTools - Extra tools to offer the LLM, appended to the built-in set
   """
 
-  return guard(cost: maxCost, time: maxTime) {
+  return guard(cost: maxCost, time: maxTime, label: "dataAgent") {
     let reply = ""
     thread(label: "dataAgent", session: session) {
       reply = answer(

--- a/packages/agency-lang/stdlib/agents/expert.agency
+++ b/packages/agency-lang/stdlib/agents/expert.agency
@@ -89,7 +89,7 @@ export def expertAgent(
   @param extraTools - Extra tools to offer the LLM, appended to the built-in set
   """
 
-  return guard(cost: maxCost, time: maxTime) {
+  return guard(cost: maxCost, time: maxTime, label: "expertAgent") {
     let guidance: ExpertGuidance = emptyGuidance
     thread(label: "expertAgent", session: session) {
       guidance = consult(

--- a/packages/agency-lang/stdlib/agents/explorer.agency
+++ b/packages/agency-lang/stdlib/agents/explorer.agency
@@ -177,7 +177,7 @@ export def explorerAgent(
   @param extraTools - Extra tools to offer the LLM, appended to the built-in set
   """
 
-  return guard(cost: maxCost, time: maxTime) {
+  return guard(cost: maxCost, time: maxTime, label: "explorerAgent") {
     let reply = ""
     thread(label: "explorerAgent", summarize: true, session: session) {
       reply = survey(

--- a/packages/agency-lang/stdlib/agents/oracle.agency
+++ b/packages/agency-lang/stdlib/agents/oracle.agency
@@ -150,7 +150,7 @@ export def oracleAgent(
   @param extraTools - Extra tools to offer the LLM, appended to the built-in set
   """
 
-  return guard(cost: maxCost, time: maxTime) {
+  return guard(cost: maxCost, time: maxTime, label: "oracleAgent") {
     let reply = ""
     thread(label: "oracleAgent", summarize: true, session: session) {
       reply = consider(

--- a/packages/agency-lang/stdlib/agents/planner.agency
+++ b/packages/agency-lang/stdlib/agents/planner.agency
@@ -246,7 +246,7 @@ export def plannerAgent(
   @param session - Session name to share a thread across calls, or "" for isolated
   @param extraTools - Extra tools to offer the LLM, appended to the built-in set
   """
-  const captured = guard(cost: maxCost, time: maxTime) {
+  const captured = guard(cost: maxCost, time: maxTime, label: "plannerAgent") {
     // The drafting call runs in its own thread so the planner honors the
     // same session contract as every other agent. The model override applies
     // to this step only: each worker agent the generated plan calls resolves

--- a/packages/agency-lang/stdlib/agents/researcher.agency
+++ b/packages/agency-lang/stdlib/agents/researcher.agency
@@ -132,7 +132,7 @@ export def researcherAgent(
   @param extraTools - Extra tools to offer the LLM, appended to the built-in set
   """
 
-  return guard(cost: maxCost, time: maxTime) {
+  return guard(cost: maxCost, time: maxTime, label: "researcherAgent") {
     let answer = ""
     thread(label: "researcherAgent", session: session) {
       answer = researchLoop(

--- a/packages/agency-lang/stdlib/agents/review.agency
+++ b/packages/agency-lang/stdlib/agents/review.agency
@@ -90,7 +90,7 @@ export def reviewAgent(
   @param session - Session name to share a thread across calls, or "" for isolated
   @param extraTools - Extra tools to offer the LLM, appended to the built-in set
   """
-  const captured = guard(cost: maxCost, time: maxTime) {
+  const captured = guard(cost: maxCost, time: maxTime, label: "reviewAgent") {
     let items: Feedback[] = []
     thread(label: "reviewAgent", session: session) {
       items = judgeWork(

--- a/packages/agency-lang/stdlib/agents/verifier.agency
+++ b/packages/agency-lang/stdlib/agents/verifier.agency
@@ -89,7 +89,7 @@ export def verifierAgent(
   @param session - Session name to share a thread across calls, or "" for isolated
   @param extraTools - Extra tools to offer the LLM, appended to the built-in set
   """
-  const captured = guard(cost: maxCost, time: maxTime) {
+  const captured = guard(cost: maxCost, time: maxTime, label: "verifierAgent") {
     let results: Feedback[][] = []
     thread(label: "verifierAgent", session: session) {
       if (threadIsNew()) {

--- a/packages/agency-lang/tests/agency/guards/unowned-guard-rejected.agency
+++ b/packages/agency-lang/tests/agency/guards/unowned-guard-rejected.agency
@@ -1,0 +1,90 @@
+// turnBudgetHandler used to pass foreign std::guard trips through, and
+// since nothing above it answers guards, an unlabeled inner guard parked
+// the turn forever (the orphaned tool_use incident). Now a foreign trip is
+// rejected: the budget is a hard stop, the trip converts to a Failure at
+// the guard site, and the caller salvages like any other guard failure.
+// These tests drive the REAL handler — turn-budget-partial.agency only
+// imitates it.
+import test { _advanceTime } from "std::date"
+import { turnBudgetHandler, TURN_BUDGET_LABEL } from "../../../lib/agents/agency-agent/lib/budget.agency"
+import { setInteractive } from "../../../lib/agents/agency-agent/lib/trace.agency"
+
+// Stands in for a subagent body that saves a partial, then overruns its
+// budget. The finalize-as-draft salvage mirrors
+// tests/agency/guards/finalize-binder-returns-draft.agency, where a
+// REJECTED guard trip returns success carrying the finalize value.
+def workWithSalvage(): string {
+  saveDraft("PARTIAL")
+  _advanceTime(20000)
+  return "FULL"
+
+  finalize as draft {
+    if (draft != null) {
+      return draft
+    }
+    return "no-draft"
+  }
+}
+
+def workBare(): string {
+  _advanceTime(20000)
+  return "FULL"
+}
+
+def innerWithSalvage(): Result<string> {
+  return guard(cost: $5, time: 10s, label: "expertAgent") {
+    return workWithSalvage()
+  }
+}
+
+def innerBare(): Result<string> {
+  return guard(cost: $5, time: 10s, label: "oracleAgent") {
+    return workBare()
+  }
+}
+
+// Foreign label + salvage: reject converts the trip to a Failure at the
+// guard site, where finalize-as-draft turns it into a success carrying
+// the partial. This is the claim "salvage still runs", demonstrated.
+node foreignGuardSalvage() {
+  handle {
+    const r = innerWithSalvage()
+    if (r is success(v)) {
+      return "salvaged:${v}"
+    }
+    return "no-salvage"
+  } with turnBudgetHandler
+}
+
+// Foreign label, no salvage: a plain Failure the caller can match on.
+node foreignGuardBare() {
+  handle {
+    const r = innerBare()
+    return "failure:${isFailure(r)}"
+  } with turnBudgetHandler
+}
+
+// The handler's OWN label still takes the non-interactive reject path,
+// proving the label match is intact. _isInteractive defaults to true, so
+// the fixture must flip it or the handler would prompt via input() and
+// hang the harness.
+node ownLabelReject() {
+  setInteractive(false)
+  handle {
+    const r = guard(time: 50ms, label: TURN_BUDGET_LABEL) {
+      return workBare()
+    }
+    return "failure:${isFailure(r)}"
+  } with turnBudgetHandler
+}
+
+// Non-guard interrupts must still pass through to whoever is outside —
+// here, the test harness resolves it. Getting the early-return split
+// wrong would make the agent reject tool approvals, which would be far
+// worse than the bug being fixed.
+node nonGuardPassthrough() {
+  handle {
+    const r = interrupt("confirm")
+    return "resolved"
+  } with turnBudgetHandler
+}

--- a/packages/agency-lang/tests/agency/guards/unowned-guard-rejected.agency
+++ b/packages/agency-lang/tests/agency/guards/unowned-guard-rejected.agency
@@ -43,10 +43,17 @@ def innerBare(): Result<string> {
   }
 }
 
+// Each node states its own interactivity instead of inheriting the
+// module default (true) — otherwise the file is order-sensitive: one
+// node flipping the module-global flag would silently change which
+// branch its siblings exercise.
+
 // Foreign label + salvage: reject converts the trip to a Failure at the
 // guard site, where finalize-as-draft turns it into a success carrying
 // the partial. This is the claim "salvage still runs", demonstrated.
+// Interactive: covers the notice-then-reject branch.
 node foreignGuardSalvage() {
+  setInteractive(true)
   handle {
     const r = innerWithSalvage()
     if (r is success(v)) {
@@ -57,7 +64,9 @@ node foreignGuardSalvage() {
 }
 
 // Foreign label, no salvage: a plain Failure the caller can match on.
+// Non-interactive: covers the reject-without-notice branch.
 node foreignGuardBare() {
+  setInteractive(false)
   handle {
     const r = innerBare()
     return "failure:${isFailure(r)}"
@@ -65,9 +74,9 @@ node foreignGuardBare() {
 }
 
 // The handler's OWN label still takes the non-interactive reject path,
-// proving the label match is intact. _isInteractive defaults to true, so
-// the fixture must flip it or the handler would prompt via input() and
-// hang the harness.
+// proving the label match is intact. Must be non-interactive: the
+// interactive own-label path prompts via input() and would hang the
+// harness.
 node ownLabelReject() {
   setInteractive(false)
   handle {
@@ -83,8 +92,9 @@ node ownLabelReject() {
 // wrong would make the agent reject tool approvals, which would be far
 // worse than the bug being fixed.
 node nonGuardPassthrough() {
+  setInteractive(false)
   handle {
-    const r = interrupt("confirm")
+    interrupt("confirm")
     return "resolved"
   } with turnBudgetHandler
 }

--- a/packages/agency-lang/tests/agency/guards/unowned-guard-rejected.test.json
+++ b/packages/agency-lang/tests/agency/guards/unowned-guard-rejected.test.json
@@ -1,0 +1,44 @@
+{
+  "tests": [
+    {
+      "nodeName": "foreignGuardSalvage",
+      "fakeClock": true,
+      "description": "A foreign std::guard trip is rejected by turnBudgetHandler; the inner guard's finalize-as-draft salvage turns the Failure into a success carrying the saved partial.",
+      "input": "",
+      "expectedOutput": "\"salvaged:PARTIAL\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "interruptHandlers": [],
+      "llmMocks": []
+    },
+    {
+      "nodeName": "foreignGuardBare",
+      "fakeClock": true,
+      "description": "A foreign std::guard trip with no salvage is rejected into a plain Failure instead of parking the turn.",
+      "input": "",
+      "expectedOutput": "\"failure:true\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "interruptHandlers": [],
+      "llmMocks": []
+    },
+    {
+      "nodeName": "ownLabelReject",
+      "fakeClock": true,
+      "description": "The turn-budget label still routes through the handler's own path: non-interactive runs honor the budget as a hard stop.",
+      "input": "",
+      "expectedOutput": "\"failure:true\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "interruptHandlers": [],
+      "llmMocks": []
+    },
+    {
+      "nodeName": "nonGuardPassthrough",
+      "fakeClock": true,
+      "description": "Non-guard interrupts pass through turnBudgetHandler to the outer resolver.",
+      "input": "",
+      "expectedOutput": "\"resolved\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "interruptHandlers": [{ "action": "approve", "expectedMessage": "confirm" }],
+      "llmMocks": []
+    }
+  ]
+}


### PR DESCRIPTION
A turn that parks on an unanswered guard trip and is then abandoned left its
session thread ending on an assistant message with unanswered tool calls.
The provider rejects every later request on that thread with a 400, so one
abandoned turn destroyed the whole session (see the trace in
docs/superpowers/specs/2026-07-22-orphaned-tool-use-on-guard-abort-design.md).

This PR:
- restructures threadRepair.ts around one shared scan (unansweredToolCalls)
  and one shared append procedure; per-message debug labels now survive
  repair
- adds repairAbandonedTurn, which synthesizes results for dangling calls
  with wording that tells the next model the turn was interrupted, and
  repairReopenedThread, which Runner.thread() calls in one line on every
  reopen (session second+ entry and thread(continue: id); checkpoint
  resumes provably skip the branch, and a test pins that)
- gives MessageThread a repair generation (markRepaired/isNewerThan) and a
  restoreThreadForResume helper that refuses restoring a checkpoint taken
  before a repair, so a late answer to an abandoned turn fails loudly
  (with a statelog runtimeError emitted before the throw) instead of
  silently overwriting newer conversation
- makes turnBudgetHandler reject unowned std::guard trips instead of
  passing them into a park nobody will resume, with the first real test
  coverage of that handler (foreign-guard salvage, bare failure, own-label
  reject, non-guard pass-through), and labels the 14 inner stdlib guards so
  stop notices can name the budget that ran out

The existing user-cancel repair policy (needsThreadRepair) is deliberately
unchanged; the new rule is separate: a thread must be valid before new work
is appended to it.

Test notes: the end-to-end "no 400" assertion is not implementable with the
mock provider (it does not enforce tool_result pairing), so the runner
tests exercise the real seam with the real ThreadStore instead. The
own-label interactive prompt path of turnBudgetHandler stays untested (it
needs input() mocking); the non-interactive path covers the same label
matching. One fixture gotcha worth knowing: _isInteractive defaults to
true, so the own-label test calls setInteractive(false) explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
