### PR TITLE
std::safeBash: use an equivalent tool instead of bash, starting with echo

### DIFF
--- a/packages/agency-lang/docs/site/stdlib/safeBash.md
+++ b/packages/agency-lang/docs/site/stdlib/safeBash.md
@@ -24,7 +24,7 @@ export type WordPart =
   | { tag: "arithmeticExpansion"; expression: string }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L5))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L8))
 
 ### BashWord
 
@@ -35,7 +35,7 @@ export type BashWord = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L27))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L17))
 
 ### Assignment
 
@@ -50,7 +50,7 @@ export type Assignment = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L33))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L23))
 
 ### Redirect
 
@@ -68,7 +68,7 @@ export type Redirect = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L41))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L31))
 
 ### SimpleCommand
 
@@ -81,7 +81,7 @@ export type SimpleCommand = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L48))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L38))
 
 ### IfCommand
 
@@ -96,7 +96,7 @@ export type IfCommand = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L55))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L45))
 
 ### LoopCommand
 
@@ -110,7 +110,7 @@ export type LoopCommand = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L64))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L54))
 
 ### ForCommand
 
@@ -125,7 +125,7 @@ export type ForCommand = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L72))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L62))
 
 ### CaseItem
 
@@ -138,7 +138,7 @@ export type CaseItem = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L81))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L71))
 
 ### CaseCommand
 
@@ -151,7 +151,7 @@ export type CaseCommand = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L88))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L78))
 
 ### Subshell
 
@@ -163,7 +163,7 @@ export type Subshell = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L95))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L85))
 
 ### Group
 
@@ -175,7 +175,7 @@ export type Group = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L101))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L91))
 
 ### ArithmeticCommand
 
@@ -190,7 +190,7 @@ export type ArithmeticCommand = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L108))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L98))
 
 ### FunctionDef
 
@@ -202,7 +202,7 @@ export type FunctionDef = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L114))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L104))
 
 ### Command
 
@@ -219,7 +219,7 @@ export type Command =
   | FunctionDef
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L120))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L110))
 
 ### Pipeline
 
@@ -234,7 +234,7 @@ export type Pipeline = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L132))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L122))
 
 ### AndOr
 
@@ -249,7 +249,7 @@ export type AndOr = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L139))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L129))
 
 ### ListItem
 
@@ -262,7 +262,7 @@ export type ListItem = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L145))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L135))
 
 ### List
 
@@ -278,7 +278,7 @@ export type List = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L154))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L144))
 
 ### BashNode
 
@@ -295,7 +295,46 @@ export type BashNode =
   | List
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L164))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L154))
+
+### OutputRedirect
+
+A bash command reduced to the only shape v1 can reason about: the words of
+ *  a single command, and an optional output redirect.
+
+```ts
+/** A bash command reduced to the only shape v1 can reason about: the words of
+ *  a single command, and an optional output redirect. */
+export type OutputRedirect = {
+  op: string;
+  path: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L168))
+
+### Cmd
+
+```ts
+export type Cmd = {
+  words: string[];
+  redirect?: OutputRedirect
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L173))
+
+### SafeBashResult
+
+```ts
+export type SafeBashResult = {
+  stdout: string;
+  stderr: string;
+  exitCode: number
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L178))
 
 ## Constants
 
@@ -310,7 +349,7 @@ export static const emptyList: List = {
 
 **Type:** [List](#list)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L159))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L149))
 
 ## Functions
 
@@ -320,7 +359,7 @@ export static const emptyList: List = {
 bashParser(code: string): Result<List>
 ```
 
-Parse a string of bash code into an AST
+Parse a string of bash code into an AST.
 
 **Parameters:**
 
@@ -330,22 +369,62 @@ Parse a string of bash code into an AST
 
 **Returns:** `Result<List>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L175))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L184))
 
 ### simplify
 
 ```ts
-simplify(node: BashNode): any
+simplify(node: List): Result<Cmd>
 ```
 
-Convert a Bash AST into a simpler JSON representation.
+Reduce a parsed bash AST to a single command's words and output redirect.
+
+  v1 understands one simple command and nothing else. A pipeline, a `&&`
+  chain, a subshell, a loop, a background job or a variable assignment is a
+  failure — not because they are unsafe, but because collapsing them to a
+  word list would lose what makes them different from a single command.
+
+  @param node - The AST from `bashParser`
 
 **Parameters:**
 
 | Name | Type | Default |
 |---|---|---|
-| node | [BashNode](#bashnode) |  |
+| node | [List](#list) |  |
 
-**Returns:** `any`
+**Returns:** `Result<Cmd>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L186))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L282))
+
+### safeBash
+
+```ts
+safeBash(command: string, cwd: string = ""): SafeBashResult
+```
+
+Run a shell command, using an equivalent tool where one exists.
+
+  `bash` cannot be pre-approved — there is no way to say in advance what an
+  arbitrary command string will do — so every call needs a human. Many of the
+  commands an agent writes have a tool that does the same job and IS
+  pre-approved. This parses the command and uses that tool when it can.
+
+  Anything it cannot parse, or cannot map, runs through `bash` exactly as
+  before, approval and all. Incompleteness costs an approval, never
+  correctness.
+
+  @param command - The shell command to run
+  @param cwd - Working directory, passed through to bash on the fallback path
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| command | `string` |  |
+| cwd | `string` | "" |
+
+**Returns:** [SafeBashResult](#safebashresult)
+
+**Throws:** `std::write`, `std::bash`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L347))

--- a/packages/agency-lang/docs/site/stdlib/safeBash.md
+++ b/packages/agency-lang/docs/site/stdlib/safeBash.md
@@ -411,6 +411,6 @@ Run a shell command, using an equivalent tool where one exists.
 
 **Returns:** [ExecResult](shell.md#execresult)
 
-**Throws:** `std::write`, `std::bash`
+**Throws:** `std::bash`, `std::write`
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L376))

--- a/packages/agency-lang/docs/site/stdlib/safeBash.md
+++ b/packages/agency-lang/docs/site/stdlib/safeBash.md
@@ -299,19 +299,17 @@ export type BashNode =
 
 ### OutputRedirect
 
-A bash command reduced to the only shape v1 can reason about: the words of
- *  a single command, and an optional output redirect.
+A bash command reduced to the only shape v1 can reason about: the words of a single command, and an optional output redirect.
 
 ```ts
-/** A bash command reduced to the only shape v1 can reason about: the words of
- *  a single command, and an optional output redirect. */
+/** A bash command reduced to the only shape v1 can reason about: the words of a single command, and an optional output redirect. */
 export type OutputRedirect = {
   op: string;
   path: string
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L168))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L167))
 
 ### Cmd
 
@@ -322,19 +320,7 @@ export type Cmd = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L173))
-
-### SafeBashResult
-
-```ts
-export type SafeBashResult = {
-  stdout: string;
-  stderr: string;
-  exitCode: number
-}
-```
-
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L178))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L172))
 
 ## Constants
 
@@ -369,7 +355,7 @@ Parse a string of bash code into an AST.
 
 **Returns:** `Result<List>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L184))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L177))
 
 ### simplify
 
@@ -394,12 +380,12 @@ Reduce a parsed bash AST to a single command's words and output redirect.
 
 **Returns:** `Result<Cmd>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L282))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L302))
 
 ### safeBash
 
 ```ts
-safeBash(command: string, cwd: string = ""): SafeBashResult
+safeBash(command: string, cwd: string = ""): ExecResult
 ```
 
 Run a shell command, using an equivalent tool where one exists.
@@ -423,8 +409,8 @@ Run a shell command, using an equivalent tool where one exists.
 | command | `string` |  |
 | cwd | `string` | "" |
 
-**Returns:** [SafeBashResult](#safebashresult)
+**Returns:** [ExecResult](shell.md#execresult)
 
 **Throws:** `std::write`, `std::bash`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L347))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L376))

--- a/packages/agency-lang/docs/site/stdlib/shell.md
+++ b/packages/agency-lang/docs/site/stdlib/shell.md
@@ -20,6 +20,27 @@ Run commands and inspect the filesystem. `exec` and `bash` run programs and
 
 ## Types
 
+### ExecResult
+
+What a shell command produced. Exported so `std::safeBash` can declare the
+ *  same return type on both its paths — a fast-path result and a real
+ *  `bash()` result have to be the same shape by construction, not by
+ *  coincidence.
+
+```ts
+/** What a shell command produced. Exported so `std::safeBash` can declare the
+ *  same return type on both its paths — a fast-path result and a real
+ *  `bash()` result have to be the same shape by construction, not by
+ *  coincidence. */
+export type ExecResult = {
+  stdout: string;
+  stderr: string;
+  exitCode: number
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L36))
+
 ## Effects
 
 ### std::exec
@@ -35,7 +56,7 @@ effect std::exec {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L38))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L42))
 
 ### std::bash
 
@@ -48,7 +69,7 @@ effect std::bash {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L46))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L50))
 
 ### std::ls
 
@@ -60,7 +81,7 @@ effect std::ls {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L52))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L56))
 
 ### std::grep
 
@@ -73,7 +94,7 @@ effect std::grep {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L57))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L61))
 
 ### std::glob
 
@@ -85,7 +106,7 @@ effect std::glob {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L63))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L67))
 
 ## Functions
 
@@ -135,7 +156,7 @@ Run an executable directly with an array of arguments, bypassing the shell, and 
 
 **Throws:** `std::exec`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L69))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L73))
 
 ### bash
 
@@ -181,7 +202,7 @@ Run a shell command string via sh -c and return its stdout, stderr, and exit cod
 
 **Throws:** `std::bash`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L133))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L137))
 
 ### ls
 
@@ -219,7 +240,7 @@ List entries in a directory. Each entry has name, path, type ("file", "dir", "sy
 
 **Throws:** `std::ls`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L182))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L186))
 
 ### grep
 
@@ -260,7 +281,7 @@ Search for a regex pattern in files under a directory. Returns matches with file
 
 **Throws:** `std::grep`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L218))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L222))
 
 ### glob
 
@@ -296,7 +317,7 @@ Find files whose paths match a glob pattern (e.g. "src/**/*.ts"). Fails if the p
 
 **Throws:** `std::glob`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L251))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L255))
 
 ### stat
 
@@ -330,7 +351,7 @@ Return metadata about a filesystem entry: whether it exists, its type ("file", "
 
 **Returns:** [StatInfo](#statinfo)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L286))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L290))
 
 ### exists
 
@@ -361,7 +382,7 @@ Return true if a file or directory exists at the given path. Probing a path outs
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L308))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L312))
 
 ### which
 
@@ -381,4 +402,4 @@ Locate an executable in PATH and return its absolute path, or an empty string if
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L328))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L332))

--- a/packages/agency-lang/docs/superpowers/ideas/2026-07-24-safebash-command-to-tool-matching.md
+++ b/packages/agency-lang/docs/superpowers/ideas/2026-07-24-safebash-command-to-tool-matching.md
@@ -1,6 +1,12 @@
 # safeBash: rewrite a bash command into an equivalent tool call
 
-## Status (2026-07-24)
+## Status (2026-07-26)
+
+Superseded by [the spec](../specs/2026-07-26-safebash-design.md), which
+records what v1 actually shipped. Kept for the reasoning and for the
+decisions as they were made.
+
+## Original status (2026-07-24)
 
 Idea, with the main design decisions already made (see Decisions below).
 Blocked on three pattern-matching items; do them in this order:

--- a/packages/agency-lang/docs/superpowers/specs/2026-07-26-safebash-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-07-26-safebash-design.md
@@ -1,0 +1,162 @@
+# safeBash: run a bash command through an equivalent tool
+
+## Status (2026-07-26)
+
+v1 implemented — `simplify`, `stringifyWordPart`, and one rule (`echo`),
+**not wired into any agent**. Later parts below are designed but unbuilt.
+
+Grew out of [the idea doc](../ideas/2026-07-24-safebash-command-to-tool-matching.md),
+which has the original reasoning and the decisions as they were made.
+
+## The problem
+
+The coding agent (`stdlib/agents/coding.agency`) is given file, git, search and
+http tools, and its prompt tells it to prefer them over bash in as many words:
+
+> **Avoid using them if at all possible**. These tools should be a last
+> resort. […] every time you use bash or exec, it will require human approval
+
+It reaches for bash anyway. The prompt is not load-bearing enough.
+
+The cost is autonomy, not safety. Read-only tools are pre-approved and run
+without a prompt. `bash` cannot be: `bash()` (`stdlib/shell.agency:133`) raises
+`interrupt std::bash(...)` on every call, because there is no way to say in
+advance what an arbitrary command string will do. So a run that could be
+unattended becomes one that has to be watched, and the human approves a stream
+of `ls`, `cat` and `git status` by hand.
+
+## The shape of the fix
+
+Parse the command the agent wrote. If it maps onto a tool the agent already
+has, call that tool instead. The tool's own interrupt policy then applies —
+which for the read-only ones means no approval at all.
+
+The bash parser lives in tarsec, re-exported through `lib/stdlib/safeBash.ts`.
+It is deliberately incomplete; anything it cannot parse falls through to real
+bash, so incompleteness costs an approval rather than correctness.
+
+## Decisions
+
+- **v1 scope: one simple command, plus `>` and `>>`.** No pipes, no `&&`/`||`,
+  no background, no `;`. Anything else falls through.
+- **A `safeBash` tool, not a handler on `std::bash`.** A tool keeps `bash()`
+  honest — it always runs bash — and makes the behavior opt-in per agent and
+  easy to test.
+- **Words that need shell evaluation: expand `$VAR` from the environment,
+  refuse the rest.** Command substitution, arithmetic expansion and globs are
+  unmapped.
+- **`echo` maps to `print`** (`stdlib/index.agency:53`), which raises no
+  interrupt, so it costs nothing. `echo … > f` maps to `write`.
+- **Return `ExecResult`-shaped output** whichever path runs. The agent should
+  not be able to tell which, except by the absence of a prompt.
+
+## The lowered shape
+
+```ts
+type OutputRedirect = { op: string, path: string }
+type Cmd = { words: string[], redirect: OutputRedirect | null }
+```
+
+The parser's AST is deeply nested — `list` → `listItem` → `andOr` → `pipeline`
+→ `simpleCommand` → `word` → parts — and matching on it directly is
+unreadable. `simplify` collapses that to the two fields above;
+`stringifyWordPart` collapses a word's parts to one string.
+
+Named `OutputRedirect` rather than `Redirect` because the AST already has a
+`Redirect` node and the two are different things.
+
+## Refusals are by name
+
+Every shape v1 cannot collapse to a word list is refused with its own message:
+
+| input | refusal |
+|---|---|
+| `cat a.txt \| grep x` | pipelines are not handled |
+| `a && b` | `` `&&` and `\|\|` are not handled `` |
+| `sleep 1 &` | background commands are not handled |
+| `FOO=1 echo hi` | leading variable assignments are not handled |
+| `echo $(date)` | `commandSubstitution` needs a shell to evaluate |
+| `echo hi 2>&1` | redirect with an explicit file descriptor |
+| `echo a; echo b` | expected a single command |
+
+A fallthrough should be explainable, not mysterious. Refusing costs an
+approval — which is what happened before safeBash existed. Guessing would cost
+correctness.
+
+## Word splitting
+
+The subtle rule, and the one that makes this feature safe or not.
+
+```bash
+F="a b"
+cat $F      # TWO arguments to bash
+cat "$F"    # one
+```
+
+An unquoted expansion whose value contains whitespace is **refused**, not
+expanded. Expanding it without splitting would make safeBash and bash disagree
+about what a command means, which is the one failure mode this feature must
+not have. Inside double quotes no splitting applies, so it expands normally.
+
+Unset is the empty string, as in bash.
+
+## Not wired in
+
+`shellTools()` (`stdlib/agents/lib/toolkits.agency:91`) is untouched. No
+agent's tool list changes, so nothing regresses, and v1 asks only "does the
+machinery work".
+
+Whether to trust it in the approval path is a different question and deserves
+its own review with the risk in isolation. It is a one-line change to
+`shellTools()` when we want it.
+
+## Next: the command table
+
+`echo` is the whole table today. The intended shape, to be confirmed per
+command against the actual tool signature:
+
+| command | tool | notes |
+|---|---|---|
+| `echo …` | `print` | no interrupt at all |
+| `echo … > f` / `>> f` | `write` | overwrite / append |
+| `cat f` | `read` | single file only |
+| `ls [dir]` | `ls` | |
+| `grep pat files` | `grep` | flag translation needed |
+| `find . -name g` | `glob` | narrow subset |
+| `git status\|log\|diff\|show\|…` | `gitStatus` etc. | `std::git` has one tool per subcommand |
+| `curl url` | `fetch` | |
+
+**Flags are the hard part, not the verb.** `ls -la`, `grep -ri` and
+`git log --oneline -n 5` each need a decision about which flags are
+representable and what to do with the rest. Default to refusing on any
+unrecognized flag: a refusal costs an approval, a wrong translation costs
+correctness.
+
+## Open questions
+
+- **Shape lock-in.** `Cmd` and `simplify` are this module's public API. If the
+  shape turns out wrong once real rules exist, changing it is a breaking
+  change to a shipped stdlib module. Sanity-checked against the table above on
+  paper and it holds; the first real rule is the test of that.
+- **Does a rewritten command get reported to the user?** Silently running
+  something other than what was asked for is the kind of thing that should be
+  observable. Leaning yes, via `whatIAmDoing`.
+- **Does `safeBash` keep the name `bash` when handed to the LLM?** Renaming
+  changes what the model writes.
+- **Should the coding agent's prompt change once this exists?** Probably not —
+  safeBash is a safety net, not a license to write bash.
+
+## Found while building
+
+`item.command`, where the field is declared `AndOr`, resolves to the type
+*alias* named `Command` — so every access below it reports a missing property.
+Worked around with `any` on three locals, each commented. Reachable only when
+a field name matches a type name; worth its own issue.
+
+## Related
+
+- `docs/site/guide/interrupts.md`, `handlers.md`, `effects.md`, `policies.md` —
+  the approval machinery this works around.
+- `stdlib/shell.agency:133` — `bash()` and its interrupt.
+- PRs #674, #676, #677, #695, #698, #700, #701 — the pattern-matching work that
+  made the match table expressible.

--- a/packages/agency-lang/docs/superpowers/specs/2026-07-26-safebash-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-07-26-safebash-design.md
@@ -146,6 +146,27 @@ correctness.
 - **Should the coding agent's prompt change once this exists?** Probably not —
   safeBash is a safety net, not a license to write bash.
 
+## Parser gaps (separate from this module)
+
+Two of the review findings are arguably the bash parser's, not safeBash's. The
+AST records what was *written* but not the shell's intent to *transform* it,
+so a consumer has to re-derive that by scanning literal text:
+
+- **No node for glob patterns.** `echo *` arrives as `literal "*"`,
+  indistinguishable from ordinary text except by scanning for `*`, `?` and
+  `[`. safeBash now does that scan, which works — the parser does keep quoted
+  and unquoted parts separate within a word, so `"a"*` is
+  `[doubleQuoted "a", literal "*"]` and only the unquoted part is checked —
+  but every consumer that wants "would bash expand this?" has to reimplement
+  it. A `{ tag: "glob", pattern }` part would make it structural.
+- **No node for tilde expansion.** `~/d` arrives as `literal "~/d"`. Same
+  argument, plus tilde has a position rule (only at the start of a word) that
+  a consumer has to know.
+
+Neither blocks v1 — the scan is correct today. They are noted because the
+workaround is a text scan for shell metacharacters, which is exactly the kind
+of thing that goes subtly wrong as coverage grows.
+
 ## Found while building
 
 `item.command`, where the field is declared `AndOr`, resolves to the type

--- a/packages/agency-lang/docs/superpowers/specs/2026-07-26-safebash-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-07-26-safebash-design.md
@@ -167,6 +167,23 @@ Neither blocks v1 — the scan is correct today. They are noted because the
 workaround is a text scan for shell metacharacters, which is exactly the kind
 of thing that goes subtly wrong as coverage grows.
 
+## Two more found while building
+
+Both pre-existing, both first hit by this file because nothing in stdlib had
+these shapes before.
+
+- **A blank line between match arms fails to parse when lowering is off.**
+  Same file: `agency tc` accepts it, `agency fmt` rejects it with "expected
+  match cases of the form `value => expression`". The formatter parses
+  un-lowered, so a blank line between arms breaks the corpus round-trip gate.
+  Worked around by removing the blank lines; the parser should take them.
+- **A call inside a match-arm guard is invisible to the effects walk**
+  (#668, already recorded as a known walker gap). A call reachable only from a
+  guard contributes no effects, which matters because effects are how the
+  language reasons about what a function may do. Avoided here by refusing
+  flags before the match rather than in a guard on every arm — which reads
+  better anyway — rather than by widening the walker inside this PR.
+
 ## Found while building
 
 `item.command`, where the field is declared `AndOr`, resolves to the type

--- a/packages/agency-lang/stdlib/safeBash.agency
+++ b/packages/agency-lang/stdlib/safeBash.agency
@@ -393,15 +393,21 @@ export def safeBash(command: string, cwd: string = ""): ExecResult {
   if (parsed is success(ast)) {
     const simplified = simplify(ast)
     if (simplified is success(cmd)) {
+      // Flags are refused before the table rather than per-arm: `echo -n`
+      // suppresses the trailing newline and `-e` interprets escapes, and
+      // `joinWords` does neither. Up here it is one rule instead of a guard
+      // repeated on every arm — and it keeps calls out of match-arm guards,
+      // which the effects walk does not descend into (#668).
+      if (hasFlags(cmd.words)) {
+        return bash(command, cwd)
+      }
       return match (cmd) {
         // `echo` has no side effect beyond its output, so there is nothing to
         // approve: print it and report what bash wrote to stdout.
-        { words: ["echo", ...rest], redirect: null } if (!hasFlags(rest)) => ok(joinWords(rest))
-
+        { words: ["echo", ...rest], redirect: null } => ok(joinWords(rest))
         // Redirected, it is a file write, which `write` already gates.
-        { words: ["echo", ...rest], redirect: { op: ">", path } } if (!hasFlags(rest)) => writeThrough(path, joinWords(rest), "overwrite", command, cwd)
-        { words: ["echo", ...rest], redirect: { op: ">>", path } } if (!hasFlags(rest)) => writeThrough(path, joinWords(rest), "append", command, cwd)
-
+        { words: ["echo", ...rest], redirect: { op: ">", path } } => writeThrough(path, joinWords(rest), "overwrite", command, cwd)
+        { words: ["echo", ...rest], redirect: { op: ">>", path } } => writeThrough(path, joinWords(rest), "append", command, cwd)
         _ => bash(command, cwd)
       }
     }

--- a/packages/agency-lang/stdlib/safeBash.agency
+++ b/packages/agency-lang/stdlib/safeBash.agency
@@ -1,0 +1,404 @@
+import { _bashParser } from "agency-lang/stdlib-lib/safeBash.js"
+import { env } from "std::system"
+import { WriteMode } from "std::index"
+import { bash } from "std::shell"
+
+/** One piece of a word. Adjacent parts concatenate: `e'f'"g"$h` is a single
+ * word of four parts. */
+export type WordPart =
+  | { tag: "literal"; text: string }
+  | { tag: "singleQuoted"; text: string }
+  | { tag: "doubleQuoted"; parts: WordPart[] }
+  | { tag: "variable"; name: string }
+  | { tag: "paramExpansion"; expression: string }
+  | { tag: "commandSubstitution"; command: List }
+  | { tag: "arithmeticExpansion"; expression: string }
+
+export type BashWord = {
+  tag: "word";
+  parts: WordPart[]
+}
+
+/** `name=value` (or `name=` with a null value) before a command. */
+export type Assignment = {
+  tag: "assignment";
+  name: string;
+  value?: BashWord
+}
+
+/** A redirect like `> out.txt`, `2>&1`, or `<<< "$str"`. `fd` is the
+ * explicit file descriptor (`2` in `2>`), or null for the default. */
+export type Redirect = {
+  tag: "redirect";
+  fd?: number;
+  op: string;
+  target: BashWord
+}
+
+export type SimpleCommand = {
+  tag: "simpleCommand";
+  assignments: Assignment[];
+  words: BashWord[];
+  redirects: Redirect[]
+}
+
+export type IfCommand = {
+  tag: "if";
+  cond: List;
+  thenBody: List;
+  elifs: { cond: List; thenBody: List }[];
+  elseBody?: List;
+  redirects: Redirect[]
+}
+
+export type LoopCommand = {
+  tag: "loop";
+  kind: "while" | "until";
+  cond: List;
+  body: List;
+  redirects: Redirect[]
+}
+
+export type ForCommand = {
+  tag: "for";
+  variable: string;
+  /** The `in word...` list, or null for the implicit `in "$@"`. */
+  words?: BashWord[];
+  body: List;
+  redirects: Redirect[]
+}
+
+export type CaseItem = {
+  patterns: BashWord[];
+  body: List;
+  /** `;;`, `;&`, `;;&`, or null when the final item ends at `esac`. */
+  terminator?: string
+}
+
+export type CaseCommand = {
+  tag: "case";
+  subject: BashWord;
+  items: CaseItem[];
+  redirects: Redirect[]
+}
+
+export type Subshell = {
+  tag: "subshell";
+  body: List;
+  redirects: Redirect[]
+}
+
+export type Group = {
+  tag: "group";
+  body: List;
+  redirects: Redirect[]
+}
+
+/** `(( expression ))` as a command. The expression is kept as raw text. */
+export type ArithmeticCommand = {
+  tag: "arithmeticCommand";
+  expression: string;
+  redirects: Redirect[]
+}
+
+export type FunctionDef = {
+  tag: "functionDef";
+  name: string;
+  body: Command
+}
+
+export type Command =
+  | SimpleCommand
+  | IfCommand
+  | LoopCommand
+  | ForCommand
+  | CaseCommand
+  | Subshell
+  | Group
+  | ArithmeticCommand
+  | FunctionDef
+
+/** One or more commands joined by `|` (or `|&`), optionally negated. */
+export type Pipeline = {
+  tag: "pipeline";
+  negated: boolean;
+  commands: Command[]
+}
+
+/** Pipelines joined by `&&` / `||`, left to right. */
+export type AndOr = {
+  tag: "andOr";
+  first: Pipeline;
+  rest: { op: "&&" | "||"; pipeline: Pipeline }[]
+}
+
+export type ListItem = {
+  tag: "listItem";
+  command: Command;
+  /** True when the command was followed by `&`. */
+  background: boolean
+}
+
+/** A sequence of commands separated by `;`, `&`, or newlines — the top
+ * level of a script, and the body of every compound command. */
+export type List = {
+  tag: "list";
+  items: ListItem[]
+}
+
+export static const emptyList: List = {
+  tag: "list",
+  items: []
+}
+
+export type BashNode =
+  | WordPart
+  | BashWord
+  | Assignment
+  | Redirect
+  | Command
+  | Pipeline
+  | AndOr
+  | ListItem
+  | List
+
+
+/** A bash command reduced to the only shape v1 can reason about: the words of
+ *  a single command, and an optional output redirect. */
+export type OutputRedirect = {
+  op: string;
+  path: string
+}
+
+export type Cmd = {
+  words: string[];
+  redirect: OutputRedirect | null
+}
+
+export type SafeBashResult = {
+  stdout: string;
+  stderr: string;
+  exitCode: number
+}
+
+export def bashParser(code: string): Result<List> {
+  """
+  Parse a string of bash code into an AST.
+  """
+  const res = _bashParser(code)
+  return match(res.success) {
+    true => success(res.result)
+    false => failure(res.error)
+  }
+}
+
+def stringifyWordPart(part: WordPart, insideQuotes: boolean): Result<string> {
+  """
+  Reduce one piece of a word to text, or explain why it cannot be.
+
+  Only the parts that are already text, or that the environment can answer,
+  are resolvable. Anything that would need a shell to evaluate is a failure,
+  because guessing at it is how safeBash and bash would come to disagree
+  about what a command means.
+  """
+  return match (part) {
+    { tag: "literal", text } => success(text)
+    { tag: "singleQuoted", text } => success(text)
+    { tag: "doubleQuoted", parts } => stringifyParts(parts, true)
+    { tag: "variable", name } => expandVariable(name, insideQuotes)
+    _ => failure("`${part.tag}` needs a shell to evaluate")
+  }
+}
+
+def expandVariable(name: string, insideQuotes: boolean): Result<string> {
+  """
+  Look a variable up in the environment. Unset is the empty string, as in bash.
+
+  An UNQUOTED value containing whitespace is refused rather than expanded:
+  bash word-splits it, so `cat $F` with `F="a b"` is two arguments, and
+  expanding it here without splitting would quietly change what the command
+  means. Inside double quotes no splitting happens, so it expands normally.
+  """
+  const value = env(name) ?? ""
+  if (!insideQuotes && value != value.trim()) {
+    return failure("unquoted `${name}` has surrounding whitespace; bash would word-split it")
+  }
+  if (!insideQuotes && value.includes(" ")) {
+    return failure("unquoted `${name}` contains a space; bash would word-split it")
+  }
+  return success(value)
+}
+
+def stringifyParts(parts: WordPart[], insideQuotes: boolean): Result<string> {
+  """
+  Concatenate the parts of a word. Adjacent parts join with no separator:
+  `e'f'"g"` is one word, `efg`.
+  """
+  let out = ""
+  for (part in parts) {
+    const piece = stringifyWordPart(part, insideQuotes)
+    if (piece is success(text)) {
+      out = out + text
+    } else {
+      return failure(piece.error)
+    }
+  }
+  return success(out)
+}
+
+def stringifyWord(word: BashWord): Result<string> {
+  """
+  Reduce a whole word to text.
+  """
+  return stringifyParts(word.parts, false)
+}
+
+def simplifyRedirects(redirects: Redirect[]): Result<OutputRedirect | null> {
+  """
+  Reduce a command's redirects to the one shape v1 handles: a single `>` or
+  `>>` to a file, with no explicit file descriptor. Everything else — `2>&1`,
+  heredocs, input redirects, more than one — is refused.
+  """
+  if (redirects.length == 0) {
+    return success(null)
+  }
+  if (redirects.length > 1) {
+    return failure("more than one redirect")
+  }
+  const only = redirects[0]
+  if (only.fd != null) {
+    return failure("redirect with an explicit file descriptor")
+  }
+  if (only.op != ">" && only.op != ">>") {
+    return failure("`${only.op}` is not an output redirect")
+  }
+  const path = stringifyWord(only.target)
+  if (path is success(text)) {
+    return success({ op: only.op, path: text })
+  }
+  return failure("redirect target: ${path.error}")
+}
+
+export def simplify(node: List): Result<Cmd> {
+  """
+  Reduce a parsed bash AST to a single command's words and output redirect.
+
+  v1 understands one simple command and nothing else. A pipeline, a `&&`
+  chain, a subshell, a loop, a background job or a variable assignment is a
+  failure — not because they are unsafe, but because collapsing them to a
+  word list would lose what makes them different from a single command.
+
+  @param node - The AST from `bashParser`
+  """
+  if (node.items.length != 1) {
+    return failure("expected a single command")
+  }
+  const item = node.items[0]
+  if (item.background) {
+    return failure("background commands are not handled")
+  }
+  // `any` on purpose: the checker resolves `item.command` to the type ALIAS
+  // named `Command` rather than the field's declared type `AndOr`, so every
+  // access below it reports a missing property. Filed separately; the shape
+  // is what the AST types say.
+  const andOr: any = item.command
+  if (andOr.rest.length > 0) {
+    return failure("`&&` and `||` are not handled")
+  }
+  const pipeline: any = andOr.first
+  if (pipeline.negated) {
+    return failure("negated commands are not handled")
+  }
+  if (pipeline.commands.length != 1) {
+    return failure("pipelines are not handled")
+  }
+  const cmd: any = pipeline.commands[0]
+  if (cmd.tag != "simpleCommand") {
+    return failure("`${cmd.tag}` is not a simple command")
+  }
+  if (cmd.assignments.length > 0) {
+    return failure("leading variable assignments are not handled")
+  }
+
+  let words: string[] = []
+  for (word in cmd.words) {
+    const text = stringifyWord(word)
+    if (text is success(value)) {
+      words.push(value)
+    } else {
+      return failure("could not read a word: ${text.error}")
+    }
+  }
+
+  const redirect = simplifyRedirects(cmd.redirects)
+  if (redirect is success(only)) {
+    return success({ words: words, redirect: only })
+  }
+  return failure("could not read the redirect: ${redirect.error}")
+}
+
+def ok(stdout: string): SafeBashResult {
+  """
+  A successful result in the shape `bash` would have returned.
+  """
+  return { stdout: stdout, stderr: "", exitCode: 0 }
+}
+
+export def safeBash(command: string, cwd: string = ""): SafeBashResult {
+  """
+  Run a shell command, using an equivalent tool where one exists.
+
+  `bash` cannot be pre-approved — there is no way to say in advance what an
+  arbitrary command string will do — so every call needs a human. Many of the
+  commands an agent writes have a tool that does the same job and IS
+  pre-approved. This parses the command and uses that tool when it can.
+
+  Anything it cannot parse, or cannot map, runs through `bash` exactly as
+  before, approval and all. Incompleteness costs an approval, never
+  correctness.
+
+  @param command - The shell command to run
+  @param cwd - Working directory, passed through to bash on the fallback path
+  """
+  const parsed = bashParser(command)
+  if (parsed is success(ast)) {
+    const simplified = simplify(ast)
+    if (simplified is success(cmd)) {
+      return match (cmd) {
+        // `echo` has no side effect beyond its output, so there is nothing to
+        // approve: print it and report what bash wrote to stdout.
+        { words: ["echo", ...rest], redirect: null } => ok(joinWords(rest))
+
+        // Redirected, it is a file write, which `write` already gates.
+        { words: ["echo", ...rest], redirect: { op: ">", path } } => writeThrough(path, joinWords(rest), "overwrite", command, cwd)
+        { words: ["echo", ...rest], redirect: { op: ">>", path } } => writeThrough(path, joinWords(rest), "append", command, cwd)
+
+        _ => bash(command, cwd)
+      }
+    }
+  }
+  // Unparseable, or a shape v1 does not map: run it as before, approval and
+  // all. Incompleteness costs an approval, never correctness.
+  return bash(command, cwd)
+}
+
+def joinWords(words: string[]): string {
+  """
+  Rejoin a command's arguments the way echo prints them: single-spaced, with a
+  trailing newline.
+  """
+  return words.join(" ") + "\n"
+}
+
+def writeThrough(path: string, content: string, mode: WriteMode, original: string, cwd: string): SafeBashResult {
+  """
+  Write the file, falling back to bash if the write itself fails so a refusal
+  never silently swallows the command.
+  """
+  const written = write(path, content, cwd, mode)
+  if (written is failure(reason)) {
+    return bash(original, cwd)
+  }
+  return ok("")
+}
+

--- a/packages/agency-lang/stdlib/safeBash.agency
+++ b/packages/agency-lang/stdlib/safeBash.agency
@@ -1,7 +1,7 @@
 import { _bashParser } from "agency-lang/stdlib-lib/safeBash.js"
 import { env } from "std::system"
 import { WriteMode } from "std::index"
-import { bash } from "std::shell"
+import { bash, ExecResult } from "std::shell"
 
 /** One piece of a word. Adjacent parts concatenate: `e'f'"g"$h` is a single
  * word of four parts. */
@@ -163,8 +163,7 @@ export type BashNode =
   | List
 
 
-/** A bash command reduced to the only shape v1 can reason about: the words of
- *  a single command, and an optional output redirect. */
+/** A bash command reduced to the only shape v1 can reason about: the words of a single command, and an optional output redirect. */
 export type OutputRedirect = {
   op: string;
   path: string
@@ -173,12 +172,6 @@ export type OutputRedirect = {
 export type Cmd = {
   words: string[];
   redirect: OutputRedirect | null
-}
-
-export type SafeBashResult = {
-  stdout: string;
-  stderr: string;
-  exitCode: number
 }
 
 export def bashParser(code: string): Result<List> {
@@ -202,12 +195,33 @@ def stringifyWordPart(part: WordPart, insideQuotes: boolean): Result<string> {
   about what a command means.
   """
   return match (part) {
-    { tag: "literal", text } => success(text)
+    { tag: "literal", text } => literalWord(text, insideQuotes)
     { tag: "singleQuoted", text } => success(text)
     { tag: "doubleQuoted", parts } => stringifyParts(parts, true)
     { tag: "variable", name } => expandVariable(name, insideQuotes)
     _ => failure("`${part.tag}` needs a shell to evaluate")
   }
+}
+
+def literalWord(text: string, insideQuotes: boolean): Result<string> {
+  """
+  Literal text, unless it is something bash would rewrite before the command
+  ever ran.
+
+  Outside quotes, `*`, `?` and `[` are globs and a leading `~` is the home
+  directory — bash replaces them, so passing them through as text would run a
+  different command. Inside quotes bash leaves them alone, so they are text.
+  """
+  if (insideQuotes) {
+    return success(text)
+  }
+  if (text.includes("*") || text.includes("?") || text.includes("[")) {
+    return failure("`${text}` is a glob; bash would expand it")
+  }
+  if (text.startsWith("~")) {
+    return failure("`${text}` is a tilde expansion; bash would expand it")
+  }
+  return success(text)
 }
 
 def expandVariable(name: string, insideQuotes: boolean): Result<string> {
@@ -220,11 +234,17 @@ def expandVariable(name: string, insideQuotes: boolean): Result<string> {
   means. Inside double quotes no splitting happens, so it expands normally.
   """
   const value = env(name) ?? ""
-  if (!insideQuotes && value != value.trim()) {
-    return failure("unquoted `${name}` has surrounding whitespace; bash would word-split it")
+  if (insideQuotes) {
+    return success(value)
   }
-  if (!insideQuotes && value.includes(" ")) {
-    return failure("unquoted `${name}` contains a space; bash would word-split it")
+  // Default IFS is space, TAB and NEWLINE — not just space.
+  if (value.includes(" ") || value.includes("\t") || value.includes("\n")) {
+    return failure("unquoted `${name}` contains whitespace; bash would word-split it")
+  }
+  // An unquoted empty expansion produces ZERO words in bash, where this would
+  // produce one empty one — an argument bash never passed.
+  if (value == "") {
+    return failure("unquoted `${name}` is empty; bash would pass no argument at all")
   }
   return success(value)
 }
@@ -302,10 +322,19 @@ export def simplify(node: List): Result<Cmd> {
   // access below it reports a missing property. Filed separately; the shape
   // is what the AST types say.
   const andOr: any = item.command
+  // The `any` above discards the checking that makes the rest of this
+  // reduction sound, so re-establish it at runtime. A shifted parser shape
+  // should fail here rather than be reduced on unchecked assumptions.
+  if (andOr.tag != "andOr") {
+    return failure("unexpected AST shape: expected an andOr")
+  }
   if (andOr.rest.length > 0) {
     return failure("`&&` and `||` are not handled")
   }
   const pipeline: any = andOr.first
+  if (pipeline.tag != "pipeline") {
+    return failure("unexpected AST shape: expected a pipeline")
+  }
   if (pipeline.negated) {
     return failure("negated commands are not handled")
   }
@@ -337,14 +366,14 @@ export def simplify(node: List): Result<Cmd> {
   return failure("could not read the redirect: ${redirect.error}")
 }
 
-def ok(stdout: string): SafeBashResult {
+def ok(stdout: string): ExecResult {
   """
   A successful result in the shape `bash` would have returned.
   """
   return { stdout: stdout, stderr: "", exitCode: 0 }
 }
 
-export def safeBash(command: string, cwd: string = ""): SafeBashResult {
+export def safeBash(command: string, cwd: string = ""): ExecResult {
   """
   Run a shell command, using an equivalent tool where one exists.
 
@@ -367,11 +396,11 @@ export def safeBash(command: string, cwd: string = ""): SafeBashResult {
       return match (cmd) {
         // `echo` has no side effect beyond its output, so there is nothing to
         // approve: print it and report what bash wrote to stdout.
-        { words: ["echo", ...rest], redirect: null } => ok(joinWords(rest))
+        { words: ["echo", ...rest], redirect: null } if (!hasFlags(rest)) => ok(joinWords(rest))
 
         // Redirected, it is a file write, which `write` already gates.
-        { words: ["echo", ...rest], redirect: { op: ">", path } } => writeThrough(path, joinWords(rest), "overwrite", command, cwd)
-        { words: ["echo", ...rest], redirect: { op: ">>", path } } => writeThrough(path, joinWords(rest), "append", command, cwd)
+        { words: ["echo", ...rest], redirect: { op: ">", path } } if (!hasFlags(rest)) => writeThrough(path, joinWords(rest), "overwrite", command, cwd)
+        { words: ["echo", ...rest], redirect: { op: ">>", path } } if (!hasFlags(rest)) => writeThrough(path, joinWords(rest), "append", command, cwd)
 
         _ => bash(command, cwd)
       }
@@ -382,6 +411,23 @@ export def safeBash(command: string, cwd: string = ""): SafeBashResult {
   return bash(command, cwd)
 }
 
+def hasFlags(words: string[]): boolean {
+  """
+  True when any argument looks like an option.
+
+  `echo -n` suppresses the trailing newline and `echo -e` interprets escapes;
+  `joinWords` does neither, so mapping those would produce different output
+  than bash. Anything starting with `-` falls through and costs an approval,
+  which is the trade this module makes everywhere else.
+  """
+  for (word in words) {
+    if (word.startsWith("-")) {
+      return true
+    }
+  }
+  return false
+}
+
 def joinWords(words: string[]): string {
   """
   Rejoin a command's arguments the way echo prints them: single-spaced, with a
@@ -390,12 +436,24 @@ def joinWords(words: string[]): string {
   return words.join(" ") + "\n"
 }
 
-def writeThrough(path: string, content: string, mode: WriteMode, original: string, cwd: string): SafeBashResult {
+def writeThrough(path: string, content: string, mode: WriteMode, original: string, cwd: string): ExecResult {
   """
   Write the file, falling back to bash if the write itself fails so a refusal
   never silently swallows the command.
+
+  Worth knowing: a user who DENIES the `std::write` approval is then asked to
+  approve `std::bash` for the same effect. That is deliberate — the
+  alternative is a command that silently does nothing — but it is a second
+  prompt for something just declined.
   """
-  const written = write(path, content, cwd, mode)
+  // `write`'s `dir` rejects an empty string, where `safeBash`'s `cwd` uses one
+  // to mean "wherever bash would have run". Normalize, or every redirected
+  // echo falls back to bash and the mapping never fires.
+  let dir = cwd
+  if (dir == "") {
+    dir = "."
+  }
+  const written = write(path, content, dir, mode)
   if (written is failure(reason)) {
     return bash(original, cwd)
   }

--- a/packages/agency-lang/stdlib/shell.agency
+++ b/packages/agency-lang/stdlib/shell.agency
@@ -29,7 +29,11 @@ import {
   ```
 */
 
-type ExecResult = {
+/** What a shell command produced. Exported so `std::safeBash` can declare the
+ *  same return type on both its paths — a fast-path result and a real
+ *  `bash()` result have to be the same shape by construction, not by
+ *  coincidence. */
+export type ExecResult = {
   stdout: string;
   stderr: string;
   exitCode: number

--- a/packages/agency-lang/tests/agency/safeBash.agency
+++ b/packages/agency-lang/tests/agency/safeBash.agency
@@ -56,6 +56,18 @@ node commandsItRefuses() {
   ]
 }
 
+node shellTransformsAreRefused() {
+  // bash rewrites an unquoted word four ways before the command runs. Passing
+  // any of them through as text would run a different command than the user
+  // wrote — the one failure mode this module must not have.
+  return [
+    refusalFor("echo *"),
+    refusalFor("echo x[1]"),
+    refusalFor("echo ~/d"),
+    refusalFor("echo \"a*b\""),
+  ]
+}
+
 node redirectsItUnderstands() {
   const parsed = bashParser("echo hi > out.txt")
   if (parsed is success(ast)) {

--- a/packages/agency-lang/tests/agency/safeBash.agency
+++ b/packages/agency-lang/tests/agency/safeBash.agency
@@ -1,0 +1,73 @@
+import { safeBash, bashParser, simplify } from "std::safeBash"
+
+def refusalFor(command: string): string {
+  // What `simplify` says about a command it will not map. The reason matters:
+  // a refusal is what sends the command to bash and costs an approval, so a
+  // wrong one is a silently worse experience, not a wrong answer.
+  const parsed = bashParser(command)
+  if (parsed is success(ast)) {
+    const cmd = simplify(ast)
+    if (cmd is failure(why)) {
+      return why
+    }
+    return "mapped"
+  }
+  return "unparseable"
+}
+
+def wordsOf(command: string): any {
+  const parsed = bashParser(command)
+  if (parsed is success(ast)) {
+    const cmd = simplify(ast)
+    if (cmd is success(c)) {
+      return c.words
+    }
+    return ["FAILED"]
+  }
+  return ["UNPARSEABLE"]
+}
+
+node echoRunsWithoutApproval() {
+  // The whole point: this used to need a human. It raises no interrupt now.
+  const r = safeBash("echo hello world")
+  return [r.stdout, r.exitCode]
+}
+
+node echoQuotingIsPreserved() {
+  // Adjacent parts concatenate, and quotes are not part of the value.
+  return [
+    wordsOf("echo 'single quoted'"),
+    wordsOf("echo \"double quoted\""),
+    wordsOf("echo a'b'\"c\""),
+  ]
+}
+
+node commandsItRefuses() {
+  // Each of these could be mapped one day; none can be mapped by collapsing
+  // it to a word list, which is what v1 does.
+  return [
+    refusalFor("cat a.txt | grep x"),
+    refusalFor("a && b"),
+    refusalFor("sleep 1 &"),
+    refusalFor("FOO=1 echo hi"),
+    refusalFor("echo $(date)"),
+    refusalFor("echo hi 2>&1"),
+    refusalFor("echo a; echo b"),
+  ]
+}
+
+node redirectsItUnderstands() {
+  const parsed = bashParser("echo hi > out.txt")
+  if (parsed is success(ast)) {
+    const cmd = simplify(ast)
+    if (cmd is success(c)) {
+      return [c.words, c.redirect.op, c.redirect.path]
+    }
+  }
+  return ["FAILED"]
+}
+
+node unparseableFallsThrough() {
+  // Not a refusal — the parser cannot even read it. Still must not crash.
+  return refusalFor("if [ -f x ]; then")
+}

--- a/packages/agency-lang/tests/agency/safeBash.test.json
+++ b/packages/agency-lang/tests/agency/safeBash.test.json
@@ -1,0 +1,39 @@
+{
+  "tests": [
+    {
+      "nodeName": "echoRunsWithoutApproval",
+      "description": "echo maps to print, so the command produces its output without raising the bash interrupt a human would have to approve.",
+      "input": "",
+      "expectedOutput": "[\"hello world\\n\",0]",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "echoQuotingIsPreserved",
+      "description": "Quotes delimit a word, they are not part of its value, and adjacent parts concatenate into one word.",
+      "input": "",
+      "expectedOutput": "[[\"echo\",\"single quoted\"],[\"echo\",\"double quoted\"],[\"echo\",\"abc\"]]",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "commandsItRefuses",
+      "description": "Every shape v1 cannot collapse to a word list is refused by name, so a fallthrough is explainable rather than mysterious.",
+      "input": "",
+      "expectedOutput": "[\"pipelines are not handled\",\"`&&` and `||` are not handled\",\"background commands are not handled\",\"leading variable assignments are not handled\",\"could not read a word: `commandSubstitution` needs a shell to evaluate\",\"could not read the redirect: redirect with an explicit file descriptor\",\"expected a single command\"]",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "redirectsItUnderstands",
+      "description": "An output redirect is lifted out of the AST into the simplified shape.",
+      "input": "",
+      "expectedOutput": "[[\"echo\",\"hi\"],\">\",\"out.txt\"]",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "unparseableFallsThrough",
+      "description": "The parser is deliberately incomplete; input it cannot read falls through rather than crashing.",
+      "input": "",
+      "expectedOutput": "\"unparseable\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/safeBash.test.json
+++ b/packages/agency-lang/tests/agency/safeBash.test.json
@@ -5,35 +5,66 @@
       "description": "echo maps to print, so the command produces its output without raising the bash interrupt a human would have to approve.",
       "input": "",
       "expectedOutput": "[\"hello world\\n\",0]",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     },
     {
       "nodeName": "echoQuotingIsPreserved",
       "description": "Quotes delimit a word, they are not part of its value, and adjacent parts concatenate into one word.",
       "input": "",
       "expectedOutput": "[[\"echo\",\"single quoted\"],[\"echo\",\"double quoted\"],[\"echo\",\"abc\"]]",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     },
     {
       "nodeName": "commandsItRefuses",
       "description": "Every shape v1 cannot collapse to a word list is refused by name, so a fallthrough is explainable rather than mysterious.",
       "input": "",
       "expectedOutput": "[\"pipelines are not handled\",\"`&&` and `||` are not handled\",\"background commands are not handled\",\"leading variable assignments are not handled\",\"could not read a word: `commandSubstitution` needs a shell to evaluate\",\"could not read the redirect: redirect with an explicit file descriptor\",\"expected a single command\"]",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     },
     {
       "nodeName": "redirectsItUnderstands",
       "description": "An output redirect is lifted out of the AST into the simplified shape.",
       "input": "",
       "expectedOutput": "[[\"echo\",\"hi\"],\">\",\"out.txt\"]",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     },
     {
       "nodeName": "unparseableFallsThrough",
       "description": "The parser is deliberately incomplete; input it cannot read falls through rather than crashing.",
       "input": "",
       "expectedOutput": "\"unparseable\"",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "shellTransformsAreRefused",
+      "description": "Globs, bracket patterns and tilde are refused unquoted because bash would expand them; quoted, they are ordinary text and still map.",
+      "input": "",
+      "expectedOutput": "[\"could not read a word: `*` is a glob; bash would expand it\",\"could not read a word: `x[1]` is a glob; bash would expand it\",\"could not read a word: `~/d` is a tilde expansion; bash would expand it\",\"mapped\"]",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Option B from our discussion: the machinery plus one rule, **not wired into any agent**.

**Spec:** `docs/superpowers/specs/2026-07-26-safebash-design.md`, added in this PR. It records the decisions, the refusal policy, the word-splitting rule, and the command table that comes next. The [idea doc](../blob/main/packages/agency-lang/docs/superpowers/ideas/2026-07-24-safebash-command-to-tool-matching.md) it grew from is marked superseded and kept for the reasoning.

## Why

`bash` cannot be pre-approved — there is no way to say in advance what an arbitrary command string will do — so `bash()` raises `std::bash` on every call. Meanwhile the tools that do the same jobs (`read`, `ls`, `grep`, `write`, the git tools) *are* pre-approved. That gap is why a run that could be unattended isn't: you end up approving a stream of `ls` and `cat`.

This parses the command and uses the equivalent tool when it can.

```ts
safeBash("echo hello world")   // prints, no interrupt raised
safeBash("echo hi > out.txt")  // write(), which is already gated
safeBash(anything else)        // bash(), approval and all
```

## Not wired in — deliberately

`shellTools()` is untouched. No agent's tool list changes, so there is nothing to regress, and this PR is only asking "does the machinery work?"

Whether to trust it in the approval path is a different question, and it deserves its own review with the risk in isolation. It's a one-line change to `shellTools()` when we want it.

## What `simplify` does

Reduces the parser's AST to the only shape v1 can reason about:

```ts
type Cmd = { words: string[], redirect: OutputRedirect | null }
```

Everything else is refused **by name** — pipelines, `&&`, background jobs, leading assignments, command substitution, non-output redirects, multiple commands — so a fallthrough is explainable rather than mysterious. Refusing costs an approval, which is exactly what happened before. Guessing would cost correctness.

## The subtle part: word splitting

`stringifyWordPart` resolves what is text or what the environment can answer. The rule worth reviewing:

```bash
F="a b"
cat $F      # TWO arguments to bash
cat "$F"    # one
```

An unquoted expansion holding whitespace is **refused**, not expanded — expanding it without splitting would quietly change what the command means, which is the one failure mode this feature must not have. Inside double quotes no splitting happens, so it expands normally.

## Tests

5 nodes, all passing:

- `echo` produces its output **without raising the interrupt** — the actual claim
- quoting: quotes delimit a word rather than being part of it, and adjacent parts concatenate (`a'b'"c"` → `abc`)
- every refusal, asserted by its exact message
- an output redirect lifted into the simplified shape
- unparseable input falls through rather than crashing — the parser is deliberately incomplete

## Two things worth knowing

**A typechecker bug I worked around.** `item.command` where the field is declared `AndOr` resolves to the type *alias* named `Command`, so every access below it reports a missing property. The three affected locals are `any` with a comment. Worth filing separately — I hit it only because a field name matched a type name.

**Shape lock-in.** `Cmd` and `simplify` are this module's public API. If the shape turns out wrong once real rules exist (`cat`, `ls`, `git`), changing it is a breaking change to a shipped stdlib module. I sanity-checked those rules against it on paper and the shape holds, but it's the thing to push on in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

