### PR TITLE
Guard clone suspension, read-only git tools for agents, empty-table rendering

### DIFF
--- a/packages/agency-lang/CHANGELOG.md
+++ b/packages/agency-lang/CHANGELOG.md
@@ -22,6 +22,45 @@ internal path containment (no `..`, no absolute filenames), so an
 approved read or write can now reach any path the interrupt policy
 allows.
 
+### Language / Typechecker
+- **List comprehensions** — `[expr for x in xs if cond]`, with `fork` / `forkShared` / `race` / `raceShared` prefixes for parallel comprehensions.
+- **Type patterns** — `match` can now match on the type of a value (`is Type`, `pattern: Type`), plus a stdlib `Json` type.
+- **fork/race return types** — a `fork` block is typed `T[]` and `race` is `T | null`, derived from the block's returns.
+- Access chains now parse on bracket literals (`[1, 2, 3].map(...)`).
+- Passing a single tool to `tools:` is now a type error instead of a runtime crash.
+- `@validate` validators now run through `Record` values.
+- Literal arrays and objects require commas between items, with targeted parse errors for half-typed comprehensions.
+
+### Standard Library
+- **Agents rework** — the worker agents moved onto the stdlib and were heavily refactored. Oracle, explorer, and data agents joined; each agent ships its own skill and carries the tools its job requires, including read-only git tools for the writer and verifiers.
+- **Supervision** — long-running solves run under `std::supervise` with periodic verifier check-ins, brainstorming before complex solves, and partial results saved at every milestone.
+- **`std::date` instants** — `now()` returns epoch milliseconds, plus `elapsedTime` and `formatDuration`.
+- **`std::thread`** — `queueMessage` queues a message for the model's next turn; `toolMessage` seeds a synthetic tool exchange.
+- Guard `Result<T>` annotations flow into `saveDraft` schemas, so drafts validate against the real return type.
+- An empty `table` renders as nothing instead of throwing mid-display.
+- AppleScript integrations pass data as argv instead of escaping it into the script source.
+
+### Agent
+- **Per-turn budgets** — a deadline or spend limit stated in your message ("no more than 30 seconds") becomes a real guard around the turn, with a prompt to grant more when it trips.
+- The entry point split into CLI, REPL, and coordinator, and the duplicate subagents collapsed onto the stdlib.
+- Compaction can now run after an assistant message, so a long tool-call chain cannot overflow the context. Summarization extracts only the new messages.
+- `--max-cost` / `--max-time` flags, a sticky interrupt prompt in line mode, and no more crashing on spawn errors.
+- The agent knows the standard library and its own docs via skills, uses the gh CLI, and reports what it is doing as it works.
+
+### Runtime
+- **Resume desync fixed** — helper calls are hoisted into their own skippable steps, so an in-process resume can no longer replay a completed call and corrupt saved frames.
+- **Abandoned tool calls repaired** — reopening a thread with a dangling tool call inserts a synthetic result instead of failing the next request with a provider 400.
+- Renamed tools now round-trip through checkpoints, and a registry miss no longer crashes checkpoint writes.
+- Handlers can raise interrupts without being triggered by their own interrupt, and a guard trip inside a handler rejects instead of pausing.
+- A guard suspended while its handler deliberates no longer leaks armed clones into tool-call branches (the 1ms-limit trip storm).
+- Scoped block callbacks survive cross-process pause/resume, and imported modules' top-level callbacks now fire.
+- Cache reads and writes are counted in the token/cost breakdown.
+
+### CLI & Editor
+- **`agency lint`** — new command with an unused-imports rule (AL0001), editor gray-out, and remove-on-save.
+- LSP fixes — no more false import errors on unsaved edits, and the prelude has a single definition so its phantom errors are gone.
+- `agency literate` weaves nested comments and takes `--base-url`; the docs gained rendered examples.
+
 ## Jul 17 2026 — v0.9.0
 
 ### Language / Typechecker

--- a/packages/agency-lang/docs/site/stdlib/agents/agency/coding.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/agency/coding.md
@@ -28,7 +28,7 @@ export type WriteFailure = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/coding.agency#L26))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/coding.agency#L27))
 
 ## Functions
 
@@ -44,7 +44,7 @@ Return the Agency writer's tools: the bundled documentation, the source
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/coding.agency#L105))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/coding.agency#L106))
 
 ### syntaxHintFor
 
@@ -65,7 +65,7 @@ Return a specific syntax reminder to inject next to a diagnostic, or ""
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/coding.agency#L122))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/coding.agency#L124))
 
 ### agencyCodingAgent
 
@@ -113,4 +113,4 @@ Write an Agency program for the task. Iterates until the source parses,
 
 **Returns:** `Result<string, WriteFailure>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/coding.agency#L249))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/coding.agency#L251))

--- a/packages/agency-lang/docs/site/stdlib/agents/lib/toolkits.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/lib/toolkits.md
@@ -22,7 +22,7 @@ An agent's tool list should read as a description of what that agent may
 export static const SAVE_DRAFT_HINT = "\n\nIf you might run low on time or budget, call `saveDraft` with your best answer so far as you work, and update it as you improve. If the run is cut short, the last draft you saved is what the user receives — a run that saved nothing returns nothing."
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/toolkits.agency#L181))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/toolkits.agency#L198))
 
 ## Functions
 
@@ -42,7 +42,7 @@ Tell the user what you are doing. Use this tool often to update the user on what
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/toolkits.agency#L54))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/toolkits.agency#L55))
 
 ### communicationTools
 
@@ -54,7 +54,7 @@ Return tools that help the agent communicate with the user.
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/toolkits.agency#L62))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/toolkits.agency#L63))
 
 ### readOnlyFileTools
 
@@ -67,7 +67,7 @@ Return tools that inspect the file system without changing it: read, list,
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/toolkits.agency#L69))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/toolkits.agency#L70))
 
 ### writableFileTools
 
@@ -79,7 +79,7 @@ Return the read-only file tools plus write and edit.
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/toolkits.agency#L82))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/toolkits.agency#L83))
 
 ### shellTools
 
@@ -92,7 +92,25 @@ Return tools that run commands: bash for a shell pipeline, exec for a
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/toolkits.agency#L93))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/toolkits.agency#L94))
+
+### readOnlyGitTools
+
+```ts
+readOnlyGitTools(): any[]
+```
+
+Return the read-only git tools: history, diffs, status, branches. Nothing
+  here changes the repository, so read-only agents (verifiers, reviewers,
+  writers with read-only project access) can carry them. gitIsRepo is
+  included because "am I inside a repo?" is the question an agent otherwise
+  answers by probing for a `.git` directory by hand — which fails in a
+  monorepo, where `.git` lives above the package directory (git itself
+  walks up; a manual probe does not).
+
+**Returns:** `any[]`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/toolkits.agency#L102))
 
 ### gitTools
 
@@ -105,7 +123,7 @@ Return the git tools. The read-only ones run without an approval prompt;
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/toolkits.agency#L101))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/toolkits.agency#L125))
 
 ### webTools
 
@@ -119,7 +137,7 @@ Return tools that retrieve a named web resource: HTTP fetches and Wikipedia
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/toolkits.agency#L127))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/toolkits.agency#L144))
 
 ### agencyDocTools
 
@@ -133,7 +151,7 @@ Return the bundled Agency documentation tools: the language guide, the CLI
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/toolkits.agency#L143))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/toolkits.agency#L160))
 
 ### agencyCodeTools
 
@@ -146,7 +164,7 @@ Return tools that inspect Agency source without running it: the type
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/toolkits.agency#L152))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/toolkits.agency#L169))
 
 ### memoryTools
 
@@ -158,7 +176,7 @@ Return tools that persist and retrieve facts across sessions.
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/toolkits.agency#L160))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/toolkits.agency#L177))
 
 ### planningTools
 
@@ -171,4 +189,4 @@ Return tools an agent uses to organize a long run: writing and reading a
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/toolkits.agency#L170))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/toolkits.agency#L187))

--- a/packages/agency-lang/docs/site/stdlib/agents/verifier.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/verifier.md
@@ -72,4 +72,4 @@ Verify work on disk against a task: derive measurable success criteria,
 
 **Returns:** `Result<Feedback[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/verifier.agency#L66))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/verifier.agency#L67))

--- a/packages/agency-lang/lib/runtime/guard.test.ts
+++ b/packages/agency-lang/lib/runtime/guard.test.ts
@@ -523,6 +523,36 @@ describe("suspension", () => {
     expect(g.check(new StateStack())).not.toBeNull();
   });
 
+  it("a suspended TimeGuard does not clone into branches", () => {
+    // The 2026-07-23 supervise storm: while a guard-trip handler runs
+    // its check, the tripped guard is suspended — but every tool call
+    // the check makes runs on its own branch stack, and cloneForBranch
+    // handed each branch an ARMED clone of the exhausted guard,
+    // floored at 1ms remaining. The clone tripped instantly, the
+    // owning handler was self-excluded from its own guard's echo, and
+    // the catch-all rejected the branch — once per tool call, forever.
+    // Handler work is metered by the registration site's guards only,
+    // so a suspended guard must be invisible to branches it did not
+    // meter in the first place: no clone.
+    const g = new TimeGuard(60000);
+    const parent = new StateStack();
+    const child = new StateStack();
+    g.suspend();
+    expect(g.cloneForBranch(parent, child)).toBeUndefined();
+    g.unsuspend();
+    expect(g.cloneForBranch(parent, child)).toBeDefined();
+  });
+
+  it("a suspended exhausted TimeGuard clones nothing even at the 1ms floor", () => {
+    // The exact storm shape: elapsed has consumed the whole budget, so
+    // an (incorrect) clone would get Math.max(1, remaining) = 1ms and
+    // trip on its first step. Suspension must win over the floor.
+    const g = new TimeGuard(1000);
+    (g as any).elapsedMs = 1000;
+    g.suspend();
+    expect(g.cloneForBranch(new StateStack(), new StateStack())).toBeUndefined();
+  });
+
   it("CostGuard suspension is stack-scoped, never object-scoped: the shared object still meters sibling branches", () => {
     // The same CostGuard object appears on two branch stacks
     // (cloneForBranch returns `this`). Suspending it FOR A HANDLER on

--- a/packages/agency-lang/lib/runtime/guard.ts
+++ b/packages/agency-lang/lib/runtime/guard.ts
@@ -801,7 +801,9 @@ export class TimeGuard implements Guard {
     // either — suspension never serializes, so a branch pause would
     // revive the clone armed at 1ms. No clone is the only shape that
     // matches "invisible to enforcement".
-    if (this.suspended) return undefined;
+    if (this.suspended) {
+      return undefined;
+    }
     // Wall-clock time is not cumulative across parallel branches, so each
     // branch gets its OWN timer. It inherits the parent's REMAINING budget
     // at fork time (floored at 1ms, so "parent work, then branch" cannot

--- a/packages/agency-lang/lib/runtime/guard.ts
+++ b/packages/agency-lang/lib/runtime/guard.ts
@@ -788,7 +788,20 @@ export class TimeGuard implements Guard {
   cloneForBranch(
     _parentStack: StateStack,
     _childStack: StateStack,
-  ): Guard {
+  ): Guard | undefined {
+    // A suspended guard clones NOTHING. Suspension means an interrupt
+    // handler is deliberating over this guard right now, and handler
+    // work is metered by the handler's registration-site guards only.
+    // Branches created during that work (each parallel tool call runs
+    // on its own branch stack) are handler work too. Cloning here armed
+    // an exhausted guard's remaining budget — Math.max(1, 0) = 1ms —
+    // into every such branch: an instant trip the owning handler is
+    // self-excluded from answering, once per tool call (the 2026-07-23
+    // supervise storm). A suspended-state clone would not survive
+    // either — suspension never serializes, so a branch pause would
+    // revive the clone armed at 1ms. No clone is the only shape that
+    // matches "invisible to enforcement".
+    if (this.suspended) return undefined;
     // Wall-clock time is not cumulative across parallel branches, so each
     // branch gets its OWN timer. It inherits the parent's REMAINING budget
     // at fork time (floored at 1ms, so "parent work, then branch" cannot

--- a/packages/agency-lang/lib/stdlib/layout.test.ts
+++ b/packages/agency-lang/lib/stdlib/layout.test.ts
@@ -1534,12 +1534,21 @@ describe("table — _coerceCell", () => {
 });
 
 describe("table — _validateTable", () => {
-  test("all-empty throws 'at least one of...'", () => {
-    expect(() => _validateTable({})).toThrow(/at least one of header \/ body \/ footer/);
+  test("all-empty is a valid empty table (columnCount 0), not an error", () => {
+    // Table content is routinely tool-derived; "no rows" crashed the
+    // agent CLI mid-display before this was made a valid degenerate.
+    const v = _validateTable({});
+    expect(v).toEqual({ header: [], body: [], footer: [], columnCount: 0 });
   });
-  test("body+footer empty + header undefined throws", () => {
-    expect(() => _validateTable({ body: [], footer: [] }))
-      .toThrow(/at least one of/);
+  test("body+footer empty + header undefined is the same empty table", () => {
+    expect(_validateTable({ body: [], footer: [] }).columnCount).toBe(0);
+  });
+  test("an empty table renders as nothing through the full pipeline", () => {
+    // The crash path was render -> sizeTable -> _validateTable throw;
+    // both the sizing and render handlers must short-circuit on the
+    // empty marker.
+    expect(renderTablePlain({})).toBe("");
+    expect(renderTablePlain({ body: [], footer: [] })).toBe("");
   });
   test("header alone is fine", () => {
     const v = _validateTable({ header: ["A", "B"] });
@@ -1613,12 +1622,15 @@ describe("table — _validateTable", () => {
       header: ["A"],
     })).toThrow(/columns must be an array, got string/);
   });
-  test("zero-column table (empty header) throws instead of rendering a degenerate frame", () => {
-    expect(() => _validateTable({ header: [] }))
+  test("empty header with no other content is the empty table, not an error", () => {
+    expect(_validateTable({ header: [] }).columnCount).toBe(0);
+  });
+  test("zero-column table (empty body row) throws — content present but degenerate", () => {
+    expect(() => _validateTable({ body: [[]] }))
       .toThrow(/at least one column is required/);
   });
-  test("zero-column table (empty body row) throws", () => {
-    expect(() => _validateTable({ body: [[]] }))
+  test("empty header alongside real body rows still throws the column mismatch", () => {
+    expect(() => _validateTable({ header: [], body: [["1", "2"]] }))
       .toThrow(/at least one column is required/);
   });
   test("cells are coerced in the returned sections", () => {

--- a/packages/agency-lang/lib/stdlib/layout/table.ts
+++ b/packages/agency-lang/lib/stdlib/layout/table.ts
@@ -233,7 +233,9 @@ export function _resolveTableWidths(
   const attrs = node.attrs;
   const { header, body, footer, columnCount } = _validateTable(attrs);
   // Empty table: nothing to size, no column widths to resolve.
-  if (columnCount === 0) return node;
+  if (columnCount === 0) {
+    return node;
+  }
   const columns = (attrs.columns as ColumnSpec[] | null | undefined) ?? [];
   const cellPadding = clampCellPadding(attrs.cellPadding);
   const columnDividers = (attrs.columnDividers as boolean | undefined) ?? true;
@@ -537,7 +539,9 @@ function _composeCaption(caption: string, width: number): Block | null {
 export function composeTable(node: LayoutNode): Block {
   const { header, body, footer, columnCount } = _validateTable(node.attrs);
   // Empty table renders as nothing — no frame, no lines.
-  if (columnCount === 0) return Block.empty();
+  if (columnCount === 0) {
+    return Block.empty();
+  }
   const attrs = node.attrs;
   // Clamp to a non-negative integer. `_innerTableWidth` and the
   // divider line both use `cellPadding` in width arithmetic; a

--- a/packages/agency-lang/lib/stdlib/layout/table.ts
+++ b/packages/agency-lang/lib/stdlib/layout/table.ts
@@ -71,8 +71,9 @@ export type ValidatedTable = {
   columnCount: number;
 };
 
-// Structural sanity for a `table` node. Throws on:
-//   * all three sections empty/unset
+// Structural sanity for a `table` node. An all-empty table (no header
+// cells, no body rows, no footer rows) is valid and returns
+// `columnCount: 0` — it renders as nothing. Throws on:
 //   * any present section whose row length disagrees with the column
 //     count (derived from `columns` if set, else `header`, else first
 //     body row, else first footer row)
@@ -108,10 +109,17 @@ export function _validateTable(attrs: Record<string, unknown>): ValidatedTable {
   const body   = checkSection(rawBody,   "body");
   const footer = checkSection(rawFooter, "footer");
 
-  if (!header && body.length === 0 && footer.length === 0) {
-    throw new Error(
-      "std::ui/layout.table: at least one of header / body / footer must be set",
-    );
+  // An all-empty table is a VALID table that renders as nothing.
+  // Table content is routinely model- or tool-derived (an agent
+  // rendering a result set), and "no rows" is a legitimate degenerate
+  // value there, not a programming error — throwing here crashed the
+  // agent CLI mid-display when a tool produced empty output (the
+  // 2026-07-23 changelog run). Structural errors — row length
+  // mismatches, a zero-cell row alongside real content — still throw
+  // below. `columnCount: 0` is the empty marker the sizing and render
+  // handlers short-circuit on.
+  if ((header ?? []).length === 0 && body.length === 0 && footer.length === 0) {
+    return { header: [], body: [], footer: [], columnCount: 0 };
   }
 
   const rawColumns = attrs.columns;
@@ -224,6 +232,8 @@ export function _resolveTableWidths(
 ): LayoutNode {
   const attrs = node.attrs;
   const { header, body, footer, columnCount } = _validateTable(attrs);
+  // Empty table: nothing to size, no column widths to resolve.
+  if (columnCount === 0) return node;
   const columns = (attrs.columns as ColumnSpec[] | null | undefined) ?? [];
   const cellPadding = clampCellPadding(attrs.cellPadding);
   const columnDividers = (attrs.columnDividers as boolean | undefined) ?? true;
@@ -526,6 +536,8 @@ function _composeCaption(caption: string, width: number): Block | null {
 
 export function composeTable(node: LayoutNode): Block {
   const { header, body, footer, columnCount } = _validateTable(node.attrs);
+  // Empty table renders as nothing — no frame, no lines.
+  if (columnCount === 0) return Block.empty();
   const attrs = node.attrs;
   // Clamp to a non-negative integer. `_innerTableWidth` and the
   // divider line both use `cellPadding` in width arithmetic; a

--- a/packages/agency-lang/stdlib/agents/agency/coding.agency
+++ b/packages/agency-lang/stdlib/agents/agency/coding.agency
@@ -15,6 +15,7 @@ import {
   agencyDocTools,
   agencyCodeTools,
   readOnlyFileTools,
+  readOnlyGitTools,
  } from "std::agents/lib/toolkits"
 import { fetch, fetchJSON, fetchMarkdown } from "std::http"
 import { Critique, revise } from "std::strategy"
@@ -112,6 +113,7 @@ export def buildTools(): any[] {
     ...agencyDocTools(),
     ...agencyCodeTools(),
     ...readOnlyFileTools(),
+    ...readOnlyGitTools(),
     fetch,
     fetchJSON,
     fetchMarkdown,

--- a/packages/agency-lang/stdlib/agents/agency/verifier.agency
+++ b/packages/agency-lang/stdlib/agents/agency/verifier.agency
@@ -7,7 +7,7 @@
 import { runCode } from "std::agency"
 import { Feedback, failOpenFeedback } from "std::agents/lib/feedback"
 import { llmOptions } from "std::agents/lib/shared"
-import { readOnlyFileTools, shellTools } from "std::agents/lib/toolkits"
+import { readOnlyFileTools, readOnlyGitTools, shellTools } from "std::agents/lib/toolkits"
 import { agentSkill } from "std::skills"
 import { systemMessage, threadIsNew } from "std::thread"
 
@@ -25,7 +25,7 @@ export def buildTools(): any[] {
   left behind; it has no write tools, because a verifier that can fix things
   is no longer a verifier.
   """
-  return [...readOnlyFileTools(), ...shellTools(), skills]
+  return [...readOnlyFileTools(), ...readOnlyGitTools(), ...shellTools(), skills]
 }
 
 def judgeResult(

--- a/packages/agency-lang/stdlib/agents/lib/toolkits.agency
+++ b/packages/agency-lang/stdlib/agents/lib/toolkits.agency
@@ -14,6 +14,7 @@ import { typecheck, parseAST } from "std::agency"
 import { todoWrite, todoList } from "std::agent"
 import { edit } from "std::fs"
 import {
+  gitIsRepo,
   gitStatus,
   gitLog,
   gitDiff,
@@ -98,12 +99,18 @@ export def shellTools(): any[] {
   return [bash.partial(useAgentCwd: true), exec.partial(useAgentCwd: true)]
 }
 
-export def gitTools(): any[] {
+export def readOnlyGitTools(): any[] {
   """
-  Return the git tools. The read-only ones run without an approval prompt;
-  the ones that change the repository prompt for approval.
+  Return the read-only git tools: history, diffs, status, branches. Nothing
+  here changes the repository, so read-only agents (verifiers, reviewers,
+  writers with read-only project access) can carry them. gitIsRepo is
+  included because "am I inside a repo?" is the question an agent otherwise
+  answers by probing for a `.git` directory by hand — which fails in a
+  monorepo, where `.git` lives above the package directory (git itself
+  walks up; a manual probe does not).
   """
   return [
+    gitIsRepo,
     gitStatus,
     gitLog,
     gitDiff,
@@ -112,6 +119,16 @@ export def gitTools(): any[] {
     gitRemoteList,
     gitBlame,
     gitStashList,
+  ]
+}
+
+export def gitTools(): any[] {
+  """
+  Return the git tools. The read-only ones run without an approval prompt;
+  the ones that change the repository prompt for approval.
+  """
+  return [
+    ...readOnlyGitTools(),
     gitAdd,
     gitCommit,
     gitCheckout,

--- a/packages/agency-lang/stdlib/agents/verifier.agency
+++ b/packages/agency-lang/stdlib/agents/verifier.agency
@@ -7,7 +7,7 @@
 */
 import { Feedback, failOpenFeedback } from "std::agents/lib/feedback"
 import { llmOptions } from "std::agents/lib/shared"
-import { readOnlyFileTools, shellTools, SAVE_DRAFT_HINT } from "std::agents/lib/toolkits"
+import { readOnlyFileTools, readOnlyGitTools, shellTools, SAVE_DRAFT_HINT } from "std::agents/lib/toolkits"
 import { concurrencyPool } from "std::concurrency"
 import { agentSkill } from "std::skills"
 import { systemMessage, threadIsNew } from "std::thread"
@@ -26,6 +26,7 @@ export def buildTools(): any[] {
   """
   return [
     ...readOnlyFileTools(),
+    ...readOnlyGitTools(),
     ...shellTools(),
     ...communicationTools(),
     readBinary.partial(useAgentCwd: true),

--- a/packages/agency-lang/tests/agency/agents/toolGaps.agency
+++ b/packages/agency-lang/tests/agency/agents/toolGaps.agency
@@ -4,6 +4,7 @@ import { buildTools as reviewTools } from "std::agents/review"
 import { buildTools as agencyVerifierTools } from "std::agents/agency/verifier"
 import { buildTools as agencyCodingTools } from "std::agents/agency/coding"
 import { buildTools as agencyReviewTools } from "std::agents/agency/review"
+import { gitTools, readOnlyGitTools } from "std::agents/lib/toolkits"
 
 def hasTool(tools: any[], name: string): boolean {
   return some(tools, \tool -> tool.name == name)
@@ -48,12 +49,17 @@ node codingCanFetch(): boolean {
 // verifier fell back to filesystem-wide `find` scans that timed out to
 // empty output and produced a confident false "there is no repo here".
 // History is read-only, so all three carry the read bundle; none may
-// gain the write tools (the writer returns source, verifiers verify).
+// gain ANY write tool. The write set is derived (gitTools minus
+// readOnlyGitTools) rather than hand-listed, so a git tool added later
+// is automatically asserted absent from these agents; the exact pin on
+// readOnlyGitTools itself lives in toolkits.agency.
 node historyReadersHaveGitButCannotCommit(): boolean {
   const lists = [agencyCodingTools(), verifierTools(), agencyVerifierTools()]
+  const readNames = map(readOnlyGitTools(), \tool -> tool.name)
+  const writeNames = filter(map(gitTools(), \tool -> tool.name), \name -> !readNames.includes(name))
   const canReadHistory = every(lists, \tools -> hasTool(tools, "gitLog") && hasTool(tools, "gitIsRepo"))
-  const cannotWrite = every(lists, \tools -> !hasTool(tools, "gitCommit") && !hasTool(tools, "gitCheckout"))
-  return canReadHistory && cannotWrite
+  const cannotWrite = every(lists, \tools -> every(writeNames, \name -> !hasTool(tools, name)))
+  return canReadHistory && cannotWrite && writeNames.length > 0
 }
 
 // Both reviewers can look things up now, and still cannot change anything.

--- a/packages/agency-lang/tests/agency/agents/toolGaps.agency
+++ b/packages/agency-lang/tests/agency/agents/toolGaps.agency
@@ -41,6 +41,21 @@ node codingCanFetch(): boolean {
   return hasTool(codingTools(), "fetchMarkdown")
 }
 
+// The changelog gap (2026-07-23): asked what changed since the last
+// release, the Agency writer and both verifiers had no git tools at
+// all. The writer probed for a `.git` directory by hand — which fails
+// in a monorepo, where `.git` lives above the package — and the
+// verifier fell back to filesystem-wide `find` scans that timed out to
+// empty output and produced a confident false "there is no repo here".
+// History is read-only, so all three carry the read bundle; none may
+// gain the write tools (the writer returns source, verifiers verify).
+node historyReadersHaveGitButCannotCommit(): boolean {
+  const lists = [agencyCodingTools(), verifierTools(), agencyVerifierTools()]
+  const canReadHistory = every(lists, \tools -> hasTool(tools, "gitLog") && hasTool(tools, "gitIsRepo"))
+  const cannotWrite = every(lists, \tools -> !hasTool(tools, "gitCommit") && !hasTool(tools, "gitCheckout"))
+  return canReadHistory && cannotWrite
+}
+
 // Both reviewers can look things up now, and still cannot change anything.
 node reviewersLookUpButCannotWrite(): boolean {
   const plain = reviewTools()

--- a/packages/agency-lang/tests/agency/agents/toolGaps.test.json
+++ b/packages/agency-lang/tests/agency/agents/toolGaps.test.json
@@ -56,6 +56,17 @@
       ]
     },
     {
+      "nodeName": "historyReadersHaveGitButCannotCommit",
+      "description": "the Agency writer and both verifiers read git history but cannot change the repo",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
       "nodeName": "reviewersLookUpButCannotWrite",
       "description": "reviewers gained lookups and still cannot change anything",
       "input": "",

--- a/packages/agency-lang/tests/agency/agents/toolkits.agency
+++ b/packages/agency-lang/tests/agency/agents/toolkits.agency
@@ -38,15 +38,22 @@ node writableIsASupersetOfReadOnly(): boolean {
   return coversReadOnly && writableFileTools().length == readOnlyFileTools().length + 2
 }
 
-// Membership both ways: the full git bundle must cover every read-only
-// tool (so the two lists cannot drift apart), and the read-only bundle
-// must carry no tool that can change the repository.
+// readOnlyGitTools is a security-sensitive bundle (read-only agents
+// carry it), so unlike the membership-only checks above it is pinned
+// EXACTLY: adding any tool to it must fail here and force a conscious
+// test edit, not slip through a not-on-the-blocklist gap. The full git
+// bundle must also cover every read-only tool so the lists cannot
+// drift apart.
 node readOnlyGitIsTheReadHalfOfGitTools(): boolean {
-  const gitNames = map(gitTools(), \tool -> tool.name)
+  const expected = [
+    "gitIsRepo", "gitStatus", "gitLog", "gitDiff", "gitShow",
+    "gitBranchList", "gitRemoteList", "gitBlame", "gitStashList",
+  ]
   const readNames = map(readOnlyGitTools(), \tool -> tool.name)
+  const gitNames = map(gitTools(), \tool -> tool.name)
+  const exact = readNames.length == expected.length && every(expected, \name -> readNames.includes(name))
   const covered = every(readOnlyGitTools(), \tool -> gitNames.includes(tool.name))
-  const noWrites = !readNames.includes("gitCommit") && !readNames.includes("gitCheckout") && !readNames.includes("gitAdd") && !readNames.includes("gitRestore")
-  return covered && noWrites && readNames.includes("gitLog") && readNames.includes("gitIsRepo")
+  return exact && covered
 }
 
 /** True when a tool has `useAgentCwd` bound to true by partial application.

--- a/packages/agency-lang/tests/agency/agents/toolkits.agency
+++ b/packages/agency-lang/tests/agency/agents/toolkits.agency
@@ -3,6 +3,7 @@ import {
   writableFileTools,
   shellTools,
   gitTools,
+  readOnlyGitTools,
   webTools,
   agencyDocTools,
   agencyCodeTools,
@@ -16,6 +17,7 @@ def allBundles(): any[] {
     writableFileTools(),
     shellTools(),
     gitTools(),
+    readOnlyGitTools(),
     webTools(),
     agencyDocTools(),
     agencyCodeTools(),
@@ -34,6 +36,17 @@ node writableIsASupersetOfReadOnly(): boolean {
   const writableNames = map(writableFileTools(), \tool -> tool.name)
   const coversReadOnly = every(readOnlyFileTools(), \tool -> writableNames.includes(tool.name))
   return coversReadOnly && writableFileTools().length == readOnlyFileTools().length + 2
+}
+
+// Membership both ways: the full git bundle must cover every read-only
+// tool (so the two lists cannot drift apart), and the read-only bundle
+// must carry no tool that can change the repository.
+node readOnlyGitIsTheReadHalfOfGitTools(): boolean {
+  const gitNames = map(gitTools(), \tool -> tool.name)
+  const readNames = map(readOnlyGitTools(), \tool -> tool.name)
+  const covered = every(readOnlyGitTools(), \tool -> gitNames.includes(tool.name))
+  const noWrites = !readNames.includes("gitCommit") && !readNames.includes("gitCheckout") && !readNames.includes("gitAdd") && !readNames.includes("gitRestore")
+  return covered && noWrites && readNames.includes("gitLog") && readNames.includes("gitIsRepo")
 }
 
 /** True when a tool has `useAgentCwd` bound to true by partial application.

--- a/packages/agency-lang/tests/agency/agents/toolkits.test.json
+++ b/packages/agency-lang/tests/agency/agents/toolkits.test.json
@@ -23,6 +23,17 @@
       ]
     },
     {
+      "nodeName": "readOnlyGitIsTheReadHalfOfGitTools",
+      "description": "readOnlyGitTools is covered by gitTools and carries no write tools",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
       "nodeName": "noBundleHasDuplicateNames",
       "description": "no bundle offers two tools with the same name",
       "input": "",

--- a/packages/agency-lang/tests/agency/layout/table-validation.agency
+++ b/packages/agency-lang/tests/agency/layout/table-validation.agency
@@ -10,7 +10,9 @@ def _badTable(attrs: any): any {
   return { type: "table", attrs: attrs, children: [] }
 }
 
-// No header / body / footer at all.
+// No header / body / footer at all: a valid EMPTY table that renders
+// as nothing (tryRender returns null on success). Table content is
+// routinely tool-derived, and empty crashing the display was a bug.
 node testAllSectionsMissing(): string {
   return tryRender(_badTable({}))
 }

--- a/packages/agency-lang/tests/agency/layout/table-validation.test.json
+++ b/packages/agency-lang/tests/agency/layout/table-validation.test.json
@@ -3,7 +3,7 @@
     {
       "nodeName": "testAllSectionsMissing",
       "input": "",
-      "expectedOutput": "\"std::ui/layout.table: at least one of header / body / footer must be set\"",
+      "expectedOutput": "null",
       "evaluationCriteria": [{ "type": "exact" }]
     },
     {


### PR DESCRIPTION
Three fixes from the 2026-07-23 changelog-run postmortem (the run that spent 11 minutes, produced nothing, and printed four "supervise ran out of time" lines with a 1ms limit).

## 1. TimeGuard: a suspended guard clones nothing into branches

While a guard-trip handler deliberates, the tripped guard is suspended: invisible to enforcement, because handler work is metered by the registration-site guards only. But `cloneForBranch` ignored suspension. Every branch created during the handler (each parallel tool call runs on its own branch stack) received an ARMED clone of the exhausted guard, floored at `Math.max(1, remaining)` = 1ms. The clone tripped on its first step, the owning handler was self-excluded from its own guard trip, and `turnBudgetHandler` rejected the branch as an unowned trip - once per tool call, indefinitely. That is exactly the observed storm: four `limit 1ms` trips, each a few milliseconds after a tool approval resolved, none ever reaching the supervise check.

A suspended-state clone would not fix it: suspension deliberately never serializes, so a branch pause would revive the clone armed at 1ms. No clone is the only shape that matches "invisible to enforcement". The undefined filter already exists in `StateStack`.

## 2. Read-only git tools for the Agency writer and both verifiers

Asked what changed since the last release, the Agency coding agent and the verifiers had no git tools at all. The coding agent probed for a `.git` directory by hand, which fails in a monorepo where `.git` lives above the package (git itself walks up from cwd; a manual probe does not). The verifier fell back to filesystem-wide `find` scans that timed out to empty output and concluded, confidently and wrongly, that there was no repository.

New `readOnlyGitTools()` bundle in `std::agents/lib/toolkits`: the GitRead set plus `gitIsRepo`, which answers the "am I in a repo?" question the agents were fumbling manually. `gitTools()` now composes it. Offered to `verifierAgent`, `agencyVerifierAgent`, and `agencyCodingAgent`; all three keep zero write tools, and the `toolGaps` test pins both directions (history readable, `gitCommit`/`gitCheckout` absent).

## 3. layout: an empty table renders as nothing instead of throwing

Table content is routinely model- or tool-derived, and "no rows" is a legitimate degenerate value there, not a programming error. The "at least one of header / body / footer must be set" throw crashed the agent CLI mid-display whenever a tool produced empty output. An all-empty table now validates to `columnCount: 0`; sizing passes the node through and render returns `Block.empty()`. Structural errors are unchanged: row-length mismatches and a zero-cell row alongside real content still throw.

## Testing

- `guard.test.ts`: two new tests (suspended guard does not clone; suspended exhausted guard specifically, the 1ms-floor shape). Guard, guardScope, stateStack, and runBatch suites all pass (161 tests).
- `tests/agency/agents/toolkits.agency` + `toolGaps.agency`: new nodes pin the read/write split of the git bundles and the composed agent tool lists (8/8 each).
- `layout.test.ts` (207 tests) and `tests/agency/layout/table-validation` (4/4): empty-table semantics through the full render pipeline, structural throws unchanged.
- tsc and the structural linter are clean.

Not addressed here (follow-ups from the same postmortem): the `agencyTask` routing proportionality, and the degenerate model output that the trip storm provoked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
