### PR TITLE
Typechecker: flatten a union whose member is itself a union

### DIFF
--- a/packages/agency-lang/lib/typeChecker/assignability.ts
+++ b/packages/agency-lang/lib/typeChecker/assignability.ts
@@ -194,6 +194,38 @@ function resolveTypeWithGuard(
     return attachAliasTags(resolved, valueSubstituted.tags);
   }
 
+  if (vt.type === "unionType") {
+    // A member of a union can itself be a union, usually through an alias:
+    //
+    //   type WordPart = { tag: "literal", ... } | { tag: "variable", ... }
+    //   type BashNode = WordPart | BashWord | ...
+    //
+    // Splice those inner members into the outer list. Everything that walks a
+    // union member by member — property access, discriminant narrowing, match
+    // exhaustiveness — only knows what to do with an object member, so an
+    // unspliced `WordPart` member looks like a member with no `tag` property
+    // and blocks all three.
+    //
+    // Members that aren't unions are kept exactly as written (not resolved), so
+    // error messages still name the alias instead of printing its whole body.
+    const flattened: VariableType[] = [];
+    let spliced = false;
+    for (const member of vt.types) {
+      const resolvedMember = resolveTypeWithGuard(member, typeAliases, inProgress);
+      if (resolvedMember.type !== "unionType") {
+        flattened.push(member);
+        continue;
+      }
+      spliced = true;
+      // The inner union's tags (from `@validate type AB = A | B`) describe its
+      // values, so each member it contributes carries them.
+      for (const inner of resolvedMember.types) {
+        flattened.push(attachAliasTags(inner, resolvedMember.tags));
+      }
+    }
+    return spliced ? { ...vt, types: flattened } : vt;
+  }
+
   return vt;
 }
 

--- a/packages/agency-lang/lib/typeChecker/matchExhaustiveness.test.ts
+++ b/packages/agency-lang/lib/typeChecker/matchExhaustiveness.test.ts
@@ -443,3 +443,36 @@ def f(b: boolean): number {
 }`, ERROR).some((m) => /not exhaustive/i.test(m))).toBe(false);
   });
 });
+
+const NESTED_UNION = `
+type A = { tag: "a", x: number }
+type B = { tag: "b", y: string }
+type AB = A | B
+type C = { tag: "c", z: boolean }
+type Node = AB | C
+`;
+
+describe("match exhaustiveness — a union member that is itself a union", () => {
+  it("counts the tags of an inner union alias as members to cover", () => {
+    const errs = check(`${NESTED_UNION}
+def f(n: Node): any {
+  return match (n.tag) {
+    "a" => 1
+    "c" => 3
+  }
+}`, ERROR);
+    expect(errs.some((e) => /not exhaustive/i.test(e) && /"b"/.test(e))).toBe(true);
+  });
+
+  it("covering every inner tag is exhaustive", () => {
+    const errs = check(`${NESTED_UNION}
+def f(n: Node): any {
+  return match (n.tag) {
+    "a" => 1
+    "b" => 2
+    "c" => 3
+  }
+}`, ERROR);
+    expect(errs).toEqual([]);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/resolveType.test.ts
+++ b/packages/agency-lang/lib/typeChecker/resolveType.test.ts
@@ -623,3 +623,58 @@ describe("resolveTypeDeep: nested generic resolution", () => {
     expect(resolveTypeDeep(numberType, {})).toEqual(numberType);
   });
 });
+
+describe("resolveType: nested unions", () => {
+  const alias = (aliasName: string): VariableType => ({
+    type: "typeAliasVariable",
+    aliasName,
+  });
+
+  it("splices a union alias used as a member of another union", () => {
+    const aliases: Record<string, TypeAliasEntry> = {
+      AB: { body: { type: "unionType", types: [alias("A"), alias("B")] } },
+      A: { body: { type: "objectType", properties: [{ key: "x", value: numberType }] } },
+      B: { body: { type: "objectType", properties: [{ key: "y", value: stringType }] } },
+      C: { body: { type: "objectType", properties: [{ key: "z", value: booleanType }] } },
+    };
+    const result = resolveType(
+      { type: "unionType", types: [alias("AB"), alias("C")] },
+      aliases,
+    );
+    // Members stay unresolved, so error messages keep saying `A`, not `{x: number}`.
+    expect(result).toEqual({
+      type: "unionType",
+      types: [alias("A"), alias("B"), alias("C")],
+    });
+  });
+
+  it("splices unions nested more than one level deep", () => {
+    const aliases: Record<string, TypeAliasEntry> = {
+      Outer: { body: { type: "unionType", types: [alias("Inner"), stringType] } },
+      Inner: { body: { type: "unionType", types: [numberType, booleanType] } },
+    };
+    const result = resolveType(
+      { type: "unionType", types: [alias("Outer"), anyType] },
+      aliases,
+    );
+    expect(result).toEqual({
+      type: "unionType",
+      types: [numberType, booleanType, stringType, anyType],
+    });
+  });
+
+  it("leaves a union with no union members untouched", () => {
+    const input: VariableType = { type: "unionType", types: [numberType, stringType] };
+    expect(resolveType(input, {})).toBe(input);
+  });
+
+  it("terminates on a self-referential union alias", () => {
+    const aliases: Record<string, TypeAliasEntry> = {
+      T: { body: { type: "unionType", types: [alias("T"), numberType] } },
+    };
+    expect(resolveType(alias("T"), aliases)).toEqual({
+      type: "unionType",
+      types: [alias("T"), numberType],
+    });
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/resolveType.test.ts
+++ b/packages/agency-lang/lib/typeChecker/resolveType.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { resolveType, resolveTypeDeep } from "./assignability.js";
-import type { TypeAliasEntry, VariableType } from "../types.js";
+import type { Tag, TypeAliasEntry, VariableType } from "../types.js";
 
 const stringType: VariableType = { type: "primitiveType", value: "string" };
 const numberType: VariableType = { type: "primitiveType", value: "number" };
@@ -675,6 +675,38 @@ describe("resolveType: nested unions", () => {
     expect(resolveType(alias("T"), aliases)).toEqual({
       type: "unionType",
       types: [alias("T"), numberType],
+    });
+  });
+
+  it("carries an inner union's validators onto every member it contributes", () => {
+    // `@validate(isPositive) type AB = A | B` means values of A and of B are
+    // both validated. Splicing must not drop that, or a value that arrives as
+    // an `A` would skip the validator the alias declared.
+    const isPositive: Tag = {
+      type: "tag",
+      name: "validate",
+      arguments: [{ type: "variableName", value: "isPositive" }],
+    };
+    const aliases: Record<string, TypeAliasEntry> = {
+      AB: {
+        body: { type: "unionType", types: [alias("A"), alias("B")] },
+        tags: [isPositive],
+      },
+      A: { body: numberType },
+      B: { body: stringType },
+      C: { body: booleanType },
+    };
+    const result = resolveType(
+      { type: "unionType", types: [alias("AB"), alias("C")] },
+      aliases,
+    );
+    expect(result).toEqual({
+      type: "unionType",
+      types: [
+        { ...alias("A"), tags: [isPositive] },
+        { ...alias("B"), tags: [isPositive] },
+        alias("C"), // outside the tagged alias — untouched
+      ],
     });
   });
 });

--- a/packages/agency-lang/lib/typeChecker/strictMemberAccess.test.ts
+++ b/packages/agency-lang/lib/typeChecker/strictMemberAccess.test.ts
@@ -337,3 +337,33 @@ def g(): string {
     expect(errors.length).toBeGreaterThan(0);
   });
 });
+
+describe("strict member access — a union member that is itself a union", () => {
+  const NESTED_UNION = `
+type A = { tag: "a", x: number }
+type B = { tag: "b", y: string }
+type AB = A | B
+type C = { tag: "c", z: boolean }
+type Node = AB | C
+`;
+
+  it("reads a discriminant shared by every tag of an inner union alias", () => {
+    const errs = check(`${NESTED_UNION}
+def f(n: Node): any {
+  return n.tag
+}`);
+    expect(errs.errors).toEqual([]);
+  });
+
+  it("narrows through an inner union alias, so the arm can read its own field", () => {
+    const errs = check(`${NESTED_UNION}
+def f(n: Node): any {
+  return match (n.tag) {
+    "a" => n.x
+    "b" => n.y
+    "c" => n.z
+  }
+}`);
+    expect(errs.errors).toEqual([]);
+  });
+});


### PR DESCRIPTION
## The bug

A union member can itself be a union, usually through an alias. Writing a Bash AST in Agency hits this immediately:

```ts
type WordPart =
  | { tag: "literal", text: string }
  | { tag: "variable", name: string }
  | ...

type BashNode = WordPart | BashWord | Assignment | ... | List
```

`resolveType` expanded type aliases but returned unions untouched, so `WordPart` and `Command` stayed single opaque members of `BashNode`. Everything downstream walks a union member by member and only knows what to do with an *object* member, so three things broke at once:

```ts
def simplify(node: BashNode): any {
  return match(node.tag) {
    "list" => [simplify(item) for item in node.items]
  }
}
```

```
error AG2008: Property 'tag' is not available on every member of
  'WordPart | BashWord | Assignment | Redirect | Command | Pipeline | AndOr | ListItem | List'
error AG2008: Property 'items' is not available on every member of 'WordPart | Command | List'
error AG5002: match is not exhaustive: missing "word", "assignment", "redirect", "pipeline", "andOr", "listItem"
```

- **Property access** (`unionPropertyAccess`, synthesizer.ts:131) counted `WordPart` as "does not have `tag`", so reading the discriminant every member shares was an error.
- **Discriminant narrowing** (`narrowUnionByDiscriminant`, narrowing.ts:341) could not tell whether `WordPart` matched `"list"`, so it kept the member and the arm body stayed unnarrowed.
- **Exhaustiveness** listed 6 tags. The type actually has 22 — everything inside `WordPart` and `Command` was invisible.

## The fix

`resolveType` now splices an inner union's members into the outer list. Two details worth calling out:

- Members that are **not** unions are kept exactly as written rather than resolved, so error messages still say `A` instead of printing `{x: number}`.
- An inner union's tags (`@validate type AB = A | B`) are merged onto each member it contributes — the tag describes those values either way.

Self-referential aliases (`type T = T | number`) terminate through the existing in-progress guard.

## Verification

- The failing `match` above now typechecks, and without a wildcard arm exhaustiveness correctly reports all 22 missing tags.
- 8 new tests across `resolveType.test.ts` (splicing, multi-level nesting, identity when nothing to splice, self-reference), `matchExhaustiveness.test.ts`, and `strictMemberAccess.test.ts`. Confirmed 4 of them fail without the fix.
- Full typechecker suite green: 1664 tests, including the 162 fixture typecheck integration tests.
- Full `lib` suite: the only failures are 5 pre-existing ones in `mcpBridge.contract` and `optimize/mutator`, verified failing on a clean tree too.
- `pnpm run lint:structure` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
