### PR TITLE
Array patterns: no rest binder means an exact length

### DIFF
--- a/packages/agency-lang/CHANGELOG.md
+++ b/packages/agency-lang/CHANGELOG.md
@@ -1,5 +1,31 @@
 ## Unreleased
 
+### Breaking: an array pattern without `...rest` now requires an exact length
+
+`["a", "b"]` used to match any array *starting* with `a`, `b` — every array
+pattern was a prefix match, and there was no way to say "exactly these two":
+
+```ts
+match (["a", "b", "c"]) {
+  ["a", "b"] => "matched"      // before: matched. now: falls through.
+  _          => "fell through"
+}
+```
+
+A pattern with no rest binder now names the whole array. Add `...rest` to get
+the old reading, which is what it always meant:
+
+```ts
+["a", "b", ...rest]    // matches ["a","b","c"], rest = ["c"]
+```
+
+This affects every construct that matches a pattern — `match` arms, the `is`
+operator, `while` conditions — but **not** destructuring: `const [a, b] = xs`
+never checked length and still does not.
+
+The change is silent. Code relying on the old prefix behavior stops matching
+with no diagnostic, because the pattern now means what it says.
+
 ### Breaking: relative paths now resolve against the working directory
 
 Every path-taking function (`read`, `write`, `edit`, `ls`, `grep`, `glob`,

--- a/packages/agency-lang/CHANGELOG.md
+++ b/packages/agency-lang/CHANGELOG.md
@@ -20,8 +20,17 @@ the old reading, which is what it always meant:
 ```
 
 This affects every construct that matches a pattern — `match` arms, the `is`
-operator, `while` conditions — but **not** destructuring: `const [a, b] = xs`
-never checked length and still does not.
+operator, `if` and `while` conditions — but **not** destructuring:
+`const [a, b] = xs` never checked length and still does not.
+
+One case changes control flow rather than which arm runs. In
+`match (xs is ["a", "b"])`, a head pattern that no longer matches returns a
+`failure` from the enclosing function instead of running an arm:
+
+```ts
+match (xs is ["a", "b"]) { ... }   // xs = ["a","b","c"]
+// before: ran an arm.  now: returns failure("... head pattern did not match")
+```
 
 The change is silent. Code relying on the old prefix behavior stops matching
 with no diagnostic, because the pattern now means what it says.

--- a/packages/agency-lang/docs/site/guide/pattern-matching.md
+++ b/packages/agency-lang/docs/site/guide/pattern-matching.md
@@ -26,6 +26,19 @@ const [head, ...rest]   = items   // head = 1, rest = [2,3,4,5]
 
 The rest binder must be the last element. You can't have `[a, ...m, b]` for example.
 
+In a **match**, an array pattern without a rest binder names the whole array,
+so the length has to match exactly. Add `...rest` when you mean "at least":
+
+```ts
+match (["a", "b", "c"]) {
+    ["a", "b"]          => "no match — the pattern names two elements"
+    ["a", "b", ...rest] => "matches, rest = [\"c\"]"
+}
+```
+
+Destructuring is different: `const [a, b] = items` takes the first two and
+ignores the rest, because a declaration binds rather than tests.
+
 ### Object destructuring
 
 ```ts

--- a/packages/agency-lang/docs/site/guide/pattern-matching.md
+++ b/packages/agency-lang/docs/site/guide/pattern-matching.md
@@ -26,8 +26,9 @@ const [head, ...rest]   = items   // head = 1, rest = [2,3,4,5]
 
 The rest binder must be the last element. You can't have `[a, ...m, b]` for example.
 
-In a **match**, an array pattern without a rest binder names the whole array,
-so the length has to match exactly. Add `...rest` when you mean "at least":
+When an array pattern is used to **match** — a `match` arm, the `is` operator,
+an `if` or `while` condition — a pattern without a rest binder names the whole
+array, so the length has to match exactly. Add `...rest` when you mean "at least":
 
 ```ts
 match (["a", "b", "c"]) {

--- a/packages/agency-lang/docs/superpowers/specs/2026-07-25-array-pattern-length-and-middle-rest-design-REVIEW.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-07-25-array-pattern-length-and-middle-rest-design-REVIEW.md
@@ -1,0 +1,128 @@
+# Review: array patterns — exact length, and a rest binder anywhere
+
+Review of [the spec](2026-07-25-array-pattern-length-and-middle-rest-design.md),
+2026-07-25.
+
+## Verdict
+
+Ready to implement once the gaps below are closed. The diagnosis in Part 1 is
+right, the language table is the correct frame for "is a middle rest exotic",
+and the performance section pre-empts the obvious objection with numbers
+instead of assertion. Rejecting a separate one-or-more sigil is well argued —
+`["a", mid, ...rest, "c"]` really does say the thing, and no language in the
+table disagrees.
+
+Two things I checked that hold up:
+
+- The tail arithmetic. `xs[xs.length - tail.length + i]` is correct, and the
+  worked example against `["a","b",...rest,"d","e"]` indexes the right
+  elements.
+- Part 1's cause. `hasRest ? ">=" : ">="` reads as an unfinished edit, not a
+  decision — same conclusion I reached reviewing #676, where the line is
+  adjacent to that change.
+
+## 1. The headline examples use syntax that does not parse
+
+Lines 77–78 both write `...rest: string[]`:
+
+```ts
+["echo", a: string, b: string, ...rest: string[], last: string]
+```
+
+That does not parse today:
+
+```
+["echo", ...rest: string[]] => "yes"
+Failed to parse: expected match cases of the form `value => expression`
+```
+
+`takesTypeSuffix` (added in #695) admits `variableName`, `objectPattern`,
+`arrayPattern` and `wildcardPattern` — not `restPattern`. So Part 2 as written
+needs a third change, and that change appears only as a Tests bullet (line
+241). It is absent from Semantics, Lowering, Errors and Sequencing.
+
+It also opens a semantics question the spec never answers: **what does
+`...rest: string[]` test?** Two readings, and they are not close:
+
+- Validate the slice element-wise against `string[]`. Cost scales with the
+  slice length, and by #695's own measurements a named type runs ~370 ns per
+  value — which would dominate every number in the performance table.
+- Assert only that the slice is an array. Always true, so the suffix is a
+  no-op and should probably be rejected rather than accepted.
+
+**Recommendation:** drop the suffix from the Part 2 examples so Part 2 is
+exactly what it claims, and give the rest-binder suffix its own part with its
+own semantics. As written the spec's two most prominent lines describe
+something it does not plan to build.
+
+## 2. The impact analysis counts match arms; `is` positions change too
+
+`if (xs is ["a", "b"])` parses and prefix-matches today — confirmed against a
+current build. `while` conditions and `match (x is [...])` heads route through
+the same `patternToCondition`, so Part 1 changes all of them.
+
+The count is genuinely zero in this repo, so "provably this small" survives
+intact. But **"Array patterns in match position: 15"** reads as though match
+arms were the whole surface, and `docs/site/guide/pattern-matching.md`
+documents `is` with array patterns — so a reader checking their own code
+against this table would check the wrong construct.
+
+State the constructs, not only the count.
+
+While there: say explicitly that **binding position is untouched**.
+`const [a, b] = xs` goes through `extractBindings`, which emits no length
+check at all, so Part 1 cannot affect destructuring. Every reader will wonder;
+the spec never says.
+
+## 3. "Exactly today's output" has to be a deliberate branch
+
+`sliceCall(source, start)` (`patternLowering.ts:1413`) emits a start-only
+slice. The two-sided form produces `xs.slice(2, xs.length - 0)` when `tail` is
+empty unless the one-argument form is kept explicitly.
+
+The spec asserts the prefix case is "unchanged rather than reimplemented"
+(line 184). That holds only if the branch is written down as a requirement.
+Otherwise every existing rest fixture churns, and a diff where the interesting
+change is buried in fixture noise stops being reviewable.
+
+Worth recording the good news too: `AccessChainElement` is already
+`{ kind: "slice"; start?; end? }` (`lib/types/access.ts:7`), so the two-sided
+slice is a parameter to machinery that exists, not a new IR node.
+
+## 4. "Reject with a diagnostic" does not say which mechanism
+
+`enforceRestAtEnd` lives in the parser (`parsers.ts:5846`). Diagnostics with
+AG codes come from the typechecker registry, so a parser cannot emit one.
+
+The Errors section therefore has an unresolved choice: either this becomes a
+good **parse error message**, or the check **moves to the typechecker** so it
+can carry a code. Since the spec's own complaint is that users get a stack
+trace instead of a diagnostic, it should say which, and pick the number.
+
+## 5. Two missing rows in the semantics table
+
+- **Rest first** — `[...rest, "c"]`. The minimal middle-rest case, and the one
+  most likely to expose an off-by-one in the tail arithmetic, since `head` is
+  empty. Neither the table nor the Tests section has it.
+- **Rest alone** — `[...rest]`, where head and tail are both empty.
+
+One line each, in the table and in Tests.
+
+## Smaller
+
+- The impact table's `affected` column means "meaning changes", but the prose
+  immediately explains that no result changes. Renaming it ("meaning changes")
+  removes the contradiction.
+- Part 1 is a silent behavior change with no diagnostic, accepted for good
+  reasons. That makes a changelog entry the only signal users get — worth
+  naming as a deliverable of that PR rather than leaving it implied.
+
+## Sequencing
+
+Splitting Part 1 into its own PR is the right call, and the reason given —
+build Part 2 on a base that is known correct — is the right reason.
+
+One addition: if the rest-binder type suffix stays in scope at all, it should
+be a third PR after Part 2, not folded into it. It is a parser change plus a
+semantics decision, and it shares nothing with the length arithmetic that
+makes Parts 1 and 2 one design.

--- a/packages/agency-lang/docs/superpowers/specs/2026-07-25-array-pattern-length-and-middle-rest-design-REVIEW.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-07-25-array-pattern-length-and-middle-rest-design-REVIEW.md
@@ -3,6 +3,15 @@
 Review of [the spec](2026-07-25-array-pattern-length-and-middle-rest-design.md),
 2026-07-25.
 
+## Status: addressed
+
+Items 2, 3, 4, 5 and both Smaller items are folded into the 2026-07-25
+revision of the spec. Item 1 (the rest-binder type suffix) is deferred to
+Part 3, which the revision adds with both semantics readings recorded.
+
+Kept alongside the spec so the reasoning behind those revisions stays
+findable. Nothing here is still open.
+
 ## Verdict
 
 Ready to implement once the gaps below are closed. The diagnosis in Part 1 is

--- a/packages/agency-lang/docs/superpowers/specs/2026-07-25-array-pattern-length-and-middle-rest-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-07-25-array-pattern-length-and-middle-rest-design.md
@@ -296,6 +296,22 @@ during implementation, but not assumed and not bundled in here.
 Measured at 2M iterations against a 5-element array, at the level the
 lowered condition runs:
 
+Note the exact-length check is not a native comparison. Every equality
+operator in Agency routes through the `__eq` helper so null and undefined
+compare equal, and `===` is a documented stylistic alias that compiles
+identically (`typescriptBuilder.ts:1379`). So `["a","b"]` emits
+`__eq(xs.length, 2)` where the rest path emits a native `xs.length >= 2`.
+Measured, that costs about 1 ns:
+
+| check | ns/op |
+|---|---|
+| native `xs.length === 2` (not what we emit) | 1.5 |
+| `__eq(xs.length, 2)` — the exact-length path | 5.8 |
+| native `xs.length >= 2` — the rest path | 4.7 |
+
+Bypassing the helper would make one generated check the only equality in the
+language that skips it, for ~1 ns. Not worth the exception.
+
 | pattern shape | ns/op |
 |---|---|
 | `["a","b"]` exact | 2.7 |

--- a/packages/agency-lang/docs/superpowers/specs/2026-07-25-array-pattern-length-and-middle-rest-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-07-25-array-pattern-length-and-middle-rest-design.md
@@ -1,0 +1,373 @@
+# Array patterns: exact length, and a rest binder anywhere
+
+## Status (2026-07-25)
+
+Spec, reviewed and updated — see
+[the review](2026-07-25-array-pattern-length-and-middle-rest-design-REVIEW.md).
+Ready to implement. Two changes to array patterns that share the same
+arithmetic, so they belong in one design even though the first is a bug fix
+and the second is a feature.
+
+Came out of the safeBash matcher work, where a bash command's words are an
+array and the interesting rules are "a verb, some flags, and a final path".
+
+## Part 1: an array pattern matches any longer array
+
+### The bug
+
+```ts
+match (["a", "b", "c"]) {
+  ["a", "b"] => "shouldn't match"
+  _          => "fell through"
+}
+// actual: "shouldn't match"
+```
+
+Every array pattern is currently a *prefix* match. `["a", "b"]` accepts any
+array that starts with `a`, `b` — there is no way to say "exactly these two".
+
+### Cause
+
+`collectChecks` (`lib/lowering/patternLowering.ts:1179`):
+
+```ts
+const hasRest = pattern.elements.some((e) => e.type === "restPattern");
+const namedCount = pattern.elements.filter((e) => e.type !== "restPattern").length;
+const lenAccess = fieldAccess(source, "length", pattern.loc);
+const op: Operator = hasRest ? ">=" : ">=";   // <- both branches
+checks.push(makeBinOp(lenAccess, op, numberLit(namedCount, pattern.loc), pattern.loc));
+```
+
+The ternary computes `hasRest` and then ignores it. The intent is legible
+from the shape of the code — the variable exists for no other reason — so
+this reads as an unfinished edit rather than a decision.
+
+### Fix
+
+```ts
+const op: Operator = hasRest ? ">=" : "==";
+```
+
+An array pattern with no rest binder requires an exact length. With a rest
+binder it requires at least as many elements as the pattern names.
+
+### Impact
+
+Every construct that routes through `patternToCondition` is affected, not
+just match arms: `match` arms, the `is` operator, `while` conditions, and
+`match (x is [...])` heads. `if (xs is ["a","b"])` prefix-matches today —
+confirmed against a current build.
+
+**Binding position is untouched.** `const [a, b] = xs` goes through
+`extractBindings`, which emits no length check at all, so destructuring
+cannot change. Part 1 is about matching only.
+
+Parsed all 1258 `.agency` files. Array patterns in those matching
+constructs: **15**.
+
+| form | count | meaning changes |
+|---|---|---|
+| with `...rest` | 2 | no — already `>=` |
+| without a rest | 13 | yes |
+
+All 13 are two-element patterns in test files, every one of them matched
+against a two-element value, so none changes result. **Zero occurrences in
+`stdlib/`.** The change is a behavior change on paper and a no-op in this
+repo.
+
+It is silent for anyone relying on the old behavior — code that matched
+before may stop matching, with no diagnostic. That is unavoidable (the whole
+point is that the pattern now means what it says) and is the reason to do it
+before the feature below rather than after, while the blast radius is
+provably this small.
+
+## Part 2: `...rest` anywhere in the pattern
+
+### What we want to write
+
+```ts
+["echo", a: string, b: string, ...rest, last: string]
+["echo", a: string, ...rest, penultimate: string, last: string]
+```
+
+A type suffix on the REST binder itself (`...rest: string[]`) is deliberately
+not here — it does not parse today and it raises a semantics question the
+length arithmetic has no opinion on. Part 3.
+
+Today the rest binder must be last. Anything else throws:
+
+```
+Error: rest pattern must be the last element of an array pattern
+```
+
+— a raw `throw new Error` from `enforceRestAtEnd` (`lib/parsers/parsers.ts:5846`),
+so the user gets a stack trace rather than a diagnostic. That is a bug
+regardless of whether we lift the restriction.
+
+### Why this is normal, and why it looked unusual
+
+Languages that match on a **sequence** support a rest in any position.
+Languages that match on an **iterator** cannot.
+
+| language | syntax | supported |
+|---|---|---|
+| Rust | `[first, .., last]` | yes |
+| Python | `case [first, *rest, last]` | yes |
+| Ruby | `[a, *middle, b]` | yes |
+| MoonBit | `[e, .., f]` | yes |
+| Scala | `case Seq(a, _*, b)` | yes |
+| JavaScript destructuring | `const [a, ...rest, b]` | **SyntaxError** |
+
+JavaScript is the outlier, and it is the one everyone has seen. Its
+destructuring consumes an iterator — lazy and single-pass — so it cannot
+know where the end is without buffering. That constraint is real for JS and
+does not apply here: Agency arrays are JS arrays with `.length`, matched by
+index.
+
+So the feature is not exotic. It looks that way from a JavaScript vantage
+point.
+
+### Semantics
+
+Adopt PEP 634's rules verbatim, since they are already precise and match
+every other language in the table:
+
+1. **At most one** rest binder per array pattern. It may occur in any
+   position.
+2. The pattern fails if the value's length is less than the number of
+   non-rest elements.
+3. Leading non-rest elements match from the front, by index.
+4. Trailing non-rest elements match from the back, by index from the end.
+5. The rest binder takes what is left in between, and binds `[]` when that
+   is empty.
+
+Rule 5 makes `...rest` **zero-or-more**, which is what Agency does today
+(`["a","b",...rest]` matches `["a","b"]` with `rest = []`) and what every
+language in the table does.
+
+Worked against `["a", "b", "c"]`:
+
+| pattern | matches | bindings |
+|---|---|---|
+| `["a", "b"]` | no | length must equal 2 |
+| `["a", "b", ...rest]` | yes | `rest = ["c"]` |
+| `["a", ...rest]` | yes | `rest = ["b", "c"]` |
+| `["a", ...rest, "c"]` | yes | `rest = ["b"]` |
+| `["a", "b", ...rest, "c"]` | yes | `rest = []` |
+| `[...rest, "c"]` | yes | `rest = ["a", "b"]` — empty head |
+| `[...rest]` | yes | `rest = ["a", "b", "c"]` — empty head and tail |
+
+### No separate one-or-more form
+
+Considered and rejected. It is already expressible with no new syntax:
+
+```ts
+["a", ...rest, "c"]         // zero or more between
+["a", mid, ...rest, "c"]    // one or more — `mid` is the guaranteed element
+```
+
+Adding a second rest sigil would mean new syntax, a decision about what it
+binds when empty, and another rule to explain, to say something the existing
+form already says. No language in the table has one.
+
+## Part 3: a type suffix on the rest binder
+
+Out of scope for Parts 1 and 2, recorded because the motivating examples
+reached for it.
+
+`["echo", ...rest: string[]]` does not parse. `takesTypeSuffix` (#695) admits
+`variableName`, `objectPattern`, `arrayPattern` and `wildcardPattern` — not
+`restPattern` — so this is a parser change, and it shares nothing with the
+length arithmetic that makes Parts 1 and 2 one design.
+
+It also needs a semantics decision the other parts do not:
+
+- **Validate the slice element-wise.** Cost scales with slice length, and a
+  named type runs ~370 ns per value (#695's measurements), so a rest of 50
+  elements would cost ~19 µs — dominating every number in the performance
+  table below.
+- **Assert only that the slice is an array.** Always true by construction, so
+  the suffix is a no-op and should be rejected rather than silently accepted.
+
+Neither reading is obviously right, which is why it gets its own design pass
+rather than a bullet here.
+
+## Lowering
+
+`collectChecks`'s `arrayPattern` case currently assumes every element sits
+at a fixed index from zero. The change is to split the element list at the
+rest binder and index the two halves from opposite ends.
+
+Given `elements`, `restIndex` (or none), `head = elements.slice(0, restIndex)`
+and `tail = elements.slice(restIndex + 1)`:
+
+```ts
+// ["a", "b", ...rest, "d", "e"]  against  xs
+xs != null && __coarseTypeTest(xs, "array")   // shape check, unchanged
+  && xs.length >= 4                           // head.length + tail.length
+  && xs[0] === "a"                             // head, indexed from the front
+  && xs[1] === "b"
+  && xs[xs.length - 2] === "d"                 // tail, indexed from the end
+  && xs[xs.length - 1] === "e"
+```
+
+Tail element `i` (0-based within `tail`) reads
+`xs[xs.length - tail.length + i]`.
+
+Bindings follow the same split. `extractBindings` binds a trailing element
+from the end, and the rest binder becomes a two-sided slice:
+
+```ts
+const rest = xs.slice(2, xs.length - 2);   // head.length, length - tail.length
+```
+
+**Requirement, not a hope:** when `tail` is empty the lowerer must emit the
+one-argument form. `sliceCall` (`patternLowering.ts:1413`) is start-only
+today, so a two-sided call would produce `xs.slice(2, xs.length - 0)` for
+every existing prefix pattern — churning every rest fixture and burying the
+interesting diff in noise. Keep the one-argument branch explicitly.
+
+The IR already supports both: `AccessChainElement` is
+`{ kind: "slice"; start?; end? }` (`lib/types/access.ts:7`), so the two-sided
+slice is an argument to existing machinery, not a new node.
+
+### Binding position gets this too
+
+`const [a, ...rest, b] = xs` is legal. `extractBindings` is the shared path,
+so a trailing binder costs the same index-from-the-end there as it does in a
+match, and the JavaScript constraint that forbids it — destructuring consumes
+an iterator — does not apply to an indexable array.
+
+Part 1 is match-only because binding position emits no length check at all;
+Part 2 applies to both, because binding is where the arithmetic lives.
+
+Nesting composes without extra work: a trailing element's own sub-pattern
+recurses with `xs[xs.length - n]` as its source, the same way a leading one
+recurses with `xs[i]`.
+
+### Errors
+
+**At most one rest binder per array pattern.** Decided, not open.
+
+```ts
+["a", ...rest]              // ok
+["a", ...rest, "c"]         // ok — Part 2 makes position free
+["a", ...x, "b", ...y]      // ERROR: at most one rest binder
+```
+
+An error rather than a warning, because there is no sensible fallback: with
+two rests nothing decides where the split falls, so any behavior we chose
+would be arbitrary. Every language in the table forbids it for the same
+reason.
+
+The budget is **per array pattern**, not per arm — nested arrays are separate
+patterns and each gets its own:
+
+```ts
+["cmd", ...outer, [x, ...inner]]    // legal, one rest each
+```
+
+This REPLACES the current rule rather than adding to it. `enforceRestAtEnd`
+(`lib/parsers/parsers.ts:5839`) goes from "rest must be the last element" to
+"at most one rest": Part 2 removes the position constraint, this keeps the
+count constraint. Same function, different job — rename it accordingly.
+
+It also stops being a crash. Today a misplaced rest is a raw
+`throw new Error` with a stack trace.
+
+**Where the check lives: pattern lowering, as a `PatternLoweringError`.** Not
+the typechecker — lowering runs BEFORE typechecking, so by the time the
+checker sees anything the array pattern is already a boolean condition and
+there is no pattern left to inspect. That rules out an AG code, since the
+diagnostic registry is the typechecker's.
+
+`LoweringError` carries a `loc` (`lib/lowering/loweringError.ts:8`), and
+`assertNoBindersInBoolIs` is the precedent: the same class of check —
+"this pattern is structurally invalid" — already lives there and produces a
+clean compile error rather than a stack trace. Point the `loc` at the second
+rest binder.
+
+Scoped to ARRAY patterns. Object patterns take a rest too (`{ a, ...rest }`)
+and whether two are currently possible there is unchecked — worth a look
+during implementation, but not assumed and not bundled in here.
+
+## Performance
+
+Measured at 2M iterations against a 5-element array, at the level the
+lowered condition runs:
+
+| pattern shape | ns/op |
+|---|---|
+| `["a","b"]` exact | 2.7 |
+| `["a","b",...rest]` prefix (today) | 5.0 |
+| `["a",...rest,"c"]` one trailing | 5.2 |
+| `["a","b",...rest,"d","e"]` two trailing | 5.7 |
+| binding `rest` — tail slice `xs.slice(2)` | 20.3 |
+| binding `rest` — middle slice `xs.slice(2,-2)` | 19.0 |
+
+A trailing element costs one extra index-from-the-end, about 0.2 ns. The
+middle slice is not more expensive than the tail slice — marginally cheaper
+here, since it copies fewer elements. There is no performance argument
+against this.
+
+## Tests
+
+**Part 1**
+
+- `["a","b"]` does not match `["a","b","c"]`; does match `["a","b"]`.
+- `["a","b",...rest]` still matches both, with `rest = ["c"]` and `[]`.
+- A nested array pattern gets the same exact-length rule.
+- Fixture check: the generated condition uses `==` without a rest and `>=`
+  with one.
+
+**Part 2**
+
+- Each row of the semantics table above, as an execution test.
+- Bindings: leading, trailing, and the rest slice, asserted by value — a
+  trailing element bound from the wrong end still *matches*, so the
+  assertion has to check what landed in each binder, not just that the arm
+  ran.
+- Length boundary: `["a", ...rest, "c"]` against `["a"]` (too short, no
+  match) and `["a","c"]` (exactly two, `rest = []`).
+- Nesting: a trailing element that is itself a pattern, e.g.
+  `["cmd", ...rest, { path: string }]`.
+- Type suffixes on trailing elements: `[...rest, last: string]`. (On the rest
+  binder itself is Part 3.)
+- Empty head: `[...rest, "c"]`, the case most likely to expose an off-by-one
+  in the tail arithmetic. And `[...rest]`, where head and tail are both empty.
+- Regression: an existing prefix pattern still emits a one-argument
+  `slice(start)`, per the Lowering requirement — a fixture check, since the
+  behavior is identical and only the generated text would show the churn.
+- Two rest binders → the new diagnostic, not a crash. Belongs in
+  `tests/agency/expectedCompileError/`.
+- The `patternGuards` tripwire keeps passing: the shape check must still
+  come first, and the tail reads must be guarded by it.
+
+## Sequencing
+
+Part 1 first, on its own PR. It is three characters plus tests, it is a
+behavior change worth isolating in history, and Part 2 builds on the same
+length arithmetic — doing it second means building on a base that is known
+correct.
+
+Part 1 changes behavior silently: code that matched before may stop matching,
+with no diagnostic, by design. A **changelog entry is a deliverable of that
+PR**, not an afterthought — it is the only signal a user gets.
+
+Part 3 last, if at all. It is a parser change plus an unmade semantics
+decision, and nothing in it depends on Parts 1 or 2.
+
+## Related
+
+- `lib/lowering/patternLowering.ts` — `collectChecks` (the length check and
+  element indexing) and `extractBindings` (the slice).
+- `lib/parsers/parsers.ts:5839` — `enforceRestAtEnd`.
+- `docs/site/guide/pattern-matching.md` — "The rest binder must be the last
+  element. You can't have `[a, ...m, b]` for example." Both halves of that
+  sentence change.
+- [PEP 634](https://peps.python.org/pep-0634/) — the semantics adopted here.
+- [Rust slice patterns](https://dev.to/sgchris/the-power-of-slice-patterns-in-rust-4a8g),
+  [Ruby pattern matching](https://docs.ruby-lang.org/en/3.4/syntax/pattern_matching_rdoc.html),
+  [MoonBit array patterns](https://tour.moonbitlang.com/pattern-matching/array-pattern/index.html).
+- [safeBash command-to-tool matching](../ideas/2026-07-24-safebash-command-to-tool-matching.md)
+  — the consumer.

--- a/packages/agency-lang/lib/lowering/patternLowering.ts
+++ b/packages/agency-lang/lib/lowering/patternLowering.ts
@@ -1172,11 +1172,14 @@ function collectChecks(pattern: MatchPattern, source: Expression, checks: Expres
       // does not distinguish an array from a string: `"abc"` has length 3 and
       // would otherwise match `[a, b]`, binding characters.
       checks.push(...shapeCheck(source, ARRAY_HINT, pattern.loc));
-      // Length check — at least as many elements as named (excluding rest).
+      // Length check. With a rest binder the pattern names a minimum; without
+      // one it names the whole array, so the length must match exactly.
+      // `["a", "b"]` used to accept ["a","b","c"] — every array pattern was a
+      // prefix match, and there was no way to say "exactly these two".
       const hasRest = pattern.elements.some((e) => e.type === "restPattern");
       const namedCount = pattern.elements.filter((e) => e.type !== "restPattern").length;
       const lenAccess = fieldAccess(source, "length", pattern.loc);
-      const op: Operator = hasRest ? ">=" : ">=";
+      const op: Operator = hasRest ? ">=" : "==";
       checks.push(makeBinOp(lenAccess, op, numberLit(namedCount, pattern.loc), pattern.loc));
       pattern.elements.forEach((el, i) => {
         if (

--- a/packages/agency-lang/lib/lowering/patternLowering.ts
+++ b/packages/agency-lang/lib/lowering/patternLowering.ts
@@ -1179,6 +1179,13 @@ function collectChecks(pattern: MatchPattern, source: Expression, checks: Expres
       const hasRest = pattern.elements.some((e) => e.type === "restPattern");
       const namedCount = pattern.elements.filter((e) => e.type !== "restPattern").length;
       const lenAccess = fieldAccess(source, "length", pattern.loc);
+      // `==` emits `__eq(len, n)` where `>=` is native. That asymmetry is
+      // deliberate language-wide, not an oversight here: every equality
+      // operator routes through `__eq` so null and undefined compare equal,
+      // and `===` is documented as a stylistic alias that compiles
+      // identically (typescriptBuilder.ts:1379, docs/dev/null-and-undefined.md).
+      // Emitting a native comparison would make this one generated check the
+      // only equality in the language that skips the helper.
       const op: Operator = hasRest ? ">=" : "==";
       checks.push(makeBinOp(lenAccess, op, numberLit(namedCount, pattern.loc), pattern.loc));
       pattern.elements.forEach((el, i) => {

--- a/packages/agency-lang/tests/agency/pattern-matching/arrayPatternExactLength.agency
+++ b/packages/agency-lang/tests/agency/pattern-matching/arrayPatternExactLength.agency
@@ -1,0 +1,65 @@
+// An array pattern with no rest binder requires an EXACT length. It used to
+// require only "at least this many", so `["a", "b"]` accepted any array
+// starting with a, b — there was no way to say "exactly these two".
+
+def arm(xs: any[]): string {
+  return match (xs) {
+    ["a", "b"] => "two"
+    _ => "fell through"
+  }
+}
+
+def withRest(xs: any[]): string {
+  return match (xs) {
+    ["a", "b", ...rest] => "two plus ${rest.length}"
+    _ => "fell through"
+  }
+}
+
+def nested(xs: any[]): string {
+  return match (xs) {
+    [["a", "b"], "z"] => "nested exact"
+    _ => "fell through"
+  }
+}
+
+def isPosition(xs: any[]): string {
+  // The `is` operator routes through the same lowering, so it changes too.
+  if (xs is ["a", "b"]) {
+    return "is matched"
+  }
+  return "is fell through"
+}
+
+def whilePosition(xs: any[]): string {
+  // So does a `while` condition. One iteration is enough to tell.
+  let seen = "never"
+  while (xs is ["a", "b"]) {
+    seen = "while matched"
+    return seen
+  }
+  return "while fell through"
+}
+
+node exactLength() {
+  // Longer no longer matches; the exact length still does.
+  return [arm(["a", "b", "c"]), arm(["a", "b"]), arm(["a"])]
+}
+
+node restStillMatchesLonger() {
+  // A rest binder keeps the "at least" reading, and still binds zero.
+  return [withRest(["a", "b", "c"]), withRest(["a", "b"]), withRest(["a"])]
+}
+
+node nestedIsExactToo() {
+  return [nested([["a", "b"], "z"]), nested([["a", "b", "c"], "z"])]
+}
+
+node isAndWhileChangeToo() {
+  return [
+    isPosition(["a", "b", "c"]),
+    isPosition(["a", "b"]),
+    whilePosition(["a", "b", "c"]),
+    whilePosition(["a", "b"]),
+  ]
+}

--- a/packages/agency-lang/tests/agency/pattern-matching/arrayPatternExactLength.agency
+++ b/packages/agency-lang/tests/agency/pattern-matching/arrayPatternExactLength.agency
@@ -33,12 +33,38 @@ def isPosition(xs: any[]): string {
 
 def whilePosition(xs: any[]): string {
   // So does a `while` condition. One iteration is enough to tell.
+  //
+  // The `return` is load-bearing for TERMINATION, not just for the result:
+  // `xs` never changes, so the condition is loop-invariant and a matching
+  // value would spin forever without it. A regression here hangs rather than
+  // fails.
   let seen = "never"
   while (xs is ["a", "b"]) {
     seen = "while matched"
     return seen
   }
   return "while fell through"
+}
+
+def headPattern(xs: any[]): string {
+  // `match (x is pattern)` is the one construct whose failure mode is not
+  // "falls through": a head pattern that does not match returns a failure
+  // from the ENCLOSING function. So the exact-length rule changes control
+  // flow here, not just which arm runs.
+  let out = "head did not run"
+  match (xs is ["a", "b"]) {
+    true => out = "head matched"
+    _ => out = "head matched, arm fell through"
+  }
+  return out
+}
+
+def arrayInObject(c: any): string {
+  // The shape this series is building toward: an array inside an object.
+  return match (c) {
+    { words: ["a", "b"] } => "object exact"
+    _ => "fell through"
+  }
 }
 
 node exactLength() {
@@ -53,6 +79,28 @@ node restStillMatchesLonger() {
 
 node nestedIsExactToo() {
   return [nested([["a", "b"], "z"]), nested([["a", "b", "c"], "z"])]
+}
+
+node headPatternReturnsFailure() {
+  // The non-matching case returns a failure from headPattern, so the caller
+  // sees a failure rather than a string. That is the control-flow change.
+  const longer = headPattern(["a", "b", "c"])
+  return isFailure(longer)
+}
+
+node headPatternStillMatchesExact() {
+  return headPattern(["a", "b"])
+}
+
+node arrayInsideObject() {
+  return [arrayInObject({ words: ["a", "b"] }), arrayInObject({ words: ["a", "b", "c"] })]
+}
+
+node destructuringUnchanged() {
+  // A declaration binds rather than tests, so it still takes the first two.
+  // This is the claim a reader most wants backed for a silent breaking change.
+  const [a, b] = ["a", "b", "c"]
+  return "${a}${b}"
 }
 
 node isAndWhileChangeToo() {

--- a/packages/agency-lang/tests/agency/pattern-matching/arrayPatternExactLength.test.json
+++ b/packages/agency-lang/tests/agency/pattern-matching/arrayPatternExactLength.test.json
@@ -5,28 +5,88 @@
       "description": "An array pattern with no rest requires an exact length: a longer array no longer matches, the exact one still does, a shorter one never did.",
       "input": "",
       "expectedOutput": "[\"fell through\",\"two\",\"fell through\"]",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     },
     {
       "nodeName": "restStillMatchesLonger",
       "description": "A rest binder keeps the at-least reading and still binds zero elements.",
       "input": "",
       "expectedOutput": "[\"two plus 1\",\"two plus 0\",\"fell through\"]",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     },
     {
       "nodeName": "nestedIsExactToo",
       "description": "A nested array pattern gets the same exact-length rule.",
       "input": "",
       "expectedOutput": "[\"nested exact\",\"fell through\"]",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     },
     {
       "nodeName": "isAndWhileChangeToo",
       "description": "The is operator and while conditions route through the same lowering, so they change with match arms.",
       "input": "",
       "expectedOutput": "[\"is fell through\",\"is matched\",\"while fell through\",\"while matched\"]",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "headPatternReturnsFailure",
+      "description": "A match(x is pattern) head that no longer matches returns a failure from the enclosing function \u2014 a control-flow change, not a fall-through.",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "headPatternStillMatchesExact",
+      "description": "The same head still matches an exact-length value.",
+      "input": "",
+      "expectedOutput": "\"head matched\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "arrayInsideObject",
+      "description": "An array nested inside an object pattern gets the exact-length rule \u2014 the shape the safeBash matcher uses.",
+      "input": "",
+      "expectedOutput": "[\"object exact\",\"fell through\"]",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "destructuringUnchanged",
+      "description": "Destructuring binds rather than tests, so const [a, b] = xs still takes the first two.",
+      "input": "",
+      "expectedOutput": "\"ab\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/pattern-matching/arrayPatternExactLength.test.json
+++ b/packages/agency-lang/tests/agency/pattern-matching/arrayPatternExactLength.test.json
@@ -1,0 +1,32 @@
+{
+  "tests": [
+    {
+      "nodeName": "exactLength",
+      "description": "An array pattern with no rest requires an exact length: a longer array no longer matches, the exact one still does, a shorter one never did.",
+      "input": "",
+      "expectedOutput": "[\"fell through\",\"two\",\"fell through\"]",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "restStillMatchesLonger",
+      "description": "A rest binder keeps the at-least reading and still binds zero elements.",
+      "input": "",
+      "expectedOutput": "[\"two plus 1\",\"two plus 0\",\"fell through\"]",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "nestedIsExactToo",
+      "description": "A nested array pattern gets the same exact-length rule.",
+      "input": "",
+      "expectedOutput": "[\"nested exact\",\"fell through\"]",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "isAndWhileChangeToo",
+      "description": "The is operator and while conditions route through the same lowering, so they change with match arms.",
+      "input": "",
+      "expectedOutput": "[\"is fell through\",\"is matched\",\"while fell through\",\"while matched\"]",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}


### PR DESCRIPTION
Part 1 of [the array-pattern spec](https://github.com/egonSchiele/agency-lang/blob/array-pattern-exact-length/packages/agency-lang/docs/superpowers/specs/2026-07-25-array-pattern-length-and-middle-rest-design.md). Part 2 (a rest binder in any position) builds on the same arithmetic and lands next.

## The bug

```ts
match (["a", "b", "c"]) {
  ["a", "b"] => "shouldn't match"
  _          => "fell through"
}
// before: "shouldn't match"
```

Every array pattern was a *prefix* match. `["a", "b"]` accepted any array starting with `a`, `b`, and there was no way to say "exactly these two".

The cause reads as an unfinished edit rather than a decision — the ternary computes `hasRest` and then ignores it:

```ts
const op: Operator = hasRest ? ">=" : ">=";   // both branches
```

## The change

```ts
const op: Operator = hasRest ? ">=" : "==";
```

A pattern with no rest binder names the whole array. With one, it names a minimum — unchanged.

| pattern | `["a","b","c"]` | `["a","b"]` |
|---|---|---|
| `["a", "b"]` | no match *(was: match)* | match |
| `["a", "b", ...rest]` | match, `rest = ["c"]` | match, `rest = []` |

## Scope

Affects every construct that routes through `patternToCondition` — `match` arms, `is`, `while` conditions — and **not** destructuring: `const [a, b] = xs` emits no length check and still takes the first two. Both directions are tested, since "does this break my destructuring" is the first thing a reader will ask.

Measured across all 1258 `.agency` files: **15** array patterns in matching constructs, 13 without a rest — all two-element patterns in test files, every one matched against a two-element value, so none changes result. **Zero in `stdlib/`**, and `make fixtures` produced no churn.

## This is a silent breaking change

Code relying on the old prefix reading stops matching with no diagnostic. That is unavoidable — the point is that the pattern now means what it says — and it is why the changelog entry is part of this commit rather than a follow-up. It is the only signal a user gets.

It is also why this is its own PR: the blast radius is provably small today, and Part 2 changes the same arithmetic. Doing it second would mean building on a base that is known wrong.

## Tests

Written first; 3 of 4 nodes failed before the change, with `restStillMatchesLonger` passing throughout as the control that the `>=` path is untouched.

- exact length: longer no longer matches, exact still does, shorter never did
- rest binder: still matches longer, still binds zero elements
- nested array patterns get the same rule
- `is` and `while` positions change with match arms

🤖 Generated with [Claude Code](https://claude.com/claude-code)
