### PR TITLE
Pattern matching: allow a `: Type` suffix on a nested pattern

### DIFF
--- a/packages/agency-lang/docs/site/guide/pattern-matching.md
+++ b/packages/agency-lang/docs/site/guide/pattern-matching.md
@@ -441,6 +441,57 @@ object types (`p: {tag: string} => ...`). It is match-arm only: in `let` /
 `const` declarations, `: Type` stays a static annotation with no runtime
 check (use the bang, `Person!`, for validated declarations).
 
+#### The suffix nests
+
+`: Type` attaches to a whole pattern, so it works anywhere a pattern
+appears — not only at the top of an arm:
+
+```ts
+match (words) {
+  ["echo", s: string]          => print(s)
+  ["cat",  p: SafePath]        => read(p)
+  [{ cmd: "echo" }: Word, ...rest] => handle(rest)
+  _                            => fallback()
+}
+```
+
+That matters when a piece of the value needs validating rather than the
+whole thing. `["cat", p: SafePath]` says the second word must pass
+`SafePath`'s validators for the arm to match at all, so the rule cannot be
+written without its own precondition.
+
+The type always attaches to a **pattern**, never to an object field. To
+constrain fields, type the object:
+
+```ts
+{ name: "Ada" }: { name: string, age: number }  => ...   // yes
+{ name, age }: Person                            => ...   // yes
+```
+
+Remember that inside an object pattern `{ name: string }` binds the `name`
+field to a variable *called* `string` — it does not test the field's type
+(the checker warns with AG5004). Type the whole object instead.
+
+#### Cost
+
+Coarse types — `string`, `number`, `boolean`, `null`, `object`, `any[]` —
+compile to a single `typeof`-style check and are effectively free (a few
+nanoseconds, about the same as comparing two literals).
+
+Every other type validates against the type's schema and runs its
+`@validate` chain, which is roughly **50x** the cost of a coarse check.
+Arms are tried in order and a failing arm pays for its check before the
+next arm runs, so a match whose early arms use named types pays for each
+one it tries. Two things follow:
+
+- Put cheap discriminating checks first. Conditions within an arm are
+  joined with `&&` and short-circuit, so `["cat", p: SafePath]` never runs
+  the validator unless the first word was already `"cat"`.
+- Order arms so common cases match early.
+
+This is nothing next to any real I/O, but it is worth knowing before
+putting a validated type in a hot loop.
+
 ### What a test checks
 
 Coarse types compile to cheap JavaScript checks: `string`, `number`,

--- a/packages/agency-lang/docs/site/guide/type-validation.md
+++ b/packages/agency-lang/docs/site/guide/type-validation.md
@@ -181,6 +181,25 @@ export function isPalindrome(value) {
 }
 ```
 
+## What validation costs
+
+Validating a value is not free. It parses the value against the type's
+schema and then runs every validator in the chain, and it is roughly **50x**
+the cost of a built-in check like `is string` — a few hundred nanoseconds
+against a few. Most of that is the schema parse, not your validator, so a
+type with no validators at all costs nearly the same as one with them.
+
+That is irrelevant next to anything that touches a disk or a network, and
+you should not think about it for ordinary code. It starts to matter in two
+places:
+
+- **Inside a loop over a large collection.** Validating once, outside the
+  loop, beats validating per element.
+- **In [pattern matching](/guide/pattern-matching).** A match tries its arms
+  in order, and an arm that fails still paid for its check. Ordering arms so
+  the common case comes first, and putting cheap literal checks before
+  validated ones inside an arm, avoids most of it — conditions short-circuit.
+
 ## References
 - [minimum](https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-validation-00#rfc.section.6.2.4)
 - [JSON Schema object](https://json-schema.org/understanding-json-schema/reference/object)

--- a/packages/agency-lang/docs/superpowers/ideas/2026-07-24-nested-type-suffix-in-patterns.md
+++ b/packages/agency-lang/docs/superpowers/ideas/2026-07-24-nested-type-suffix-in-patterns.md
@@ -1,0 +1,161 @@
+# Allow a `: Type` suffix on a binder nested inside a pattern
+
+## Status (2026-07-25)
+
+**Implemented**, pending review. Wanted by the safeBash matcher, which
+would like to say "this word must be a valid path" in the pattern rather
+than in the arm body.
+
+The syntax question this doc raised turned out not to exist: the suffix
+attaches to a whole PATTERN, never to an object field, so there is no
+`{ name: n: string }` form to design. Typing an object is
+`{ name: "Ada" }: { name: string }`, which already worked at arm level.
+The change is purely where the existing parser is wired.
+
+## The Problem
+
+The bind-and-test form works at the top of an arm:
+
+```ts
+match (input) {
+  s: string           => s          // ok
+  {name, age}: Person => greet(...) // ok
+  [x, y]: number[]    => "pair"     // ok
+}
+```
+
+but not on a binder *inside* an array or object pattern:
+
+```ts
+match (words) {
+  ["echo", str: string] => print(str)
+}
+// Failed to parse: expected match cases of the form `value => expression`
+```
+
+A parse error, so there is no diagnostic pointing at the real problem —
+the whole match block fails to parse and the message describes the block,
+not the element.
+
+The workaround is a guard (`["echo", str] if (str is string)`), which
+today crashes codegen — see
+[the guard lowering bug](2026-07-24-match-arm-guard-is-expression-not-lowered.md).
+Once that is fixed the workaround exists, but it splits one idea across
+two places and reads worse:
+
+```ts
+["cat", p] if (p is SafePath) => read(p)   // workaround
+["cat", p: SafePath]          => read(p)   // wanted
+```
+
+## Why it matters beyond ergonomics
+
+The suffix is not sugar for a type annotation — for any type that is not
+one of the coarse built-ins, it runs the type's full `@validate` chain
+(`docs/site/guide/pattern-matching.md`, "What a test checks"). So a
+validated type becomes usable as a matching condition:
+
+```ts
+@validate(insideProjectRoot)
+type SafePath = string
+
+match (cmd.words) {
+  ["cat", p: SafePath] => read(p)     // only matches paths that validate
+  _                    => fallback()
+}
+```
+
+That is exactly the shape the safeBash matcher wants: the safety
+precondition lives in the pattern, where it cannot be forgotten, instead
+of in the arm body, where it can.
+
+## Proposed Behavior
+
+Accept `<pattern>: Type` anywhere a pattern element is accepted — array
+elements, object property values, and nested combinations — with the same
+semantics the top-level form already has:
+
+1. The test decides whether the arm matches.
+2. The binder binds the **original** value, not the validator's
+   transformed one (the existing rule, and it should not change here).
+3. A type-suffixed element does not satisfy exhaustiveness, same as the
+   top-level form.
+
+Two syntax questions for design:
+
+- **Ambiguity with object patterns.** Inside `{ }`, `key: value` already
+  means "match this property". So `{ name: n: string }` needs a decision:
+  require parens (`{ name: (n: string) }`), or accept the double colon as
+  written. The array case (`[a: string]`) has no such conflict.
+- **The existing footgun.** `{name: string}` inside an object pattern
+  binds a variable *called* `string` (AG5004 warns). If nested suffixes
+  land, that warning becomes more important, not less — someone who
+  learns `[p: SafePath]` will try `{path: SafePath}` and get a binder.
+  Consider whether AG5004 should become an error inside object patterns
+  once a correct spelling exists.
+
+## Resolution
+
+`matchPatternParser` now parses a base pattern and then peeks for a
+`: Type` suffix, so the suffix is available wherever a pattern appears —
+array elements, object property values, any depth. Written as
+parse-then-peek rather than as another `or` alternative on purpose: an
+alternative that began by parsing a pattern would left-recurse, and even
+guarded against that it would re-parse every nested element twice.
+
+`ObjectPatternProperty["value"]` and `ArrayPattern["elements"]` gained
+`TypePattern`, which DELETED the three "safe narrowing" casts that were
+justified by "nested elements never carry a typePattern". Net removal of
+casts, not addition.
+
+Lowering needed no change at all: `collectChecks`'s `typePattern` case
+already emitted the test and recursed into the inner pattern.
+
+Two consequences worth knowing:
+
+- A property value is itself a pattern, so `{ name: n: string }` parses
+  as "suffix on the binder `n`". Legal but unidiomatic; type the object.
+- `_: Type` works nested too, producing the same `pattern: null` node the
+  arm-level `wildcardSuffixParser` does.
+
+## Touch Points
+
+- `lib/parsers/parsers.ts` — the pattern-element parsers for array and
+  object patterns; the top-level arm parser already handles the suffix
+  (`:3274` area handles `is Type =>` arms), so the work is threading the
+  same suffix parse into element position.
+- `lib/types/pattern.ts` — `typePattern` node already exists; nested use
+  may need no new node, only new parse positions.
+- `lib/lowering/patternLowering.ts:1078` — `collectChecks`'s `typePattern`
+  case already emits the runtime test and recurses into the inner
+  pattern, so nested lowering may work unchanged once parsing does.
+- `lib/backends/agencyGenerator.ts` — the formatter must print nested
+  suffixes back out.
+- `lib/typeChecker/typePatterns.ts` / `matchArmNarrowing` — narrowing for
+  a nested binder.
+
+## Tests
+
+- `["echo", s: string]` matches a string element, falls through on a
+  non-string.
+- `["cat", p: SafePath]` where the validator rejects → arm does not match,
+  falls through (and the validator ran).
+- The bound value is the original, not the transformed one — a repairing
+  validator (clamp-style) still binds the un-repaired input.
+- A nested suffix inside an object pattern, in whichever spelling design
+  picks.
+- Exhaustiveness: a match whose only arms use nested type suffixes still
+  requires `_`.
+- Formatter round-trip: `pnpm run fmt` on a file with nested suffixes is
+  a fixpoint.
+
+## Related
+
+- `docs/site/guide/pattern-matching.md` — "Type patterns", which
+  currently says the suffix works on "binders, object patterns, array
+  patterns"; that is true only at the top of an arm, and the doc should
+  say so until this lands.
+- `docs/site/guide/type-validation.md` — the `@validate` chain the suffix
+  runs.
+- [safeBash command-to-tool matching](2026-07-24-safebash-command-to-tool-matching.md)
+  — the consumer.

--- a/packages/agency-lang/lib/backends/agencyGenerator.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.ts
@@ -579,7 +579,7 @@ export class AgencyGenerator {
       case "resultPattern":
         return this.formatPattern(node);
       case "isExpression":
-        return `${this.processNode(node.expression).trim()} is ${this.formatPattern(node.pattern)}`;
+        return `${this.processNode(node.expression).trim()} is ${this.formatIsRhs(node.pattern)}`;
       case "parallelBlock":
         return this.processParallelBlock(node);
       case "seqBlock":
@@ -920,19 +920,44 @@ export class AgencyGenerator {
         return rp.binding === null ? rp.kind : `${rp.kind}(${rp.binding})`;
       }
       case "typePattern": {
-        // After `is` the surrounding printer already wrote the operator, so
-        // the test-only form is just the type. The bind-and-test form only
-        // occurs in match arms, printed by formatArmCaseValue.
+        // A test-only type pattern (no binder) has THREE spellings, one per
+        // context, and this is the general one:
+        //
+        //   after `is`   -> the bare type; the caller wrote the operator
+        //                   (formatIsRhs)
+        //   an arm       -> `is Type`, the canonical arm spelling
+        //                   (formatArmCaseValue)
+        //   nested       -> `_: Type`, here
+        //
+        // The bare form is only safe where an operator precedes it. Printed
+        // bare inside an array or object pattern it re-parses as a BINDER
+        // named after the type, which matches anything — a formatter pass
+        // would quietly turn a validated rule into an unvalidated one.
         const tp = pattern as TypePattern;
         const typeStr = variableTypeToString(tp.typeHint, this.typeAliases, true);
         return tp.pattern === null
-          ? typeStr
+          ? `_: ${typeStr}`
           : `${this.formatPattern(tp.pattern)}: ${typeStr}`;
       }
       default:
         // variableName / literals — defer to existing rendering
         return this.processNode(pattern as AgencyNode).trim();
     }
+  }
+
+  /**
+   * The right side of the `is` operator. A test-only type pattern prints as
+   * the bare type here, because the operator is already on the page —
+   * `x is string`, not `x is _: string`.
+   */
+  private formatIsRhs(pattern: MatchPattern): string {
+    if (pattern.type === "typePattern") {
+      const tp = pattern as TypePattern;
+      if (tp.pattern === null) {
+        return variableTypeToString(tp.typeHint, this.typeAliases, true);
+      }
+    }
+    return this.formatPattern(pattern);
   }
 
   /**

--- a/packages/agency-lang/lib/formatter.test.ts
+++ b/packages/agency-lang/lib/formatter.test.ts
@@ -162,11 +162,14 @@ describe("formatSource", () => {
       "",
     ].join("\n");
     const formatted = formatSource(input);
-    expect(formatted).toContain("[\"echo\", s: string] =>");
-    expect(formatted).toContain("[\"cat\", p: SafePath] =>");
-    expect(formatted).toContain("[{ cmd: \"echo\" }: Word, ...rest] =>");
+    // formatSource returns null when the source does not parse, so a parse
+    // failure must not read as a silently-skipped assertion.
+    expect(formatted).not.toBeNull();
+    expect(formatted!).toContain("[\"echo\", s: string] =>");
+    expect(formatted!).toContain("[\"cat\", p: SafePath] =>");
+    expect(formatted!).toContain("[{ cmd: \"echo\" }: Word, ...rest] =>");
     // Formatting the output again changes nothing.
-    expect(formatSource(formatted)).toBe(formatted);
+    expect(formatSource(formatted!)).toBe(formatted);
   });
 
   it("round-trips a generics fixture (type params + Record) unchanged", () => {

--- a/packages/agency-lang/lib/formatter.test.ts
+++ b/packages/agency-lang/lib/formatter.test.ts
@@ -144,6 +144,31 @@ describe("formatSource", () => {
     expect(formatted).toBe(input.trimEnd() + "\n");
   });
 
+  it("prints a `: Type` suffix nested inside a pattern, and round-trips it", () => {
+    // The suffix used to be arm-level only, so the printer never met one in
+    // element or property position. A printer that dropped it would silently
+    // turn a validated rule into an unvalidated one.
+    const input = [
+      "node main() {",
+      "  const w = [\"cat\", \"f.txt\"]",
+      "  const r = match (w) {",
+      "    [\"echo\", s: string] => s",
+      "    [\"cat\", p: SafePath] => p",
+      "    [{ cmd: \"echo\" }: Word, ...rest] => \"word\"",
+      "    _ => \"other\"",
+      "  }",
+      "  print(r)",
+      "}",
+      "",
+    ].join("\n");
+    const formatted = formatSource(input);
+    expect(formatted).toContain("[\"echo\", s: string] =>");
+    expect(formatted).toContain("[\"cat\", p: SafePath] =>");
+    expect(formatted).toContain("[{ cmd: \"echo\" }: Word, ...rest] =>");
+    // Formatting the output again changes nothing.
+    expect(formatSource(formatted)).toBe(formatted);
+  });
+
   it("round-trips a generics fixture (type params + Record) unchanged", () => {
     const fixturePath = path.join(__dirname, "../tests/formatter/generics.agency");
     const input = fs.readFileSync(fixturePath, "utf-8");

--- a/packages/agency-lang/lib/formatter.test.ts
+++ b/packages/agency-lang/lib/formatter.test.ts
@@ -155,6 +155,13 @@ describe("formatSource", () => {
       "    [\"echo\", s: string] => s",
       "    [\"cat\", p: SafePath] => p",
       "    [{ cmd: \"echo\" }: Word, ...rest] => \"word\"",
+      // A wildcard with a suffix has no binder, so it takes formatPattern's
+      // `pattern === null` branch — the branch written for after-`is`, where
+      // the operator is already on the page. Printed bare in element position
+      // it would come back as a BINDER named SafePath that matches anything,
+      // silently turning a validated rule into an unvalidated one.
+      "    [\"cat\", _: SafePath] => \"anon\"",
+      "    { path: _: SafePath } => \"anon obj\"",
       "    _ => \"other\"",
       "  }",
       "  print(r)",
@@ -168,6 +175,8 @@ describe("formatSource", () => {
     expect(formatted!).toContain("[\"echo\", s: string] =>");
     expect(formatted!).toContain("[\"cat\", p: SafePath] =>");
     expect(formatted!).toContain("[{ cmd: \"echo\" }: Word, ...rest] =>");
+    expect(formatted!).toContain("[\"cat\", _: SafePath] =>");
+    expect(formatted!).toContain("{ path: _: SafePath } =>");
     // Formatting the output again changes nothing.
     expect(formatSource(formatted!)).toBe(formatted);
   });

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -5901,10 +5901,9 @@ const _objectPatternShorthandParser: Parser<ObjectPatternShorthand> = (
 
 // Shared helpers for binding and match object-property parsers. The two
 // only differ by the inner value parser (bindingPatternParser vs
-// matchPatternParser). The value type is narrower than MatchPattern:
-// typePattern is top-level-only (is-RHS and arm position), so nested
-// property values never carry one — the parsers wired in here cannot
-// produce it, which is what makes the seam cast at the match call site safe.
+// matchPatternParser). Both produce a subset of MatchPattern; the binding
+// parser cannot produce a resultPattern or a typePattern, which is why
+// binding position keeps `: Type` as a static annotation.
 const propertyWithValueParser = (
   valueParser: Parser<ObjectPatternProperty["value"]>,
 ): Parser<ObjectPatternProperty> => (input: string) => {
@@ -6053,7 +6052,7 @@ const _isRhsParser = (input: string): ParserResult<MatchPattern> => {
 };
 export const isRhsParser: Parser<MatchPattern> = _isRhsParser;
 
-const _matchPatternParser = (input: string): ParserResult<MatchPattern> => {
+const _matchPatternBase = (input: string): ParserResult<MatchPattern> => {
   // NOTE: cannot reuse simpleLiteralParser directly because it tries
   // numberParser before variableNameParser, and numberParser is greedy on `_`
   // (e.g. `_foo` would parse as `{type: "number", value: ""}` with rest `foo`).
@@ -6076,6 +6075,52 @@ const _matchPatternParser = (input: string): ParserResult<MatchPattern> => {
   );
   return parser(input) as ParserResult<MatchPattern>;
 };
+
+/** Pattern shapes a `: Type` suffix may follow. The suffix attaches to a whole
+ *  pattern, never to an object field — `{ name: n }: {name: string}` is the
+ *  spelling, and there is no per-field form. */
+function takesTypeSuffix(pattern: MatchPattern): boolean {
+  return (
+    pattern.type === "variableName" ||
+    pattern.type === "objectPattern" ||
+    pattern.type === "arrayPattern" ||
+    pattern.type === "wildcardPattern"
+  );
+}
+
+/**
+ * A match pattern, plus an optional `: Type` suffix.
+ *
+ * The suffix used to be arm-level only, which meant `["cat", p: SafePath]` did
+ * not parse — you could type the whole arm but not a piece of it. Wiring it in
+ * HERE makes it available wherever a pattern appears, at any depth, because
+ * nested elements and property values both come through this parser.
+ *
+ * Written as parse-base-then-peek rather than as another `or` alternative on
+ * purpose. An alternative that began by parsing a pattern would left-recurse
+ * (this parser calling itself at the same position), and even guarded against
+ * that it would re-parse every nested element twice — once speculatively for
+ * the suffix form, once for the plain one. Peeking costs one optional parse of
+ * `:` and nothing else.
+ */
+const _matchPatternParser = (input: string): ParserResult<MatchPattern> => {
+  const base = _matchPatternBase(input);
+  if (!base.success) return base;
+  const pattern = base.result as MatchPattern;
+  if (!takesTypeSuffix(pattern)) return base;
+  const suffix = armTypeSuffixParser(base.rest);
+  if (!suffix.success) return base;
+  return success(
+    {
+      type: "typePattern" as const,
+      // `_: Type` is a test with nothing to bind, matching wildcardSuffixParser.
+      pattern: pattern.type === "wildcardPattern" ? null : (pattern as BindingPattern),
+      typeHint: (suffix.result as { typeHint: VariableType }).typeHint,
+      loc: "loc" in pattern ? pattern.loc : undefined,
+    } as MatchPattern,
+    suffix.rest,
+  );
+};
 export const matchPatternParser: Parser<MatchPattern> = _matchPatternParser;
 
 export const arrayMatchPatternParser: Parser<ArrayPattern> = label(
@@ -6090,8 +6135,6 @@ export const arrayMatchPatternParser: Parser<ArrayPattern> = label(
           or(
             sepBy(
               commaWithNewline,
-              // Safe narrowing: nested array elements never carry a
-              // typePattern (top-level-only; see ArrayPattern in pattern.ts).
               lazy(() => matchPatternParser) as Parser<ArrayPattern["elements"][number]>,
             ),
             succeed([]),
@@ -6111,12 +6154,7 @@ export const arrayMatchPatternParser: Parser<ArrayPattern> = label(
 
 const _matchObjectPropertyParser: Parser<
   ObjectPatternProperty | ObjectPatternShorthand | RestPattern
-> = objectPatternPropertyParser(
-  // Safe narrowing: matchPatternParser only produces typePattern where
-  // typePatternParser is wired (is-RHS and arm top level), never in nested
-  // property position.
-  lazy(() => matchPatternParser) as Parser<ObjectPatternProperty["value"]>,
-);
+> = objectPatternPropertyParser(lazy(() => matchPatternParser));
 
 export const objectMatchPatternParser: Parser<ObjectPattern> = label(
   "an object match pattern",

--- a/packages/agency-lang/lib/parsers/pattern.test.ts
+++ b/packages/agency-lang/lib/parsers/pattern.test.ts
@@ -924,3 +924,78 @@ describe("type patterns after `is`", () => {
     });
   });
 });
+
+describe("a `: Type` suffix nested inside a pattern", () => {
+  it("parses a suffixed binder as an array element", () => {
+    const result = matchPatternParser('["echo", s: string]');
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.result).toMatchObject({
+      type: "arrayPattern",
+      elements: [
+        { type: "string" },
+        {
+          type: "typePattern",
+          pattern: { type: "variableName", value: "s" },
+          typeHint: { type: "primitiveType", value: "string" },
+        },
+      ],
+    });
+  });
+
+  it("parses a suffixed object pattern as an array element", () => {
+    const result = matchPatternParser('[{ cmd: "echo" }: Word, ...rest]');
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const elements = (result.result as any).elements;
+    expect(elements[0]).toMatchObject({
+      type: "typePattern",
+      pattern: { type: "objectPattern" },
+    });
+    expect(elements[1]).toMatchObject({ type: "restPattern" });
+  });
+
+  it("parses a suffix on a binder nested two levels deep", () => {
+    const result = matchPatternParser('{ words: ["cat", p: SafePath], redirect: null }');
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const words = (result.result as any).properties[0].value;
+    expect(words.type).toBe("arrayPattern");
+    expect(words.elements[1]).toMatchObject({
+      type: "typePattern",
+      pattern: { type: "variableName", value: "p" },
+    });
+  });
+
+  it("leaves a pattern with no suffix alone", () => {
+    const result = matchPatternParser('["echo", s]');
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect((result.result as any).elements[1]).toMatchObject({
+      type: "variableName",
+      value: "s",
+    });
+  });
+
+  it("does not consume the object-pattern colon as a suffix", () => {
+    // `{ name: n }` is a field match, not a suffix on anything. The value
+    // parser must stop at `}` rather than treating the field colon as ours.
+    const result = matchPatternParser("{ name: n }");
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect((result.result as any).properties[0]).toMatchObject({
+      type: "objectPatternProperty",
+      key: "name",
+      value: { type: "variableName", value: "n" },
+    });
+  });
+
+  it("does not take a suffix on a pattern kind that cannot carry one", () => {
+    // A literal is not suffixable, so this must not silently become a
+    // typePattern wrapping a string literal.
+    const result = matchPatternParser('["echo", "hi"]');
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect((result.result as any).elements[1].type).toBe("string");
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/matchExhaustiveness.test.ts
+++ b/packages/agency-lang/lib/typeChecker/matchExhaustiveness.test.ts
@@ -476,3 +476,48 @@ def f(n: Node): any {
     expect(errs).toEqual([]);
   });
 });
+
+describe("match exhaustiveness — a nested type suffix can fail", () => {
+  const UNION = `
+type A = { tag: "a", v: any }
+type B = { tag: "b", v: any }
+`;
+
+  it("an arm with a nested type suffix does not cover its case", () => {
+    // `{ tag: "a", v: _: string }` matches only when v is a string, so it
+    // cannot stand in for the whole `A` case. Without this the match looks
+    // exhaustive while a runtime value can fall through every arm — which for
+    // an expression match means no value at all.
+    const errs = check(`${UNION}
+def f(x: A | B): string {
+  return match (x) {
+    { tag: "a", v: _: string } => "a"
+    { tag: "b" } => "b"
+  }
+}`, ERROR);
+    expect(errs.some((e) => /not exhaustive/i.test(e))).toBe(true);
+  });
+
+  it("the same arms without the suffix are exhaustive", () => {
+    const errs = check(`${UNION}
+def f(x: A | B): string {
+  return match (x) {
+    { tag: "a" } => "a"
+    { tag: "b" } => "b"
+  }
+}`, ERROR);
+    expect(errs).toEqual([]);
+  });
+
+  it("adding a wildcard arm makes the suffixed version exhaustive again", () => {
+    const errs = check(`${UNION}
+def f(x: A | B): string {
+  return match (x) {
+    { tag: "a", v: _: string } => "a"
+    { tag: "b" } => "b"
+    _ => "other"
+  }
+}`, ERROR);
+    expect(errs).toEqual([]);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/matchExhaustiveness.ts
+++ b/packages/agency-lang/lib/typeChecker/matchExhaustiveness.ts
@@ -59,6 +59,31 @@ function objectPatternDiscriminantValue(
   return null;
 }
 
+/**
+ * True when a pattern contains a type test somewhere INSIDE it — an element or
+ * property carrying a `: Type` suffix.
+ *
+ * Such an arm can fail at runtime even though its shape matched: a coarse test
+ * can reject the value, and a named type runs validators that can reject it
+ * too. So it cannot stand in for the case its shape pins, exactly like a
+ * guarded arm. A typePattern at the TOP of an arm needs no special handling —
+ * it is neither a literal, a result pattern, nor a bare binder, so it already
+ * contributes nothing to coverage and is not a catch-all.
+ */
+function hasNestedTypeTest(caseValue: CaseValue): boolean {
+  if (caseValue === "_") return false;
+  const top = caseValue.type === "typePattern" ? caseValue.pattern : caseValue;
+  return top !== null && containsTypePattern(top as unknown);
+}
+
+function containsTypePattern(value: unknown): boolean {
+  if (!value || typeof value !== "object") return false;
+  if (Array.isArray(value)) return value.some(containsTypePattern);
+  const record = value as Record<string, unknown>;
+  if (record.type === "typePattern") return true;
+  return Object.keys(record).some((k) => k !== "loc" && containsTypePattern(record[k]));
+}
+
 /** True for a catch-all arm: the `_` default, or an un-guarded bare binding. */
 function isCatchAll(arm: NormalizedArm): boolean {
   if (arm.guarded) return false;
@@ -294,7 +319,10 @@ function normalizeSite(
     const scrutineeType = synthType(node.value as Expression, scope, ctx);
     const arms = node.matchSource.map((a) => ({
       caseValue: a.caseValue,
-      guarded: a.guard !== undefined,
+      // `guarded` means "this arm can fail for a reason coverage cannot see".
+      // A nested type test is one of those reasons, so it rides the same flag
+      // rather than adding a parallel concept every decision point must learn.
+      guarded: a.guard !== undefined || hasNestedTypeTest(a.caseValue),
     }));
     return { scrutineeType, arms, loc: node.loc, isExpression: node.matchExprId !== undefined };
   }
@@ -303,7 +331,10 @@ function normalizeSite(
     const scrutineeType = synthType(node.expression as Expression, scope, ctx);
     const arms = node.cases
       .filter((c): c is MatchBlockCase => c.type === "matchBlockCase")
-      .map((c) => ({ caseValue: c.caseValue, guarded: c.guard !== undefined }));
+      .map((c) => ({
+        caseValue: c.caseValue,
+        guarded: c.guard !== undefined || hasNestedTypeTest(c.caseValue),
+      }));
     return { scrutineeType, arms, loc: node.loc, isExpression: node.matchExprId !== undefined };
   }
   return null;

--- a/packages/agency-lang/lib/typeChecker/typePatterns.test.ts
+++ b/packages/agency-lang/lib/typeChecker/typePatterns.test.ts
@@ -262,3 +262,39 @@ def f(x: any): string {
     expect(warning!.loc?.line).toBeGreaterThan(firstArmLine);
   });
 });
+
+describe("type patterns: narrowing at arm level vs nested", () => {
+  const SRC = `
+def takesString(s: string): string { return s }
+`;
+
+  it("an arm-level suffix narrows the binder", () => {
+    const errs = check(`${SRC}
+def f(x: string | number): string {
+  return match (x) {
+    v: string => takesString(v)
+    _ => "none"
+  }
+}`);
+    expect(errs.filter((e) => (e.severity ?? "error") === "error")).toEqual([]);
+  });
+
+  it("a NESTED suffix does not narrow the binder (known gap)", () => {
+    // Pins current behavior rather than endorsing it. At runtime the arm only
+    // matches when the element IS a string, so the checker is more conservative
+    // than reality — it rejects a valid program rather than accepting an
+    // invalid one, which is the safe direction to be wrong in. Lifting this
+    // means teaching arm narrowing to walk into nested pattern positions.
+    const errs = check(`${SRC}
+def f(xs: (string | number)[]): string {
+  return match (xs) {
+    ["k", v: string] => takesString(v)
+    _ => "none"
+  }
+}`);
+    const hard = errs.filter((e) => (e.severity ?? "error") === "error");
+    expect(hard.map((e) => e.message).join("\n")).toMatch(
+      /'string \| number' is not assignable to parameter type 'string'/,
+    );
+  });
+});

--- a/packages/agency-lang/lib/types/pattern.ts
+++ b/packages/agency-lang/lib/types/pattern.ts
@@ -5,9 +5,9 @@ import type { Expression, VariableType } from "../types.js";
 export type ObjectPatternProperty = {
   type: "objectPatternProperty";
   key: string;
-  // ResultPattern is only valid in match-position use; the parser does not
-  // produce it in binding-position contexts.
-  value: BindingPattern | Literal | ResultPattern;
+  // ResultPattern and TypePattern are only valid in match-position use; the
+  // parser does not produce either in binding-position contexts.
+  value: BindingPattern | Literal | ResultPattern | TypePattern;
 };
 
 export type ObjectPatternShorthand = {
@@ -22,9 +22,16 @@ export type ObjectPattern = BaseNode & {
 
 export type ArrayPattern = BaseNode & {
   type: "arrayPattern";
-  // ResultPattern is only valid in match-position use; the parser does not
-  // produce it in binding-position contexts.
-  elements: (BindingPattern | Literal | WildcardPattern | RestPattern | ResultPattern)[];
+  // ResultPattern and TypePattern are only valid in match-position use; the
+  // parser does not produce either in binding-position contexts.
+  elements: (
+    | BindingPattern
+    | Literal
+    | WildcardPattern
+    | RestPattern
+    | ResultPattern
+    | TypePattern
+  )[];
 };
 
 export type RestPattern = BaseNode & {
@@ -49,7 +56,13 @@ export type ResultPattern = BaseNode & {
 };
 
 // A runtime type test in pattern position. Two spellings share this node:
-// `is Type` (pattern: null) and the match-arm bind-and-test `pattern: Type`.
+// `is Type` (pattern: null) and the bind-and-test `pattern: Type`.
+//
+// The suffix attaches to a whole PATTERN — a binder, an object pattern, or an
+// array pattern — never to an object field. `{ name: n }: {name: string}` is
+// the spelling; there is no per-field form. It is legal wherever a match
+// pattern appears, at any depth.
+//
 // Deliberately NOT part of BindingPattern — type patterns are illegal in
 // let/const/for, where `: Type` must stay a static annotation.
 export type TypePattern = BaseNode & {

--- a/packages/agency-lang/tests/agency/pattern-matching/nestedTypeSuffix.agency
+++ b/packages/agency-lang/tests/agency/pattern-matching/nestedTypeSuffix.agency
@@ -1,0 +1,74 @@
+// A `: Type` suffix attaches to a whole pattern — a binder, an object pattern,
+// or an array pattern. It already worked at the top of an arm; these are the
+// same shapes nested inside another pattern.
+
+def notEmpty(v: string): Result<string> {
+  if (v == "") {
+    return failure("empty path")
+  }
+  return success(v)
+}
+
+@validate(notEmpty)
+type SafePath = string
+
+type Word = { cmd: string }
+
+def describe(words: any[]): string {
+  return match (words) {
+    ["echo", s: string] => "echo string: ${s}"
+    ["echo", n: number] => "echo number: ${n}"
+    _ => "other"
+  }
+}
+
+def readPath(words: any[]): string {
+  return match (words) {
+    ["cat", p: SafePath] => "read ${p}"
+    _ => "cannot map"
+  }
+}
+
+def firstWord(items: any[]): string {
+  return match (items) {
+    [{ cmd: "echo" }: Word, ...rest] => "echo word, ${rest.length} more"
+    _ => "other"
+  }
+}
+
+def deep(cmd: any): string {
+  // object > array > binder-with-suffix, which is the shape a lowered bash
+  // command matcher wants.
+  return match (cmd) {
+    { words: ["cat", p: SafePath], redirect: null } => "read ${p}"
+    _ => "other"
+  }
+}
+
+node binderSuffix() {
+  // The suffix decides which arm matches, on element type alone.
+  return [describe(["echo", "hi"]), describe(["echo", 42]), describe(["ls"])]
+}
+
+node validatedSuffix() {
+  // A named type runs its validator: a path that fails validation does not
+  // match, and falls through.
+  return [readPath(["cat", "f.txt"]), readPath(["cat", ""])]
+}
+
+node nestedObjectSuffix() {
+  return [firstWord([{ cmd: "echo" }, "x"]), firstWord([{ cmd: "ls" }, "x"])]
+}
+
+node deeplyNested() {
+  return [
+    deep({ words: ["cat", "f.txt"], redirect: null }),
+    deep({ words: ["cat", ""], redirect: null }),
+  ]
+}
+
+node bindsTheOriginal() {
+  // Rule 1 from the type-patterns spec still holds nested: the binder gets the
+  // value as it arrived, not whatever the validator returned.
+  return readPath(["cat", "f.txt"])
+}

--- a/packages/agency-lang/tests/agency/pattern-matching/nestedTypeSuffix.test.json
+++ b/packages/agency-lang/tests/agency/pattern-matching/nestedTypeSuffix.test.json
@@ -1,0 +1,59 @@
+{
+  "tests": [
+    {
+      "nodeName": "binderSuffix",
+      "description": "A type suffix on a binder nested in an array pattern decides the arm: the same shape dispatches on element type.",
+      "input": "",
+      "expectedOutput": "[\"echo string: hi\",\"echo number: 42\",\"other\"]",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "validatedSuffix",
+      "description": "A named type nested in a pattern runs its validator, so a value that fails validation does not match and falls through.",
+      "input": "",
+      "expectedOutput": "[\"read f.txt\",\"cannot map\"]",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "nestedObjectSuffix",
+      "description": "An object pattern nested in an array can carry its own type suffix.",
+      "input": "",
+      "expectedOutput": "[\"echo word, 1 more\",\"other\"]",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "deeplyNested",
+      "description": "Object containing an array containing a validated binder — the shape a lowered bash command matcher uses.",
+      "input": "",
+      "expectedOutput": "[\"read f.txt\",\"other\"]",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "bindsTheOriginal",
+      "description": "A nested type suffix binds the value as it arrived; validators decide whether the arm matches, they never rewrite what is bound.",
+      "input": "",
+      "expectedOutput": "\"read f.txt\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Third of the pattern-matching items behind the safeBash command matcher, after #676 and #677.

## The problem

The bind-and-test suffix worked at the top of an arm but not inside another pattern — you could type a whole arm, but not a piece of one:

```ts
match (words) {
  ["cat", p: SafePath] => read(p)
}
// Failed to parse: expected match cases of the form `value => expression`
```

That matters more than ergonomics. For anything but a coarse built-in, the suffix runs the type's full `@validate` chain, so a validated type becomes a *matching condition* — the arm only matches when the value passes. Nested, that puts a rule's safety precondition in the pattern where it cannot be forgotten, instead of in the arm body where it can.

## No new syntax

The suffix attaches to a whole **pattern** — a binder, an object pattern, an array pattern — and never to an object field. So there is no per-field form to invent. Typing an object is what it always was, and already worked:

```ts
{ name: "Ada" }: { name: string, age: number }  =>  ✓ before and after
{ name, age }: Person                            =>  ✓ before and after
```

This PR is purely about *where* the existing parser is wired.

## The change

`matchPatternParser` parses a base pattern and then peeks for a `: Type` suffix, which makes it available wherever a pattern appears, at any depth.

Parse-then-peek rather than another `or` alternative, deliberately: an alternative that began by parsing a pattern would left-recurse on itself, and even guarded against that it would re-parse every nested element twice — once speculatively for the suffix form, once for the plain one. Peeking costs one optional parse of `:`.

`ObjectPatternProperty["value"]` and `ArrayPattern["elements"]` gained `TypePattern`, which **deleted** the three "safe narrowing" casts justified by *"nested elements never carry a typePattern"* (`parsers.ts` :5905, :6094, :6115). A net removal of casts.

**Lowering needed nothing.** `collectChecks`'s `typePattern` case already emitted the runtime test and recursed into the inner pattern, so it handled nested suffixes the moment they could be parsed.

## Now possible

```ts
match (words) {
  ["echo", s: string]              => print(s)
  ["cat",  p: SafePath]            => read(p)          // validator decides the match
  [{ cmd: "echo" }: Word, ...rest] => handle(rest)
  _                                => fallback()
}

// object > array > validated binder — the shape the bash matcher wants
{ words: ["cat", p: SafePath], redirect: null } => read(p)
```

One consequence to know: a property value is itself a pattern, so `{ name: n: string }` parses as a suffix on the binder `n`. Legal but unidiomatic — type the object instead.

## Verification

Test-first; each case watched failing before the change.

- New `tests/agency/pattern-matching/nestedTypeSuffix.agency` — 5/5, was a parse error. Covers dispatch on element type, a validated type that rejects and falls through, a nested object pattern with its own suffix, object > array > validated binder, and Rule 1 (the binder gets the original value, not the validator's).
- Six parser tests in `pattern.test.ts`, four of which fail without the change; the other two are negative controls — that the object-pattern field colon is not eaten as a suffix, and that a non-suffixable kind (a literal) does not silently become a `typePattern`.
- A formatter test: nested suffixes print back out and re-formatting is a fixpoint. Without the change it fails.
- Existing `type-patterns` 9/9, so arm-level behavior is unchanged. `pattern-matching` 29/29, `destructuring` 6/6, plus `match`, `matchExpression`, `goto-match-arm`, `module-level-match`, `match-yield-seq-thread`, `match-expr-in-handler`.
- Full `lib` suite: 9553 passed, only the 5 known pre-existing failures (`mcpBridge.contract` x4, `optimize/mutator` x1). `lib/compiler/splice/rebuild.test.ts` failed on one run and passed on another with no change in between — flaky, and it fails on a stashed tree too.
- `make fixtures` produced no changes. `make` and `pnpm run lint:structure` clean.

## Docs

`pattern-matching.md` gains the nested form, the rule that the type attaches to a pattern and not a field, and a pointer back to the AG5004 footgun. Both it and `type-validation.md` gain a cost note, measured at 200k iterations:

| check | ns/op |
|---|---|
| literal compare | 3 |
| `__coarseTypeTest(v, "string")` | 7 |
| validated type, passes | 372 |
| validated type, fails | 393 |

Coarse types are free; a named type is ~50x that, and most of it is the schema parse rather than the validator. Since arms are tried in order and conditions short-circuit, the guidance is to put cheap discriminating checks first — `["cat", p: SafePath]` never runs the validator unless the first word already matched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
