### PR TITLE
feat(lsp): semantic tokens so function references get a real color

### DIFF
--- a/packages/agency-lang/lib/lsp/documentState.ts
+++ b/packages/agency-lang/lib/lsp/documentState.ts
@@ -11,6 +11,10 @@ export type DocumentState = {
   semanticIndex: SemanticIndex;
   scopes: ScopeInfo[];
   symbolTable: SymbolTable;
+  /** The document version this state was built from. Lets a consumer
+   *  tell a fresh state from one the debounce has left behind — see
+   *  DocumentStateCache, which serves stale state on purpose. */
+  version: number;
   /** Lint results computed by the diagnostics pass, reused by the
    *  code-action path so a lightbulb request does not re-parse and re-lint
    *  the document. Valid only while the document is still at

--- a/packages/agency-lang/lib/lsp/documentState.ts
+++ b/packages/agency-lang/lib/lsp/documentState.ts
@@ -11,10 +11,6 @@ export type DocumentState = {
   semanticIndex: SemanticIndex;
   scopes: ScopeInfo[];
   symbolTable: SymbolTable;
-  /** The document version this state was built from. Lets a consumer
-   *  tell a fresh state from one the debounce has left behind — see
-   *  DocumentStateCache, which serves stale state on purpose. */
-  version: number;
   /** Lint results computed by the diagnostics pass, reused by the
    *  code-action path so a lightbulb request does not re-parse and re-lint
    *  the document. Valid only while the document is still at

--- a/packages/agency-lang/lib/lsp/documentStateCache.test.ts
+++ b/packages/agency-lang/lib/lsp/documentStateCache.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { DocumentStateCache } from "./documentStateCache.js";
+import type { DocumentState } from "./documentState.js";
+
+/** A stand-in state — the cache stores states without inspecting them. */
+function stateAtVersion(version: number): DocumentState {
+  return { version } as DocumentState;
+}
+
+const URI = "file:///test.agency";
+
+describe("DocumentStateCache", () => {
+  it("serves the state that was set", () => {
+    const cache = new DocumentStateCache();
+    cache.set(URI, stateAtVersion(1));
+    expect(cache.get(URI)?.version).toBe(1);
+    expect(cache.getLastGood(URI)?.version).toBe(1);
+  });
+
+  it("keeps the last good state when a parse fails", () => {
+    // The whole reason this class exists. A half-typed line produces no
+    // state, and highlighting that returned nothing here would blank
+    // every colour in the file on almost every keystroke.
+    const cache = new DocumentStateCache();
+    cache.set(URI, stateAtVersion(1));
+    cache.clearCurrent(URI);
+
+    expect(cache.get(URI)).toBeUndefined();
+    expect(cache.getLastGood(URI)?.version).toBe(1);
+  });
+
+  it("serves a stale last-good state rather than nothing", () => {
+    // After a failure the buffer keeps moving. The retained state is
+    // then older than the document, and that is the intended trade:
+    // colours lagging by a debounce are invisible, colours vanishing
+    // are not. The version field is what lets a caller tell.
+    const cache = new DocumentStateCache();
+    cache.set(URI, stateAtVersion(4));
+    cache.clearCurrent(URI);
+
+    const served = cache.getLastGood(URI);
+    expect(served).toBeDefined();
+    expect(served!.version).toBe(4);
+  });
+
+  it("advances the last good state on each success", () => {
+    const cache = new DocumentStateCache();
+    cache.set(URI, stateAtVersion(1));
+    cache.set(URI, stateAtVersion(2));
+    expect(cache.getLastGood(URI)?.version).toBe(2);
+  });
+
+  it("forgets everything when the document closes", () => {
+    // Retention is a feature while a document is open and a leak after
+    // it is closed.
+    const cache = new DocumentStateCache();
+    cache.set(URI, stateAtVersion(1));
+    cache.remove(URI);
+
+    expect(cache.get(URI)).toBeUndefined();
+    expect(cache.getLastGood(URI)).toBeUndefined();
+  });
+
+  it("keeps documents separate", () => {
+    const cache = new DocumentStateCache();
+    const other = "file:///other.agency";
+    cache.set(URI, stateAtVersion(1));
+    cache.set(other, stateAtVersion(2));
+    cache.clearCurrent(URI);
+
+    expect(cache.get(other)?.version).toBe(2);
+    expect(cache.get(URI)).toBeUndefined();
+  });
+
+  it("offers a current state for document-independent requests", () => {
+    const cache = new DocumentStateCache();
+    expect(cache.anyCurrent()).toBeUndefined();
+    cache.set(URI, stateAtVersion(1));
+    expect(cache.anyCurrent()?.version).toBe(1);
+  });
+});

--- a/packages/agency-lang/lib/lsp/documentStateCache.test.ts
+++ b/packages/agency-lang/lib/lsp/documentStateCache.test.ts
@@ -2,9 +2,13 @@ import { describe, expect, it } from "vitest";
 import { DocumentStateCache } from "./documentStateCache.js";
 import type { DocumentState } from "./documentState.js";
 
-/** A stand-in state — the cache stores states without inspecting them. */
-function stateAtVersion(version: number): DocumentState {
-  return { version } as DocumentState;
+/**
+ * A stand-in state. The cache stores states without inspecting them, so
+ * what matters is only that two of them are distinguishable — hence
+ * assertions on identity rather than on any field.
+ */
+function aState(): DocumentState {
+  return {} as DocumentState;
 }
 
 const URI = "file:///test.agency";
@@ -12,49 +16,52 @@ const URI = "file:///test.agency";
 describe("DocumentStateCache", () => {
   it("serves the state that was set", () => {
     const cache = new DocumentStateCache();
-    cache.set(URI, stateAtVersion(1));
-    expect(cache.get(URI)?.version).toBe(1);
-    expect(cache.getLastGood(URI)?.version).toBe(1);
+    const state = aState();
+    cache.set(URI, state);
+    expect(cache.get(URI)).toBe(state);
+    expect(cache.getLastGood(URI)).toBe(state);
   });
 
   it("keeps the last good state when a parse fails", () => {
     // The whole reason this class exists. A half-typed line produces no
     // state, and highlighting that returned nothing here would blank
-    // every colour in the file on almost every keystroke.
+    // every color in the file on almost every keystroke.
     const cache = new DocumentStateCache();
-    cache.set(URI, stateAtVersion(1));
+    const good = aState();
+    cache.set(URI, good);
     cache.clearCurrent(URI);
 
     expect(cache.get(URI)).toBeUndefined();
-    expect(cache.getLastGood(URI)?.version).toBe(1);
+    expect(cache.getLastGood(URI)).toBe(good);
   });
 
-  it("serves a stale last-good state rather than nothing", () => {
-    // After a failure the buffer keeps moving. The retained state is
-    // then older than the document, and that is the intended trade:
-    // colours lagging by a debounce are invisible, colours vanishing
-    // are not. The version field is what lets a caller tell.
+  it("keeps serving the last good state across repeated failures", () => {
+    // The buffer keeps moving while it does not parse. The retained
+    // state gets older, and that is the intended trade: colors lagging
+    // are invisible, colors vanishing are not. Positions from a state
+    // this old are bounds-checked by getSemanticTokens, not here.
     const cache = new DocumentStateCache();
-    cache.set(URI, stateAtVersion(4));
-    cache.clearCurrent(URI);
+    const good = aState();
+    cache.set(URI, good);
+    for (let i = 0; i < 3; i++) cache.clearCurrent(URI);
 
-    const served = cache.getLastGood(URI);
-    expect(served).toBeDefined();
-    expect(served!.version).toBe(4);
+    expect(cache.getLastGood(URI)).toBe(good);
   });
 
   it("advances the last good state on each success", () => {
     const cache = new DocumentStateCache();
-    cache.set(URI, stateAtVersion(1));
-    cache.set(URI, stateAtVersion(2));
-    expect(cache.getLastGood(URI)?.version).toBe(2);
+    const older = aState();
+    const newer = aState();
+    cache.set(URI, older);
+    cache.set(URI, newer);
+    expect(cache.getLastGood(URI)).toBe(newer);
   });
 
   it("forgets everything when the document closes", () => {
     // Retention is a feature while a document is open and a leak after
     // it is closed.
     const cache = new DocumentStateCache();
-    cache.set(URI, stateAtVersion(1));
+    cache.set(URI, aState());
     cache.remove(URI);
 
     expect(cache.get(URI)).toBeUndefined();
@@ -64,11 +71,12 @@ describe("DocumentStateCache", () => {
   it("keeps documents separate", () => {
     const cache = new DocumentStateCache();
     const other = "file:///other.agency";
-    cache.set(URI, stateAtVersion(1));
-    cache.set(other, stateAtVersion(2));
+    const otherState = aState();
+    cache.set(URI, aState());
+    cache.set(other, otherState);
     cache.clearCurrent(URI);
 
-    expect(cache.get(other)?.version).toBe(2);
+    expect(cache.get(other)).toBe(otherState);
     expect(cache.get(URI)).toBeUndefined();
   });
 
@@ -86,15 +94,17 @@ describe("DocumentStateCache", () => {
 
   it("stores and retrieves a prototype-shaped key like any other", () => {
     const cache = new DocumentStateCache();
-    cache.set("toString", stateAtVersion(9));
-    expect(cache.get("toString")?.version).toBe(9);
+    const state = aState();
+    cache.set("toString", state);
+    expect(cache.get("toString")).toBe(state);
     expect(cache.get("valueOf")).toBeUndefined();
   });
 
   it("offers a current state for document-independent requests", () => {
     const cache = new DocumentStateCache();
     expect(cache.anyCurrent()).toBeUndefined();
-    cache.set(URI, stateAtVersion(1));
-    expect(cache.anyCurrent()?.version).toBe(1);
+    const state = aState();
+    cache.set(URI, state);
+    expect(cache.anyCurrent()).toBe(state);
   });
 });

--- a/packages/agency-lang/lib/lsp/documentStateCache.test.ts
+++ b/packages/agency-lang/lib/lsp/documentStateCache.test.ts
@@ -72,6 +72,25 @@ describe("DocumentStateCache", () => {
     expect(cache.get(URI)).toBeUndefined();
   });
 
+  it("reports a miss for names that live on Object.prototype", () => {
+    // URIs come from the client, so the key space is not ours to
+    // constrain. On a plain object these would resolve off the
+    // prototype chain and hand back a function where a caller expects
+    // either a state or nothing.
+    const cache = new DocumentStateCache();
+    for (const key of ["__proto__", "toString", "constructor", "hasOwnProperty"]) {
+      expect(cache.get(key)).toBeUndefined();
+      expect(cache.getLastGood(key)).toBeUndefined();
+    }
+  });
+
+  it("stores and retrieves a prototype-shaped key like any other", () => {
+    const cache = new DocumentStateCache();
+    cache.set("toString", stateAtVersion(9));
+    expect(cache.get("toString")?.version).toBe(9);
+    expect(cache.get("valueOf")).toBeUndefined();
+  });
+
   it("offers a current state for document-independent requests", () => {
     const cache = new DocumentStateCache();
     expect(cache.anyCurrent()).toBeUndefined();

--- a/packages/agency-lang/lib/lsp/documentStateCache.ts
+++ b/packages/agency-lang/lib/lsp/documentStateCache.ts
@@ -8,13 +8,13 @@
  *
  * For a feature like go-to-definition that is fine: no state, no answer,
  * and the user sees nothing missing. For semantic tokens it is not, because
- * "no answer" means every colour in the file disappears until the line
+ * "no answer" means every color in the file disappears until the line
  * parses again.
  *
  * So this cache keeps two things per document: the CURRENT state, which
  * goes away when a parse fails, and the LAST GOOD state, which does not.
  * Callers that need an answer on every keystroke read `getLastGood`.
- * Colours lagging the cursor by a debounce are invisible; colours
+ * Colors lagging the cursor by a debounce are invisible; colors
  * vanishing are not.
  *
  * It lives in its own module rather than as two Maps inside `startServer`
@@ -71,6 +71,9 @@ export class DocumentStateCache {
   /** Any current state, for requests that are document-independent
    *  (workspace symbols). */
   anyCurrent(): DocumentState | undefined {
-    return Object.values(this.current)[0];
+    for (const uri in this.current) {
+      return this.current[uri];
+    }
+    return undefined;
   }
 }

--- a/packages/agency-lang/lib/lsp/documentStateCache.ts
+++ b/packages/agency-lang/lib/lsp/documentStateCache.ts
@@ -1,0 +1,71 @@
+/**
+ * Per-document state, with a retention rule.
+ *
+ * The server rebuilds document state on a debounce, and a failed parse
+ * produces no state at all. Features that answer a request per keystroke
+ * therefore see "no state" constantly while the user types a line — most
+ * of the time the buffer is simply half-written.
+ *
+ * For a feature like go-to-definition that is fine: no state, no answer,
+ * and the user sees nothing missing. For semantic tokens it is not, because
+ * "no answer" means every colour in the file disappears until the line
+ * parses again.
+ *
+ * So this cache keeps two things per document: the CURRENT state, which
+ * goes away when a parse fails, and the LAST GOOD state, which does not.
+ * Callers that need an answer on every keystroke read `getLastGood`.
+ * Colours lagging the cursor by a debounce are invisible; colours
+ * vanishing are not.
+ *
+ * It lives in its own module rather than as two Maps inside `startServer`
+ * so the retention rule has one home instead of being re-decided at each
+ * call site, and so it can be tested — the behaviour it exists for only
+ * shows up across a sequence of updates.
+ */
+import type { DocumentState } from "./documentState.js";
+
+export class DocumentStateCache {
+  private current: Record<string, DocumentState> = {};
+  private lastGood: Record<string, DocumentState> = {};
+
+  /** Record a successful build. */
+  set(uri: string, state: DocumentState): void {
+    this.current[uri] = state;
+    this.lastGood[uri] = state;
+  }
+
+  /** Record that the document no longer has usable state — a failed
+   *  parse. The last good state deliberately survives. */
+  clearCurrent(uri: string): void {
+    delete this.current[uri];
+  }
+
+  /** The state for this document right now, or undefined if the latest
+   *  parse failed. */
+  get(uri: string): DocumentState | undefined {
+    return this.current[uri];
+  }
+
+  /**
+   * The most recent state that parsed, even if the buffer has since
+   * stopped parsing or moved on. May be older than the document — a
+   * caller that cares can compare `state.version` against the document,
+   * but for highlighting, stale beats absent.
+   */
+  getLastGood(uri: string): DocumentState | undefined {
+    return this.lastGood[uri];
+  }
+
+  /** Forget the document entirely. For close, where retention would be
+   *  a leak rather than a feature. */
+  remove(uri: string): void {
+    delete this.current[uri];
+    delete this.lastGood[uri];
+  }
+
+  /** Any current state, for requests that are document-independent
+   *  (workspace symbols). */
+  anyCurrent(): DocumentState | undefined {
+    return Object.values(this.current)[0];
+  }
+}

--- a/packages/agency-lang/lib/lsp/documentStateCache.ts
+++ b/packages/agency-lang/lib/lsp/documentStateCache.ts
@@ -25,8 +25,13 @@
 import type { DocumentState } from "./documentState.js";
 
 export class DocumentStateCache {
-  private current: Record<string, DocumentState> = {};
-  private lastGood: Record<string, DocumentState> = {};
+  // Null-prototype: the keys are document URIs, which come from the
+  // client. A plain object would resolve names like `__proto__` or
+  // `toString` off the prototype chain rather than reporting a miss.
+  // No URI can currently collide, but the guard costs nothing and the
+  // keys are not ours to constrain.
+  private current: Record<string, DocumentState> = Object.create(null);
+  private lastGood: Record<string, DocumentState> = Object.create(null);
 
   /** Record a successful build. */
   set(uri: string, state: DocumentState): void {

--- a/packages/agency-lang/lib/lsp/scopeResolution.ts
+++ b/packages/agency-lang/lib/lsp/scopeResolution.ts
@@ -13,15 +13,22 @@ export function findDefForScope(name: string, program: AgencyProgram) {
 }
 
 /**
- * Find the innermost scope that contains the given character offset.
- * Falls back to the top-level scope if no function/node scope matches.
+ * Build a reusable scope finder.
+ *
+ * Matching an offset to a scope needs a name→definition map, and
+ * building that map costs a scan of `program.nodes` for every scope. For
+ * a one-shot question — a hover, a go-to-definition — paying that once
+ * per call is fine.
+ *
+ * It is not fine for a caller asking about every identifier in the file:
+ * that turns one document into scopes × nodes × identifiers work. So the
+ * map is built here, once, and the returned function reuses it.
+ * `findContainingScope` is the one-shot form, and calls this.
  */
-export function findContainingScope(
-  offset: number,
+export function makeScopeFinder(
   scopes: ScopeInfo[],
   program: AgencyProgram,
-): ScopeInfo | undefined {
-  // Build name→def map once to avoid repeated linear scans
+): (offset: number) => ScopeInfo | undefined {
   const defMap: Record<string, ReturnType<typeof findDefForScope>> = {};
   for (const scopeInfo of scopes) {
     if (scopeInfo.name !== "top-level" && !(scopeInfo.name in defMap)) {
@@ -29,24 +36,41 @@ export function findContainingScope(
     }
   }
 
-  let best: ScopeInfo | undefined;
-  for (const scopeInfo of scopes) {
-    if (scopeInfo.name === "top-level") {
-      if (!best) best = scopeInfo;
-      continue;
-    }
-    const def = defMap[scopeInfo.name];
-    if (!def?.loc) continue;
-    if (offset >= def.loc.start && offset <= def.loc.end) {
-      if (!best || best.name === "top-level") {
-        best = scopeInfo;
-      } else {
-        const bestDef = defMap[best.name];
-        if (bestDef?.loc && def.loc.start > bestDef.loc.start) {
+  return (offset: number) => {
+    let best: ScopeInfo | undefined;
+    for (const scopeInfo of scopes) {
+      if (scopeInfo.name === "top-level") {
+        if (!best) best = scopeInfo;
+        continue;
+      }
+      const def = defMap[scopeInfo.name];
+      if (!def?.loc) continue;
+      if (offset >= def.loc.start && offset <= def.loc.end) {
+        if (!best || best.name === "top-level") {
           best = scopeInfo;
+        } else {
+          const bestDef = defMap[best.name];
+          if (bestDef?.loc && def.loc.start > bestDef.loc.start) {
+            best = scopeInfo;
+          }
         }
       }
     }
-  }
-  return best;
+    return best;
+  };
+}
+
+/**
+ * Find the innermost scope that contains the given character offset.
+ * Falls back to the top-level scope if no function/node scope matches.
+ *
+ * Asking this repeatedly for the same document rebuilds the definition
+ * map each time — use `makeScopeFinder` for that.
+ */
+export function findContainingScope(
+  offset: number,
+  scopes: ScopeInfo[],
+  program: AgencyProgram,
+): ScopeInfo | undefined {
+  return makeScopeFinder(scopes, program)(offset);
 }

--- a/packages/agency-lang/lib/lsp/semanticTokens.test.ts
+++ b/packages/agency-lang/lib/lsp/semanticTokens.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from "vitest";
+import { TextDocument } from "vscode-languageserver-textdocument";
+import {
+  getSemanticTokens,
+  SEMANTIC_TOKENS_LEGEND,
+  TOKEN_MODIFIERS,
+  TOKEN_TYPES,
+} from "./semanticTokens.js";
+import { runDiagnostics } from "./diagnostics.js";
+import { SymbolTable } from "../symbolTable.js";
+import type { DocumentState } from "./documentState.js";
+
+/**
+ * Build state the way the server does. Going through `runDiagnostics`
+ * rather than calling `parseAgency` here matters: the parser has two
+ * modes and they disagree about offsets, so a harness that picks the
+ * mode itself can silently drift from what the server does.
+ */
+function stateFor(source: string): DocumentState {
+  const doc = TextDocument.create("file:///test.agency", "agency", 1, source);
+  const result = runDiagnostics(doc, "/test.agency", {}, new SymbolTable());
+  if (!result.program || !result.info) {
+    throw new Error("test source failed to parse");
+  }
+  return {
+    program: result.program,
+    info: result.info,
+    semanticIndex: result.semanticIndex,
+    scopes: result.scopes,
+    symbolTable: new SymbolTable(),
+    version: 1,
+    lintFindings: result.lintFindings,
+    lintBatchEdits: result.lintBatchEdits,
+    lintVersion: 1,
+  };
+}
+
+type DecodedToken = {
+  text: string;
+  line: number;
+  col: number;
+  type: string;
+  modifiers: string[];
+};
+
+/**
+ * Decode the wire format and slice the SOURCE at each decoded position.
+ *
+ * The slicing is the point. A test that asserts line and column numbers
+ * is reading the same `loc` the implementation read, so a systematic
+ * position error agrees with itself and passes. Asserting on the text
+ * actually covered by the token catches an off-by-one column, a length
+ * taken from the node span instead of the name, and a botched delta.
+ *
+ * The delta arithmetic here is deliberately written out rather than
+ * imported from the implementation — a decoder that shares the encoder's
+ * bug agrees with it.
+ */
+function decodeTokens(data: number[], source: string): DecodedToken[] {
+  const lines = source.split("\n");
+  const tokens: DecodedToken[] = [];
+  let line = 0;
+  let col = 0;
+
+  for (let i = 0; i < data.length; i += 5) {
+    const [deltaLine, deltaCol, length, typeIndex, modifierBits] = data.slice(i, i + 5);
+    line += deltaLine;
+    if (deltaLine === 0 && i > 0) {
+      col += deltaCol;
+    } else {
+      col = deltaCol;
+    }
+    tokens.push({
+      text: (lines[line] ?? "").slice(col, col + length),
+      line,
+      col,
+      type: TOKEN_TYPES[typeIndex],
+      modifiers: TOKEN_MODIFIERS.filter((_, bit) => (modifierBits & (1 << bit)) !== 0),
+    });
+  }
+  return tokens;
+}
+
+function tokensFor(source: string): DecodedToken[] {
+  return decodeTokens(getSemanticTokens(stateFor(source)).data, source);
+}
+
+/** Just the identifier texts, in emitted order. */
+function textsFor(source: string): string[] {
+  return tokensFor(source).map((t) => t.text);
+}
+
+describe("semantic tokens legend", () => {
+  it("is a wire contract — reordering re-colours every open editor", () => {
+    expect(SEMANTIC_TOKENS_LEGEND.tokenTypes).toEqual(["function"]);
+    expect(SEMANTIC_TOKENS_LEGEND.tokenModifiers).toEqual(["defaultLibrary"]);
+  });
+});
+
+describe("getSemanticTokens", () => {
+  it("colours a local bound to a function and used bare", () => {
+    // The whole reason this feature exists: no grammar can know `f` is a
+    // function, because that needs type inference.
+    const tokens = tokensFor(
+      `def helper(): number {\n  return 1\n}\n\nnode main() {\n  const f = helper\n  print(f)\n}`,
+    );
+    const bare = tokens.filter((t) => t.text === "f");
+    expect(bare.length).toBe(1);
+    expect(bare[0].type).toBe("function");
+    expect(bare[0].line).toBe(6);
+  });
+
+  it("colours a local that shadows a top-level function of the same name", () => {
+    // If resolution regressed to the name-keyed SemanticIndex, the local
+    // and the top-level definition would be indistinguishable.
+    const source = `def run(): number {\n  return 1\n}\n\ndef other(): number {\n  return 2\n}\n\nnode main() {\n  const run = other\n  print(run)\n}`;
+    const tokens = tokensFor(source);
+    const shadowed = tokens.filter((t) => t.text === "run" && t.line === 10);
+    expect(shadowed.length).toBe(1);
+    expect(shadowed[0].type).toBe("function");
+  });
+
+  it("colours a function referenced inside a string interpolation", () => {
+    // Interpolated expressions are real AST nodes with real positions.
+    const source = `def helper(): number {\n  return 1\n}\n\nnode main() {\n  print("value \${helper()} here")\n}`;
+    const tokens = tokensFor(source);
+    const interpolated = tokens.filter((t) => t.text === "helper" && t.line === 5);
+    expect(interpolated.length).toBe(1);
+    expect(interpolated[0].type).toBe("function");
+  });
+
+  it("does not colour a function name that only appears in string text", () => {
+    // Paired on purpose. A file containing ONLY the string would pass
+    // against an empty slot table, since string text is never an
+    // identifier node — it would test the parser, not this code. With a
+    // real call in the same file, the exact count is what fails if
+    // anyone regresses to whole-word source matching.
+    const source = `def helper(): number {\n  return 1\n}\n\nnode main() {\n  print("the helper function")\n  helper()\n}`;
+    const helperTokens = tokensFor(source).filter((t) => t.text === "helper");
+    expect(helperTokens.length).toBe(1);
+    expect(helperTokens[0].line).toBe(6);
+  });
+
+  it("marks builtins with the defaultLibrary modifier", () => {
+    // Asserts the decoded bit, not merely that a modifier exists — an
+    // off-by-one bit position is invisible otherwise.
+    const tokens = tokensFor(`node main() {\n  print("hi")\n}`);
+    const print = tokens.find((t) => t.text === "print");
+    expect(print).toBeDefined();
+    expect(print!.modifiers).toEqual(["defaultLibrary"]);
+  });
+
+  it("marks language primitives as well as prelude functions", () => {
+    // Two separate registries feed the modifier — `print` above comes
+    // from the prelude, `llm` is a language primitive. Both must count.
+    const tokens = tokensFor(`node main() {\n  let x: string = llm("hi")\n}`);
+    const llm = tokens.find((t) => t.text === "llm");
+    expect(llm).toBeDefined();
+    expect(llm!.modifiers).toEqual(["defaultLibrary"]);
+  });
+
+  it("does not mark a user function that shadows a prelude name", () => {
+    // `print` is a prelude name, but here it is the user's own function.
+    const tokens = tokensFor(
+      `def print(msg: string): string {\n  return msg\n}\n\nnode main() {\n  print("hi")\n}`,
+    );
+    const call = tokens.find((t) => t.text === "print" && t.line === 5);
+    expect(call).toBeDefined();
+    expect(call!.modifiers).toEqual([]);
+  });
+
+  it("leaves user functions without the defaultLibrary modifier", () => {
+    const tokens = tokensFor(
+      `def helper(): number {\n  return 1\n}\n\nnode main() {\n  helper()\n}`,
+    );
+    const helper = tokens.find((t) => t.text === "helper" && t.line === 5);
+    expect(helper!.modifiers).toEqual([]);
+  });
+});
+
+describe("getSemanticTokens delta encoding", () => {
+  it("encodes two tokens on the same line", () => {
+    // Same-line and cross-line deltas are different branches of the
+    // encoder. A suite with one token per line passes either way.
+    const tokens = tokensFor(
+      `def outer(x: number): number {\n  return x\n}\n\ndef inner(): number {\n  return 1\n}\n\nnode main() {\n  outer(inner())\n}`,
+    );
+    const onCallLine = tokens.filter((t) => t.line === 9);
+    expect(onCallLine.map((t) => t.text)).toEqual(["outer", "inner"]);
+    expect(onCallLine[0].col).toBe(2);
+    expect(onCallLine[1].col).toBe(8);
+  });
+
+  it("encodes tokens separated by blank lines", () => {
+    const tokens = tokensFor(
+      `def a1(): number {\n  return 1\n}\n\ndef b2(): number {\n  return 2\n}\n\nnode main() {\n  a1()\n\n\n  b2()\n}`,
+    );
+    const calls = tokens.filter((t) => t.text === "a1" || t.text === "b2");
+    expect(calls.map((t) => [t.text, t.line])).toEqual([
+      ["a1", 9],
+      ["b2", 12],
+    ]);
+  });
+
+  it("emits tokens in source order when the walk yields out of order", () => {
+    // walkNodes yields an assignment's value BEFORE its target access
+    // chain, so `handlers[pick()] = run` walks `run`, then `pick`.
+    // Without the sort this produces negative deltas and the decoder
+    // reads garbage.
+    const source = `def pick(): number {\n  return 0\n}\n\ndef run(): number {\n  return 1\n}\n\nnode main() {\n  let handlers = [1, 2]\n  handlers[pick()] = run\n}`;
+    const onLine = tokensFor(source).filter((t) => t.line === 10);
+    expect(onLine.map((t) => t.text)).toEqual(["pick", "run"]);
+    // Columns strictly increase — the property that the delta encoding
+    // depends on and that an unsorted push violates.
+    expect(onLine[0].col).toBeLessThan(onLine[1].col);
+  });
+});
+
+describe("getSemanticTokens known gaps", () => {
+  it("TRIPWIRE: cannot colour identifiers inside a valueAccess chain", () => {
+    // The parser attaches no `loc` to a valueAccess base or to the calls
+    // in its chain, so `helper(1).invoke()` has no position to emit.
+    //
+    // WHEN THIS TEST FAILS: the parser has started carrying loc on those
+    // nodes. That is the good outcome — identifierSlots will pick them up
+    // with no change (its guard is on loc, not on node kind). Delete this
+    // test, and revisit whether the extension's TextMate grammar should
+    // stop guessing at function-ness.
+    //
+    // Paired with a bare call so it cannot pass against a broken walk.
+    const source = `def helper(x: number): number {\n  return x\n}\n\nnode main() {\n  helper(1)\n  helper(1).invoke()\n}`;
+    const helperTokens = tokensFor(source).filter((t) => t.text === "helper");
+    expect(helperTokens.length).toBe(1);
+    expect(helperTokens[0].line).toBe(5);
+  });
+
+  it.skip("block-scope shadowing is not resolved", () => {
+    // findContainingScope only matches scopes named by a top-level
+    // function or graphNode definition, so a name shadowed inside an
+    // `if` branch resolves against the enclosing function instead.
+    // Unskip when findContainingScope learns about block scopes.
+    const source = `def helper(): number {\n  return 1\n}\n\nnode main() {\n  if (true) {\n    const helper = 5\n    print(helper)\n  }\n}`;
+    expect(textsFor(source)).not.toContain("helper");
+  });
+});

--- a/packages/agency-lang/lib/lsp/semanticTokens.test.ts
+++ b/packages/agency-lang/lib/lsp/semanticTokens.test.ts
@@ -28,7 +28,6 @@ function stateFor(source: string): DocumentState {
     semanticIndex: result.semanticIndex,
     scopes: result.scopes,
     symbolTable: new SymbolTable(),
-    version: 1,
     lintFindings: result.lintFindings,
     lintBatchEdits: result.lintBatchEdits,
     lintVersion: 1,
@@ -39,6 +38,11 @@ type DecodedToken = {
   text: string;
   line: number;
   col: number;
+  /** The length the server ENCODED, before source slicing truncates it.
+   *  The stale-position tests need this: a token running past a
+   *  shortened line has an emitted length longer than the text left to
+   *  slice, and only the raw number shows that. */
+  length: number;
   type: string;
   modifiers: string[];
 };
@@ -74,6 +78,7 @@ function decodeTokens(data: number[], source: string): DecodedToken[] {
       text: (lines[line] ?? "").slice(col, col + length),
       line,
       col,
+      length,
       type: TOKEN_TYPES[typeIndex],
       modifiers: TOKEN_MODIFIERS.filter((_, bit) => (modifierBits & (1 << bit)) !== 0),
     });
@@ -91,14 +96,14 @@ function textsFor(source: string): string[] {
 }
 
 describe("semantic tokens legend", () => {
-  it("is a wire contract — reordering re-colours every open editor", () => {
+  it("is a wire contract — reordering re-colors every open editor", () => {
     expect(SEMANTIC_TOKENS_LEGEND.tokenTypes).toEqual(["function"]);
     expect(SEMANTIC_TOKENS_LEGEND.tokenModifiers).toEqual(["defaultLibrary"]);
   });
 });
 
 describe("getSemanticTokens", () => {
-  it("colours a local bound to a function and used bare", () => {
+  it("colors a local bound to a function and used bare", () => {
     // The whole reason this feature exists: no grammar can know `f` is a
     // function, because that needs type inference.
     const tokens = tokensFor(
@@ -110,7 +115,7 @@ describe("getSemanticTokens", () => {
     expect(bare[0].line).toBe(6);
   });
 
-  it("colours a local that shadows a top-level function of the same name", () => {
+  it("colors a local that shadows a top-level function of the same name", () => {
     // If resolution regressed to the name-keyed SemanticIndex, the local
     // and the top-level definition would be indistinguishable.
     const source = `def run(): number {\n  return 1\n}\n\ndef other(): number {\n  return 2\n}\n\nnode main() {\n  const run = other\n  print(run)\n}`;
@@ -120,7 +125,7 @@ describe("getSemanticTokens", () => {
     expect(shadowed[0].type).toBe("function");
   });
 
-  it("colours a function referenced inside a string interpolation", () => {
+  it("colors a function referenced inside a string interpolation", () => {
     // Interpolated expressions are real AST nodes with real positions.
     const source = `def helper(): number {\n  return 1\n}\n\nnode main() {\n  print("value \${helper()} here")\n}`;
     const tokens = tokensFor(source);
@@ -129,7 +134,7 @@ describe("getSemanticTokens", () => {
     expect(interpolated[0].type).toBe("function");
   });
 
-  it("does not colour a function name that only appears in string text", () => {
+  it("does not color a function name that only appears in string text", () => {
     // Paired on purpose. A file containing ONLY the string would pass
     // against an empty slot table, since string text is never an
     // identifier node — it would test the parser, not this code. With a
@@ -230,8 +235,53 @@ describe("getSemanticTokens delta encoding", () => {
   });
 });
 
+describe("getSemanticTokens against a changed document", () => {
+  // The load-bearing assumption behind DocumentStateCache is that
+  // serving stale tokens is safe. It is only safe if positions from the
+  // old text cannot land somewhere meaningless in the new one, and every
+  // other test here builds state and reads tokens from the SAME string,
+  // so none of them exercise this at all.
+
+  const LONG = `def helper(): number {\n  return 1\n}\n\nnode main() {\n  helper()\n  helper()\n}`;
+
+  it("drops tokens on lines the document no longer has", () => {
+    // The deletion case: state built on an 8-line file, buffer is now 3
+    // lines. Tokens for the deleted lines must not be emitted.
+    const short = `def helper(): number {\n  return 1\n}`;
+    const data = getSemanticTokens(stateFor(LONG), short).data;
+    const lineCount = short.split("\n").length;
+
+    for (const token of decodeTokens(data, short)) {
+      expect(token.line).toBeLessThan(lineCount);
+    }
+  });
+
+  it("drops tokens that would run past the end of a shortened line", () => {
+    // The line still exists but is now too short to contain the token.
+    // Emitting it would paint whatever text now sits at that column.
+    const trimmed = LONG.split("\n")
+      .map((line) => (line.includes("helper()") ? "  x" : line))
+      .join("\n");
+    const lines = trimmed.split("\n");
+
+    for (const token of decodeTokens(getSemanticTokens(stateFor(LONG), trimmed).data, trimmed)) {
+      // Emitted length, not sliced text length — an over-long token
+      // slices to a shorter string, which would hide the very bug.
+      expect(token.col + token.length).toBeLessThanOrEqual(lines[token.line].length);
+    }
+  });
+
+  it("emits every token when the text is unchanged", () => {
+    // The bounds check must not cost anything in the normal case.
+    const withCheck = getSemanticTokens(stateFor(LONG), LONG).data;
+    const withoutCheck = getSemanticTokens(stateFor(LONG)).data;
+    expect(withCheck).toEqual(withoutCheck);
+    expect(withCheck.length).toBeGreaterThan(0);
+  });
+});
+
 describe("getSemanticTokens known gaps", () => {
-  it("TRIPWIRE: cannot colour identifiers inside a valueAccess chain", () => {
+  it("TRIPWIRE: cannot color identifiers inside a valueAccess chain", () => {
     // The parser attaches no `loc` to a valueAccess base or to the calls
     // in its chain, so `helper(1).invoke()` has no position to emit.
     //

--- a/packages/agency-lang/lib/lsp/semanticTokens.test.ts
+++ b/packages/agency-lang/lib/lsp/semanticTokens.test.ts
@@ -169,6 +169,20 @@ describe("getSemanticTokens", () => {
     expect(call!.modifiers).toEqual([]);
   });
 
+  it("does not mark a local alias that reuses a prelude name", () => {
+    // `const print = helper` binds the name `print` to the user's own
+    // function. The scope resolves it to functionRefType{name:"helper"},
+    // and the stdlib question is asked of THAT name, not of what was
+    // typed. A real prelude call resolves to nothing, so it is
+    // unaffected.
+    const tokens = tokensFor(
+      `def helper(): number {\n  return 1\n}\n\nnode main() {\n  const print = helper\n  print()\n}`,
+    );
+    const aliased = tokens.find((t) => t.text === "print" && t.line === 6);
+    expect(aliased).toBeDefined();
+    expect(aliased!.modifiers).toEqual([]);
+  });
+
   it("leaves user functions without the defaultLibrary modifier", () => {
     const tokens = tokensFor(
       `def helper(): number {\n  return 1\n}\n\nnode main() {\n  helper()\n}`,

--- a/packages/agency-lang/lib/lsp/semanticTokens.ts
+++ b/packages/agency-lang/lib/lsp/semanticTokens.ts
@@ -27,7 +27,7 @@ import type { DocumentState } from "./documentState.js";
  * The wire legend. Indices sent on the wire are positions in these
  * arrays, so the ORDER is part of the protocol contract — an already-open
  * editor holds the legend it was given at initialize time and will
- * re-colour every token if these are reordered. Both the capability
+ * re-color every token if these are reordered. Both the capability
  * announcement and the encoder read these same arrays so no index is
  * ever hand-written. `semanticTokens.test.ts` pins the order.
  */
@@ -41,16 +41,22 @@ export const SEMANTIC_TOKENS_LEGEND = {
   tokenModifiers: [...TOKEN_MODIFIERS],
 };
 
+/** PRELUDE_NAMES is a readonly array, so `includes` is a linear scan.
+ *  This runs per identifier, so the membership test is hoisted once. */
+const PRELUDE_NAME_SET: Record<string, true> = Object.fromEntries(
+  PRELUDE_NAMES.map((name) => [name, true]),
+);
+
 const FUNCTION_TYPE_INDEX = TOKEN_TYPES.indexOf("function");
 const DEFAULT_LIBRARY_BIT = 1 << TOKEN_MODIFIERS.indexOf("defaultLibrary");
 
 /**
  * Which symbol kinds get a function token. `node` shares it because a
- * node call parses as an ordinary `functionCall` — colouring nodes
+ * node call parses as an ordinary `functionCall` — coloring nodes
  * differently would encode a distinction the AST does not make.
  *
  * `type` and `constant` are null: this first version emits function
- * tokens only. Every identifier left uncoloured is one the TextMate
+ * tokens only. Every identifier left uncolored is one the TextMate
  * grammar still handles, so a narrow table means no visible gaps.
  */
 const TOKEN_TYPE_BY_SYMBOL_KIND: Record<SymbolKind, TokenType | null> = {
@@ -122,7 +128,8 @@ function isDeclaredInFile(name: string, state: DocumentState): boolean {
 function isStandardLibrary(name: string, state: DocumentState): boolean {
   if (isDeclaredInFile(name, state)) return false;
   return (
-    Object.hasOwn(BUILTIN_FUNCTION_TYPES, name) || PRELUDE_NAMES.includes(name)
+    Object.hasOwn(BUILTIN_FUNCTION_TYPES, name) ||
+    Object.hasOwn(PRELUDE_NAME_SET, name)
   );
 }
 
@@ -136,6 +143,11 @@ function isStandardLibrary(name: string, state: DocumentState): boolean {
  * 2. The declaration index, for top-level and imported symbols.
  * 3. The call syntax itself. `name(...)` is a call whatever we know
  *    about `name`, which covers builtins and unresolved imports.
+ *
+ * Consequence of (3) worth knowing: in a file with type errors,
+ * `notAFunction()` still gets a function token. The syntax says call, and
+ * guessing otherwise would mean flickering colors while a name is being
+ * typed. Reporting the error is the diagnostics pass's job, not this one.
  */
 function isFunctionReference(
   slot: IdentifierSlot,
@@ -178,7 +190,7 @@ function toToken(
 /**
  * Source order. This is load-bearing, not tidiness: `SemanticTokensBuilder`
  * subtracts from whatever was pushed last and never sorts, so an
- * out-of-order push produces negative deltas and silently garbled colour.
+ * out-of-order push produces negative deltas and silently garbled color.
  * `walkNodes` genuinely yields out of source order — an assignment yields
  * its value before the target's access chain, so `obj[i] = f()` walks `f`
  * before `i`.
@@ -188,7 +200,42 @@ function byPosition(a: Token, b: Token): number {
   return a.col - b.col;
 }
 
-export function getSemanticTokens(state: DocumentState): SemanticTokens {
+/**
+ * Would this token land on text that still exists?
+ *
+ * The state a token is computed from can be older than the buffer it is
+ * being rendered against — that is the deliberate trade in
+ * DocumentStateCache. Usually the difference is a debounce and positions
+ * still line up. After a deletion they do not: a token can name a line
+ * that no longer exists, or a column past the end of a line that shrank.
+ *
+ * Dropping those is better than clamping them. A clamped token paints
+ * whatever text now sits at that position, which is a wrong color on a
+ * real word; a dropped one just leaves the grammar's color in place.
+ */
+function fitsInCurrentText(token: Token, lines: string[] | null): boolean {
+  if (lines === null) return true;
+  const line = lines[token.line];
+  if (line === undefined) return false;
+  return token.col + token.length <= line.length;
+}
+
+/**
+ * `currentText` is the buffer as it is RIGHT NOW, which may differ from
+ * the text `state` was built from. Omit it and no bounds check runs.
+ *
+ * Cost is O(identifiers x scopes): makeScopeFinder builds its definition
+ * map once, but the finder it returns still scans the scope list per
+ * call. Linear in identifiers alone would need the scopes sorted by
+ * range and a binary search. Measured at 0.3-0.7 ms on real stdlib files
+ * and 5.4 ms on a generated 1200-line file, so this is a note for the
+ * next reader rather than a todo.
+ */
+export function getSemanticTokens(
+  state: DocumentState,
+  currentText?: string,
+): SemanticTokens {
+  const lines = currentText === undefined ? null : currentText.split("\n");
   const slots = [...walkNodes(state.program.nodes)].flatMap(({ node }) =>
     identifierSlots(node),
   );
@@ -197,6 +244,7 @@ export function getSemanticTokens(state: DocumentState): SemanticTokens {
   const tokens = slots
     .map((slot) => toToken(slot, state, findScope))
     .filter((token): token is Token => token !== null)
+    .filter((token) => fitsInCurrentText(token, lines))
     .sort(byPosition);
 
   const builder = new SemanticTokensBuilder();

--- a/packages/agency-lang/lib/lsp/semanticTokens.ts
+++ b/packages/agency-lang/lib/lsp/semanticTokens.ts
@@ -20,7 +20,7 @@ import { PRELUDE_NAMES } from "../prelude.js";
 import { walkNodes } from "../utils/node.js";
 import { identifierSlots } from "../utils/identifierSlots.js";
 import type { IdentifierSlot } from "../utils/identifierSlots.js";
-import { findContainingScope } from "./scopeResolution.js";
+import { makeScopeFinder } from "./scopeResolution.js";
 import type { DocumentState } from "./documentState.js";
 
 /**
@@ -68,20 +68,19 @@ type Token = {
   modifiers: number;
 };
 
+/** Resolves an offset to its innermost scope. Built once per document —
+ *  building it per identifier is what made this quadratic. */
+type ScopeFinder = ReturnType<typeof makeScopeFinder>;
+
 /** What the scope says this name is bound to here, if anything. A name
  *  bound to a function infers to `functionRefType`, whose own `name` is
  *  the function it refers to — `const f = helper` resolves to
  *  `functionRefType{ name: "helper" }`. */
 function resolveFunctionRef(
   slot: IdentifierSlot,
-  state: DocumentState,
+  findScope: ScopeFinder,
 ): { name: string } | null {
-  const containingScope = findContainingScope(
-    slot.scopeOffset,
-    state.scopes,
-    state.program,
-  );
-  const inferred = containingScope?.scope.lookup(slot.name);
+  const inferred = findScope(slot.scopeOffset)?.scope.lookup(slot.name);
   if (inferred && (inferred as { type?: string }).type === "functionRefType") {
     return inferred as unknown as { name: string };
   }
@@ -153,8 +152,12 @@ function isFunctionReference(
   return slot.isCall;
 }
 
-function toToken(slot: IdentifierSlot, state: DocumentState): Token | null {
-  const resolved = resolveFunctionRef(slot, state);
+function toToken(
+  slot: IdentifierSlot,
+  state: DocumentState,
+  findScope: ScopeFinder,
+): Token | null {
+  const resolved = resolveFunctionRef(slot, findScope);
   if (!isFunctionReference(slot, state, resolved)) return null;
 
   // The stdlib question is asked of what the name RESOLVES to, not of
@@ -190,8 +193,9 @@ export function getSemanticTokens(state: DocumentState): SemanticTokens {
     identifierSlots(node),
   );
 
+  const findScope = makeScopeFinder(state.scopes, state.program);
   const tokens = slots
-    .map((slot) => toToken(slot, state))
+    .map((slot) => toToken(slot, state, findScope))
     .filter((token): token is Token => token !== null)
     .sort(byPosition);
 

--- a/packages/agency-lang/lib/lsp/semanticTokens.ts
+++ b/packages/agency-lang/lib/lsp/semanticTokens.ts
@@ -68,6 +68,33 @@ type Token = {
   modifiers: number;
 };
 
+/** What the scope says this name is bound to here, if anything. A name
+ *  bound to a function infers to `functionRefType`, whose own `name` is
+ *  the function it refers to — `const f = helper` resolves to
+ *  `functionRefType{ name: "helper" }`. */
+function resolveFunctionRef(
+  slot: IdentifierSlot,
+  state: DocumentState,
+): { name: string } | null {
+  const containingScope = findContainingScope(
+    slot.scopeOffset,
+    state.scopes,
+    state.program,
+  );
+  const inferred = containingScope?.scope.lookup(slot.name);
+  if (inferred && (inferred as { type?: string }).type === "functionRefType") {
+    return inferred as unknown as { name: string };
+  }
+  return null;
+}
+
+/** Does the file declare or import this name itself? `Object.hasOwn`
+ *  rather than a lookup, because the index is a plain object and a
+ *  name like `constructor` would otherwise read off the prototype. */
+function isDeclaredInFile(name: string, state: DocumentState): boolean {
+  return Object.hasOwn(state.semanticIndex, name);
+}
+
 /**
  * Is this name part of the language rather than the user's code? Two
  * registries, because Agency has two kinds of given-to-you function and
@@ -76,14 +103,27 @@ type Token = {
  * into every file — `print`, `map`, `filter`.
  *
  * Both are existing single sources of truth, so this reads them rather
- * than restating either. A user who defines their own `print` shadows
- * the prelude one, so a locally declared name is never marked.
+ * than restating either.
+ *
+ * Two ways a user can hold a stdlib NAME without meaning the stdlib
+ * function, and each is handled by asking a different question:
+ *
+ *   const print = helper   // an alias — the binding resolves to `helper`
+ *   def print(...)         // their own function — the file declares it
+ *   import { print } from …
+ *
+ * The first is why the check runs on the RESOLVED name: a scope lookup
+ * on that `print` yields `functionRefType{ name: "helper" }`, and a real
+ * prelude call resolves to nothing at all, since the prelude is ambient
+ * rather than a scope binding. The second is why any name the file
+ * declares or imports is excluded outright. Erring toward "not stdlib"
+ * is deliberate: failing to dim library code is a smaller wrong than
+ * dimming the user's own.
  */
 function isStandardLibrary(name: string, state: DocumentState): boolean {
-  if (state.semanticIndex[name]?.source === "local") return false;
+  if (isDeclaredInFile(name, state)) return false;
   return (
-    Object.prototype.hasOwnProperty.call(BUILTIN_FUNCTION_TYPES, name) ||
-    PRELUDE_NAMES.includes(name)
+    Object.hasOwn(BUILTIN_FUNCTION_TYPES, name) || PRELUDE_NAMES.includes(name)
   );
 }
 
@@ -91,23 +131,19 @@ function isStandardLibrary(name: string, state: DocumentState): boolean {
  * Does this name refer to a function here? Three sources, in the order
  * that respects shadowing:
  *
- * 1. The enclosing scope's inferred type. A local bound to a function
- *    infers to `functionRefType`, and a local shadowing a top-level
- *    function wins because scope lookup starts innermost.
+ * 1. The enclosing scope's inferred type, so a local bound to a function
+ *    — and a local shadowing a top-level function — wins, because scope
+ *    lookup starts innermost.
  * 2. The declaration index, for top-level and imported symbols.
  * 3. The call syntax itself. `name(...)` is a call whatever we know
  *    about `name`, which covers builtins and unresolved imports.
  */
-function isFunctionReference(slot: IdentifierSlot, state: DocumentState): boolean {
-  const containingScope = findContainingScope(
-    slot.scopeOffset,
-    state.scopes,
-    state.program,
-  );
-  const inferred = containingScope?.scope.lookup(slot.name);
-  if (inferred && (inferred as { type?: string }).type === "functionRefType") {
-    return true;
-  }
+function isFunctionReference(
+  slot: IdentifierSlot,
+  state: DocumentState,
+  resolved: { name: string } | null,
+): boolean {
+  if (resolved) return true;
 
   const declared = state.semanticIndex[slot.name];
   if (declared && TOKEN_TYPE_BY_SYMBOL_KIND[declared.kind] === "function") {
@@ -118,7 +154,13 @@ function isFunctionReference(slot: IdentifierSlot, state: DocumentState): boolea
 }
 
 function toToken(slot: IdentifierSlot, state: DocumentState): Token | null {
-  if (!isFunctionReference(slot, state)) return null;
+  const resolved = resolveFunctionRef(slot, state);
+  if (!isFunctionReference(slot, state, resolved)) return null;
+
+  // The stdlib question is asked of what the name RESOLVES to, not of
+  // what was typed — see isStandardLibrary.
+  const effectiveName = resolved?.name ?? slot.name;
+
   return {
     line: slot.line,
     col: slot.col,
@@ -126,7 +168,7 @@ function toToken(slot: IdentifierSlot, state: DocumentState): Token | null {
     // `end - start` would paint a call's arguments too.
     length: slot.name.length,
     typeIndex: FUNCTION_TYPE_INDEX,
-    modifiers: isStandardLibrary(slot.name, state) ? DEFAULT_LIBRARY_BIT : 0,
+    modifiers: isStandardLibrary(effectiveName, state) ? DEFAULT_LIBRARY_BIT : 0,
   };
 }
 

--- a/packages/agency-lang/lib/lsp/semanticTokens.ts
+++ b/packages/agency-lang/lib/lsp/semanticTokens.ts
@@ -1,0 +1,167 @@
+/**
+ * Semantic tokens — highlighting that needs a typecheck.
+ *
+ * A TextMate grammar can see `helper(...)` and guess "function". It
+ * cannot see that `const f = helper` makes a later bare `f` a function
+ * too, because that needs type inference. That case is the reason this
+ * file exists.
+ *
+ * The shape is deliberately a pipeline: walk the AST, ask
+ * `identifierSlots` where the names are, resolve each one, sort, encode.
+ * No AST knowledge lives here — "where is a name" is owned entirely by
+ * `lib/utils/identifierSlots.ts`, so a new node kind is registered in one
+ * place rather than being hunted through a switch here.
+ */
+import { SemanticTokensBuilder } from "vscode-languageserver/node.js";
+import type { SemanticTokens } from "vscode-languageserver/node.js";
+import type { SymbolKind } from "../symbolTable.js";
+import { BUILTIN_FUNCTION_TYPES } from "../typeChecker/builtins.js";
+import { PRELUDE_NAMES } from "../prelude.js";
+import { walkNodes } from "../utils/node.js";
+import { identifierSlots } from "../utils/identifierSlots.js";
+import type { IdentifierSlot } from "../utils/identifierSlots.js";
+import { findContainingScope } from "./scopeResolution.js";
+import type { DocumentState } from "./documentState.js";
+
+/**
+ * The wire legend. Indices sent on the wire are positions in these
+ * arrays, so the ORDER is part of the protocol contract — an already-open
+ * editor holds the legend it was given at initialize time and will
+ * re-colour every token if these are reordered. Both the capability
+ * announcement and the encoder read these same arrays so no index is
+ * ever hand-written. `semanticTokens.test.ts` pins the order.
+ */
+export const TOKEN_TYPES = ["function"] as const;
+export const TOKEN_MODIFIERS = ["defaultLibrary"] as const;
+
+export type TokenType = (typeof TOKEN_TYPES)[number];
+
+export const SEMANTIC_TOKENS_LEGEND = {
+  tokenTypes: [...TOKEN_TYPES],
+  tokenModifiers: [...TOKEN_MODIFIERS],
+};
+
+const FUNCTION_TYPE_INDEX = TOKEN_TYPES.indexOf("function");
+const DEFAULT_LIBRARY_BIT = 1 << TOKEN_MODIFIERS.indexOf("defaultLibrary");
+
+/**
+ * Which symbol kinds get a function token. `node` shares it because a
+ * node call parses as an ordinary `functionCall` — colouring nodes
+ * differently would encode a distinction the AST does not make.
+ *
+ * `type` and `constant` are null: this first version emits function
+ * tokens only. Every identifier left uncoloured is one the TextMate
+ * grammar still handles, so a narrow table means no visible gaps.
+ */
+const TOKEN_TYPE_BY_SYMBOL_KIND: Record<SymbolKind, TokenType | null> = {
+  function: "function",
+  node: "function",
+  type: null,
+  constant: null,
+};
+
+type Token = {
+  line: number;
+  col: number;
+  length: number;
+  typeIndex: number;
+  modifiers: number;
+};
+
+/**
+ * Is this name part of the language rather than the user's code? Two
+ * registries, because Agency has two kinds of given-to-you function and
+ * a theme dimming "library code" wants both: language primitives like
+ * `llm` and `success`, and the standard-library prelude auto-imported
+ * into every file — `print`, `map`, `filter`.
+ *
+ * Both are existing single sources of truth, so this reads them rather
+ * than restating either. A user who defines their own `print` shadows
+ * the prelude one, so a locally declared name is never marked.
+ */
+function isStandardLibrary(name: string, state: DocumentState): boolean {
+  if (state.semanticIndex[name]?.source === "local") return false;
+  return (
+    Object.prototype.hasOwnProperty.call(BUILTIN_FUNCTION_TYPES, name) ||
+    PRELUDE_NAMES.includes(name)
+  );
+}
+
+/**
+ * Does this name refer to a function here? Three sources, in the order
+ * that respects shadowing:
+ *
+ * 1. The enclosing scope's inferred type. A local bound to a function
+ *    infers to `functionRefType`, and a local shadowing a top-level
+ *    function wins because scope lookup starts innermost.
+ * 2. The declaration index, for top-level and imported symbols.
+ * 3. The call syntax itself. `name(...)` is a call whatever we know
+ *    about `name`, which covers builtins and unresolved imports.
+ */
+function isFunctionReference(slot: IdentifierSlot, state: DocumentState): boolean {
+  const containingScope = findContainingScope(
+    slot.scopeOffset,
+    state.scopes,
+    state.program,
+  );
+  const inferred = containingScope?.scope.lookup(slot.name);
+  if (inferred && (inferred as { type?: string }).type === "functionRefType") {
+    return true;
+  }
+
+  const declared = state.semanticIndex[slot.name];
+  if (declared && TOKEN_TYPE_BY_SYMBOL_KIND[declared.kind] === "function") {
+    return true;
+  }
+
+  return slot.isCall;
+}
+
+function toToken(slot: IdentifierSlot, state: DocumentState): Token | null {
+  if (!isFunctionReference(slot, state)) return null;
+  return {
+    line: slot.line,
+    col: slot.col,
+    // The identifier's own length. A node's loc spans the whole node, so
+    // `end - start` would paint a call's arguments too.
+    length: slot.name.length,
+    typeIndex: FUNCTION_TYPE_INDEX,
+    modifiers: isStandardLibrary(slot.name, state) ? DEFAULT_LIBRARY_BIT : 0,
+  };
+}
+
+/**
+ * Source order. This is load-bearing, not tidiness: `SemanticTokensBuilder`
+ * subtracts from whatever was pushed last and never sorts, so an
+ * out-of-order push produces negative deltas and silently garbled colour.
+ * `walkNodes` genuinely yields out of source order — an assignment yields
+ * its value before the target's access chain, so `obj[i] = f()` walks `f`
+ * before `i`.
+ */
+function byPosition(a: Token, b: Token): number {
+  if (a.line !== b.line) return a.line - b.line;
+  return a.col - b.col;
+}
+
+export function getSemanticTokens(state: DocumentState): SemanticTokens {
+  const slots = [...walkNodes(state.program.nodes)].flatMap(({ node }) =>
+    identifierSlots(node),
+  );
+
+  const tokens = slots
+    .map((slot) => toToken(slot, state))
+    .filter((token): token is Token => token !== null)
+    .sort(byPosition);
+
+  const builder = new SemanticTokensBuilder();
+  for (const token of tokens) {
+    builder.push(
+      token.line,
+      token.col,
+      token.length,
+      token.typeIndex,
+      token.modifiers,
+    );
+  }
+  return builder.build();
+}

--- a/packages/agency-lang/lib/lsp/server.ts
+++ b/packages/agency-lang/lib/lsp/server.ts
@@ -216,7 +216,18 @@ export function startServer(): void {
     // Types can change without the user touching the buffer — an import
     // saved elsewhere, an agency.json edit. Nothing prompts the client to
     // re-pull tokens in that case, so ask it to.
-    connection.languages.semanticTokens.refresh();
+    //
+    // The typings say this returns void; it actually returns the
+    // sendRequest promise, which REJECTS on clients that do not support
+    // the request. Unhandled, that becomes a process-level rejection in
+    // a server meant to run for hours, so the promise is caught here
+    // despite the declared type.
+    const refreshed: unknown = connection.languages.semanticTokens.refresh();
+    if (refreshed instanceof Promise) {
+      refreshed.catch((e) => {
+        connection.console.error(`semantic tokens refresh failed: ${String(e)}`);
+      });
+    }
   });
 
   connection.onDefinition((params) => {

--- a/packages/agency-lang/lib/lsp/server.ts
+++ b/packages/agency-lang/lib/lsp/server.ts
@@ -143,7 +143,6 @@ export function startServer(): void {
         semanticIndex,
         scopes,
         symbolTable,
-        version: doc.version,
         lintFindings,
         lintBatchEdits,
         lintVersion: doc.version,
@@ -350,11 +349,17 @@ export function startServer(): void {
 
   connection.languages.semanticTokens.on((params) => {
     // Last-good, not current: a document mid-edit often does not parse,
-    // and returning nothing would blank every colour in the file.
+    // and returning nothing would blank every color in the file.
     const state = docStates.getLastGood(params.textDocument.uri);
     if (!state) return { data: [] };
+    // Pass the CURRENT text, not the text the state was built from. When
+    // the two differ — the state is stale by a debounce, or the user just
+    // deleted a block — tokens computed against the old text can point
+    // past the end of a line that has since shrunk. getSemanticTokens
+    // drops those rather than emitting coordinates into empty space.
+    const doc = documents.get(params.textDocument.uri);
     try {
-      return getSemanticTokens(state);
+      return getSemanticTokens(state, doc?.getText());
     } catch (e) {
       // Never let a highlighting bug take down the request — but never
       // swallow it silently either, or it becomes untraceable.

--- a/packages/agency-lang/lib/lsp/server.ts
+++ b/packages/agency-lang/lib/lsp/server.ts
@@ -32,7 +32,8 @@ import { handleRename, handlePrepareRename } from "./rename.js";
 import { handleTypeDefinition } from "./typeDefinition.js";
 import { getCodeActions, REMOVE_UNUSED_IMPORTS_KIND } from "./codeAction.js";
 import { getWorkspaceSymbols } from "./workspaceSymbol.js";
-import type { DocumentState } from "./documentState.js";
+import { getSemanticTokens, SEMANTIC_TOKENS_LEGEND } from "./semanticTokens.js";
+import { DocumentStateCache } from "./documentStateCache.js";
 
 // eslint-disable-next-line max-lines-per-function -- LSP server wiring; refactor tracked separately
 export function startServer(): void {
@@ -42,8 +43,10 @@ export function startServer(): void {
   );
   const documents = new TextDocuments(TextDocument);
 
-  // Per-document state: parsed program, compilation info, semantic index, scopes, symbol table
-  const docStates = new Map<string, DocumentState>();
+  // Per-document state: parsed program, compilation info, semantic index,
+  // scopes, symbol table. Keeps a last-good copy so highlighting survives
+  // the half-typed lines that fail to parse — see DocumentStateCache.
+  const docStates = new DocumentStateCache();
 
   // Debounce timers for diagnostics (per URI)
   const debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -81,6 +84,10 @@ export function startServer(): void {
         },
         workspaceSymbolProvider: true,
         documentLinkProvider: {},
+        semanticTokensProvider: {
+          legend: SEMANTIC_TOKENS_LEGEND,
+          full: true,
+        },
       },
     };
   });
@@ -136,12 +143,13 @@ export function startServer(): void {
         semanticIndex,
         scopes,
         symbolTable,
+        version: doc.version,
         lintFindings,
         lintBatchEdits,
         lintVersion: doc.version,
       });
     } else {
-      docStates.delete(doc.uri);
+      docStates.clearCurrent(doc.uri);
     }
   }
 
@@ -172,7 +180,7 @@ export function startServer(): void {
 
   documents.onDidClose((event) => {
     connection.sendDiagnostics({ uri: event.document.uri, diagnostics: [] });
-    docStates.delete(event.document.uri);
+    docStates.remove(event.document.uri);
   });
 
   connection.onDidChangeWatchedFiles((params) => {
@@ -205,6 +213,10 @@ export function startServer(): void {
         updateDocument(doc);
       }
     }
+    // Types can change without the user touching the buffer — an import
+    // saved elsewhere, an agency.json edit. Nothing prompts the client to
+    // re-pull tokens in that case, so ask it to.
+    connection.languages.semanticTokens.refresh();
   });
 
   connection.onDefinition((params) => {
@@ -320,9 +332,24 @@ export function startServer(): void {
   });
 
   connection.onWorkspaceSymbol((params) => {
-    const firstState = docStates.values().next().value;
+    const firstState = docStates.anyCurrent();
     if (!firstState) return [];
     return getWorkspaceSymbols(params.query, firstState.symbolTable);
+  });
+
+  connection.languages.semanticTokens.on((params) => {
+    // Last-good, not current: a document mid-edit often does not parse,
+    // and returning nothing would blank every colour in the file.
+    const state = docStates.getLastGood(params.textDocument.uri);
+    if (!state) return { data: [] };
+    try {
+      return getSemanticTokens(state);
+    } catch (e) {
+      // Never let a highlighting bug take down the request — but never
+      // swallow it silently either, or it becomes untraceable.
+      connection.console.error(`semantic tokens failed: ${String(e)}`);
+      return { data: [] };
+    }
   });
 
   documents.listen(connection);

--- a/packages/agency-lang/lib/utils/identifierSlots.test.ts
+++ b/packages/agency-lang/lib/utils/identifierSlots.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { identifierSlots, REGISTERED_IDENTIFIER_KINDS } from "./identifierSlots.js";
+import { EXPRESSION_NODE_TYPES } from "../types.js";
+import type { AgencyNode } from "../types.js";
+
+function slotsFor(node: unknown) {
+  return identifierSlots(node as AgencyNode);
+}
+
+describe("identifierSlots completeness", () => {
+  it("registers every expression node kind", () => {
+    // The registry is a Record over AgencyNode["type"], so a missing kind
+    // is a COMPILE error — that is the real enforcement and it fails by
+    // name. This test covers the other direction: it catches a kind that
+    // was added to the language and to the registry, but by someone who
+    // did not think about whether it holds an identifier.
+    const missing = EXPRESSION_NODE_TYPES.filter(
+      (kind) => !REGISTERED_IDENTIFIER_KINDS.includes(kind),
+    );
+    expect(missing).toEqual([]);
+  });
+
+  it("returns no slots for an unknown node kind rather than throwing", () => {
+    // Templates and tests can synthesize nodes outside the union.
+    expect(slotsFor({ type: "notARealNodeKind" })).toEqual([]);
+  });
+});
+
+describe("identifierSlots positions", () => {
+  const loc = { line: 3, col: 7, start: 42, end: 48 };
+
+  it("reads a plain variable reference", () => {
+    expect(slotsFor({ type: "variableName", value: "helper", loc })).toEqual([
+      { name: "helper", line: 3, col: 7, scopeOffset: 42, isCall: false },
+    ]);
+  });
+
+  it("reads a call and marks it as one", () => {
+    const slots = slotsFor({
+      type: "functionCall",
+      functionName: "helper",
+      arguments: [],
+      loc,
+    });
+    expect(slots).toEqual([
+      { name: "helper", line: 3, col: 7, scopeOffset: 42, isCall: true },
+    ]);
+  });
+
+  it("does not carry the node span as a length source", () => {
+    // The slot exposes `name`, never end-start. A functionCall's loc
+    // spans `helper(y)`, so a consumer using the span would paint the
+    // arguments. Nothing in the slot makes that possible.
+    const slots = slotsFor({
+      type: "functionCall",
+      functionName: "helper",
+      arguments: [],
+      loc: { line: 0, col: 0, start: 0, end: 999 },
+    });
+    expect(slots[0].name.length).toBe(6);
+    expect(Object.keys(slots[0])).not.toContain("end");
+  });
+});
+
+describe("identifierSlots exclusions", () => {
+  const loc = { line: 1, col: 2, start: 10, end: 14 };
+
+  it("skips `null`, which the parser represents as a variable name", () => {
+    expect(slotsFor({ type: "variableName", value: "null", loc })).toEqual([]);
+  });
+
+  it("skips nodes with no loc — this is what the valueAccess gap looks like", () => {
+    // walkNodes descends into a valueAccess base, so an unlocated
+    // variableName really does arrive here. The guard is on loc rather
+    // than on node kind, so these start producing slots automatically
+    // once the parser carries positions for them.
+    expect(slotsFor({ type: "variableName", value: "obj" })).toEqual([]);
+    expect(
+      slotsFor({ type: "functionCall", functionName: "invoke", arguments: [] }),
+    ).toEqual([]);
+  });
+
+  it("skips a template hole used as a callee", () => {
+    expect(
+      slotsFor({
+        type: "functionCall",
+        functionName: { type: "hole", name: "name" },
+        arguments: [],
+        loc,
+      }),
+    ).toEqual([]);
+  });
+
+  it("skips declaration sites, which the grammar already colours", () => {
+    expect(
+      slotsFor({
+        type: "function",
+        functionName: "helper",
+        parameters: [],
+        body: [],
+        loc,
+      }),
+    ).toEqual([]);
+    expect(
+      slotsFor({ type: "graphNode", nodeName: "main", parameters: [], body: [], loc }),
+    ).toEqual([]);
+  });
+});

--- a/packages/agency-lang/lib/utils/identifierSlots.test.ts
+++ b/packages/agency-lang/lib/utils/identifierSlots.test.ts
@@ -1,23 +1,94 @@
 import { describe, expect, it } from "vitest";
-import { identifierSlots, REGISTERED_IDENTIFIER_KINDS } from "./identifierSlots.js";
-import { EXPRESSION_NODE_TYPES } from "../types.js";
+import { identifierSlots, IDENTIFIER_BEARING_KINDS } from "./identifierSlots.js";
+import { parseAgency } from "../parser.js";
+import { walkNodes } from "./node.js";
 import type { AgencyNode } from "../types.js";
 
 function slotsFor(node: unknown) {
   return identifierSlots(node as AgencyNode);
 }
 
+/** Synthetic nodes of each identifier-bearing kind, shaped as the parser
+ *  produces them. Used to prove the registry entry still does something. */
+const SAMPLE_NODES: Record<(typeof IDENTIFIER_BEARING_KINDS)[number], unknown> = {
+  variableName: {
+    type: "variableName",
+    value: "helper",
+    loc: { line: 0, col: 0, start: 0, end: 6 },
+  },
+  functionCall: {
+    type: "functionCall",
+    functionName: "helper",
+    arguments: [],
+    loc: { line: 0, col: 0, start: 0, end: 8 },
+  },
+};
+
 describe("identifierSlots completeness", () => {
-  it("registers every expression node kind", () => {
-    // The registry is a Record over AgencyNode["type"], so a missing kind
-    // is a COMPILE error — that is the real enforcement and it fails by
-    // name. This test covers the other direction: it catches a kind that
-    // was added to the language and to the registry, but by someone who
-    // did not think about whether it holds an identifier.
-    const missing = EXPRESSION_NODE_TYPES.filter(
-      (kind) => !REGISTERED_IDENTIFIER_KINDS.includes(kind),
+  // NOTE on what enforces what. The registry is
+  // `{ [K in AgencyNode["type"]]: SlotExtractor<K> }`, so a node kind
+  // added to the language fails to COMPILE until it is registered, and
+  // each extractor sees its own node type so an AST field rename is also
+  // a compile error. Those are the real guarantees; neither needs a test.
+  //
+  // What the compiler cannot catch is an entry that is present but
+  // wrong — flipped to `none`, or reading a field that exists but is not
+  // the name. That is what the two tests below are for.
+
+  it.each(IDENTIFIER_BEARING_KINDS)(
+    "%s still produces a slot",
+    (kind) => {
+      // Fails if someone sets this entry to `none`, which compiles fine
+      // and would silently stop coloring that whole node kind.
+      const slots = slotsFor(SAMPLE_NODES[kind]);
+      expect(slots.length).toBe(1);
+      expect(slots[0].name).toBe("helper");
+    },
+  );
+
+  it("finds every located name in a real parsed file", () => {
+    // The corpus check: parse real code, collect every node the walk
+    // reaches that carries both a name and a position, and assert the
+    // table accounts for all of them. Fails if an extractor starts
+    // dropping nodes it used to handle — a guard the synthetic cases
+    // above cannot give, since they never exercise the walk.
+    const source = [
+      `def helper(x: number): number {`,
+      `  return x + 1`,
+      `}`,
+      ``,
+      `node main() {`,
+      `  const f = helper`,
+      `  const y = f(3)`,
+      `  print("interpolated \${helper(y)}")`,
+      `  for (item in [1, 2]) {`,
+      `    print(item)`,
+      `  }`,
+      `}`,
+    ].join("\n");
+
+    const parsed = parseAgency(source, {}, false);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+
+    const located: string[] = [];
+    for (const { node } of walkNodes(parsed.result.nodes)) {
+      const any = node as { type: string; loc?: unknown; value?: unknown; functionName?: unknown };
+      if (!any.loc) continue;
+      if (any.type === "variableName" && any.value !== "null") {
+        located.push(String(any.value));
+      }
+      if (any.type === "functionCall" && typeof any.functionName === "string") {
+        located.push(any.functionName);
+      }
+    }
+
+    const found = [...walkNodes(parsed.result.nodes)].flatMap(({ node }) =>
+      identifierSlots(node).map((slot) => slot.name),
     );
-    expect(missing).toEqual([]);
+
+    expect(located.length).toBeGreaterThan(5);
+    expect(found.sort()).toEqual(located.sort());
   });
 
   it("returns no slots for an unknown node kind rather than throwing", () => {
@@ -91,7 +162,7 @@ describe("identifierSlots exclusions", () => {
     ).toEqual([]);
   });
 
-  it("skips declaration sites, which the grammar already colours", () => {
+  it("skips declaration sites, which the grammar already colors", () => {
     expect(
       slotsFor({
         type: "function",

--- a/packages/agency-lang/lib/utils/identifierSlots.ts
+++ b/packages/agency-lang/lib/utils/identifierSlots.ts
@@ -24,9 +24,9 @@
  * 1. Positions come from `loc.line` / `loc.col`, which are 0-indexed in
  *    the USER'S file whichever parse mode ran. `loc.start` / `loc.end`
  *    are offsets into whatever the parser actually saw, which differs
- *    between the two modes. See docs/dev/locations.md — and note it says
- *    the LSP's choice of mode is historical and could change, which is
- *    exactly why nothing here may depend on it. `scopeOffset` is safe
+ *    between the two modes. See `docs/dev/locations.md` — and note it
+ *    says the LSP's choice of mode is historical and could change, which
+ *    is exactly why nothing here may depend on it. `scopeOffset` is safe
  *    because it is only ever compared with offsets from the same parse.
  * 2. A slot's length is the identifier's own length, taken by the
  *    consumer from `name`. A node's `loc` spans the WHOLE node — a
@@ -40,6 +40,7 @@
  * it fails by name in the same way.
  */
 import type { AgencyNode } from "../types.js";
+import type { SourceLocation } from "../types/base.js";
 import { isNullLiteral } from "./node.js";
 
 export type IdentifierSlot = {
@@ -50,8 +51,7 @@ export type IdentifierSlot = {
   /** 0-based column of the identifier's first character. */
   col: number;
   /** Offset for `findContainingScope`. Only comparable against other
-   *  offsets from the SAME parse — see the parse-mode note in
-   *  docs on Background A. */
+   *  offsets from the SAME parse — see `docs/dev/locations.md`. */
   scopeOffset: number;
   /** True when the source wrote this as a call, `name(...)`. Lets a
    *  consumer distinguish a call site from a bare reference without
@@ -59,10 +59,18 @@ export type IdentifierSlot = {
   isCall: boolean;
 };
 
-/** Extracts the identifier references a node contributes itself. Child
- *  nodes are NOT visited here — `walkNodes` reaches them and asks this
- *  table about each one in turn. */
-type SlotExtractor = (node: any) => IdentifierSlot[];
+/** Extracts the identifier references a node of kind `K` contributes
+ *  itself. Child nodes are NOT visited here — `walkNodes` reaches them
+ *  and asks this table about each one in turn.
+ *
+ *  Parameterised by kind so each extractor receives its OWN node type
+ *  rather than `any`. That is what makes a rename of `functionName` in
+ *  the AST a compile error here instead of a silent zero-slot return —
+ *  which would be the same "missing color nobody reports" failure this
+ *  module exists to prevent, arriving through the back door. */
+type SlotExtractor<K extends AgencyNode["type"]> = (
+  node: Extract<AgencyNode, { type: K }>,
+) => IdentifierSlot[];
 
 /**
  * Nodes reached through a `valueAccess` — its base and the calls in its
@@ -78,10 +86,13 @@ type SlotExtractor = (node: any) => IdentifierSlot[];
  * file. `semanticTokens.test.ts` has a tripwire test that fails at that
  * moment.
  */
-const located = (node: { loc?: { line: number; col: number; start: number } }) =>
-  node.loc !== undefined;
+function located<T extends { loc?: SourceLocation }>(
+  node: T,
+): node is T & { loc: SourceLocation } {
+  return node.loc !== undefined;
+}
 
-const variableNameSlots: SlotExtractor = (node) => {
+const variableNameSlots: SlotExtractor<"variableName"> = (node) => {
   // The parser has no `null` literal node — it represents `null` as a
   // variableName (see isNullLiteral in node.ts). It is a keyword, not a
   // reference to anything.
@@ -98,7 +109,7 @@ const variableNameSlots: SlotExtractor = (node) => {
   ];
 };
 
-const functionCallSlots: SlotExtractor = (node) => {
+const functionCallSlots: SlotExtractor<"functionCall"> = (node) => {
   // In templates `functionName` can be an identifier hole rather than a
   // string. A hole stands for a name it does not yet have.
   if (typeof node.functionName !== "string") return [];
@@ -117,7 +128,9 @@ const functionCallSlots: SlotExtractor = (node) => {
   ];
 };
 
-const none: SlotExtractor = () => [];
+/** Declares a kind as holding no identifier reference of its own.
+ *  Takes no arguments, so it satisfies every `SlotExtractor<K>`. */
+const none = () => [];
 
 /**
  * Every `AgencyNode` kind, mapped to what identifier references it
@@ -133,7 +146,7 @@ const none: SlotExtractor = () => [];
  * the name offset from keyword length. Semantic tokens exist here to
  * cover what the grammar CANNOT know, and declarations are not that.
  */
-const REGISTRY: Record<AgencyNode["type"], SlotExtractor> = {
+const REGISTRY: { [K in AgencyNode["type"]]: SlotExtractor<K> } = {
   variableName: variableNameSlots,
   functionCall: functionCallSlots,
 
@@ -211,12 +224,27 @@ const REGISTRY: Record<AgencyNode["type"], SlotExtractor> = {
 
 /** The identifier references this node contributes itself. */
 export function identifierSlots(node: AgencyNode): IdentifierSlot[] {
-  const extractor = REGISTRY[node.type];
-  // Unreachable while the Record above type-checks; a runtime guard for
-  // AST nodes synthesized outside the union (templates, tests).
+  // The one cast in this file. TypeScript cannot see that REGISTRY[k]
+  // and a node of kind k agree, though the mapped type guarantees it;
+  // the extractors themselves stay fully typed, which is the point.
+  const extractor = REGISTRY[node.type] as
+    | ((node: AgencyNode) => IdentifierSlot[])
+    | undefined;
+  // Unreachable while the registry type-checks. A runtime guard for AST
+  // nodes synthesized outside the union (templates, tests).
   if (!extractor) return [];
   return extractor(node);
 }
 
-/** Exported for the completeness test. */
-export const REGISTERED_IDENTIFIER_KINDS = Object.keys(REGISTRY);
+/**
+ * The kinds that actually yield identifier references. Exported so the
+ * test can assert each one still produces a slot — a registry entry
+ * flipped to `none` compiles fine and would silently stop coloring.
+ *
+ * A new node kind is NOT added here by default, which is the limit of
+ * what this can enforce: the registry forces an author to make a choice,
+ * and the corpus test in identifierSlots.test.ts catches a wrong choice
+ * for the two shapes we know about. Neither can know that some future
+ * node kind carries a name.
+ */
+export const IDENTIFIER_BEARING_KINDS = ["variableName", "functionCall"] as const;

--- a/packages/agency-lang/lib/utils/identifierSlots.ts
+++ b/packages/agency-lang/lib/utils/identifierSlots.ts
@@ -1,0 +1,222 @@
+/**
+ * identifierSlots — the single source of truth for "which positions of a
+ * node hold an identifier REFERENCE, and where in the user's file that
+ * identifier sits". The third member of the slot-table family, after
+ * `bodySlots` (statement bodies) and `expressionSlots` (expression
+ * positions).
+ *
+ * Why it exists: the same reason as its two siblings. `expressionSlots`
+ * records that hand-written expression-position lists drifted and three
+ * holes appeared in one week; `bodySlots` records the identical history
+ * for statement bodies. Semantic-token highlighting asks the same
+ * question one level over — "where are the names?" — and a per-node-kind
+ * switch buried in the LSP handler would drift the same way, except the
+ * symptom is a missing color, which nobody files a bug about.
+ *
+ * Consumers:
+ *   - `getSemanticTokens` (lib/lsp/semanticTokens.ts)
+ *
+ * This table answers WHERE a name is, never WHAT it means. Resolving a
+ * name to a symbol needs scopes and belongs to the consumer.
+ *
+ * Two rules the whole table obeys, so no consumer can get them wrong:
+ *
+ * 1. Positions come from `loc.line` / `loc.col`, which are 0-indexed in
+ *    the USER'S file whichever parse mode ran. `loc.start` / `loc.end`
+ *    are offsets into whatever the parser actually saw, which differs
+ *    between the two modes. See docs/dev/locations.md — and note it says
+ *    the LSP's choice of mode is historical and could change, which is
+ *    exactly why nothing here may depend on it. `scopeOffset` is safe
+ *    because it is only ever compared with offsets from the same parse.
+ * 2. A slot's length is the identifier's own length, taken by the
+ *    consumer from `name`. A node's `loc` spans the WHOLE node — a
+ *    functionCall's loc covers `helper(y)`, not `helper` — so
+ *    `end - start` would paint the arguments.
+ *
+ * Completeness is enforced by the compiler, not by review: the registry
+ * below is a `Record<AgencyNode["type"], …>`, so adding a node kind to
+ * the language fails to compile until it is registered here. That is
+ * strictly stronger than the runtime lists `expressionSlots` uses, and
+ * it fails by name in the same way.
+ */
+import type { AgencyNode } from "../types.js";
+import { isNullLiteral } from "./node.js";
+
+export type IdentifierSlot = {
+  /** The identifier text as written. Also the token's length. */
+  name: string;
+  /** 0-based line in the user's file. */
+  line: number;
+  /** 0-based column of the identifier's first character. */
+  col: number;
+  /** Offset for `findContainingScope`. Only comparable against other
+   *  offsets from the SAME parse — see the parse-mode note in
+   *  docs on Background A. */
+  scopeOffset: number;
+  /** True when the source wrote this as a call, `name(...)`. Lets a
+   *  consumer distinguish a call site from a bare reference without
+   *  re-inspecting the AST. */
+  isCall: boolean;
+};
+
+/** Extracts the identifier references a node contributes itself. Child
+ *  nodes are NOT visited here — `walkNodes` reaches them and asks this
+ *  table about each one in turn. */
+type SlotExtractor = (node: any) => IdentifierSlot[];
+
+/**
+ * Nodes reached through a `valueAccess` — its base and the calls in its
+ * chain — carry no `loc` from the parser. `obj.a` and
+ * `helper(1).invoke()` produce a single located `valueAccess` node whose
+ * children have no position at all.
+ *
+ * That gap is handled by the `loc` guards below rather than by a special
+ * case: `walkNodes` DOES descend into those children, so they arrive
+ * here as ordinary `variableName` / `functionCall` nodes, and the guard
+ * drops them for want of a position. When the parser starts carrying
+ * `loc` on them, they will begin producing slots with no change to this
+ * file. `semanticTokens.test.ts` has a tripwire test that fails at that
+ * moment.
+ */
+const located = (node: { loc?: { line: number; col: number; start: number } }) =>
+  node.loc !== undefined;
+
+const variableNameSlots: SlotExtractor = (node) => {
+  // The parser has no `null` literal node — it represents `null` as a
+  // variableName (see isNullLiteral in node.ts). It is a keyword, not a
+  // reference to anything.
+  if (isNullLiteral(node)) return [];
+  if (!located(node)) return [];
+  return [
+    {
+      name: node.value,
+      line: node.loc.line,
+      col: node.loc.col,
+      scopeOffset: node.loc.start,
+      isCall: false,
+    },
+  ];
+};
+
+const functionCallSlots: SlotExtractor = (node) => {
+  // In templates `functionName` can be an identifier hole rather than a
+  // string. A hole stands for a name it does not yet have.
+  if (typeof node.functionName !== "string") return [];
+  if (!located(node)) return [];
+  // A functionCall's loc.col points at the first character of the
+  // callee, which is what we want; its loc.end points past the closing
+  // paren, which is why length comes from the name instead.
+  return [
+    {
+      name: node.functionName,
+      line: node.loc.line,
+      col: node.loc.col,
+      scopeOffset: node.loc.start,
+      isCall: true,
+    },
+  ];
+};
+
+const none: SlotExtractor = () => [];
+
+/**
+ * Every `AgencyNode` kind, mapped to what identifier references it
+ * contributes. `none` means "this kind holds no identifier reference of
+ * its own" — which is the answer for the large majority, because their
+ * names are either declarations (see below) or live in child nodes that
+ * `walkNodes` visits separately.
+ *
+ * DECLARATION sites are deliberately absent. `def helper` and
+ * `node main` are purely syntactic: a TextMate grammar colors them
+ * correctly without a typecheck, and their `loc.col` points at the
+ * keyword rather than the name, so emitting them would mean re-deriving
+ * the name offset from keyword length. Semantic tokens exist here to
+ * cover what the grammar CANNOT know, and declarations are not that.
+ */
+const REGISTRY: Record<AgencyNode["type"], SlotExtractor> = {
+  variableName: variableNameSlots,
+  functionCall: functionCallSlots,
+
+  // Declarations — see the note above.
+  function: none,
+  graphNode: none,
+  typeAlias: none,
+  effectDeclaration: none,
+
+  // Container nodes: their identifiers live in children that walkNodes
+  // descends into, so each child arrives here on its own.
+  assignment: none,
+  valueAccess: none,
+  binOpExpression: none,
+  agencyArray: none,
+  agencyObject: none,
+  string: none,
+  multiLineString: none,
+  returnStatement: none,
+  matchYield: none,
+  matchBlock: none,
+  gotoStatement: none,
+  ifElse: none,
+  whileLoop: none,
+  forLoop: none,
+  comprehension: none,
+  messageThread: none,
+  parallelBlock: none,
+  seqBlock: none,
+  handleBlock: none,
+  finalizeBlock: none,
+  guardBlock: none,
+  withModifier: none,
+  staticStatement: none,
+  blockArgument: none,
+  tryExpression: none,
+  newExpression: none,
+  interruptStatement: none,
+  isExpression: none,
+  typeTestExpression: none,
+
+  // Import statements name symbols, but as strings with no per-name
+  // loc — there is no position to emit.
+  importStatement: none,
+  importNodeStatement: none,
+  exportFromStatement: none,
+
+  // Leaves and non-code nodes.
+  number: none,
+  unitLiteral: none,
+  boolean: none,
+  null: none,
+  regex: none,
+  schemaExpression: none,
+  comment: none,
+  multiLineComment: none,
+  newLine: none,
+  rawCode: none,
+  skill: none,
+  keyword: none,
+  tag: none,
+  debuggerStatement: none,
+  awaitPending: none,
+  markDestructiveRan: none,
+  hole: none,
+
+  // Patterns bind names, they do not reference them.
+  objectPattern: none,
+  arrayPattern: none,
+  restPattern: none,
+  wildcardPattern: none,
+  resultPattern: none,
+  typePattern: none,
+};
+
+/** The identifier references this node contributes itself. */
+export function identifierSlots(node: AgencyNode): IdentifierSlot[] {
+  const extractor = REGISTRY[node.type];
+  // Unreachable while the Record above type-checks; a runtime guard for
+  // AST nodes synthesized outside the union (templates, tests).
+  if (!extractor) return [];
+  return extractor(node);
+}
+
+/** Exported for the completeness test. */
+export const REGISTERED_IDENTIFIER_KINDS = Object.keys(REGISTRY);


### PR DESCRIPTION
## What

Adds `textDocument/semanticTokens` to the LSP server, so the VS Code extension can color identifiers that resolve to functions.

A TextMate grammar can see `helper(...)` and guess "function". It cannot see this:

```agency
const f = helper
print(f)          // f is a function, but only a typecheck knows that
```

That case is the reason for the feature.

## How

Three new pieces, plus wiring in `server.ts`.

**`lib/utils/identifierSlots.ts`** answers one question: where are the identifier references in this node? It is the third member of the slot-table family after `bodySlots` and `expressionSlots`, and it exists for the reason those two do. From `expressionSlots`' header:

> hand-written expression-position lists drift. The hoisting pass shipped with its own list and three holes were found in one week

The alternative was a per-node-kind switch inside the token handler, which is that same drift-prone list one level over — except the symptom here is a missing color, which nobody files a bug about. Completeness is enforced by the compiler rather than by review: the registry is a `Record<AgencyNode["type"], ...>`, so adding a node kind to the language fails to compile until it is registered.

**`lib/lsp/semanticTokens.ts`** is a pipeline — walk, resolve, sort, encode — with no AST knowledge of its own. Resolution tries the enclosing scope first so a local shadowing a top-level function wins, then the declaration index, then the call syntax itself.

**`lib/lsp/documentStateCache.ts`** keeps a last-good state per document. `updateDocument` drops state whenever a parse fails, which is most of the time while a line is being typed. Serving only current state would blank every color in the file on nearly every keystroke, so the tokens handler reads last-good instead. Colors lagging by a debounce are invisible; colors vanishing are not.

## Three things worth a reviewer's attention

**`SemanticTokensBuilder` does not sort.** It subtracts from whatever was pushed last, so an out-of-order push produces negative deltas and silently garbled color with no error. And `walkNodes` genuinely yields out of source order: an assignment yields its value before the target access chain, so `obj[i] = f()` walks `f` before `i`. The sort is load-bearing, and there is a test that fails without it.

**Token length comes from the identifier name, never `end - start`.** A node's `loc` spans the whole node, so a `functionCall`'s loc covers `helper(y)`. Using the span would paint the arguments.

**Identifiers inside a `valueAccess` get no token.** `obj.a` and `helper(1).invoke()` parse to a single located node whose children carry no `loc` at all. The guard is on `loc` rather than on node kind, so those start producing tokens with no change to this code once the parser carries positions. There is a tripwire test that fails at that moment and says what to do.

## Scope

This version emits **function tokens only**. Every identifier left uncolored is one the TextMate grammar still handles today, so a narrow table means no visible gaps — and it means the extension needs no grammar changes and no `contributes` entry, since `function` is a standard token type every theme already colors.

## Testing

29 new tests across the three modules; the full `lib/lsp` and `lib/utils` suites pass (226 tests), `tsc` and the structural linter are clean.

The assertions decode the wire format and then slice the **source text** at each decoded position, so a test asserts `{ text: "helper", type: "function" }`. Asserting line and column numbers alone would be reading the same `loc` the implementation read, so a systematic position error would agree with itself and pass. The decoder does its own delta arithmetic rather than importing one from the implementation, since a shared decoder inherits the encoder's bug.

Two mutations were run to confirm the suite bites:

| Mutation | Result |
|---|---|
| remove `.sort(byPosition)` | 1 test fails (source-order test) |
| token length off by one | 8 tests fail |

Known limits, stated rather than implied:

- Block-scope shadowing is not resolved — `findContainingScope` only matches scopes named by a top-level definition. There is a skipped test naming this, ready to unskip.
- Nothing here proves VS Code actually paints the color. That needs the manual check below.

## Not in this PR

The extension-side work. Per the plan it is a README note about `editor.semanticTokenColorCustomizations` and nothing else — no client code, no `contributes`, no grammar change. It also cannot land usefully until `agency-lang` cuts a release and the extension bumps its devDependency, so it belongs in a separate PR on that repo after this one ships.

## Manual verification after release

- `"agency.trace.server": "verbose"`, then confirm `semanticTokensProvider` in the initialize result.
- `Developer: Inspect Editor Tokens and Colors` on a bare `f` bound to a function — that is the definitive check, not eyeballing the color.
