### PR TITLE
Reify: std::agency describe() reports a module's exports as data

### DIFF
--- a/packages/agency-lang/docs/site/guide/templates.md
+++ b/packages/agency-lang/docs/site/guide/templates.md
@@ -155,6 +155,50 @@ Destructuring binders are tracked like any other name: `const { key } = …`, ar
 
 Two binder forms are not yet tracked for collisions: names bound by result patterns (`if (r is success(v)) { … }` binds `v`) and names bound inside match arms. If a filler or template uses one of those names on the other side, rename it yourself.
 
+## Asking a module what it exports
+
+Generators get much more interesting when they can ask questions instead of being handed lists. `describe(source)` returns a module's exported surface as data — each exported function, node, type, const, and re-export, with its signature, docstring, transitive effect list, and `destructive`/`idempotent` markers:
+
+```ts
+const info = describe(toolsSource)
+// info.value.exports:
+// [{ name: "fetchArticle", kind: "def",
+//    signature: "fetchArticle(url: string): string",
+//    docstring: "Fetch one article body by URL.",
+//    effects: [], destructive: false, idempotent: true, reexportedFrom: null },
+//  { name: "saveNote", kind: "def", effects: ["std::write"], destructive: true, ... }]
+```
+
+The template payoff is that safety checks become loops. To supervise a set of tools, generate one handler arm per effect any of them can raise and splice the arms into a supervisor template — an effect with no handler cannot exist, because the loop is the completeness proof:
+
+```ts
+import { describe, loadTemplate, fill, parseStatements, toSource, runCode } from "std::agency"
+
+def superviseTools(toolsSource: string, task: string): Result {
+  const info = describe(toolsSource)
+  if (isFailure(info)) {
+    return info
+  }
+  let arms = []
+  for (exp in info.value.exports) {
+    for (effect in exp.effects) {
+      const arm = parseStatements("reject ${effect}")
+      if (isSuccess(arm)) {
+        arms = [...arms, arm.value]
+      }
+    }
+  }
+  const tpl = loadTemplate(__dirname, "supervisor.agency")   // contains #...handlerArms
+  const program = fill(tpl.value, { handlerArms: arms, task: task })
+  if (isFailure(program)) {
+    return program
+  }
+  return runCode(toSource(program.value))
+}
+```
+
+Effects use the same names and `"unknown"` sentinel as `getEffects`, so a bare `interrupt(...)` in a tool never disappears from the handler list. Re-exports resolve when the source module is a `std::` path; a re-export from a relative path cannot be read from a source string, so its entry reports `effects: ["unknown"]` rather than pretending to know.
+
 ## What is checked, and when
 
 Three checkpoints, from weakest to strongest:

--- a/packages/agency-lang/docs/site/stdlib/agency.md
+++ b/packages/agency-lang/docs/site/stdlib/agency.md
@@ -30,7 +30,7 @@ export type CompiledProgram = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L68))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L69))
 
 ### SourceLocation
 
@@ -43,7 +43,7 @@ export type SourceLocation = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L72))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L73))
 
 ### TypeCheckDiagnostic
 
@@ -62,7 +62,7 @@ export type TypeCheckDiagnostic = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L79))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L80))
 
 ### TypeCheckReport
 
@@ -73,7 +73,7 @@ export type TypeCheckReport = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L92))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L93))
 
 ### EffectsByExport
 
@@ -84,7 +84,43 @@ Per-exported-symbol effect lists, keyed by node/function name.
 export type EffectsByExport = Record<string, string[]>
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L388))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L389))
+
+### ExportInfo
+
+What describe reports for one exported symbol. `signature` is the
+printed declaration with no keywords or docs; `docstring` is the symbol's
+docstring (defs and nodes) or doc comment (types); `effects` uses the same
+names and "unknown" sentinel as getEffects, and is empty for types.
+
+```ts
+/** What describe reports for one exported symbol. `signature` is the
+printed declaration with no keywords or docs; `docstring` is the symbol's
+docstring (defs and nodes) or doc comment (types); `effects` uses the same
+names and "unknown" sentinel as getEffects, and is empty for types. */
+export type ExportInfo = {
+  name: string;
+  kind: "def" | "node" | "type";
+  signature: string;
+  docstring?: string;
+  effects: string[];
+  destructive: boolean;
+  idempotent: boolean
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L408))
+
+### ModuleInfo
+
+```ts
+export type ModuleInfo = {
+  description?: string;
+  exports: ExportInfo[]
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L418))
 
 ### AST
 
@@ -107,7 +143,7 @@ export type AST = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L429))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L462))
 
 ### Code
 
@@ -129,7 +165,7 @@ export type Code = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L482))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L515))
 
 ### HoleInfo
 
@@ -143,7 +179,7 @@ export type HoleInfo = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L489))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L522))
 
 ## Effects
 
@@ -156,7 +192,7 @@ effect std::read {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L50))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L51))
 
 ### std::write
 
@@ -167,7 +203,7 @@ effect std::write {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L54))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L55))
 
 ### std::run
 
@@ -183,7 +219,7 @@ effect std::run {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L58))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L59))
 
 ## Functions
 
@@ -205,7 +241,7 @@ Compile Agency source code. Returns a CompiledProgram on success, or a failure w
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L97))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L98))
 
 ### run
 
@@ -270,7 +306,7 @@ and a child process has maxDepth=5, maxDepth=3 is used.
 
 **Throws:** `std::run`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L117))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L118))
 
 ### runFile
 
@@ -323,7 +359,7 @@ Exceeding a resource limit kills the subprocess and returns a `limit_exceeded` f
 
 **Throws:** `std::run`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L217))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L218))
 
 ### runCode
 
@@ -389,7 +425,7 @@ re-raises std::run and the child's own effects re-prompt.
 
 **Throws:** `std::run`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L317))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L318))
 
 ### typecheck
 
@@ -413,7 +449,7 @@ Relative imports (./foo.agency) cannot be resolved from a source string.
 
 **Returns:** `Result<TypeCheckReport>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L378))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L379))
 
 ### getEffects
 
@@ -437,7 +473,32 @@ Map each exported node and function in the source to the list of
 
 **Returns:** `Result<EffectsByExport>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L390))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L391))
+
+### describe
+
+```ts
+describe(source: string): Result<ModuleInfo>
+```
+
+Describe what an Agency module exports: each exported function, node, and type, in source order, with its signature, docstring, transitive effect list, and destructive/idempotent markers. Use this instead of reading source when generating code shaped by a module - for example, one handler per effect its tools can raise.
+
+  @param source - Agency source code as a string
+
+The reify primitive: exports-as-data, so generators can be shaped by
+what a module contains instead of hand-maintained lists. Underscore-prefixed
+exports are omitted, matching the `agency doc` rule — they are lowering
+targets, not caller surface.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| source | `string` |  |
+
+**Returns:** `Result<ModuleInfo>`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L427))
 
 ### typecheckFile
 
@@ -462,7 +523,7 @@ Type-check an Agency file on disk. The file is read from dir/filename,
 
 **Throws:** `std::read`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L409))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L442))
 
 ### parseAST
 
@@ -482,7 +543,7 @@ Parse Agency source code into an abstract syntax tree.
 
 **Returns:** `Result<AST>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L435))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L468))
 
 ### writeAST
 
@@ -519,7 +580,7 @@ Output is canonical formatter output (the same style as `pnpm run fmt`):
 
 **Throws:** `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L447))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L480))
 
 ### format
 
@@ -539,7 +600,7 @@ Format Agency source code with the standard Agency formatter.
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L469))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L502))
 
 ### loadTemplate
 
@@ -563,7 +624,7 @@ Load an Agency file containing holes as a template.
 
 **Throws:** `std::read`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L497))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L530))
 
 ### holesOf
 
@@ -583,7 +644,7 @@ The unfilled holes in a template, in the order they appear. Each entry has the h
 
 **Returns:** `HoleInfo[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L511))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L544))
 
 ### fill
 
@@ -605,7 +666,7 @@ Fill holes in a template. Plain values become literals and are never parsed; Cod
 
 **Returns:** `Result<Code>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L520))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L553))
 
 ### toSource
 
@@ -625,7 +686,7 @@ Print a Code value back to Agency source, including any unfilled holes.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L530))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L563))
 
 ### parseExpr
 
@@ -645,7 +706,7 @@ Parse a single Agency expression into a Code fragment that can fill an expr hole
 
 **Returns:** `Result<Code>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L539))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L572))
 
 ### parseStatements
 
@@ -665,7 +726,7 @@ Parse a list of Agency statements into a Code fragment that can fill a statement
 
 **Returns:** `Result<Code>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L548))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L581))
 
 ### formatFile
 
@@ -692,7 +753,7 @@ Read and write happen inside the same interrupt, so approving it approves both.
 
 **Throws:** `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L559))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L592))
 
 ### walkAST
 
@@ -721,7 +782,7 @@ Walk every node in a deep-cloned copy of the AST, invoking the visitor
 
 **Returns:** [AST](#ast)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L578))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L611))
 
 ### getNodesOfType
 
@@ -743,7 +804,7 @@ Parse Agency source code and return every AST node whose `type` field matches an
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L598))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L631))
 
 ### getImports
 
@@ -763,7 +824,7 @@ Return every import statement in the source (i.e. `import { x } from "..."`).
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L611))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L644))
 
 ### getFunctions
 
@@ -783,7 +844,7 @@ Return every function definition (`def foo(...) { ... }`) in the source.
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L620))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L653))
 
 ### getGraphNodes
 
@@ -803,7 +864,7 @@ Return every graph node definition (`node main() { ... }`) in the source.
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L629))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L662))
 
 ### filterImports
 
@@ -855,7 +916,7 @@ Parse Agency source, drop imports that fail the policy, and return the resulting
 
 **Returns:** `Result<{ source: string; filtered: boolean }>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L656))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L689))
 
 ### getVersion
 
@@ -867,4 +928,4 @@ Get the current version of the Agency standard library.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L682))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L715))

--- a/packages/agency-lang/docs/site/stdlib/agency.md
+++ b/packages/agency-lang/docs/site/stdlib/agency.md
@@ -89,27 +89,38 @@ export type EffectsByExport = Record<string, string[]>
 ### ExportInfo
 
 What describe reports for one exported symbol. `signature` is the
-printed declaration with no keywords or docs; `docstring` is the symbol's
-docstring (defs and nodes) or doc comment (types); `effects` uses the same
-names and "unknown" sentinel as getEffects, and is empty for types.
+printed declaration line without the export keyword or tool markers;
+`docstring` is the symbol's docstring (defs and nodes) or doc comment
+(types); `effects` uses the same names and "unknown" sentinel as
+getEffects, and is empty for types and consts. Re-exported symbols carry
+the module path they came through in `reexportedFrom` (the outermost hop
+when re-exports chain); when that module cannot be read from a source
+string (relative paths), the entry has kind "reexport" and its effects
+are ["unknown"] rather than silently missing.
 
 ```ts
 /** What describe reports for one exported symbol. `signature` is the
-printed declaration with no keywords or docs; `docstring` is the symbol's
-docstring (defs and nodes) or doc comment (types); `effects` uses the same
-names and "unknown" sentinel as getEffects, and is empty for types. */
+printed declaration line without the export keyword or tool markers;
+`docstring` is the symbol's docstring (defs and nodes) or doc comment
+(types); `effects` uses the same names and "unknown" sentinel as
+getEffects, and is empty for types and consts. Re-exported symbols carry
+the module path they came through in `reexportedFrom` (the outermost hop
+when re-exports chain); when that module cannot be read from a source
+string (relative paths), the entry has kind "reexport" and its effects
+are ["unknown"] rather than silently missing. */
 export type ExportInfo = {
   name: string;
-  kind: "def" | "node" | "type";
+  kind: "def" | "node" | "type" | "const" | "reexport";
   signature: string;
   docstring?: string;
   effects: string[];
   destructive: boolean;
-  idempotent: boolean
+  idempotent: boolean;
+  reexportedFrom?: string
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L408))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L413))
 
 ### ModuleInfo
 
@@ -120,7 +131,7 @@ export type ModuleInfo = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L418))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L424))
 
 ### AST
 
@@ -143,7 +154,7 @@ export type AST = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L462))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L469))
 
 ### Code
 
@@ -165,7 +176,7 @@ export type Code = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L515))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L522))
 
 ### HoleInfo
 
@@ -179,7 +190,7 @@ export type HoleInfo = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L522))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L529))
 
 ## Effects
 
@@ -481,14 +492,15 @@ Map each exported node and function in the source to the list of
 describe(source: string): Result<ModuleInfo>
 ```
 
-Describe what an Agency module exports: each exported function, node, and type, in source order, with its signature, docstring, transitive effect list, and destructive/idempotent markers. Use this instead of reading source when generating code shaped by a module - for example, one handler per effect its tools can raise.
+Describe what an Agency module exports: each exported function, node, type, const, and re-export, in source order, with its signature, docstring, transitive effect list, and destructive/idempotent markers. Re-exports from std:: modules resolve to full entries; re-exports from relative paths cannot be read from a source string and come back with effects ["unknown"]. Use this instead of reading source when generating code shaped by a module - for example, one handler per effect its tools can raise.
 
   @param source - Agency source code as a string
 
 The reify primitive: exports-as-data, so generators can be shaped by
 what a module contains instead of hand-maintained lists. Underscore-prefixed
 exports are omitted, matching the `agency doc` rule — they are lowering
-targets, not caller surface.
+targets, not caller surface. `description` is the module doc comment's
+one-line summary, extracted the same way `agency doc` extracts it.
 
 **Parameters:**
 
@@ -498,7 +510,7 @@ targets, not caller surface.
 
 **Returns:** `Result<ModuleInfo>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L427))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L434))
 
 ### typecheckFile
 
@@ -523,7 +535,7 @@ Type-check an Agency file on disk. The file is read from dir/filename,
 
 **Throws:** `std::read`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L442))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L449))
 
 ### parseAST
 
@@ -543,7 +555,7 @@ Parse Agency source code into an abstract syntax tree.
 
 **Returns:** `Result<AST>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L468))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L475))
 
 ### writeAST
 
@@ -580,7 +592,7 @@ Output is canonical formatter output (the same style as `pnpm run fmt`):
 
 **Throws:** `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L480))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L487))
 
 ### format
 
@@ -600,7 +612,7 @@ Format Agency source code with the standard Agency formatter.
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L502))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L509))
 
 ### loadTemplate
 
@@ -624,7 +636,7 @@ Load an Agency file containing holes as a template.
 
 **Throws:** `std::read`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L530))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L537))
 
 ### holesOf
 
@@ -644,7 +656,7 @@ The unfilled holes in a template, in the order they appear. Each entry has the h
 
 **Returns:** `HoleInfo[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L544))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L551))
 
 ### fill
 
@@ -666,7 +678,7 @@ Fill holes in a template. Plain values become literals and are never parsed; Cod
 
 **Returns:** `Result<Code>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L553))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L560))
 
 ### toSource
 
@@ -686,7 +698,7 @@ Print a Code value back to Agency source, including any unfilled holes.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L563))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L570))
 
 ### parseExpr
 
@@ -706,7 +718,7 @@ Parse a single Agency expression into a Code fragment that can fill an expr hole
 
 **Returns:** `Result<Code>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L572))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L579))
 
 ### parseStatements
 
@@ -726,7 +738,7 @@ Parse a list of Agency statements into a Code fragment that can fill a statement
 
 **Returns:** `Result<Code>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L581))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L588))
 
 ### formatFile
 
@@ -753,7 +765,7 @@ Read and write happen inside the same interrupt, so approving it approves both.
 
 **Throws:** `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L592))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L599))
 
 ### walkAST
 
@@ -782,7 +794,7 @@ Walk every node in a deep-cloned copy of the AST, invoking the visitor
 
 **Returns:** [AST](#ast)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L611))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L618))
 
 ### getNodesOfType
 
@@ -804,7 +816,7 @@ Parse Agency source code and return every AST node whose `type` field matches an
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L631))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L638))
 
 ### getImports
 
@@ -824,7 +836,7 @@ Return every import statement in the source (i.e. `import { x } from "..."`).
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L644))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L651))
 
 ### getFunctions
 
@@ -844,7 +856,7 @@ Return every function definition (`def foo(...) { ... }`) in the source.
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L653))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L660))
 
 ### getGraphNodes
 
@@ -864,7 +876,7 @@ Return every graph node definition (`node main() { ... }`) in the source.
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L662))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L669))
 
 ### filterImports
 
@@ -916,7 +928,7 @@ Parse Agency source, drop imports that fail the policy, and return the resulting
 
 **Returns:** `Result<{ source: string; filtered: boolean }>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L689))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L696))
 
 ### getVersion
 
@@ -928,4 +940,4 @@ Get the current version of the Agency standard library.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L715))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L722))

--- a/packages/agency-lang/lib/backends/agencyGenerator.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.ts
@@ -1038,11 +1038,26 @@ export class AgencyGenerator {
     );
   }
 
-  /** The signature of a `def`/`node` with no keyword and no body — just
-   *  `name(params): ReturnType raises <...>` — used by `agency doc`. Params
-   *  wrap onto their own lines the same way the formatter wraps source, and
-   *  the declared `raises` clause is included. */
-  signatureOf(node: FunctionDefinition | GraphNodeDefinition): string {
+  /** The signature of a `def`/`node`/`type` with no export keyword, no
+   *  markers, no docs, and no body — used by `agency doc` and by
+   *  `std::agency`'s `describe`. For defs/nodes this is
+   *  `name(params): ReturnType raises <...>` (params wrap the way the
+   *  formatter wraps source); for type aliases it is the declaration line
+   *  `type Name<...> = ...`, produced here rather than by printing the
+   *  node and stripping keywords, so all three kinds share one canonical
+   *  signature path. */
+  signatureOf(node: FunctionDefinition | GraphNodeDefinition | TypeAlias): string {
+    if (node.type === "typeAlias") {
+      // Mirror processTypeAlias' registration so alias-typed members
+      // referenced later print consistently.
+      this.typeAliases[node.aliasName] = node.aliasedType;
+      if (node.isEffectSet) {
+        return `effectSet ${node.aliasName} = ${this.effectSetTypeToString(node.aliasedType)}`;
+      }
+      const typeParamsStr = this.formatTypeParams(node.typeParams);
+      const valueParamsStr = this.formatValueParams(node.valueParams);
+      return `type ${node.aliasName}${typeParamsStr}${valueParamsStr} = ${this.aliasedTypeToString(node.aliasedType)}`;
+    }
     const name = declaredName(node.type === "function" ? node.functionName : node.nodeName);
     return this.buildSignature(name, node, "");
   }

--- a/packages/agency-lang/lib/cli/doc.ts
+++ b/packages/agency-lang/lib/cli/doc.ts
@@ -283,60 +283,16 @@ function formatDocComment(comment: AgencyMultiLineComment): string {
   return comment.content.trim();
 }
 
-export function extractSummaryOverride(content: string): {
-  override: string | null;
-  body: string;
-} {
-  const lines = content.split("\n");
-  const firstIdx = lines.findIndex((l) => l.trim() !== "");
-  if (firstIdx === -1) return { override: null, body: content };
-  const first = lines[firstIdx].trim();
-  if (/^@summary(\s+|$)/.test(first)) {
-    const text = first.slice("@summary".length).trim();
-    const rest = lines.slice(0, firstIdx).concat(lines.slice(firstIdx + 1));
-    return {
-      override: text === "" ? null : text,
-      body: rest.join("\n"),
-    };
-  }
-  return { override: null, body: content };
-}
-
-export function firstParagraph(body: string): string {
-  const lines = body.split("\n").map((line) => line.trim());
-  const start = lines.findIndex((line) => line !== "");
-  if (start === -1) return "";
-  const afterLead = lines.slice(start);
-  const end = afterLead.findIndex(
-    (line) => line === "" || line.startsWith("```"),
-  );
-  const paragraph = end === -1 ? afterLead : afterLead.slice(0, end);
-  return paragraph.join(" ").replace(/\s+/g, " ").trim();
-}
-
-export function firstSentence(text: string): string {
-  const match = text.match(/^.*?[.!?](?=\s|$)/);
-  return match ? match[0] : text;
-}
-
-export function sanitizeDescription(raw: string): string {
-  return raw
-    .replace(/["\\]/g, "")
-    .replace(/\s+/g, " ")
-    .replace(/^#{1,6}\s+/, "")
-    .trim();
-}
-
-export function moduleDescription(
-  comment: AgencyMultiLineComment | undefined,
-): string | null {
-  if (!comment) return null;
-  const { override, body } = extractSummaryOverride(comment.content);
-  const raw = override ?? firstSentence(firstParagraph(body));
-  if (!raw) return null;
-  const value = sanitizeDescription(raw);
-  return value === "" ? null : value;
-}
+// Moved to lib/utils/moduleDoc.ts so std::agency's describe() shares the
+// same "module summary" extraction; re-exported here for existing callers.
+export {
+  extractSummaryOverride,
+  firstParagraph,
+  firstSentence,
+  sanitizeDescription,
+  moduleDescription,
+} from "../utils/moduleDoc.js";
+import { extractSummaryOverride, moduleDescription } from "../utils/moduleDoc.js";
 
 function formatTypeAlias(alias: TypeAlias, ctx: DocContext): string {
   const code = generateAgency({

--- a/packages/agency-lang/lib/runtime/template/hygiene.ts
+++ b/packages/agency-lang/lib/runtime/template/hygiene.ts
@@ -50,7 +50,7 @@ function chainKeysOf(scopes: Scope[]): string[] {
  *  these unions (literals, wildcards, resultPattern) bind nothing here —
  *  note that skipping resultPattern is also why `is success(v)` binders
  *  stay untracked (recorded known limit, see the templates guide). */
-function patternBinders(pattern: BindingPattern): string[] {
+export function patternBinders(pattern: BindingPattern): string[] {
   if (pattern.type === "variableName") return [pattern.value];
   if (pattern.type === "restPattern") return [pattern.identifier];
   if (pattern.type === "wildcardPattern") return [];

--- a/packages/agency-lang/lib/stdlib/agency.test.ts
+++ b/packages/agency-lang/lib/stdlib/agency.test.ts
@@ -12,6 +12,7 @@ import { tmpdir } from "os";
 import { join } from "path";
 import {
   _compileFile,
+  _describe,
   _parseAST,
   _writeAST,
   _format,
@@ -564,5 +565,93 @@ node main() { return 1 }`;
     const result = _filterImports(src, [], [], ["stdlib"], []);
     expect(result.filtered).toBe(false);
     expect(result.source).toBe(_format(src));
+  });
+});
+
+describe("_describe (reify)", () => {
+  const source = [
+    "/** @module",
+    "  @summary Tools for the news agent.",
+    "*/",
+    "",
+    "/** Fetches one article. */",
+    "export idempotent def fetchArticle(url: string): string {",
+    "  \"\"\"",
+    "  Fetch one article body by URL.",
+    "  \"\"\"",
+    "  return \"body\"",
+    "}",
+    "",
+    "export destructive def saveNote(text: string) {",
+    "  write(\"notes.txt\", text)",
+    "}",
+    "",
+    "def helper(): number {",
+    "  return 1",
+    "}",
+    "",
+    "export def _plumbing(): number {",
+    "  return 2",
+    "}",
+    "",
+    "/** One extracted article. */",
+    "export type Article = {",
+    "  title: string,",
+    "  words: number",
+    "}",
+    "",
+    "export node main(): string {",
+    "  return fetchArticle(\"x\")",
+    "}",
+    "",
+  ].join("\n");
+
+  it("lists exported defs, nodes, and types in source order, skipping non-exports and underscore plumbing", () => {
+    const info = _describe(source);
+    expect(info.exports.map((e) => [e.name, e.kind])).toEqual([
+      ["fetchArticle", "def"],
+      ["saveNote", "def"],
+      ["Article", "type"],
+      ["main", "node"],
+    ]);
+  });
+
+  it("carries signatures, docstrings, and tool markers", () => {
+    const info = _describe(source);
+    const fetch = info.exports.find((e) => e.name === "fetchArticle");
+    expect(fetch?.signature).toContain("fetchArticle(url: string): string");
+    expect(fetch?.signature).not.toContain("export");
+    expect(fetch?.docstring).toContain("Fetch one article body");
+    expect(fetch?.idempotent).toBe(true);
+    expect(fetch?.destructive).toBe(false);
+    const save = info.exports.find((e) => e.name === "saveNote");
+    expect(save?.destructive).toBe(true);
+    expect(save?.docstring).toBe(null);
+  });
+
+  it("reports transitive effects with the same names getEffects uses", () => {
+    const info = _describe(source);
+    const save = info.exports.find((e) => e.name === "saveNote");
+    expect(save?.effects).toEqual(["std::write"]);
+    const article = info.exports.find((e) => e.name === "Article");
+    expect(article?.effects).toEqual([]);
+  });
+
+  it("prints a type alias signature without the export keyword", () => {
+    const info = _describe(source);
+    const article = info.exports.find((e) => e.name === "Article");
+    expect(article?.signature).toMatch(/^type Article = \{/);
+    expect(article?.signature).toContain("title: string");
+    expect(article?.docstring).toContain("One extracted article");
+  });
+
+  it("surfaces the module doc comment as the description", () => {
+    const info = _describe(source);
+    expect(info.description).toContain("Tools for the news agent");
+  });
+
+  it("returns no description and no exports for a bare program", () => {
+    const info = _describe("node main() {\n  return 1\n}\n");
+    expect(info).toEqual({ description: null, exports: [] });
   });
 });

--- a/packages/agency-lang/lib/stdlib/agency.test.ts
+++ b/packages/agency-lang/lib/stdlib/agency.test.ts
@@ -655,3 +655,74 @@ describe("_describe (reify)", () => {
     expect(info).toEqual({ description: null, exports: [] });
   });
 });
+
+describe("_describe (reify): re-exports, consts, module summary", () => {
+  it("resolves std:: re-exports to real entries with reexportedFrom", () => {
+    const info = _describe('export { map, filter as keep } from "std::index"\n');
+    expect(info.exports.map((e) => [e.name, e.kind, e.reexportedFrom])).toEqual([
+      ["map", "def", "std::index"],
+      ["keep", "def", "std::index"],
+    ]);
+    expect(info.exports[0].signature).toContain("map(");
+  });
+
+  it("star re-exports from std:: enumerate the source module, outermost path winning", () => {
+    // std::array is nothing but a re-export block over std::index — the
+    // module shape that motivated re-export support (it used to describe
+    // as an empty surface).
+    const info = _describe('export * from "std::array"\n');
+    expect(info.exports.length).toBeGreaterThan(3);
+    expect(info.exports.every((e) => e.reexportedFrom === "std::array")).toBe(true);
+    expect(info.exports.some((e) => e.name === "map" && e.kind === "def")).toBe(true);
+  });
+
+  it("unresolvable re-exports come back thin with the unknown sentinel, markers applied", () => {
+    const info = _describe(
+      'export { helper, destructive rmrf } from "./local.agency"\n',
+    );
+    expect(info.exports.map((e) => [e.name, e.kind])).toEqual([
+      ["helper", "reexport"],
+      ["rmrf", "reexport"],
+    ]);
+    expect(info.exports[0].effects).toEqual(["unknown"]);
+    expect(info.exports[0].reexportedFrom).toBe("./local.agency");
+    expect(info.exports[1].destructive).toBe(true);
+  });
+
+  it("exported consts are surface, one entry per bound name", () => {
+    const src = [
+      'export const version: string = "1.0"',
+      "",
+      "def pair(): { a: number, b: number } {",
+      "  return { a: 1, b: 2 }",
+      "}",
+      "",
+      "export const { a, b } = pair()",
+      "",
+      "node main() {",
+      "  return version",
+      "}",
+      "",
+    ].join("\n");
+    const info = _describe(src);
+    const consts = info.exports.filter((e) => e.kind === "const");
+    expect(consts.map((e) => e.name)).toEqual(["version", "a", "b"]);
+    expect(consts[0].signature).toBe("const version: string");
+    expect(consts[1].signature).toBe("const a");
+  });
+
+  it("description is the summary line only, never glued to the body prose", () => {
+    const src = [
+      "/** @module",
+      "@summary News tools.",
+      "Longer prose about the news tools that must not be glued on.",
+      "*/",
+      "",
+      "node main() {",
+      "  return 1",
+      "}",
+      "",
+    ].join("\n");
+    expect(_describe(src).description).toBe("News tools.");
+  });
+});

--- a/packages/agency-lang/lib/stdlib/agency.ts
+++ b/packages/agency-lang/lib/stdlib/agency.ts
@@ -2,15 +2,18 @@ import { compileSource, typeCheckSource, getEffectsFromSource, TypeCheckReport }
 import { writeFileSync, readFileSync, realpathSync, existsSync } from "fs";
 import { resolve, sep } from "path";
 import { parseAgency, replaceBlankLines } from "../parser.js";
-import { generateAgency } from "../backends/agencyGenerator.js";
+import { AgencyGenerator, generateAgency } from "../backends/agencyGenerator.js";
+import { TypescriptPreprocessor } from "../preprocessors/typescriptPreprocessor.js";
 import { walkNodesArray } from "../utils/node.js";
+import { docStringText } from "../utils/docStringText.js";
+import { declaredName } from "../types/hole.js";
 import { deepCopy } from "../utils.js";
 import {
   ImportKind,
   ImportPolicy,
   isImportAllowed,
 } from "../importPaths.js";
-import type { AgencyProgram, AgencyNode } from "../types.js";
+import type { AgencyMultiLineComment, AgencyProgram, AgencyNode } from "../types.js";
 import type { ImportStatement } from "../types/importStatement.js";
 import { _write } from "./builtins.js";
 import {
@@ -175,6 +178,113 @@ export function _typecheck(source: string): TypeCheckReport {
 
 export function _getEffects(source: string): Record<string, string[]> {
   return getEffectsFromSource(source);
+}
+
+// ---------------------------------------------------------------------------
+// Reify: describe a module's exports as data
+// ---------------------------------------------------------------------------
+
+export type ExportInfo = {
+  name: string;
+  kind: "def" | "node" | "type";
+  signature: string;
+  docstring: string | null;
+  effects: string[];
+  destructive: boolean;
+  idempotent: boolean;
+};
+
+export type ModuleInfo = {
+  description: string | null;
+  exports: ExportInfo[];
+};
+
+/** One ExportInfo per EXPORTED top-level def, node, and type alias, in
+ *  source order. Underscore-prefixed exports are omitted — the same rule
+ *  `agency doc` applies: they are exported for the compiler's sake
+ *  (lowering targets like `_guard`), not for callers. Effects come from
+ *  the same transitive analysis as _getEffects, sentinel included. */
+export function _describe(source: string): ModuleInfo {
+  const program = parseSource(source);
+  // Doc comments live as loose comment nodes until attachment — the same
+  // pass `agency doc` runs. It hoists the @module comment onto
+  // program.docComment and pins each doc comment to its declaration.
+  new TypescriptPreprocessor(program, {}).attachDocComments();
+  const effects = getEffectsFromSource(source);
+  const generator = new AgencyGenerator();
+  const exports: ExportInfo[] = [];
+  for (const node of program.nodes) {
+    const info = exportInfoFor(node, generator, effects);
+    if (info) exports.push(info);
+  }
+  return {
+    description: moduleDocText(program.docComment),
+    exports,
+  };
+}
+
+/** The module doc comment's text, with the doc-generator @summary marker
+ *  dropped — the marker structures `agency doc` pages, not prose. */
+function moduleDocText(comment: AgencyMultiLineComment | undefined): string | null {
+  if (!comment) return null;
+  const text = comment.content.trim().replace(/^@summary\s+/, "");
+  return text === "" ? null : text;
+}
+
+function exportInfoFor(
+  node: AgencyNode,
+  generator: AgencyGenerator,
+  effects: Record<string, string[]>,
+): ExportInfo | null {
+  if (node.type === "function" && node.exported) {
+    const name = declaredName(node.functionName);
+    if (name.startsWith("_")) return null;
+    return {
+      name,
+      kind: "def",
+      signature: generator.signatureOf(node),
+      docstring: node.docString ? docStringText(node.docString) : null,
+      effects: effects[name] ?? [],
+      destructive: node.markers?.destructive === true,
+      idempotent: node.markers?.idempotent === true,
+    };
+  }
+  if (node.type === "graphNode" && node.exported) {
+    const name = declaredName(node.nodeName);
+    if (name.startsWith("_")) return null;
+    return {
+      name,
+      kind: "node",
+      signature: generator.signatureOf(node),
+      docstring: node.docString ? docStringText(node.docString) : null,
+      effects: effects[name] ?? [],
+      // Nodes carry no tool markers; only defs can be declared
+      // destructive or idempotent.
+      destructive: false,
+      idempotent: false,
+    };
+  }
+  if (node.type === "typeAlias" && node.exported) {
+    if (node.aliasName.startsWith("_")) return null;
+    // The canonical printer emits the full declaration. The doc comment
+    // is already carried in `docstring` and the export keyword is
+    // caller-visible noise, so both are kept out of the signature — the
+    // same shape def/node signatures have (no keywords, no docs).
+    const bare = { ...node, docComment: undefined };
+    const printed = generateAgency({ type: "agencyProgram", nodes: [bare] })
+      .trim()
+      .replace(/^export\s+/, "");
+    return {
+      name: node.aliasName,
+      kind: "type",
+      signature: printed,
+      docstring: node.docComment?.content.trim() || null,
+      effects: [],
+      destructive: false,
+      idempotent: false,
+    };
+  }
+  return null;
 }
 
 // The real file path is handed to the type-checker so relative imports in

--- a/packages/agency-lang/lib/stdlib/agency.ts
+++ b/packages/agency-lang/lib/stdlib/agency.ts
@@ -5,7 +5,12 @@ import { parseAgency, replaceBlankLines } from "../parser.js";
 import { AgencyGenerator, generateAgency } from "../backends/agencyGenerator.js";
 import { TypescriptPreprocessor } from "../preprocessors/typescriptPreprocessor.js";
 import { walkNodesArray } from "../utils/node.js";
-import { docStringText } from "../utils/docStringText.js";
+import { docCommentText, docStringText } from "../utils/docStringText.js";
+import { moduleDescription } from "../utils/moduleDoc.js";
+import { patternBinders } from "../runtime/template/hygiene.js";
+import { resolveAgencyImportPath, isStdlibImport } from "../importPaths.js";
+import type { ExportFromStatement, NamedExportBody } from "../types.js";
+import { variableTypeToString } from "../backends/typescriptGenerator/typeToString.js";
 import { declaredName } from "../types/hole.js";
 import { deepCopy } from "../utils.js";
 import {
@@ -184,14 +189,18 @@ export function _getEffects(source: string): Record<string, string[]> {
 // Reify: describe a module's exports as data
 // ---------------------------------------------------------------------------
 
+export type ExportKind = "def" | "node" | "type" | "const" | "reexport";
+
 export type ExportInfo = {
   name: string;
-  kind: "def" | "node" | "type";
+  kind: ExportKind;
   signature: string;
   docstring: string | null;
   effects: string[];
   destructive: boolean;
   idempotent: boolean;
+  /** The module path this export was re-exported from, else null. */
+  reexportedFrom: string | null;
 };
 
 export type ModuleInfo = {
@@ -199,92 +208,222 @@ export type ModuleInfo = {
   exports: ExportInfo[];
 };
 
-/** One ExportInfo per EXPORTED top-level def, node, and type alias, in
- *  source order. Underscore-prefixed exports are omitted — the same rule
- *  `agency doc` applies: they are exported for the compiler's sake
- *  (lowering targets like `_guard`), not for callers. Effects come from
- *  the same transitive analysis as _getEffects, sentinel included. */
+/** The `agency doc` visibility rule, applied here for the same reason:
+ *  underscore-prefixed exports are lowering targets (`_guard`) and
+ *  compiler plumbing, exported for the compiler's sake, not for callers
+ *  — so they are not part of the surface describe reports. */
+function isInternalExport(name: string): boolean {
+  return name.startsWith("_");
+}
+
+/** One ExportInfo per EXPORTED top-level def, node, type alias, const,
+ *  and re-exported name, in source order. Effects come from the same
+ *  transitive analysis as _getEffects, sentinel included. Re-exports
+ *  from std:: modules resolve by describing the source module; other
+ *  re-exports (relative paths cannot resolve from a bare source string)
+ *  come back as thin "reexport" entries whose effects carry the
+ *  "unknown" sentinel — never a silent omission. */
 export function _describe(source: string): ModuleInfo {
+  return describeSource(source, []);
+}
+
+/** True when the re-export's source module can be read from a bare
+ *  source string: std:: paths resolve without an importing file;
+ *  relative and pkg:: paths do not. */
+function isResolvableReExport(node: ExportFromStatement): boolean {
+  return node.isAgencyImport && isStdlibImport(node.modulePath);
+}
+
+function describeSource(source: string, visited: string[]): ModuleInfo {
   const program = parseSource(source);
   // Doc comments live as loose comment nodes until attachment — the same
   // pass `agency doc` runs. It hoists the @module comment onto
   // program.docComment and pins each doc comment to its declaration.
   new TypescriptPreprocessor(program, {}).attachDocComments();
-  const effects = getEffectsFromSource(source);
+  // The effects pipeline REQUIRES every re-export to resolve, and
+  // relative/pkg paths cannot resolve from a bare string — so effects
+  // run on a copy with unresolvable re-exports stripped. They are
+  // surface plumbing, not behavior; a local call to a stripped name
+  // degrades to the "unknown" sentinel, which is the honest answer.
+  const unresolvable = program.nodes.some(
+    (node) => node.type === "exportFromStatement" && !isResolvableReExport(node),
+  );
+  const effectsSource = unresolvable
+    ? generateAgency({
+        ...deepCopy(program),
+        nodes: deepCopy(program).nodes.filter(
+          (node) => node.type !== "exportFromStatement" || isResolvableReExport(node),
+        ),
+      })
+    : source;
+  const effects = getEffectsFromSource(effectsSource);
   const generator = new AgencyGenerator();
   const exports: ExportInfo[] = [];
   for (const node of program.nodes) {
-    const info = exportInfoFor(node, generator, effects);
-    if (info) exports.push(info);
+    if (node.type === "exportFromStatement") {
+      exports.push(...reExportInfos(node, visited));
+      continue;
+    }
+    exports.push(...localExportInfos(node, generator, effects));
   }
   return {
-    description: moduleDocText(program.docComment),
+    description: moduleDescription(program.docComment),
     exports,
   };
 }
 
-/** The module doc comment's text, with the doc-generator @summary marker
- *  dropped — the marker structures `agency doc` pages, not prose. */
-function moduleDocText(comment: AgencyMultiLineComment | undefined): string | null {
-  if (!comment) return null;
-  const text = comment.content.trim().replace(/^@summary\s+/, "");
-  return text === "" ? null : text;
-}
-
-function exportInfoFor(
+function localExportInfos(
   node: AgencyNode,
   generator: AgencyGenerator,
   effects: Record<string, string[]>,
-): ExportInfo | null {
+): ExportInfo[] {
   if (node.type === "function" && node.exported) {
     const name = declaredName(node.functionName);
-    if (name.startsWith("_")) return null;
-    return {
-      name,
-      kind: "def",
-      signature: generator.signatureOf(node),
-      docstring: node.docString ? docStringText(node.docString) : null,
-      effects: effects[name] ?? [],
-      destructive: node.markers?.destructive === true,
-      idempotent: node.markers?.idempotent === true,
-    };
+    if (isInternalExport(name)) return [];
+    return [
+      {
+        name,
+        kind: "def",
+        signature: generator.signatureOf(node),
+        docstring: node.docString ? docStringText(node.docString) : null,
+        effects: effects[name] ?? [],
+        destructive: node.markers?.destructive === true,
+        idempotent: node.markers?.idempotent === true,
+        reexportedFrom: null,
+      },
+    ];
   }
   if (node.type === "graphNode" && node.exported) {
     const name = declaredName(node.nodeName);
-    if (name.startsWith("_")) return null;
-    return {
-      name,
-      kind: "node",
-      signature: generator.signatureOf(node),
-      docstring: node.docString ? docStringText(node.docString) : null,
-      effects: effects[name] ?? [],
-      // Nodes carry no tool markers; only defs can be declared
-      // destructive or idempotent.
-      destructive: false,
-      idempotent: false,
-    };
+    if (isInternalExport(name)) return [];
+    return [
+      {
+        name,
+        kind: "node",
+        signature: generator.signatureOf(node),
+        docstring: node.docString ? docStringText(node.docString) : null,
+        effects: effects[name] ?? [],
+        // Nodes carry no tool markers; only defs can be declared
+        // destructive or idempotent.
+        destructive: false,
+        idempotent: false,
+        reexportedFrom: null,
+      },
+    ];
   }
   if (node.type === "typeAlias" && node.exported) {
-    if (node.aliasName.startsWith("_")) return null;
-    // The canonical printer emits the full declaration. The doc comment
-    // is already carried in `docstring` and the export keyword is
-    // caller-visible noise, so both are kept out of the signature — the
-    // same shape def/node signatures have (no keywords, no docs).
-    const bare = { ...node, docComment: undefined };
-    const printed = generateAgency({ type: "agencyProgram", nodes: [bare] })
-      .trim()
-      .replace(/^export\s+/, "");
-    return {
-      name: node.aliasName,
-      kind: "type",
-      signature: printed,
-      docstring: node.docComment?.content.trim() || null,
-      effects: [],
-      destructive: false,
-      idempotent: false,
-    };
+    if (isInternalExport(node.aliasName)) return [];
+    return [
+      {
+        name: node.aliasName,
+        kind: "type",
+        signature: generator.signatureOf(node),
+        docstring: node.docComment ? docCommentText(node.docComment) : null,
+        effects: [],
+        destructive: false,
+        idempotent: false,
+        reexportedFrom: null,
+      },
+    ];
   }
-  return null;
+  if (node.type === "assignment" && node.exported && node.declKind) {
+    // `export const version: string = ...` — one entry per bound name
+    // (destructuring exports bind several). The signature stays to the
+    // declaration shape (`const name: type`); values can be arbitrarily
+    // large and belong to the source, not the surface.
+    const names = node.pattern ? patternBinders(node.pattern) : [node.variableName];
+    const typeStr = node.typeHint ? `: ${variableTypeToString(node.typeHint, {}, true)}` : "";
+    return names
+      .filter((name) => !isInternalExport(name))
+      .map((name) => ({
+        name,
+        kind: "const" as const,
+        signature: `${node.declKind} ${name}${node.pattern ? "" : typeStr}`,
+        docstring: null,
+        effects: [],
+        destructive: false,
+        idempotent: false,
+        reexportedFrom: null,
+      }));
+  }
+  // Fail LOUDLY on any exported declaration kind this dispatch does not
+  // know: a silent `return []` here is how a whole class of exports
+  // vanishes from the reported surface without any test noticing (the
+  // exact failure mode re-exports had before they were handled). The
+  // throw surfaces through `try _describe(...)` as a Result failure.
+  if ((node as { exported?: boolean }).exported === true) {
+    throw new Error(
+      `describe does not handle exported "${node.type}" declarations yet — add a branch to localExportInfos`,
+    );
+  }
+  return [];
+}
+
+function reExportInfos(node: ExportFromStatement, visited: string[]): ExportInfo[] {
+  const from = node.modulePath;
+  if (isResolvableReExport(node)) {
+    const abs = resolveAgencyImportPath(from, "");
+    if (!visited.includes(abs) && existsSync(abs)) {
+      const inner = describeSource(readFileSync(abs, "utf-8"), [...visited, abs]);
+      if (node.body.kind === "starExport") {
+        return inner.exports.map((info) => ({ ...info, reexportedFrom: from }));
+      }
+      const byName: Record<string, ExportInfo> = Object.create(null);
+      for (const info of inner.exports) byName[info.name] = info;
+      return resolveNamedReExports(node.body, from, byName);
+    }
+  }
+  if (node.body.kind === "starExport") {
+    return [thinReExport("*", "*", from)];
+  }
+  return resolveNamedReExports(node.body, from, Object.create(null));
+}
+
+function resolveNamedReExports(
+  body: NamedExportBody,
+  from: string,
+  byName: Record<string, ExportInfo>,
+): ExportInfo[] {
+  return body.names.flatMap((sourceName) => {
+    const localName = body.aliases[sourceName] ?? sourceName;
+    if (isInternalExport(localName)) return [];
+    const found = Object.hasOwn(byName, sourceName) ? byName[sourceName] : null;
+    const base = found ?? thinReExport(sourceName, localName, from);
+    return [
+      {
+        ...base,
+        name: localName,
+        reexportedFrom: from,
+        // Re-export sites may add tool markers the source did not have.
+        destructive:
+          base.destructive || (body.destructiveNames ?? []).includes(sourceName),
+        idempotent:
+          base.idempotent || (body.idempotentNames ?? []).includes(sourceName),
+      },
+    ];
+  });
+}
+
+/** What is reportable about a re-export whose source module cannot be
+ *  read here. Effects carry the "unknown" sentinel — same philosophy as
+ *  getEffects: never silently under-report what code might do. */
+function thinReExport(sourceName: string, localName: string, from: string): ExportInfo {
+  const spelled =
+    sourceName === "*"
+      ? `export * from "${from}"`
+      : sourceName === localName
+        ? `export { ${sourceName} } from "${from}"`
+        : `export { ${sourceName} as ${localName} } from "${from}"`;
+  return {
+    name: localName,
+    kind: "reexport",
+    signature: spelled,
+    docstring: null,
+    effects: ["unknown"],
+    destructive: false,
+    idempotent: false,
+    reexportedFrom: from,
+  };
 }
 
 // The real file path is handed to the type-checker so relative imports in

--- a/packages/agency-lang/lib/utils/docStringText.ts
+++ b/packages/agency-lang/lib/utils/docStringText.ts
@@ -54,3 +54,11 @@ export function docStringText(
     )
     .join("");
 }
+
+/** Canonical doc-comment → plain text, the doc-comment sibling of
+ *  docStringText above: trimmed content, no markers. Doc comments cannot
+ *  interpolate, so this is simple — the helper exists so every consumer
+ *  normalizes the same way. */
+export function docCommentText(comment: { content: string }): string {
+  return comment.content.trim();
+}

--- a/packages/agency-lang/lib/utils/expressionSlots.test.ts
+++ b/packages/agency-lang/lib/utils/expressionSlots.test.ts
@@ -468,7 +468,7 @@ describe("walker coverage: walkNodes reaches every expression position", () => {
   for (const lower of [true, false]) {
     const label = lower ? "lowered" : "unlowered";
 
-    it(`${label}: slot-table agreement — every expression slot of a walked node is itself walked`, () => {
+    it(`${label}: slot-table agreement — every expression slot of a walked node is itself walked`, { timeout: 30_000 }, () => {
       // A CONSISTENCY check, not reachability: both sides start from a
       // node the walker already yielded, so this can never prove a node
       // reachable. What it pins is that expressionSlots and walkNodes
@@ -497,7 +497,7 @@ describe("walker coverage: walkNodes reaches every expression position", () => {
       }
     });
 
-    it(`${label}: structural reachability — every expression node in the AST is walked`, () => {
+    it(`${label}: structural reachability — every expression node in the AST is walked`, { timeout: 30_000 }, () => {
       for (const { file, nodes } of corpusPrograms(lower)) {
         const walked = new Set(walkNodesArray(nodes).map((v) => v.node));
         for (const { node, via } of structuralNodes(nodes, "(root)", VIA_CLEAR)) {
@@ -517,7 +517,7 @@ describe("walker coverage: walkNodes reaches every expression position", () => {
 
   }
 
-  it("known gaps are still gaps (staleness guard, both modes)", () => {
+  it("known gaps are still gaps (staleness guard, both modes)", { timeout: 30_000 }, () => {
     // Each KNOWN_WALKER_GAPS entry must still shield at least one
     // unwalked expression node in AT LEAST one parse mode. When the
     // follow-up PR fixes walkNodes, this fails until the entry is
@@ -547,7 +547,7 @@ describe("walker coverage: walkNodes reaches every expression position", () => {
     }
   });
 
-  it("liveness: the corpus actually exercises the historically-missed positions", () => {
+  it("liveness: the corpus actually exercises the historically-missed positions", { timeout: 30_000 }, () => {
     // A coverage invariant over kinds the corpus never contains proves
     // nothing. Pin the kinds whose walker descent was added by hand
     // during Template Agency development, in the mode each occurs in.

--- a/packages/agency-lang/lib/utils/moduleDoc.ts
+++ b/packages/agency-lang/lib/utils/moduleDoc.ts
@@ -1,0 +1,66 @@
+import type { AgencyMultiLineComment } from "../types.js";
+
+/**
+ * Module doc-comment text extraction, shared by `agency doc` (index cards
+ * and page headers) and `std::agency`'s `describe` (the `ModuleInfo.
+ * description` field) so "the module's summary" means the same thing
+ * everywhere it appears.
+ */
+
+/** Split an `@summary` override line off a module doc comment's content. */
+export function extractSummaryOverride(content: string): {
+  override: string | null;
+  body: string;
+} {
+  const lines = content.split("\n");
+  const firstIdx = lines.findIndex((l) => l.trim() !== "");
+  if (firstIdx === -1) return { override: null, body: content };
+  const first = lines[firstIdx].trim();
+  if (/^@summary(\s+|$)/.test(first)) {
+    const text = first.slice("@summary".length).trim();
+    const rest = lines.slice(0, firstIdx).concat(lines.slice(firstIdx + 1));
+    return {
+      override: text === "" ? null : text,
+      body: rest.join("\n"),
+    };
+  }
+  return { override: null, body: content };
+}
+
+export function firstParagraph(body: string): string {
+  const lines = body.split("\n").map((line) => line.trim());
+  const start = lines.findIndex((line) => line !== "");
+  if (start === -1) return "";
+  const afterLead = lines.slice(start);
+  const end = afterLead.findIndex(
+    (line) => line === "" || line.startsWith("```"),
+  );
+  const paragraph = end === -1 ? afterLead : afterLead.slice(0, end);
+  return paragraph.join(" ").replace(/\s+/g, " ").trim();
+}
+
+export function firstSentence(text: string): string {
+  const match = text.match(/^.*?[.!?](?=\s|$)/);
+  return match ? match[0] : text;
+}
+
+export function sanitizeDescription(raw: string): string {
+  return raw
+    .replace(/["\\]/g, "")
+    .replace(/\s+/g, " ")
+    .replace(/^#{1,6}\s+/, "")
+    .trim();
+}
+
+/** The module's one-line summary: the `@summary` override if present,
+ *  else the first sentence of the first paragraph, sanitized. */
+export function moduleDescription(
+  comment: AgencyMultiLineComment | undefined,
+): string | null {
+  if (!comment) return null;
+  const { override, body } = extractSummaryOverride(comment.content);
+  const raw = override ?? firstSentence(firstParagraph(body));
+  if (!raw) return null;
+  const value = sanitizeDescription(raw);
+  return value === "" ? null : value;
+}

--- a/packages/agency-lang/stdlib/agency.agency
+++ b/packages/agency-lang/stdlib/agency.agency
@@ -402,17 +402,23 @@ export idempotent def getEffects(source: string): Result<EffectsByExport> {
 }
 
 /** What describe reports for one exported symbol. `signature` is the
-printed declaration with no keywords or docs; `docstring` is the symbol's
-docstring (defs and nodes) or doc comment (types); `effects` uses the same
-names and "unknown" sentinel as getEffects, and is empty for types. */
+printed declaration line without the export keyword or tool markers;
+`docstring` is the symbol's docstring (defs and nodes) or doc comment
+(types); `effects` uses the same names and "unknown" sentinel as
+getEffects, and is empty for types and consts. Re-exported symbols carry
+the module path they came through in `reexportedFrom` (the outermost hop
+when re-exports chain); when that module cannot be read from a source
+string (relative paths), the entry has kind "reexport" and its effects
+are ["unknown"] rather than silently missing. */
 export type ExportInfo = {
   name: string,
-  kind: "def" | "node" | "type",
+  kind: "def" | "node" | "type" | "const" | "reexport",
   signature: string,
   docstring: string | null,
   effects: string[],
   destructive: boolean,
-  idempotent: boolean
+  idempotent: boolean,
+  reexportedFrom: string | null
 }
 
 export type ModuleInfo = {
@@ -423,10 +429,11 @@ export type ModuleInfo = {
 /** The reify primitive: exports-as-data, so generators can be shaped by
 what a module contains instead of hand-maintained lists. Underscore-prefixed
 exports are omitted, matching the `agency doc` rule — they are lowering
-targets, not caller surface. */
+targets, not caller surface. `description` is the module doc comment's
+one-line summary, extracted the same way `agency doc` extracts it. */
 export idempotent def describe(source: string): Result<ModuleInfo> {
   """
-  Describe what an Agency module exports: each exported function, node, and type, in source order, with its signature, docstring, transitive effect list, and destructive/idempotent markers. Use this instead of reading source when generating code shaped by a module - for example, one handler per effect its tools can raise.
+  Describe what an Agency module exports: each exported function, node, type, const, and re-export, in source order, with its signature, docstring, transitive effect list, and destructive/idempotent markers. Re-exports from std:: modules resolve to full entries; re-exports from relative paths cannot be read from a source string and come back with effects ["unknown"]. Use this instead of reading source when generating code shaped by a module - for example, one handler per effect its tools can raise.
 
   @param source - Agency source code as a string
   """

--- a/packages/agency-lang/stdlib/agency.agency
+++ b/packages/agency-lang/stdlib/agency.agency
@@ -7,6 +7,7 @@ import {
   _typecheck,
   _typecheckFile,
   _getEffects,
+  _describe,
   _parseAST,
   _writeAST,
   _format,
@@ -398,6 +399,38 @@ export idempotent def getEffects(source: string): Result<EffectsByExport> {
   @param source - Agency source code as a string
   """
   return try _getEffects(source)
+}
+
+/** What describe reports for one exported symbol. `signature` is the
+printed declaration with no keywords or docs; `docstring` is the symbol's
+docstring (defs and nodes) or doc comment (types); `effects` uses the same
+names and "unknown" sentinel as getEffects, and is empty for types. */
+export type ExportInfo = {
+  name: string,
+  kind: "def" | "node" | "type",
+  signature: string,
+  docstring: string | null,
+  effects: string[],
+  destructive: boolean,
+  idempotent: boolean
+}
+
+export type ModuleInfo = {
+  description: string | null,
+  exports: ExportInfo[]
+}
+
+/** The reify primitive: exports-as-data, so generators can be shaped by
+what a module contains instead of hand-maintained lists. Underscore-prefixed
+exports are omitted, matching the `agency doc` rule — they are lowering
+targets, not caller surface. */
+export idempotent def describe(source: string): Result<ModuleInfo> {
+  """
+  Describe what an Agency module exports: each exported function, node, and type, in source order, with its signature, docstring, transitive effect list, and destructive/idempotent markers. Use this instead of reading source when generating code shaped by a module - for example, one handler per effect its tools can raise.
+
+  @param source - Agency source code as a string
+  """
+  return try _describe(source)
 }
 
 

--- a/packages/agency-lang/tests/agency/describe.agency
+++ b/packages/agency-lang/tests/agency/describe.agency
@@ -1,0 +1,44 @@
+import { describe } from "std::agency"
+
+// Reify: exports-as-data. The generator-facing fields — kind, effects,
+// markers, docstring — come back as a record a program can loop over,
+// which is what makes "one handler per effect" computable.
+node main() {
+  const src = """
+/** @module
+  @summary News tools.
+*/
+
+/** Fetches one article. */
+export idempotent def fetchArticle(url: string): string {
+  return "body"
+}
+
+export destructive def saveNote(text: string) {
+  write("notes.txt", text)
+}
+
+def helper(): number {
+  return 1
+}
+
+export type Article = {
+  title: string
+}
+"""
+  const info = describe(src)
+  if (info is failure(err)) {
+    return "failed: ${err}"
+  }
+  const names = [e.name for e in info.value.exports]
+  const save = info.value.exports[1]
+  if (save == null) {
+    return "missing saveNote"
+  }
+  return {
+    description: info.value.description,
+    names: names,
+    saveEffects: save.effects,
+    saveDestructive: save.destructive,
+  }
+}

--- a/packages/agency-lang/tests/agency/describe.test.json
+++ b/packages/agency-lang/tests/agency/describe.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "describe returns exports-as-data: names in source order, effects, markers, module description",
+      "input": "",
+      "expectedOutput": "{\"description\":\"News tools.\",\"names\":[\"fetchArticle\",\"saveNote\",\"Article\"],\"saveEffects\":[\"std::write\"],\"saveDestructive\":true}",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}


### PR DESCRIPTION
The reify primitive from the Template Agency spec's deferred list: ask what a module exports without reading its source, so generators can be shaped by what a module *contains* instead of hand-maintained lists.

## The API

One new export from `std::agency`:

```
export idempotent def describe(source: string): Result<ModuleInfo>

type ExportInfo = {
  name: string,
  kind: "def" | "node" | "type",
  signature: string,        // printed declaration, no keywords, no docs
  docstring: string | null, // docstring (defs/nodes) or doc comment (types)
  effects: string[],        // same names + "unknown" sentinel as getEffects
  destructive: boolean,
  idempotent: boolean
}

type ModuleInfo = {
  description: string | null,   // module @module doc comment text
  exports: ExportInfo[]         // source order
}
```

Underscore-prefixed exports are omitted — the same rule `agency doc` applies (they are lowering targets like `_guard`, not caller surface).

## What it unlocks

The spec's killer use case becomes writable: handler completeness as a property of the *generator*. `describe(toolsSource)` gives the per-export effect lists; a loop emits one handler arm per effect into a `#...handlerArms` splice; an effect with no arm cannot exist by construction. Given that CLAUDE.md treats a skipped handler as a critical bug, that loop is the safety payoff this feature exists for. Second-order: agents get "what does this module export and what can it raise" as a cheap tool, and the spec's fill-time effect-bounds idea (`getEffects(filler) ⊆ declared bound`) becomes a small follow-up rather than a design.

## Implementation: assembly, not analysis

Everything `describe` reports already had a canonical producer, and `_describe` only assembles them:

- signatures: `AgencyGenerator.signatureOf` (what `agency doc` renders)
- docstrings: `docStringText`; doc-comment attachment via the preprocessor's `attachDocComments()` — the exact pass `agency doc` runs, which is also what hoists the `@module` comment onto `program.docComment`
- effects: `getEffectsFromSource`, the same transitive analysis behind `getEffects`
- markers/export flags: read off the nodes

Type-alias signatures print through the canonical generator on a copy without the attached doc comment (otherwise the comment prints into the signature), with the `export` keyword stripped to match how def/node signatures omit keywords.

## Tests

- Unit (`lib/stdlib/agency.test.ts`): source order + non-export/underscore skipping, signatures/docstrings/markers, effect names (`["std::write"]` transitively), type-alias signature shape and doc comment, module description, bare-program empty case.
- Execution (`tests/agency/describe.agency`): the record crosses the stdlib boundary into Agency code — a program loops `info.value.exports` with a comprehension and reads `effects`/`destructive`/`description`. No LLM calls.

Also in this PR: explicit 30s timeouts on the walker-coverage corpus tests — the unlowered corpus parse could cross vitest's 5s default under full-suite load (seen once as a flake).

Full suite: 9,312 green; three unrelated subprocess-spawn tests timed out under load and pass in isolation (`scripts/agency.test.ts`, `lib/debugger/driver.test.ts`, `lib/cli/runPolicy.spawn.test.ts`). `lint:structure` clean, `make` + `make doc` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
