### PR TITLE
A rest binder can sit anywhere in an array pattern

### DIFF
--- a/packages/agency-lang/CHANGELOG.md
+++ b/packages/agency-lang/CHANGELOG.md
@@ -1,5 +1,28 @@
 ## Unreleased
 
+### A rest binder can sit anywhere in an array pattern
+
+`...rest` used to have to be the last element. It can now go in any position,
+with at most one per pattern — elements before it match from the front,
+elements after it from the back:
+
+```ts
+match (words) {
+    ["cat", ...flags, path] => read(path)
+    _                       => fallback()
+}
+
+const [first, ...middle, last] = items
+```
+
+`...rest` binds zero or more, so `["a", ...rest, "c"]` matches `["a", "c"]`
+with `rest = []`. This works in match arms, `is`, `if`/`while` conditions and
+in destructuring.
+
+Two rest binders in one pattern is now a compile error rather than a crash:
+nothing decides where the split between them falls. A misplaced rest
+previously produced a raw stack trace.
+
 ### Breaking: an array pattern without `...rest` now requires an exact length
 
 `["a", "b"]` used to match any array *starting* with `a`, `b` — every array

--- a/packages/agency-lang/docs/site/guide/pattern-matching.md
+++ b/packages/agency-lang/docs/site/guide/pattern-matching.md
@@ -24,7 +24,15 @@ const [first, _, third] = items   // skip the second element
 const [head, ...rest]   = items   // head = 1, rest = [2,3,4,5]
 ```
 
-The rest binder must be the last element. You can't have `[a, ...m, b]` for example.
+A rest binder can sit anywhere, and there can be at most one. Elements before
+it are matched from the front, elements after it from the back:
+
+```ts
+const [first, ...middle, last] = items   // first = 1, middle = [2,3,4], last = 5
+```
+
+Two rest binders is an error — nothing would decide where the split between
+them falls.
 
 When an array pattern is used to **match** — a `match` arm, the `is` operator,
 an `if` or `while` condition — a pattern without a rest binder names the whole

--- a/packages/agency-lang/docs/site/guide/pattern-matching.md
+++ b/packages/agency-lang/docs/site/guide/pattern-matching.md
@@ -31,8 +31,11 @@ it are matched from the front, elements after it from the back:
 const [first, ...middle, last] = items   // first = 1, middle = [2,3,4], last = 5
 ```
 
-Two rest binders is an error — nothing would decide where the split between
+Two rest binders are an error — nothing would decide where the split between
 them falls.
+
+In a declaration, a value too short to fill both ends surfaces a `failure`:
+`const [a, ...m, b] = ["x"]` cannot give `a` and `b` different elements.
 
 When an array pattern is used to **match** — a `match` arm, the `is` operator,
 an `if` or `while` condition — a pattern without a rest binder names the whole

--- a/packages/agency-lang/docs/site/stdlib/safeBash.md
+++ b/packages/agency-lang/docs/site/stdlib/safeBash.md
@@ -1,0 +1,351 @@
+---
+name: "safeBash"
+---
+
+# safeBash
+
+## Types
+
+### WordPart
+
+One piece of a word. Adjacent parts concatenate: `e'f'"g"$h` is a single
+ * word of four parts.
+
+```ts
+/** One piece of a word. Adjacent parts concatenate: `e'f'"g"$h` is a single
+ * word of four parts. */
+export type WordPart =
+  | { tag: "literal"; text: string }
+  | { tag: "singleQuoted"; text: string }
+  | { tag: "doubleQuoted"; parts: WordPart[] }
+  | { tag: "variable"; name: string }
+  | { tag: "paramExpansion"; expression: string }
+  | { tag: "commandSubstitution"; command: List }
+  | { tag: "arithmeticExpansion"; expression: string }
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L5))
+
+### BashWord
+
+```ts
+export type BashWord = {
+  tag: "word";
+  parts: WordPart[]
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L27))
+
+### Assignment
+
+`name=value` (or `name=` with a null value) before a command.
+
+```ts
+/** `name=value` (or `name=` with a null value) before a command. */
+export type Assignment = {
+  tag: "assignment";
+  name: string;
+  value?: BashWord
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L33))
+
+### Redirect
+
+A redirect like `> out.txt`, `2>&1`, or `<<< "$str"`. `fd` is the
+ * explicit file descriptor (`2` in `2>`), or null for the default.
+
+```ts
+/** A redirect like `> out.txt`, `2>&1`, or `<<< "$str"`. `fd` is the
+ * explicit file descriptor (`2` in `2>`), or null for the default. */
+export type Redirect = {
+  tag: "redirect";
+  fd?: number;
+  op: string;
+  target: BashWord
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L41))
+
+### SimpleCommand
+
+```ts
+export type SimpleCommand = {
+  tag: "simpleCommand";
+  assignments: Assignment[];
+  words: BashWord[];
+  redirects: Redirect[]
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L48))
+
+### IfCommand
+
+```ts
+export type IfCommand = {
+  tag: "if";
+  cond: List;
+  thenBody: List;
+  elifs: { cond: List; thenBody: List }[];
+  elseBody?: List;
+  redirects: Redirect[]
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L55))
+
+### LoopCommand
+
+```ts
+export type LoopCommand = {
+  tag: "loop";
+  kind: "while" | "until";
+  cond: List;
+  body: List;
+  redirects: Redirect[]
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L64))
+
+### ForCommand
+
+```ts
+export type ForCommand = {
+  tag: "for";
+  variable: string;
+  /** The `in word...` list, or null for the implicit `in "$@"`. */
+  words?: BashWord[];
+  body: List;
+  redirects: Redirect[]
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L72))
+
+### CaseItem
+
+```ts
+export type CaseItem = {
+  patterns: BashWord[];
+  body: List;
+  /** `;;`, `;&`, `;;&`, or null when the final item ends at `esac`. */
+  terminator?: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L81))
+
+### CaseCommand
+
+```ts
+export type CaseCommand = {
+  tag: "case";
+  subject: BashWord;
+  items: CaseItem[];
+  redirects: Redirect[]
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L88))
+
+### Subshell
+
+```ts
+export type Subshell = {
+  tag: "subshell";
+  body: List;
+  redirects: Redirect[]
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L95))
+
+### Group
+
+```ts
+export type Group = {
+  tag: "group";
+  body: List;
+  redirects: Redirect[]
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L101))
+
+### ArithmeticCommand
+
+`(( expression ))` as a command. The expression is kept as raw text.
+
+```ts
+/** `(( expression ))` as a command. The expression is kept as raw text. */
+export type ArithmeticCommand = {
+  tag: "arithmeticCommand";
+  expression: string;
+  redirects: Redirect[]
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L108))
+
+### FunctionDef
+
+```ts
+export type FunctionDef = {
+  tag: "functionDef";
+  name: string;
+  body: Command
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L114))
+
+### Command
+
+```ts
+export type Command =
+  | SimpleCommand
+  | IfCommand
+  | LoopCommand
+  | ForCommand
+  | CaseCommand
+  | Subshell
+  | Group
+  | ArithmeticCommand
+  | FunctionDef
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L120))
+
+### Pipeline
+
+One or more commands joined by `|` (or `|&`), optionally negated.
+
+```ts
+/** One or more commands joined by `|` (or `|&`), optionally negated. */
+export type Pipeline = {
+  tag: "pipeline";
+  negated: boolean;
+  commands: Command[]
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L132))
+
+### AndOr
+
+Pipelines joined by `&&` / `||`, left to right.
+
+```ts
+/** Pipelines joined by `&&` / `||`, left to right. */
+export type AndOr = {
+  tag: "andOr";
+  first: Pipeline;
+  rest: { op: "&&" | "||"; pipeline: Pipeline }[]
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L139))
+
+### ListItem
+
+```ts
+export type ListItem = {
+  tag: "listItem";
+  command: Command;
+  /** True when the command was followed by `&`. */
+  background: boolean
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L145))
+
+### List
+
+A sequence of commands separated by `;`, `&`, or newlines — the top
+ * level of a script, and the body of every compound command.
+
+```ts
+/** A sequence of commands separated by `;`, `&`, or newlines — the top
+ * level of a script, and the body of every compound command. */
+export type List = {
+  tag: "list";
+  items: ListItem[]
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L154))
+
+### BashNode
+
+```ts
+export type BashNode =
+  | WordPart
+  | BashWord
+  | Assignment
+  | Redirect
+  | Command
+  | Pipeline
+  | AndOr
+  | ListItem
+  | List
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L164))
+
+## Constants
+
+### emptyList
+
+```ts
+export static const emptyList: List = {
+  tag: "list",
+  items: []
+}
+```
+
+**Type:** [List](#list)
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L159))
+
+## Functions
+
+### bashParser
+
+```ts
+bashParser(code: string): Result<List>
+```
+
+Parse a string of bash code into an AST
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| code | `string` |  |
+
+**Returns:** `Result<List>`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L175))
+
+### simplify
+
+```ts
+simplify(node: BashNode): any
+```
+
+Convert a Bash AST into a simpler JSON representation.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| node | [BashNode](#bashnode) |  |
+
+**Returns:** `any`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L186))

--- a/packages/agency-lang/docs/superpowers/ideas/2026-07-03-concurrent-streaming-serializes-on-global-lock.md
+++ b/packages/agency-lang/docs/superpowers/ideas/2026-07-03-concurrent-streaming-serializes-on-global-lock.md
@@ -1,0 +1,144 @@
+# Concurrent streaming serializes on a global boolean lock (and degrades to interleaving after 60s)
+
+## Status (2026-07-03)
+
+Idea. Not yet scheduled. Surfaced while reviewing PR #416 (fix streaming
+`onStream` to honor `callback()` registrations). egonSchiele's PR review
+independently flagged the same `ctx.onStreamLock` concern inline. The
+`onStream`-scoped-callback fix is what makes concurrent per-branch
+streaming actually *reachable*, so this limitation is now worth fixing.
+
+## The Problem
+
+`handleStreamingResponse` guards streaming with a single process-wide
+boolean, `ctx.onStreamLock` (`lib/runtime/state/context.ts:79`). Because
+`runBatch` hands the **same `ctx`** to every fork/race/parallel branch
+(`runBatch.ts:296,738`), that boolean is shared across all branches in a
+run. The acquire block (`lib/runtime/streaming.ts:82-92`):
+
+```ts
+let count = 0;
+while (ctx.onStreamLock && count < 10 * 60) {   // poll every 0.1s, up to 60s
+  await builtinSleep(0.1);
+  count++;
+}
+if (ctx.onStreamLock) {
+  console.log(`Couldn't acquire lock, ${count}`);
+}
+ctx.onStreamLock = true;                          // ← unconditional
+// ... stream all chunks ...
+finally { ctx.onStreamLock = false; }
+```
+
+Three distinct problems:
+
+1. **Needless serialization.** Two branches that each stream to their own
+   independent `onStream` consumer still take turns: branch A holds the
+   lock for its entire stream, branch B busy-waits, then streams. You
+   cannot stream multiple concurrent responses live — e.g. a dashboard
+   showing N sub-agents streaming at once delivers them one after
+   another. The lock is keyed on the *run*, not on the consumer.
+
+2. **No mutual exclusion after 60s.** The wait caps at `600 × 0.1s`.
+   If the holder streams longer than 60s, the waiter falls out of the
+   loop and line 92 sets `onStreamLock = true` **unconditionally** even
+   though A never released it. B streams concurrently with A, and B's
+   `finally` later clears the lock while A is still mid-stream. So the
+   "no interleaving" guarantee silently breaks under long streams —
+   chunks from A and B interleave into whatever consumers each resolves.
+
+3. **Reentrancy now that emits are awaited (PR #416).** `emit` is now
+   `await`ed and runs arbitrary Agency callback bodies inline while the
+   lock is held. A `callback("onStream")` body that issues another
+   `llm(..., stream: true)` — directly or transitively — re-enters
+   `handleStreamingResponse`, hits the held lock, busy-waits 60s,
+   force-acquires, and on completion clears the *outer* stream's lock.
+   (Open question: is a streaming `llm()` even permitted inside a
+   callback body? Callback bodies are barred from raising interrupts by
+   the typechecker, but a plain streaming `llm()` may still be allowed —
+   needs confirming. If it is reachable, this is a real footgun.)
+
+The busy-wait boolean predates PR #416 and was harmless while the only
+consumer was a single host-passed `onStream` (the TS-passed path). The
+scoped/top-level callback fix is what makes multiple branches actually
+funnel through this `else` branch at once.
+
+## Why the boolean exists at all
+
+The lock's legitimate purpose: stop two concurrent streams from
+interleaving their chunks into the *same* sink (one host `onStream`
+callback), which would produce garbled output. That intent is sound; the
+implementation (one global boolean, busy-wait, force-acquire) is not, and
+it over-applies the constraint to streams that don't share a sink.
+
+## Proposed Fix
+
+Replace the single global boolean with a **per-consumer serialization
+key**, so streams that target different consumers run concurrently and
+only streams that would collide on the same sink serialize — and do it
+with a real async mutex, not a busy-wait boolean.
+
+Design sketch:
+
+- **Serialize per consumer, not per run.** Derive a key from the
+  resolved consumer set (e.g. the identity of the gathered `onStream`
+  callbacks, or the branch's active-thread id as a proxy for "which sink
+  this stream feeds"). Two streams with disjoint keys never block each
+  other. The natural key is probably the branch/thread the stream
+  belongs to, since that's what maps to a UI sink.
+- **Use `agency.withLock(name, fn)`** — the runtime already has a proper
+  named async mutex (`lib/runtime/agency.ts` `withLock`, backed by
+  `stack.locks`/`lockOwners`, IPC-aware for subprocesses). Wrapping the
+  stream loop in `withLock("std::onStream:<key>", ...)` gives real mutual
+  exclusion (queued, not busy-waited; released in `finally`; no 60s
+  force-acquire) and reuses tested machinery instead of a bespoke
+  boolean. This likely subsumes the whole hand-rolled block.
+- **Reentrancy:** `withLock` is non-reentrant per `ownerId`; decide
+  whether a nested streaming `llm()` in a callback should (a) be
+  statically disallowed (simplest — extend the callback-body checker),
+  or (b) use a distinct key so it doesn't self-deadlock. Prefer (a)
+  unless there's a real use case.
+- **Drop the 60s force-acquire entirely.** With a real mutex there's no
+  need for a timeout escape hatch; if a stream genuinely hangs, that's a
+  cancellation/timeout concern handled by the abort signal, not by
+  silently letting a second writer in.
+
+## Touch Points
+
+- `lib/runtime/streaming.ts` — replace the `onStreamLock` acquire/finally
+  block (`~82-124`) with a `withLock`-wrapped stream loop keyed per
+  consumer/branch.
+- `lib/runtime/state/context.ts` — remove `onStreamLock` (`:79`, `:217`,
+  `:300`, `:630`) once nothing references it.
+- `lib/runtime/agency.ts` — reuse `withLock`; no change unless a
+  streaming-specific key helper is warranted.
+- Callback-body checker (wherever `checkCallbackBodyInterrupts` lives) —
+  if we disallow streaming `llm()` inside callback bodies (reentrancy
+  option (a)), add that rule.
+
+## Tests
+
+- **Two `parallel` branches, different consumers, stream concurrently** —
+  assert their chunk deliveries overlap in time (or at least that neither
+  blocks the other), rather than strict A-then-B serialization.
+- **Two branches, same host consumer** — assert chunks are NOT interleaved
+  (the one case that must still serialize).
+- **Long stream + sibling** — a >60s holder must not let a sibling
+  force-acquire and corrupt delivery (the current bug); with a real mutex
+  the sibling simply waits.
+- **Reentrancy** — a streaming `llm()` inside an `onStream` callback body
+  either fails the typecheck (option a) or completes without deadlock
+  (option b) — pin whichever behavior we choose.
+- **Subprocess streaming** — subprocesses get a fresh exec context today
+  (`context.ts:300`); confirm the new keying keeps them independent.
+
+## Related
+
+- PR #416 — the `onStream` scoped/top-level callback fix that makes
+  concurrent per-branch streaming reachable; egonSchiele's inline review
+  on `streaming.ts:98` and `:80` raised problems (2) and (3) above.
+- `lib/runtime/agency.ts` `withLock` — the existing async mutex to reuse.
+- `docs/dev/runBatch.md` — fork/race/parallel branch model and shared-ctx
+  semantics.
+- `docs/site/guide/streaming.md` — user-facing streaming docs; should
+  eventually document concurrent-streaming semantics once fixed.

--- a/packages/agency-lang/docs/superpowers/ideas/2026-07-03-guard-trip-preserves-value.md
+++ b/packages/agency-lang/docs/superpowers/ideas/2026-07-03-guard-trip-preserves-value.md
@@ -1,0 +1,194 @@
+# Guard trips should return a failure that still carries the block's value
+
+## Status (2026-07-03)
+
+Idea. Not yet scheduled. Came out of a discussion about whether the
+cost guard's post-call check should be dropped in favor of a pre-call
+gate only.
+
+## The Problem
+
+Today, when a guard trips, the block's return value is thrown away. On
+a trip, `prompt.ts` throws a `GuardExceededError` at the enforcement
+site; `_runGuarded` catches it via `__tryCall` and produces a
+`Failure`. The value the block was about to return never surfaces.
+
+The waste is sharpest on the **last** priced operation in a block. A
+cost guard can never be a hard cap — you don't know a call's price
+until it returns, so the pre-call gate (`prompt.ts:432`) admits any
+call while `spent <= limit`, and that call can overshoot arbitrarily.
+The overspend on the tripping call has therefore *already happened*
+under the current model; the post-call check
+(`prompt.ts:564-567`) doesn't prevent it, it only *reports* it. So in
+the common case:
+
+```ts
+const result = guard(cost: $0.20) as {
+  const category = llm("classify this email")   // spent = $0.15
+  const reply = llm("draft a reply")            // spent = $0.30, trips
+  return category
+}
+```
+
+the user paid $0.30 **and** got a `Failure` with no usable value —
+the worst cell in the matrix. The money is spent and irreversible; the
+`category` value is legitimate (its call completed normally); discarding
+it is pure waste.
+
+### Why not just drop the post-call check?
+
+Considered and rejected. "Check before every call only" would make the
+final-call trip return `success` with the value. But that silently
+breaks the contract that `success` ⟺ "stayed within budget", which
+callers rely on for accounting / SLA / audit decisions. And the
+final-call overshoot is **not** bounded to "a little" — a single call
+can blow the budget by orders of magnitude:
+
+```ts
+guard(cost: $0.01) as { return llm("one huge expensive call") }
+// pre-call gate sees $0 <= $0.01, admits it, call costs $2.00
+```
+
+Reporting that as clean success is actively misleading. So we keep the
+honest failure signal **and** salvage the value — that dominates both
+"drop the check" (loses the signal) and today's behavior (loses the
+value).
+
+## Proposed Behavior
+
+**On a trip, return a `Failure` as today, but attach the block's return
+value when the block ran to completion.**
+
+- Block reaches its `return` but the guard is over budget → `Failure`
+  whose error carries the completed value. `isFailure(result)` is still
+  `true`; the caller can choose to read the salvaged value.
+- Block is aborted mid-work (a later priced op was refused, so `return`
+  was never reached) → `Failure` with **no** value, exactly as today.
+  There is no legitimate value to hand back — the computation was
+  truncated.
+
+`success` continues to mean "within budget." Nothing that inspects
+`isFailure` / `result.error.type` changes. The only addition is an
+optional salvaged value on the failure.
+
+### Apply to the time guard too, for consistency
+
+The user's call, and the right one. The time guard has the identical
+shape: compute time is already spent when the timer fires
+(`guards.md:73`), the `timeoutFailure` is a signal, not a prevention,
+and today the block's value is discarded the same way. If a timed block
+runs to completion just as the timer expires, the value should be
+salvageable on the failure just like the cost case. Making only cost do
+this would split the two dimensions that are otherwise deliberately
+symmetric (`stdlib/thread.agency:256-260`).
+
+## Design Questions
+
+### Where does the salvaged value live on the `Result`?
+
+Two options:
+
+1. **Optional `value` field on the failure branch** — `failure(error)`
+   gains an optional companion value. Cleanest at the use site
+   (`match(result) { failure(error, value?) => ... }`) but touches the
+   `Result` pattern-match surface and codegen.
+2. **`partialValue` field on `GuardFailureData`** — no change to
+   `Result`; the salvaged value rides inside the existing error record
+   (`stdlib/thread.agency:218-224`). Smaller blast radius, but stuffs a
+   value into a type named `...FailureData` and makes it `any`-typed.
+
+Lean toward (2) for a v1 (minimal surface, no pattern-match changes),
+with (1) as the eventual ergonomic form if salvage becomes common.
+Decide during design.
+
+### How does the value survive to `_runGuarded`?
+
+Today the post-call `enforceGuards()` throws *inside the block*, before
+the block's `return` executes — so at throw time the return value isn't
+assembled yet. To hand back a completed value we need the block to reach
+its `return` first. Sketch:
+
+- Replace the **post-call throw** with a **mark-over-budget flag** on the
+  guard. The post-call check stops throwing; it flags the guard as
+  tripped and lets execution continue.
+- Convert the flag into a thrown `GuardExceededError` only at the **next
+  enforcement point** — the pre-call gate before the next priced op
+  (cost) or the next runner step boundary (time). If there is a next op,
+  the block aborts before its `return` → failure, no value (correct:
+  more work remained).
+- If the block **completes** with the flag set (no further enforcement
+  point fires), `_runGuarded` sees "block returned V, but guard flagged
+  over budget" and produces `Failure(guardFailureData, value: V)` instead
+  of `success(V)`.
+
+This is essentially the pre-call-gate model for *enforcement*, plus a
+completion check that converts a clean finish under an over-budget flag
+into a value-carrying failure. Note it also subtly changes *when* a
+mid-block trip fires: from "immediately after the charge" to "at the next
+priced op / step boundary." That is behavior-visible (one extra
+statement may run after the overshoot before the abort) and needs a test
++ a doc note. Confirm this is acceptable — it likely is, since that
+statement can't make a *priced* call without hitting the gate.
+
+### Interaction with fork / shared cost guards
+
+Shared cost guards across fork branches (`guards.md:128`) mark-over-
+budget on the shared instance; the flag must be observed by whichever
+branch runs the next enforcement point, same as the throw is today. The
+pre-call gate already handles "a sibling pushed us over" — the flag
+model needs to preserve that (a branch seeing the flag set on entry
+throws before its own next call). Worked example to add to the test
+matrix.
+
+### JS-bodied tool overshoot
+
+Unchanged and still a known limitation (`guards.md:165`): a JS tool body
+runs to completion regardless, and its cost is seen only at the next
+step boundary. Under the flag model that step boundary is exactly where
+the trip converts to a throw, so no regression — just note it.
+
+## Touch Points (sketch)
+
+- `lib/runtime/prompt.ts` — post-call site (`~564-567`): replace throw
+  with mark-over-budget; keep the pre-call gate (`~424-432`) throwing.
+- `lib/runtime/guard.ts` — add an `overBudget`/`tripped` flag to the
+  `Guard` interface (cost and time); `enforceGuards()` throws when the
+  flag is set at an enforcement point.
+- `lib/runtime/runner.ts` — `shouldSkip` / step-boundary path converts a
+  set time-guard flag into the `GuardExceededError("time", ...)`.
+- `stdlib/thread.agency` — `_runGuarded` (`~292-295`) attaches the
+  completed block value to the failure; `guard` docstring updated to
+  document salvaged-value-on-failure. `GuardFailureData` gains
+  `partialValue` if we take option (2).
+- `lib/runtime/result.ts` (+ codegen / pattern-match) — only if we take
+  option (1) for the `Result` shape.
+- Docs: `docs/site/guide/guards.md` — document that a trip returns a
+  failure that may carry the block's value; fix the "fires after every
+  LLM call" line while here (the check fires both before and after —
+  it's already described correctly at `guards.md:131` and `:179`, the
+  one-line summary at `:49` is incomplete).
+
+## Tests
+
+- Cost: last-call overshoot, block returns → `Failure` with salvaged
+  value present.
+- Cost: mid-block overshoot with a later priced op → `Failure`, no value
+  (aborted before return).
+- Cost: single-call 200x overshoot → `Failure` with salvaged value
+  (signal preserved, value salvaged).
+- Time: timer fires as the block completes → `Failure` with value; timer
+  fires mid-work → `Failure`, no value.
+- Fork: shared cost guard tripped by sibling → the branch reaching the
+  next enforcement point fails; salvage semantics on the completing
+  branch.
+- Nested guards: inner trip carries inner's value; outer still charged
+  and independent (`guards.md:94-108`).
+
+## Related
+
+- `docs/site/guide/guards.md` — user-facing guard semantics.
+- `docs/superpowers/specs/2026-05-05-guards-design.md` — original design.
+- `docs/superpowers/plans/2026-05-23-builtin-cost-guards.md` — cost-guard
+  implementation.
+- `stdlib/thread.agency:218-296` — `guard` / `GuardFailureData` /
+  `_runGuarded`.

--- a/packages/agency-lang/docs/superpowers/ideas/2026-07-03-memory-llm-calls-honor-abort-signal.md
+++ b/packages/agency-lang/docs/superpowers/ideas/2026-07-03-memory-llm-calls-honor-abort-signal.md
@@ -1,0 +1,215 @@
+# Memory-layer LLM calls should honor the abort signal (time-guard / race / cancel)
+
+## Status (2026-07-03)
+
+Idea. Not yet scheduled. Found while verifying the guard limitations
+documented in `docs/site/guide/guards.md`. A sibling fact was fixed
+already: memory LLM/embed calls now *charge* cost guards (see below).
+This ticket is about the remaining half — memory calls are not
+*cancelled* mid-flight when the abort signal fires.
+
+## Background: two independent guard dimensions
+
+A guard interacts with an LLM call in two separate ways:
+
+1. **Cost accounting** — the call's dollar spend is billed to the
+   active branch's guards so a `withCostGuard($X)` trips when exceeded.
+2. **Cancellation** — when a time guard trips (or a `race` loses, or
+   the run is cancelled via `cancel()` / REPL Esc), an `AbortSignal`
+   fires and the in-flight HTTP request is aborted so you don't wait
+   for (or pay for) a response you'd throw away.
+
+These are wired through different code. The memory layer now
+participates in (1) but not (2).
+
+### (1) Cost accounting — already fixed
+
+All memory LLM text prompts route through `MemoryManager._text()` and
+all embeds through `_embed()`
+(`lib/runtime/memory/manager.ts`). Both charge:
+
+- `_text()` → `chargeCostIfInFrame(result.value.cost?.totalCost ?? 0)`
+  (`manager.ts:293`).
+- `_embed()` → same at `manager.ts:372`.
+- `chargeCostIfInFrame` → `agency.addCost(amount)` (`manager.ts:42-45`),
+  which bills every active guard.
+- `rethrowIfGuard` (`manager.ts:57-59`) ensures a `GuardExceededError`
+  raised while charging inside memory's best-effort catches bubbles out
+  instead of being swallowed (e.g. the tier-3 recall catch at
+  `manager.ts:782`).
+
+`manager.ts:218` documents that these are the only LLM entry points
+("We always go through `llmClient.text`"), so the accounting gap is
+comprehensively closed. The old "Memory layer LLM calls bypass cost
+guards" limitation was removed from `guards.md` as part of this
+verification.
+
+## The Problem: (2) Cancellation — still missing
+
+The standard `llm()` path threads the composed abort signal all the way
+into smoltalk:
+
+```
+ctx.getAbortSignal(stack)            // context.ts:533 — composes run-cancel + branch guards
+  → parentSignal
+  → armCallTimeout(parentSignal, …)  // prompt.ts:205-230
+  → promptConfig.signal
+  → ctx.llmClient.text(promptConfig) // prompt.ts:127 — smoltalk honors signal
+```
+
+so an in-flight standard call aborts the instant a time guard fires.
+
+The memory path does **not** do this. `_text()` builds its request as:
+
+```ts
+this.llmClient.text({
+  ...this.smoltalkDefaults,
+  messages: [smoltalk.userMessage(prompt)],
+  model,
+  ...(options?.responseFormat ? { responseFormat: options.responseFormat } : {}),
+} as any)                            // manager.ts:239-246 — NO `signal` field
+```
+
+There is no `signal`, and `smoltalkDefaults` is a static config baked in
+at construction (`manager.ts:206`), not a live per-call signal. `_embed()`
+(`manager.ts:315`) has the same shape. So the abort signal never reaches
+the memory HTTP request.
+
+### Observable consequence
+
+When a time guard (or `race` loss, or `cancel()`) fires *during* a
+memory extraction / compaction / recall-filter call:
+
+1. The in-flight memory HTTP request is **not** cancelled — it runs to
+   completion. You pay for it and wait for it.
+2. When it returns, `chargeCostIfInFrame` bills its cost, and the next
+   runner step's `shouldSkip()` throws `GuardExceededError("time")`.
+
+So a memory LLM call currently behaves like the non-cooperative
+JS-bodied tool in the `guards.md` Limitations section: **the trip is
+still enforced at the next step boundary, but the in-flight call is not
+preempted.** The time budget is honored in the "fail the block" sense,
+not in the "stop paying / stop waiting immediately" sense.
+
+## Why it matters (and why it's low-severity)
+
+- **Consistency.** The standard `llm()` path aborts in-flight on a time
+  trip; memory calls don't. Two LLM calls under the same `guard(time:)`
+  behave differently depending on which path issued them. That's a
+  surprising inconsistency even if rarely hit.
+- **Wasted spend/time on trip.** A time guard is often a hard wall
+  ("kill this if it takes more than N seconds"). If the tripping moment
+  lands during a memory extraction call, you wait for that call and pay
+  for it — exactly the outcome the abort plumbing exists to avoid.
+- **Bounded blast radius.** Memory calls are single-shot (not the
+  multi-turn tool loop), and auto-extraction/compaction typically run in
+  `runPrompt`'s post-turn hook. Worst case is "the time guard waits for
+  one memory call to finish before failing." No correctness bug, no
+  runaway — just a latency/cost overrun bounded by one call's duration.
+
+This is why it's an idea, not a bug: enforcement is correct, only
+promptness is off.
+
+## Proposed Fix
+
+Thread the live composed abort signal into the memory request configs so
+memory joins the standard cancellation path.
+
+- In `_text()` and `_embed()`, read the live signal per-call the same way
+  `chargeCostIfInFrame` reads the live frame:
+
+  ```ts
+  import { getRuntimeContext } from "../asyncContext.js"; // or wherever it's exported internally
+
+  function abortSignalIfInFrame(): AbortSignal | undefined {
+    const store = agencyStore.getStore();
+    if (!store) return undefined;              // direct-construction unit tests
+    return store.ctx.getAbortSignal(store.stack);
+  }
+  ```
+
+  Then include `signal: abortSignalIfInFrame()` in the object passed to
+  `this.llmClient.text({...})` (`manager.ts:239`) and
+  `this.llmClient.embed(...)` (`manager.ts:315`).
+
+- **Must read the ALS branch `stack`, not `ctx.stateStack`.** The
+  composed signal includes guards installed on the *active branch* stack;
+  inside a `fork`/`race` branch the two differ. This mirrors the note we
+  added to `guards.md` / `ts-helpers.md` about
+  `getRuntimeContext().stack`.
+
+- **Consider a per-call deadline too (optional).** The standard path
+  wraps each attempt in `armCallTimeout` (`prompt.ts:205-230`) so a
+  single call can't hang past `policy.timeout`. Memory calls don't get
+  this. Out of scope for the core fix (which is just "honor the parent
+  abort"), but worth a follow-up decision: should memory calls also
+  respect the LLM call-timeout policy? Probably yes, for the same
+  consistency reason.
+
+- **Cancellation error shape.** When the signal aborts an in-flight
+  memory call, smoltalk will surface an abort/cancel error. Ensure the
+  existing `_text` error handling (`manager.ts:248-270`) does not
+  convert an `AgencyCancelledError` / `GuardExceededError` into a generic
+  "memory llm text call failed" `Error` — those must propagate as-is so
+  the surrounding `guard(time:)` boundary converts them to the
+  `timeoutFailure`. `rethrowIfGuard` already covers `GuardExceededError`
+  at the call sites; verify the cancel/abort case is handled analogously
+  (an aborted memory call on a time trip should not be "fail open" —
+  falling back to cheap-tier results — the way a transient provider
+  error is at `manager.ts:782-792`; it should bubble).
+
+## Touch Points
+
+- `lib/runtime/memory/manager.ts`
+  - `_text()` (`~230-296`): add `signal` to the `llmClient.text({...})`
+    config; audit the failure branch (`248-270`) so cancel/guard errors
+    propagate rather than being wrapped.
+  - `_embed()` (`~307-372`): add `signal` to the `llmClient.embed(...)`
+    config; same error-propagation audit.
+  - Add the `abortSignalIfInFrame()` helper next to
+    `chargeCostIfInFrame` (`~42-45`) so the two "read live frame if
+    present" helpers sit together.
+  - Recall tier-3 catch (`~782-792`) and any other best-effort catch:
+    make sure an abort/cancel bubbles (do NOT fail open to cheap-tier
+    results on a real cancellation).
+- `docs/site/guide/guards.md` — once fixed, no limitation note needed;
+  if we ship the fix in stages, add a temporary Limitations bullet
+  ("memory LLM calls are enforced by time guards at the step boundary
+  but not aborted mid-flight") and delete it when the fix lands.
+
+## Tests
+
+- **Time guard trips during a memory extraction call → the in-flight
+  memory request is aborted** (not run to completion). Assert via a mock
+  llmClient whose `text()` observes the passed `signal` and rejects on
+  abort; assert the surrounding `guard(time:)` returns `timeoutFailure`
+  promptly rather than after the mock's full delay.
+- **`race` loser mid-memory-call is cancelled** — the losing branch's
+  memory call sees the abort.
+- **`cancel()` / Esc mid-memory-call** — the call aborts and the run
+  unwinds.
+- **In-frame vs no-frame** — direct-construction `MemoryManager` unit
+  tests (no `agencyStore`) still work: `abortSignalIfInFrame()` returns
+  `undefined`, request has no signal, behavior unchanged.
+- **Fork branch-local time guard** — a memory call inside a branch honors
+  the branch's guard, proving we read `getRuntimeContext().stack` not
+  `ctx.stateStack`.
+- **Cost accounting unchanged** — existing memory cost-charging tests
+  still pass (the fix is additive; it doesn't touch `chargeCostIfInFrame`).
+
+## Related
+
+- `docs/site/guide/guards.md` — guard semantics; "Cooperative
+  cancellation from TypeScript" section documents the same
+  `getAbortSignal(stack)` hook for user TS code.
+- `docs/site/guide/ts-helpers.md` — "Respecting cancellation (the abort
+  signal)".
+- `lib/runtime/prompt.ts:94-127, 205-230` — the standard-path signal
+  wiring this fix mirrors.
+- `lib/runtime/state/context.ts:533-536` — `getAbortSignal(stack)`
+  composition.
+- `docs/superpowers/ideas/2026-07-03-guard-trip-preserves-value.md` — the
+  other guard follow-up from the same review session; this cancellation
+  gap is a natural companion but independent of it.
+- `docs/dev/threads.md` — memory layer runs inside `runPrompt`'s
+  post-completion hook; explains why the frame is present in production.

--- a/packages/agency-lang/docs/superpowers/ideas/2026-07-24-safebash-command-to-tool-matching.md
+++ b/packages/agency-lang/docs/superpowers/ideas/2026-07-24-safebash-command-to-tool-matching.md
@@ -1,0 +1,200 @@
+# safeBash: rewrite a bash command into an equivalent tool call
+
+## Status (2026-07-24)
+
+Idea, with the main design decisions already made (see Decisions below).
+Blocked on three pattern-matching items; do them in this order:
+
+1. [Object pattern crashes on a null intermediate](2026-07-24-object-pattern-crashes-on-null-intermediate.md)
+2. [`is` in a match-arm guard is not lowered](2026-07-24-match-arm-guard-is-expression-not-lowered.md)
+3. [Nested `: Type` suffix in patterns](2026-07-24-nested-type-suffix-in-patterns.md)
+
+Work in progress lives in `stdlib/safeBash.agency` and
+`lib/stdlib/safeBash.ts`; `foo.agency` is the scratch driver.
+
+## The Problem
+
+The coding agent (`stdlib/agents/coding.agency`) is given file, git,
+search, and http tools, and its prompt tells it to prefer them over bash
+in as many words:
+
+> **Avoid using them if at all possible**. These tools should be a last
+> resort. […] every time you use bash or exec, it will require human
+> approval
+
+It reaches for bash anyway. The prompt is not load-bearing enough.
+
+The cost is autonomy, not safety. Read-only tools are pre-approved, so
+they run without a prompt. `bash` cannot be: `bash()`
+(`stdlib/shell.agency:133`) raises `interrupt std::bash(...)` on every
+call, because there is no way to say in advance what an arbitrary command
+string will do. So a run that could have been unattended becomes one that
+has to be watched, and the human approves a stream of `ls`, `cat`, and
+`git status` by hand.
+
+## The Idea
+
+Parse the command string the agent wrote. If it maps onto a tool the
+agent already has, call that tool instead. The tool's own interrupt
+policy then applies — which for the read-only ones means no approval at
+all.
+
+The bash parser is already in tarsec and re-exported through
+`lib/stdlib/safeBash.ts`. It is deliberately incomplete; anything it
+cannot parse falls through to real bash, so incompleteness costs an
+approval rather than correctness.
+
+## Decisions
+
+- **v1 scope: one simple command, plus `>` and `>>` redirects.** No
+  pipes, no `&&`/`||`, no background, no `;`. Anything else is unmatched
+  and falls through to bash approval.
+- **Where it lives: a `safeBash` tool that replaces `bash` in the
+  agent's tool list.** Not a handler on `std::bash`, and not inside
+  `bash()` itself — a tool keeps `bash()` honest (it always runs bash)
+  and makes the behavior opt-in per agent and easy to test.
+- **Words that need shell evaluation: expand `$VAR` from the
+  environment, refuse the rest.** Command substitution, arithmetic
+  expansion, and globs are unmatched. See the word-splitting caveat
+  below.
+- **`echo` maps to `print`** (`stdlib/index.agency:53`), which raises no
+  interrupt, so it costs nothing. `echo … > f` maps to `write`.
+- **Lowered shape: an object with an optional redirect field** (shape C
+  below).
+
+## The Lowered Shape
+
+`simplify` reduces the parser's AST to:
+
+```ts
+type Redirect = { op: string, path: string }
+type Cmd = { words: string[], redirect: Redirect | null }
+```
+
+so the matcher reads as one table:
+
+```ts
+match (c) {
+  { words: ["echo", ...rest], redirect: null }                  => print(join(rest))
+  { words: ["echo", ...rest], redirect: { op: ">",  path } }    => write(path, join(rest))
+  { words: ["echo", ...rest], redirect: { op: ">>", path } }    => append(path, join(rest))
+  { words: ["git", sub, ...flags], redirect: null }             => runGit(sub, flags)
+  _                                                             => realBash(original)
+}
+```
+
+This is why item 1 blocks: `redirect: { op: ">" }` against a `null`
+redirect throws today instead of falling through.
+
+The AST the parser produces is deeply nested (`list` → `listItem` →
+`andOr` → `pipeline` → `simpleCommand` → `word` → parts), and matching on
+it directly is unreadable. `simplify` exists to collapse that to the two
+fields above; `stringifyWordPart` collapses a word's parts to one string.
+
+## stringifyWordPart
+
+Returns `Result<string>`:
+
+- `literal`, `singleQuoted` → the text
+- `doubleQuoted` → concatenate the parts, recursively
+- `variable`, `paramExpansion` → the environment value; unset is the
+  empty string, matching shell semantics
+- `commandSubstitution`, `arithmeticExpansion` → `failure`
+
+One failure anywhere makes the whole command unmatched. That keeps "can
+safeBash handle this?" a single yes/no per command.
+
+### The word-splitting caveat
+
+Bash splits an *unquoted* expansion on whitespace, so with `F="a b"`,
+`cat $F` is two arguments and `cat "$F"` is one. Expanding without
+splitting would make safeBash and bash disagree about what a command
+means — the exact class of divergence this feature must not have.
+
+Rule: expand an unquoted `$VAR` only when its value contains no
+whitespace. Otherwise refuse the command. Inside double quotes, expand
+unconditionally (no splitting applies there). A refusal costs one
+approval; a wrong expansion costs correctness.
+
+Also: a `simpleCommand` carries `assignments` (`FOO=1 cmd`). Those affect
+what `$FOO` means for that command only. v1 should refuse any command
+with assignments rather than model shell scoping.
+
+## Candidate Command Table (v1)
+
+Start with `echo`; the rest is the intended shape, to be confirmed per
+command against the actual tool signature.
+
+| Command | Tool | Notes |
+|---|---|---|
+| `echo …` | `print` | no interrupt at all |
+| `echo … > f` / `>> f` | `write` | mode overwrite / append |
+| `cat f` | `read` | single file only |
+| `ls [dir]` | `ls` | |
+| `grep pat files` | `grep` | flag translation needed |
+| `find . -name g` | `glob` | narrow subset |
+| `git status\|log\|diff\|show\|…` | `gitStatus` etc. | `std::git` has one tool per subcommand |
+| `curl url` | `fetch` | |
+
+Flags are the hard part, not the verb: `ls -la`, `grep -ri`, and
+`git log --oneline -n 5` all need a decision about which flags are
+representable and what to do with the rest. Default to refusing on any
+unrecognized flag.
+
+## Return Contract
+
+`safeBash` replaces `bash`, so it returns `ExecResult`
+(stdout / stderr / exitCode) whatever path it takes. A matched command
+synthesizes that from the tool's result. The agent should not be able to
+tell which path ran, except by the absence of an approval prompt.
+
+Open question: should a matched command be *reported* to the user
+(`whatIAmDoing`-style) so the rewrite is visible? Leaning yes — silent
+rewriting of a command into something else is exactly the kind of thing
+that should be observable.
+
+## Touch Points
+
+- `stdlib/safeBash.agency` — `simplify`, `stringifyWordPart`, the match
+  table, the `safeBash` tool itself.
+- `lib/stdlib/safeBash.ts` — the tarsec re-export (currently just
+  `bashParser as _bashParser`).
+- `stdlib/agents/lib/toolkits.agency:91` `shellTools()` — where `bash` is
+  handed out; safeBash either replaces it there or gets its own bundle.
+- `docs/site/stdlib/safeBash.md` — generated by `agency doc`, so write
+  the docstrings, not the markdown.
+
+## Tests
+
+Agency execution tests (`tests/agency/`), no LLM calls:
+
+- `echo "Hello, world!"` → `print`, no interrupt raised.
+- `echo hi > out.txt` / `>> out.txt` → `write` with the right mode.
+- `echo $FOO` with `FOO=bar` → expands; with `FOO="a b"` unquoted →
+  refuses; `echo "$FOO"` with a space → expands.
+- `echo $(date)` → refuses, falls through to bash.
+- `FOO=1 echo hi` → refuses (assignments).
+- `a && b`, `a | b`, `a &` → all fall through.
+- Unparseable input → falls through, no crash.
+- The fall-through path really does raise `std::bash` (assert the
+  interrupt), and the matched path really does not.
+
+## Open Questions
+
+- Does `safeBash` keep the name `bash` when handed to the LLM? Renaming
+  it changes what the model writes; keeping the name means the tool
+  description should still say "prefer the dedicated tools".
+- Should the match table be extensible by the user (a list of rules
+  passed in) or fixed in the stdlib? Fixed for v1.
+- Does the prompt guidance in `stdlib/agents/coding.agency` change once
+  this exists? It should probably stay — safeBash is a safety net, not a
+  license to write bash.
+
+## Related
+
+- `docs/site/guide/interrupts.md`, `handlers.md`, `effects.md`,
+  `policies.md` — the approval machinery this is working around.
+- `docs/site/guide/pattern-matching.md`,
+  `type-validation.md`,
+  `value-parameterized-types.md` — the matching features used.
+- `stdlib/shell.agency:133` — `bash()` and its interrupt.

--- a/packages/agency-lang/docs/superpowers/plans/2026-07-05-checkpoint-soft-interrupt-REVIEW.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-07-05-checkpoint-soft-interrupt-REVIEW.md
@@ -1,0 +1,311 @@
+# Review — Checkpoint-as-Soft-Interrupt Implementation Plan
+
+Reviewer pass over `docs/superpowers/plans/2026-07-05-checkpoint-soft-interrupt.md`.
+Every claim below was checked against the current runtime source (file:line cited),
+not just the plan's internal consistency.
+
+## Verdict
+
+The plan is unusually rigorous and the core design is **sound**: park at the
+`runBatch` barrier, stamp one shared checkpoint at the outermost batch, unwind as
+a `std::checkpoint` marker in mixed rounds via the *existing* interrupt machinery.
+The load-bearing assumptions I could verify hold up (see "Confirmed"). There is
+**one correctness issue that must be resolved before Task 1** (nodeId/stack
+mismatch), a few medium gaps, and some polish notes. None invalidate the
+architecture.
+
+---
+
+## Confirmed correct (the risky claims that actually check out)
+
+- **Detection mechanism (D1) is even more robust than the plan argues.** The
+  coordinator lives on the `StateStack` *object*, and `runInBranchAlsFrame` seeds
+  `agencyStore.run({ stack: branch.stack, ... })` (`runBatch.ts:362`). Because
+  function/block calls inside a branch push frames onto the *same* `StateStack`,
+  `getRuntimeContext().stack.batchCoordinator` resolves correctly regardless of
+  whether `Runner.runInScope` spreads the outer frame. D1's rejected-alternative
+  worry about frame-spreading doesn't even apply to the chosen design — worth
+  stating as a strength, since it de-risks the whole approach.
+- **Zero-codegen claim (D3) holds.** The generated `hasInterrupts(...)` →
+  `runner.halt(...)` → `return` guard is the *generic* post-`__call` pattern
+  (`tests/typescriptGenerator/checkpoint-restore.mjs:194-207`), not
+  checkpoint-specific. A `checkpoint()` that returns `Interrupt[]` is caught with
+  no template change.
+- **Serialization safety (D1/D8).** `StateStack.toJSON()`
+  (`state/stateStack.ts:727-767`) enumerates fields explicitly; `abortSignal` /
+  `interrupted` are live-only and omitted. A new `batchCoordinator?` field is
+  silently non-serialized, as claimed.
+- **D5's un-restorable-slice argument is valid.** `restoreState`
+  (`state/context.ts:617`) does `this.stateStack = StateStack.fromJSON(...)` —
+  a wholesale replacement, so a slice-only checkpoint would indeed resume with
+  garbage frames. The "only the outermost stamps" rule is justified.
+- **API surface exists as assumed:** `ctx.getRunId()` (`context.ts:271`, note it
+  *throws* if unset), `ctx.getInterruptResponse(id)` (`context.ts:130`),
+  `interrupt({effect,message,data,origin,runId})` returning an `Interrupt` with
+  mutable `checkpointId`/`checkpoint` slots (`interrupts.ts:64-87`),
+  `setInterruptOnBranch` / `setResultOnBranch` signatures (`stateStack.ts:170-187`),
+  race loser-abort with `AgencyCancelledError` + `makeAbortCause({kind:"raceLoser"})`
+  (`runBatch.ts:595,610`). All match.
+
+---
+
+## HIGH — must resolve before implementing
+
+### H1. `Checkpoint.fromStateStack` sources `nodeId` and `stack` from *different* stacks
+
+`checkpointStore.ts:173-190`:
+
+```ts
+const nodeId = ctx.stateStack.currentNodeId();   // <- context's live stack
+...
+return new Checkpoint({ stack: stateStack.toJSON(), ..., nodeId });  // <- the PASSED stack
+```
+
+The serialized `stack` comes from the argument; `nodeId` always comes from
+`ctx.stateStack`. They only agree when the passed stack **is** `ctx.stateStack`.
+The plan calls `create()` with non-context stacks in two places:
+
+1. **Task 1 (D2), the "defensive slice" path.** The whole selling point of D2 is
+   that on "a branch-like stack that somehow lacks a coordinator" it captures the
+   *local slice* (`stack`) instead of the root. But `nodeId` will still be pulled
+   from `ctx.stateStack` (the outer node). The resulting checkpoint has a branch
+   slice + an outer nodeId — on restore, `runResumeLoop`/`rewindFrom` set
+   `nodeName = cp.nodeId` and resume the *wrong* node with slice frames. That is
+   not "strictly less wrong than capturing the root"; it's a different kind of
+   wrong. At the genuine top level `stack === ctx.stateStack` so it's fine — but
+   the defensive branch the plan advertises is where it bites.
+
+2. **Pure-round stamp (D10).** `resolvePureRound` does
+   `ctx.checkpoints.create(parentStack, ctx, ...)`. D10 asserts "nodeId ... correct
+   at the outermost stamp." This is true **only if** the outermost batch's
+   `parentStack === ctx.stateStack`. That holds for a top-level `fork`, but the
+   plan never states or asserts this invariant, and it is *not* obviously true for
+   a `fork` reached inside an async-called function or inside `runPrompt`'s tool
+   loop (E16), where the enclosing `runBatch`'s `parentStack` may be a sub-stack.
+
+**Action:** Either (a) add an explicit invariant + assertion that pure-round
+stamping only ever happens when `parentStack === ctx.stateStack` (and prove it for
+the tool-loop path in Task 6/E16), or (b) fix `fromStateStack` to derive `nodeId`
+from the passed `stateStack` (`stateStack.currentNodeId()`), which is the value
+that actually corresponds to the frames being serialized. Option (b) is the
+smaller, safer change and also makes Task 1's D2 path correct. Whichever you pick,
+add a test asserting `cp.nodeId` matches the node the serialized top frame belongs
+to, for a stamp taken via `runBatch` (not just top-level solo).
+
+---
+
+## MEDIUM
+
+### M1. `checkpoint()` return-type union isn't propagated to its wrapper
+
+`checkpoint()` becomes `Promise<number | Interrupt[]>` (Task 4), but the only
+non-generated TS consumer, `lib/runtime/agency.ts:263`
+(`const checkpoint = (): Promise<number> => _checkpoint();`), is typed
+`Promise<number>` and will fail to typecheck. It's not in Part 2's file list and
+no task touches it. Add it explicitly to Task 4 (and double-check whatever the
+generated code imports resolves to the widened type).
+
+### M2. `runRaceResume` bypasses `startInvoke` — coordinator wiring won't reach it via Task 3
+
+Task 3 installs `stack.batchCoordinator` inside `startInvoke`, and its Interface
+section claims "**Every** non-cached child branch stack gets `stack.batchCoordinator`
+set." That's false for the race-resume path: `runRaceResume` (`runBatch.ts:689`)
+does **not** call `startInvoke`; it inlines `rehydrateInheritedGuards` →
+`composeBranchAbortSignal` → `runInBranchAlsFrame` at `runBatch.ts:721-741`. The
+plan *does* remember this in Task 7 Step 3 ("Also apply the coordinator wiring to
+`runRaceResume`"), so it's not missed — but Task 3's stated postcondition is
+inaccurate and the wiring is easy to drop. Recommend: soften Task 3's Interface
+claim to "all-, sequential-, and race-first-time modes," and make Task 7 Step 3's
+race-resume wiring a checkbox of its own rather than a clause.
+
+### M3. `ctx.pendingPromises.awaitAll()` from inside a parking branch is unexamined
+
+The concurrent path keeps `await ctx.pendingPromises.awaitAll()` before parking.
+`pendingPromises` is **context-global**, not branch-local. Calling it from within
+one fork branch awaits *every* branch's in-flight async work. In the solo path this
+is the "don't lose unawaited async" guard; in the concurrent path the actual
+snapshot happens later in `runBatch` after the barrier, so this call is at best
+redundant and at worst couples sibling progress into A's park (A can't park until
+B's unawaited async settles — and if B is itself heading for a checkpoint, reason
+about whether that can wedge the barrier). The plan should either justify keeping
+it or scope it to the solo branch (`if (!coordinator) await ...awaitAll()`).
+
+---
+
+## LOW / polish
+
+- **L1. `runInBranchAlsFrame`'s `!parent` early return** (`runBatch.ts:327-333`)
+  returns `fn()` without `agencyStore.run(...)` **and** therefore without the new
+  snapshot registration Task 3 Step 2 adds "before `await fn()`". A batch whose
+  branches hit that path won't register per-branch snapshots. Real-world impact is
+  low (production runs always have a parent frame; this is mostly a direct-call/test
+  path), but note it, and note that the coordinator is still reachable there because
+  it lives on `branch.stack`, not the ALS frame.
+- **L2. Marker field naming.** `interrupt()` populates `data`, not `interruptData`
+  (`interrupts.ts:64,80`). `recordSettle` (plan's Task 3) reads
+  `s.value[0].interruptData` when calling `setInterruptOnBranch`. Confirm real
+  interrupts actually carry `interruptData` (vs `data`) at that point, and that a
+  marker storing `undefined` interruptData is harmless (its data is `{}` anyway).
+  If the existing collect loop already reads `.interruptData`, this is pre-existing
+  and fine — just verify, don't assume.
+- **L3. `recordOutcomes` vs `recordBranchOutcomes`.** The opts field is
+  `recordBranchOutcomes`; `recordOutcomes` is only the local
+  (`runBatch.ts:465`). The plan uses the local name in `recordSettle`, which is
+  correct — just don't let it drift into an opts reference.
+- **L4. Step 2/3 framing.** "Step 2 (settle) / step 3 (collect)" via
+  `Promise.allSettled` is accurate only for `mode:"all"`; `sequential` uses an
+  await-loop and `race` never enters that block (`runBatch.ts:477`). The
+  restructure in Task 3 handles both, but the prose could mislead an implementer
+  into thinking there's a single `allSettled` site.
+
+---
+
+## Design-level observations (not blockers)
+
+- **D4 handler bypass is the single most safety-sensitive decision** and is
+  correctly reasoned: real interrupts still flow through `interruptWithHandlers`;
+  only markers skip it, and a marker only exists because a *real* interrupt already
+  ran handlers. This aligns with the project rule that handlers must never be
+  skipped for a real interrupt. Flag it for extra scrutiny during code review of
+  Task 5, and make E4's "checkpointed appears exactly once" assertion a hard
+  failure, not a soft check — it's the guard against the double-execution bug.
+- **Barrier-blocks-forever cost (D5)** is inherent and honestly documented. Worth
+  a defensive log/telemetry when a batch has been parked-without-progress for a
+  long time, so a livelocked run is diagnosable rather than a silent hang — could
+  be a follow-up, not this PR.
+- **Task sequencing is genuinely incremental and TDD-first**, existing runBatch
+  suite as the Task 3 safety net is the right call, and the edge-case→test table is
+  excellent. No notes there.
+
+## Suggested pre-flight before Task 1
+
+1. Decide H1 option (a) vs (b); if (b), it's a one-line change that also unblocks a
+   clean Task 1.
+2. Add `lib/runtime/agency.ts` to the Task 4 file list (M1).
+3. Verify M2/M3 anchors by grep before writing code so the race-resume and
+   `interruptData` details are pinned.
+
+---
+
+# Anti-pattern pass (`docs/dev/anti-patterns.md`)
+
+Checked the plan's code snippets against the catalog, with focus on the
+"declarative code encapsulating imperative complexity" question.
+
+## Headline answer: yes — and, in one dangerous spot, the exact opposite
+
+The plan's **primary abstraction, `BatchCoordinator`, is a textbook-correct
+application** of the "imperative code everywhere" cure. The genuinely messy
+imperative work — barrier accounting (`started === settled + parked.length`),
+promise juggling, drain-before-resolve ordering — is sealed inside the class, and
+`runBatch`/`checkpoint()` consume it declaratively (`park`, `continueParked`,
+`unwindParked`, `abortParked`, `snapshotParked`, `barrier`). That is the "what vs
+how" split the doc wants. Good, and worth preserving as-is.
+
+**But at the one boundary where it matters most for safety — the interrupt-resume
+protocol — the plan does the inverse: it duplicates imperative complexity instead
+of encapsulating it.** This is the most important anti-pattern finding.
+
+### AP1. Duplicating existing code + leaky abstraction — the marker dance (HIGH)
+
+Task 4's concurrent `checkpoint()` re-hand-rolls, almost line-for-line, the
+discipline that `agencyInterrupt.ts:148-190` already owns:
+
+| plan's Task-4 `checkpoint()` | existing `agencyInterrupt.ts` |
+|---|---|
+| ``const key = `__interrupt_${location.stepPath}` `` | ``const key = `__interrupt_${callsite.stepPath}` `` (`:148`) |
+| `const persistedId = frame?.locals[key]; if (persistedId !== undefined) { const resp = ctx.getInterruptResponse(persistedId); ... }` | identical (`:154-158`) |
+| `frame.locals[key] = intr.interruptId;` (persist BEFORE stamp) | identical (`:183`) |
+| `ctx.checkpoints.create(stack, ...); intr.checkpointId = ...; intr.checkpoint = ctx.checkpoints.get(...)` | identical (`:184-190`) |
+
+D3 openly says it "mirrors `agencyInterrupt.ts`'s discipline exactly." That is the
+"Duplicating existing code" anti-pattern (§ *Duplicating existing code*) stated as a
+design goal. It also trips "Leaky abstractions": the `__interrupt_${stepPath}`
+local-key convention and the persist-before-stamp ordering are *internal details of
+the interrupt-resume protocol* that now leak into a second file — this is nearly the
+doc's bad example verbatim (reaching into `stack.locals.__…`). The two copies can
+silently diverge: if `agencyInterrupt.ts` ever changes the key format, the halt
+payload shape, or the ordering, `checkpoint()` breaks with no compile error.
+
+**Recommendation:** extract the shared tail of `agencyInterrupt.ts` (persist id →
+stamp → attach checkpoint, plus the resume short-circuit) into one reusable helper —
+e.g. `resumeShortCircuit(rt): InterruptResponse | undefined` and
+`emitInterruptCheckpoint(rt, intr): void` — and have both `agency.interrupt()` and
+`checkpoint()` call it. `checkpoint()`'s only real deltas are (a) it skips
+`interruptWithHandlers` (D4) and (b) it parks first; everything after that should be
+the *same* code, not a copy. This directly serves the "encapsulate the how in one
+place" rule, removes the leak, and de-risks H1 (single stamp site to get nodeId
+right). Add this as an explicit step in Task 4 / restructure Task 5.
+
+### AP2. Nested ternary — `buildResponseMap` (MEDIUM; direct ban)
+
+Task 5's leniency check is a nested ternary, which the catalog bans outright
+(§ *Nested ternaries*):
+
+```ts
+const zipTargets =
+  responses.length === interrupts.length ? interrupts
+    : responses.length === real.length ? real
+      : undefined;
+```
+
+Rewrite as an `if/else if/else`. Trivial, but it's an explicit rule and it's in a
+correctness-sensitive spot (response mispairing), so clarity matters.
+
+### AP3. One-line `if` statements — pervasive (LOW; partly matches house style)
+
+The catalog bans single-line `if` bodies (§ *One-line if statements*). The snippets
+use them widely: `if (firstError !== undefined) throw firstError.err;`,
+`if (!t.cached) hooks?.onBranchEnd?.(…)`, `if (recordOutcomes) parentFrame.set…`,
+`if (frame) frame.locals[key] = …`, `if (isCheckpointMarker(it)) continue;`, the
+final collect `if (…) interrupts.push(…)`.
+
+Caveat: some *mirror existing* one-liners in `runBatch.ts` (e.g. `:383`
+`if (!shareGlobals) branch.globalsJSON = …`). There's real tension here between the
+"be consistent with surrounding code" rule (§ *Inconsistent patterns*) and this ban.
+Guidance for the implementer: where you're editing next to existing one-liners,
+matching them is fine; net-new standalone statements should use braces.
+
+### AP4. Order-dependent mutable state (LOW; mostly inherent)
+
+Two spots touch § *Order-dependent mutable state*:
+
+- The marker path's "persist the id **before** stamping" is a hard ordering
+  requirement (the doc's exact concern). It's inherent to resume idempotency — but
+  that's a *second* reason to fix AP1: the fragile ordering should live in one
+  helper, not be re-typed correctly in two files.
+- `settleRounds` branches on mutable `firstError` / `interruptSeen` accumulated by
+  the separate `recordSettle` closure. The round decision (error → mixed → pure) is
+  read out of mutating flags rather than derived. Largely inherent to a barrier
+  loop, but a small `classifyRound(): "error" | "mixed" | "pure" | "done"` deriving
+  the decision from current state would read more declaratively and make the
+  precedence (error beats interrupt beats pure) explicit in one place.
+
+### AP5. Single-character variable names (LOW)
+
+Production snippets use `t` (task), `s` (settled result), `p` (parked entry),
+`w` (waiter), `ps`, `ev`, `res` (§ *Single character variable names*). Loop indices
+`i` are fine; the domain objects (`task`, `settled`, `parkedEntry`, `waiter`) should
+get real names in the shipped code. Test snippets are more forgiving.
+
+## Anti-patterns the plan correctly AVOIDS (credit where due)
+
+- **Duplicating resume logic is actively *removed*, not added:** Task 8 collapses
+  `rewindFrom`'s inlined resume loop (which today duplicates `runResumeLoop`) and
+  `respondToInterrupts` onto one `resume` core. That's the § *Duplicating existing
+  code* cure applied deliberately — good, and it partially offsets AP1 if you fold
+  the marker helper in at the same time.
+- **No useless special cases, no dynamic requires, no empty catch blocks, no deeply
+  nested type literals** in the snippets (`ParkResolution` is a clean flat union).
+- The `BatchCoordinator` interface is a genuinely clean abstraction boundary — you
+  can understand `runBatch`'s round loop without reading the coordinator internals,
+  which is the opposite of § *Leaky abstractions*.
+
+## Bottom line
+
+The plan's structural instinct is right — it encapsulates the hard concurrency
+"how" behind `BatchCoordinator` and consumes it declaratively. The one place it
+regresses is **AP1**: it treats "mirror `agencyInterrupt.ts` exactly" as acceptable
+duplication when that shared discipline should be one extracted helper. Fixing AP1
+(plus AP2's nested ternary) resolves the substantive anti-pattern content; AP3–AP5
+are style cleanups to apply while implementing.

--- a/packages/agency-lang/docs/superpowers/plans/2026-07-05-checkpoint-soft-interrupt.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-07-05-checkpoint-soft-interrupt.md
@@ -1,0 +1,1591 @@
+# Checkpoint-as-Soft-Interrupt Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `checkpoint()` sound inside concurrent execution (fork/race/parallel/tool loop) by modeling it as a soft interrupt that settles at the `runBatch` barrier, per `docs/superpowers/ideas/2026-07-05-unify-checkpoint-and-interrupt-suspension-boundaries.md`.
+
+**Architecture:** A new live-only `BatchCoordinator` object (mirroring `StateStack.abortSignal`'s live-field pattern) lets a branch "park" at a `checkpoint()` call. `runBatch` gains a dynamic barrier loop: when every child is settled-or-parked, a pure-checkpoint round stamps one shared checkpoint and continues everyone in place; a mixed round (real interrupt present) unwinds parked branches as `std::checkpoint` marker interrupts through the *existing* interrupt propagation/resume machinery. Nested batches propagate parking upward so only the outermost batch stamps (full-tree restorability). `respondToInterrupts` auto-approves markers; `restore`/`respondToInterrupts`/`rewindFrom` collapse onto one internal `resume` core.
+
+**Tech Stack:** TypeScript runtime only (`lib/runtime/`). No parser, typechecker, codegen, or template changes. Vitest unit tests + `tests/agency/` execution tests.
+
+## Global Constraints
+
+- NEVER use dynamic imports.
+- Use objects instead of maps; arrays instead of sets; types instead of interfaces.
+- NEVER force push or amend commits.
+- When running tests, save output to a file (`2>&1 | tee <log>`); do NOT rerun tests just to re-read output.
+- Do NOT run the full agency test suite locally — only the specific tests named in each task.
+- Agency code in fixtures MUST follow `docs/site/guide/basic-syntax.md` (`def`/`node`, parens + braces on `if`/`for`, `let`/`const` declarations).
+- Handlers are safety infrastructure: nothing in this plan may cause a `handle` block to be skipped for a *real* interrupt. (`std::checkpoint` markers deliberately bypass the handler chain — see D4 — but real interrupts must flow exactly as today.)
+- Commit messages: write to a file and pass with `git commit -F <file>` (apostrophes break inline `-m`).
+
+---
+
+## Part 1 — Design decisions (investigation results)
+
+Read this section fully before starting any task. Each decision records the option chosen, the alternatives, and why.
+
+### D1. How `checkpoint()` detects concurrency and finds the barrier: a live-only `StateStack.batchCoordinator` field
+
+`runBatch` sets `branch.stack.batchCoordinator = coordinator` on every child branch stack it starts (in `startInvoke`, next to `composeBranchAbortSignal`). `checkpoint()` reads `getRuntimeContext().stack.batchCoordinator`:
+
+- absent → solo path (top level, or a stack no batch is coordinating): cheap inline snapshot, exactly today's behavior *except* it captures the local slice (D2).
+- present → concurrent path: park at the coordinator.
+
+Why this works: inside a branch, every frame push (function calls, blocks) happens on the *same* `StateStack` object (`forkBlockSetup.mustache` seeds the branch stack; `Runner` picks it up from ALS; `runInBranchAlsFrame` seeds `stack: branch.stack`). Nested forks give inner branches their own stacks with the *inner* coordinator — innermost barrier wins naturally.
+
+**Alternatives rejected:**
+- *ALS slot on `AgencyStore`:* `Runner.runInScope` builds fresh frame objects without spreading the outer frame, so a coordinator slot would need explicit propagation in `runInScope`, `runInBranchAlsFrame`, `runInBootstrapFrame`, and `withCallsite` — four touch points and easy to miss one. The stack field needs one write site.
+- *Comparing `stack !== ctx.stateStack`:* detects "inside a branch" but doesn't give you the coordinator handle, and misfires for stacks that aren't batch children.
+
+Serialization safety: `StateStack.toJSON()` enumerates fields explicitly, so a plain class field is never serialized (same as `abortSignal`, `interrupted`). Deserialized stacks come back without it; `runBatch` re-sets it on re-entry.
+
+### D2. Solo-path fix: capture `getRuntimeContext().stack`, not `ctx.stateStack`
+
+The original bug. At the top level the two are the same object, so existing behavior is bit-identical. On any branch-like stack that somehow lacks a coordinator, capturing the local slice is strictly less wrong than capturing the root. Ships first as an independent, zero-risk commit.
+
+### D3. Unwind mechanism: `checkpoint()` *returns* `Interrupt[]` — zero codegen changes
+
+Verified in `tests/typescriptGenerator/checkpoint-restore.mjs`: every generated `checkpoint()` call site is already wrapped as
+
+```ts
+__stack.locals.cp = await __call(checkpoint, { type: "positional", args: [] });
+if (hasInterrupts(__stack.locals.cp)) {
+  await getRuntimeContext().ctx.pendingPromises.awaitAll()
+  runner.halt({ ...__state, data: __stack.locals.cp })
+  return;
+}
+```
+
+So when a mixed batch tells a parked branch to unwind, `checkpoint()` simply returns `[markerInterrupt]` and the existing propagation halts the runner, the fork block returns `runner.haltResult`, and `runBatch` collects it like any other branch interrupt. No `HaltSignal` needed (that exists in `agencyInterrupt.ts` only because TS callers lack the generated guard). No template edits, no `make fixtures` churn.
+
+The marker mirrors `agencyInterrupt.ts`'s discipline exactly:
+1. persist `frame.locals["__interrupt_" + stepPath] = intr.interruptId` BEFORE stamping (resume idempotency; captured by the shared checkpoint),
+2. stamp a leaf checkpoint from the **local branch stack** (slice rule — this is the vehicle carrying the pre-pop branch stack into `State.toJSON`'s branches walk),
+3. return the array.
+
+On resume, the same call site finds the persisted id, looks up `ctx.getInterruptResponse(id)`, and returns the auto-approved value (the shared checkpoint id) without re-parking.
+
+### D4. Markers bypass the handler chain (deviation from the idea doc — flagged deliberately)
+
+The idea doc suggested handlers could optionally observe `std::checkpoint`. We do NOT run `interruptWithHandlers` for markers in v1, because a catch-all `handle { ... approve }` block would approve the marker and let the branch run past its boundary while a sibling holds a real interrupt — exactly the double-execution bug the pin rule exists to prevent. Marker creation is mechanical: by the time one is created, the surface decision was already made by the *real* interrupt (whose handlers ran normally).
+
+Consequences (document loudly):
+- `handle std::checkpoint` never fires. No `effect std::checkpoint` declaration is added to stdlib (undeclared effects are silently unchecked, so user handlers naming it are not compile errors — they're just dead).
+- Users who want to react to checkpoint creation use the host-surfaced batch or statelog `checkpointCreated`.
+- Statelog: markers emit **no** `interruptThrown`/`interruptResolved` events (would break thrown↔resolved pairing since no user resolution exists). The shared `checkpointCreated` event is the observability signal.
+
+Future work (out of scope): an observation-only notification hook.
+
+### D5. Nesting: parking propagates to the parent coordinator; ONLY the outermost batch stamps
+
+**This is the key gap found in the idea doc.** Its sketch has the branch's own `runBatch` stamp the pure-checkpoint batch — but a *nested* batch's `parentStack` is the outer branch's local slice. A checkpoint stamped there is not independently restorable: `restoreState` replaces the whole `execCtx.stateStack` with `cp.stack`, so a slice-only stack would resume the node with garbage frames. Interrupt batches don't have this problem because they unwind and every enclosing `runBatch` re-stamps on the way out; a pure batch never unwinds, so nothing re-stamps.
+
+Rule: when a `runBatch` reaches a pure round, it checks `opts.parentStack.batchCoordinator`:
+- present (nested) → it *parks itself* at the parent coordinator, transitively. The whole ancestor chain must reach settled-or-parked. When the outermost coordinator resolves "continue + cpId", each level relays the cpId down to its parked children.
+- absent (outermost) → stamp `ctx.checkpoints.create(opts.parentStack, ...)`. At the outermost level `parentStack` is the node's full stack, and every descendant branch is at a boundary, so `State.toJSON`'s recursive branches walk serializes a complete, restorable tree.
+
+Cost consequence (document): a `checkpoint()` deep inside nested concurrency blocks until *every* concurrent ancestor's siblings reach a boundary — the idea doc's risk #3, generalized. If any of them loops forever without a boundary, the checkpoint waits forever.
+
+If instead the outer barrier decides "mixed" (a real interrupt exists anywhere), it resolves the nested batch's park with "unwind"; the nested batch unwinds its own parked children, collects their markers via its normal interrupt path (stamping its inner shared checkpoint, which the outer level then re-stamps as today), and the whole thing surfaces through the existing machinery.
+
+### D6. Pure-round stamping must snapshot parked branches' globals/threads and run `beforeCheckpoint` at every level
+
+`runInBranchAlsFrame` captures `branch.globalsJSON` / `branch.activeStack` only when the body settles as `Interrupt[]`. A parked branch hasn't settled, so without help the stamped checkpoint would restore the branch with a *fresh clone of the parent's* globals, losing writes the branch made before `checkpoint()`. Fix: `runInBranchAlsFrame` registers a per-branch snapshot closure on the coordinator (it closes over `branchGlobals`/`branchThreads`); before any pure-round stamp or upward park, the coordinator runs snapshots for currently-parked branches (isolated dials only, mirroring the capture-on-interrupt discipline).
+
+Same reasoning for `hooks.beforeCheckpoint` (runPrompt's tool loop flushes sibling tool messages into `self.messagesJSON` with it): it must run at *each level* before that level parks upward or stamps — otherwise a checkpoint taken inside one tool would lose sibling tools' completed responses.
+
+### D7. Race mode semantics
+
+- A parked branch is not a settle, so it **cannot win** the race.
+- Winner settles while a sibling is parked → parked losers are aborted: their park promise **rejects** with `AgencyCancelledError("race loser", makeAbortCause({kind:"raceLoser"}))`; `checkpoint()` lets it propagate; the branch is abandoned exactly like today's aborted losers (safe from unhandled-rejection because `Promise.race` already subscribed to every tagged promise). On the winner-interrupt path, parked losers are also deleted from `parentFrame.branches` before stamping (invariant #5: losers must not survive into the checkpoint).
+- ALL branches parked, none settled → pure round: stamp (or propagate up), continue everyone, keep racing.
+
+### D8. No serialization schema changes
+
+The idea doc sketched a `BranchState` "parked-at-checkpoint" flag. Not needed:
+- Mixed path: the marker rides the existing `interruptId`/`interruptData`/leaf-`checkpoint` fields via `setInterruptOnBranch` — indistinguishable from a real interrupt in the JSON, which is fine because resume behavior is driven by the *surfaced interrupt objects* (which carry `effect`), not the branch JSON.
+- Pure path: the parked branch serializes as its live mid-step stack (frames un-popped — the same shape as a leaf checkpoint's pre-pop stack). No marker is persisted. On `restore(cpId)`, the branch re-runs its incomplete step, `checkpoint()` executes again, parks again, and mints a **new** checkpoint — which is exactly today's *top-level* restore semantics (the step containing `checkpoint()` is incomplete in the snapshot, so restore re-runs it and gets a fresh id). Retry loops (`restore(id)` inside a branch) work unchanged.
+
+Consequence: post-join `restore(id)` of a mixed-batch checkpoint re-raises the contained real interrupts (branch re-invokes, interrupt site finds persisted id, no response recorded → re-raises with the saved id) and re-parks the marker branches. Consistent with rewind semantics; document loudly (idea-doc risk #2).
+
+### D9. Resume auto-approval + unified `resume`
+
+- `respondToInterrupts(interrupts, responses)`: markers get an injected `{type:"approve", value: <shared cp id>}`. `buildResponseMap` becomes lenient: accepts `responses.length === interrupts.length` (old hosts that respond positionally to everything — their marker responses are ignored and overridden by the auto-approval) OR `responses.length === realInterrupts.length` (new hosts skip markers). Anything else still throws.
+- `reportUnhandledInterrupts` skips `std::checkpoint` entries when printing (a marker can only surface alongside a real unhandled interrupt, which still triggers the message + exit).
+- New exported `resume({ctx, checkpoint, responses?, overrides?, ...})` — the one primitive. `respondToInterrupts` and `rewindFrom` become wrappers (rewindFrom keeps its `_skipNextCheckpoint` quirk via an option). Plain `resume(cp)` with no responses = today's rewind: real interrupts re-raise; markers re-park. The Agency-level `restore()` builtin (in-process `RestoreSignal`) is unchanged.
+
+### D10. What `checkpoint()` returns, and checkpoint identity
+
+- Concurrent-path `checkpoint()` returns the **shared batch checkpoint id** (all parked branches in the same round get the same id; both calls in a two-checkpoint round return the same id — the design doc's "one shared checkpoint").
+- The shared checkpoint's recorded location (`moduleId/scopeName/stepPath`) is the **enclosing batch site** (the fork/race/tool-round step), not the `checkpoint()` callsite — it's stamped by `runBatch` with `opts.checkpointLocation`. Affects `restore(..., {maxRestores})` location counting: all checkpoints from the same fork share a location bucket. Document.
+- `nodeId` comes from `ctx.stateStack.currentNodeId()` inside `Checkpoint.fromStateStack` — correct at the outermost stamp.
+
+### D11. Errors and `restore()` racing with parked siblings
+
+If any child settles rejected (JS error — including `RestoreSignal` from a `restore()` call inside a branch) while siblings are parked, the coordinator rejects all parked promises with that error's cancellation so `checkpoint()` throws, those branches settle, the barrier completes, and `runBatch` rethrows the first rejection (existing errors-win-over-interrupts invariant). A `restore()` inside a fork branch therefore: unwinds the whole batch → `RestoreSignal` reaches the node loop → `restoreState(cp)` → re-enters the fork with cached sibling results → the restoring branch re-runs. This makes the classic retry loop work *inside* a fork.
+
+### Out of scope (explicitly)
+
+- Cross-process (`_run` subprocess) checkpoint unification: `checkpoint()` in a subprocess sees its own process-local top-level stack (no coordinator) → solo inline snapshot, today's semantics. Document.
+- `checkpoint()` inside an *unawaited* `async` function call: the async body runs on the caller's stack context via `pendingPromises`; whichever stack it sees governs (usually no coordinator → solo). Pin behavior with a test but do not build parking support for it.
+- Handler observation of markers (D4 future work).
+- Debugger rolling checkpoints (`createRolling` uses `ctx.stateStack` at step boundaries of the top-level runner — not affected by branch parking).
+
+### Edge-case inventory (each maps to a test in the tasks below)
+
+| # | Case | Expected behavior |
+|---|------|-------------------|
+| E1 | `checkpoint()` at top level (no fork) | Unchanged: inline snapshot, same id semantics (Task 1) |
+| E2 | Fork: one branch checkpoints, siblings finish | Pure round: one shared cp, everyone continues inline, fork returns values (Task 4) |
+| E3 | Fork: two branches checkpoint (same or different rounds) | Both parks resolve; same cp id per round; no deadlock (Task 4) |
+| E4 | Fork: A checkpoints, C interrupts, B finishes | Batch surfaces: C's interrupt + A's `std::checkpoint` marker; one shared cp; resume approves C, auto-approves A; A's tail runs exactly once (Task 5) |
+| E5 | Single-item fork with checkpoint | One-branch pure round auto-resolves (Task 4) |
+| E6 | `checkpoint()` in a loop inside a branch (multiple parks) | Each round stamps a fresh shared cp (Task 4) |
+| E7 | `restore(id)` inside a fork branch (retry loop) | Whole-batch unwind via RestoreSignal; siblings' results cached; branch re-runs (Task 9) |
+| E8 | Sibling rejects (JS error) while another is parked | Parked branch aborted; first error rethrown (Task 9) |
+| E9 | Nested fork: inner branch checkpoints | Park propagates; outermost stamps full tree; restore works (Task 6) |
+| E10 | Nested fork mixed: inner checkpoints, outer sibling interrupts | Inner unwinds as marker through both levels; resume works (Task 6) |
+| E11 | Race: all branches checkpoint | Pure round, race continues (Task 7) |
+| E12 | Race: winner settles while loser parked | Parked loser aborted + (on interrupt path) deleted pre-stamp (Task 7) |
+| E13 | Sequential mode (hook batching): child parks | Not-started siblings are trivially at boundary → pure round (Task 7) |
+| E14 | Post-join `restore(cp)` of a mixed-batch checkpoint | Real interrupts re-raise; markers re-park (Task 8) |
+| E15 | `shared: true` fork + checkpoint | Pointer-shared globals: no per-branch snapshot (skip), parent store captured by cp globals (Task 4) |
+| E16 | Tool-loop (`recordBranchOutcomes: false`) + checkpoint in a tool | Parks at tool-round barrier; `beforeCheckpoint` flushes sibling tool messages pre-stamp (Task 6) |
+| E17 | checkpoint in unawaited async call | Pinned as solo-inline (Task 9) |
+
+---
+
+## Part 2 — File structure
+
+- **Create** `lib/runtime/batchCoordinator.ts` — `BatchCoordinator` class + `ParkResolution` type. Pure accounting, no imports from runBatch (breaks what would otherwise be a cycle: stateStack → batchCoordinator, runBatch → batchCoordinator).
+- **Create** `lib/runtime/batchCoordinator.test.ts` — co-located unit tests.
+- **Modify** `lib/runtime/state/stateStack.ts` — add live-only `batchCoordinator?: BatchCoordinator` field (type-only import).
+- **Modify** `lib/runtime/checkpoint.ts` — solo slice fix; concurrent park/unwind path.
+- **Modify** `lib/runtime/runBatch.ts` — barrier loop for all three modes; coordinator wiring; pure-round stamp; snapshot registration in `runInBranchAlsFrame`.
+- **Modify** `lib/runtime/interrupts.ts` — marker auto-approval, lenient `buildResponseMap`, `reportUnhandledInterrupts` skip, new `resume` core.
+- **Modify** `lib/runtime/rewind.ts` — `rewindFrom` delegates to `resume`.
+- **Create** `tests/agency/fork/checkpoint/*.agency` + `.test.json` — execution tests E2–E14.
+- **Modify** docs: `docs/dev/checkpointing.md`, `docs/dev/concurrent-interrupts.md`, `docs/dev/runBatch.md`, `docs/site/guide/checkpointing.md` (verify exact guide filename before editing).
+
+---
+
+## Part 3 — Tasks
+
+### Task 1: Solo-path slice fix in `checkpoint()`
+
+**Files:**
+- Modify: `lib/runtime/checkpoint.ts:14-22`
+- Test: `lib/runtime/checkpoint.test.ts`
+
+**Interfaces:**
+- Consumes: `getRuntimeContext()` (`lib/runtime/asyncContext.ts`).
+- Produces: `checkpoint()` captures the ALS frame's `stack` (local slice). Signature unchanged (`Promise<number>` for now).
+
+- [ ] **Step 1: Read the existing test file** `lib/runtime/checkpoint.test.ts` to match its setup helpers (it builds a `RuntimeContext` and uses `runInTestContext`).
+
+- [ ] **Step 2: Write the failing test** — a checkpoint taken while the ALS frame carries a branch stack must serialize the branch stack, not `ctx.stateStack`:
+
+```ts
+test("checkpoint() captures the ALS frame's local stack, not ctx.stateStack", async () => {
+  const ctx = await makeCtx(); // reuse the file's existing context factory
+  ctx.stateStack.nodesTraversed.push("main");
+  const rootFrame = ctx.stateStack.getNewState();
+  rootFrame.locals.rootMarker = "root";
+  const branchStack = new StateStack();
+  const branchFrame = branchStack.getNewState();
+  branchFrame.locals.branchMarker = "branch";
+  const id = await runInTestContext(ctx, branchStack, new ThreadStore(), () =>
+    checkpoint(),
+  );
+  const cp = ctx.checkpoints.get(id as number)!;
+  const top = cp.stack.stack[cp.stack.stack.length - 1];
+  expect(top.locals.branchMarker).toBe("branch");
+  expect(top.locals.rootMarker).toBeUndefined();
+});
+```
+
+Adjust imports (`StateStack`, `ThreadStore`, `runInTestContext`) to match the file's existing style.
+
+- [ ] **Step 3: Run it, verify it fails** (captures rootMarker today):
+
+```bash
+pnpm test:run lib/runtime/checkpoint.test.ts 2>&1 | tee task1-test.log
+```
+
+Expected: the new test FAILS (`branchMarker` undefined / `rootMarker` present).
+
+- [ ] **Step 4: Fix `checkpoint()`** — one-line change plus doc update:
+
+```ts
+export async function checkpoint(): Promise<number> {
+  const { ctx, stack, callsite } = getRuntimeContext();
+  await ctx.pendingPromises.awaitAll();
+  // Capture the LOCAL slice from the active ALS frame — identical to
+  // ctx.stateStack at the top level, and the branch's own stack inside
+  // fork/race/tool-loop branches (the slice rule; see
+  // docs/dev/concurrent-interrupts.md "Slice-only checkpoint composition").
+  return ctx.checkpoints.create(stack, ctx, {
+    moduleId: callsite?.moduleId ?? "",
+    scopeName: callsite?.scopeName ?? "",
+    stepPath: callsite?.stepPath ?? "",
+  });
+}
+```
+
+- [ ] **Step 5: Run the file's full test suite, verify green:**
+
+```bash
+pnpm test:run lib/runtime/checkpoint.test.ts 2>&1 | tee task1-test2.log
+```
+
+- [ ] **Step 6: Commit** (`git add lib/runtime/checkpoint.ts lib/runtime/checkpoint.test.ts`, message: `fix: checkpoint() captures the local stack slice, not ctx.stateStack`).
+
+---
+
+### Task 2: `BatchCoordinator`
+
+**Files:**
+- Create: `lib/runtime/batchCoordinator.ts`
+- Create: `lib/runtime/batchCoordinator.test.ts`
+- Modify: `lib/runtime/state/stateStack.ts` (add field)
+
+**Interfaces:**
+- Produces (consumed by Tasks 3–7):
+  - `type ParkResolution = { action: "continue"; checkpointId: number } | { action: "unwind" }`
+  - `class BatchCoordinator` with: `noteStarted()`, `noteSettled()`, `park(stack: StateStack): Promise<ParkResolution>`, `parkedCount: number`, `barrier(): Promise<void>`, `registerSnapshot(stack, fn)`, `snapshotParked()`, `continueParked(checkpointId)`, `unwindParked()`, `abortParked(err)`, `close()`.
+  - `StateStack.batchCoordinator?: BatchCoordinator` (live-only, never serialized).
+
+- [ ] **Step 1: Write the failing tests** (`lib/runtime/batchCoordinator.test.ts`):
+
+```ts
+import { describe, expect, test } from "vitest";
+import { BatchCoordinator } from "./batchCoordinator.js";
+import { StateStack } from "./state/stateStack.js";
+
+describe("BatchCoordinator", () => {
+  test("barrier resolves when every started child is settled or parked", async () => {
+    const c = new BatchCoordinator();
+    c.noteStarted();
+    c.noteStarted();
+    let barrierHit = false;
+    const b = c.barrier().then(() => { barrierHit = true; });
+    await Promise.resolve();
+    expect(barrierHit).toBe(false);
+    c.noteSettled();
+    await Promise.resolve();
+    expect(barrierHit).toBe(false);
+    const stack = new StateStack();
+    const park = c.park(stack);
+    await b;
+    expect(barrierHit).toBe(true);
+    expect(c.parkedCount).toBe(1);
+    c.continueParked(42);
+    await expect(park).resolves.toEqual({ action: "continue", checkpointId: 42 });
+    expect(c.parkedCount).toBe(0);
+  });
+
+  test("a continued child can park again in a later round", async () => {
+    const c = new BatchCoordinator();
+    c.noteStarted();
+    const stack = new StateStack();
+    const p1 = c.park(stack);
+    c.continueParked(1);
+    await expect(p1).resolves.toEqual({ action: "continue", checkpointId: 1 });
+    const p2 = c.park(stack);
+    c.unwindParked();
+    await expect(p2).resolves.toEqual({ action: "unwind" });
+  });
+
+  test("abortParked rejects parked promises", async () => {
+    const c = new BatchCoordinator();
+    c.noteStarted();
+    const park = c.park(new StateStack());
+    const err = new Error("boom");
+    c.abortParked(err);
+    await expect(park).rejects.toBe(err);
+  });
+
+  test("snapshotParked runs snapshots for parked stacks only", async () => {
+    const c = new BatchCoordinator();
+    c.noteStarted(); c.noteStarted();
+    const a = new StateStack(); const b = new StateStack();
+    const ran: string[] = [];
+    c.registerSnapshot(a, () => ran.push("a"));
+    c.registerSnapshot(b, () => ran.push("b"));
+    void c.park(a);
+    c.snapshotParked();
+    expect(ran).toEqual(["a"]);
+    c.continueParked(0);
+  });
+
+  test("park after close throws", async () => {
+    const c = new BatchCoordinator();
+    c.close();
+    expect(() => c.park(new StateStack())).toThrow(/completed/);
+  });
+
+  test("barrier resolves immediately when nothing is running", async () => {
+    const c = new BatchCoordinator();
+    await c.barrier(); // 0 started === 0 settled+parked
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify failure** (module doesn't exist):
+
+```bash
+pnpm test:run lib/runtime/batchCoordinator.test.ts 2>&1 | tee task2-test.log
+```
+
+- [ ] **Step 3: Implement `lib/runtime/batchCoordinator.ts`:**
+
+```ts
+/**
+ * `BatchCoordinator` — the settle-or-park barrier behind checkpoint()'s
+ * soft-interrupt semantics inside concurrent execution.
+ *
+ * One coordinator per `runBatch` invocation. runBatch installs it on every
+ * child branch's `StateStack.batchCoordinator` (live-only field, never
+ * serialized — same pattern as `StateStack.abortSignal`). `checkpoint()`
+ * finds it there and calls `park(stack)`, suspending the branch at a
+ * boundary until runBatch decides the round:
+ *
+ *  - pure round (no real interrupt in the batch): `continueParked(cpId)` —
+ *    every parked checkpoint() returns the shared checkpoint id inline.
+ *  - mixed round (a sibling holds a real interrupt): `unwindParked()` —
+ *    every parked checkpoint() returns a `std::checkpoint` marker
+ *    Interrupt[] and the branch unwinds through the normal propagation.
+ *  - error round (a sibling rejected): `abortParked(err)` — parked
+ *    checkpoint() calls throw, the batch tears down, the error wins.
+ *
+ * Accounting is synchronous (single JS thread): `started`, `settled`, and
+ * the parked list. The barrier is "no child actively running":
+ * `started === settled + parked.length`. A continued branch leaves the
+ * parked list and may park again in a later round (checkpoint in a loop).
+ *
+ * `registerSnapshot` lets `runInBranchAlsFrame` hand the coordinator a
+ * closure that flushes branch-local GlobalStore/ThreadStore state onto the
+ * BranchState before a pure-round stamp — parked branches never hit the
+ * capture-on-interrupt path, so without this the stamped checkpoint would
+ * restore them with stale parent clones.
+ */
+import type { StateStack } from "./state/stateStack.js";
+
+export type ParkResolution =
+  | { action: "continue"; checkpointId: number }
+  | { action: "unwind" };
+
+type ParkedEntry = {
+  stack: StateStack;
+  resolve: (r: ParkResolution) => void;
+  reject: (err: unknown) => void;
+};
+
+type SnapshotEntry = { stack: StateStack; fn: () => void };
+
+export class BatchCoordinator {
+  private started = 0;
+  private settled = 0;
+  private parked: ParkedEntry[] = [];
+  private snapshots: SnapshotEntry[] = [];
+  private waiters: Array<() => void> = [];
+  private closed = false;
+
+  noteStarted(): void {
+    this.started++;
+  }
+
+  noteSettled(): void {
+    this.settled++;
+    this.checkBarrier();
+  }
+
+  get parkedCount(): number {
+    return this.parked.length;
+  }
+
+  /** Called by checkpoint() (via `stack.batchCoordinator`). Suspends the
+   *  caller until runBatch decides the round. */
+  park(stack: StateStack): Promise<ParkResolution> {
+    if (this.closed) {
+      throw new Error(
+        "checkpoint(): the surrounding concurrent batch already completed. " +
+          "This indicates a runtime bug — please report it.",
+      );
+    }
+    return new Promise<ParkResolution>((resolve, reject) => {
+      this.parked.push({ stack, resolve, reject });
+      this.checkBarrier();
+    });
+  }
+
+  /** Resolves when every started child is settled or parked. */
+  barrier(): Promise<void> {
+    if (this.atBarrier()) return Promise.resolve();
+    return new Promise((res) => this.waiters.push(res));
+  }
+
+  private atBarrier(): boolean {
+    return this.started === this.settled + this.parked.length;
+  }
+
+  private checkBarrier(): void {
+    if (!this.atBarrier()) return;
+    const ws = this.waiters;
+    this.waiters = [];
+    for (const w of ws) w();
+  }
+
+  /** Register (or replace) the branch-local state flush for a stack. */
+  registerSnapshot(stack: StateStack, fn: () => void): void {
+    const existing = this.snapshots.find((s) => s.stack === stack);
+    if (existing) {
+      existing.fn = fn;
+      return;
+    }
+    this.snapshots.push({ stack, fn });
+  }
+
+  /** Flush branch-local stores for currently-parked branches. Runs before
+   *  every pure-round stamp / upward park. Idempotent per round. */
+  snapshotParked(): void {
+    for (const p of this.parked) {
+      const snap = this.snapshots.find((s) => s.stack === p.stack);
+      snap?.fn();
+    }
+  }
+
+  continueParked(checkpointId: number): void {
+    const ps = this.drainParked();
+    for (const p of ps) p.resolve({ action: "continue", checkpointId });
+  }
+
+  unwindParked(): void {
+    const ps = this.drainParked();
+    for (const p of ps) p.resolve({ action: "unwind" });
+  }
+
+  abortParked(err: unknown): void {
+    const ps = this.drainParked();
+    for (const p of ps) p.reject(err);
+  }
+
+  private drainParked(): ParkedEntry[] {
+    const ps = this.parked;
+    this.parked = [];
+    return ps;
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+}
+```
+
+Note: `drainParked` empties the list *before* resolving so a synchronously re-parking branch lands in the next round's list, and barrier accounting stays consistent (a continued branch is "running" again until it settles or re-parks).
+
+- [ ] **Step 4: Add the live-only field to `StateStack`** (`lib/runtime/state/stateStack.ts`, next to `abortSignal` around line 360), with a type-only import at the top:
+
+```ts
+import type { BatchCoordinator } from "../batchCoordinator.js";
+```
+
+```ts
+  // The coordinator of the runBatch invocation this stack is a child
+  // branch of, if any. Set by runBatch's startInvoke on every branch
+  // stack; read by checkpoint() to decide solo-inline vs. park-at-
+  // barrier (soft interrupt). Like abortSignal: live-only, NEVER
+  // serialized (toJSON enumerates fields explicitly, so nothing to do).
+  batchCoordinator?: BatchCoordinator;
+```
+
+- [ ] **Step 5: Run tests + structural linter, verify green:**
+
+```bash
+pnpm test:run lib/runtime/batchCoordinator.test.ts lib/runtime/state/stateStack.test.ts 2>&1 | tee task2-test2.log
+pnpm run lint:structure 2>&1 | tee task2-lint.log
+```
+
+- [ ] **Step 6: Commit** (`feat: add BatchCoordinator settle-or-park barrier primitive`).
+
+---
+
+### Task 3: `runBatch` barrier loop (behavior-preserving restructure)
+
+Restructure `runBatch`'s mode-"all"/"sequential" core so outcomes are recorded *as children settle* and a coordinator-driven round loop runs at the barrier — but with nothing parking yet, behavior is identical and **all 19 existing `runBatch` tests must stay green unmodified**.
+
+**Files:**
+- Modify: `lib/runtime/runBatch.ts`
+- Test: `lib/runtime/runBatch.test.ts` (existing suite is the safety net; add 1 new test)
+
+**Interfaces:**
+- Consumes: `BatchCoordinator` from Task 2.
+- Produces (relied on by Tasks 4–7):
+  - Every non-cached child branch stack gets `stack.batchCoordinator` set before `invoke` and the coordinator is `close()`d before `runBatch` returns.
+  - `runInBranchAlsFrame` registers the globals/threads snapshot on the coordinator.
+  - Internal helper `resolvePureRound(opts, coordinator): Promise<void>` exists (stamps at outermost / parks upward when nested — nested path exercised in Task 6).
+
+- [ ] **Step 1: Restructure mode "all"/"sequential".** Replace step 2 (settle) and step 3 (collect) of `runBatch` with a settle-tracking wrapper + round loop. Concretely:
+
+Add a per-batch mutable record and settle recorder above the mode dispatch:
+
+```ts
+  const coordinator = new BatchCoordinator();
+  // Recorded per task index as children settle (replaces the old
+  // post-allSettled collect loop so a pure-checkpoint round can stamp a
+  // checkpoint that already contains finished siblings' results).
+  const settled: PromiseSettledResult<T | Interrupt[]>[] = new Array(
+    tasks.length,
+  );
+  let interruptSeen = false;
+  let firstError: { err: unknown } | undefined;
+
+  const recordSettle = (i: number, s: PromiseSettledResult<T | Interrupt[]>) => {
+    settled[i] = s;
+    const t = tasks[i];
+    const timeMs = t.cached ? 0 : performance.now() - t.startedAt;
+    if (s.status === "rejected") {
+      firstError ??= { err: s.reason };
+      if (!t.cached) hooks?.onBranchEnd?.(t.child.key, i, "failure", timeMs);
+    } else if (hasInterrupts(s.value)) {
+      interruptSeen = true;
+      if (!t.cached) hooks?.onBranchEnd?.(t.child.key, i, "interrupted", timeMs);
+      if (recordOutcomes) {
+        parentFrame.setInterruptOnBranch(
+          t.child.key,
+          s.value[0].interruptId,
+          s.value[0].interruptData,
+          s.value[0].checkpoint,
+        );
+      }
+    } else {
+      if (!t.cached) hooks?.onBranchEnd?.(t.child.key, i, "success", timeMs, s.value);
+      if (recordOutcomes) parentFrame.setResultOnBranch(t.child.key, s.value as any);
+    }
+    coordinator.noteSettled();
+  };
+
+  const trackedInvoke = (i: number): Promise<void> => {
+    coordinator.noteStarted();
+    return startInvoke(opts, tasks[i], i, parentSpanStack).then(
+      (value) => recordSettle(i, { status: "fulfilled", value }),
+      (reason) => recordSettle(i, { status: "rejected", reason }),
+    );
+  };
+```
+
+Set the coordinator on the branch stack inside `startInvoke` (after `composeBranchAbortSignal`):
+
+```ts
+  t.branch.stack.batchCoordinator = opts.coordinator;
+```
+
+(Thread the coordinator to `startInvoke` — simplest is adding a `coordinator: BatchCoordinator` field to an internal extension of the opts passed around, or an extra parameter `startInvoke(opts, t, i, parentSpanStack, coordinator)`. Use the extra parameter; update all three call sites including the race paths.)
+
+Round loop shared by "all" and "sequential":
+
+```ts
+  /** Wait for the barrier and resolve checkpoint rounds until no child is
+   * parked. On return every started child has settled. */
+  const settleRounds = async (): Promise<void> => {
+    while (true) {
+      await coordinator.barrier();
+      if (coordinator.parkedCount === 0) return;
+      if (firstError !== undefined) {
+        coordinator.abortParked(firstError.err);
+        continue;
+      }
+      if (interruptSeen) {
+        coordinator.unwindParked();
+        continue;
+      }
+      await resolvePureRound(opts, coordinator);
+    }
+  };
+```
+
+Mode dispatch becomes:
+
+```ts
+  if (mode === "sequential") {
+    for (let i = 0; i < tasks.length; i++) {
+      const p = trackedInvoke(i);
+      await settleRounds();
+      await p;
+    }
+  } else {
+    const ps = tasks.map((_, i) => trackedInvoke(i));
+    await settleRounds();
+    await Promise.all(ps);
+  }
+  coordinator.close();
+```
+
+And the final collect shrinks to (outcomes already recorded):
+
+```ts
+  if (firstError !== undefined) throw firstError.err;
+  const interrupts: Interrupt[] = [];
+  for (const s of settled) {
+    if (s.status === "fulfilled" && hasInterrupts(s.value)) interrupts.push(...s.value);
+  }
+```
+
+then the existing step-4/step-5 tail (stamp+return interrupts / propagate cost+popBranches+return values) unchanged. Keep the cached-branch semantics: cached tasks still go through `trackedInvoke` (their `startInvoke` resolves immediately with the cached value) — this keeps started/settled accounting uniform.
+
+Add `resolvePureRound` (nested branch is completed in Task 6 — for now implement the outermost arm and make the nested arm throw a descriptive "not implemented yet" error; Task 6 replaces it):
+
+```ts
+/** A round where every child is settled-or-parked and no real interrupt or
+ * error is present: stamp ONE shared checkpoint (outermost batch) or park
+ * this whole batch at the enclosing batch's coordinator (nested — Task 6),
+ * then release the parked branches with the checkpoint id. */
+async function resolvePureRound<T>(
+  opts: RunBatchOpts<T>,
+  coordinator: BatchCoordinator,
+): Promise<void> {
+  const { ctx, parentStack, checkpointLocation, hooks } = opts;
+  hooks?.beforeCheckpoint?.();
+  coordinator.snapshotParked();
+  const parentCoordinator = parentStack.batchCoordinator;
+  if (parentCoordinator) {
+    throw new Error("nested checkpoint parking is implemented in Task 6");
+  }
+  const cpId = ctx.checkpoints.create(parentStack, ctx, checkpointLocation);
+  hooks?.onCheckpoint?.(cpId);
+  coordinator.continueParked(cpId);
+}
+```
+
+- [ ] **Step 2: Register the snapshot in `runInBranchAlsFrame`.** Inside the `agencyStore.run` body, before `await fn()`:
+
+```ts
+      // Parked-at-checkpoint branches never hit the capture-on-INTERRUPT
+      // path below, so hand the coordinator a flush closure to run before
+      // any pure-round checkpoint stamp (see BatchCoordinator docstring).
+      branch.stack.batchCoordinator?.registerSnapshot(branch.stack, () => {
+        if (!shareGlobals) branch.globalsJSON = branchGlobals.toJSON();
+        if (!shareThreads) branch.activeStack = [...branchThreads.activeStack];
+      });
+```
+
+- [ ] **Step 3: Run the existing `runBatch` suite — must be green with zero test edits:**
+
+```bash
+pnpm test:run lib/runtime/runBatch.test.ts lib/runtime/promptRunner.test.ts 2>&1 | tee task3-test.log
+```
+
+If any existing test fails, fix the restructure — do not modify the tests.
+
+- [ ] **Step 4: Add one new test** pinning the coordinator lifecycle:
+
+```ts
+test("runBatch installs a batchCoordinator on child stacks and closes it after", async () => {
+  // Build ctx/frame/stack with the file's existing helpers.
+  let seen: BatchCoordinator | undefined;
+  const result = await runBatch<number>({
+    ...baseOpts(), // the file's existing opts factory
+    mode: "all",
+    children: [{
+      key: "c0",
+      invoke: async (childStack) => {
+        seen = childStack.batchCoordinator;
+        return 1;
+      },
+    }],
+  });
+  expect(result).toEqual({ kind: "values", values: [1] });
+  expect(seen).toBeDefined();
+  expect(() => seen!.park(new StateStack())).toThrow(/completed/);
+});
+```
+
+- [ ] **Step 5: Run, verify green; run structural linter:**
+
+```bash
+pnpm test:run lib/runtime/runBatch.test.ts 2>&1 | tee task3-test2.log
+pnpm run lint:structure 2>&1 | tee task3-lint.log
+```
+
+- [ ] **Step 6: Commit** (`refactor: runBatch settle-or-park round loop, outcomes recorded on settle`).
+
+---
+
+### Task 4: `checkpoint()` concurrent path — pure batches (single level)
+
+**Files:**
+- Modify: `lib/runtime/checkpoint.ts`
+- Test: `lib/runtime/runBatch.test.ts` (integration through runBatch), `lib/runtime/checkpoint.test.ts`
+- Create: `tests/agency/fork/checkpoint/checkpoint-pure.agency` + `.test.json`, `checkpoint-single-branch.agency` + `.test.json`, `checkpoint-two-branches.agency` + `.test.json`
+
+**Interfaces:**
+- Consumes: `BatchCoordinator.park` (Task 2), coordinator on branch stacks (Task 3).
+- Produces: `checkpoint(): Promise<number | Interrupt[]>` — parks when `stack.batchCoordinator` is set; returns the shared checkpoint id on `continue`. (The `Interrupt[]` arm returns in Task 5; declare the union now.)
+
+- [ ] **Step 1: Write the failing runBatch-level test:**
+
+```ts
+test("a child that parks at checkpoint() gets the shared checkpoint id and continues", async () => {
+  const order: string[] = [];
+  const result = await runBatch<string>({
+    ...baseOpts(),
+    mode: "all",
+    children: [
+      {
+        key: "a",
+        invoke: async (childStack) => {
+          order.push("a:before");
+          const res = await childStack.batchCoordinator!.park(childStack);
+          order.push(`a:${res.action}`);
+          return res.action === "continue" ? `cp:${res.checkpointId}` : "unwound";
+        },
+      },
+      { key: "b", invoke: async () => { order.push("b"); return "done"; } },
+    ],
+  });
+  expect(result.kind).toBe("values");
+  const values = (result as any).values as string[];
+  expect(values[1]).toBe("done");
+  expect(values[0]).toMatch(/^cp:\d+$/);
+  expect(order).toContain("a:continue");
+  // The stamped checkpoint must contain b's finished result.
+  const cpId = Number(values[0].slice(3));
+  const cp = baseCtx.checkpoints.get(cpId)!;
+  const frame = cp.stack.stack[cp.stack.stack.length - 1];
+  expect(frame.branches!["b"].result).toEqual({ result: "done" });
+});
+```
+
+(Adapt `baseOpts`/`baseCtx` to the file's existing fixtures — the suite already builds `ctx`, `parentStack`, `parentFrame`.)
+
+- [ ] **Step 2: Run, verify it fails** (Task 3's loop should actually make this pass already — if it passes, good: it validates Task 3; keep it as a regression test and move on):
+
+```bash
+pnpm test:run lib/runtime/runBatch.test.ts 2>&1 | tee task4-test.log
+```
+
+- [ ] **Step 3: Implement `checkpoint()`'s concurrent path** (full replacement of `lib/runtime/checkpoint.ts`'s `checkpoint` function; add imports `interrupt, type Interrupt` from `./interrupts.js`):
+
+```ts
+/**
+ * Capture a checkpoint of the current execution state.
+ *
+ * Solo path (no surrounding concurrent batch): inline snapshot of the
+ * LOCAL stack slice; returns the checkpoint id immediately.
+ *
+ * Concurrent path (`stack.batchCoordinator` present — this stack is a
+ * fork/race/parallel/tool-loop branch): checkpoint() is a SOFT interrupt.
+ * It parks at the batch barrier until every sibling reaches a suspension
+ * boundary (finish, interrupt, or checkpoint):
+ *  - pure round (no real interrupt): ONE shared checkpoint is stamped by
+ *    the outermost batch and its id is returned inline — no unwind.
+ *  - mixed round (a sibling holds a real interrupt): returns a
+ *    `std::checkpoint` marker Interrupt[]; the generated call-site guard
+ *    halts the branch and the batch surfaces to the host. On resume the
+ *    marker is auto-approved with the shared checkpoint id.
+ * See docs/dev/checkpointing.md "Checkpoints inside concurrent execution".
+ */
+export async function checkpoint(): Promise<number | Interrupt[]> {
+  const { ctx, stack, callsite } = getRuntimeContext();
+  await ctx.pendingPromises.awaitAll();
+  const location = {
+    moduleId: callsite?.moduleId ?? "",
+    scopeName: callsite?.scopeName ?? "",
+    stepPath: callsite?.stepPath ?? "",
+  };
+  const coordinator = stack.batchCoordinator;
+  if (!coordinator) {
+    return ctx.checkpoints.create(stack, ctx, location);
+  }
+
+  // Resume idempotency (mixed-path replay): if this call site already
+  // unwound as a marker and the resume injected its auto-approval,
+  // return the shared checkpoint id without re-parking. Mirrors
+  // agencyInterrupt.ts's persisted-id short-circuit.
+  const frame = stack.lastFrame();
+  const key = `__interrupt_${location.stepPath}`;
+  const persistedId = frame?.locals[key];
+  if (persistedId !== undefined) {
+    const resp = ctx.getInterruptResponse(persistedId);
+    if (resp !== undefined) return (resp as { value?: number }).value as number;
+  }
+
+  const res = await coordinator.park(stack);
+  if (res.action === "continue") return res.checkpointId;
+
+  // Unwind: a sibling holds a real interrupt, so this branch must pin at
+  // its boundary. Become a std::checkpoint marker interrupt and let the
+  // generated call-site `hasInterrupts` guard halt the branch. Handler
+  // chains are deliberately bypassed (a handler approving the marker
+  // would let this branch run past the shared resume point — double
+  // execution on resume).
+  const intr = interrupt({
+    effect: "std::checkpoint",
+    message: "checkpoint() suspended together with a concurrent interrupt",
+    data: {},
+    origin: location.moduleId,
+    runId: ctx.getRunId(),
+  });
+  // Persist the id BEFORE stamping the leaf checkpoint so the snapshot
+  // captures it (resume replays this step and short-circuits above).
+  if (frame) frame.locals[key] = intr.interruptId;
+  const leafCpId = ctx.checkpoints.create(stack, ctx, location);
+  intr.checkpointId = leafCpId;
+  intr.checkpoint = ctx.checkpoints.get(leafCpId);
+  return [intr];
+}
+```
+
+Verify `ctx.getRunId()` exists on `RuntimeContext` (it's used in `interrupts.ts:376`).
+
+- [ ] **Step 4: Add a checkpoint-level unit test** (in `checkpoint.test.ts`): install a coordinator on the test stack, resolve the park from the test body, assert the returned id:
+
+```ts
+test("checkpoint() parks at the batch coordinator and returns the shared id", async () => {
+  const ctx = await makeCtx();
+  ctx.stateStack.nodesTraversed.push("main");
+  const branchStack = new StateStack();
+  branchStack.getNewState();
+  const coordinator = new BatchCoordinator();
+  coordinator.noteStarted();
+  branchStack.batchCoordinator = coordinator;
+  const pending = runInTestContext(ctx, branchStack, new ThreadStore(), () => checkpoint());
+  await coordinator.barrier();
+  coordinator.continueParked(99);
+  await expect(pending).resolves.toBe(99);
+});
+```
+
+- [ ] **Step 5: Run unit tests:**
+
+```bash
+pnpm test:run lib/runtime/checkpoint.test.ts lib/runtime/runBatch.test.ts 2>&1 | tee task4-test2.log
+```
+
+- [ ] **Step 6: Check how the agency test harness responds to interrupts.** Before writing execution tests, read the test runner (find it via `grep -rn "interruptHandlers" lib/ --include=*.ts | head`) and `docs/misc/TESTING.md` to confirm (a) how `interruptHandlers` map to surfaced interrupts (positional vs. per-interrupt) and (b) that a test with NO `interruptHandlers` fails loudly if something surfaces. Record findings in the task notes; Task 5 depends on them.
+
+- [ ] **Step 7: Write execution tests** (`tests/agency/fork/checkpoint/`):
+
+`checkpoint-pure.agency` (E2):
+
+```agency
+node main() {
+  let results = fork(["a", "b", "c"]) as item {
+    if (item == "a") {
+      const id = checkpoint()
+      if (id >= 0) {
+        return "checkpointed"
+      }
+      return "impossible"
+    }
+    return "done: ${item}"
+  }
+  return results
+}
+```
+
+`checkpoint-pure.test.json`:
+
+```json
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "checkpoint() in a fork branch auto-resolves when siblings finish (pure batch)",
+      "input": "",
+      "expectedOutput": "[\"checkpointed\",\"done: b\",\"done: c\"]",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}
+```
+
+`checkpoint-single-branch.agency` (E5): same shape with `fork(["a"])`, expected `["checkpointed"]`.
+
+`checkpoint-two-branches.agency` (E3):
+
+```agency
+node main() {
+  let results = fork(["a", "b"]) as item {
+    const id = checkpoint()
+    if (id >= 0) {
+      return "cp-ok: ${item}"
+    }
+    return "impossible"
+  }
+  return results
+}
+```
+
+expected `["cp-ok: a","cp-ok: b"]`.
+
+- [ ] **Step 8: Run the three execution tests, save output:**
+
+```bash
+pnpm run agency test tests/agency/fork/checkpoint/checkpoint-pure.agency 2>&1 | tee task4-agency.log
+pnpm run agency test tests/agency/fork/checkpoint/checkpoint-single-branch.agency 2>&1 | tee -a task4-agency.log
+pnpm run agency test tests/agency/fork/checkpoint/checkpoint-two-branches.agency 2>&1 | tee -a task4-agency.log
+```
+
+Expected: all pass. (If the runner wants the `.test.json` path instead, use that — check TESTING.md.)
+
+- [ ] **Step 9: Commit** (`feat: checkpoint() parks as a soft interrupt inside concurrent batches (pure path)`).
+
+---
+
+### Task 5: Mixed batches — the `std::checkpoint` marker + resume auto-approval
+
+**Files:**
+- Modify: `lib/runtime/interrupts.ts` (`buildResponseMap`, `respondToInterrupts`, `reportUnhandledInterrupts`)
+- Test: `lib/runtime/interrupts.test.ts`, `lib/runtime/runBatch.test.ts`
+- Create: `tests/agency/fork/checkpoint/checkpoint-mixed.agency` + `.test.json`
+
+**Interfaces:**
+- Consumes: marker-producing `checkpoint()` (Task 4 built the unwind arm; this task makes runBatch trigger it and resume honor it).
+- Produces:
+  - `respondToInterrupts` auto-approves `effect === "std::checkpoint"` interrupts with `{type:"approve", value: <shared cp id>}`.
+  - `buildResponseMap(interrupts, responses)` accepts `responses.length === interrupts.length` (marker responses overridden) or `=== real.length`.
+
+- [ ] **Step 1: Write the failing runBatch test (mixed round):**
+
+```ts
+test("a parked child is unwound when a sibling interrupts (mixed batch)", async () => {
+  const result = await runBatch<any>({
+    ...baseOpts(),
+    mode: "all",
+    children: [
+      {
+        key: "a",
+        invoke: async (childStack) => {
+          const res = await childStack.batchCoordinator!.park(childStack);
+          expect(res).toEqual({ action: "unwind" });
+          // Simulate checkpoint()'s marker (unit level; the real marker
+          // creation is covered by the execution test).
+          return [makeTestInterrupt("std::checkpoint")];
+        },
+      },
+      { key: "b", invoke: async () => [makeTestInterrupt("std::ask")] },
+    ],
+  });
+  expect(result.kind).toBe("interrupts");
+  const intrs = (result as any).interrupts as Interrupt[];
+  expect(intrs.map((i) => i.effect).sort()).toEqual(["std::ask", "std::checkpoint"]);
+  // Both share the batch checkpoint (existing stamp+overwrite).
+  expect(intrs[0].checkpointId).toBe(intrs[1].checkpointId);
+});
+```
+
+(`makeTestInterrupt` = the file's existing interrupt factory helper, or build via `interrupt({...})` with a leaf checkpoint attached the way existing tests do.)
+
+- [ ] **Step 2: Run, verify** — with Task 3's loop this may already pass (the `unwindParked` arm). If so it's a pinned regression; continue.
+
+```bash
+pnpm test:run lib/runtime/runBatch.test.ts 2>&1 | tee task5-test.log
+```
+
+- [ ] **Step 3: Write failing tests for the resume half** (`lib/runtime/interrupts.test.ts`):
+
+```ts
+describe("std::checkpoint markers in respondToInterrupts", () => {
+  test("buildResponseMap-lenient: responses may omit markers", ... );
+  test("markers are auto-approved with the shared checkpoint id", ...);
+  test("a user response supplied for a marker is overridden by the auto-approval", ...);
+});
+```
+
+Concretely, the middle test: build two interrupts (one `std::ask`, one `std::checkpoint`) sharing a stamped checkpoint object, call `respondToInterrupts` with ONE response (`approve()`), and assert the run resumes (use the file's existing respond-path fixtures — there are existing `respondToInterrupts` tests to copy setup from; if the existing tests are integration-style through compiled fixtures, put these assertions on a new exported pure helper instead — see Step 4's `injectMarkerApprovals`).
+
+- [ ] **Step 4: Implement.** In `lib/runtime/interrupts.ts`:
+
+1. Marker predicate + constant near the top:
+
+```ts
+/** Effect name of the soft-interrupt marker emitted by checkpoint() when a
+ * concurrent batch surfaces with a real interrupt. Markers bypass handler
+ * chains and are auto-approved on resume — see lib/runtime/checkpoint.ts. */
+export const CHECKPOINT_EFFECT = "std::checkpoint";
+
+export function isCheckpointMarker(i: Interrupt): boolean {
+  return i.effect === CHECKPOINT_EFFECT;
+}
+```
+
+2. `buildResponseMap` leniency (replace the length check):
+
+```ts
+function buildResponseMap(
+  interrupts: Interrupt[],
+  responses: InterruptResponse[],
+): Record<string, { response: InterruptResponse }> {
+  const real = interrupts.filter((i) => !isCheckpointMarker(i));
+  const zipTargets =
+    responses.length === interrupts.length
+      ? interrupts
+      : responses.length === real.length
+        ? real
+        : undefined;
+  if (zipTargets === undefined) {
+    throw new Error(
+      `respondToInterrupts: expected ${real.length} responses` +
+        (real.length !== interrupts.length
+          ? ` (or ${interrupts.length} including std::checkpoint markers)`
+          : "") +
+        ` but got ${responses.length}`,
+    );
+  }
+  const responseMap: Record<string, { response: InterruptResponse }> = {};
+  for (let i = 0; i < zipTargets.length; i++) {
+    responseMap[zipTargets[i].interruptId] = { response: deepClone(responses[i]) };
+  }
+  return responseMap;
+}
+```
+
+3. Auto-approval injection + statelog skip in `respondToInterrupts`, after the shared checkpoint is resolved:
+
+```ts
+  // std::checkpoint markers are auto-approved with the shared checkpoint
+  // id: on replay the marker's call site returns this value inline as the
+  // checkpoint() result. Overrides any user-supplied response for a
+  // marker — rejecting a checkpoint is meaningless (it has nothing to
+  // approve), so the auto-approval always wins.
+  for (const intr of interrupts) {
+    if (isCheckpointMarker(intr)) {
+      responseMap[intr.interruptId] = {
+        response: { type: "approve", value: checkpoint.id } as InterruptResponse,
+      };
+    }
+  }
+```
+
+and in the `interruptResolved` statelog loop, guard positional pairing: iterate `real` (non-marker) interrupts zipped against the map (look responses up by `interruptId` from `responseMap` instead of positional `responses[i]`, so the lenient shapes don't mispair) and skip markers entirely.
+
+4. `reportUnhandledInterrupts`: `if (isCheckpointMarker(it)) continue;` at the top of its loop.
+
+- [ ] **Step 5: Run unit tests:**
+
+```bash
+pnpm test:run lib/runtime/interrupts.test.ts lib/runtime/runBatch.test.ts 2>&1 | tee task5-test2.log
+```
+
+- [ ] **Step 6: Execution test E4** (`tests/agency/fork/checkpoint/checkpoint-mixed.agency`):
+
+```agency
+node main() {
+  let results = fork(["a", "b", "c"]) as item {
+    if (item == "a") {
+      const id = checkpoint()
+      if (id >= 0) {
+        return "checkpointed"
+      }
+      return "impossible"
+    }
+    if (item == "c") {
+      interrupt("approve c?")
+      return "approved: c"
+    }
+    return "done: b"
+  }
+  return results
+}
+```
+
+`.test.json` (shape depends on Task 4 Step 6 findings — if `interruptHandlers` map positionally to the *surfaced* array, supply one `approve` and rely on the lenient real-only zip; if the harness auto-responds to each surfaced interrupt, supply what it needs):
+
+```json
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "checkpoint marker surfaces alongside a real interrupt and auto-approves on resume",
+      "input": "",
+      "expectedOutput": "[\"checkpointed\",\"done: b\",\"approved: c\"]",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "interruptHandlers": [{ "action": "approve" }]
+    }
+  ]
+}
+```
+
+```bash
+pnpm run agency test tests/agency/fork/checkpoint/checkpoint-mixed.agency 2>&1 | tee task5-agency.log
+```
+
+The load-bearing assertion is `"checkpointed"` appearing exactly once — the pinned branch's tail (`return "checkpointed"`) ran only on resume, not twice.
+
+- [ ] **Step 7: Commit** (`feat: std::checkpoint marker interrupts — mixed batches surface and auto-approve on resume`).
+
+---
+
+### Task 6: Nested batches — park propagation to the outermost coordinator
+
+**Files:**
+- Modify: `lib/runtime/runBatch.ts` (`resolvePureRound` nested arm)
+- Test: `lib/runtime/runBatch.test.ts`
+- Create: `tests/agency/fork/checkpoint/checkpoint-nested.agency` + `.test.json`, `checkpoint-nested-mixed.agency` + `.test.json`
+
+**Interfaces:**
+- Consumes: `BatchCoordinator.park` (parent side), Task 3's `resolvePureRound` stub.
+- Produces: nested pure rounds park upward; only the outermost stamps; mixed decisions cascade down as `unwind`.
+
+- [ ] **Step 1: Write the failing unit test** — two nested `runBatch`es built by hand:
+
+```ts
+test("nested pure round parks at the parent coordinator; only the outermost stamps", async () => {
+  const created: number[] = [];
+  // Count checkpoint creations via ctx.checkpoints (compare store size
+  // before/after, or wrap onCheckpoint hooks at both levels).
+  const result = await runBatch<any>({
+    ...baseOpts(),
+    mode: "all",
+    hooks: { onCheckpoint: (id) => created.push(id) },
+    children: [
+      {
+        key: "outerA",
+        invoke: async (outerStack) => {
+          // inner batch runs on the outer branch's stack as its parentStack
+          const innerFrame = outerStack.getNewState();
+          const inner = await runBatch<any>({
+            ...baseOpts(),
+            parentStack: outerStack,
+            parentFrame: innerFrame,
+            mode: "all",
+            children: [
+              {
+                key: "innerX",
+                invoke: async (innerStack) => {
+                  const res = await innerStack.batchCoordinator!.park(innerStack);
+                  return res.action === "continue" ? res.checkpointId : "unwound";
+                },
+              },
+            ],
+          });
+          outerStack.pop();
+          return (inner as any).values[0];
+        },
+      },
+      { key: "outerB", invoke: async () => "b-done" },
+    ],
+  });
+  expect(result.kind).toBe("values");
+  const cpId = (result as any).values[0];
+  expect(typeof cpId).toBe("number");
+  expect(created).toEqual([cpId]); // exactly one stamp, at the OUTER level
+});
+```
+
+- [ ] **Step 2: Run, verify it fails** with Task 3's "implemented in Task 6" error:
+
+```bash
+pnpm test:run lib/runtime/runBatch.test.ts 2>&1 | tee task6-test.log
+```
+
+- [ ] **Step 3: Implement the nested arm of `resolvePureRound`:**
+
+```ts
+  if (parentCoordinator) {
+    // Nested batch: a checkpoint stamped HERE would capture only this
+    // branch's slice — not restorable (restoreState replaces the whole
+    // stack). Park this entire batch at the enclosing batch's barrier
+    // instead; the outermost batch stamps the full tree once every
+    // concurrent ancestor is settled-or-parked, and the id is relayed
+    // back down. If the parent decides "unwind" (a real interrupt exists
+    // somewhere in the tree), cascade the unwind to our parked children —
+    // they surface as std::checkpoint markers through the normal
+    // interrupt path and this batch re-stamps on the way out as today.
+    const res = await parentCoordinator.park(parentStack);
+    if (res.action === "unwind") {
+      coordinator.unwindParked();
+      return;
+    }
+    coordinator.continueParked(res.checkpointId);
+    return;
+  }
+```
+
+- [ ] **Step 4: Run unit tests green:**
+
+```bash
+pnpm test:run lib/runtime/runBatch.test.ts 2>&1 | tee task6-test2.log
+```
+
+- [ ] **Step 5: Execution tests.**
+
+`checkpoint-nested.agency` (E9):
+
+```agency
+node main() {
+  let results = fork(["outer1", "outer2"]) as o {
+    if (o == "outer1") {
+      let inner = fork(["i1"]) as i {
+        const id = checkpoint()
+        if (id >= 0) {
+          return "inner-checkpointed"
+        }
+        return "impossible"
+      }
+      return inner
+    }
+    return "outer2-done"
+  }
+  return results
+}
+```
+
+expected `[["inner-checkpointed"],"outer2-done"]` (verify exact serialization of nested arrays against an existing nested-fork fixture in `tests/agency/fork/nested/` and adjust).
+
+`checkpoint-nested-mixed.agency` (E10): same shape but `outer2` raises `interrupt("approve?")` before returning; `.test.json` supplies one `approve`; expected output has both branches completed, `"inner-checkpointed"` exactly once.
+
+```bash
+pnpm run agency test tests/agency/fork/checkpoint/checkpoint-nested.agency 2>&1 | tee task6-agency.log
+pnpm run agency test tests/agency/fork/checkpoint/checkpoint-nested-mixed.agency 2>&1 | tee -a task6-agency.log
+```
+
+- [ ] **Step 6 (E16, tool loop): Execution test only if cheap.** The tool loop requires an LLM call (expensive). Write `tests/agency/fork/checkpoint/checkpoint-in-tool.agency` — an `llm(...)` prompt with a tool whose body calls `checkpoint()` — ONLY if an existing multi-tool fixture (`tests/agency/fork/llm-tools/`) can be minimally adapted with one LLM call. Otherwise cover the tool-loop path with a `promptRunner.test.ts` unit test that drives `PromptRunner.parallel` with a parking child, asserting `beforeCheckpoint` ran before the stamp (spy ordering). Do not add more than one LLM call.
+
+- [ ] **Step 7: Commit** (`feat: nested batch checkpoint parking — only the outermost batch stamps`).
+
+---
+
+### Task 7: Race and sequential modes
+
+**Files:**
+- Modify: `lib/runtime/runBatch.ts` (`runRaceFirstTime`, `runRaceResume`)
+- Test: `lib/runtime/runBatch.test.ts`
+- Create: `tests/agency/fork/checkpoint/checkpoint-race.agency` + `.test.json`
+
+**Interfaces:**
+- Consumes: coordinator from Task 3 (already wired into `startInvoke` for all modes).
+- Produces: race honors D7 (parked can't win; all-parked → pure round; winner-settle aborts parked losers); sequential parking already works via Task 3's loop — pin with a test.
+
+- [ ] **Step 1: Write the failing race tests:**
+
+```ts
+test("race: all branches parked → pure round stamps and racing continues", async () => {
+  const result = await runBatch<string>({
+    ...baseOpts(),
+    mode: "race",
+    raceWinnerLocalKey: "__race_winner_0",
+    children: ["a", "b"].map((k) => ({
+      key: `race_${k}`,
+      invoke: async (childStack) => {
+        const res = await childStack.batchCoordinator!.park(childStack);
+        if (res.action !== "continue") return "unwound";
+        return `won-${k}`;
+      },
+    })),
+  });
+  expect(result.kind).toBe("values");
+  expect((result as any).values[0]).toMatch(/^won-/);
+});
+
+test("race: parked loser is aborted when the winner settles", async () => {
+  let loserErr: unknown;
+  const result = await runBatch<string>({
+    ...baseOpts(),
+    mode: "race",
+    raceWinnerLocalKey: "__race_winner_0",
+    children: [
+      { key: "winner", invoke: async () => "fast" },
+      {
+        key: "loser",
+        invoke: async (childStack) => {
+          try {
+            await childStack.batchCoordinator!.park(childStack);
+          } catch (e) {
+            loserErr = e;
+            throw e;
+          }
+          return "slow";
+        },
+      },
+    ],
+  });
+  expect((result as any).values).toEqual(["fast"]);
+  await vi.waitFor(() => expect(loserErr).toBeInstanceOf(AgencyCancelledError));
+});
+```
+
+- [ ] **Step 2: Run, verify failure** (race currently `Promise.race`s settles only — the all-parked case hangs; use vitest timeouts):
+
+```bash
+pnpm test:run lib/runtime/runBatch.test.ts -t "race:" 2>&1 | tee task7-test.log
+```
+
+- [ ] **Step 3: Implement race parking.** In `runRaceFirstTime`, wire `trackedInvoke`-style settle tracking (coordinator `noteStarted`/`noteSettled` around the tagged promises — reuse the same helpers; keep the winner/first-failure identification), then replace the bare `await Promise.race(tagged)` with a decision loop:
+
+```ts
+  // Race barrier: either somebody settles (winner / first failure), or
+  // everyone parks at a checkpoint (all-parked pure round: stamp or park
+  // upward, continue everyone, keep racing). A parked branch is NOT a
+  // settle and cannot win.
+  const firstSettle = Promise.race(tagged).then(
+    (w) => ({ kind: "winner" as const, w }),
+    (e) => ({ kind: "failed" as const, e }),
+  );
+  let raceOutcome: Awaited<typeof firstSettle>;
+  while (true) {
+    const ev = await Promise.race([
+      firstSettle,
+      coordinator.barrier().then(() => "barrier" as const),
+    ]);
+    if (ev !== "barrier") { raceOutcome = ev; break; }
+    if (coordinator.parkedCount === 0) { raceOutcome = await firstSettle; break; }
+    await resolvePureRound(opts, coordinator);
+  }
+```
+
+then dispatch `raceOutcome` into the existing winner/failure code paths. After the winner is known, abort parked losers *before* the existing loser abort/delete loop:
+
+```ts
+  coordinator.abortParked(
+    new AgencyCancelledError("race loser", makeAbortCause({ kind: "raceLoser" })),
+  );
+```
+
+(the existing `deleteBranch` loop over non-winner tasks already removes their branches on both winner-value and winner-interrupt paths — verify the interrupt path deletes parked losers too, since invariant #5 forbids losers surviving into the stamp). Also apply the coordinator wiring to `runRaceResume` (single child; parking there means a solo racer checkpointed — barrier of one → pure round). Close the coordinator on all exits.
+
+Subtle: `resolvePureRound` in race mode runs while `firstSettle` is subscribed; because a pure round only fires when *nobody* has settled, there is no decision race — re-check `coordinator.parkedCount` right after the barrier as shown.
+
+- [ ] **Step 4: Sequential-mode pin test** (E13 — should already pass via Task 3):
+
+```ts
+test("sequential: a parked child resolves a pure round while later children are unstarted", async () => {
+  const result = await runBatch<string>({
+    ...baseOpts(),
+    mode: "sequential",
+    children: [
+      {
+        key: "s0",
+        invoke: async (childStack) => {
+          const res = await childStack.batchCoordinator!.park(childStack);
+          return res.action === "continue" ? "s0-cp" : "s0-unwound";
+        },
+      },
+      { key: "s1", invoke: async () => "s1-done" },
+    ],
+  });
+  expect((result as any).values).toEqual(["s0-cp", "s1-done"]);
+});
+```
+
+- [ ] **Step 5: Run the whole runBatch suite:**
+
+```bash
+pnpm test:run lib/runtime/runBatch.test.ts 2>&1 | tee task7-test2.log
+```
+
+- [ ] **Step 6: Execution test E11** (`checkpoint-race.agency`, single item to keep output deterministic):
+
+```agency
+node main() {
+  let result = race(["only"]) as item {
+    const id = checkpoint()
+    if (id >= 0) {
+      return "raced-with-checkpoint"
+    }
+    return "impossible"
+  }
+  return result
+}
+```
+
+expected `"raced-with-checkpoint"`.
+
+```bash
+pnpm run agency test tests/agency/fork/checkpoint/checkpoint-race.agency 2>&1 | tee task7-agency.log
+```
+
+- [ ] **Step 7: Commit** (`feat: checkpoint parking in race and sequential batch modes`).
+
+---
+
+### Task 8: Unified `resume(cp, responses?)`
+
+**Files:**
+- Modify: `lib/runtime/interrupts.ts` (extract `resume` core; `respondToInterrupts` delegates)
+- Modify: `lib/runtime/rewind.ts` (`rewindFrom` delegates)
+- Modify: `lib/runtime/index.ts` (export `resume`)
+- Test: `lib/runtime/interrupts.test.ts`, existing `rewind`-related tests
+
+**Interfaces:**
+- Produces:
+
+```ts
+export async function resume(args: {
+  ctx: RuntimeContext<GraphState>;
+  checkpoint: Checkpoint;
+  /** interruptId → response. Absent/partial: uncovered real interrupts
+   * re-raise on replay; std::checkpoint markers re-park. */
+  responses?: Record<string, InterruptResponse>;
+  overrides?: Record<string, unknown>;
+  metadata?: Record<string, any>;
+  registerTopLevelCallbacks?: (ctx: RuntimeContext<GraphState>) => void | Promise<void>;
+  moduleDir?: string;
+  /** rewindFrom compatibility (skip re-stamping at the restored step). */
+  skipNextCheckpoint?: boolean;
+}): Promise<any>;
+```
+
+- [ ] **Step 1: Read `rewind.ts` fully** and diff its loop against `respondToInterrupts`+`runResumeLoop`. Confirm the deltas are exactly: response map (respond-only), `_skipNextCheckpoint` (rewind-only), runId minting (rewind mints, respond reuses `interrupt.runId`), overrides application (both), statelog details. If additional deltas exist, list them in the code comment and preserve each.
+
+- [ ] **Step 2: Write the failing test:**
+
+```ts
+test("resume(cp) without responses re-raises the contained interrupts", async () => {
+  // Reuse an existing respondToInterrupts fixture that produces a
+  // surfaced batch; then call resume({ctx, checkpoint: interrupts[0].checkpoint!})
+  // and assert the return value is an Interrupt[] batch with the SAME
+  // interruptIds (invariant #4: saved ids are reused on re-raise).
+});
+```
+
+Model the setup on the existing `respondToInterrupts` tests in `interrupts.test.ts` (or `tests/agency-js/interrupts/` if unit setup is impractical — prefer unit).
+
+- [ ] **Step 3: Implement.** Extract the shared body (createExecutionContext → loadProviderModules → statelog checkpointRestored → registerTopLevelCallbacks in bootstrap frame → `applyOverrides` → `restoreState` → optional `setInterruptResponses` → optional `_skipNextCheckpoint` → metadata.callbacks/debugger → `runResumeLoop`) into `resume`, then:
+
+- `respondToInterrupts` = validate + `buildResponseMap` + marker auto-approvals + per-response statelog, then `resume({..., responses: responseMap-values})` (adapt: `resume` takes `Record<string, InterruptResponse>`; wrap into the store's `{response}` shape inside `resume`).
+- `rewindFrom` = deepClone cp + `resume({..., overrides, skipNextCheckpoint: true, metadata})`, preserving its runId-minting and its distinctive statelog events.
+
+Keep both public signatures byte-compatible — generated code (`imports.ts` template output) calls them.
+
+- [ ] **Step 4: Run every suite that touches these paths:**
+
+```bash
+pnpm test:run lib/runtime/interrupts.test.ts lib/runtime/runBatch.test.ts lib/runtime/checkpoint.test.ts 2>&1 | tee task8-test.log
+pnpm run agency test tests/agency/fork/fork-multi-interrupt.agency 2>&1 | tee task8-agency.log
+pnpm run agency test tests/agency/fork/checkpoint/checkpoint-mixed.agency 2>&1 | tee -a task8-agency.log
+```
+
+Also run one rewind-flavored test — find it via `grep -rln "rewindFrom" tests/ lib/ --include=*.test.ts | head` and run what exists.
+
+- [ ] **Step 5: Export** `resume` from `lib/runtime/index.ts` next to the `respondToInterrupts` export.
+
+- [ ] **Step 6: Commit** (`feat: unified resume(cp, responses?) core behind respondToInterrupts and rewindFrom`).
+
+---
+
+### Task 9: Error paths and remaining edge pins
+
+**Files:**
+- Test: `lib/runtime/runBatch.test.ts`
+- Create: `tests/agency/fork/checkpoint/checkpoint-restore-in-fork.agency` + `.test.json`, `checkpoint-loop-in-fork.agency` + `.test.json`
+
+- [ ] **Step 1 (E8): unit test — sibling rejection aborts parked branches:**
+
+```ts
+test("a sibling rejection aborts parked branches and the error wins", async () => {
+  let parkRejected = false;
+  await expect(
+    runBatch<any>({
+      ...baseOpts(),
+      mode: "all",
+      children: [
+        {
+          key: "parked",
+          invoke: async (childStack) => {
+            try {
+              await childStack.batchCoordinator!.park(childStack);
+            } catch (e) {
+              parkRejected = true;
+              throw e;
+            }
+            return "unreachable";
+          },
+        },
+        { key: "bomb", invoke: async () => { throw new Error("boom"); } },
+      ],
+    }),
+  ).rejects.toThrow("boom");
+  expect(parkRejected).toBe(true);
+});
+```
+
+Run; if it fails, fix `settleRounds`' error arm (Task 3) accordingly.
+
+- [ ] **Step 2 (E7): execution test — retry loop inside a fork:**
+
+`checkpoint-restore-in-fork.agency`:
+
+```agency
+shared attempts = 0
+
+node main() {
+  let results = fork(["only"]) as item {
+    const id = checkpoint()
+    attempts = attempts + 1
+    if (attempts < 3) {
+      restore(id, {})
+    }
+    return attempts
+  }
+  return results
+}
+```
+
+expected `[3]`. (Verify `shared` declaration syntax against `tests/agency/` fixtures using `shared` — e.g. the checkpointing doc's examples — before finalizing.)
+
+- [ ] **Step 3 (E6): execution test — checkpoint in a loop inside a branch:**
+
+`checkpoint-loop-in-fork.agency`:
+
+```agency
+node main() {
+  let results = fork(["a", "b"]) as item {
+    let ids = []
+    for (i in range(2)) {
+      const id = checkpoint()
+      ids = push(ids, id)
+    }
+    return len(ids)
+  }
+  return results
+}
+```
+
+expected `[2,2]`. (Verify `range`/`push`/`len` names against stdlib — `grep -rn "def range\|def push\|def len" stdlib/*.agency` — and substitute the real ones.)
+
+- [ ] **Step 4 (E17): pin async-call behavior.** Write a small execution test `checkpoint-async-call.agency` where an `async`-called function invokes `checkpoint()` and is awaited later at top level; assert it completes and returns a numeric id (solo path — read `docs/dev/async.md` first; if the async body actually inherits a branch stack in some configuration, adjust the expectation and document what you find in the test description).
+
+- [ ] **Step 5: Run all new tests, save logs:**
+
+```bash
+pnpm test:run lib/runtime/runBatch.test.ts 2>&1 | tee task9-test.log
+pnpm run agency test tests/agency/fork/checkpoint/checkpoint-restore-in-fork.agency 2>&1 | tee task9-agency.log
+pnpm run agency test tests/agency/fork/checkpoint/checkpoint-loop-in-fork.agency 2>&1 | tee -a task9-agency.log
+pnpm run agency test tests/agency/fork/checkpoint/checkpoint-async-call.agency 2>&1 | tee -a task9-agency.log
+```
+
+- [ ] **Step 6: Commit** (`test: checkpoint soft-interrupt edge cases — restore-in-fork, loops, errors, async`).
+
+---
+
+### Task 10: Documentation
+
+**Files:**
+- Modify: `docs/dev/checkpointing.md` — new section "Checkpoints inside concurrent execution": the boundary rule (finish OR interrupt OR checkpoint), solo vs. park, marker semantics, D8's restore-reruns-checkpoint semantics, barrier cost, location/maxRestores nuance (D10), subprocess/async carve-outs.
+- Modify: `docs/dev/concurrent-interrupts.md` — add `BatchCoordinator` + the third settle outcome to the runBatch section; add invariant: "**Only the outermost batch stamps a pure-checkpoint round.** A nested batch parks upward; a slice-stamped pure checkpoint is not restorable."; update the invariants list and Key files.
+- Modify: `docs/dev/runBatch.md` — document the settle-or-park barrier, `resolvePureRound`, race/sequential parking semantics, and the new no-throw-plus-no-park contract notes.
+- Modify: the user-facing guide page (find it: `ls docs/site/guide/ | grep -i checkpoint`) — document `checkpoint()` in `fork`/`race`: blocks until siblings reach a boundary; may pause together with a sibling's interrupt (and the host sees a `std::checkpoint` entry it can ignore); `restore` of a fork checkpoint re-asks contained interrupts. Keep it user-level (no coordinator internals).
+- Modify: `docs/superpowers/ideas/2026-07-05-unify-checkpoint-and-interrupt-suspension-boundaries.md` — update Status to "planned/in progress", link this plan, and record the two design amendments discovered during planning: nested parking must propagate to the outermost batch (D5), and markers bypass handler chains (D4).
+
+- [ ] **Step 1: Write the doc changes** per the file list above.
+- [ ] **Step 2: Check for dead references:** `grep -rn "respondToInterrupts\|rewindFrom" docs/dev/*.md | head` and update descriptions to mention the shared `resume` core.
+- [ ] **Step 3: Commit** (`docs: checkpoint soft-interrupt model — boundary rule, nesting, resume unification`).
+
+---
+
+## Part 4 — Final verification (after all tasks)
+
+- [ ] `pnpm test:run lib/runtime/ 2>&1 | tee final-unit.log` — full runtime unit suite.
+- [ ] Run ONLY the new + directly-adjacent agency tests locally (`tests/agency/fork/checkpoint/*`, `tests/agency/fork/fork-multi-interrupt`, one race test). The full agency suite runs in CI on the PR.
+- [ ] `pnpm run lint:structure 2>&1 | tee final-lint.log`.
+- [ ] `make 2>&1 | tee final-make.log` — full build (stdlib untouched, but confirm the runtime compiles into the distributed build).
+- [ ] Re-read D4/D5/D8 and confirm the implementation matches; if anything drifted, update the docs task output to match reality.
+
+## Self-review notes (already applied)
+
+- Spec coverage: idea-doc sections map to tasks — governing rule/barrier (T2–T4), soft-interrupt model (T4–T5), pin rule + worked example (T5, E4 test), unified resume (T8), risks 1–5 (D4, E14, D5-cost-doc, D-determinism-doc, T4's auto-resolve tests). Open questions resolved: auto-resolve mechanics = live-suspended parks, never unwinds (D5/T3); handler-reject of a checkpoint = not expressible v1 (D4); naming = `std::checkpoint` effect string, no stdlib `effect` declaration (D4).
+- Two deliberate deviations from the idea doc, both flagged inline: nested stamping moved to the outermost batch (idea doc's sketch was slice-unsound), and no `BranchState` schema change (D8 shows it's unnecessary).
+- Type consistency: `ParkResolution`, `BatchCoordinator` method names, `CHECKPOINT_EFFECT`, and `resume` signature are each defined once (Tasks 2, 5, 8) and consumed by name elsewhere.

--- a/packages/agency-lang/docs/superpowers/specs/2026-07-25-array-pattern-length-and-middle-rest-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-07-25-array-pattern-length-and-middle-rest-design.md
@@ -4,7 +4,8 @@
 
 Spec, reviewed and updated — see
 [the review](2026-07-25-array-pattern-length-and-middle-rest-design-REVIEW.md).
-Ready to implement. Two changes to array patterns that share the same
+Parts 1 and 2 are implemented (#700 and this branch). Part 3 — a type suffix
+on the rest binder itself — remains unbuilt and undecided. Two changes to array patterns that share the same
 arithmetic, so they belong in one design even though the first is a bug fix
 and the second is a feature.
 

--- a/packages/agency-lang/lib/lowering/patternGuards.tripwire.test.ts
+++ b/packages/agency-lang/lib/lowering/patternGuards.tripwire.test.ts
@@ -123,9 +123,16 @@ function corpusPatterns(): { file: string; pattern: MatchPattern }[] {
 
   const out: { file: string; pattern: MatchPattern }[] = [];
   for (const file of files) {
-    const parsed = parseAgency(readFileSync(file, "utf8"), {}, true, false);
-    // Some corpus files are deliberate parse-error fixtures; skip them rather
-    // than fail, the walker corpus does the same for its own reasons.
+    // Some corpus files are deliberate compile-error fixtures
+    // (tests/agency/expectedCompileError). They fail two ways: a returned
+    // failure, and a THROW — the array-pattern arity check throws so its
+    // message survives the surrounding `or` combinators. Skip both.
+    let parsed;
+    try {
+      parsed = parseAgency(readFileSync(file, "utf8"), {}, true, false);
+    } catch {
+      continue;
+    }
     if (!parsed.success) continue;
     for (const node of walkEveryNode(parsed.result.nodes)) {
       if (node.type === "matchBlock") {
@@ -350,7 +357,12 @@ describe("lowering leaves no pattern-specific nodes behind", () => {
     ];
     const failures: string[] = [];
     for (const file of files) {
-      const parsed = parseAgency(readFileSync(file, "utf8"), {}, true, true);
+      let parsed;
+      try {
+        parsed = parseAgency(readFileSync(file, "utf8"), {}, true, true);
+      } catch {
+        continue; // deliberate compile-error fixture; see corpusPatterns
+      }
       if (!parsed.success) continue;
       for (const node of walkSkippingMatchSource(parsed.result.nodes)) {
         if (MUST_NOT_SURVIVE.includes(node.type as string)) {

--- a/packages/agency-lang/lib/lowering/patternLowering.ts
+++ b/packages/agency-lang/lib/lowering/patternLowering.ts
@@ -1057,14 +1057,37 @@ class PatternLowerer {
           return [makeAssign(prop.identifier, makeObjectRestCall(source, namedKeys, loc), declKind, loc)];
         });
       }
-      case "arrayPattern":
-        return pattern.elements.flatMap((el, i): Assignment[] => {
+      case "arrayPattern": {
+        // Same split as collectChecks: head binders read from the front, the
+        // rest takes the middle, tail binders read from the back.
+        const { head, tail } = splitAtRest(pattern.elements);
+        const headBindings = head.flatMap((el, i): Assignment[] => {
           if (el.type === "wildcardPattern") return [];
-          if (el.type === "restPattern") {
-            return [makeAssign(el.identifier, sliceCall(source, i, loc), declKind, loc)];
-          }
           return this.extractBindings(el, indexAccess(source, i, loc), declKind, loc);
         });
+        const restBindings = pattern.elements.flatMap((el): Assignment[] =>
+          el.type === "restPattern"
+            ? [
+                makeAssign(
+                  el.identifier,
+                  restSlice(source, head.length, tail.length, loc),
+                  declKind,
+                  loc,
+                ),
+              ]
+            : [],
+        );
+        const tailBindings = tail.flatMap((el, i): Assignment[] => {
+          if (el.type === "wildcardPattern") return [];
+          return this.extractBindings(
+            el,
+            indexFromEnd(source, tail.length - i, loc),
+            declKind,
+            loc,
+          );
+        });
+        return [...headBindings, ...restBindings, ...tailBindings];
+      }
       case "variableName":
         return [makeAssign(pattern.value, cloneExpr(source), declKind, loc)];
       case "wildcardPattern":
@@ -1188,13 +1211,28 @@ function collectChecks(pattern: MatchPattern, source: Expression, checks: Expres
       // only equality in the language that skips the helper.
       const op: Operator = hasRest ? ">=" : "==";
       checks.push(makeBinOp(lenAccess, op, numberLit(namedCount, pattern.loc), pattern.loc));
-      pattern.elements.forEach((el, i) => {
-        if (
-          el.type !== "wildcardPattern" &&
-          el.type !== "restPattern" &&
-          el.type !== "variableName"
-        ) {
+
+      // A rest binder may sit anywhere, so elements before it are indexed from
+      // the front and elements after it from the back. With no rest (or a
+      // trailing one) `tail` is empty and this is the original front-indexed
+      // walk.
+      const { head, tail } = splitAtRest(pattern.elements);
+      const needsCheck = (el: { type: string }): boolean =>
+        el.type !== "wildcardPattern" &&
+        el.type !== "restPattern" &&
+        el.type !== "variableName";
+
+      head.forEach((el, i) => {
+        if (needsCheck(el)) {
           collectChecks(el as MatchPattern, indexAccess(source, i, pattern.loc), checks);
+        }
+      });
+      tail.forEach((el, i) => {
+        if (needsCheck(el)) {
+          // 1-based from the end: the last element of `tail` is the last
+          // element of the array.
+          const fromEnd = tail.length - i;
+          collectChecks(el as MatchPattern, indexFromEnd(source, fromEnd, pattern.loc), checks);
         }
       });
       break;
@@ -1418,6 +1456,68 @@ function indexAccess(source: Expression, i: number, loc: SourceLocation | undefi
     [{ kind: "index", index: numberLit(i, loc) }],
     loc,
   );
+}
+
+/**
+ * `source[source.length - fromEnd]` — an element counted from the back, for
+ * the elements that follow a rest binder. `fromEnd` is 1-based: the last
+ * element is 1.
+ */
+function indexFromEnd(
+  source: Expression,
+  fromEnd: number,
+  loc: SourceLocation | undefined,
+): ValueAccess {
+  const offset = makeBinOp(
+    fieldAccess(cloneExpr(source), "length", loc),
+    "-",
+    numberLit(fromEnd, loc),
+    loc,
+  );
+  return chainAccess(source, [{ kind: "index", index: offset }], loc);
+}
+
+/**
+ * The slice a rest binder takes. With nothing after it this is the
+ * one-argument `source.slice(start)` — the same node the prefix case has
+ * always produced, kept deliberately so lifting this restriction does not
+ * churn every existing rest fixture.
+ */
+function restSlice(
+  source: Expression,
+  start: number,
+  tailCount: number,
+  loc: SourceLocation | undefined,
+): ValueAccess {
+  if (tailCount === 0) return sliceCall(source, start, loc);
+  const end = makeBinOp(
+    fieldAccess(cloneExpr(source), "length", loc),
+    "-",
+    numberLit(tailCount, loc),
+    loc,
+  );
+  return chainAccess(
+    source,
+    [{ kind: "slice", start: numberLit(start, loc), end }],
+    loc,
+  );
+}
+
+/**
+ * Split an array pattern at its rest binder. `restIndex` is -1 when there is
+ * none, in which case everything is head and the two halves behave exactly as
+ * they did before rest binders could sit anywhere.
+ */
+function splitAtRest<T extends { type: string }>(
+  elements: readonly T[],
+): { head: readonly T[]; tail: readonly T[]; restIndex: number } {
+  const restIndex = elements.findIndex((e) => e.type === "restPattern");
+  if (restIndex === -1) return { head: elements, tail: [], restIndex };
+  return {
+    head: elements.slice(0, restIndex),
+    tail: elements.slice(restIndex + 1),
+    restIndex,
+  };
 }
 
 function sliceCall(source: Expression, start: number, loc: SourceLocation | undefined): ValueAccess {

--- a/packages/agency-lang/lib/lowering/patternLowering.ts
+++ b/packages/agency-lang/lib/lowering/patternLowering.ts
@@ -1077,11 +1077,18 @@ class PatternLowerer {
               ]
             : [],
         );
+        // A tail binder reads from the end, which aliases a leading binder when
+        // the value is too short. Matching cannot reach that state (the length
+        // check fails first); a declaration can, so guard the source here.
+        const guardedSource =
+          tail.length > 0
+            ? requireLengthCall(source, head.length + tail.length, loc)
+            : source;
         const tailBindings = tail.flatMap((el, i): Assignment[] => {
           if (el.type === "wildcardPattern") return [];
           return this.extractBindings(
             el,
-            indexFromEnd(source, tail.length - i, loc),
+            indexFromEnd(guardedSource, tail.length - i, loc),
             declKind,
             loc,
           );
@@ -1483,6 +1490,28 @@ function indexFromEnd(
  * always produced, kept deliberately so lifting this restriction does not
  * churn every existing rest fixture.
  */
+/**
+ * `__requireLength(source, min)` — the guard a DECLARATION needs and a match
+ * gets for free. `collectChecks` emits a length check before any element read;
+ * `extractBindings` emits none, because a declaration binds rather than tests.
+ * Without this, `const [a, ...m, b] = ["a"]` binds `a` and `b` to the same
+ * element, silently.
+ */
+function requireLengthCall(
+  source: Expression,
+  min: number,
+  loc: SourceLocation | undefined,
+): Expression {
+  return {
+    type: "functionCall",
+    functionName: "__requireLength",
+    // Lowerer-created, so the undefined-function check skips it.
+    synthetic: true,
+    arguments: [cloneExpr(source), numberLit(min, loc)],
+    loc,
+  } as Expression;
+}
+
 function restSlice(
   source: Expression,
   start: number,

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -5842,17 +5842,32 @@ export const restPatternParser: Parser<RestPattern> = label(
 
 // ---- helpers shared by binding and match array parsers ----
 
-function enforceRestAtEnd<T extends { type: string }>(
+/**
+ * At most ONE rest binder per array pattern. Position is free — `[a, ...m, b]`
+ * is legal, with `a` read from the front and `b` from the back.
+ *
+ * Two rests have no meaning to give: nothing decides where the split between
+ * them falls, so `[a, ...x, b, ...y]` would be arbitrary whichever way we
+ * resolved it. Every language with sequence patterns forbids it for the same
+ * reason.
+ *
+ * The budget is per array pattern, not per arm — a nested array is its own
+ * pattern and gets its own: `[a, ...outer, [b, ...inner]]` is fine.
+ */
+function enforceAtMostOneRest<T extends { type: string }>(
   elements: readonly T[],
 ): void {
-  for (let i = 0; i < elements.length - 1; i++) {
-    if (elements[i].type === "restPattern") {
+  let seen = false;
+  for (const element of elements) {
+    if (element.type !== "restPattern") continue;
+    if (seen) {
       // Throw to surface the message past surrounding `or` combinators,
       // which would otherwise swallow it as "all parsers failed".
       throw new Error(
-        "rest pattern must be the last element of an array pattern",
+        "an array pattern may have at most one rest binder (`...name`)",
       );
     }
+    seen = true;
   }
 }
 
@@ -5889,7 +5904,7 @@ export const arrayBindingPatternParser: Parser<ArrayPattern> = label(
     );
     const result = parser(input);
     if (!result.success) return result;
-    enforceRestAtEnd(result.result.elements);
+    enforceAtMostOneRest(result.result.elements);
     return result;
   },
 );
@@ -6182,7 +6197,7 @@ export const arrayMatchPatternParser: Parser<ArrayPattern> = label(
     );
     const result = parser(input);
     if (!result.success) return result;
-    enforceRestAtEnd(result.result.elements);
+    enforceAtMostOneRest(result.result.elements);
     return result;
   },
 );

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -5,6 +5,7 @@
 // =============================================================================
 
 // --- tarsec imports (combined from all parser files) ---
+import { TarsecError } from "tarsec";
 import {
   anyChar,
   between,
@@ -5863,9 +5864,19 @@ function enforceAtMostOneRest<T extends { type: string }>(
     if (seen) {
       // Throw to surface the message past surrounding `or` combinators,
       // which would otherwise swallow it as "all parsers failed".
-      throw new Error(
-        "an array pattern may have at most one rest binder (`...name`)",
-      );
+      //
+      // A TarsecError specifically, not a bare Error: `parseAgency` catches
+      // the former and renders it as an ordinary parse failure, and lets
+      // anything else escape as an uncaught exception. Users got fifteen
+      // frames of tarsec internals and no file or line.
+      const message = "an array pattern may have at most one rest binder (`...name`)";
+      throw new TarsecError({
+        line: 0,
+        column: 0,
+        length: 1,
+        message,
+        prettyMessage: message,
+      });
     }
     seen = true;
   }

--- a/packages/agency-lang/lib/parsers/pattern.test.ts
+++ b/packages/agency-lang/lib/parsers/pattern.test.ts
@@ -131,8 +131,25 @@ describe("bindingPatternParser", () => {
       expect(result.success).toBe(false);
     });
 
-    it("rejects rest in non-final position [a, ...b, c]", () => {
-      expect(() => bindingPatternParser("[a, ...b, c]")).toThrow(/rest.*last/i);
+    it("accepts rest in a non-final position [a, ...b, c]", () => {
+      // Was rejected. A rest binder may now sit anywhere: `a` binds from the
+      // front, `c` from the back, `b` takes what is between them.
+      const result = bindingPatternParser("[a, ...b, c]");
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      expect((result.result as any).elements.map((e: any) => e.type)).toEqual([
+        "variableName",
+        "restPattern",
+        "variableName",
+      ]);
+    });
+
+    it("rejects two rest binders [a, ...b, c, ...d]", () => {
+      // The constraint that replaced "rest must be last": nothing would decide
+      // where the split between two rests falls.
+      expect(() => bindingPatternParser("[a, ...b, c, ...d]")).toThrow(
+        /at most one rest binder/i,
+      );
     });
   });
 
@@ -375,8 +392,21 @@ describe("matchPatternParser", () => {
   });
 
   describe("array rest enforcement (match patterns too)", () => {
-    it("rejects rest in non-final position [a, ...b, c]", () => {
-      expect(() => matchPatternParser("[a, ...b, c]")).toThrow(/rest.*last/i);
+    it("accepts rest in a non-final position [a, ...b, c]", () => {
+      const result = matchPatternParser("[a, ...b, c]");
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      expect((result.result as any).elements.map((e: any) => e.type)).toEqual([
+        "variableName",
+        "restPattern",
+        "variableName",
+      ]);
+    });
+
+    it("rejects two rest binders [a, ...b, c, ...d]", () => {
+      expect(() => matchPatternParser("[a, ...b, c, ...d]")).toThrow(
+        /at most one rest binder/i,
+      );
     });
   });
 });

--- a/packages/agency-lang/lib/runtime/index.ts
+++ b/packages/agency-lang/lib/runtime/index.ts
@@ -155,6 +155,7 @@ export { acceptsFailures } from "./failurePropagation.js";
 export { Schema, __validateType } from "./schema.js";
 export { __coarseTypeTest } from "./typeTest.js";
 export { __eq } from "./eq.js";
+export { __requireLength } from "./requireLength.js";
 export { __nn } from "./nn.js";
 export {
   __validateChain,

--- a/packages/agency-lang/lib/runtime/requireLength.ts
+++ b/packages/agency-lang/lib/runtime/requireLength.ts
@@ -1,0 +1,23 @@
+/**
+ * Guard for a destructuring pattern whose rest binder has elements after it:
+ * `const [a, ...mid, b] = xs`.
+ *
+ * Matching protects itself — an array pattern emits a length check, so a value
+ * too short to fill both ends simply does not match. A DECLARATION emits no
+ * such check: it binds rather than tests. Without this, `["a"]` would bind
+ * both `a` and `b` to the same element, because `xs[xs.length - 1]` is
+ * `xs[0]`, and the wrong values would be silent.
+ *
+ * Throws, which Agency surfaces as a `failure` Result — the behavior
+ * `pattern-matching.md` already documents for a destructuring that cannot be
+ * satisfied, and what Python does for `a, *m, b = ["x"]`.
+ */
+export function __requireLength(value: unknown[], min: number): unknown[] {
+  if (value.length < min) {
+    throw new TypeError(
+      `cannot destructure ${value.length} element${value.length === 1 ? "" : "s"} ` +
+        `into a pattern that needs at least ${min}`,
+    );
+  }
+  return value;
+}

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
@@ -30,7 +30,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/agency/expectedCompileError/twoRestBinders.agency
+++ b/packages/agency-lang/tests/agency/expectedCompileError/twoRestBinders.agency
@@ -1,0 +1,12 @@
+// Two rest binders have no meaning to give: nothing decides where the split
+// between them falls, so any behavior would be arbitrary. One max.
+def f(xs: any[]): string {
+  return match (xs) {
+    ["a", ...x, "b", ...y] => "ambiguous"
+    _ => "no"
+  }
+}
+
+node main() {
+  return f(["a", "b"])
+}

--- a/packages/agency-lang/tests/agency/expectedCompileError/twoRestBinders.test.json
+++ b/packages/agency-lang/tests/agency/expectedCompileError/twoRestBinders.test.json
@@ -1,4 +1,4 @@
 {
-  "expectedCompileError": "at most one rest binder",
-  "description": "An array pattern with two rest binders is rejected, with a message rather than a stack trace"
+  "expectedCompileError": "Failed to parse",
+  "description": "Two rest binders is a normal parse failure. Asserting the `Failed to parse` prefix rather than the message text is deliberate: the message alone also appears inside a stack trace, so it would pass whether or not the error is presented as a diagnostic."
 }

--- a/packages/agency-lang/tests/agency/expectedCompileError/twoRestBinders.test.json
+++ b/packages/agency-lang/tests/agency/expectedCompileError/twoRestBinders.test.json
@@ -1,0 +1,4 @@
+{
+  "expectedCompileError": "at most one rest binder",
+  "description": "An array pattern with two rest binders is rejected, with a message rather than a stack trace"
+}

--- a/packages/agency-lang/tests/agency/pattern-matching/arrayPatternMiddleRest.agency
+++ b/packages/agency-lang/tests/agency/pattern-matching/arrayPatternMiddleRest.agency
@@ -92,6 +92,22 @@ node nestedAndTypedTails() {
   ]
 }
 
+def tooShortToFillBothEnds(xs: any[]): any {
+  // A declaration binds rather than tests, so nothing stops the two ends from
+  // reading the same element. Matching cannot reach this state — the length
+  // check fails first — which is why the guard belongs here and not there.
+  const [first, ...mid, last] = xs
+  return [first, mid, last]
+}
+
+node declarationTooShortIsAFailure() {
+  return isFailure(tooShortToFillBothEnds(["a"]))
+}
+
+node declarationLongEnoughStillBinds() {
+  return tooShortToFillBothEnds(["a", "b"])
+}
+
 node bindingPositionToo() {
   // `const [a, ...rest, b] = xs` is legal: binding shares the arithmetic.
   const [first, ...mid, last] = ["a", "b", "c", "d"]

--- a/packages/agency-lang/tests/agency/pattern-matching/arrayPatternMiddleRest.agency
+++ b/packages/agency-lang/tests/agency/pattern-matching/arrayPatternMiddleRest.agency
@@ -1,0 +1,99 @@
+// A rest binder may sit anywhere in an array pattern, not just last. Leading
+// elements match from the front, trailing ones from the back, and the rest
+// takes what is left in between.
+
+def one(xs: any[]): string {
+  return match (xs) {
+    ["a", ...rest, "c"] => "matched, rest=${rest.length}"
+    _ => "fell through"
+  }
+}
+
+def two(xs: any[]): string {
+  return match (xs) {
+    ["a", ...rest, "d", "e"] => "matched, rest=${rest.length}"
+    _ => "fell through"
+  }
+}
+
+def emptyHead(xs: any[]): string {
+  // No leading elements — the case most likely to expose an off-by-one.
+  return match (xs) {
+    [...rest, "c"] => "matched, rest=${rest.length}"
+    _ => "fell through"
+  }
+}
+
+def restAlone(xs: any[]): string {
+  return match (xs) {
+    [...rest] => "matched, rest=${rest.length}"
+    _ => "fell through"
+  }
+}
+
+def bindings(xs: any[]): any[] {
+  // A trailing element bound from the WRONG end still makes the arm match, so
+  // the assertion has to be on what landed in each binder.
+  return match (xs) {
+    [first, ...mid, last] => [first, mid, last]
+    _ => ["fell through"]
+  }
+}
+
+def nestedTail(xs: any[]): string {
+  // A trailing element that is itself a pattern.
+  return match (xs) {
+    ["cmd", ...rest, { path: string }] => "nested tail"
+    _ => "fell through"
+  }
+}
+
+def typedTail(xs: any[]): string {
+  // A type suffix on a trailing element (on the REST binder is Part 3).
+  return match (xs) {
+    ["cmd", ...rest, last: number] => "numeric last"
+    _ => "fell through"
+  }
+}
+
+node oneTrailing() {
+  // Zero or more between: ["a","c"] gives rest = [].
+  return [one(["a", "b", "c"]), one(["a", "c"]), one(["a", "b", "x"]), one(["a"])]
+}
+
+node twoTrailing() {
+  return [two(["a", "b", "c", "d", "e"]), two(["a", "d", "e"]), two(["a", "d"])]
+}
+
+node emptyHeadAndRestAlone() {
+  return [
+    emptyHead(["a", "b", "c"]),
+    emptyHead(["c"]),
+    emptyHead(["a"]),
+    restAlone(["a", "b", "c"]),
+    restAlone([]),
+  ]
+}
+
+node bindingsLandInTheRightPlaces() {
+  return bindings(["a", "b", "c", "d"])
+}
+
+node bindingsWithEmptyMiddle() {
+  return bindings(["a", "b"])
+}
+
+node nestedAndTypedTails() {
+  return [
+    nestedTail(["cmd", "x", { path: "f.txt" }]),
+    nestedTail(["cmd", { path: 42 }]),
+    typedTail(["cmd", "x", 7]),
+    typedTail(["cmd", "x", "no"]),
+  ]
+}
+
+node bindingPositionToo() {
+  // `const [a, ...rest, b] = xs` is legal: binding shares the arithmetic.
+  const [first, ...mid, last] = ["a", "b", "c", "d"]
+  return [first, mid, last]
+}

--- a/packages/agency-lang/tests/agency/pattern-matching/arrayPatternMiddleRest.test.json
+++ b/packages/agency-lang/tests/agency/pattern-matching/arrayPatternMiddleRest.test.json
@@ -1,0 +1,53 @@
+{
+  "tests": [
+    {
+      "nodeName": "oneTrailing",
+      "description": "One trailing element after the rest: matches when the last element agrees, binds zero or more in between, and fails when too short.",
+      "input": "",
+      "expectedOutput": "[\"matched, rest=1\",\"matched, rest=0\",\"fell through\",\"fell through\"]",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "twoTrailing",
+      "description": "Two trailing elements, indexed from the end.",
+      "input": "",
+      "expectedOutput": "[\"matched, rest=2\",\"matched, rest=0\",\"fell through\"]",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "emptyHeadAndRestAlone",
+      "description": "An empty head, and a rest with neither head nor tail.",
+      "input": "",
+      "expectedOutput": "[\"matched, rest=2\",\"matched, rest=0\",\"fell through\",\"matched, rest=3\",\"matched, rest=0\"]",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "bindingsLandInTheRightPlaces",
+      "description": "The leading binder gets the first element, the trailing binder the last, and the rest exactly what is between them.",
+      "input": "",
+      "expectedOutput": "[\"a\",[\"b\",\"c\"],\"d\"]",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "bindingsWithEmptyMiddle",
+      "description": "With nothing between them the rest binds an empty array, and the two named binders do not overlap.",
+      "input": "",
+      "expectedOutput": "[\"a\",[],\"b\"]",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "nestedAndTypedTails",
+      "description": "A trailing element that is itself a pattern, and one carrying a type suffix.",
+      "input": "",
+      "expectedOutput": "[\"nested tail\",\"fell through\",\"numeric last\",\"fell through\"]",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "bindingPositionToo",
+      "description": "const [a, ...rest, b] = xs is legal; binding position shares the same arithmetic.",
+      "input": "",
+      "expectedOutput": "[\"a\",[\"b\",\"c\"],\"d\"]",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/pattern-matching/arrayPatternMiddleRest.test.json
+++ b/packages/agency-lang/tests/agency/pattern-matching/arrayPatternMiddleRest.test.json
@@ -5,49 +5,99 @@
       "description": "One trailing element after the rest: matches when the last element agrees, binds zero or more in between, and fails when too short.",
       "input": "",
       "expectedOutput": "[\"matched, rest=1\",\"matched, rest=0\",\"fell through\",\"fell through\"]",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     },
     {
       "nodeName": "twoTrailing",
       "description": "Two trailing elements, indexed from the end.",
       "input": "",
       "expectedOutput": "[\"matched, rest=2\",\"matched, rest=0\",\"fell through\"]",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     },
     {
       "nodeName": "emptyHeadAndRestAlone",
       "description": "An empty head, and a rest with neither head nor tail.",
       "input": "",
       "expectedOutput": "[\"matched, rest=2\",\"matched, rest=0\",\"fell through\",\"matched, rest=3\",\"matched, rest=0\"]",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     },
     {
       "nodeName": "bindingsLandInTheRightPlaces",
       "description": "The leading binder gets the first element, the trailing binder the last, and the rest exactly what is between them.",
       "input": "",
       "expectedOutput": "[\"a\",[\"b\",\"c\"],\"d\"]",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     },
     {
       "nodeName": "bindingsWithEmptyMiddle",
       "description": "With nothing between them the rest binds an empty array, and the two named binders do not overlap.",
       "input": "",
       "expectedOutput": "[\"a\",[],\"b\"]",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     },
     {
       "nodeName": "nestedAndTypedTails",
       "description": "A trailing element that is itself a pattern, and one carrying a type suffix.",
       "input": "",
       "expectedOutput": "[\"nested tail\",\"fell through\",\"numeric last\",\"fell through\"]",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     },
     {
       "nodeName": "bindingPositionToo",
       "description": "const [a, ...rest, b] = xs is legal; binding position shares the same arithmetic.",
       "input": "",
       "expectedOutput": "[\"a\",[\"b\",\"c\"],\"d\"]",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "declarationTooShortIsAFailure",
+      "description": "A declaration whose value cannot fill both ends surfaces a failure rather than aliasing the two binders to the same element.",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "declarationLongEnoughStillBinds",
+      "description": "Exactly enough elements: the two named binders take the two elements and the rest is empty.",
+      "input": "",
+      "expectedOutput": "[\"a\",[],\"b\"]",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptBuilder/simple.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/simple.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/array.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/array.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/codeLiteral.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/codeLiteral.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/comments.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comments.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/comprehension.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comprehension.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/destructiveBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/destructiveBlock.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/destructiveNested.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/destructiveNested.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/goto.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/goto.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/imports.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/imports.mjs
@@ -40,7 +40,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/input.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/input.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/intersectionTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/intersectionTypes.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlockBlockArms.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlockBlockArms.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/matchExpression.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchExpression.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/recursiveTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recursiveTypes.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/schemaChaining.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaChaining.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
@@ -26,7 +26,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/simple.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/simple.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/skill.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/skill.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/slice.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/slice.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/splat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/splat.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/static.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/static.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/type-patterns.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/type-patterns.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/typeOperators.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeOperators.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/utilityTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/utilityTypes.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
@@ -25,7 +25,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __registerCallbacksInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
   Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,


### PR DESCRIPTION
Part 2 of [the array-pattern spec](../blob/main/packages/agency-lang/docs/superpowers/specs/2026-07-25-array-pattern-length-and-middle-rest-design.md), after #700. This is the last blocker for the safeBash command matcher.

## What works now

```ts
match (words) {
    ["cat", ...flags, path]           => read(path)
    ["a", ...rest, "d", "e"]          => ...        // two trailing
    [...rest, "c"]                    => ...        // empty head
    ["cmd", ...rest, { path: string }] => ...        // trailing sub-pattern
}

const [first, ...middle, last] = items              // binding position too
```

`...rest` binds zero or more, so `["a", ...rest, "c"]` matches `["a", "c"]` with `rest = []` — matching Rust, Python, Ruby and Scala.

## Lowering

Split the element list at the rest binder; index the head from the front and the tail from the back (`xs[xs.length - n]`). The rest becomes a two-sided slice.

**The one-argument slice is kept for the no-tail case**, as the spec requires — a two-sided call would emit `xs.slice(2, xs.length - 0)` for every existing prefix pattern and bury the real diff in fixture churn. `make fixtures` produced **no changes**, which is the check that it held.

`enforceRestAtEnd` becomes `enforceAtMostOneRest`: Part 2 removes the position constraint, the count constraint stays. Two rests have no meaning to give — nothing decides where the split between them falls. The budget is per array pattern, so `[a, ...outer, [b, ...inner]]` is fine.

Binding position is included per the spec. The JavaScript constraint that forbids it there — destructuring consumes an iterator, so it cannot know where the end is — does not apply to an indexable array.

## Tests

7 execution nodes, all failing before the change, plus an `expectedCompileError` for two rest binders.

The design point worth reviewing: **the binder tests assert what landed in each binder, not just that the arm ran.** A trailing element bound from the wrong end still *matches* — the arm fires, and only the values distinguish correct from subtly wrong:

```ts
bindings(["a","b","c","d"])  →  ["a", ["b","c"], "d"]
bindings(["a","b"])          →  ["a", [],        "b"]    // binders must not overlap
```

Covered: one and two trailing elements, empty head, rest alone, empty middle, a trailing sub-pattern, a type-suffixed trailing element, and binding position.

## One thing I had to fix in passing

The `patternGuards` tripwire's corpus loop handled a returned parse failure but not a **throwing** one. The arity check throws so its message survives the surrounding `or` combinators, and the new `expectedCompileError` fixture is the first corpus file that fails that way. The loop now tolerates both.

Worth noting the tripwire still passes with middle-rest patterns in the corpus — so the shape check continues to guard the new from-the-end reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
