### PR TITLE
Perf tests (1/3): informational scaling-ratio suite + harness + lint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,14 +71,11 @@ jobs:
       run: pnpm run docs
     - run: pnpm test:run
 
-  # Performance regression suite. INFORMATIONAL ONLY for now: PERF_ENFORCE is
-  # unset, so a slow-scaling measurement records a breach but does not throw,
-  # and continue-on-error keeps even an unexpected failure from blocking a
-  # merge while thresholds are calibrated from the uploaded results. Flip to
-  # gating later by setting PERF_ENFORCE=1 and removing continue-on-error —
-  # the tests do not change. Single node version (not the 22/23 matrix) so the
-  # numbers come from one machine class. No `make`: these tests all run from
-  # source through vitest; add it only when dist-dependent perf tests land.
+  # Performance regression suite, INFORMATIONAL ONLY: PERF_ENFORCE is unset (a
+  # breach records but does not throw) and continue-on-error means nothing here
+  # blocks a merge while thresholds are calibrated. Flip to gating by setting
+  # PERF_ENFORCE=1 and dropping continue-on-error. Single node (numbers from one
+  # machine class); no `make` (these tests run from source via vitest).
   perf:
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,58 @@ jobs:
       run: pnpm run docs
     - run: pnpm test:run
 
+  # Performance regression suite. INFORMATIONAL ONLY for now: PERF_ENFORCE is
+  # unset, so a slow-scaling measurement records a breach but does not throw,
+  # and continue-on-error keeps even an unexpected failure from blocking a
+  # merge while thresholds are calibrated from the uploaded results. Flip to
+  # gating later by setting PERF_ENFORCE=1 and removing continue-on-error —
+  # the tests do not change. Single node version (not the 22/23 matrix) so the
+  # numbers come from one machine class. No `make`: these tests all run from
+  # source through vitest; add it only when dist-dependent perf tests land.
+  perf:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        persist-credentials: false
+
+    - name: Set up pnpm
+      uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+      with:
+        version: 9
+        run_install: false
+
+    - name: Set up Node.js
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      with:
+        node-version: 22.x
+        cache: 'pnpm'
+    - run: pnpm install
+    - name: Perf summary header
+      run: |
+        {
+          echo "### Performance measurements (informational)"
+          echo ""
+          echo "| test | growth factor / ms | bound | status |"
+          echo "| --- | --- | --- | --- |"
+        } >> "$GITHUB_STEP_SUMMARY"
+    - name: Run performance suite (informational)
+      working-directory: packages/agency-lang
+      run: pnpm test:perf
+
+    # Upload the per-measurement records so a p95 can be aggregated across many
+    # runs during the informational period — step summaries alone can't do that.
+    - name: Upload perf results
+      if: always()
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      with:
+        name: perf-results
+        path: packages/agency-lang/perf-results.jsonl
+        if-no-files-found: warn
+
   # Integration tests (tarball install, bundlers, CLI, StateLog, stdlib
   # sandbox). These are node-22-only and independent of the unit suite, so
   # they run in parallel with `build` rather than serially behind it.

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 # so the intent survives if the broad dot-rule is ever narrowed.
 .agency-build/
 **/index.mts
+# Perf suite output (written to cwd by the harness recorder).
+**/perf-results.jsonl
 **/__evaluate.*
 **/__judge*
 **/tests/**/*.evaluate.js

--- a/packages/agency-lang/lib/perf/fixtures.test.ts
+++ b/packages/agency-lang/lib/perf/fixtures.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, afterAll } from "vitest";
+import * as fs from "fs";
+import { parseAgency } from "../parser.js";
+import {
+  manyFunctions,
+  manyUnusedImports,
+  manyRedundantPreludeImports,
+  deepNesting,
+  wideUnion,
+  oneHugeFunction,
+  multiFileProject,
+} from "./fixtures.js";
+
+function parses(source: string): boolean {
+  return parseAgency(source, {}, false).success;
+}
+
+describe("perf fixtures parse and scale", () => {
+  const stringGens: [string, (n: number) => string][] = [
+    ["manyFunctions", (n) => manyFunctions(n)],
+    ["manyFunctions(no docstrings)", (n) => manyFunctions(n, { docstrings: false })],
+    ["manyUnusedImports", manyUnusedImports],
+    ["manyRedundantPreludeImports", manyRedundantPreludeImports],
+    ["deepNesting", deepNesting],
+    ["wideUnion", wideUnion],
+    ["oneHugeFunction", oneHugeFunction],
+  ];
+
+  for (const [name, gen] of stringGens) {
+    it(`${name} produces parseable source that grows with n`, () => {
+      expect(parses(gen(10))).toBe(true);
+      expect(gen(20).length).toBeGreaterThan(gen(10).length);
+    });
+  }
+
+  const createdDirs: string[] = [];
+  afterAll(() => {
+    for (const dir of createdDirs) fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("multiFileProject materializes a directory of n files", () => {
+    const dir = multiFileProject(8);
+    createdDirs.push(dir);
+    expect(fs.existsSync(dir)).toBe(true);
+    const files = fs.readdirSync(dir).filter((f) => f.endsWith(".agency"));
+    expect(files).toHaveLength(8);
+    expect(parses(fs.readFileSync(`${dir}/file7.agency`, "utf-8"))).toBe(true);
+  });
+});

--- a/packages/agency-lang/lib/perf/fixtures.ts
+++ b/packages/agency-lang/lib/perf/fixtures.ts
@@ -1,0 +1,111 @@
+/**
+ * Synthesized fixtures for the perf suite. Each string generator produces
+ * Agency source of controlled size so scaling tests can pick exact N and 8N.
+ * Every generator's output MUST parse — a fixture that silently fails to parse
+ * makes the thing under test return nothing and the perf number becomes
+ * meaningless (fixtures.test.ts pins this).
+ */
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+/** n exported functions with small bodies. `docstrings: false` drops the
+ *  docstring so every function becomes a missing-docstring finding (AL0002);
+ *  `true` (the default) is the clean shape for parse/typecheck/fmt/compile. */
+export function manyFunctions(n: number, opts: { docstrings?: boolean } = {}): string {
+  const withDoc = opts.docstrings ?? true;
+  const parts: string[] = [];
+  for (let i = 0; i < n; i++) {
+    parts.push(`export def fn${i}(a: number, b: number): number {`);
+    if (withDoc) parts.push(`  """Compute a result from a and b for case ${i}."""`);
+    parts.push(`  let x = a + b`);
+    parts.push(`  let y = x + 1`);
+    parts.push(`  return y`);
+    parts.push(`}`);
+  }
+  return `${parts.join("\n")}\n`;
+}
+
+/** n unused named imports from distinct modules — a findings-dense input for
+ *  the unused-import rule (AL0001). A trivial function keeps the file valid. */
+export function manyUnusedImports(n: number): string {
+  const parts: string[] = [];
+  for (let i = 0; i < n; i++) {
+    parts.push(`import { thing${i} } from "./mod${i}.agency"`);
+  }
+  parts.push(`export def noop(): number { return 1 }`);
+  return `${parts.join("\n")}\n`;
+}
+
+/** n redundant `import { map } from "std::index"` statements — findings-dense
+ *  for the redundant-prelude rule (AL0003), each at a growing offset (the shape
+ *  that exposed the locFromOffsets O(n^2)). */
+export function manyRedundantPreludeImports(n: number): string {
+  const parts: string[] = [];
+  for (let i = 0; i < n; i++) {
+    parts.push(`import { map } from "std::index"`);
+  }
+  parts.push(`export def noop(): number { return 1 }`);
+  return `${parts.join("\n")}\n`;
+}
+
+/** One function whose body is n-deep nested `if` blocks. Stresses recursive
+ *  descent in the parser, generator, and type checker. */
+export function deepNesting(n: number): string {
+  const lines: string[] = [`export def deep(x: number): number {`];
+  for (let i = 0; i < n; i++) {
+    lines.push(`${"  ".repeat(i + 1)}if (x > ${i}) {`);
+  }
+  lines.push(`${"  ".repeat(n + 1)}return x`);
+  for (let i = n - 1; i >= 0; i--) {
+    lines.push(`${"  ".repeat(i + 1)}}`);
+  }
+  lines.push(`  return 0`);
+  lines.push(`}`);
+  return `${lines.join("\n")}\n`;
+}
+
+/** An n-arm string-literal union used by a function. Type checkers commonly go
+ *  quadratic on union handling, so this is the typecheck-specific stressor. */
+export function wideUnion(n: number): string {
+  const arms = Array.from({ length: n }, (_, i) => `"a${i}"`).join(" | ");
+  const parts: string[] = [`type Wide = ${arms}`, ``];
+  // A handful of functions that take and return the wide union, so the type is
+  // resolved at several sites rather than once.
+  for (let i = 0; i < 5; i++) {
+    parts.push(`export def use${i}(v: Wide): Wide {`);
+    parts.push(`  return v`);
+    parts.push(`}`);
+  }
+  return `${parts.join("\n")}\n`;
+}
+
+/** One function with n statements — same total size as manyFunctions(n) but a
+ *  different shape, to catch per-function-overhead regressions. */
+export function oneHugeFunction(n: number): string {
+  const lines: string[] = [`export def huge(a: number): number {`, `  let acc = a`];
+  for (let i = 0; i < n; i++) {
+    lines.push(`  acc = acc + ${i}`);
+  }
+  lines.push(`  return acc`);
+  lines.push(`}`);
+  return `${lines.join("\n")}\n`;
+}
+
+/**
+ * Materializes a temp directory of n interdependent `.agency` files and returns
+ * its PATH (not a string) — bundle and the build manifest read files from disk.
+ * File i imports a name from file i-1, so the project has a real dependency
+ * chain. Caller is responsible for cleanup.
+ */
+export function multiFileProject(n: number): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "perf-project-"));
+  for (let i = 0; i < n; i++) {
+    const lines: string[] = [];
+    if (i > 0) lines.push(`import { val${i - 1} } from "./file${i - 1}.agency"`);
+    const prev = i > 0 ? `val${i - 1}` : "0";
+    lines.push(`export const val${i}: number = ${prev} + ${i}`);
+    fs.writeFileSync(path.join(dir, `file${i}.agency`), `${lines.join("\n")}\n`, "utf-8");
+  }
+  return dir;
+}

--- a/packages/agency-lang/lib/perf/fixtures.ts
+++ b/packages/agency-lang/lib/perf/fixtures.ts
@@ -1,9 +1,7 @@
 /**
- * Synthesized fixtures for the perf suite. Each string generator produces
- * Agency source of controlled size so scaling tests can pick exact N and 8N.
- * Every generator's output MUST parse — a fixture that silently fails to parse
- * makes the thing under test return nothing and the perf number becomes
- * meaningless (fixtures.test.ts pins this).
+ * Size-controlled fixtures for the perf suite. Every generator's output must
+ * parse (fixtures.test.ts pins this) — a fixture that silently fails to parse
+ * measures nothing and the perf number becomes meaningless.
  */
 import * as fs from "fs";
 import * as os from "os";
@@ -92,12 +90,8 @@ export function oneHugeFunction(n: number): string {
   return `${lines.join("\n")}\n`;
 }
 
-/**
- * Materializes a temp directory of n interdependent `.agency` files and returns
- * its PATH (not a string) — bundle and the build manifest read files from disk.
- * File i imports a name from file i-1, so the project has a real dependency
- * chain. Caller is responsible for cleanup.
- */
+/** A temp directory of n chained `.agency` files (each imports the previous),
+ *  returned as a PATH — bundle and the manifest read from disk. Caller cleans up. */
 export function multiFileProject(n: number): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "perf-project-"));
   for (let i = 0; i < n; i++) {

--- a/packages/agency-lang/lib/perf/harness.perf.test.ts
+++ b/packages/agency-lang/lib/perf/harness.perf.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { measureMs, growthFactor, GROWTH_BOUND } from "./harness.js";
+
+// The timing-dependent harness meta-tests. They live in the serialized perf
+// suite (not the parallel default unit run) so CPU contention can't flake the
+// `< GROWTH_BOUND` assertion into a merge-blocking failure. Closures are sized
+// so a single call is several ms — well above timing noise — and use pure
+// arithmetic loops (no large arrays) to stay memory-cheap at 8x sizes.
+
+function linearWork(n: number): () => number {
+  return () => {
+    let s = 0;
+    for (let i = 0; i < n; i++) s = (s + i * 2654435761) >>> 0;
+    return s;
+  };
+}
+
+function quadraticWork(n: number): () => number {
+  return () => {
+    let s = 0;
+    for (let i = 0; i < n; i++) {
+      for (let j = 0; j < n; j++) s = (s + (i ^ j)) >>> 0;
+    }
+    return s;
+  };
+}
+
+describe("perf harness timing (serialized)", () => {
+  it("measureMs returns a positive, roughly stable time", () => {
+    const fn = linearWork(4_000_000);
+    const a = measureMs(fn);
+    const b = measureMs(fn);
+    expect(a).toBeGreaterThan(0);
+    expect(Math.max(a, b) / Math.min(a, b)).toBeLessThan(5);
+  });
+
+  it("canary: a quadratic algorithm's growth factor is well above the bound", () => {
+    // Normalized quadratic ≈ 8 at an 8x step — huge margin over the bound.
+    const factor = growthFactor(quadraticWork, 700, 5600);
+    expect(factor).toBeGreaterThan(GROWTH_BOUND * 1.5);
+  });
+
+  it("self-consistency: a linear algorithm's growth factor is below the bound", () => {
+    // The test the old un-normalized (bound == step) design would have failed on
+    // correct code: a raw ratio of ~8 is not < 8. Normalization makes it ~1.
+    const factor = growthFactor(linearWork, 4_000_000, 32_000_000);
+    expect(factor).toBeLessThan(GROWTH_BOUND);
+  });
+});

--- a/packages/agency-lang/lib/perf/harness.test.ts
+++ b/packages/agency-lang/lib/perf/harness.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+  measureMs,
+  growthFactor,
+  expectPerf,
+  GROWTH_BOUND,
+} from "./harness.js";
+
+// A linear closure: O(n) work whose result is returned (so it is not
+// dead-code-eliminated). Sized so a single call is comfortably measurable.
+function linearWork(n: number): () => number {
+  const arr = Array.from({ length: n }, (_, i) => i);
+  return () => {
+    let sum = 0;
+    for (let i = 0; i < arr.length; i++) sum += arr[i];
+    return sum;
+  };
+}
+
+// A quadratic closure: O(n^2) work. At an 8x step this grows ~64x, so its
+// normalized growth factor is ~8 — far above the bound.
+function quadraticWork(n: number): () => number {
+  return () => {
+    let sum = 0;
+    for (let i = 0; i < n; i++) {
+      for (let j = 0; j < n; j++) sum += i ^ j;
+    }
+    return sum;
+  };
+}
+
+describe("perf harness", () => {
+  it("measureMs returns a positive, roughly stable time", () => {
+    const fn = linearWork(200_000);
+    const a = measureMs(fn);
+    const b = measureMs(fn);
+    expect(a).toBeGreaterThan(0);
+    // Same closure twice: within a wide tolerance (CI noise), not identical.
+    expect(Math.max(a, b) / Math.min(a, b)).toBeLessThan(5);
+  });
+
+  it("canary: a quadratic algorithm's growth factor is well above the bound", () => {
+    const factor = growthFactor(quadraticWork, 500, 4000);
+    // Normalized quadratic ≈ 8 at an 8x step; assert it clears the bound with room.
+    expect(factor).toBeGreaterThan(GROWTH_BOUND * 1.5);
+  });
+
+  it("self-consistency: a linear algorithm's growth factor is below the bound", () => {
+    // This is the test the old RATIO_BOUND=8-vs-8x-step design would have failed
+    // on correct code: a raw ratio of ~8 is not < 8. Normalization makes it ~1.
+    const factor = growthFactor(linearWork, 500_000, 4_000_000);
+    expect(factor).toBeLessThan(GROWTH_BOUND);
+  });
+
+  it("schedule: samples are interleaved, order-alternated, and warmed up front", () => {
+    const log: number[] = [];
+    const build = (n: number) => () => {
+      log.push(n);
+      return n;
+    };
+    const warmup = 2;
+    const rounds = 4;
+    growthFactor(build, 1, 8, { warmup, rounds });
+
+    // Warmup prefix: `warmup` calls of small, then `warmup` of large — both
+    // sizes warmed before any timed round.
+    const prefix = log.slice(0, 2 * warmup);
+    expect(prefix).toEqual([1, 1, 8, 8]);
+
+    // Timed portion: `rounds` pairs, order alternating small→large, large→small.
+    const timed = log.slice(2 * warmup);
+    expect(timed).toHaveLength(2 * rounds);
+    for (let r = 0; r < rounds; r++) {
+      const pair = timed.slice(2 * r, 2 * r + 2);
+      expect(pair).toEqual(r % 2 === 0 ? [1, 8] : [8, 1]);
+    }
+  });
+});
+
+describe("expectPerf recorder and gate", () => {
+  let resultsFile: string;
+  let savedEnforce: string | undefined;
+  let savedFile: string | undefined;
+
+  beforeEach(() => {
+    resultsFile = path.join(os.tmpdir(), `perf-test-${process.pid}-${Date.now()}.jsonl`);
+    savedEnforce = process.env.PERF_ENFORCE;
+    savedFile = process.env.PERF_RESULTS_FILE;
+    process.env.PERF_RESULTS_FILE = resultsFile;
+    delete process.env.PERF_ENFORCE;
+  });
+
+  afterEach(() => {
+    if (savedEnforce === undefined) delete process.env.PERF_ENFORCE;
+    else process.env.PERF_ENFORCE = savedEnforce;
+    if (savedFile === undefined) delete process.env.PERF_RESULTS_FILE;
+    else process.env.PERF_RESULTS_FILE = savedFile;
+    if (fs.existsSync(resultsFile)) fs.unlinkSync(resultsFile);
+  });
+
+  it("records one parseable line per call, with the label and value", () => {
+    expectPerf("test:label", 1.23, 2.0);
+    const lines = fs.readFileSync(resultsFile, "utf-8").trim().split("\n");
+    expect(lines).toHaveLength(1);
+    const rec = JSON.parse(lines[0]);
+    expect(rec.label).toBe("test:label");
+    expect(rec.value).toBe(1.23);
+    expect(rec.pass).toBe(true);
+  });
+
+  it("does not throw on a breach when PERF_ENFORCE is unset (informational)", () => {
+    expect(() => expectPerf("test:breach", 9.0, 2.0)).not.toThrow();
+  });
+
+  it("throws on a breach when PERF_ENFORCE is set", () => {
+    process.env.PERF_ENFORCE = "1";
+    expect(() => expectPerf("test:breach", 9.0, 2.0)).toThrow(/perf regression/);
+  });
+
+  it("does not throw when under bound even with PERF_ENFORCE set", () => {
+    process.env.PERF_ENFORCE = "1";
+    expect(() => expectPerf("test:ok", 1.0, 2.0)).not.toThrow();
+  });
+});

--- a/packages/agency-lang/lib/perf/harness.test.ts
+++ b/packages/agency-lang/lib/perf/harness.test.ts
@@ -2,60 +2,17 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import {
-  measureMs,
-  growthFactor,
-  expectPerf,
-  GROWTH_BOUND,
-} from "./harness.js";
+import { growthFactor, expectPerf } from "./harness.js";
 
-// A linear closure: O(n) work whose result is returned (so it is not
-// dead-code-eliminated). Sized so a single call is comfortably measurable.
-function linearWork(n: number): () => number {
-  const arr = Array.from({ length: n }, (_, i) => i);
-  return () => {
-    let sum = 0;
-    for (let i = 0; i < arr.length; i++) sum += arr[i];
-    return sum;
-  };
-}
+// Only the deterministic (timing-independent) harness tests live here, in the
+// default unit suite. The timing-dependent ones (measureMs, canary,
+// self-consistency) are in harness.perf.test.ts — the default suite runs files
+// in parallel, and a `< GROWTH_BOUND` assertion on real timings could flake
+// under that contention and block a merge. The serialized perf suite runs them
+// safely.
 
-// A quadratic closure: O(n^2) work. At an 8x step this grows ~64x, so its
-// normalized growth factor is ~8 — far above the bound.
-function quadraticWork(n: number): () => number {
-  return () => {
-    let sum = 0;
-    for (let i = 0; i < n; i++) {
-      for (let j = 0; j < n; j++) sum += i ^ j;
-    }
-    return sum;
-  };
-}
-
-describe("perf harness", () => {
-  it("measureMs returns a positive, roughly stable time", () => {
-    const fn = linearWork(200_000);
-    const a = measureMs(fn);
-    const b = measureMs(fn);
-    expect(a).toBeGreaterThan(0);
-    // Same closure twice: within a wide tolerance (CI noise), not identical.
-    expect(Math.max(a, b) / Math.min(a, b)).toBeLessThan(5);
-  });
-
-  it("canary: a quadratic algorithm's growth factor is well above the bound", () => {
-    const factor = growthFactor(quadraticWork, 500, 4000);
-    // Normalized quadratic ≈ 8 at an 8x step; assert it clears the bound with room.
-    expect(factor).toBeGreaterThan(GROWTH_BOUND * 1.5);
-  });
-
-  it("self-consistency: a linear algorithm's growth factor is below the bound", () => {
-    // This is the test the old RATIO_BOUND=8-vs-8x-step design would have failed
-    // on correct code: a raw ratio of ~8 is not < 8. Normalization makes it ~1.
-    const factor = growthFactor(linearWork, 500_000, 4_000_000);
-    expect(factor).toBeLessThan(GROWTH_BOUND);
-  });
-
-  it("schedule: samples are interleaved, order-alternated, and warmed up front", () => {
+describe("growthFactor schedule", () => {
+  it("interleaves, order-alternates, and warms both sizes up front", () => {
     const log: number[] = [];
     const build = (n: number) => () => {
       log.push(n);
@@ -65,17 +22,14 @@ describe("perf harness", () => {
     const rounds = 4;
     growthFactor(build, 1, 8, { warmup, rounds });
 
-    // Warmup prefix: `warmup` calls of small, then `warmup` of large — both
-    // sizes warmed before any timed round.
-    const prefix = log.slice(0, 2 * warmup);
-    expect(prefix).toEqual([1, 1, 8, 8]);
+    // Warmup prefix: `warmup` calls of small, then `warmup` of large.
+    expect(log.slice(0, 2 * warmup)).toEqual([1, 1, 8, 8]);
 
     // Timed portion: `rounds` pairs, order alternating small→large, large→small.
     const timed = log.slice(2 * warmup);
     expect(timed).toHaveLength(2 * rounds);
     for (let r = 0; r < rounds; r++) {
-      const pair = timed.slice(2 * r, 2 * r + 2);
-      expect(pair).toEqual(r % 2 === 0 ? [1, 8] : [8, 1]);
+      expect(timed.slice(2 * r, 2 * r + 2)).toEqual(r % 2 === 0 ? [1, 8] : [8, 1]);
     }
   });
 });
@@ -118,6 +72,11 @@ describe("expectPerf recorder and gate", () => {
   it("throws on a breach when PERF_ENFORCE is set", () => {
     process.env.PERF_ENFORCE = "1";
     expect(() => expectPerf("test:breach", 9.0, 2.0)).toThrow(/perf regression/);
+  });
+
+  it("treats PERF_ENFORCE=0 as OFF (does not gate)", () => {
+    process.env.PERF_ENFORCE = "0";
+    expect(() => expectPerf("test:breach", 9.0, 2.0)).not.toThrow();
   });
 
   it("does not throw when under bound even with PERF_ENFORCE set", () => {

--- a/packages/agency-lang/lib/perf/harness.ts
+++ b/packages/agency-lang/lib/perf/harness.ts
@@ -1,0 +1,155 @@
+/**
+ * Performance-test harness. The "how" of measuring, so the perf tests state only
+ * the "what" ("does lint scale under the growth bound?").
+ *
+ * Why a custom harness and not vitest's `bench` (tinybench): `bench` is
+ * mean-based and comparison-shaped, and gives no clean seam for a normalized
+ * growth-factor assertion or the informational-vs-gating `PERF_ENFORCE` gate.
+ * Both of those are the point here, so we own the loop.
+ *
+ * The core idea (see docs/superpowers/specs/2026-07-24-ci-performance-tests-design.md):
+ * assert how work GROWS with input size, not absolute milliseconds. A ratio of
+ * two measurements from the same run cancels steady-state machine speed, which
+ * is what makes it robust on a noisy CI runner. `growthFactor` normalizes that
+ * ratio by the size step so a perfectly linear algorithm reads 1.0 regardless of
+ * the step, and a quadratic reads ~step.
+ */
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+/** Normalized growth bound: 1.0 = perfectly linear. Above this trips the check.
+ *  Start loose and tighten from the informational data; a quadratic reads ~8 at
+ *  an 8x step, so 2.0 leaves generous room above linear while catching genuine
+ *  super-linear growth. */
+export const GROWTH_BOUND = 2.0;
+export const WARMUP = 2;
+export const RUNS = 7;
+
+function median(xs: number[]): number {
+  const sorted = [...xs].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 1 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+// A sink the timed closures write into, so V8 cannot dead-code-eliminate the
+// work under measurement when its result would otherwise be unused.
+let sink: unknown;
+
+function timeOnce(fn: () => unknown): number {
+  const start = performance.now();
+  sink = fn();
+  return performance.now() - start;
+}
+
+/** Median elapsed ms over `runs` timed calls after `warmup` untimed ones. For
+ *  the Layer-2 absolute smoke checks (a single closure, no ratio). Not used
+ *  inside `growthFactor` — nesting a median there would make one size's runs
+ *  contiguous again and defeat the interleave. */
+export function measureMs(
+  fn: () => unknown,
+  opts: { warmup?: number; runs?: number } = {},
+): number {
+  const warmup = opts.warmup ?? WARMUP;
+  const runs = opts.runs ?? RUNS;
+  for (let i = 0; i < warmup; i++) fn();
+  const times: number[] = [];
+  for (let i = 0; i < runs; i++) times.push(timeOnce(fn));
+  return median(times);
+}
+
+/**
+ * The normalized growth number: 1.0 = linear, `large/small` (the step) =
+ * quadratic. `build(n)` does all untimed setup and returns the timed closure.
+ *
+ * Schedule (this is the load-bearing correctness code):
+ *  - Warm up BOTH sizes up front, or round 1 times cold-JIT code for one size.
+ *  - One raw timing per size per round (no nested median).
+ *  - Alternate the within-round order across rounds (even: small→large, odd:
+ *    large→small). Interleaving cancels random second-to-second noise;
+ *    alternating also cancels monotonic drift (a runner getting steadily busier
+ *    would otherwise bias the always-later size the same way every round, and a
+ *    median can't remove a bias present in every round).
+ */
+export function growthFactor(
+  build: (n: number) => () => unknown,
+  small: number,
+  large: number,
+  opts: { rounds?: number; warmup?: number } = {},
+): number {
+  const rounds = opts.rounds ?? RUNS;
+  const warmup = opts.warmup ?? WARMUP;
+  const smallFn = build(small);
+  const largeFn = build(large);
+  for (let i = 0; i < warmup; i++) smallFn();
+  for (let i = 0; i < warmup; i++) largeFn();
+  const ratios: number[] = [];
+  for (let round = 0; round < rounds; round++) {
+    let tSmall: number;
+    let tLarge: number;
+    if (round % 2 === 0) {
+      tSmall = timeOnce(smallFn);
+      tLarge = timeOnce(largeFn);
+    } else {
+      tLarge = timeOnce(largeFn);
+      tSmall = timeOnce(smallFn);
+    }
+    ratios.push(tLarge / tSmall);
+  }
+  return median(ratios) / (large / small);
+}
+
+type PerfRecord = { label: string; value: number; bound: number; pass: boolean };
+
+function recordResult(rec: PerfRecord): void {
+  const file =
+    process.env.PERF_RESULTS_FILE ?? path.join(process.cwd(), "perf-results.jsonl");
+  fs.appendFileSync(file, `${JSON.stringify({ ...rec, ts: new Date().toISOString() })}\n`);
+  const summary = process.env.GITHUB_STEP_SUMMARY;
+  if (summary) {
+    fs.appendFileSync(
+      summary,
+      `| ${rec.label} | ${rec.value.toFixed(3)} | ${rec.bound} | ${rec.pass ? "✅" : "⚠️"} |\n`,
+    );
+  }
+}
+
+/**
+ * Record a measurement, then gate on it. With `PERF_ENFORCE` unset (the
+ * informational default) a breach is logged but does NOT throw, so nothing
+ * blocks a merge while thresholds are being calibrated. With `PERF_ENFORCE`
+ * set, a breach throws like a normal assertion. Tests never branch on the env
+ * or write the summary themselves — that "how" lives here, which is why the
+ * flip to gating is a one-line change.
+ */
+export function expectPerf(label: string, actual: number, bound: number): void {
+  const pass = actual < bound;
+  recordResult({ label, value: actual, bound, pass });
+  const enforce = Boolean(process.env.PERF_ENFORCE);
+  const line = `${pass ? "PASS" : "BREACH"} ${label}: ${actual.toFixed(3)} (bound ${bound})`;
+  if (enforce && !pass) {
+    throw new Error(`perf regression: ${line}`);
+  }
+  // eslint-disable-next-line no-console -- perf results are the point of the run
+  console.log(`[perf] ${line}${enforce ? "" : " (informational)"}`);
+}
+
+// A counter so two calls in the same millisecond still get distinct paths.
+let cacheFreeCounter = 0;
+
+/**
+ * The single home for parse-cache neutralization. Writes `source` to a fresh
+ * unique temp path and returns it. The process-wide `parseAgencyFileCached`
+ * keys on the file PATH (`${t|r}:${absPath}`), so a never-repeated path
+ * guarantees a cache miss — while the CONTENT stays fixed, so the measured
+ * workload does not vary run to run. Used only by the file-based compile /
+ * incremental-build tests; the string-level tests never touch that cache.
+ */
+export function cacheFreePath(source: string, ext = ".agency"): string {
+  const p = path.join(
+    os.tmpdir(),
+    `perf-cachefree-${process.pid}-${Date.now()}-${cacheFreeCounter++}${ext}`,
+  );
+  fs.writeFileSync(p, source, "utf-8");
+  return p;
+}

--- a/packages/agency-lang/lib/perf/harness.ts
+++ b/packages/agency-lang/lib/perf/harness.ts
@@ -1,27 +1,15 @@
 /**
- * Performance-test harness. The "how" of measuring, so the perf tests state only
- * the "what" ("does lint scale under the growth bound?").
- *
- * Why a custom harness and not vitest's `bench` (tinybench): `bench` is
- * mean-based and comparison-shaped, and gives no clean seam for a normalized
- * growth-factor assertion or the informational-vs-gating `PERF_ENFORCE` gate.
- * Both of those are the point here, so we own the loop.
- *
- * The core idea (see docs/superpowers/specs/2026-07-24-ci-performance-tests-design.md):
- * assert how work GROWS with input size, not absolute milliseconds. A ratio of
- * two measurements from the same run cancels steady-state machine speed, which
- * is what makes it robust on a noisy CI runner. `growthFactor` normalizes that
- * ratio by the size step so a perfectly linear algorithm reads 1.0 regardless of
- * the step, and a quadratic reads ~step.
+ * Performance-test harness: the measuring "how" so perf tests state only the
+ * "what". We assert how work grows with input size, not absolute ms, so the
+ * check survives noisy CI. Not vitest `bench`: it is mean-based with no seam
+ * for a normalized ratio or the PERF_ENFORCE gate. Rationale in
+ * docs/superpowers/specs/2026-07-24-ci-performance-tests-design.md.
  */
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 
-/** Normalized growth bound: 1.0 = perfectly linear. Above this trips the check.
- *  Start loose and tighten from the informational data; a quadratic reads ~8 at
- *  an 8x step, so 2.0 leaves generous room above linear while catching genuine
- *  super-linear growth. */
+/** Normalized: 1.0 = linear, ~step = quadratic. Start loose, calibrate from data. */
 export const GROWTH_BOUND = 2.0;
 export const WARMUP = 2;
 export const RUNS = 7;
@@ -32,8 +20,7 @@ function median(xs: number[]): number {
   return sorted.length % 2 === 1 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
 }
 
-// A sink the timed closures write into, so V8 cannot dead-code-eliminate the
-// work under measurement when its result would otherwise be unused.
+// Written by every timed closure so V8 can't dead-code-eliminate the work.
 let sink: unknown;
 
 function timeOnce(fn: () => unknown): number {
@@ -42,10 +29,9 @@ function timeOnce(fn: () => unknown): number {
   return performance.now() - start;
 }
 
-/** Median elapsed ms over `runs` timed calls after `warmup` untimed ones. For
- *  the Layer-2 absolute smoke checks (a single closure, no ratio). Not used
- *  inside `growthFactor` — nesting a median there would make one size's runs
- *  contiguous again and defeat the interleave. */
+/** Median ms over `runs` timed calls after `warmup` untimed ones. For the
+ *  absolute smoke checks; growthFactor times differently (a nested median
+ *  would defeat its interleave). */
 export function measureMs(
   fn: () => unknown,
   opts: { warmup?: number; runs?: number } = {},
@@ -59,17 +45,13 @@ export function measureMs(
 }
 
 /**
- * The normalized growth number: 1.0 = linear, `large/small` (the step) =
- * quadratic. `build(n)` does all untimed setup and returns the timed closure.
+ * Normalized growth: 1.0 = linear, ~step = quadratic. `build(n)` does untimed
+ * setup and returns the timed closure.
  *
- * Schedule (this is the load-bearing correctness code):
- *  - Warm up BOTH sizes up front, or round 1 times cold-JIT code for one size.
- *  - One raw timing per size per round (no nested median).
- *  - Alternate the within-round order across rounds (even: small→large, odd:
- *    large→small). Interleaving cancels random second-to-second noise;
- *    alternating also cancels monotonic drift (a runner getting steadily busier
- *    would otherwise bias the always-later size the same way every round, and a
- *    median can't remove a bias present in every round).
+ * The schedule is load-bearing: warm both sizes first, one timing per size per
+ * round, and alternate the within-round order. Interleaving cancels random
+ * noise; alternating also cancels monotonic drift (a fixed order would bias the
+ * always-later size every round, which a median can't remove).
  */
 export function growthFactor(
   build: (n: number) => () => unknown,
@@ -114,14 +96,8 @@ function recordResult(rec: PerfRecord): void {
   }
 }
 
-/**
- * Record a measurement, then gate on it. With `PERF_ENFORCE` unset (the
- * informational default) a breach is logged but does NOT throw, so nothing
- * blocks a merge while thresholds are being calibrated. With `PERF_ENFORCE`
- * set, a breach throws like a normal assertion. Tests never branch on the env
- * or write the summary themselves — that "how" lives here, which is why the
- * flip to gating is a one-line change.
- */
+/** Record, then gate: with PERF_ENFORCE unset a breach only logs (informational);
+ *  set, it throws. Tests never touch the env, so the flip to gating is one line. */
 export function expectPerf(label: string, actual: number, bound: number): void {
   const pass = actual < bound;
   recordResult({ label, value: actual, bound, pass });
@@ -134,17 +110,11 @@ export function expectPerf(label: string, actual: number, bound: number): void {
   console.log(`[perf] ${line}${enforce ? "" : " (informational)"}`);
 }
 
-// A counter so two calls in the same millisecond still get distinct paths.
 let cacheFreeCounter = 0;
 
-/**
- * The single home for parse-cache neutralization. Writes `source` to a fresh
- * unique temp path and returns it. The process-wide `parseAgencyFileCached`
- * keys on the file PATH (`${t|r}:${absPath}`), so a never-repeated path
- * guarantees a cache miss — while the CONTENT stays fixed, so the measured
- * workload does not vary run to run. Used only by the file-based compile /
- * incremental-build tests; the string-level tests never touch that cache.
- */
+/** Writes `source` to a fresh unique temp path so the process-wide parse cache
+ *  (keyed on path) always misses, with content fixed so the workload stays
+ *  constant. Only the file-based compile/build tests need this. */
 export function cacheFreePath(source: string, ext = ".agency"): string {
   const p = path.join(
     os.tmpdir(),

--- a/packages/agency-lang/lib/perf/harness.ts
+++ b/packages/agency-lang/lib/perf/harness.ts
@@ -14,6 +14,17 @@ export const GROWTH_BOUND = 2.0;
 export const WARMUP = 2;
 export const RUNS = 7;
 
+// Floor for a single timing before it goes into a ratio (guards divide-by-zero).
+const MIN_MS = 1e-4;
+
+/** Gating is on only when PERF_ENFORCE is set to a real truthy value. Treats
+ *  "0"/"false"/"" as off so `PERF_ENFORCE=0` doesn't accidentally enable it
+ *  (plain `Boolean("0")` is true). */
+function perfEnforceEnabled(): boolean {
+  const v = process.env.PERF_ENFORCE;
+  return v !== undefined && v !== "" && v !== "0" && v.toLowerCase() !== "false";
+}
+
 function median(xs: number[]): number {
   const sorted = [...xs].sort((a, b) => a - b);
   const mid = Math.floor(sorted.length / 2);
@@ -76,7 +87,9 @@ export function growthFactor(
       tLarge = timeOnce(largeFn);
       tSmall = timeOnce(smallFn);
     }
-    ratios.push(tLarge / tSmall);
+    // Floor each timing so a sample that measures as 0ms degrades to a finite
+    // ratio instead of Infinity/NaN poisoning the median.
+    ratios.push(Math.max(tLarge, MIN_MS) / Math.max(tSmall, MIN_MS));
   }
   return median(ratios) / (large / small);
 }
@@ -101,7 +114,7 @@ function recordResult(rec: PerfRecord): void {
 export function expectPerf(label: string, actual: number, bound: number): void {
   const pass = actual < bound;
   recordResult({ label, value: actual, bound, pass });
-  const enforce = Boolean(process.env.PERF_ENFORCE);
+  const enforce = perfEnforceEnabled();
   const line = `${pass ? "PASS" : "BREACH"} ${label}: ${actual.toFixed(3)} (bound ${bound})`;
   if (enforce && !pass) {
     throw new Error(`perf regression: ${line}`);

--- a/packages/agency-lang/lib/perf/lint.perf.test.ts
+++ b/packages/agency-lang/lib/perf/lint.perf.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import { parseAgency } from "../parser.js";
+import type { LintContext, LintRule } from "../linter/types.js";
+import { lintSource } from "../linter/registry.js";
+import { unusedImportsRule } from "../linter/rules/unusedImports.js";
+import { missingDocstringRule } from "../linter/rules/missingDocstring.js";
+import { redundantPreludeImportRule } from "../linter/rules/redundantPreludeImport.js";
+import {
+  manyFunctions,
+  manyUnusedImports,
+  manyRedundantPreludeImports,
+} from "./fixtures.js";
+import { growthFactor, measureMs, expectPerf, GROWTH_BOUND } from "./harness.js";
+
+const SMALL = 1000;
+const LARGE = 8000;
+
+function ctxFor(source: string): LintContext {
+  const parsed = parseAgency(source, {}, false);
+  if (!parsed.success) throw new Error("perf fixture did not parse");
+  return { program: parsed.result, source, filePath: "/perf.agency" };
+}
+
+// Each rule paired with a findings-dense fixture that makes it emit one finding
+// per declaration. A single fixture cannot feed all three (missing-docstring
+// wants undocumented functions, unused-import wants unused imports,
+// redundant-prelude wants std::index imports), so each rule brings its own.
+const cases: { name: string; rule: LintRule; fixture: (n: number) => string }[] = [
+  {
+    name: "missingDocstring",
+    rule: missingDocstringRule,
+    fixture: (n) => manyFunctions(n, { docstrings: false }),
+  },
+  { name: "unusedImport", rule: unusedImportsRule, fixture: manyUnusedImports },
+  {
+    name: "redundantPreludeImport",
+    rule: redundantPreludeImportRule,
+    fixture: manyRedundantPreludeImports,
+  },
+];
+
+describe("lint rule scaling (per rule)", () => {
+  for (const { name, rule, fixture } of cases) {
+    it(`${name} scales linearly in file size`, () => {
+      // Parse each size once (untimed); the closure runs only rule.run.
+      // `rule.run` on a parsed string is cache-free (no parseAgencyFileCached).
+      const ctxBySize: Record<number, LintContext> = {
+        [SMALL]: ctxFor(fixture(SMALL)),
+        [LARGE]: ctxFor(fixture(LARGE)),
+      };
+
+      // Work-happened assertion: the rule must actually emit one finding per
+      // declaration on the large input, or a silently-empty fixture would make
+      // the ratio meaningless and pass forever (the bogus-benchmark trap).
+      expect(rule.run(ctxBySize[LARGE]).length).toBe(LARGE);
+
+      const build = (n: number) => () => rule.run(ctxBySize[n]);
+      const factor = growthFactor(build, SMALL, LARGE);
+      expectPerf(`lint:${name}`, factor, GROWTH_BOUND);
+    });
+  }
+});
+
+describe("lint stdlib smoke (Layer 2, coarse)", () => {
+  it("lints the whole stdlib under a generous ceiling", () => {
+    const stdlibDir = path.resolve(__dirname, "../../stdlib");
+    const files: string[] = [];
+    const walk = (dir: string): void => {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) walk(full);
+        else if (entry.name.endsWith(".agency")) files.push(full);
+      }
+    };
+    walk(stdlibDir);
+    expect(files.length).toBeGreaterThan(0); // work-happened
+
+    const sources = files.map((f) => [f, fs.readFileSync(f, "utf-8")] as const);
+    const ms = measureMs(
+      () => {
+        for (const [f, src] of sources) lintSource(src, f, {});
+      },
+      { warmup: 1, runs: 3 },
+    );
+    // Deliberately loose: this is a smoke alarm for catastrophic (5-10x)
+    // breakage, not a precise detector. Calibrate the ceiling from data.
+    expectPerf("lint:stdlib-smoke-ms", ms, 5000);
+  });
+});

--- a/packages/agency-lang/lib/perf/lint.perf.test.ts
+++ b/packages/agency-lang/lib/perf/lint.perf.test.ts
@@ -23,10 +23,8 @@ function ctxFor(source: string): LintContext {
   return { program: parsed.result, source, filePath: "/perf.agency" };
 }
 
-// Each rule paired with a findings-dense fixture that makes it emit one finding
-// per declaration. A single fixture cannot feed all three (missing-docstring
-// wants undocumented functions, unused-import wants unused imports,
-// redundant-prelude wants std::index imports), so each rule brings its own.
+// Each rule needs its own findings-dense fixture (one finding per declaration);
+// no single fixture feeds all three rules.
 const cases: { name: string; rule: LintRule; fixture: (n: number) => string }[] = [
   {
     name: "missingDocstring",
@@ -44,16 +42,14 @@ const cases: { name: string; rule: LintRule; fixture: (n: number) => string }[] 
 describe("lint rule scaling (per rule)", () => {
   for (const { name, rule, fixture } of cases) {
     it(`${name} scales linearly in file size`, () => {
-      // Parse each size once (untimed); the closure runs only rule.run.
-      // `rule.run` on a parsed string is cache-free (no parseAgencyFileCached).
+      // Parse each size once (untimed); the closure runs only the cache-free
+      // rule.run.
       const ctxBySize: Record<number, LintContext> = {
         [SMALL]: ctxFor(fixture(SMALL)),
         [LARGE]: ctxFor(fixture(LARGE)),
       };
 
-      // Work-happened assertion: the rule must actually emit one finding per
-      // declaration on the large input, or a silently-empty fixture would make
-      // the ratio meaningless and pass forever (the bogus-benchmark trap).
+      // Work-happened: a silently-empty fixture would measure nothing and pass.
       expect(rule.run(ctxBySize[LARGE]).length).toBe(LARGE);
 
       const build = (n: number) => () => rule.run(ctxBySize[n]);
@@ -84,8 +80,7 @@ describe("lint stdlib smoke (Layer 2, coarse)", () => {
       },
       { warmup: 1, runs: 3 },
     );
-    // Deliberately loose: this is a smoke alarm for catastrophic (5-10x)
-    // breakage, not a precise detector. Calibrate the ceiling from data.
+    // Loose on purpose: a smoke alarm for catastrophic breakage, not precise.
     expectPerf("lint:stdlib-smoke-ms", ms, 5000);
   });
 });

--- a/packages/agency-lang/lib/perf/lint.perf.test.ts
+++ b/packages/agency-lang/lib/perf/lint.perf.test.ts
@@ -49,7 +49,9 @@ describe("lint rule scaling (per rule)", () => {
         [LARGE]: ctxFor(fixture(LARGE)),
       };
 
-      // Work-happened: a silently-empty fixture would measure nothing and pass.
+      // Work-happened, both measurement points: a silently-degenerate fixture
+      // at either size would make the ratio meaningless.
+      expect(rule.run(ctxBySize[SMALL]).length).toBe(SMALL);
       expect(rule.run(ctxBySize[LARGE]).length).toBe(LARGE);
 
       const build = (n: number) => () => rule.run(ctxBySize[n]);

--- a/packages/agency-lang/package.json
+++ b/packages/agency-lang/package.json
@@ -7,6 +7,7 @@
     "test": "vitest --test-timeout=1000",
     "test:run": "vitest run",
     "test:integration": "vitest run -c vitest.integration.config.ts",
+    "test:perf": "vitest run -c vitest.perf.config.ts",
     "test:agency": "time node ./dist/scripts/agency.js test tests/agency -p 12",
     "test:agency-js": "time node ./dist/scripts/agency.js test js tests/agency-js -p 12",
     "test:agents": "time node ./dist/scripts/agency.js test lib/agents -p 12",

--- a/packages/agency-lang/vitest.config.ts
+++ b/packages/agency-lang/vitest.config.ts
@@ -14,7 +14,10 @@ export default defineConfig({
     // gated integration suite uses vitest.integration.config.ts), and a bare
     // denylist of subdirs would silently sweep any newly-added tests/<dir>
     // into this run.
-    exclude: ['**/node_modules/**', '**/dist/**', 'tests', '.worktrees/**', 'runs/**'],
+    // `*.perf.test.ts` is the performance suite — slow, timing-sensitive, and
+    // run apart via vitest.perf.config.ts (the `test:perf` script). Excluding it
+    // here keeps it out of the default unit run and watch mode.
+    exclude: ['**/node_modules/**', '**/dist/**', 'tests', '.worktrees/**', 'runs/**', '**/*.perf.test.ts'],
     setupFiles: ['./lib/parsers/vitest.setup.ts'],
   },
   resolve: {

--- a/packages/agency-lang/vitest.perf.config.ts
+++ b/packages/agency-lang/vitest.perf.config.ts
@@ -1,11 +1,9 @@
 import { defineConfig } from "vitest/config";
 import path from "path";
 
-// The performance suite. Kept apart from the default unit run (which excludes
-// `**/*.perf.test.ts`) because these tests are slow by nature and must not run
-// concurrently: parallel test files contend for CPU and poison the timings the
-// whole suite depends on. Mirrors vitest.integration.config.ts's separate-config
-// pattern.
+// The performance suite (mirrors vitest.integration.config.ts). Kept apart from
+// the default unit run because it is slow and must run serially — parallel tests
+// contend for CPU and poison the timings.
 export default defineConfig({
   test: {
     globals: true,

--- a/packages/agency-lang/vitest.perf.config.ts
+++ b/packages/agency-lang/vitest.perf.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+// The performance suite. Kept apart from the default unit run (which excludes
+// `**/*.perf.test.ts`) because these tests are slow by nature and must not run
+// concurrently: parallel test files contend for CPU and poison the timings the
+// whole suite depends on. Mirrors vitest.integration.config.ts's separate-config
+// pattern.
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["**/*.perf.test.ts"],
+    exclude: ["**/node_modules/**", "**/dist/**", "tests", ".worktrees/**", "runs/**"],
+    setupFiles: ["./lib/parsers/vitest.setup.ts"],
+    // Perf measurements repeat large workloads many times; the default 5s
+    // per-test timeout is far too short for a scaling test on an 8000-node file.
+    testTimeout: 120_000,
+    // Serialize everything — no cross-test CPU contention.
+    fileParallelism: false,
+    pool: "threads",
+    poolOptions: { threads: { singleThread: true } },
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./lib"),
+    },
+  },
+});


### PR DESCRIPTION
PR 1 of the CI performance-tests plan (spec + reviews under `docs/superpowers/`). Adds the measurement apparatus and proves it end to end on the command that motivated the effort — the linter, whose accidental O(n²) shipped latent because nothing in CI watched for perf regressions. PR 2 (parse/typecheck/fmt + per-stage compile) and PR 3 (LSP + the other commands) follow after this merges.

## The approach: ratios, not milliseconds

Absolute-time thresholds (`compile in < 500ms`) flake on shared runners and rot as machines get faster. Instead we measure **how work grows with input size**. `growthFactor` normalizes the growth by the size step, so a linear algorithm reads **~1.0** and a quadratic reads **~step** (≈8 at an 8× step) regardless of the machine — because the ratio is taken from two measurements in the same run, absolute speed cancels. The schedule **interleaves and order-alternates** its samples so both random second-to-second noise and monotonic drift cancel in the ratio.

## What's here

- **`lib/perf/harness.ts`** — `measureMs`; `growthFactor` (interleaved, alternated, normalized); `expectPerf` (the `PERF_ENFORCE` gate: records-and-passes when unset, throws when set); a JSONL + step-summary recorder; and `cacheFreePath` for the later file-based tests. Meta-tests: a **canary** (a real O(n²) closure must trip the bound), **self-consistency** (linear stays under it — the test the naive `bound = step` design would have failed on correct code), a **schedule test** (fails if interleaving/alternation isn't implemented), and a **recorder test**.
- **`lib/perf/fixtures.ts`** — size-controlled generators, each verified to parse.
- **`lib/perf/lint.perf.test.ts`** — **per-rule** scaling (a single-rule regression can't hide in an all-rules average — exactly how the AL0002 O(n²) hid), each with a **work-happened assertion** so a silently-empty fixture can't pass forever.
- **`vitest.perf.config.ts`** + `test:perf` script; `*.perf.test.ts` excluded from the default unit run (and serialized, long timeout, so tests don't contend).
- An **informational `perf` job** in `test.yml`: single node 22.x, `PERF_ENFORCE` unset, `continue-on-error`, uploads `perf-results.jsonl` for cross-run calibration.

## Proof the suite works

Reverting the linter to its pre-fix O(n²) scan makes `lint:missingDocstring` measure **7.997** (normalized ~8) and, under `PERF_ENFORCE=1`, **fail** the bound of 2. With the indexed path it measures **~1.07** and passes. Local run of all four lint measurements: factors 1.07 / 1.24 / 1.07, stdlib smoke ~835 ms — full `test:perf` in ~14 s.

## Informational only

Nothing here can block a merge until a deliberate flip — set `PERF_ENFORCE=1` and drop `continue-on-error` — after thresholds are calibrated from the uploaded artifacts (start `GROWTH_BOUND = 2.0`). That milestone, and PRs 2–3, are in the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
