### PR TITLE
agency explain --list includes lint codes

### DIFF
--- a/packages/agency-lang/lib/cli/explain.test.ts
+++ b/packages/agency-lang/lib/cli/explain.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { renderDiagnosticText, renderDiagnosticList } from "./explain.js";
 import { DIAGNOSTICS } from "@/typeChecker/diagnostics.js";
+import { LINT_DIAGNOSTICS } from "@/linter/diagnostics.js";
 
 // termcolors colors unconditionally; strip ANSI to assert on text.
 // (Same pattern as lib/typeChecker/formatErrors.test.ts:10.)
@@ -64,5 +65,17 @@ describe("lint code fallthrough", () => {
 
   it("still rejects unknown codes", () => {
     expect(renderDiagnosticText("AL9999").found).toBe(false);
+  });
+});
+
+describe("renderDiagnosticList lint section", () => {
+  it("lists every active AL code under a Lint heading", () => {
+    const out = renderDiagnosticList();
+    expect(out).toContain("Lint");
+    for (const [, e] of Object.entries(LINT_DIAGNOSTICS).filter(
+      ([, entry]) => !("retired" in entry),
+    )) {
+      expect(out).toContain(e.code);
+    }
   });
 });

--- a/packages/agency-lang/lib/cli/explain.ts
+++ b/packages/agency-lang/lib/cli/explain.ts
@@ -89,5 +89,12 @@ export function renderDiagnosticList(): string {
     if (rows.length === 0) continue;
     blocks.push([color.underline(cat.title), ...rows].join("\n"));
   }
+  const lintRows = Object.entries(LINT_DIAGNOSTICS)
+    .filter(([, e]) => !("retired" in e))
+    .sort(([, a], [, b]) => a.code.localeCompare(b.code))
+    .map(([, e]) => `  ${color.bold(e.code)}  ${e.message}`);
+  if (lintRows.length > 0) {
+    blocks.push([color.underline("Lint"), ...lintRows].join("\n"));
+  }
   return blocks.join("\n\n");
 }


### PR DESCRIPTION
Closes the last gap from the `agency lint` work (#643/#647): `agency explain --list` grouped only the type checker's `AG####` codes, so the `AL####` codes were explainable individually but invisible in the list — even though the unknown-code error message points users at `--list`.

`renderDiagnosticList` now appends a "Lint" block after the category blocks, using the same retired-filter and code sort as the `AG` rows. With one lint rule today the output gains:

```
Lint
  AL0001  '{name}' is imported but never used.
```

Tested: the new list test asserts every active `AL` code appears under the Lint heading; all 9 explain tests green; structural linter clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
