### PR TITLE
Test runner: expectedCompileError asserts a file fails to compile

### DIFF
--- a/packages/agency-lang/agency.json
+++ b/packages/agency-lang/agency.json
@@ -19,7 +19,8 @@
   },
   "coverage": {
     "exclude": [
-      "tests/agency/topsort/cycles/**"
+      "tests/agency/topsort/cycles/**",
+      "tests/agency/expectedCompileError/**"
     ]
   }
 }

--- a/packages/agency-lang/docs/misc/TESTING.md
+++ b/packages/agency-lang/docs/misc/TESTING.md
@@ -156,6 +156,50 @@ File-level fields (siblings of `tests`):
 - `skipOnCI` (optional) — `true` to skip every test in the file when running in CI
 - `skipReason` (optional) — human-readable reason printed when a file is skipped
 - `defaultTimeoutMs` (optional) — file-level default timeout, overridden by per-test `timeoutMs`
+- `expectedCompileError` (optional) — assert that the sibling `.agency` file **fails to compile**, and that the failure text contains this substring. A file that sets it has no `tests` array: the compile is the test. See below.
+
+### Expected compile errors
+
+Some things are supposed to be rejected at compile time — a program with an
+unfilled template hole, a type error you want pinned by its diagnostic code.
+A `.test.json` can assert that:
+
+```json
+{
+  "expectedCompileError": "AG2001",
+  "description": "A string cannot be assigned to a number"
+}
+```
+
+The test passes when compiling the sibling `.agency` file fails **and** the
+failure text contains the substring. Substring rather than exact match,
+because compiler output carries absolute paths and line numbers that differ
+by machine; the diagnostic code is the stable part. Parse errors carry no
+code, so those tests pin a phrase from the message instead
+(`"Failed to parse"`).
+
+Two things to know:
+
+- The compile runs in a child `agency compile` process whose working
+  directory is the fixture's own directory, and the CLI reads its config
+  from exactly there: `<fixture dir>/agency.json`, used as-is — not merged
+  over the project config the way the rest of the runner does it, and not
+  inherited from the repo root. A fixture directory without its own
+  `agency.json` compiles with an **empty** config (typechecker off), so
+  every fixture directory in this mode ships a complete `agency.json`.
+  Type-error fixtures need `typechecker.strict`, and the diagnostic must
+  be error severity — strict mode only refuses to compile on errors, not
+  warnings.
+- These files are skipped by the up-front precompile pass, which is what
+  lets a deliberately-broken source sit in the tree without ending the run.
+  Keep them in a directory of their own, and add that directory to
+  `coverage.exclude` in `agency.json` so `--coverage` does not try to
+  compile them for a source map.
+
+`llmMocks`, `fetchMocks`, and a non-empty `tests` array are rejected rather
+than ignored — nothing runs in this mode, so their presence means the test
+was expected to do something it does not do. File-level `skip` keeps its
+meaning and wins: a skipped file is skipped, compile expectation and all.
 
 ### Evaluation criteria
 

--- a/packages/agency-lang/lib/cli/expectedCompileError.test.ts
+++ b/packages/agency-lang/lib/cli/expectedCompileError.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "vitest";
+import {
+  findIncompatibleField,
+  judgeCompileAttempt,
+} from "./expectedCompileError.js";
+
+describe("judgeCompileAttempt", () => {
+  test("nonzero exit whose output contains the substring passes", () => {
+    const verdict = judgeCompileAttempt("AG2001", {
+      exitCode: 1,
+      output: "main.agency:3:5 - error AG2001: Type 'string' is not assignable",
+    });
+    expect(verdict.ok).toBe(true);
+  });
+
+  test("nonzero exit without the substring fails and shows both sides", () => {
+    const verdict = judgeCompileAttempt("AG2001", {
+      exitCode: 1,
+      output: "Failed to parse Agency program: unexpected {",
+    });
+    expect(verdict.ok).toBe(false);
+    if (verdict.ok) return;
+    expect(verdict.reason).toContain("AG2001");
+    expect(verdict.reason).toContain("Failed to parse");
+  });
+
+  test("a clean compile fails, naming what was expected", () => {
+    const verdict = judgeCompileAttempt("AG8001", {
+      exitCode: 0,
+      output: "main.agency → main.js (in 12.00ms)",
+    });
+    expect(verdict.ok).toBe(false);
+    if (verdict.ok) return;
+    expect(verdict.reason).toContain("compiled");
+    expect(verdict.reason).toContain("AG8001");
+  });
+
+  test("a timed-out compile fails as a timeout, not as a mismatch", () => {
+    const verdict = judgeCompileAttempt("AG8001", {
+      exitCode: null,
+      output: "",
+      killedBy: "timeout",
+    });
+    expect(verdict.ok).toBe(false);
+    if (verdict.ok) return;
+    expect(verdict.reason).toContain("timed out");
+  });
+
+  test("a suite-aborted compile fails as an abort", () => {
+    const verdict = judgeCompileAttempt("AG8001", {
+      exitCode: null,
+      output: "",
+      killedBy: "abort",
+    });
+    expect(verdict.ok).toBe(false);
+    if (verdict.ok) return;
+    expect(verdict.reason).toContain("aborted");
+  });
+
+  test("a killed compile that printed the substring still fails", () => {
+    // Output produced before the kill says nothing about the exit path;
+    // treating it as a pass would let a hung compile masquerade as a
+    // clean refusal.
+    const verdict = judgeCompileAttempt("AG8001", {
+      exitCode: null,
+      output: "error AG8001: unfilled holes",
+      killedBy: "timeout",
+    });
+    expect(verdict.ok).toBe(false);
+  });
+});
+
+describe("findIncompatibleField", () => {
+  test("a non-empty tests array is incompatible", () => {
+    expect(findIncompatibleField({ tests: [{}] })).toBe("tests");
+  });
+
+  test("file-level fetchMocks are incompatible", () => {
+    expect(findIncompatibleField({ fetchMocks: [] })).toBe("fetchMocks");
+  });
+
+  test("file-level llmMocks are incompatible", () => {
+    expect(findIncompatibleField({ llmMocks: [] })).toBe("llmMocks");
+  });
+
+  test("an absent or empty tests array is fine", () => {
+    expect(findIncompatibleField({})).toBe(null);
+    expect(findIncompatibleField({ tests: [] })).toBe(null);
+  });
+});

--- a/packages/agency-lang/lib/cli/expectedCompileError.ts
+++ b/packages/agency-lang/lib/cli/expectedCompileError.ts
@@ -1,0 +1,79 @@
+/**
+ * Deciding whether a `.test.json` with `expectedCompileError` passed.
+ *
+ * Kept free of I/O so every branch is testable without spawning a
+ * compiler or committing a fixture that fails on purpose. The spawning
+ * lives in lib/cli/test.ts; this file only judges what came back.
+ */
+import { formatDiff } from "@/utils/diff.js";
+
+/** What a child `agency compile` produced. `exitCode` is null when the
+ *  child was killed rather than exiting on its own. `output` is stderr
+ *  and stdout concatenated: the compiler's failure paths do not agree on
+ *  a stream (parse and typecheck errors go to stderr, an uncaught codegen
+ *  throw is reported by node itself), and a fixture author should not
+ *  have to know which one their diagnostic takes. */
+export type CompileAttempt = {
+  exitCode: number | null;
+  output: string;
+  killedBy?: "timeout" | "abort";
+};
+
+export type CompileVerdict = { ok: true } | { ok: false; reason: string };
+
+export function judgeCompileAttempt(
+  expected: string,
+  attempt: CompileAttempt,
+): CompileVerdict {
+  // A killed child says nothing about whether the file compiles, so this
+  // is reported as its own outcome rather than as a mismatch — even when
+  // the expected text appears in what it printed before dying.
+  if (attempt.killedBy === "timeout") {
+    return {
+      ok: false,
+      reason: "The compile timed out, so it never reported success or failure.",
+    };
+  }
+  if (attempt.killedBy === "abort") {
+    return {
+      ok: false,
+      reason: "The compile was aborted with the suite before it finished.",
+    };
+  }
+  if (attempt.exitCode === 0) {
+    return {
+      ok: false,
+      reason: `The file compiled, but was expected to fail with: ${expected}`,
+    };
+  }
+  if (!attempt.output.includes(expected)) {
+    return {
+      ok: false,
+      reason:
+        `The compile failed, but not with the expected message.\n` +
+        formatDiff(expected, attempt.output),
+    };
+  }
+  return { ok: true };
+}
+
+/**
+ * Name the first field that cannot be combined with
+ * `expectedCompileError`, or null when there is none. Nothing runs in
+ * this mode, so mocks and cases are not merely unused — they mean the
+ * author expected something this mode does not do, and a silent ignore
+ * would hide that.
+ */
+export function findIncompatibleField(tests: {
+  tests?: unknown[];
+  fetchMocks?: unknown[];
+  llmMocks?: unknown;
+}): string | null {
+  if (Array.isArray(tests.tests) && tests.tests.length > 0) return "tests";
+  if (tests.fetchMocks !== undefined) return "fetchMocks";
+  // llmMocks is a per-case field today, but a file-level one is a natural
+  // thing to write; catching it here keeps this mode's "rejected, not
+  // ignored" promise honest.
+  if (tests.llmMocks !== undefined) return "llmMocks";
+  return null;
+}

--- a/packages/agency-lang/lib/cli/precompile.test.ts
+++ b/packages/agency-lang/lib/cli/precompile.test.ts
@@ -78,6 +78,22 @@ describe("groupTestSources", () => {
     expect(groups[0].files).toEqual([path.join(root, "live/main.agency")]);
   });
 
+  test("expectedCompileError test files are excluded", () => {
+    const root = writeTree({
+      live: { "main.agency": TRIVIAL, "main.test.json": TEST_JSON },
+      broken: {
+        "main.agency": "this does not even parse {{{",
+        "main.test.json": JSON.stringify({ expectedCompileError: "AG2001" }),
+      },
+    });
+    const groups = groupTestSources({}, [
+      path.join(root, "live/main.test.json"),
+      path.join(root, "broken/main.test.json"),
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].files).toEqual([path.join(root, "live/main.agency")]);
+  });
+
   test("key-order-different but equal local configs are compatible (zod-normalized keys)", () => {
     // Two dirs whose agency.json files have the same content in different
     // key order, sharing an imported module. The session derives config

--- a/packages/agency-lang/lib/cli/precompile.test.ts
+++ b/packages/agency-lang/lib/cli/precompile.test.ts
@@ -78,17 +78,24 @@ describe("groupTestSources", () => {
     expect(groups[0].files).toEqual([path.join(root, "live/main.agency")]);
   });
 
-  test("expectedCompileError test files are excluded", () => {
+  test("expectedCompileError test files are excluded, even wrongly typed", () => {
     const root = writeTree({
       live: { "main.agency": TRIVIAL, "main.test.json": TEST_JSON },
       broken: {
         "main.agency": "this does not even parse {{{",
         "main.test.json": JSON.stringify({ expectedCompileError: "AG2001" }),
       },
+      // Presence must be enough: precompiling this in-process would
+      // process.exit(1) and end the suite; the runner rejects the type.
+      mistyped: {
+        "main.agency": "this does not even parse {{{",
+        "main.test.json": JSON.stringify({ expectedCompileError: null }),
+      },
     });
     const groups = groupTestSources({}, [
       path.join(root, "live/main.test.json"),
       path.join(root, "broken/main.test.json"),
+      path.join(root, "mistyped/main.test.json"),
     ]);
     expect(groups).toHaveLength(1);
     expect(groups[0].files).toEqual([path.join(root, "live/main.agency")]);

--- a/packages/agency-lang/lib/cli/precompile.ts
+++ b/packages/agency-lang/lib/cli/precompile.ts
@@ -34,7 +34,10 @@ export type { CompileGroup as PrecompileGroup };
 // the process before any test runs:
 //   - `skip: true` (or `skipOnCI: true` under CI), mirroring runTestFile.
 //   - `expectedCompileError`, whose whole point is a source that fails;
-//     runTestFile compiles it in a child process instead.
+//     runTestFile compiles it in a child process instead. Presence, not
+//     type: a wrongly-typed value must still keep the broken source out
+//     of this pass — the runner validates the type and fails just that
+//     fixture.
 // Malformed .test.json is treated as live; the runner will surface the
 // real error.
 function isExcludedFromPrecompile(testJsonFile: string): boolean {
@@ -43,7 +46,7 @@ function isExcludedFromPrecompile(testJsonFile: string): boolean {
     return (
       tests.skip === true ||
       (tests.skipOnCI === true && !!process.env.CI) ||
-      typeof tests.expectedCompileError === "string"
+      tests.expectedCompileError !== undefined
     );
   } catch {
     return false;

--- a/packages/agency-lang/lib/cli/precompile.ts
+++ b/packages/agency-lang/lib/cli/precompile.ts
@@ -29,14 +29,22 @@ const BASE_GROUP_LABEL = "<base config>";
 // Back-compat name for existing importers (precompile.test.ts).
 export type { CompileGroup as PrecompileGroup };
 
-// File-level skip mirror of runTestFile's check: a `skip: true` (or
-// `skipOnCI: true` under CI) .test.json never runs, so its source must not
-// be precompiled either — it may intentionally not compile. Malformed
-// .test.json is treated as live; the runner will surface the real error.
-function isFileLevelSkipped(testJsonFile: string): boolean {
+// Two kinds of .test.json must not be precompiled, both because their
+// source may intentionally not compile — and a failure in this pass ends
+// the process before any test runs:
+//   - `skip: true` (or `skipOnCI: true` under CI), mirroring runTestFile.
+//   - `expectedCompileError`, whose whole point is a source that fails;
+//     runTestFile compiles it in a child process instead.
+// Malformed .test.json is treated as live; the runner will surface the
+// real error.
+function isExcludedFromPrecompile(testJsonFile: string): boolean {
   try {
     const tests = JSON.parse(fs.readFileSync(testJsonFile, "utf-8"));
-    return tests.skip === true || (tests.skipOnCI === true && !!process.env.CI);
+    return (
+      tests.skip === true ||
+      (tests.skipOnCI === true && !!process.env.CI) ||
+      typeof tests.expectedCompileError === "string"
+    );
   } catch {
     return false;
   }
@@ -54,7 +62,7 @@ export function groupTestSources(
       .resolve(testJsonFile)
       .replace(/\.test\.json$/, ".agency");
     if (!fs.existsSync(sourceFile)) continue;
-    if (isFileLevelSkipped(testJsonFile)) continue;
+    if (isExcludedFromPrecompile(testJsonFile)) continue;
 
     const dir = path.dirname(sourceFile);
     const localConfigPath = path.join(dir, "agency.json");

--- a/packages/agency-lang/lib/cli/test.ts
+++ b/packages/agency-lang/lib/cli/test.ts
@@ -859,7 +859,9 @@ async function runExpectedCompileError(
   log: (msg: string) => void,
 ): Promise<TestStats> {
   const expected = tests.expectedCompileError!;
-  const sourcePath = testFile.replace(/\.test\.json$/, ".agency");
+  // Absolute, because the child runs with cwd set to the fixture's
+  // directory — a runner-relative path would no longer resolve there.
+  const sourcePath = path.resolve(testFile.replace(/\.test\.json$/, ".agency"));
   const siblingJs = sourcePath.replace(/\.agency$/, ".js");
 
   log(color.cyan(`Expecting compile to fail with: ${expected}`));

--- a/packages/agency-lang/lib/cli/test.ts
+++ b/packages/agency-lang/lib/cli/test.ts
@@ -18,6 +18,12 @@ import {
 } from "./util.js";
 import { color } from "@/utils/termcolors.js";
 import { formatDiff } from "@/utils/diff.js";
+import {
+  findIncompatibleField,
+  judgeCompileAttempt,
+  type CompileAttempt,
+} from "./expectedCompileError.js";
+import { safeDeleteFile } from "@/utils.js";
 import { AgencyConfig } from "@/config.js";
 import path from "path";
 import { compile, loadConfig } from "./commands.js";
@@ -78,7 +84,23 @@ type TestCase = {
 };
 type Tests = {
   sourceFile?: string;
-  tests: TestCase[];
+  // Optional because a file with `expectedCompileError` has no cases to
+  // run: the compile itself is the test.
+  tests?: TestCase[];
+  // When set, this file asserts that its sibling .agency FAILS to compile
+  // and that the failure text contains this substring. Diagnostic codes
+  // ("AG8001") are the intended values; a distinctive phrase works too,
+  // which is what parse errors need since they carry no code.
+  //
+  // The compile runs in a child `agency compile` process. That is not an
+  // implementation detail: compile() reports parse failures, strict type
+  // errors, and closure failures with process.exit(1) rather than a throw
+  // (lib/compiler/buildSession.ts), so compiling in-process would kill the
+  // test runner. Such files are also skipped by the precompile pass
+  // (lib/cli/precompile.ts) for the same reason.
+  expectedCompileError?: string;
+  // Printed when the file runs, same role as the per-case field.
+  description?: string;
   // File-level fetch mocks applied to every test; overridden per-test.
   fetchMocks?: FetchMock[];
   // If true, skip every test in this file. Equivalent to setting `skip: true`
@@ -112,9 +134,12 @@ const TIMEOUT_CEILINGS = {
 
 const DEFAULT_PER_TEST_MS = 2 * 60 * 1000; // 2 minutes
 
-function resolveTimeoutMs(testCase: TestCase, fileDefaults: Tests): number {
+function resolveTimeoutMs(
+  testCase: TestCase | undefined,
+  fileDefaults: Tests,
+): number {
   const requested =
-    testCase.timeoutMs ?? fileDefaults.defaultTimeoutMs ?? DEFAULT_PER_TEST_MS;
+    testCase?.timeoutMs ?? fileDefaults.defaultTimeoutMs ?? DEFAULT_PER_TEST_MS;
   // Clamp to >= 1ms: Node treats `timeout: 0` (and negative) as "no
   // timeout", which would defeat the entire defensive-timeout goal.
   // Clamp to <= ceiling so a stray huge value can't escape the cap.
@@ -227,7 +252,7 @@ function writeTestCase(
   if (interruptHandlers && interruptHandlers.length > 0) {
     testCase.interruptHandlers = interruptHandlers;
   }
-  tests.tests.push(testCase);
+  (tests.tests ??= []).push(testCase);
   fs.writeFileSync(testFilePath, JSON.stringify(tests, null, 2));
   return testFilePath;
 }
@@ -770,6 +795,131 @@ async function runTestWithRetries(
   return outcome;
 }
 
+/**
+ * Compile `sourcePath` in a child `agency compile` process and report what
+ * happened. Never throws for a compile failure — a failed compile is the
+ * expected outcome here, so it comes back as data.
+ */
+async function compileInSubprocess(
+  sourcePath: string,
+  timeoutMs: number,
+  signal: AbortSignal,
+): Promise<CompileAttempt> {
+  // The CLI entry this runner is itself executing, so the child is
+  // guaranteed to be the same build as the parent.
+  const cliEntry = process.argv[1];
+  const options = {
+    cwd: path.dirname(sourcePath),
+    maxBuffer: 10 * 1024 * 1024,
+    timeout: timeoutMs,
+    // isTimeoutError only recognizes a timeout kill by SIGKILL.
+    killSignal: "SIGKILL" as const,
+    signal,
+    env: { ...process.env, AGENCY_ALLOW_TEST_IMPORTS: "1" },
+  };
+  try {
+    const { stdout, stderr } = await execFileAsync(
+      process.execPath,
+      [cliEntry, "compile", sourcePath],
+      options,
+    );
+    return { exitCode: 0, output: `${stderr}${stdout}` };
+  } catch (e) {
+    // Abort before timeout, mirroring the per-case path (runSingleTest):
+    // both kills use SIGKILL here, and the abort shape is the more
+    // specific claim.
+    if (isAbortError(e)) {
+      return { exitCode: null, output: "", killedBy: "abort" };
+    }
+    if (isTimeoutError(e)) {
+      return { exitCode: null, output: "", killedBy: "timeout" };
+    }
+    const err = e as { code?: unknown; stdout?: string; stderr?: string };
+    // An error with no captured streams never ran a compile — a missing
+    // CLI entry, a bad cwd. Reporting it as a compile attempt would let a
+    // broken harness masquerade as a failing fixture.
+    if (err.stdout === undefined && err.stderr === undefined) {
+      throw e;
+    }
+    return {
+      exitCode: typeof err.code === "number" ? err.code : 1,
+      output: `${err.stderr ?? ""}${err.stdout ?? ""}`,
+    };
+  }
+}
+
+/**
+ * Run a `.test.json` whose `expectedCompileError` is set. The file counts
+ * as exactly one test so suite totals and sharding stay honest.
+ */
+async function runExpectedCompileError(
+  tests: Tests,
+  testFile: string,
+  suite: SuiteContext,
+  log: (msg: string) => void,
+): Promise<TestStats> {
+  const expected = tests.expectedCompileError!;
+  const sourcePath = testFile.replace(/\.test\.json$/, ".agency");
+  const siblingJs = sourcePath.replace(/\.agency$/, ".js");
+
+  log(color.cyan(`Expecting compile to fail with: ${expected}`));
+  if (tests.description) {
+    log(color.cyan("Description:", tests.description) + "\n");
+  }
+
+  const fail = (reason: string): TestStats => {
+    log(color.red(`  ✗ ${reason}`));
+    return {
+      passed: 0,
+      failed: 1,
+      filesPassed: 0,
+      filesFailed: 1,
+      failedFiles: [testFile],
+      slowTests: [],
+    };
+  };
+
+  const incompatible = findIncompatibleField(tests);
+  if (incompatible) {
+    // Returned normally, so the file belongs in `completed` (the
+    // suite-abort summary's definition, SuiteContext) even though it
+    // never compiled anything.
+    suite.completed.push(testFile);
+    return fail(
+      `'${incompatible}' cannot be combined with 'expectedCompileError': ` +
+        `nothing runs in this mode, only the compile.`,
+    );
+  }
+
+  // Any .js here is from an earlier run, and these sources exist to be
+  // broken — preferCompiled (lib/cli/util.ts) would happily execute one.
+  // safeDeleteFile no-ops quietly when there is nothing to delete.
+  safeDeleteFile(siblingJs, false);
+  const attempt = await compileInSubprocess(
+    sourcePath,
+    resolveTimeoutMs(undefined, tests),
+    suite.abortController.signal,
+  );
+  safeDeleteFile(siblingJs, false);
+
+  // Matches the per-case path: a file that ran to a verdict is completed,
+  // pass or fail. Only an abort leaves it off the list.
+  if (attempt.killedBy !== "abort") suite.completed.push(testFile);
+
+  const verdict = judgeCompileAttempt(expected, attempt);
+  if (!verdict.ok) return fail(verdict.reason);
+
+  log(color.green(`  ✓ Compile failed as expected`));
+  return {
+    passed: 1,
+    failed: 0,
+    filesPassed: 1,
+    filesFailed: 0,
+    failedFiles: [],
+    slowTests: [],
+  };
+}
+
 async function runTestFile(
   config: AgencyConfig,
   testFile: string,
@@ -796,7 +946,8 @@ async function runTestFile(
     }
 
     let passed = 0;
-    const total = tests.tests.length;
+    const cases = tests.tests ?? [];
+    const total = cases.length;
 
     // File-level skip: if the .test.json has `"skip": true` at the top
     // level, skip every test in the file. This makes top-level skip work
@@ -816,6 +967,13 @@ async function runTestFile(
       };
     }
 
+    // After the skip check — a skipped file is skipped no matter what
+    // else it declares — and before any per-case machinery, because a
+    // file in this mode has no cases: the compile is the test.
+    if (tests.expectedCompileError !== undefined) {
+      return await runExpectedCompileError(tests, testFile, suite, log);
+    }
+
     let skipped = 0;
     const slowTests: SlowTest[] = [];
     let aborted = false;
@@ -828,7 +986,7 @@ async function runTestFile(
         break;
       }
 
-      const testCase = tests.tests[i];
+      const testCase = cases[i];
       const interruptInfo = testCase.interruptHandlers
         ? ` interrupts=${testCase.interruptHandlers.length}`
         : "";

--- a/packages/agency-lang/lib/cli/test.ts
+++ b/packages/agency-lang/lib/cli/test.ts
@@ -858,7 +858,7 @@ async function runExpectedCompileError(
   suite: SuiteContext,
   log: (msg: string) => void,
 ): Promise<TestStats> {
-  const expected = tests.expectedCompileError!;
+  const expected = tests.expectedCompileError;
   // Absolute, because the child runs with cwd set to the fixture's
   // directory — a runner-relative path would no longer resolve there.
   const sourcePath = path.resolve(testFile.replace(/\.test\.json$/, ".agency"));
@@ -880,6 +880,16 @@ async function runExpectedCompileError(
       slowTests: [],
     };
   };
+
+  // The precompile pass excludes these files on field PRESENCE, so a
+  // wrongly-typed value lands here rather than exiting the suite there —
+  // this is where it gets its clear per-fixture failure.
+  if (typeof expected !== "string") {
+    suite.completed.push(testFile);
+    return fail(
+      `'expectedCompileError' must be a string, got: ${JSON.stringify(expected)}`,
+    );
+  }
 
   const incompatible = findIncompatibleField(tests);
   if (incompatible) {
@@ -948,7 +958,7 @@ async function runTestFile(
     }
 
     let passed = 0;
-    const cases = tests.tests ?? [];
+    const cases = Array.isArray(tests.tests) ? tests.tests : [];
     const total = cases.length;
 
     // File-level skip: if the .test.json has `"skip": true` at the top
@@ -974,6 +984,27 @@ async function runTestFile(
     // file in this mode has no cases: the compile is the test.
     if (tests.expectedCompileError !== undefined) {
       return await runExpectedCompileError(tests, testFile, suite, log);
+    }
+
+    // Neither cases nor a compile expectation: the file is malformed.
+    // Before `tests` became optional this crashed the runner with a
+    // TypeError; passing silently as "0/0" would be quieter than either.
+    // (An explicit empty `tests: []` keeps its longstanding 0/0 pass.)
+    if (!Array.isArray(tests.tests)) {
+      log(
+        color.red(
+          `  ✗ ${testFile} has no 'tests' array and no 'expectedCompileError'`,
+        ),
+      );
+      suite.completed.push(testFile);
+      return {
+        passed: 0,
+        failed: 1,
+        filesPassed: 0,
+        filesFailed: 1,
+        failedFiles: [testFile],
+        slowTests: [],
+      };
     }
 
     let skipped = 0;

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -259,10 +259,17 @@ export function createProgram(deps: CliDependencies = {}): Command {
             process.exit(0);
           });
         } else {
+          // Test-harness only, mirroring the option every other test-runner
+          // compile passes (lib/cli/util.ts). Set by lib/cli/test.ts on the
+          // child it spawns for `expectedCompileError` files; nothing else
+          // sets it, so the default stays deny.
+          const allowTestImports =
+            process.env.AGENCY_ALLOW_TEST_IMPORTS === "1";
           for (const input of inputs) {
             compile(config, input, undefined, {
               ts: opts.ts,
               freshness: opts.force ? "force" : undefined,
+              allowTestImports,
             });
           }
           // If installed globally, the user will hit ERR_MODULE_NOT_FOUND

--- a/packages/agency-lang/tests/agency/expectedCompileError/agency.json
+++ b/packages/agency-lang/tests/agency/expectedCompileError/agency.json
@@ -1,0 +1,6 @@
+{
+  "typechecker": {
+    "enabled": true,
+    "strict": true
+  }
+}

--- a/packages/agency-lang/tests/agency/expectedCompileError/parseFailure.agency
+++ b/packages/agency-lang/tests/agency/expectedCompileError/parseFailure.agency
@@ -1,0 +1,3 @@
+node main() {
+  return "unterminated
+}

--- a/packages/agency-lang/tests/agency/expectedCompileError/parseFailure.test.json
+++ b/packages/agency-lang/tests/agency/expectedCompileError/parseFailure.test.json
@@ -1,0 +1,4 @@
+{
+  "expectedCompileError": "Failed to parse",
+  "description": "A file that cannot be parsed reports as one failing compile, and does not end the suite"
+}

--- a/packages/agency-lang/tests/agency/expectedCompileError/typeError.agency
+++ b/packages/agency-lang/tests/agency/expectedCompileError/typeError.agency
@@ -1,0 +1,4 @@
+node main(): string {
+  const n: number = "not a number"
+  return n
+}

--- a/packages/agency-lang/tests/agency/expectedCompileError/typeError.test.json
+++ b/packages/agency-lang/tests/agency/expectedCompileError/typeError.test.json
@@ -1,0 +1,4 @@
+{
+  "expectedCompileError": "AG2001",
+  "description": "A type error under strict mode reports as one failing compile, matched by diagnostic code"
+}


### PR DESCRIPTION
## What

A `.test.json` can now assert that its sibling `.agency` file **fails to compile** and that the failure text contains a given substring:

```json
{
  "expectedCompileError": "AG2001",
  "description": "A type error under strict mode reports as one failing compile"
}
```

This lets compile-time diagnostics (starting with the code-templates `AG8001`/`AG8002`) be tested from the ordinary test suite. Spec: `docs/superpowers/specs/2026-07-23-test-runner-expected-compile-error.md` (plan alongside in `plans/`).

## Why a child process

`compile()` reports most failures with `process.exit(1)` rather than a throw — parse failures, strict type errors, and import-closure failures all exit (`lib/compiler/buildSession.ts`). An in-process attempt would kill the test runner mid-run. The runner instead spawns `agency compile` (the same `dist` build it is itself running, via `process.argv[1]`) and judges the child by exit code plus combined stderr/stdout. This also makes diagnostic-code matching work: `code` and `message` are separate fields in-process and only get joined by `formatErrors` when printing.

## Pieces

- **`lib/cli/expectedCompileError.ts`** — the pure verdict logic (`judgeCompileAttempt`, `findIncompatibleField`), fully unit-tested including the wrong-way-round cases (clean compile, wrong message, timeout, abort). No I/O; the spawning lives in `test.ts`.
- **`lib/cli/test.ts`** — `expectedCompileError` on the `Tests` type (`tests` becomes optional; the file is one test), `compileInSubprocess`, `runExpectedCompileError`. File-level `skip` wins over the mode. Sibling `.js` is deleted before and after the compile (via `safeDeleteFile`) so `preferCompiled` can never execute a stale artifact. Spawn failures that never ran a compile (missing CLI entry, bad cwd) rethrow instead of masquerading as a failing fixture.
- **`lib/cli/precompile.ts`** — these files are carved out of the up-front precompile pass (next to the existing `skip: true` exclusion, same reason: the source intentionally does not compile).
- **`scripts/agency.ts`** — `agency compile` honors `AGENCY_ALLOW_TEST_IMPORTS=1`, the env-var channel the runner already uses to talk to its children. This also forces `freshness: "always"`, so a stale manifest entry can never short-circuit the child to a false success.
- **Fixtures** (`tests/agency/expectedCompileError/`) — a parse failure (the case that proves the design: in-process it would end the suite) and a strict-mode type error matched by its `AG2001` code. The directory ships its own complete `agency.json` (the child reads config from exactly its cwd — missing means empty config, not inherited) and is excluded from `coverage.exclude` so `--coverage` does not compile the broken source for a source map.
- **`docs/misc/TESTING.md`** — documents the field, the config gotcha, and that `llmMocks`/`fetchMocks`/a non-empty `tests` array are rejected rather than silently ignored.

## Verification

- `pnpm test:run lib/cli`: 518 passed (baseline before this branch: 507)
- `pnpm run a test tests/agency/expectedCompileError`: 2/2, no stray `.js` left behind
- Same with `--coverage`: 2/2, report path survives
- Wrong-way-round proved by hand: expecting `AG9999` against the parse fixture yields 1/2 with a diff and a normal summary — no killed process
- `AGENCY_ALLOW_TEST_IMPORTS` verified in both directions against a scratch `import test` file
- `pnpm run typecheck`, `pnpm run lint:structure`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
