### PR TITLE
Lint rules: missing-docstring (AL0002) and redundant-prelude-import (AL0003)

### DIFF
--- a/packages/agency-lang/docs/site/cli/lint.md
+++ b/packages/agency-lang/docs/site/cli/lint.md
@@ -31,10 +31,11 @@ The linter reports style and hygiene notices — things worth cleaning up, not t
 
 Because of that, `agency lint` **exits 0 on hint-level findings**, so putting it in CI reports findings without failing the build. If a future rule ships at `warning` severity or above, findings at that level will fail the run.
 
-## What the rules skip
+## The rules
 
-- **Auto-imported prelude names.** Every Agency file gets the `std::index` prelude (`print`, `map`, `range`, …) without importing it, so `std::index` imports are never reported.
-- **Test-only imports.** `import test { … }` exists for the test harness; its names are expected to look unused in a normal compile.
+- **AL0001 — unused import.** A named import (or `import node`) the file never references. Conservative on purpose: if the name appears anywhere — even where a shadowing local is the real target — the import is kept. Never examines `std::index` imports (every file gets the prelude names without importing them) or `import test { … }` imports (their names are expected to look unused in a normal compile).
+- **AL0002 — missing docstring.** An exported function without a docstring. In Agency, functions are tools, and the docstring becomes the tool description the LLM reads — an exported function without one hands every agent that imports it a tool with no description. A comment above the function does not count; only a docstring reaches the LLM. See the [documentation guide](/cli/doc) for docstring conventions.
+- **AL0003 — redundant prelude import.** An explicit `import { map } from "std::index"` of a name the prelude already provides. Aliased imports (`map as arrMap`) and imports carrying a `destructive`/`idempotent` marker do real work and are never reported — and `std::index` exports that are not in the prelude (types like `WriteMode`) must be imported, so they are never reported either.
 
 ## The same findings in your editor
 

--- a/packages/agency-lang/docs/site/diagnostics/index.md
+++ b/packages/agency-lang/docs/site/diagnostics/index.md
@@ -153,3 +153,5 @@ or suppress a type-checker one on the next line with `// @tc-ignore AG####`.
 | Code | Message |
 | --- | --- |
 | [AL0001](lint.md#al0001) | '&#123;name&#125;' is imported but never used. |
+| [AL0002](lint.md#al0002) | '&#123;name&#125;' is exported but has no docstring. |
+| [AL0003](lint.md#al0003) | '&#123;name&#125;' is already available without an import. |

--- a/packages/agency-lang/docs/site/diagnostics/lint.md
+++ b/packages/agency-lang/docs/site/diagnostics/lint.md
@@ -20,3 +20,29 @@ imports add noise and can hide a mistake (an import you meant to use). This is a
 hint, not an error — the program still compiles and runs. The editor grays the
 name out and offers "Remove unused import"; `agency lint` reports it. Names
 imported from `std::index` and `import test { … }` imports are not reported.
+
+<a id="al0002"></a>
+
+## AL0002 — '&#123;name&#125;' is exported but has no docstring.
+
+*Default severity: hint.*
+
+In Agency, functions are tools: an exported function's
+docstring becomes the tool description the LLM reads when deciding whether
+and how to call it. An exported function without one gives every agent that
+imports it a tool with no description. Add a docstring — terse and
+user-facing, describing what the tool does. A comment above the function
+does not count: comments never reach the LLM.
+
+<a id="al0003"></a>
+
+## AL0003 — '&#123;name&#125;' is already available without an import.
+
+*Default severity: hint.*
+
+Every Agency file gets the prelude (print, map,
+filter, range, and the rest) without importing anything, so importing one of
+those names from `std::index` is redundant. Not everything in std::index is
+prelude, though: types like `WriteMode` must be imported, and an aliased
+import (`map as arrMap`) or one carrying a `destructive`/`idempotent`
+marker does real work — none of those are reported.

--- a/packages/agency-lang/docs/site/stdlib/agents/agency/review.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/agency/review.md
@@ -19,8 +19,8 @@ an optional LLM judgment of whether the code accomplishes a task.
 reportFeedback(report: TypeCheckReport): Feedback[]
 ```
 
-Convert a typecheck report into findings: one error item per error, one
-  advisory item per warning.
+Convert a typecheck report into findings: one error item per error,
+  one advisory item per warning.
 
 **Parameters:**
 
@@ -30,7 +30,7 @@ Convert a typecheck report into findings: one error item per error, one
 
 **Returns:** `Feedback[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/review.agency#L21))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/review.agency#L19))
 
 ### buildTools
 

--- a/packages/agency-lang/docs/site/stdlib/agents/lib/expertGuidance.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/lib/expertGuidance.md
@@ -54,6 +54,9 @@ export static const emptyGuidance: ExpertGuidance = {
 renderGuidance(guidance: ExpertGuidance): string
 ```
 
+Fold expert guidance into a context block the coding agent reads
+  before it starts. Empty guidance yields an empty string.
+
 **Parameters:**
 
 | Name | Type | Default |
@@ -62,7 +65,7 @@ renderGuidance(guidance: ExpertGuidance): string
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/expertGuidance.agency#L25))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/expertGuidance.agency#L22))
 
 ### guidanceOrEmpty
 
@@ -70,9 +73,8 @@ renderGuidance(guidance: ExpertGuidance): string
 guidanceOrEmpty(result: Result<ExpertGuidance>): ExpertGuidance
 ```
 
-Unwrap a consult Result, failing open: a consult that errored yields empty
-  guidance, so the caller proceeds exactly as it would without a consult.
-  Guidance can only help, never block.
+Unwrap a consult Result, failing open: a consult that errored yields
+  empty guidance, so the caller proceeds as if no consult happened.
 
 **Parameters:**
 
@@ -82,4 +84,4 @@ Unwrap a consult Result, failing open: a consult that errored yields empty
 
 **Returns:** [ExpertGuidance](#expertguidance)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/expertGuidance.agency#L37))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/expertGuidance.agency#L33))

--- a/packages/agency-lang/docs/site/stdlib/agents/lib/feedback.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/lib/feedback.md
@@ -112,9 +112,9 @@ True when any finding is an error, or when the feedback Result itself
 failOpenFeedback(feedback: Result<Feedback[]>): Result<Feedback[]>
 ```
 
-Pass a successful feedback list through unchanged; map any failure to no
-  findings. Use this to make a checker fail open: a checker that could not run
-  reports nothing rather than a blocking error.
+Pass a successful feedback list through unchanged; map any failure to
+  no findings, so a checker that could not run reports nothing rather than
+  a blocking error.
 
 **Parameters:**
 
@@ -124,4 +124,4 @@ Pass a successful feedback list through unchanged; map any failure to no
 
 **Returns:** `Result<Feedback[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/feedback.agency#L84))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/lib/feedback.agency#L81))

--- a/packages/agency-lang/docs/site/stdlib/agents/planner.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/planner.md
@@ -52,8 +52,8 @@ Return the planner's tools: read-only access to the project it is planning
 planCodePrompt(task: string, planText: string): string
 ```
 
-Build the code-generation instruction: emit a program whose `node main` composes
-  the building blocks to carry out `planText` for `task`.
+Build the code-generation instruction: emit a program whose node main
+  composes the building blocks to carry out planText for task.
 
 **Parameters:**
 
@@ -64,7 +64,7 @@ Build the code-generation instruction: emit a program whose `node main` composes
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L69))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L67))
 
 ### renderEffects
 
@@ -72,8 +72,8 @@ Build the code-generation instruction: emit a program whose `node main` composes
 renderEffects(effects: Result<EffectsByExport>): string
 ```
 
-Human-readable capability envelope for the approval prompt, or an honest
-  note when the effects could not be computed.
+Human-readable capability envelope for the approval prompt, or an
+  honest note when the effects could not be computed.
 
 **Parameters:**
 
@@ -83,7 +83,7 @@ Human-readable capability envelope for the approval prompt, or an honest
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L97))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L95))
 
 ### runApproved
 
@@ -95,6 +95,10 @@ runApproved(
   state: PlanState,
 ): PlanState raises <std::agents::planApprove>
 ```
+
+Gate generated code behind user approval, then run it: shows the plan,
+  source, and capability envelope, and returns a rejected state instead of
+  running when approval is declined.
 
 **Parameters:**
 
@@ -161,4 +165,4 @@ Plan-as-code: draft (or use a seed) plan, generate an agent that solves the
 
 **Throws:** `std::agents::planApprove`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L221))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L224))

--- a/packages/agency-lang/docs/site/stdlib/index.md
+++ b/packages/agency-lang/docs/site/stdlib/index.md
@@ -124,8 +124,9 @@ Return the agent working directory, or an empty string if none is set.
 applyAgentCwd(dir: string): string
 ```
 
-Used by read, write, and other functions to resolve
-relative paths against the agent working directory.
+Resolve a relative path against the agent working directory (set with
+  setAgentCwd). Absolute paths and an unset working directory pass through
+  unchanged. read, write, and the other file tools already call this.
 
 **Parameters:**
 
@@ -135,7 +136,7 @@ relative paths against the agent working directory.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L101))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L98))
 
 ### printJSON
 

--- a/packages/agency-lang/docs/site/stdlib/math.md
+++ b/packages/agency-lang/docs/site/stdlib/math.md
@@ -38,6 +38,8 @@ Round a number to a given number of decimal places.
 add(a: number, b: number): number
 ```
 
+Add two numbers.
+
 **Parameters:**
 
 | Name | Type | Default |
@@ -55,6 +57,8 @@ add(a: number, b: number): number
 subtract(a: number, b: number): number
 ```
 
+Subtract b from a.
+
 **Parameters:**
 
 | Name | Type | Default |
@@ -64,7 +68,7 @@ subtract(a: number, b: number): number
 
 **Returns:** `number`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/math.agency#L21))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/math.agency#L22))
 
 ### multiply
 
@@ -72,6 +76,8 @@ subtract(a: number, b: number): number
 multiply(a: number, b: number): number
 ```
 
+Multiply two numbers.
+
 **Parameters:**
 
 | Name | Type | Default |
@@ -81,13 +87,15 @@ multiply(a: number, b: number): number
 
 **Returns:** `number`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/math.agency#L25))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/math.agency#L27))
 
 ### divide
 
 ```ts
 divide(a: number, b: number): Result<number>
 ```
+
+Divide a by b. Fails when b is zero.
 
 **Parameters:**
 
@@ -98,4 +106,4 @@ divide(a: number, b: number): Result<number>
 
 **Returns:** `Result<number>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/math.agency#L29))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/math.agency#L32))

--- a/packages/agency-lang/docs/site/stdlib/mcp.md
+++ b/packages/agency-lang/docs/site/stdlib/mcp.md
@@ -39,15 +39,19 @@ effect mcp::call {
 isMcpAvailable(): boolean
 ```
 
+True when the @agency-lang/mcp package is installed and reachable.
+
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/mcp.agency#L30))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/mcp.agency#L29))
 
 ### readProjectMcpConfig
 
 ```ts
 readProjectMcpConfig(dir: string): Record<string, any>
 ```
+
+Read the mcpServers block from the project agency.json under `dir`.
 
 **Parameters:**
 
@@ -57,7 +61,7 @@ readProjectMcpConfig(dir: string): Record<string, any>
 
 **Returns:** `Record<string, any>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/mcp.agency#L35))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/mcp.agency#L34))
 
 ### mergeMcpServers
 
@@ -68,6 +72,8 @@ mergeMcpServers(
 ): Record<string, any>
 ```
 
+Merge global and project mcpServers configs (project wins on collision).
+
 **Parameters:**
 
 | Name | Type | Default |
@@ -77,13 +83,16 @@ mergeMcpServers(
 
 **Returns:** `Record<string, any>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/mcp.agency#L40))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/mcp.agency#L39))
 
 ### loadMcpTools
 
 ```ts
 loadMcpTools(merged: Record<string, any>, onOAuthRequired = null): any[]
 ```
+
+Load gated MCP tools for every server in `merged`. Returns [] when the
+  package is absent, incompatible, or no servers are configured.
 
 **Parameters:**
 
@@ -94,7 +103,7 @@ loadMcpTools(merged: Record<string, any>, onOAuthRequired = null): any[]
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/mcp.agency#L46))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/mcp.agency#L44))
 
 ### loadMcpToolsWithStatus
 
@@ -105,6 +114,8 @@ loadMcpToolsWithStatus(
 ): McpLoadResult
 ```
 
+Like loadMcpTools, but also returns a per-server status map for /mcp.
+
 **Parameters:**
 
 | Name | Type | Default |
@@ -114,4 +125,4 @@ loadMcpToolsWithStatus(
 
 **Returns:** [McpLoadResult](#mcploadresult)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/mcp.agency#L51))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/mcp.agency#L50))

--- a/packages/agency-lang/docs/site/stdlib/policy.md
+++ b/packages/agency-lang/docs/site/stdlib/policy.md
@@ -151,7 +151,7 @@ export type Decision =
   | "reject-always"
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L131))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L136))
 
 ### ScopedField
 
@@ -183,7 +183,7 @@ export type ScopedField = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L149))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L154))
 
 ### ScopedRuleFields
 
@@ -226,7 +226,7 @@ export type ScopedField = {
 export type ScopedRuleFields = Record<InterruptEffect, ScopedField[]>
 ````
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L172))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L177))
 
 ### ParsePolicyFailureStatus
 
@@ -238,7 +238,7 @@ export type ParsePolicyFailureStatus =
   | "policy-not-valid"
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L375))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L380))
 
 ### ParsePolicyFailure
 
@@ -249,7 +249,7 @@ export type ParsePolicyFailure = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L381))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L386))
 
 ## Constants
 
@@ -293,6 +293,9 @@ export static const BUILTIN_POLICIES = _BUILTIN_POLICIES
 withWritesPolicy(baseDir: string)
 ```
 
+The recommended policy plus file-system and git-write effects, each
+  scoped to `baseDir` and its children.
+
 **Parameters:**
 
 | Name | Type | Default |
@@ -307,6 +310,9 @@ withWritesPolicy(baseDir: string)
 builtinPolicy(name: string, baseDir: string): Policy | null
 ```
 
+Resolve a built-in policy name to a concrete Policy, scoping
+  cwd-relative variants to `baseDir`. Returns null for an unknown name.
+
 **Parameters:**
 
 | Name | Type | Default |
@@ -316,7 +322,7 @@ builtinPolicy(name: string, baseDir: string): Policy | null
 
 **Returns:** `Policy | null`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L113))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L115))
 
 ### builtinPolicyNames
 
@@ -324,9 +330,11 @@ builtinPolicy(name: string, baseDir: string): Policy | null
 builtinPolicyNames(): string[]
 ```
 
+The names accepted by builtinPolicy, e.g. for an approval prompt.
+
 **Returns:** `string[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L117))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L121))
 
 ### checkPolicy
 
@@ -355,7 +363,7 @@ Evaluate a policy against an interrupt. Returns approve(), reject(), or propagat
 | policy | `Record<string, any>` |  |
 | interrupt | `Record<string, any>` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L207))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L212))
 
 ### validatePolicy
 
@@ -383,7 +391,7 @@ Validate that a policy object is well-formed. Returns { success: true } if valid
 
 **Returns:** `Result<void>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L229))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L234))
 
 ### buildScopedMatch
 
@@ -433,7 +441,7 @@ Build a match object for an interrupt, pinned to the configured fields. Returns 
 
 **Returns:** `Record<string, string>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L264))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L269))
 
 ### recordRule
 
@@ -481,7 +489,7 @@ Return a new policy with a catch-all rule for an effect appended. A single bare 
 
 **Returns:** [Policy](#policy)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L314))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L319))
 
 ### recordScopedRule
 
@@ -523,7 +531,7 @@ Return a new policy with a scoped approve rule prepended for the interrupt's eff
 
 **Returns:** [Policy](#policy)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L351))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L356))
 
 ### parsePolicyFile
 
@@ -555,13 +563,15 @@ Read + parse + validate a policy file from disk. Returns {} on any
 
 **Returns:** `Result<Policy, ParsePolicyFailure>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L397))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L402))
 
 ### setPolicy
 
 ```ts
 setPolicy(path: string, policy: Policy)
 ```
+
+Install `policy` as the active policy and persist it to `path`.
 
 * Set the policy to be used with the CLI handler
   * returned by `cliPolicyHandler`. The handler's internal state
@@ -576,7 +586,7 @@ setPolicy(path: string, policy: Policy)
 | path | `string` |  |
 | policy | [Policy](#policy) |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L442))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L447))
 
 ### writePolicyFile
 
@@ -607,13 +617,15 @@ Validate and write a policy to a JSON file. Throws if the policy is invalid.
 | policy | [Policy](#policy) |  |
 | allowedPaths | `string[]` | [] |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L458))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L464))
 
 ### flushPolicy
 
 ```ts
 flushPolicy()
 ```
+
+Write any pending always-rule additions to the policy file now.
 
 * Force-write the `cliPolicyHandler`'s in-memory policy to disk
  * now. Use between user turns when you want the **last** decision
@@ -625,7 +637,7 @@ flushPolicy()
  * `std::write` via `with approve` (you opted in by installing the
  * handler).
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L523))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L529))
 
 ### cliPolicyHandler
 
@@ -710,4 +722,4 @@ CLI sugar for an interactive policy handler. Loads and saves the policy file, pr
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L891))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L898))

--- a/packages/agency-lang/docs/site/stdlib/ui/cli.md
+++ b/packages/agency-lang/docs/site/stdlib/ui/cli.md
@@ -78,6 +78,8 @@ Line-mode REPL with the same call signature as the std::ui TUI repl,
 clearScreen()
 ```
 
+Clear the terminal screen.
+
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/cli.agency#L106))
 
 ### clearHistory
@@ -90,13 +92,16 @@ Clear the input history of the currently running `repl()` session: both
   its in-session up-arrow recall and the `historyFile` that session was started
   with. A no-op when called outside an interactive `repl()`.
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/cli.agency#L110))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/cli.agency#L111))
 
 ### hline
 
 ```ts
 hline(char: string = "─", width: number = null): string
 ```
+
+Return a horizontal rule: `char` repeated `width` times (terminal
+  width when `width` is omitted).
 
 **Parameters:**
 
@@ -107,7 +112,7 @@ hline(char: string = "─", width: number = null): string
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/cli.agency#L121))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/cli.agency#L122))
 
 ### interruptChoice
 
@@ -146,4 +151,4 @@ Approval prompt for line mode: renders a sticky footer pinned to the
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/cli.agency#L126))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/cli.agency#L129))

--- a/packages/agency-lang/docs/site/stdlib/weather.md
+++ b/packages/agency-lang/docs/site/stdlib/weather.md
@@ -78,6 +78,8 @@ Usage from Agency code:
 celsiusToFahrenheit(celsius: number): number
 ```
 
+Convert a temperature from Celsius to Fahrenheit.
+
 **Parameters:**
 
 | Name | Type | Default |
@@ -94,6 +96,8 @@ celsiusToFahrenheit(celsius: number): number
 fahrenheitToCelsius(fahrenheit: number): number
 ```
 
+Convert a temperature from Fahrenheit to Celsius.
+
 **Parameters:**
 
 | Name | Type | Default |
@@ -102,4 +106,4 @@ fahrenheitToCelsius(fahrenheit: number): number
 
 **Returns:** `number`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/weather.agency#L69))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/weather.agency#L70))

--- a/packages/agency-lang/lib/linter/diagnosticExplanations.ts
+++ b/packages/agency-lang/lib/linter/diagnosticExplanations.ts
@@ -7,4 +7,16 @@ imports add noise and can hide a mistake (an import you meant to use). This is a
 hint, not an error — the program still compiles and runs. The editor grays the
 name out and offers "Remove unused import"; \`agency lint\` reports it. Names
 imported from \`std::index\` and \`import test { … }\` imports are not reported.`,
+  missingDocstring: `In Agency, functions are tools: an exported function's
+docstring becomes the tool description the LLM reads when deciding whether
+and how to call it. An exported function without one gives every agent that
+imports it a tool with no description. Add a docstring — terse and
+user-facing, describing what the tool does. A comment above the function
+does not count: comments never reach the LLM.`,
+  redundantPreludeImport: `Every Agency file gets the prelude (print, map,
+filter, range, and the rest) without importing anything, so importing one of
+those names from \`std::index\` is redundant. Not everything in std::index is
+prelude, though: types like \`WriteMode\` must be imported, and an aliased
+import (\`map as arrMap\`) or one carrying a \`destructive\`/\`idempotent\`
+marker does real work — none of those are reported.`,
 };

--- a/packages/agency-lang/lib/linter/diagnostics.ts
+++ b/packages/agency-lang/lib/linter/diagnostics.ts
@@ -21,6 +21,16 @@ export const LINT_DIAGNOSTICS = {
     severity: "hint",
     message: "'{name}' is imported but never used.",
   },
+  missingDocstring: {
+    code: "AL0002",
+    severity: "hint",
+    message: "'{name}' is exported but has no docstring.",
+  },
+  redundantPreludeImport: {
+    code: "AL0003",
+    severity: "hint",
+    message: "'{name}' is already available without an import.",
+  },
 } as const;
 
 export type LintDiagnosticName = keyof typeof LINT_DIAGNOSTICS;

--- a/packages/agency-lang/lib/linter/registry.ts
+++ b/packages/agency-lang/lib/linter/registry.ts
@@ -2,9 +2,15 @@ import { parseAgency } from "../parser.js";
 import type { AgencyConfig } from "../config.js";
 import type { LintContext, LintFinding, LintRule } from "./types.js";
 import { unusedImportsRule } from "./rules/unusedImports.js";
+import { missingDocstringRule } from "./rules/missingDocstring.js";
+import { redundantPreludeImportRule } from "./rules/redundantPreludeImport.js";
 
 /** Every enabled rule. Append a rule here to enable it. */
-export const LINT_RULES: LintRule[] = [unusedImportsRule];
+export const LINT_RULES: LintRule[] = [
+  unusedImportsRule,
+  missingDocstringRule,
+  redundantPreludeImportRule,
+];
 
 /** Run every rule over the context and concatenate their findings. */
 export function runLinter(ctx: LintContext): LintFinding[] {

--- a/packages/agency-lang/lib/linter/rules/importFixes.ts
+++ b/packages/agency-lang/lib/linter/rules/importFixes.ts
@@ -1,0 +1,96 @@
+import type {
+  ImportStatement,
+  ImportNodeStatement,
+  NamedImport,
+} from "../../types/importStatement.js";
+import { AgencyGenerator } from "../../backends/agencyGenerator.js";
+import type { LintEdit } from "../types.js";
+import { statementSpan } from "./util.js";
+
+/** Print a single import statement back to Agency source. `preserveOrder` is
+ *  required: without it the generator buffers imports and returns "". */
+function printImport(node: ImportStatement | ImportNodeStatement): string {
+  return new AgencyGenerator({ preserveOrder: true }).processNode(node).trim();
+}
+
+/** A copy of a NamedImport with the given local names removed (dropping their
+ *  aliases and retry-safety markers). Returns null if that empties the group. */
+function namedImportWithout(nameType: NamedImport, localNames: string[]): NamedImport | null {
+  // Map each local name back to its original imported name (alias-aware).
+  const originals = localNames.map(
+    (localName) =>
+      Object.keys(nameType.aliases).find((o) => nameType.aliases[o] === localName) ??
+      localName,
+  );
+  // Hole entries (template import specifiers) are never reported unused.
+  const importedNames = nameType.importedNames.filter(
+    (n) => typeof n !== "string" || !originals.includes(n),
+  );
+  if (importedNames.length === 0) {
+    return null;
+  }
+  const aliases = { ...nameType.aliases };
+  for (const original of originals) {
+    delete aliases[original];
+  }
+  const next: NamedImport = { type: "namedImport", importedNames, aliases };
+  const destructive = nameType.destructiveNames?.filter((n) => !originals.includes(n));
+  const idempotent = nameType.idempotentNames?.filter((n) => !originals.includes(n));
+  if (destructive && destructive.length > 0) {
+    next.destructiveNames = destructive;
+  }
+  if (idempotent && idempotent.length > 0) {
+    next.idempotentNames = idempotent;
+  }
+  return next;
+}
+
+/** A copy of the statement with the local names removed, or null if the whole
+ *  statement should be deleted. */
+function rebuildWithout(
+  stmt: ImportStatement | ImportNodeStatement,
+  localNames: string[],
+): ImportStatement | ImportNodeStatement | null {
+  if (stmt.type === "importNodeStatement") {
+    const importedNodes = stmt.importedNodes.filter((n) => !localNames.includes(n));
+    if (importedNodes.length === 0) {
+      return null;
+    }
+    return { ...stmt, importedNodes };
+  }
+  const importedNames = stmt.importedNames
+    .map((nameType) =>
+      nameType.type === "namedImport" ? namedImportWithout(nameType, localNames) : nameType,
+    )
+    .filter((nameType): nameType is NonNullable<typeof nameType> => nameType !== null);
+  if (importedNames.length === 0) {
+    return null;
+  }
+  return { ...stmt, importedNames };
+}
+
+/** The single edit that removes `localNames` from `stmt`: either the statement
+ *  regenerated without them, or (when nothing survives) a deletion of the
+ *  whole statement including its trailing newline, so no blank line is left
+ *  behind. The parser's span already includes the trailing newline it
+ *  consumed; the regeneration path replaces only the trimmed statement text. */
+export function removalEdit(
+  source: string,
+  stmt: ImportStatement | ImportNodeStatement,
+  localNames: string[],
+): LintEdit {
+  const loc = stmt.loc ?? { line: 0, col: 0, start: 0, end: 0 };
+  const span = statementSpan(source, stmt);
+  const rebuilt = rebuildWithout(stmt, localNames);
+  if (rebuilt === null) {
+    // The parser's span usually already consumed the statement's trailing
+    // newline. Only extend past one when it did not (statement at EOF or
+    // followed by `;`); extending unconditionally would eat the NEXT line's
+    // newline and collapse an intentional blank line between imports.
+    const spanEndsWithNewline = source[loc.end - 1] === "\n";
+    const end =
+      !spanEndsWithNewline && source[loc.end] === "\n" ? loc.end + 1 : loc.end;
+    return { start: loc.start, end, newText: "" };
+  }
+  return { start: span.start, end: span.end, newText: printImport(rebuilt) };
+}

--- a/packages/agency-lang/lib/linter/rules/missingDocstring.test.ts
+++ b/packages/agency-lang/lib/linter/rules/missingDocstring.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { parseAgency } from "../../parser.js";
+import { lintSource } from "../registry.js";
+import type { LintContext } from "../types.js";
+import { missingDocstringRule } from "./missingDocstring.js";
+
+function ctxFor(source: string): LintContext {
+  const parsed = parseAgency(source, {}, false);
+  if (!parsed.success) throw new Error("test source did not parse");
+  return { program: parsed.result, source, filePath: "/test.agency" };
+}
+
+function names(source: string): string[] {
+  return missingDocstringRule.run(ctxFor(source)).map((f) => {
+    const m = f.message.match(/'(\w+)'/);
+    return m ? m[1] : "";
+  });
+}
+
+describe("missing-docstring rule", () => {
+  it("flags an exported function without a docstring", () => {
+    expect(names(`export def fetchUser(id: string): string { return id }\n`))
+      .toEqual(["fetchUser"]);
+  });
+
+  it("does not flag an exported function with a docstring", () => {
+    const src = [
+      `export def fetchUser(id: string): string {`,
+      `  """`,
+      `  Fetch a user record by id.`,
+      `  """`,
+      `  return id`,
+      `}`,
+      ``,
+    ].join("\n");
+    expect(names(src)).toEqual([]);
+  });
+
+  it("does not flag a private function", () => {
+    expect(names(`def helper(x: number): number { return x }\n`)).toEqual([]);
+  });
+
+  it("does not flag exported nodes (docstrings only reach agency doc)", () => {
+    expect(names(`export node main() { return 1 }\n`)).toEqual([]);
+  });
+
+  it("a standalone comment above the function is not a docstring", () => {
+    // The `//` line parses as a sibling `comment` node; the function's
+    // docString stays unset, so the finding remains. (The AST's docComment
+    // field is populated only by the TypescriptPreprocessor, which the
+    // linter never runs — the rule needs no docComment logic at all.)
+    const src = [
+      `// Fetches a user. This comment never reaches the LLM.`,
+      `export def fetchUser(id: string): string { return id }`,
+      ``,
+    ].join("\n");
+    expect(names(src)).toEqual(["fetchUser"]);
+  });
+
+  it("anchors the finding on the function name token, with no fix", () => {
+    const src = `export def fetchUser(id: string): string { return id }\n`;
+    const f = missingDocstringRule.run(ctxFor(src))[0];
+    expect(src.slice(f.loc.start, f.loc.end)).toBe("fetchUser");
+    expect(f.fix).toBeUndefined();
+  });
+
+  it("surfaces through lintSource end to end", () => {
+    const findings = lintSource(`export def f(): number { return 1 }\n`, "/t.agency", {});
+    expect(findings.map((x) => x.code)).toContain("AL0002");
+  });
+});

--- a/packages/agency-lang/lib/linter/rules/missingDocstring.ts
+++ b/packages/agency-lang/lib/linter/rules/missingDocstring.ts
@@ -1,7 +1,7 @@
 import type { FunctionDefinition } from "../../types/function.js";
 import type { LintContext, LintFinding, LintRule } from "../types.js";
 import { lintDiagnostic } from "../diagnostics.js";
-import { nameRange, statementSpan } from "./util.js";
+import { buildLineIndex, nameRange, statementSpan } from "./util.js";
 
 /** Exported functions with no docstring. Functions only: a function's
  *  docstring becomes its tool description in the generated JS
@@ -26,9 +26,10 @@ function undocumentedExports(
 export const missingDocstringRule: LintRule = {
   name: "missingDocstring",
   run(ctx: LintContext): LintFinding[] {
+    const lineIndex = buildLineIndex(ctx.source);
     return undocumentedExports(ctx).map((fn) => {
       const span = statementSpan(ctx.source, fn);
-      const range = nameRange(ctx.source, span.start, span.end, fn.functionName);
+      const range = nameRange(ctx.source, span.start, span.end, fn.functionName, lineIndex);
       return lintDiagnostic("missingDocstring", { name: fn.functionName }, range);
     });
   },

--- a/packages/agency-lang/lib/linter/rules/missingDocstring.ts
+++ b/packages/agency-lang/lib/linter/rules/missingDocstring.ts
@@ -1,0 +1,35 @@
+import type { FunctionDefinition } from "../../types/function.js";
+import type { LintContext, LintFinding, LintRule } from "../types.js";
+import { lintDiagnostic } from "../diagnostics.js";
+import { nameRange, statementSpan } from "./util.js";
+
+/** Exported functions with no docstring. Functions only: a function's
+ *  docstring becomes its tool description in the generated JS
+ *  (buildToolDefinition takes a FunctionDefinition); a node's docstring is
+ *  read only by `agency doc`. In the lint AST a leading comment is a
+ *  sibling node and docComment is never populated (that field is filled by
+ *  the TypescriptPreprocessor, which the linter does not run), so the
+ *  docString check is the complete test. */
+function undocumentedExports(
+  ctx: LintContext,
+): (FunctionDefinition & { functionName: string })[] {
+  return ctx.program.nodes.filter(
+    (node): node is FunctionDefinition & { functionName: string } =>
+      node.type === "function" &&
+      node.exported === true &&
+      !node.docString &&
+      // A Hole-named function is a template fragment, not a real export.
+      typeof node.functionName === "string",
+  );
+}
+
+export const missingDocstringRule: LintRule = {
+  name: "missingDocstring",
+  run(ctx: LintContext): LintFinding[] {
+    return undocumentedExports(ctx).map((fn) => {
+      const span = statementSpan(ctx.source, fn);
+      const range = nameRange(ctx.source, span.start, span.end, fn.functionName);
+      return lintDiagnostic("missingDocstring", { name: fn.functionName }, range);
+    });
+  },
+};

--- a/packages/agency-lang/lib/linter/rules/redundantPreludeImport.test.ts
+++ b/packages/agency-lang/lib/linter/rules/redundantPreludeImport.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { parseAgency } from "../../parser.js";
+import { lintSource } from "../registry.js";
+import type { LintContext, LintFinding } from "../types.js";
+import { redundantPreludeImportRule } from "./redundantPreludeImport.js";
+
+function ctxFor(source: string): LintContext {
+  const parsed = parseAgency(source, {}, false);
+  if (!parsed.success) throw new Error("test source did not parse");
+  return { program: parsed.result, source, filePath: "/test.agency" };
+}
+
+function names(source: string): string[] {
+  return redundantPreludeImportRule.run(ctxFor(source)).map((f) => {
+    const m = f.message.match(/'(\w+)'/);
+    return m ? m[1] : "";
+  });
+}
+
+function applied(source: string, f: LintFinding): string {
+  let out = source;
+  for (const e of [...(f.fix?.edits ?? [])].sort((a, b) => b.start - a.start)) {
+    out = out.slice(0, e.start) + e.newText + out.slice(e.end);
+  }
+  return out;
+}
+
+describe("redundant-prelude-import rule", () => {
+  it("flags a prelude name imported from std::index (used or not — redundancy is not usage)", () => {
+    expect(names(`import { map } from "std::index"\nnode main() { return 1 }\n`))
+      .toEqual(["map"]);
+  });
+
+  it("flags each redundant name when a statement has two", () => {
+    expect(names(`import { map, filter } from "std::index"\nnode main() { return 1 }\n`))
+      .toEqual(["map", "filter"]);
+  });
+
+  it("keeps a std::index name that is NOT in the prelude (types like WriteMode)", () => {
+    expect(names(`import { WriteMode } from "std::index"\ndef pick(m: WriteMode): WriteMode { return m }\n`))
+      .toEqual([]);
+  });
+
+  it("keeps an aliased prelude import (the alias binds a new name)", () => {
+    expect(names(`import { map as arrMap } from "std::index"\nnode main() { return 1 }\n`))
+      .toEqual([]);
+  });
+
+  it("keeps a destructive-marked prelude import (the marker changes retry behavior)", () => {
+    expect(names(`import { destructive write } from "std::index"\nnode main() { return 1 }\n`))
+      .toEqual([]);
+  });
+
+  it("keeps an idempotent-marked prelude import", () => {
+    expect(names(`import { idempotent write } from "std::index"\nnode main() { return 1 }\n`))
+      .toEqual([]);
+  });
+
+  it("skips non-std::index imports and testOnly imports", () => {
+    expect(names(`import { map } from "./mymap.agency"\nnode main() { return 1 }\n`)).toEqual([]);
+    expect(names(`import test { map } from "std::index"\nnode main() { return 1 }\n`)).toEqual([]);
+  });
+
+  it("fix removes just the redundant name, keeping non-prelude names", () => {
+    const src = `import { map, WriteMode } from "std::index"\ndef pick(m: WriteMode): WriteMode { return m }\n`;
+    const f = redundantPreludeImportRule.run(ctxFor(src))[0];
+    const out = applied(src, f);
+    expect(out).toContain(`import { WriteMode } from "std::index"`);
+    expect(out).not.toContain("map,");
+  });
+
+  it("with two redundant names, each individual fix removes only its own name", () => {
+    const src = `import { map, filter } from "std::index"\nnode main() { return 1 }\n`;
+    const [forMap] = redundantPreludeImportRule.run(ctxFor(src));
+    expect(applied(src, forMap)).toContain(`import { filter } from "std::index"`);
+  });
+
+  it("fix deletes the whole statement when every name is redundant", () => {
+    const src = `import { map } from "std::index"\nnode main() { return 1 }\n`;
+    const f = redundantPreludeImportRule.run(ctxFor(src))[0];
+    expect(applied(src, f)).toBe(`node main() { return 1 }\n`);
+  });
+
+  it("surfaces through lintSource end to end", () => {
+    const findings = lintSource(`import { map } from "std::index"\nnode main() { return 1 }\n`, "/t.agency", {});
+    expect(findings.map((x) => x.code)).toContain("AL0003");
+  });
+});

--- a/packages/agency-lang/lib/linter/rules/redundantPreludeImport.ts
+++ b/packages/agency-lang/lib/linter/rules/redundantPreludeImport.ts
@@ -47,6 +47,12 @@ export const redundantPreludeImportRule: LintRule = {
     return redundantNamesIn(ctx).map(({ stmt, name }) => {
       const span = statementSpan(ctx.source, stmt);
       const range = nameRange(ctx.source, span.start, span.end, name);
+      // Each fix regenerates the WHOLE statement minus one name, so two
+      // findings on the same statement carry overlapping edits. Safe for
+      // one-at-a-time quick fixes (the editor re-lints between them), but
+      // a future batch/fix-all action must group per statement and
+      // regenerate once, the way unusedImportsBatchEdits does — never
+      // concatenate these per-name fixes.
       const fix: LintFix = {
         title: `Remove redundant import '${name}'`,
         edits: [removalEdit(ctx.source, stmt, [name])],

--- a/packages/agency-lang/lib/linter/rules/redundantPreludeImport.ts
+++ b/packages/agency-lang/lib/linter/rules/redundantPreludeImport.ts
@@ -1,0 +1,57 @@
+import type { ImportStatement, NamedImport } from "../../types/importStatement.js";
+import { PRELUDE_NAMES } from "../../prelude.js";
+import type { LintContext, LintFinding, LintFix, LintRule } from "../types.js";
+import { lintDiagnostic } from "../diagnostics.js";
+import { nameRange, statementSpan } from "./util.js";
+import { removalEdit } from "./importFixes.js";
+
+/** A name is redundant only when it is completely plain: provided by the
+ *  prelude, not rebound under an alias, and carrying no retry-safety
+ *  marker. The membership test is PRELUDE_NAMES, NOT the module path:
+ *  std::index also exports names outside the prelude (types like
+ *  WriteMode — the mirror test covers functions only), and importing
+ *  those is the only way to get them. Plainness is what makes the removal
+ *  fix safe. */
+function isRedundant(nameType: NamedImport, name: string): boolean {
+  return (
+    PRELUDE_NAMES.includes(name) &&
+    !Object.hasOwn(nameType.aliases, name) &&
+    !nameType.destructiveNames?.includes(name) &&
+    !nameType.idempotentNames?.includes(name)
+  );
+}
+
+function redundantNamesIn(ctx: LintContext): { stmt: ImportStatement; name: string }[] {
+  return ctx.program.nodes
+    .filter(
+      (node): node is ImportStatement =>
+        node.type === "importStatement" &&
+        node.modulePath === "std::index" &&
+        !node.testOnly,
+    )
+    .flatMap((stmt) =>
+      stmt.importedNames
+        .filter((nameType): nameType is NamedImport => nameType.type === "namedImport")
+        .flatMap((nameType) =>
+          nameType.importedNames
+            .filter((name): name is string => typeof name === "string") // template holes are not names
+            .filter((name) => isRedundant(nameType, name))
+            .map((name) => ({ stmt, name })),
+        ),
+    );
+}
+
+export const redundantPreludeImportRule: LintRule = {
+  name: "redundantPreludeImport",
+  run(ctx: LintContext): LintFinding[] {
+    return redundantNamesIn(ctx).map(({ stmt, name }) => {
+      const span = statementSpan(ctx.source, stmt);
+      const range = nameRange(ctx.source, span.start, span.end, name);
+      const fix: LintFix = {
+        title: `Remove redundant import '${name}'`,
+        edits: [removalEdit(ctx.source, stmt, [name])],
+      };
+      return lintDiagnostic("redundantPreludeImport", { name }, range, fix);
+    });
+  },
+};

--- a/packages/agency-lang/lib/linter/rules/redundantPreludeImport.ts
+++ b/packages/agency-lang/lib/linter/rules/redundantPreludeImport.ts
@@ -2,7 +2,7 @@ import type { ImportStatement, NamedImport } from "../../types/importStatement.j
 import { PRELUDE_NAMES } from "../../prelude.js";
 import type { LintContext, LintFinding, LintFix, LintRule } from "../types.js";
 import { lintDiagnostic } from "../diagnostics.js";
-import { nameRange, statementSpan } from "./util.js";
+import { buildLineIndex, nameRange, statementSpan } from "./util.js";
 import { removalEdit } from "./importFixes.js";
 
 /** A name is redundant only when it is completely plain: provided by the
@@ -44,9 +44,10 @@ function redundantNamesIn(ctx: LintContext): { stmt: ImportStatement; name: stri
 export const redundantPreludeImportRule: LintRule = {
   name: "redundantPreludeImport",
   run(ctx: LintContext): LintFinding[] {
+    const lineIndex = buildLineIndex(ctx.source);
     return redundantNamesIn(ctx).map(({ stmt, name }) => {
       const span = statementSpan(ctx.source, stmt);
-      const range = nameRange(ctx.source, span.start, span.end, name);
+      const range = nameRange(ctx.source, span.start, span.end, name, lineIndex);
       // Each fix regenerates the WHOLE statement minus one name, so two
       // findings on the same statement carry overlapping edits. Safe for
       // one-at-a-time quick fixes (the editor re-lints between them), but

--- a/packages/agency-lang/lib/linter/rules/unusedImports.ts
+++ b/packages/agency-lang/lib/linter/rules/unusedImports.ts
@@ -6,7 +6,8 @@ import type {
 import { getImportedNames } from "../../types/importStatement.js";
 import type { LintContext, LintEdit, LintFinding, LintFix, LintRule } from "../types.js";
 import { lintDiagnostic } from "../diagnostics.js";
-import { nameRange, statementSpan, walkValues } from "./util.js";
+import { buildLineIndex, nameRange, statementSpan, walkValues } from "./util.js";
+import type { LineIndex } from "./util.js";
 import { removalEdit } from "./importFixes.js";
 
 /** Names referenced anywhere in the file body. Conservative: an imported name
@@ -69,9 +70,10 @@ function findingFor(
   ctx: LintContext,
   stmt: ImportStatement | ImportNodeStatement,
   localName: string,
+  lineIndex: LineIndex,
 ): LintFinding {
   const span = statementSpan(ctx.source, stmt);
-  const range = nameRange(ctx.source, span.start, span.end, localName);
+  const range = nameRange(ctx.source, span.start, span.end, localName, lineIndex);
   const fix: LintFix = {
     title: `Remove unused import '${localName}'`,
     edits: [removalEdit(ctx.source, stmt, [localName])],
@@ -114,8 +116,9 @@ function unusedByStatement(
 export const unusedImportsRule: LintRule = {
   name: "unusedImport",
   run(ctx: LintContext): LintFinding[] {
+    const lineIndex = buildLineIndex(ctx.source);
     return unusedByStatement(ctx).flatMap(({ stmt, unusedNames }) =>
-      unusedNames.map((localName) => findingFor(ctx, stmt, localName)),
+      unusedNames.map((localName) => findingFor(ctx, stmt, localName, lineIndex)),
     );
   },
 };

--- a/packages/agency-lang/lib/linter/rules/unusedImports.ts
+++ b/packages/agency-lang/lib/linter/rules/unusedImports.ts
@@ -1,14 +1,13 @@
-import type { SourceLocation } from "../../types/base.js";
-import type { AgencyProgram } from "../../types.js";
+import type { AgencyNode } from "../../types.js";
 import type {
   ImportStatement,
   ImportNodeStatement,
-  NamedImport,
 } from "../../types/importStatement.js";
 import { getImportedNames } from "../../types/importStatement.js";
-import { AgencyGenerator } from "../../backends/agencyGenerator.js";
 import type { LintContext, LintEdit, LintFinding, LintFix, LintRule } from "../types.js";
 import { lintDiagnostic } from "../diagnostics.js";
+import { nameRange, statementSpan, walkValues } from "./util.js";
+import { removalEdit } from "./importFixes.js";
 
 /** Names referenced anywhere in the file body. Conservative: an imported name
  *  found here is treated as used, so the rule never removes a used import.
@@ -25,191 +24,36 @@ import { lintDiagnostic } from "../diagnostics.js";
  *  their names are too generic to collect blindly: `value` (string literals
  *  also have one) and `name` (parameters also have one).
  *
- *  This is a generic structural walk, NOT walkNodes: walkNodes visits
- *  statement-level AgencyNodes and does not descend into type hints or tag
- *  arguments, which are exactly the positions that would cause a false
- *  "unused" (and a deleted needed import) if missed. Import statements are
- *  excluded so an import does not count as its own use. */
-export function collectReferencedNames(program: AgencyProgram): Record<string, true> {
+ *  Import statements are excluded so an import does not count as its own
+ *  use. The descent itself is walkValues (util.ts) — see its comment for
+ *  why the linter has a bespoke walk at all. */
+export function collectReferencedNames(nodes: AgencyNode[]): Record<string, true> {
   // Null prototype: identifiers are user-controlled, and on a plain object a
   // key like "__proto__" or "constructor" would hit the prototype chain.
   const used: Record<string, true> = Object.create(null);
-  const visit = (value: unknown): void => {
-    if (Array.isArray(value)) {
-      for (const item of value) {
-        visit(item);
-      }
-      return;
-    }
-    if (value && typeof value === "object") {
-      const node = value as Record<string, unknown>;
-      if (typeof node.functionName === "string") {
-        used[node.functionName] = true;
-      }
-      if (typeof node.aliasName === "string") {
-        used[node.aliasName] = true;
-      }
-      if (typeof node.handlerName === "string") {
-        used[node.handlerName] = true;
-      }
-      if (node.type === "variableName" && typeof node.value === "string") {
-        used[node.value] = true;
-      }
-      if (node.type === "genericType" && typeof node.name === "string") {
-        used[node.name] = true;
-      }
-      for (const key of Object.keys(node)) {
-        visit(node[key]);
-      }
-    }
-  };
-  for (const node of program.nodes) {
+  for (const node of nodes) {
     if (node.type === "importStatement" || node.type === "importNodeStatement") {
       continue;
     }
-    visit(node);
+    walkValues(node, (n) => {
+      if (typeof n.functionName === "string") {
+        used[n.functionName] = true;
+      }
+      if (typeof n.aliasName === "string") {
+        used[n.aliasName] = true;
+      }
+      if (typeof n.handlerName === "string") {
+        used[n.handlerName] = true;
+      }
+      if (n.type === "variableName" && typeof n.value === "string") {
+        used[n.value] = true;
+      }
+      if (n.type === "genericType" && typeof n.name === "string") {
+        used[n.name] = true;
+      }
+    });
   }
   return used;
-}
-
-/** 0-indexed line/col plus offsets, matching the codebase's SourceLocation. */
-export function locFromOffsets(source: string, start: number, end: number): SourceLocation {
-  let line = 0;
-  let lastNewline = -1;
-  for (let i = 0; i < start; i++) {
-    if (source[i] === "\n") {
-      line++;
-      lastNewline = i;
-    }
-  }
-  return { line, col: start - lastNewline - 1, start, end };
-}
-
-const escapeForRegex = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-
-/** The local name's character range within a statement's source span, matched
- *  on word boundaries so `b` never matches inside `ab` or inside the module
- *  path. Falls back to the whole statement span if the token is somehow not
- *  found (dimming the whole statement is honest; pointing at the wrong
- *  character is not). */
-function nameRange(
-  source: string,
-  stmtStart: number,
-  stmtEnd: number,
-  localName: string,
-): SourceLocation {
-  const span = source.slice(stmtStart, stmtEnd);
-  const match = new RegExp(
-    `(?<![A-Za-z0-9_])${escapeForRegex(localName)}(?![A-Za-z0-9_])`,
-  ).exec(span);
-  if (!match) {
-    return locFromOffsets(source, stmtStart, stmtEnd);
-  }
-  const start = stmtStart + match.index;
-  return locFromOffsets(source, start, start + localName.length);
-}
-
-/** The statement's span with trailing whitespace trimmed off: the parser's
- *  span includes the optional trailing newline it consumed, which is not part
- *  of the statement text we match names in or replace on regeneration. */
-function statementSpan(
-  source: string,
-  stmt: ImportStatement | ImportNodeStatement,
-): { start: number; end: number } {
-  const loc = stmt.loc ?? { line: 0, col: 0, start: 0, end: 0 };
-  let end = loc.end;
-  while (end > loc.start && /\s/.test(source[end - 1])) {
-    end--;
-  }
-  return { start: loc.start, end };
-}
-
-/** Print a single import statement back to Agency source. `preserveOrder` is
- *  required: without it the generator buffers imports and returns "". */
-function printImport(node: ImportStatement | ImportNodeStatement): string {
-  return new AgencyGenerator({ preserveOrder: true }).processNode(node).trim();
-}
-
-/** A copy of a NamedImport with the given local names removed (dropping their
- *  aliases and retry-safety markers). Returns null if that empties the group. */
-function namedImportWithout(nameType: NamedImport, localNames: string[]): NamedImport | null {
-  // Map each local name back to its original imported name (alias-aware).
-  const originals = localNames.map(
-    (localName) =>
-      Object.keys(nameType.aliases).find((o) => nameType.aliases[o] === localName) ??
-      localName,
-  );
-  // Hole entries (template import specifiers) are never reported unused.
-  const importedNames = nameType.importedNames.filter(
-    (n) => typeof n !== "string" || !originals.includes(n),
-  );
-  if (importedNames.length === 0) {
-    return null;
-  }
-  const aliases = { ...nameType.aliases };
-  for (const original of originals) {
-    delete aliases[original];
-  }
-  const next: NamedImport = { type: "namedImport", importedNames, aliases };
-  const destructive = nameType.destructiveNames?.filter((n) => !originals.includes(n));
-  const idempotent = nameType.idempotentNames?.filter((n) => !originals.includes(n));
-  if (destructive && destructive.length > 0) {
-    next.destructiveNames = destructive;
-  }
-  if (idempotent && idempotent.length > 0) {
-    next.idempotentNames = idempotent;
-  }
-  return next;
-}
-
-/** A copy of the statement with the local names removed, or null if the whole
- *  statement should be deleted. */
-function rebuildWithout(
-  stmt: ImportStatement | ImportNodeStatement,
-  localNames: string[],
-): ImportStatement | ImportNodeStatement | null {
-  if (stmt.type === "importNodeStatement") {
-    const importedNodes = stmt.importedNodes.filter((n) => !localNames.includes(n));
-    if (importedNodes.length === 0) {
-      return null;
-    }
-    return { ...stmt, importedNodes };
-  }
-  const importedNames = stmt.importedNames
-    .map((nameType) =>
-      nameType.type === "namedImport" ? namedImportWithout(nameType, localNames) : nameType,
-    )
-    .filter((nameType): nameType is NonNullable<typeof nameType> => nameType !== null);
-  if (importedNames.length === 0) {
-    return null;
-  }
-  return { ...stmt, importedNames };
-}
-
-/** The single edit that removes `localNames` from `stmt`: either the statement
- *  regenerated without them, or (when nothing survives) a deletion of the
- *  whole statement including its trailing newline, so no blank line is left
- *  behind. The parser's span already includes the trailing newline it
- *  consumed; the regeneration path replaces only the trimmed statement text. */
-function removalEdit(
-  source: string,
-  stmt: ImportStatement | ImportNodeStatement,
-  localNames: string[],
-): LintEdit {
-  const loc = stmt.loc ?? { line: 0, col: 0, start: 0, end: 0 };
-  const span = statementSpan(source, stmt);
-  const rebuilt = rebuildWithout(stmt, localNames);
-  if (rebuilt === null) {
-    // The parser's span usually already consumed the statement's trailing
-    // newline. Only extend past one when it did not (statement at EOF or
-    // followed by `;`); extending unconditionally would eat the NEXT line's
-    // newline and collapse an intentional blank line between imports.
-    const spanEndsWithNewline = source[loc.end - 1] === "\n";
-    const end =
-      !spanEndsWithNewline && source[loc.end] === "\n" ? loc.end + 1 : loc.end;
-    return { start: loc.start, end, newText: "" };
-  }
-  return { start: span.start, end: span.end, newText: printImport(rebuilt) };
 }
 
 /** One edit per statement, each regenerated with ALL of its unused names
@@ -240,7 +84,7 @@ function findingFor(
 function unusedByStatement(
   ctx: LintContext,
 ): { stmt: ImportStatement | ImportNodeStatement; unusedNames: string[] }[] {
-  const used = collectReferencedNames(ctx.program);
+  const used = collectReferencedNames(ctx.program.nodes);
   const groups: { stmt: ImportStatement | ImportNodeStatement; unusedNames: string[] }[] = [];
   for (const node of ctx.program.nodes) {
     if (node.type === "importStatement") {

--- a/packages/agency-lang/lib/linter/rules/util.test.ts
+++ b/packages/agency-lang/lib/linter/rules/util.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { buildLineIndex, locFromOffsets } from "./util.js";
+
+describe("locFromOffsets line index", () => {
+  // The indexed path is a performance optimization (O(log n) per lookup vs an
+  // O(offset) rescan). It must produce byte-identical results to the scan, or
+  // it silently corrupts every finding's line/col on large files.
+  it("the indexed path matches the linear scan at every offset", () => {
+    const source = [
+      `import { map } from "std::index"`,
+      ``,
+      `export def first(): number {`,
+      `  return 1`,
+      `}`,
+      `export def second(): number {`,
+      `  return 2`,
+      `}`,
+      ``,
+    ].join("\n");
+    const lineIndex = buildLineIndex(source);
+    for (let offset = 0; offset <= source.length; offset++) {
+      expect(locFromOffsets(source, offset, offset + 1, lineIndex)).toEqual(
+        locFromOffsets(source, offset, offset + 1),
+      );
+    }
+  });
+
+  it("matches the scan for a source with no newlines", () => {
+    const source = `export def only(): number { return 1 }`;
+    const lineIndex = buildLineIndex(source);
+    for (let offset = 0; offset <= source.length; offset++) {
+      expect(locFromOffsets(source, offset, offset, lineIndex)).toEqual(
+        locFromOffsets(source, offset, offset),
+      );
+    }
+  });
+
+  it("agrees on an offset sitting exactly on a newline (it belongs to the next line)", () => {
+    const source = `a\nb\nc`;
+    const newlineOffset = source.indexOf("\n"); // offset 1
+    const lineIndex = buildLineIndex(source);
+    expect(locFromOffsets(source, newlineOffset, newlineOffset, lineIndex)).toEqual(
+      locFromOffsets(source, newlineOffset, newlineOffset),
+    );
+  });
+});

--- a/packages/agency-lang/lib/linter/rules/util.ts
+++ b/packages/agency-lang/lib/linter/rules/util.ts
@@ -1,0 +1,78 @@
+import type { SourceLocation } from "../../types/base.js";
+
+/** Visit every object in an AST subtree (descending arrays and object
+ *  values alike). The linter's ONE bespoke descent — it exists because
+ *  walkNodes does not reach type hints or tag arguments, which are
+ *  positions rules must see. Collectors (collectReferencedNames,
+ *  usedNamesIn, reassignedNames) are callbacks over this shared HOW,
+ *  each stating only WHAT it collects. */
+export function walkValues(
+  root: unknown,
+  visit: (node: Record<string, unknown>) => void,
+): void {
+  if (Array.isArray(root)) {
+    for (const item of root) {
+      walkValues(item, visit);
+    }
+    return;
+  }
+  if (root && typeof root === "object") {
+    const node = root as Record<string, unknown>;
+    visit(node);
+    for (const key of Object.keys(node)) {
+      walkValues(node[key], visit);
+    }
+  }
+}
+
+/** 0-indexed line/col plus offsets, matching the codebase's SourceLocation. */
+export function locFromOffsets(source: string, start: number, end: number): SourceLocation {
+  let line = 0;
+  let lastNewline = -1;
+  for (let i = 0; i < start; i++) {
+    if (source[i] === "\n") {
+      line++;
+      lastNewline = i;
+    }
+  }
+  return { line, col: start - lastNewline - 1, start, end };
+}
+
+const escapeForRegex = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+/** The local name's character range within a statement's source span, matched
+ *  on word boundaries so `b` never matches inside `ab` or inside the module
+ *  path. Falls back to the whole statement span if the token is somehow not
+ *  found (dimming the whole statement is honest; pointing at the wrong
+ *  character is not). */
+export function nameRange(
+  source: string,
+  stmtStart: number,
+  stmtEnd: number,
+  localName: string,
+): SourceLocation {
+  const span = source.slice(stmtStart, stmtEnd);
+  const match = new RegExp(
+    `(?<![A-Za-z0-9_])${escapeForRegex(localName)}(?![A-Za-z0-9_])`,
+  ).exec(span);
+  if (!match) {
+    return locFromOffsets(source, stmtStart, stmtEnd);
+  }
+  const start = stmtStart + match.index;
+  return locFromOffsets(source, start, start + localName.length);
+}
+
+/** The statement's span with trailing whitespace trimmed off: the parser's
+ *  span includes the optional trailing newline it consumed, which is not part
+ *  of the statement text we match names in or replace on regeneration. */
+export function statementSpan(
+  source: string,
+  node: { loc?: SourceLocation },
+): { start: number; end: number } {
+  const loc = node.loc ?? { line: 0, col: 0, start: 0, end: 0 };
+  let end = loc.end;
+  while (end > loc.start && /\s/.test(source[end - 1])) {
+    end--;
+  }
+  return { start: loc.start, end };
+}

--- a/packages/agency-lang/lib/linter/rules/util.ts
+++ b/packages/agency-lang/lib/linter/rules/util.ts
@@ -25,8 +25,56 @@ export function walkValues(
   }
 }
 
-/** 0-indexed line/col plus offsets, matching the codebase's SourceLocation. */
-export function locFromOffsets(source: string, start: number, end: number): SourceLocation {
+/** Sorted offsets of every "\n" in `source`. Build this ONCE per lint pass
+ *  (buildLineIndex) and hand it to locFromOffsets/nameRange so each
+ *  offset→line/col lookup is a binary search instead of a rescan from byte 0.
+ *  Without it, a rule that emits one finding per declaration turns a
+ *  whole-file pass into O(n²): each finding pays O(its own offset), and the
+ *  offsets span the file. */
+export type LineIndex = number[];
+
+export function buildLineIndex(source: string): LineIndex {
+  const newlines: LineIndex = [];
+  for (let i = 0; i < source.length; i++) {
+    if (source[i] === "\n") {
+      newlines.push(i);
+    }
+  }
+  return newlines;
+}
+
+/** The 0-indexed line of `offset` (= count of newlines strictly before it) and
+ *  the offset of the last newline before it (or -1). Binary search over the
+ *  sorted index; matches the linear scan below exactly, including a newline
+ *  sitting exactly at `offset` (which belongs to the next line, not this one). */
+function lineAt(lineIndex: LineIndex, offset: number): { line: number; lastNewline: number } {
+  let lo = 0;
+  let hi = lineIndex.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (lineIndex[mid] < offset) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+  return { line: lo, lastNewline: lo > 0 ? lineIndex[lo - 1] : -1 };
+}
+
+/** 0-indexed line/col plus offsets, matching the codebase's SourceLocation.
+ *  Pass a `lineIndex` (buildLineIndex) to make this O(log n); without one it
+ *  falls back to an O(offset) scan — fine for a handful of calls, quadratic
+ *  across a finding-per-declaration pass. */
+export function locFromOffsets(
+  source: string,
+  start: number,
+  end: number,
+  lineIndex?: LineIndex,
+): SourceLocation {
+  if (lineIndex) {
+    const { line, lastNewline } = lineAt(lineIndex, start);
+    return { line, col: start - lastNewline - 1, start, end };
+  }
   let line = 0;
   let lastNewline = -1;
   for (let i = 0; i < start; i++) {
@@ -50,16 +98,17 @@ export function nameRange(
   stmtStart: number,
   stmtEnd: number,
   localName: string,
+  lineIndex?: LineIndex,
 ): SourceLocation {
   const span = source.slice(stmtStart, stmtEnd);
   const match = new RegExp(
     `(?<![A-Za-z0-9_])${escapeForRegex(localName)}(?![A-Za-z0-9_])`,
   ).exec(span);
   if (!match) {
-    return locFromOffsets(source, stmtStart, stmtEnd);
+    return locFromOffsets(source, stmtStart, stmtEnd, lineIndex);
   }
   const start = stmtStart + match.index;
-  return locFromOffsets(source, start, start + localName.length);
+  return locFromOffsets(source, start, start + localName.length, lineIndex);
 }
 
 /** The statement's span with trailing whitespace trimmed off: the parser's

--- a/packages/agency-lang/lib/lsp/diagnostics.test.ts
+++ b/packages/agency-lang/lib/lsp/diagnostics.test.ts
@@ -380,11 +380,14 @@ describe("lint diagnostics", () => {
 });
 
 describe("lint snapshot is isolated from prunePreludeShadows", () => {
-  it("produces identical lint findings on a second run of the same document", () => {
+  it("lints the import as written even though prune strips the shadowed name", () => {
     // `def map` shadows the prelude's map, so prunePreludeShadows strips
     // `map` from EVERY std::index import statement in place — including
-    // this user-written one. Without the clone, the second run sees an
-    // already-emptied import object.
+    // this user-written one. Without cloneForLint the linter would see an
+    // already-emptied import and report nothing; the AL0003 finding is
+    // direct proof the snapshot kept the name. (Each runDiagnostics call
+    // re-parses, so a re-run-equality assertion alone would pass with or
+    // without the clone.)
     const source = [
       `import { map } from "std::index"`,
       `def map(x: number): number { return x }`,
@@ -392,9 +395,8 @@ describe("lint snapshot is isolated from prunePreludeShadows", () => {
       ``,
     ].join("\n");
     const doc = makeDoc(source);
-    const first = runDiagnostics(doc, "/test.agency", {}, emptySymbolTable);
-    const second = runDiagnostics(doc, "/test.agency", {}, emptySymbolTable);
-    expect(second.lintFindings).toEqual(first.lintFindings);
+    const { lintFindings } = runDiagnostics(doc, "/test.agency", {}, emptySymbolTable);
+    expect(lintFindings.map((f) => f.code)).toContain("AL0003");
   });
 });
 

--- a/packages/agency-lang/lib/lsp/diagnostics.test.ts
+++ b/packages/agency-lang/lib/lsp/diagnostics.test.ts
@@ -5,6 +5,7 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import { runDiagnostics } from "./diagnostics.js";
+import { lintSource } from "../linter/registry.js";
 import { SymbolTable } from "../symbolTable.js";
 
 function makeDoc(content: string, uri = "file:///test.agency") {
@@ -395,4 +396,20 @@ describe("lint snapshot is isolated from prunePreludeShadows", () => {
     const second = runDiagnostics(doc, "/test.agency", {}, emptySymbolTable);
     expect(second.lintFindings).toEqual(first.lintFindings);
   });
+});
+
+it("CLI and LSP agree on AL0003 when a prelude name is shadowed", () => {
+  // Without the cloneForLint snapshot, prunePreludeShadows strips `map` from
+  // the user's import before the LSP linter runs, and only the CLI reports it.
+  const source = [
+    `import { map } from "std::index"`,
+    `def map(x: number): number { return x }`,
+    `node main() { return map(1) }`,
+    ``,
+  ].join("\n");
+  const cliFindings = lintSource(source, "/test.agency", {}).map((f) => f.code);
+  const doc = makeDoc(source);
+  const { lintFindings } = runDiagnostics(doc, "/test.agency", {}, emptySymbolTable);
+  expect(lintFindings.map((f) => f.code)).toEqual(cliFindings);
+  expect(cliFindings).toContain("AL0003");
 });

--- a/packages/agency-lang/lib/lsp/diagnostics.test.ts
+++ b/packages/agency-lang/lib/lsp/diagnostics.test.ts
@@ -377,3 +377,22 @@ describe("lint diagnostics", () => {
     expect(diagnostics.filter((d) => d.code === "AL0001")).toEqual([]);
   });
 });
+
+describe("lint snapshot is isolated from prunePreludeShadows", () => {
+  it("produces identical lint findings on a second run of the same document", () => {
+    // `def map` shadows the prelude's map, so prunePreludeShadows strips
+    // `map` from EVERY std::index import statement in place — including
+    // this user-written one. Without the clone, the second run sees an
+    // already-emptied import object.
+    const source = [
+      `import { map } from "std::index"`,
+      `def map(x: number): number { return x }`,
+      `node main() { return map(1) }`,
+      ``,
+    ].join("\n");
+    const doc = makeDoc(source);
+    const first = runDiagnostics(doc, "/test.agency", {}, emptySymbolTable);
+    const second = runDiagnostics(doc, "/test.agency", {}, emptySymbolTable);
+    expect(second.lintFindings).toEqual(first.lintFindings);
+  });
+});

--- a/packages/agency-lang/lib/lsp/diagnostics.ts
+++ b/packages/agency-lang/lib/lsp/diagnostics.ts
@@ -64,6 +64,22 @@ function ensureStdlibImport(
   return { ...program, nodes: [synthetic, ...program.nodes] };
 }
 
+/** The lint snapshot must be the parse as written. prunePreludeShadows
+ *  (below) mutates std::index import statements IN PLACE — including
+ *  user-written ones — so those few nodes are deep-copied. Everything
+ *  else is shared: no other pass mutates nodes before runLinter today,
+ *  and the CLI/LSP agreement test is the tripwire if one starts. */
+function cloneForLint(program: AgencyProgram): AgencyProgram {
+  return {
+    ...program,
+    nodes: program.nodes.map((node) =>
+      node.type === "importStatement" && node.modulePath === "std::index"
+        ? structuredClone(node)
+        : node,
+    ),
+  };
+}
+
 type DiagnosticsResult = {
   diagnostics: Diagnostic[];
   program: AgencyProgram | null;
@@ -109,12 +125,12 @@ export function runDiagnostics(
   }
 
   let program = parseResult.result;
-  // The linter needs the pristine parse: later passes (resolveReExports,
-  // resolveImports) return rewritten programs whose import statements are
-  // replaced or dropped. The pipeline below reassigns `program`, so this
-  // alias keeps pointing at the original. Parsed with applyTemplate=false,
-  // so finding offsets index straight into `source`.
-  const lintProgram = parseResult.result;
+  // The linter needs the parse as written. Later passes (resolveReExports,
+  // resolveImports) return rewritten programs, which reassigning `program`
+  // handles — but prunePreludeShadows mutates std::index import statements
+  // IN PLACE, so cloneForLint deep-copies those few nodes. Parsed with
+  // applyTemplate=false, so finding offsets index straight into `source`.
+  const lintProgram = cloneForLint(parseResult.result);
 
   // The CLI parses source through a template that auto-injects an
   // `import { ... } from "std::index"` statement. The LSP path uses

--- a/packages/agency-lang/lib/preprocessors/typescriptPreprocessor.ts
+++ b/packages/agency-lang/lib/preprocessors/typescriptPreprocessor.ts
@@ -1333,9 +1333,14 @@ export class TypescriptPreprocessor {
     }
 
     // Resolve scope on expressions inside function/node doc string
-    // interpolations. These execute at module load time when the tool
-    // definition is constructed, so they only see top-level (global /
-    // static / imported) names, never function parameters or locals.
+    // interpolations. A FUNCTION docstring executes at module load time
+    // when its tool definition is constructed (typescriptBuilder emits it
+    // as the tool description), so it only sees top-level (global /
+    // static / imported) names, never parameters or locals. A NODE
+    // docstring never reaches generated code — its only consumers are
+    // `agency doc` and the interpolation-presence check in
+    // typescriptBuilder — but it gets the same resolution so those
+    // renderers see consistent scopes.
     for (const node of this.program.nodes) {
       if (node.type !== "function" && node.type !== "graphNode") continue;
       if (!node.docString) continue;

--- a/packages/agency-lang/stdlib/agents/agency/review.agency
+++ b/packages/agency-lang/stdlib/agents/agency/review.agency
@@ -16,9 +16,9 @@ import { systemMessage, threadIsNew } from "std::thread"
 
 static const systemPrompt = """You review Agency-language code. Return a list of feedback items. Set error=true only if the code does not accomplish the task. Keep feedback brief and concrete."""
 
-/** Convert a typecheck report into findings: one error item per error, one
-  advisory item per warning. */
 export def reportFeedback(report: TypeCheckReport): Feedback[] {
+  """Convert a typecheck report into findings: one error item per error,
+  one advisory item per warning."""
   const feedback: Feedback[] = []
   for (error in report.errors) {
     feedback.push({ error: true, feedback: "Error: ${error.message}" })

--- a/packages/agency-lang/stdlib/agents/lib/expertGuidance.agency
+++ b/packages/agency-lang/stdlib/agents/lib/expertGuidance.agency
@@ -19,10 +19,9 @@ export static const emptyGuidance: ExpertGuidance = {
   checklist: []
 }
 
-// Fold expert guidance into a context block the coding agent reads before it
-// starts. An empty consult (no rules, no checklist) yields an empty string, so
-// the coding agent runs exactly as it would without a consult.
 export def renderGuidance(guidance: ExpertGuidance): string {
+  """Fold expert guidance into a context block the coding agent reads
+  before it starts. Empty guidance yields an empty string."""
   if (guidance.rules.length == 0 && guidance.checklist.length == 0) {
     return ""
   }
@@ -31,10 +30,9 @@ export def renderGuidance(guidance: ExpertGuidance): string {
   return "Domain expertise for this task (${guidance.domain}):\n\nKey rules and conventions:\n${rules}\n\nAcceptance checklist — your finished work MUST satisfy every item:\n${checks}"
 }
 
-/** Unwrap a consult Result, failing open: a consult that errored yields empty
-  guidance, so the caller proceeds exactly as it would without a consult.
-  Guidance can only help, never block. */
 export def guidanceOrEmpty(result: Result<ExpertGuidance>): ExpertGuidance {
+  """Unwrap a consult Result, failing open: a consult that errored yields
+  empty guidance, so the caller proceeds as if no consult happened."""
   return match(result) {
     success(guidance) => guidance
     failure(_) => emptyGuidance

--- a/packages/agency-lang/stdlib/agents/lib/feedback.agency
+++ b/packages/agency-lang/stdlib/agents/lib/feedback.agency
@@ -78,10 +78,10 @@ export def feedbackHasErrors(feedback: Result<Feedback[]>): boolean {
   return true
 }
 
-/** Pass a successful feedback list through unchanged; map any failure to no
-  findings. Use this to make a checker fail open: a checker that could not run
-  reports nothing rather than a blocking error. */
 export def failOpenFeedback(feedback: Result<Feedback[]>): Result<Feedback[]> {
+  """Pass a successful feedback list through unchanged; map any failure to
+  no findings, so a checker that could not run reports nothing rather than
+  a blocking error."""
   return match(feedback) {
     success(items) => success(items)
     failure(_) => success([])

--- a/packages/agency-lang/stdlib/agents/planner.agency
+++ b/packages/agency-lang/stdlib/agents/planner.agency
@@ -64,9 +64,9 @@ node main(): string {
   return result.value
 }"""
 
-/** Build the code-generation instruction: emit a program whose `node main` composes
-  the building blocks to carry out `planText` for `task`. */
 export def planCodePrompt(task: string, planText: string): string {
+  """Build the code-generation instruction: emit a program whose node main
+  composes the building blocks to carry out planText for task."""
   return """Write a complete Agency program (a node main) that carries out this plan, composing the building blocks below.
 
 Task:
@@ -92,9 +92,9 @@ def renderEffectLines(byExport: Record<string, string[]>): string {
   return lines.join("\n")
 }
 
-/** Human-readable capability envelope for the approval prompt, or an honest
-  note when the effects could not be computed. */
 export def renderEffects(effects: Result<EffectsByExport>): string {
+  """Human-readable capability envelope for the approval prompt, or an
+  honest note when the effects could not be computed."""
   return match(effects) {
     failure(_) => "(capabilities could not be computed)"
     success(byExport) => renderEffectLines(byExport)
@@ -189,6 +189,9 @@ export def runApproved(
   src: string,
   state: PlanState,
 ): PlanState raises <std::agents::planApprove> {
+  """Gate generated code behind user approval, then run it: shows the plan,
+  source, and capability envelope, and returns a rejected state instead of
+  running when approval is declined."""
   const eff = getEffects(src)
   // Show the plan alongside the generated source and capability envelope, so the
   // approval prompt reflects what the user is actually approving.

--- a/packages/agency-lang/stdlib/index.agency
+++ b/packages/agency-lang/stdlib/index.agency
@@ -95,10 +95,10 @@ export def getAgentCwd(): string {
   return _agentCwd
 }
 
-/** Used by read, write, and other functions to resolve
-relative paths against the agent working directory.
-*/
 export def applyAgentCwd(dir: string): string {
+  """Resolve a relative path against the agent working directory (set with
+  setAgentCwd). Absolute paths and an unset working directory pass through
+  unchanged. read, write, and the other file tools already call this."""
   const base = getAgentCwd()
   if (base == "") {
     return dir

--- a/packages/agency-lang/stdlib/math.agency
+++ b/packages/agency-lang/stdlib/math.agency
@@ -15,18 +15,22 @@ export def round(num: number, precision: number): number {
 }
 
 export def add(a: number, b: number): number {
+  """Add two numbers."""
   return a + b
 }
 
 export def subtract(a: number, b: number): number {
+  """Subtract b from a."""
   return a - b
 }
 
 export def multiply(a: number, b: number): number {
+  """Multiply two numbers."""
   return a * b
 }
 
 export def divide(a: number, b: number): Result<number> {
+  """Divide a by b. Fails when b is zero."""
   if (b == 0) {
     return failure("Cannot divide by zero")
   }

--- a/packages/agency-lang/stdlib/mcp.agency
+++ b/packages/agency-lang/stdlib/mcp.agency
@@ -26,28 +26,28 @@ effect mcp::call {
   args: Record<string, any>
 }
 
-/// True when the @agency-lang/mcp package is installed and reachable.
 export def isMcpAvailable(): boolean {
+  """True when the @agency-lang/mcp package is installed and reachable."""
   return _isMcpAvailable()
 }
 
-/// Read the mcpServers block from the project agency.json under `dir`.
 export def readProjectMcpConfig(dir: string): Record<string, any> {
+  """Read the mcpServers block from the project agency.json under `dir`."""
   return _readProjectMcpConfig(dir)
 }
 
-/// Merge global and project mcpServers configs (project wins on collision).
 export def mergeMcpServers(global: Record<string, any>, project: Record<string, any>): Record<string, any> {
+  """Merge global and project mcpServers configs (project wins on collision)."""
   return _mergeMcpServers(global, project)
 }
 
-/// Load gated MCP tools for every server in `merged`. Returns [] when the
-/// package is absent, incompatible, or no servers are configured.
 export def loadMcpTools(merged: Record<string, any>, onOAuthRequired?): any[] {
+  """Load gated MCP tools for every server in `merged`. Returns [] when the
+  package is absent, incompatible, or no servers are configured."""
   return _loadMcpTools(merged, onOAuthRequired)
 }
 
-/// Like loadMcpTools, but also returns a per-server status map for /mcp.
 export def loadMcpToolsWithStatus(merged: Record<string, any>, onOAuthRequired?): McpLoadResult {
+  """Like loadMcpTools, but also returns a per-server status map for /mcp."""
   return _loadMcpToolsWithStatus(merged, onOAuthRequired)
 }

--- a/packages/agency-lang/stdlib/policy.agency
+++ b/packages/agency-lang/stdlib/policy.agency
@@ -107,14 +107,19 @@ export static const approveAllPolicy = _approveAllPolicy
 export static const BUILTIN_POLICIES = _BUILTIN_POLICIES
 
 export def withWritesPolicy(baseDir: string) {
+  """The recommended policy plus file-system and git-write effects, each
+  scoped to `baseDir` and its children."""
   return _withWritesPolicy(baseDir)
 }
 
 export def builtinPolicy(name: string, baseDir: string): Policy | null {
+  """Resolve a built-in policy name to a concrete Policy, scoping
+  cwd-relative variants to `baseDir`. Returns null for an unknown name."""
   return _builtinPolicy(name, baseDir)
 }
 
 export def builtinPolicyNames(): string[] {
+  """The names accepted by builtinPolicy, e.g. for an approval prompt."""
   return _builtinPolicyNames()
 }
 
@@ -440,6 +445,7 @@ export def parsePolicyFile(path: string): Result<Policy, ParsePolicyFailure> {
   * with `parsePolicyFile` or constructing one by hand.
   */
 export def setPolicy(path: string, policy: Policy) {
+  """Install `policy` as the active policy and persist it to `path`."""
   _policy = policy
   _policyLoaded = true
   writePolicyFile(path, policy, []) with approve
@@ -521,6 +527,7 @@ def maybeFlush() {
  * handler).
  */
 export def flushPolicy() {
+  """Write any pending always-rule additions to the policy file now."""
   if (_pendingSave) {
     _pendingSave = false
     if (_policy != null) {

--- a/packages/agency-lang/stdlib/ui/cli.agency
+++ b/packages/agency-lang/stdlib/ui/cli.agency
@@ -104,6 +104,7 @@ export def repl(
 }
 
 export def clearScreen() {
+  """Clear the terminal screen."""
   _clearScreen()
 }
 
@@ -119,6 +120,8 @@ def termWidth(): number {
 }
 
 export def hline(char: string = "─", width: number = null): string {
+  """Return a horizontal rule: `char` repeated `width` times (terminal
+  width when `width` is omitted)."""
   let _width = width || termWidth()
   return char.repeat(_width)
 }

--- a/packages/agency-lang/stdlib/weather.agency
+++ b/packages/agency-lang/stdlib/weather.agency
@@ -63,10 +63,12 @@ export def weather(location: string, units: "imperial" | "metric" = "imperial"):
 }
 
 export def celsiusToFahrenheit(celsius: number): number {
+  """Convert a temperature from Celsius to Fahrenheit."""
   return celsius * 9 / 5 + 32
 }
 
 export def fahrenheitToCelsius(fahrenheit: number): number {
+  """Convert a temperature from Fahrenheit to Celsius."""
   let diff = fahrenheit - 32
   return diff * 5 / 9
 }


### PR DESCRIPTION
PR A of three from the lint-rules-v2 plan (spec + reviews in the worktree-lint-list worktree). Adds the two AST-only rules; PR B (severity plumbing + AL0004) and PR C (scope rules) follow after this merges.

## AL0002 — missing-docstring

An exported function with no docstring. Functions are tools: the docstring becomes the tool description the LLM reads, so an undocumented export hands every importing agent a tool with no description. Functions only — a compile trace confirmed node docstrings never reach generated code (their only consumers are `agency doc` and an interpolation-presence check), and the stale preprocessor comment implying otherwise is reworded in this PR. No autofix: the fix is prose only the author can write.

**Noise measurement (per the plan):** 56 findings across the repo — 26 in `stdlib/`, 30 in test fixtures. The 26 stdlib docstrings are **fixed in this PR** (second commit): most were existing `///` or `/** */` doc comments converted to docstrings so they actually reach the LLM, which is exactly the near-miss the rule exists to catch. Fixture findings are left alone (not user-facing). Stdlib reference docs regenerated via `make`.

## AL0003 — redundant-prelude-import

`import { map } from "std::index"` imports a name every file already has. The rule's membership test is `PRELUDE_NAMES.includes(name)` — NOT the module path — because `std::index` also exports names outside the prelude (types like `WriteMode`, which must be imported and are never flagged). Also never flagged: aliased names (`map as arrMap` binds a new name) and names carrying `destructive`/`idempotent` markers (the marker changes retry behavior; deleting it would be a safety regression). The removal fix reuses the AL0001 regeneration machinery, safe precisely because every flagged name is plain.

## LSP correctness fix underneath both

The LSP's lint snapshot was not actually pristine: `prunePreludeShadows` mutates user-written `std::index` import statements in place before the linter runs (the old alias protected the nodes array, not the objects). AL0001 never noticed because it skips those statements; AL0003 reads exactly them. `cloneForLint` now deep-copies just the `std::index` import nodes into the snapshot, pinned by a re-run-stability test and a CLI/LSP agreement test on the shadowed-prelude case.

## Refactor (from the plan's anti-pattern review)

- `walkValues` in `lib/linter/rules/util.ts` is now the linter's ONE recursive descent; `collectReferencedNames` is a callback over it (and re-signed to take `AgencyNode[]`, its only caller updated).
- Range helpers (`nameRange`, `statementSpan`, `locFromOffsets`) and the import-fix machinery (`removalEdit` et al.) extracted to shared modules for the new rules.
- Rule bodies are declarative helper→map with named predicates (`undocumentedExports`, `isRedundant`), matching AL0001's shape.

Main drifted under the plan in one spot: template holes (#665) make `importedNames` and `functionName` `string | Hole`, so both new rules filter to string entries (a hole is a template fragment, not a lintable name).

## Testing

205 tests green across linter/LSP/CLI/docs (18 new rule tests including the at-risk keeps: `WriteMode`, aliased, destructive/idempotent-marked, two-redundant-names fixes; per-rule `lintSource` smoke tests; snapshot stability + CLI/LSP agreement). Structural linter clean. Diagnostics docs regenerated — AL0002/AL0003 now on `docs/site/diagnostics/lint.md`, plus the rules section of `docs/site/cli/lint.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
