### PR TITLE
Pattern matching: check a value's shape before reading into it

### DIFF
--- a/packages/agency-lang/docs/superpowers/ideas/2026-07-24-is-object-narrowing-loses-union-members.md
+++ b/packages/agency-lang/docs/superpowers/ideas/2026-07-24-is-object-narrowing-loses-union-members.md
@@ -1,0 +1,98 @@
+# `is object` narrows a union to opaque `object`, losing its members
+
+## Status (2026-07-24)
+
+Idea. Found while fixing
+[the object-pattern shape check](2026-07-24-object-pattern-crashes-on-null-intermediate.md),
+which is shipping a workaround for it rather than a fix.
+
+Not urgent — the workaround costs one comparison and nothing is broken —
+but the gap will bite again wherever `is object` meets a union.
+
+## The Problem
+
+Narrowing by `is object` replaces the type with the opaque `object` type
+instead of filtering the union's object-like members:
+
+```ts
+type Redirect = { op: string, path: string }
+
+def f(r: Redirect | null): string {
+  if (r is object) { return r.op }   // error AG2011:
+  return "no"                        //   Property 'op' does not exist on type 'object'
+}
+```
+
+The test proves `r` is a non-null object, and the only non-null member of
+`Redirect | null` is `Redirect`, so `r` is a `Redirect` in that branch.
+The checker instead lands on `object`, which has no fields at all.
+
+The null check narrows correctly, which makes the contrast sharp:
+
+```ts
+if (r != null) { return r.op }   // fine
+```
+
+## Why it matters
+
+Object patterns emit a shape check before reading fields (see the linked
+idea). The natural check is the coarse `is object` test, and on its own it
+would make every pattern that reads through a nullable field fail to
+typecheck — `{ redirect: { op: ">" } }` against a `Redirect | null` field
+would report AG2011 even though it runs correctly.
+
+The workaround shipped in `shapeCheck` (`lib/lowering/patternLowering.ts`)
+is to emit **both**, null check first:
+
+```ts
+source != null && __coarseTypeTest(source, "object")
+```
+
+The `!= null` does the union filtering, and the coarse test that follows
+does not clobber it. That composes today and is verified by tests, but it
+means the generated condition carries a redundant comparison purely to
+work around the narrowing, and the comment there has to explain why.
+
+## Proposed Behavior
+
+Narrowing by a coarse type test should FILTER a union, the way
+`narrowUnionByDiscriminant` does, rather than replace it:
+
+- `Redirect | null` narrowed by `is object` → `Redirect`
+- `Redirect | string | null` by `is object` → `Redirect`
+- `Redirect | Other | null` by `is object` → `Redirect | Other`
+- A non-union, non-object type by `is object` → unchanged behavior
+- Nothing object-like in the union → fall back to today's `object`, never
+  to `never`
+
+The same argument applies to the other coarse kinds: `is string` on
+`string | null` should give `string`, `is any[]` on `Foo[] | null` should
+give `Foo[]`. Worth checking whether those already work or share the bug.
+
+Once this lands, `shapeCheck` can drop the `!= null` half and emit just
+the coarse test — smaller generated conditions, and one mechanism instead
+of two.
+
+## Touch Points
+
+- `lib/typeChecker/narrowing.ts` — the coarse-test narrowing path; model on
+  `narrowUnionByDiscriminant` (`:319`), which already filters members
+  soundly and never narrows to `never`.
+- `lib/lowering/patternLowering.ts` `shapeCheck` — simplify once fixed.
+- `docs/site/guide/pattern-matching.md` — "Narrowing is positive-only …
+  `object` narrows to the opaque `object` type" describes today's
+  behavior and would need updating.
+
+## Tests
+
+- Each bullet under Proposed Behavior as a typecheck test.
+- The union-flattening interaction: a union whose member is itself a union
+  alias (see PR #674) narrowed by `is object`.
+- Regression: `is object` on a plain `any` still gives opaque `object`.
+
+## Related
+
+- [Object pattern crashes on a null intermediate](2026-07-24-object-pattern-crashes-on-null-intermediate.md)
+  — carries the workaround.
+- PR #674 — union flattening in `resolveType`, same family of union
+  handling.

--- a/packages/agency-lang/docs/superpowers/ideas/2026-07-24-object-pattern-crashes-on-null-intermediate.md
+++ b/packages/agency-lang/docs/superpowers/ideas/2026-07-24-object-pattern-crashes-on-null-intermediate.md
@@ -1,0 +1,184 @@
+# A nested object pattern crashes instead of failing to match
+
+## Status (2026-07-24)
+
+**Implemented**, pending review. Found while designing the safeBash command
+matcher (see [safeBash command-to-tool matching](2026-07-24-safebash-command-to-tool-matching.md)),
+where the natural shape for a lowered bash command has an optional
+`redirect` field.
+
+Two decisions came out of implementation, both recorded in Resolution
+below: the check is the strong one (a full shape test, not just `!= null`),
+and it is emitted as a PAIR — `!= null` first, then the coarse test —
+because `is object` narrowing loses union members. That second half is a
+workaround for a separate gap:
+[is object narrowing loses union members](2026-07-24-is-object-narrowing-loses-union-members.md).
+
+## The Problem
+
+A pattern that reads a field of a field lowers to a bare member-access
+chain with nothing checking the intermediate. When the intermediate is
+`null`, the arm does not fail to match — it throws.
+
+```ts
+type Redirect = { op: string, path: string }
+type Cmd = { words: string[], redirect: Redirect | null }
+
+def run(c: Cmd): string {
+  return match (c) {
+    { words: ["echo", ...rest], redirect: { op: ">", path } } => "write ${path}"
+    _ => "fallback"
+  }
+}
+
+run({ words: ["echo", "hi"], redirect: null })
+// expected: "fallback"
+// actual:   failure("Cannot read properties of null (reading 'op')")
+```
+
+The same thing happens with no nesting at all, when the scrutinee itself
+is null:
+
+```ts
+match (x) {          // x is null
+  { a: 1 } => "one"
+  _        => "fallback"
+}
+// actual: failure("Cannot read properties of null (reading 'a')")
+```
+
+An array pattern has the identical shape (`null.length`).
+
+This is worse than a wrong answer: a pattern's whole job is to decide
+whether a value matches, and "this value does not match" is the case that
+crashes. Today it is masked by luck — `&&` short-circuits, so an earlier
+check in the same arm that happens to fail first hides the problem. Reorder
+the arms, or make the earlier checks pass, and it surfaces.
+
+### The typechecker already reports this
+
+The checker is right and worth listening to:
+
+```
+error AG2008: Property 'op' is not available on every member of
+  'Redirect | null'; narrow the value before accessing it.
+```
+
+It is describing the generated condition exactly. That means the fix
+below also silences the diagnostic, rather than needing separate work:
+`&&` narrowing already handles the guarded form
+(`r != null && r.op == ">"` typechecks clean today).
+
+## Cause
+
+`collectChecks` (`lib/lowering/patternLowering.ts:1042`) walks a pattern
+and pushes one boolean check per constraint, joined with `&&` by
+`patternToCondition` (`:1035`). The `objectPattern` case recurses
+straight into `fieldAccess(source, prop.key)` (`:1047`) without first
+requiring that `source` is a non-null object. `arrayPattern` (`:1052`)
+likewise reads `source.length` (`:1056`) before establishing that
+`source` is an array.
+
+## Proposed Behavior
+
+Before an object pattern reads any field, require that the value is a
+non-null object. Before an array pattern reads `length`, require that the
+value is an array.
+
+```ts
+// { redirect: { op: ">" } } against `c`
+c != null && c.redirect != null && c.redirect.op == ">"
+```
+
+Emit the guard for the pattern's own source, not only for nested ones —
+the top-level null scrutinee above is the same bug one level up.
+
+Open question for design: how strict should the guard be? A `!= null`
+check is the minimum that fixes the crash. An `is object` / `is any[]`
+test is stronger and matches what the pattern actually asserts (an object
+pattern should not match the number `3`), but it is a behavior change
+beyond the crash — a pattern that currently matches a non-object by
+reading `undefined` fields off it would start failing to match. Decide
+during design; lean toward the stronger check, since the weaker one
+leaves `match (3) { { a: 1 } => ... }` still reading `(3).a`.
+
+Redundant guards are acceptable: `patternToCondition` already joins with
+`&&`, so a duplicate `c != null` costs one cheap comparison. Prefer
+correctness over minimal output; if the noise matters, dedupe checks by
+their printed source in a later pass.
+
+## Touch Points
+
+- `lib/lowering/patternLowering.ts:1042` `collectChecks` — push the
+  existence guard in the `objectPattern` and `arrayPattern` cases before
+  recursing / reading `length`.
+- `lib/lowering/patternLowering.ts:1035` `patternToCondition` — nothing
+  needed if the guards are pushed as ordinary checks, since the reduce
+  already joins them left to right and `&&` short-circuits in the right
+  order.
+- Fixture expectations under `tests/typescriptGenerator/` that pin the
+  generated condition for object/array patterns will need regenerating
+  (`make fixtures`).
+
+## Tests
+
+Agency execution tests (`tests/agency/`), no LLM calls needed:
+
+- Nested object pattern where the intermediate is `null` → falls through
+  to `_`, no failure.
+- Top-level object pattern against `null` → falls through.
+- Array pattern against `null` → falls through.
+- Nested pattern where the intermediate is present → still matches, and
+  the binding is correct.
+- Arm ordering: the crashing arm placed FIRST (so no earlier `&&` can
+  short-circuit it away) — this is the case that fails today.
+- A typecheck test asserting the AG2008 above is gone for the guarded
+  form.
+
+## Resolution
+
+`collectChecks` now pushes a `shapeCheck` at the head of the
+`objectPattern` and `arrayPattern` cases:
+
+```ts
+source != null && __coarseTypeTest(source, "object")   // object patterns
+source != null && __coarseTypeTest(source, "array")    // array patterns
+```
+
+**Why the strong check.** The crash was one symptom; the wrong matches
+were the other. A bare `!= null` would have fixed only the crash and left
+`{ a }` matching `3` and `[a, b]` matching `"abc"` — the kind of thing a
+safeBash rule must not do.
+
+**Why the pair.** The coarse test alone suffices at runtime. The `!= null`
+in front is for the type checker: `is object` narrowing lands on opaque
+`object`, so a pattern reading through a `Redirect | null` field would
+report AG2011. `!= null` filters the union properly and the coarse test
+does not clobber it. Remove the `!= null` half once the narrowing gap is
+fixed.
+
+**Behavior changes beyond the crash**, each covered by a test:
+
+- `{ a }` no longer matches a non-object; `[a, b]` no longer matches a
+  string.
+- An object pattern does not match an array, since Agency's `object` is
+  defined as non-null and non-array. `[a, b]` is the spelling for arrays.
+- `match (3 is { s, b })` now reports the head-pattern mismatch as a
+  failure instead of binding `undefined` and running an arm. A binder-only
+  head pattern previously produced no condition at all, so it had nothing
+  to gate on.
+
+One fixture line changed across the whole fixture set
+(`tests/typescriptGenerator/type-patterns.mjs`): a `{name, age}: Person`
+arm now carries the object test after its schema validation. Redundant
+there, and left in — one mechanism beats a special case.
+
+## Related
+
+- `docs/site/guide/pattern-matching.md` — "Failure semantics" currently
+  says destructuring a `null` surfaces as a `failure` Result. That is
+  about `const { name } = null`, a declaration. Match arms should be
+  different: a non-matching value is not an error. Worth a doc note once
+  fixed.
+- [safeBash command-to-tool matching](2026-07-24-safebash-command-to-tool-matching.md)
+  — the consumer that needs this.

--- a/packages/agency-lang/lib/lowering/patternGuards.tripwire.test.ts
+++ b/packages/agency-lang/lib/lowering/patternGuards.tripwire.test.ts
@@ -1,0 +1,368 @@
+/**
+ * Tripwire for the rule `collectChecks` must uphold.
+ *
+ * A pattern's job is to answer "does this value match". So the boolean
+ * condition it lowers to has to be a TOTAL function of the value: safe to
+ * evaluate on anything, and true only for values the pattern matches. Most
+ * cases get that for free — `resultPattern` asks via `isSuccess(v)`,
+ * `typePattern` via `__coarseTypeTest(v, kind)`, a literal via `v == lit`, and
+ * all three are total on any input. Raw member access is the one non-total
+ * operation available, and it is exactly what `objectPattern` and
+ * `arrayPattern` use.
+ *
+ * The rule that makes them total: a case must assert the shape it is about to
+ * destructure BEFORE destructuring it, and `patternToCondition` joins checks
+ * with `&&` in order, so an earlier conjunct short-circuits a later read.
+ *
+ * Stated as an invariant this file can check:
+ *
+ *   In a lowered pattern condition, every member access is preceded in the
+ *   `&&` chain by a shape check on each of its prefixes.
+ *
+ * A new pattern kind that reads a field without guarding it fails here rather
+ * than waiting for someone to hit the crash. Patterns come from the corpus —
+ * real ones the compiler already handles — so nothing is hand-enumerated
+ * except the kind list, whose exhaustiveness the type system checks below.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync, statSync } from "fs";
+import { join } from "path";
+import { fileURLToPath } from "url";
+import { lowerPatterns } from "./patternLowering.js";
+import { parseAgency } from "../parser.js";
+import type { AgencyNode, Expression, IfElse, MatchBlock } from "../types.js";
+import type { MatchPattern } from "../types/pattern.js";
+import type { BinOpExpression } from "../types/binop.js";
+import type { ValueAccess } from "../types/access.js";
+
+const __dirname = join(fileURLToPath(import.meta.url), "..");
+
+// ---------------------------------------------------------------------------
+// The kind list, tied to the union so it cannot drift
+// ---------------------------------------------------------------------------
+
+/** Every `type` a `MatchPattern` node can carry. */
+const PATTERN_KINDS = [
+  "objectPattern",
+  "arrayPattern",
+  "restPattern",
+  "wildcardPattern",
+  "variableName",
+  "resultPattern",
+  "typePattern",
+  "number",
+  "unitLiteral",
+  "multiLineString",
+  "string",
+  "boolean",
+  "null",
+] as const;
+
+// Adding a member to `MatchPattern` without listing it here is a COMPILE
+// error, so the coverage test below can never silently stop covering a kind.
+type MissingKind = Exclude<MatchPattern["type"], (typeof PATTERN_KINDS)[number]>;
+const _kindListIsExhaustive: MissingKind extends never ? true : never = true;
+void _kindListIsExhaustive;
+
+/**
+ * Kinds the corpus does not exercise, so the invariant below never sees them.
+ * Keyed by kind, valued with why. The staleness guard asserts each entry is
+ * STILL absent, so a corpus that grows to cover one fails until its entry is
+ * deleted — the list cannot rot into a permanent excuse.
+ */
+const KNOWN_UNCOVERED_KINDS: Record<string, string> = {
+  unitLiteral: "no stdlib/fixture match arm matches on a unit literal (30s, $5)",
+  multiLineString: 'no match arm matches on a """..."""  literal',
+};
+
+// ---------------------------------------------------------------------------
+// Corpus
+// ---------------------------------------------------------------------------
+
+function collectAgencyFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...collectAgencyFiles(full));
+    else if (entry.endsWith(".agency")) out.push(full);
+  }
+  return out;
+}
+
+function* walkEveryNode(value: unknown): Generator<Record<string, unknown>> {
+  if (!value || typeof value !== "object") return;
+  if (Array.isArray(value)) {
+    for (const item of value) yield* walkEveryNode(item);
+    return;
+  }
+  const record = value as Record<string, unknown>;
+  if (typeof record.type === "string") yield record;
+  for (const key of Object.keys(record)) {
+    if (key === "loc") continue;
+    yield* walkEveryNode(record[key]);
+  }
+}
+
+/**
+ * Every pattern the corpus actually writes, taken from the two positions that
+ * feed `patternToCondition`: a match arm's `caseValue` and the pattern after
+ * `is`. Parsed UNLOWERED — lowering is what we are about to run ourselves.
+ */
+let corpusCache: { file: string; pattern: MatchPattern }[] | null = null;
+
+function corpusPatterns(): { file: string; pattern: MatchPattern }[] {
+  if (corpusCache) return corpusCache;
+  const root = join(__dirname, "../..");
+  const files = [
+    ...collectAgencyFiles(join(root, "stdlib")),
+    ...collectAgencyFiles(join(root, "tests/typescriptGenerator")),
+    ...collectAgencyFiles(join(root, "tests/agency")),
+  ];
+  expect(files.length).toBeGreaterThan(50);
+
+  const out: { file: string; pattern: MatchPattern }[] = [];
+  for (const file of files) {
+    const parsed = parseAgency(readFileSync(file, "utf8"), {}, true, false);
+    // Some corpus files are deliberate parse-error fixtures; skip them rather
+    // than fail, the walker corpus does the same for its own reasons.
+    if (!parsed.success) continue;
+    for (const node of walkEveryNode(parsed.result.nodes)) {
+      if (node.type === "matchBlock") {
+        for (const c of (node as unknown as MatchBlock).cases) {
+          if (c.type === "matchBlockCase" && c.caseValue !== "_") {
+            out.push({ file, pattern: c.caseValue as MatchPattern });
+          }
+        }
+      }
+      if (node.type === "isExpression") {
+        out.push({ file, pattern: node.pattern as MatchPattern });
+      }
+    }
+  }
+  corpusCache = out;
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// The invariant
+// ---------------------------------------------------------------------------
+
+/** Flatten a left-associated `&&` chain into its conjuncts, in evaluation order. */
+function conjuncts(expr: Expression): Expression[] {
+  if (expr.type === "binOpExpression" && (expr as BinOpExpression).operator === "&&") {
+    const bin = expr as BinOpExpression;
+    return [...conjuncts(bin.left), ...conjuncts(bin.right)];
+  }
+  return [expr];
+}
+
+/**
+ * A dotted/indexed path for the access expressions patterns build, or null for
+ * anything else. `__scrutinee_1.redirect` and `__scrutinee_1[0]` are paths; a
+ * function call is not.
+ */
+function pathOf(expr: Expression): string | null {
+  if (expr.type === "variableName") return (expr as { value: string }).value;
+  if (expr.type !== "valueAccess") return null;
+  const access = expr as ValueAccess;
+  const base = pathOf(access.base as Expression);
+  if (base === null) return null;
+  let path = base;
+  for (const link of access.chain) {
+    if (link.kind === "property") path += `.${link.name}`;
+    else if (link.kind === "index") path += `[${JSON.stringify(link.index)}]`;
+    else return null;
+  }
+  return path;
+}
+
+/** Every path a conjunct READS THROUGH — the proper prefixes of its accesses. */
+function readThrough(expr: Expression): string[] {
+  const out: string[] = [];
+  for (const node of walkEveryNode(expr)) {
+    if (node.type !== "valueAccess") continue;
+    const access = node as unknown as ValueAccess;
+    const base = pathOf(access.base as Expression);
+    if (base === null) continue;
+    // Reading `a.b.c` reads through `a` and `a.b`, but not `a.b.c` itself.
+    let path = base;
+    out.push(path);
+    for (const link of access.chain.slice(0, -1)) {
+      if (link.kind === "property") path += `.${link.name}`;
+      else if (link.kind === "index") path += `[${JSON.stringify(link.index)}]`;
+      else break;
+      out.push(path);
+    }
+  }
+  return out;
+}
+
+/** The path a conjunct PROVES safe to read through, if it is a shape check. */
+function proves(expr: Expression): string | null {
+  if (expr.type === "typeTestExpression") {
+    return pathOf((expr as { expression: Expression }).expression);
+  }
+  if (expr.type === "binOpExpression") {
+    const bin = expr as BinOpExpression;
+    const nullSide =
+      bin.right.type === "null" ? bin.left : bin.left.type === "null" ? bin.right : null;
+    if ((bin.operator === "!=" || bin.operator === "!==") && nullSide) {
+      return pathOf(nullSide);
+    }
+  }
+  return null;
+}
+
+/** Paths read before anything proved them safe. Empty means the rule holds. */
+function unguardedReads(condition: Expression): string[] {
+  const proven = new Set<string>();
+  const violations: string[] = [];
+  for (const conjunct of conjuncts(condition)) {
+    for (const path of readThrough(conjunct)) {
+      if (!proven.has(path)) violations.push(path);
+    }
+    const provedPath = proves(conjunct);
+    if (provedPath !== null) proven.add(provedPath);
+  }
+  return violations;
+}
+
+/** Lower `pattern` as the only arm of a match and return every arm condition. */
+function conditionsFor(pattern: MatchPattern): Expression[] {
+  const matchBlock = {
+    type: "matchBlock",
+    expression: { type: "variableName", value: "__src" },
+    cases: [
+      { type: "matchBlockCase", caseValue: pattern, body: [] },
+      { type: "matchBlockCase", caseValue: "_", body: [] },
+    ],
+  } as unknown as AgencyNode;
+  const lowered = lowerPatterns([matchBlock]);
+  const out: Expression[] = [];
+  for (const node of walkEveryNode(lowered)) {
+    if (node.type === "ifElse") out.push((node as unknown as IfElse).condition);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("pattern conditions never read through an unguarded value", () => {
+  it("every corpus pattern guards each value it destructures", { timeout: 60_000 }, () => {
+    const failures: string[] = [];
+    for (const { file, pattern } of corpusPatterns()) {
+      for (const condition of conditionsFor(pattern)) {
+        for (const path of unguardedReads(condition)) {
+          failures.push(`${file}: ${pattern.type} reads through ${path} unguarded`);
+        }
+      }
+    }
+    expect(
+      failures.slice(0, 10),
+      `A pattern case reads a field off a value nothing established the shape of. ` +
+        `That value can be null (the condition throws instead of failing the arm) or the ` +
+        `wrong type (the condition is vacuously true and the arm matches something it ` +
+        `should not). Push a shapeCheck at the head of the case in collectChecks.`,
+    ).toEqual([]);
+  });
+
+  it("the corpus exercises every pattern kind", { timeout: 60_000 }, () => {
+    const seen = new Set<string>();
+    for (const { pattern } of corpusPatterns()) {
+      for (const node of walkEveryNode(pattern)) seen.add(node.type as string);
+    }
+    const uncovered = PATTERN_KINDS.filter(
+      (kind) => !seen.has(kind) && !Object.hasOwn(KNOWN_UNCOVERED_KINDS, kind),
+    );
+    expect(
+      uncovered,
+      `These pattern kinds appear nowhere in the corpus, so the invariant above ` +
+        `never sees them. Add a corpus program that uses one, or record it in ` +
+        `KNOWN_UNCOVERED_KINDS with the reason.`,
+    ).toEqual([]);
+  });
+
+  it("known-uncovered kinds are still uncovered (staleness guard)", { timeout: 60_000 }, () => {
+    const seen = new Set<string>();
+    for (const { pattern } of corpusPatterns()) {
+      for (const node of walkEveryNode(pattern)) seen.add(node.type as string);
+    }
+    const nowCovered = Object.keys(KNOWN_UNCOVERED_KINDS).filter((kind) => seen.has(kind));
+    expect(
+      nowCovered,
+      `The corpus now exercises these kinds, so their KNOWN_UNCOVERED_KINDS entries ` +
+        `are stale. Delete the entries — the invariant covers them for real now.`,
+    ).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The module's own stated invariant, checked
+// ---------------------------------------------------------------------------
+
+/**
+ * Node kinds pattern lowering is supposed to eliminate. `patternLowering.ts`
+ * opens by claiming "After this pass, the AST contains NO pattern-specific
+ * nodes"; nothing checked it, and an `isExpression` surviving in a match-arm
+ * guard is what reached codegen as "Unhandled Agency node type: isExpression".
+ */
+const MUST_NOT_SURVIVE = [
+  "objectPattern",
+  "arrayPattern",
+  "restPattern",
+  "wildcardPattern",
+  "objectPatternProperty",
+  "objectPatternShorthand",
+  "resultPattern",
+  "typePattern",
+  "isExpression",
+];
+
+/**
+ * Walk a lowered tree, skipping `matchSource`: the scrutinee assignment keeps a
+ * deliberate cloned snapshot of the un-lowered arms there for the
+ * exhaustiveness pass, so pattern nodes inside it are expected, not leaks.
+ */
+function* walkSkippingMatchSource(value: unknown): Generator<Record<string, unknown>> {
+  if (!value || typeof value !== "object") return;
+  if (Array.isArray(value)) {
+    for (const item of value) yield* walkSkippingMatchSource(item);
+    return;
+  }
+  const record = value as Record<string, unknown>;
+  if (typeof record.type === "string") yield record;
+  for (const key of Object.keys(record)) {
+    if (key === "loc" || key === "matchSource") continue;
+    yield* walkSkippingMatchSource(record[key]);
+  }
+}
+
+describe("lowering leaves no pattern-specific nodes behind", () => {
+  it("no corpus program keeps a pattern node after lowering", { timeout: 60_000 }, () => {
+    const root = join(__dirname, "../..");
+    const files = [
+      ...collectAgencyFiles(join(root, "stdlib")),
+      ...collectAgencyFiles(join(root, "tests/typescriptGenerator")),
+      ...collectAgencyFiles(join(root, "tests/agency")),
+    ];
+    const failures: string[] = [];
+    for (const file of files) {
+      const parsed = parseAgency(readFileSync(file, "utf8"), {}, true, true);
+      if (!parsed.success) continue;
+      for (const node of walkSkippingMatchSource(parsed.result.nodes)) {
+        if (MUST_NOT_SURVIVE.includes(node.type as string)) {
+          failures.push(`${file}: ${node.type as string} survived lowering`);
+        }
+      }
+    }
+    expect(
+      failures.slice(0, 10),
+      `Pattern lowering is supposed to remove these (see the header of ` +
+        `patternLowering.ts). Anything left reaches the TypeScript builder, which ` +
+        `has no case for it and throws "Unhandled Agency node type".`,
+    ).toEqual([]);
+  });
+});

--- a/packages/agency-lang/lib/lowering/patternLowering.test.ts
+++ b/packages/agency-lang/lib/lowering/patternLowering.test.ts
@@ -180,15 +180,27 @@ describe("object destructuring", () => {
 // ---------------------------------------------------------------------------
 
 describe("`is` operator in boolean context", () => {
-  it("lowers `const r = x is { type: \"foo\" }` to equality check", () => {
+  it("lowers `const r = x is { type: \"foo\" }` to a shape check AND an equality check", () => {
     const lowered = lower(`let x = { type: "foo" }\nconst r = x is { type: "foo" }`);
-    // [x, r = (x.type == "foo")]
+    // [x, r = (isObject(x) && x.type == "foo")]
     expect(lowered).toHaveLength(2);
     const rAssign = lowered[1] as Assignment;
     expect(rAssign.variableName).toBe("r");
     const value = rAssign.value as BinOpExpression;
     expect(value.type).toBe("binOpExpression");
-    expect(value.operator).toBe("==");
+    expect(value.operator).toBe("&&");
+    // The shape check comes first, so the field read on the right is only
+    // reached for a value that has fields — `3 is {type:"foo"}` and
+    // `null is {type:"foo"}` both answer false instead of reading `.type`.
+    // Left is the shape check pair `(x != null && isObject(x))`.
+    const shape = value.left as BinOpExpression;
+    expect(shape.operator).toBe("&&");
+    expect(shape.left).toMatchObject({ type: "binOpExpression", operator: "!=" });
+    expect(shape.right).toMatchObject({
+      type: "typeTestExpression",
+      typeHint: { type: "primitiveType", value: "object" },
+    });
+    expect(value.right).toMatchObject({ type: "binOpExpression", operator: "==" });
   });
 
   it("throws on shorthand binder in pure-boolean `is` context", () => {
@@ -349,12 +361,31 @@ describe("match block lowering", () => {
       ],
     } as MatchBlock;
     const lowered = lowerPatterns([matchBlock]);
-    // [scrutinee, assert (object pattern), s = __scrutinee.s, b = __scrutinee.b, ifElse]
-    const sIdx = lowered.findIndex((n) => n.type === "assignment" && (n as Assignment).variableName === "s");
-    const bIdx = lowered.findIndex((n) => n.type === "assignment" && (n as Assignment).variableName === "b");
+    // [scrutinee,
+    //  if (__scrutinee != null && isObject(__scrutinee)) { s = …, b = …, ifElse }
+    //  else return failure(…)]
+    //
+    // Even a binder-only head pattern carries a shape check now, so the
+    // bindings sit inside the head-pattern guard rather than at the top level.
+    // `match (3 is { s, b })` therefore reports the head mismatch as a failure
+    // instead of binding `undefined` and running an arm.
+    expect(lowered).toHaveLength(2);
+    const headGuard = lowered[1] as IfElse;
+    expect(headGuard.type).toBe("ifElse");
+    const shape = headGuard.condition as BinOpExpression;
+    expect(shape.operator).toBe("&&");
+    expect(shape.left).toMatchObject({ type: "binOpExpression", operator: "!=" });
+    expect(shape.right).toMatchObject({
+      type: "typeTestExpression",
+      typeHint: { type: "primitiveType", value: "object" },
+    });
+
+    const inside = headGuard.thenBody;
+    const sIdx = inside.findIndex((n) => n.type === "assignment" && (n as Assignment).variableName === "s");
+    const bIdx = inside.findIndex((n) => n.type === "assignment" && (n as Assignment).variableName === "b");
     expect(sIdx).toBeGreaterThan(-1);
     expect(bIdx).toBeGreaterThan(sIdx);
-    const ifNode = lowered[lowered.length - 1] as IfElse;
+    const ifNode = inside[inside.length - 1] as IfElse;
     expect(ifNode.type).toBe("ifElse");
     // The first arm condition is the guard `s > 5`
     expect((ifNode.condition as BinOpExpression).operator).toBe(">");

--- a/packages/agency-lang/lib/lowering/patternLowering.test.ts
+++ b/packages/agency-lang/lib/lowering/patternLowering.test.ts
@@ -182,7 +182,7 @@ describe("object destructuring", () => {
 describe("`is` operator in boolean context", () => {
   it("lowers `const r = x is { type: \"foo\" }` to a shape check AND an equality check", () => {
     const lowered = lower(`let x = { type: "foo" }\nconst r = x is { type: "foo" }`);
-    // [x, r = (isObject(x) && x.type == "foo")]
+    // [x, r = ((x != null && isObject(x)) && x.type == "foo")]
     expect(lowered).toHaveLength(2);
     const rAssign = lowered[1] as Assignment;
     expect(rAssign.variableName).toBe("r");

--- a/packages/agency-lang/lib/lowering/patternLowering.ts
+++ b/packages/agency-lang/lib/lowering/patternLowering.ts
@@ -1060,6 +1060,9 @@ const ARRAY_HINT: VariableType = {
  * filters the union properly and leaves `Redirect`, and the coarse test that
  * follows does not clobber that. Two cheap comparisons buy a pattern that
  * both runs right and typechecks.
+ *
+ * The `!= null` half can be dropped once that narrowing gap is fixed:
+ * docs/superpowers/ideas/2026-07-24-is-object-narrowing-loses-union-members.md
  */
 function shapeCheck(
   source: Expression,
@@ -1084,6 +1087,11 @@ function collectChecks(pattern: MatchPattern, source: Expression, checks: Expres
       // shape has to fail the arm rather than throw on `null.a` — or match by
       // reading `undefined` off a number. `&&` short-circuits, so this also
       // makes the reads below safe.
+      //
+      // Note this rejects ARRAYS too, not only null and non-objects: Agency's
+      // `object` is non-null and non-array (lib/runtime/typeTest.ts). So
+      // `{ length: 2 }` no longer matches an array — `[a, b]` is the spelling
+      // for that. One definition of `object`, not two.
       checks.push(...shapeCheck(source, OBJECT_HINT, pattern.loc));
       for (const prop of pattern.properties) {
         if (prop.type === "objectPatternProperty") {

--- a/packages/agency-lang/lib/lowering/patternLowering.ts
+++ b/packages/agency-lang/lib/lowering/patternLowering.ts
@@ -24,6 +24,7 @@ import type {
   MatchBlock,
   MatchBlockCase,
   ReturnStatement,
+  VariableType,
   WhileLoop,
 } from "../types.js";
 import { isExpressionNode } from "../types.js";
@@ -1039,9 +1040,51 @@ function patternToCondition(pattern: MatchPattern, source: Expression): Expressi
   return checks.reduce((a, b) => makeBinOp(a, "&&", b, undefined));
 }
 
+/** `is object` — non-null, non-array (lib/runtime/typeTest.ts). */
+const OBJECT_HINT: VariableType = { type: "primitiveType", value: "object" };
+/** `is any[]` — the coarse "is an array" check. */
+const ARRAY_HINT: VariableType = {
+  type: "arrayType",
+  elementType: { type: "primitiveType", value: "any" },
+};
+
+/**
+ * The shape check an object or array pattern emits before reading into a
+ * value: `source != null && __coarseTypeTest(source, kind)`.
+ *
+ * The coarse test alone is enough at runtime — it already rejects null. The
+ * `!= null` in front is there for the TYPE CHECKER: narrowing by `is object`
+ * lands on the opaque `object` type, which has no fields, so
+ * `{ redirect: { op: ">" } }` against a `Redirect | null` field would report
+ * "Property 'op' does not exist on type 'object'". Narrowing by `!= null`
+ * filters the union properly and leaves `Redirect`, and the coarse test that
+ * follows does not clobber that. Two cheap comparisons buy a pattern that
+ * both runs right and typechecks.
+ */
+function shapeCheck(
+  source: Expression,
+  typeHint: VariableType,
+  loc: SourceLocation | undefined,
+): Expression[] {
+  const notNull = makeBinOp(cloneExpr(source), "!=", nullLit(loc), loc);
+  const coarse = {
+    type: "typeTestExpression",
+    expression: cloneExpr(source),
+    typeHint,
+    loc,
+  } as Expression;
+  return [notNull, coarse];
+}
+
 function collectChecks(pattern: MatchPattern, source: Expression, checks: Expression[]): void {
   switch (pattern.type) {
     case "objectPattern":
+      // Shape check FIRST: everything below reads a field off `source`, and a
+      // pattern's job is to answer "does this match", so a value of the wrong
+      // shape has to fail the arm rather than throw on `null.a` — or match by
+      // reading `undefined` off a number. `&&` short-circuits, so this also
+      // makes the reads below safe.
+      checks.push(...shapeCheck(source, OBJECT_HINT, pattern.loc));
       for (const prop of pattern.properties) {
         if (prop.type === "objectPatternProperty") {
           collectChecks(prop.value as MatchPattern, fieldAccess(source, prop.key, pattern.loc), checks);
@@ -1050,6 +1093,10 @@ function collectChecks(pattern: MatchPattern, source: Expression, checks: Expres
       }
       break;
     case "arrayPattern": {
+      // Shape check FIRST, for the same reason — and because `.length` alone
+      // does not distinguish an array from a string: `"abc"` has length 3 and
+      // would otherwise match `[a, b]`, binding characters.
+      checks.push(...shapeCheck(source, ARRAY_HINT, pattern.loc));
       // Length check — at least as many elements as named (excluding rest).
       const hasRest = pattern.elements.some((e) => e.type === "restPattern");
       const namedCount = pattern.elements.filter((e) => e.type !== "restPattern").length;
@@ -1403,6 +1450,14 @@ function boolLit(value: boolean, loc: SourceLocation | undefined): Literal {
   return { type: "boolean", value, loc: loc as SourceLocation };
 }
 
-// Note: no explicit null/undefined checks are emitted. Native JS already throws
-// `TypeError: Cannot read properties of null (reading 'foo')` on `__tmp.foo`,
-// which is sufficient for users to diagnose destructuring failures.
+function nullLit(loc: SourceLocation | undefined): Expression {
+  return { type: "null", loc: loc as SourceLocation } as Expression;
+}
+
+// Note: BINDING extraction emits no null/undefined checks. Native JS already
+// throws `TypeError: Cannot read properties of null (reading 'foo')` on
+// `__tmp.foo`, which is sufficient for users to diagnose a failed
+// destructuring — and `const { name } = null` producing a failure Result is
+// the documented behavior. MATCHING is different: a value that does not match
+// must fail the arm, not throw, so `collectChecks` guards its reads. See
+// `shapeCheck`.

--- a/packages/agency-lang/lib/typeChecker/strictMemberAccess.test.ts
+++ b/packages/agency-lang/lib/typeChecker/strictMemberAccess.test.ts
@@ -367,3 +367,23 @@ def f(n: Node): any {
     expect(errs.errors).toEqual([]);
   });
 });
+
+describe("strict member access — a pattern that reads through a nullable field", () => {
+  const NULLABLE = `
+type Redirect = { op: string, path: string }
+type Cmd = { words: string[], redirect: Redirect | null }
+`;
+
+  it("reports nothing for a nested object pattern on a nullable field", () => {
+    // The lowered condition guards the read, so the checker should see the
+    // narrowed `Redirect`, not `Redirect | null` and not an opaque `object`.
+    const errs = check(`${NULLABLE}
+def f(c: Cmd): string {
+  return match (c) {
+    { words: ["echo"], redirect: { op: ">", path } } => path
+    _ => "none"
+  }
+}`);
+    expect(errs.errors).toEqual([]);
+  });
+});

--- a/packages/agency-lang/tests/agency/pattern-matching/patternShapeGuard.agency
+++ b/packages/agency-lang/tests/agency/pattern-matching/patternShapeGuard.agency
@@ -47,7 +47,20 @@ node nullIntermediate() {
 
 node wrongShape() {
   // A number is not an object; a string is not an array. Neither matches.
-  return [objBinder(3), arrBinder("abc"), objLiteral("hello")]
+  //
+  // The last two are the cross cases. An object pattern does not match an
+  // array, because Agency's `object` is non-null and non-array — the least
+  // predictable consequence of the shape check, so it is pinned here. An array
+  // pattern against an object failed before this change too, but only by
+  // accident: `({a:1}).length` is undefined and `undefined >= 2` is false.
+  // Now it fails because the check says so.
+  return [
+    objBinder(3),
+    arrBinder("abc"),
+    objLiteral("hello"),
+    objBinder([1, 2]),
+    arrBinder({ a: 1 }),
+  ]
 }
 
 node rightShape() {

--- a/packages/agency-lang/tests/agency/pattern-matching/patternShapeGuard.agency
+++ b/packages/agency-lang/tests/agency/pattern-matching/patternShapeGuard.agency
@@ -1,0 +1,61 @@
+// An object or array pattern must check the value's shape before reading
+// into it. A value of the wrong shape does not match; it must never crash,
+// and must never match by reading `undefined` off something that isn't an
+// object.
+
+type Redirect = { op: string, path: string }
+type Cmd = { words: string[], redirect: Redirect | null }
+
+def objLiteral(x: any): string {
+  return match (x) {
+    { a: 1 } => "matched"
+    _ => "fell through"
+  }
+}
+
+def objBinder(x: any): string {
+  return match (x) {
+    { a } => "matched ${a}"
+    _ => "fell through"
+  }
+}
+
+def arrBinder(x: any): string {
+  return match (x) {
+    [a, b] => "matched ${a}${b}"
+    _ => "fell through"
+  }
+}
+
+def nested(c: Cmd): string {
+  return match (c) {
+    { words: ["echo", ...rest], redirect: { op: ">", path } } => "write ${path}"
+    _ => "fell through"
+  }
+}
+
+node nullScrutinee() {
+  // A null value must fall through, not crash reading a field off null.
+  return [objLiteral(null), objBinder(null), arrBinder(null)]
+}
+
+node nullIntermediate() {
+  // The redirected arm is FIRST, so no earlier `&&` can short-circuit the
+  // null read away. This is the case that crashes today.
+  return nested({ words: ["echo", "hi"], redirect: null })
+}
+
+node wrongShape() {
+  // A number is not an object; a string is not an array. Neither matches.
+  return [objBinder(3), arrBinder("abc"), objLiteral("hello")]
+}
+
+node rightShape() {
+  // Positive controls: correct shapes still match and still bind.
+  return [
+    objLiteral({ a: 1 }),
+    objBinder({ a: 7 }),
+    arrBinder([1, 2]),
+    nested({ words: ["echo", "hi"], redirect: { op: ">", path: "out.txt" } }),
+  ]
+}

--- a/packages/agency-lang/tests/agency/pattern-matching/patternShapeGuard.test.json
+++ b/packages/agency-lang/tests/agency/pattern-matching/patternShapeGuard.test.json
@@ -1,0 +1,48 @@
+{
+  "tests": [
+    {
+      "nodeName": "nullScrutinee",
+      "description": "An object or array pattern matched against null falls through instead of crashing on a field read.",
+      "input": "",
+      "expectedOutput": "[\"fell through\",\"fell through\",\"fell through\"]",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "nullIntermediate",
+      "description": "A nested object pattern whose intermediate field is null falls through. The arm is first, so no earlier check short-circuits the null read away.",
+      "input": "",
+      "expectedOutput": "\"fell through\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "wrongShape",
+      "description": "An object pattern does not match a number and an array pattern does not match a string, even when the pattern is binders only and has no literal to disagree with.",
+      "input": "",
+      "expectedOutput": "[\"fell through\",\"fell through\",\"fell through\"]",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "rightShape",
+      "description": "Values of the correct shape still match and still bind.",
+      "input": "",
+      "expectedOutput": "[\"matched\",\"matched 7\",\"matched 12\",\"write out.txt\"]",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/pattern-matching/patternShapeGuard.test.json
+++ b/packages/agency-lang/tests/agency/pattern-matching/patternShapeGuard.test.json
@@ -24,9 +24,9 @@
     },
     {
       "nodeName": "wrongShape",
-      "description": "An object pattern does not match a number and an array pattern does not match a string, even when the pattern is binders only and has no literal to disagree with.",
+      "description": "An object pattern does not match a number or an array; an array pattern does not match a string or an object. Binder-only patterns have no literal to disagree with, so only the shape check can reject them.",
       "input": "",
-      "expectedOutput": "[\"fell through\",\"fell through\",\"fell through\"]",
+      "expectedOutput": "[\"fell through\",\"fell through\",\"fell through\",\"fell through\",\"fell through\"]",
       "evaluationCriteria": [
         {
           "type": "exact"

--- a/packages/agency-lang/tests/typescriptGenerator/type-patterns.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/type-patterns.mjs
@@ -317,7 +317,7 @@ return;
   },
 
   {
-    condition: async () => isSuccess(__validateType(__stack.locals.__scrutinee_7, Person)),
+    condition: async () => isSuccess(__validateType(__stack.locals.__scrutinee_7, Person)) && !__eq(__stack.locals.__scrutinee_7, null) && __coarseTypeTest(__stack.locals.__scrutinee_7, "object"),
     body: async (runner) => {
 await runner.step(5, async (runner) => {
 __stack.locals.name = __stack.locals.__scrutinee_7.name;


### PR DESCRIPTION
## The bug

An object or array pattern lowered to a bare member-access chain, with nothing establishing that the value had the shape the pattern requires. A pattern's job is to decide whether a value matches — and the case that did *not* match was the case that crashed:

```ts
type Redirect = { op: string, path: string }
type Cmd = { words: string[], redirect: Redirect | null }

match (c) {                                            // c.redirect is null
  { words: ["echo", ...rest], redirect: { op: ">", path } } => "write ${path}"
  _                                                         => "fallback"
}
// expected: "fallback"
// actual:   failure("Cannot read properties of null (reading 'op')")
```

Today it's masked by `&&` short-circuiting whenever an earlier check in the same arm happens to fail first. Reorder the arms and it surfaces.

The same missing check produced **wrong answers**, not only crashes:

| pattern | value | before | after |
|---|---|---|---|
| `{ a: 1 }` / `{ a }` | `null` | crash | no match |
| `[a, b]` | `null` | crash | no match |
| `{ a }` | `3` | matches, binds `a = undefined` | no match |
| `[a, b]` | `"abc"` | matches, binds characters | no match |
| `{ a: 1 }` | `3` | no match — by accident, `(3).a` is `undefined` | no match, checked |

## The fix

`collectChecks` (`lib/lowering/patternLowering.ts`) emits a shape check at the head of the `objectPattern` and `arrayPattern` cases:

```ts
source != null && __coarseTypeTest(source, "object")   // object patterns
source != null && __coarseTypeTest(source, "array")    // array patterns
```

`__coarseTypeTest` is the same runtime test a `p: Type` arm already emits, so codegen, the formatter, and the typechecker all handle it unchanged.

**Why the pair and not just the coarse test.** The coarse test alone is sufficient at runtime. The `!= null` in front is for the type checker: narrowing by `is object` lands on the *opaque* `object` type, which has no fields, so a pattern reading through a `Redirect | null` field reports `AG2011: Property 'op' does not exist on type 'object'` despite running correctly. `!= null` filters the union properly and the coarse test that follows does not clobber it. That narrowing gap is written up in `docs/superpowers/ideas/2026-07-24-is-object-narrowing-loses-union-members.md`; the `!= null` half can be removed once it's fixed.

## Behavior changes beyond the crash

Each covered by a test:

- `{ a }` no longer matches a non-object; `[a, b]` no longer matches a string.
- An object pattern does not match an array, consistent with Agency's `object` being defined as non-null and non-array. `[a, b]` is the spelling for arrays.
- `match (3 is { s, b })` now reports the head-pattern mismatch as a failure instead of binding `undefined` and running an arm. A binder-only head pattern previously produced no condition at all, so it had nothing to gate on.

## Verification

- New `tests/agency/pattern-matching/patternShapeGuard.agency` — 4/4 passing, **1/4 before the fix**, with a positive-control node so the test isn't vacuous.
- Full `lib` suite: 9418 passed; the only failures are 5 pre-existing ones (`mcpBridge.contract` ×4, `optimize/mutator` ×1), verified failing on a clean tree.
- Agency execution tests: `pattern-matching` 16/16, `destructuring` 6/6, plus `match`, `matchExpression`, `type-patterns`, `match-expr-in-handler`, `goto-match-arm`, `module-level-match`, `match-yield-seq-thread`, `regexMatch` — all pass.
- Three expectations updated, all of which pinned the old condition shape. Exactly **one** fixture line changed across the entire fixture set (`type-patterns.mjs`: a `{name, age}: Person` arm now carries the object test after its schema validation — redundant there, left in rather than special-cased).
- `make` and `pnpm run lint:structure` clean.

## Note

`lib/typeChecker/strictMemberAccess.test.ts` is also touched by #674; both append at the end of the file, so expect a trivial conflict whichever lands second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
