### PR TITLE
std::safeBash: follow the rewritten bash parser

### DIFF
--- a/packages/agency-lang/TODO.md
+++ b/packages/agency-lang/TODO.md
@@ -267,3 +267,24 @@ This should work in string interpolation:
 ---
 
 Should be able to call methods on comprehensions, like `join`.
+
+---
+
+Can't have periods in type names, so can't reference stuff from a namespace import
+
+```
+export def simplify(ast: act.Command): Result<Cmd> {
+  ```
+
+---
+
+if a var is exported, it should never be marked unused.
+
+---
+
+Can't have rest + type in a match arm:
+
+fails:
+```
+["echo", (...args):PrintArg[], ">", filename] => writeAction(filename, ".", joinWords(args), "overwrite")
+```

--- a/packages/agency-lang/docs/site/stdlib/safeBash.md
+++ b/packages/agency-lang/docs/site/stdlib/safeBash.md
@@ -19,7 +19,7 @@ export type Word =
   | InterpolatedVariableWord
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L7))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L16))
 
 ### ScriptName
 
@@ -27,7 +27,7 @@ export type Word =
 export type ScriptName = LiteralWord | PathWord
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L16))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L25))
 
 ### LiteralWord
 
@@ -38,7 +38,7 @@ export type LiteralWord = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L18))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L27))
 
 ### PathWord
 
@@ -49,7 +49,7 @@ export type PathWord = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L23))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L32))
 
 ### FlagWord
 
@@ -61,7 +61,7 @@ export type FlagWord = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L28))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L37))
 
 ### SingleQuotedWord
 
@@ -72,7 +72,7 @@ export type SingleQuotedWord = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L34))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L43))
 
 ### DoubleQuotedWord
 
@@ -83,7 +83,7 @@ export type DoubleQuotedWord = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L39))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L48))
 
 ### VariableWord
 
@@ -94,7 +94,7 @@ export type VariableWord = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L44))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L53))
 
 ### InterpolatedVariableWord
 
@@ -117,7 +117,7 @@ export type InterpolatedVariableWord = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L53))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L62))
 
 ### Assignment
 
@@ -132,7 +132,7 @@ export type Assignment = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L63))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L72))
 
 ### Redirect
 
@@ -154,7 +154,7 @@ export type Redirect = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L73))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L82))
 
 ### SimpleCommand
 
@@ -174,7 +174,7 @@ export type SimpleCommand = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L80))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L89))
 
 ### Command
 
@@ -182,7 +182,7 @@ export type SimpleCommand = {
 export type Command = SimpleCommand | And | Or | Parens
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L94))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L103))
 
 ### And
 
@@ -194,7 +194,7 @@ export type And = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L96))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L105))
 
 ### Or
 
@@ -206,7 +206,7 @@ export type Or = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L102))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L111))
 
 ### Parens
 
@@ -217,7 +217,7 @@ export type Parens = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L108))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L117))
 
 ### BashNode
 
@@ -231,7 +231,7 @@ export type BashNode =
   | ScriptName
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L113))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L122))
 
 ### BashAST
 
@@ -239,35 +239,23 @@ export type BashNode =
 export type BashAST = Command[]
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L121))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L130))
 
 ### OutputRedirect
 
-A bash command reduced to the only shape v1 can reason about: a command
- * name, its arguments as text, and an optional output redirect.
+An output redirect reduced to the shape v1 handles: `>` or `>>` to a
+ * path, with no explicit file descriptor.
 
 ```ts
-/** A bash command reduced to the only shape v1 can reason about: a command
- * name, its arguments as text, and an optional output redirect. */
+/** An output redirect reduced to the shape v1 handles: `>` or `>>` to a
+ * path, with no explicit file descriptor. */
 export type OutputRedirect = {
   op: string;
   path: string
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L125))
-
-### Cmd
-
-```ts
-export type Cmd = {
-  command: string;
-  args: string[];
-  redirect?: OutputRedirect
-}
-```
-
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L130))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L134))
 
 ## Functions
 
@@ -287,54 +275,168 @@ Parse a string of bash code into an AST.
 
 **Returns:** `Result<BashAST>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L136))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L139))
 
-### simplify
+### makeAction
 
 ```ts
-simplify(ast: BashAST): Result<Cmd>
+makeAction(command: SimpleCommand): Result<Action>
 ```
 
-Reduce a parsed bash AST to a single command's name, arguments and output
-  redirect.
+Decide what a single command means, without doing any of it.
 
-  v1 understands one simple command and nothing else. A `&&` / `||` chain,
-  a parenthesized group or a leading variable assignment is a failure — not
-  because they are unsafe, but because collapsing them to a command and a
-  list of arguments would lose what makes them different from a single
-  command.
+  Everything this returns is a plain data object, so the whole mapping can
+  be tested by looking at what comes out. A command with no better mapping
+  becomes a `BashAction`, which is still a decision rather than a hole: it
+  says "this one has to go to bash", and `runAction` is what pays the
+  approval for it.
 
-  @param ast - The AST from `bashParser`
+  @param command - One simple command from the parsed AST
 
 **Parameters:**
 
 | Name | Type | Default |
 |---|---|---|
-| ast | [BashAST](#bashast) |  |
+| command | [SimpleCommand](#simplecommand) |  |
 
-**Returns:** `Result<Cmd>`
+**Returns:** `Result<Action>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L275))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L387))
+
+### runAction
+
+```ts
+runAction(action: Action): Result<string>
+```
+
+Do what the action says. The only step with effects.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| action | [Action](safeBash/actions.md#action) |  |
+
+**Returns:** `Result<string>`
+
+**Throws:** `std::write`, `std::git::status`, `std::git::diff`, `std::git::log`, `std::bash`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L476))
+
+### runCommand
+
+```ts
+runCommand(command: Command): Result<string>
+```
+
+Run one command, whatever shape it is.
+
+  Every branch returns a `Result`, and a failure is never swallowed: the
+  caller has to decide what a failed command means, because `&&` and `||`
+  answer that question differently.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| command | [Command](#command) |  |
+
+**Returns:** `Result<string>`
+
+**Throws:** `std::write`, `std::git::status`, `std::git::diff`, `std::git::log`, `std::bash`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L498))
+
+### commandsToStr
+
+```ts
+commandsToStr(commands: Command[]): string
+```
+
+Render commands back to bash source, one per line.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| commands | `Command[]` |  |
+
+**Returns:** `string`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L586))
+
+### runCommands
+
+```ts
+runCommands(commands: Command[]): Result<string>
+```
+
+Run a sequence of commands, stopping at the first failure.
+
+  On a failure the model gets the whole picture rather than a bare error:
+  what already ran and what it produced, which command failed and why, and
+  what never ran. There is no falling back to bash for the sequence — some
+  of it has already happened, and re-running the lot would repeat it.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| commands | `Command[]` |  |
+
+**Returns:** `Result<string>`
+
+**Throws:** `std::write`, `std::git::status`, `std::git::diff`, `std::git::log`, `std::bash`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L601))
+
+### makeActions
+
+```ts
+makeActions(source: string): Result<Action[]>
+```
+
+Every action a string of bash would turn into, without running any of it.
+
+  This is the whole decision-making half of the module in one call, which
+  is what makes it testable: hand it a string, look at what comes out.
+
+  The list is in source order and includes both halves of a `&&` or `||`,
+  so it says what each command WOULD do, not what will actually run — only
+  running the chain decides that.
+
+  @param source - One or more bash commands
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| source | `string` |  |
+
+**Returns:** `Result<Action[]>`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L646))
 
 ### safeBash
 
 ```ts
-safeBash(command: string, cwd: string = ""): ExecResult
+safeBash(command: string, cwd: string = ""): Result<string>
 ```
 
 Run a shell command, using an equivalent tool where one exists.
 
   `bash` cannot be pre-approved — there is no way to say in advance what an
-  arbitrary command string will do — so every call needs a human. Many of the
-  commands an agent writes have a tool that does the same job and IS
+  arbitrary command string will do — so every call needs a human. Many of
+  the commands an agent writes have a tool that does the same job and IS
   pre-approved. This parses the command and uses that tool when it can.
 
-  Anything it cannot parse, or cannot map, runs through `bash` exactly as
-  before, approval and all. Incompleteness costs an approval, never
-  correctness.
+  A command with no equivalent still runs, through bash, approval and all.
+  What is NOT possible is silently doing something other than what was
+  asked: a command that cannot be mapped is handed to bash unchanged, and a
+  sequence that fails partway says exactly how far it got.
 
   @param command - The shell command to run
-  @param cwd - Working directory, passed through to bash on the fallback path
+  @param cwd - Working directory
 
 **Parameters:**
 
@@ -343,8 +445,8 @@ Run a shell command, using an equivalent tool where one exists.
 | command | `string` |  |
 | cwd | `string` | "" |
 
-**Returns:** [ExecResult](shell.md#execresult)
+**Returns:** `Result<string>`
 
-**Throws:** `std::write`, `std::bash`
+**Throws:** `std::bash`, `std::write`, `std::git::status`, `std::git::diff`, `std::git::log`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L364))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L713))

--- a/packages/agency-lang/docs/site/stdlib/safeBash.md
+++ b/packages/agency-lang/docs/site/stdlib/safeBash.md
@@ -6,36 +6,118 @@ name: "safeBash"
 
 ## Types
 
-### WordPart
-
-One piece of a word. Adjacent parts concatenate: `e'f'"g"$h` is a single
- * word of four parts.
+### Word
 
 ```ts
-/** One piece of a word. Adjacent parts concatenate: `e'f'"g"$h` is a single
- * word of four parts. */
-export type WordPart =
-  | { tag: "literal"; text: string }
-  | { tag: "singleQuoted"; text: string }
-  | { tag: "doubleQuoted"; parts: WordPart[] }
-  | { tag: "variable"; name: string }
-  | { tag: "paramExpansion"; expression: string }
-  | { tag: "commandSubstitution"; command: List }
-  | { tag: "arithmeticExpansion"; expression: string }
+export type Word =
+  | LiteralWord
+  | PathWord
+  | FlagWord
+  | SingleQuotedWord
+  | DoubleQuotedWord
+  | VariableWord
+  | InterpolatedVariableWord
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L8))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L7))
 
-### BashWord
+### ScriptName
 
 ```ts
-export type BashWord = {
-  tag: "word";
-  parts: WordPart[]
+export type ScriptName = LiteralWord | PathWord
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L16))
+
+### LiteralWord
+
+```ts
+export type LiteralWord = {
+  tag: "literal";
+  text: string
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L17))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L18))
+
+### PathWord
+
+```ts
+export type PathWord = {
+  tag: "path";
+  text: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L23))
+
+### FlagWord
+
+```ts
+export type FlagWord = {
+  tag: "flag";
+  flagName: string;
+  flagValue?: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L28))
+
+### SingleQuotedWord
+
+```ts
+export type SingleQuotedWord = {
+  tag: "singleQuoted";
+  text: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L34))
+
+### DoubleQuotedWord
+
+```ts
+export type DoubleQuotedWord = {
+  tag: "doubleQuoted";
+  parts: Word[]
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L39))
+
+### VariableWord
+
+```ts
+export type VariableWord = {
+  tag: "variable";
+  name: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L44))
+
+### InterpolatedVariableWord
+
+A word built from two or more adjacent parts: `$HOME.txt`, `"a"b`,
+ * `"$HOME"/x`. These are ONE word in bash; split into separate words they
+ * become separate arguments and the command means something else.
+
+```ts
+/** A word built from two or more adjacent parts: `$HOME.txt`, `"a"b`,
+ * `"$HOME"/x`. These are ONE word in bash; split into separate words they
+ * become separate arguments and the command means something else.
+ */
+export type InterpolatedVariableWord = {
+  tag: "interpolatedVariable";
+  parts: (
+  | LiteralWord
+  | VariableWord
+  | SingleQuotedWord
+  | DoubleQuotedWord)[]
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L53))
 
 ### Assignment
 
@@ -46,29 +128,33 @@ export type BashWord = {
 export type Assignment = {
   tag: "assignment";
   name: string;
-  value?: BashWord
+  value?: Word
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L23))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L63))
 
 ### Redirect
 
-A redirect like `> out.txt`, `2>&1`, or `<<< "$str"`. `fd` is the
- * explicit file descriptor (`2` in `2>`), or null for the default.
+A redirect like `> out.txt`, `>> log`, `2> err.txt` or `< in.txt`.
+ * `fd` is the explicit file descriptor (`2` in `2>`), or undefined for the
+ * default. Only `>`, `>>`, `<` and `&>` are recognized; `2>&1`, heredocs
+ * and here-strings are rejected rather than parsed.
 
 ```ts
-/** A redirect like `> out.txt`, `2>&1`, or `<<< "$str"`. `fd` is the
- * explicit file descriptor (`2` in `2>`), or null for the default. */
+/** A redirect like `> out.txt`, `>> log`, `2> err.txt` or `< in.txt`.
+ * `fd` is the explicit file descriptor (`2` in `2>`), or undefined for the
+ * default. Only `>`, `>>`, `<` and `&>` are recognized; `2>&1`, heredocs
+ * and here-strings are rejected rather than parsed. */
 export type Redirect = {
   tag: "redirect";
   fd?: number;
   op: string;
-  target: BashWord
+  target: Word
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L31))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L73))
 
 ### SimpleCommand
 
@@ -76,273 +162,119 @@ export type Redirect = {
 export type SimpleCommand = {
   tag: "simpleCommand";
   assignments: Assignment[];
-  words: BashWord[];
+  /* The command name, or null for an assignment-only line (`FOO=bar`).
+   *  Bash requires at least one of a command name or an assignment. */
+  command?: ScriptName;
+  /** Every word after the command name, in source order. There is no
+   *  `subcommands` field: no syntactic rule separates `git status` from
+   *  `echo status`, so splitting them would put a command's real
+   *  arguments in whichever bucket the preceding word happened to pick. */
+  args: Word[];
   redirects: Redirect[]
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L38))
-
-### IfCommand
-
-```ts
-export type IfCommand = {
-  tag: "if";
-  cond: List;
-  thenBody: List;
-  elifs: { cond: List; thenBody: List }[];
-  elseBody?: List;
-  redirects: Redirect[]
-}
-```
-
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L45))
-
-### LoopCommand
-
-```ts
-export type LoopCommand = {
-  tag: "loop";
-  kind: "while" | "until";
-  cond: List;
-  body: List;
-  redirects: Redirect[]
-}
-```
-
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L54))
-
-### ForCommand
-
-```ts
-export type ForCommand = {
-  tag: "for";
-  variable: string;
-  /** The `in word...` list, or null for the implicit `in "$@"`. */
-  words?: BashWord[];
-  body: List;
-  redirects: Redirect[]
-}
-```
-
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L62))
-
-### CaseItem
-
-```ts
-export type CaseItem = {
-  patterns: BashWord[];
-  body: List;
-  /** `;;`, `;&`, `;;&`, or null when the final item ends at `esac`. */
-  terminator?: string
-}
-```
-
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L71))
-
-### CaseCommand
-
-```ts
-export type CaseCommand = {
-  tag: "case";
-  subject: BashWord;
-  items: CaseItem[];
-  redirects: Redirect[]
-}
-```
-
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L78))
-
-### Subshell
-
-```ts
-export type Subshell = {
-  tag: "subshell";
-  body: List;
-  redirects: Redirect[]
-}
-```
-
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L85))
-
-### Group
-
-```ts
-export type Group = {
-  tag: "group";
-  body: List;
-  redirects: Redirect[]
-}
-```
-
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L91))
-
-### ArithmeticCommand
-
-`(( expression ))` as a command. The expression is kept as raw text.
-
-```ts
-/** `(( expression ))` as a command. The expression is kept as raw text. */
-export type ArithmeticCommand = {
-  tag: "arithmeticCommand";
-  expression: string;
-  redirects: Redirect[]
-}
-```
-
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L98))
-
-### FunctionDef
-
-```ts
-export type FunctionDef = {
-  tag: "functionDef";
-  name: string;
-  body: Command
-}
-```
-
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L104))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L80))
 
 ### Command
 
 ```ts
-export type Command =
-  | SimpleCommand
-  | IfCommand
-  | LoopCommand
-  | ForCommand
-  | CaseCommand
-  | Subshell
-  | Group
-  | ArithmeticCommand
-  | FunctionDef
+export type Command = SimpleCommand | And | Or | Parens
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L110))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L94))
 
-### Pipeline
-
-One or more commands joined by `|` (or `|&`), optionally negated.
+### And
 
 ```ts
-/** One or more commands joined by `|` (or `|&`), optionally negated. */
-export type Pipeline = {
-  tag: "pipeline";
-  negated: boolean;
-  commands: Command[]
+export type And = {
+  tag: "and";
+  left: Command;
+  right: Command
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L122))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L96))
 
-### AndOr
-
-Pipelines joined by `&&` / `||`, left to right.
+### Or
 
 ```ts
-/** Pipelines joined by `&&` / `||`, left to right. */
-export type AndOr = {
-  tag: "andOr";
-  first: Pipeline;
-  rest: { op: "&&" | "||"; pipeline: Pipeline }[]
+export type Or = {
+  tag: "or";
+  left: Command;
+  right: Command
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L129))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L102))
 
-### ListItem
+### Parens
 
 ```ts
-export type ListItem = {
-  tag: "listItem";
-  command: Command;
-  /** True when the command was followed by `&`. */
-  background: boolean
+export type Parens = {
+  tag: "parens";
+  command: Command
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L135))
-
-### List
-
-A sequence of commands separated by `;`, `&`, or newlines — the top
- * level of a script, and the body of every compound command.
-
-```ts
-/** A sequence of commands separated by `;`, `&`, or newlines — the top
- * level of a script, and the body of every compound command. */
-export type List = {
-  tag: "list";
-  items: ListItem[]
-}
-```
-
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L144))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L108))
 
 ### BashNode
 
 ```ts
 export type BashNode =
-  | WordPart
-  | BashWord
+  | Command
+  | SimpleCommand
   | Assignment
   | Redirect
-  | Command
-  | Pipeline
-  | AndOr
-  | ListItem
-  | List
+  | Word
+  | ScriptName
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L154))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L113))
+
+### BashAST
+
+```ts
+export type BashAST = Command[]
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L121))
 
 ### OutputRedirect
 
-A bash command reduced to the only shape v1 can reason about: the words of a single command, and an optional output redirect.
+A bash command reduced to the only shape v1 can reason about: a command
+ * name, its arguments as text, and an optional output redirect.
 
 ```ts
-/** A bash command reduced to the only shape v1 can reason about: the words of a single command, and an optional output redirect. */
+/** A bash command reduced to the only shape v1 can reason about: a command
+ * name, its arguments as text, and an optional output redirect. */
 export type OutputRedirect = {
   op: string;
   path: string
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L167))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L125))
 
 ### Cmd
 
 ```ts
 export type Cmd = {
-  words: string[];
+  command: string;
+  args: string[];
   redirect?: OutputRedirect
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L172))
-
-## Constants
-
-### emptyList
-
-```ts
-export static const emptyList: List = {
-  tag: "list",
-  items: []
-}
-```
-
-**Type:** [List](#list)
-
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L149))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L130))
 
 ## Functions
 
 ### bashParser
 
 ```ts
-bashParser(code: string): Result<List>
+bashParser(code: string): Result<BashAST>
 ```
 
 Parse a string of bash code into an AST.
@@ -353,34 +285,36 @@ Parse a string of bash code into an AST.
 |---|---|---|
 | code | `string` |  |
 
-**Returns:** `Result<List>`
+**Returns:** `Result<BashAST>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L177))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L136))
 
 ### simplify
 
 ```ts
-simplify(node: List): Result<Cmd>
+simplify(ast: BashAST): Result<Cmd>
 ```
 
-Reduce a parsed bash AST to a single command's words and output redirect.
+Reduce a parsed bash AST to a single command's name, arguments and output
+  redirect.
 
-  v1 understands one simple command and nothing else. A pipeline, a `&&`
-  chain, a subshell, a loop, a background job or a variable assignment is a
-  failure — not because they are unsafe, but because collapsing them to a
-  word list would lose what makes them different from a single command.
+  v1 understands one simple command and nothing else. A `&&` / `||` chain,
+  a parenthesized group or a leading variable assignment is a failure — not
+  because they are unsafe, but because collapsing them to a command and a
+  list of arguments would lose what makes them different from a single
+  command.
 
-  @param node - The AST from `bashParser`
+  @param ast - The AST from `bashParser`
 
 **Parameters:**
 
 | Name | Type | Default |
 |---|---|---|
-| node | [List](#list) |  |
+| ast | [BashAST](#bashast) |  |
 
 **Returns:** `Result<Cmd>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L302))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L275))
 
 ### safeBash
 
@@ -411,6 +345,6 @@ Run a shell command, using an equivalent tool where one exists.
 
 **Returns:** [ExecResult](shell.md#execresult)
 
-**Throws:** `std::bash`, `std::write`
+**Throws:** `std::write`, `std::bash`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L376))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L364))

--- a/packages/agency-lang/docs/site/stdlib/safeBash.md
+++ b/packages/agency-lang/docs/site/stdlib/safeBash.md
@@ -280,7 +280,7 @@ Parse a string of bash code into an AST.
 ### makeAction
 
 ```ts
-makeAction(command: SimpleCommand): Result<Action>
+makeAction(command: SimpleCommand, cwd: string = ""): Result<Action>
 ```
 
 Decide what a single command means, without doing any of it.
@@ -298,10 +298,11 @@ Decide what a single command means, without doing any of it.
 | Name | Type | Default |
 |---|---|---|
 | command | [SimpleCommand](#simplecommand) |  |
+| cwd | `string` | "" |
 
 **Returns:** `Result<Action>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L387))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L404))
 
 ### runAction
 
@@ -321,12 +322,12 @@ Do what the action says. The only step with effects.
 
 **Throws:** `std::write`, `std::git::status`, `std::git::diff`, `std::git::log`, `std::bash`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L476))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L501))
 
 ### runCommand
 
 ```ts
-runCommand(command: Command): Result<string>
+runCommand(command: Command, cwd: string = ""): Result<string>
 ```
 
 Run one command, whatever shape it is.
@@ -340,12 +341,13 @@ Run one command, whatever shape it is.
 | Name | Type | Default |
 |---|---|---|
 | command | [Command](#command) |  |
+| cwd | `string` | "" |
 
 **Returns:** `Result<string>`
 
 **Throws:** `std::write`, `std::git::status`, `std::git::diff`, `std::git::log`, `std::bash`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L498))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L523))
 
 ### commandsToStr
 
@@ -363,12 +365,12 @@ Render commands back to bash source, one per line.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L586))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L619))
 
 ### runCommands
 
 ```ts
-runCommands(commands: Command[]): Result<string>
+runCommands(commands: Command[], cwd: string = ""): Result<string>
 ```
 
 Run a sequence of commands, stopping at the first failure.
@@ -383,17 +385,18 @@ Run a sequence of commands, stopping at the first failure.
 | Name | Type | Default |
 |---|---|---|
 | commands | `Command[]` |  |
+| cwd | `string` | "" |
 
 **Returns:** `Result<string>`
 
 **Throws:** `std::write`, `std::git::status`, `std::git::diff`, `std::git::log`, `std::bash`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L601))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L634))
 
 ### makeActions
 
 ```ts
-makeActions(source: string): Result<Action[]>
+makeActions(source: string, cwd: string = ""): Result<Action[]>
 ```
 
 Every action a string of bash would turn into, without running any of it.
@@ -412,10 +415,11 @@ Every action a string of bash would turn into, without running any of it.
 | Name | Type | Default |
 |---|---|---|
 | source | `string` |  |
+| cwd | `string` | "" |
 
 **Returns:** `Result<Action[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L646))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L679))
 
 ### safeBash
 
@@ -449,4 +453,4 @@ Run a shell command, using an equivalent tool where one exists.
 
 **Throws:** `std::bash`, `std::write`, `std::git::status`, `std::git::diff`, `std::git::log`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L713))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L747))

--- a/packages/agency-lang/docs/site/stdlib/safeBash/actions.md
+++ b/packages/agency-lang/docs/site/stdlib/safeBash/actions.md
@@ -207,7 +207,7 @@ gitDiffAction(action: GitDiffAction): Result<string>
 
 **Throws:** `std::git::diff`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L98))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L99))
 
 ### gitLogAction
 
@@ -225,7 +225,7 @@ gitLogAction(action: GitLogAction): Result<string>
 
 **Throws:** `std::git::log`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L110))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L108))
 
 ### bashAction
 
@@ -248,4 +248,4 @@ Run the command through bash, approval and all.
 
 **Throws:** `std::bash`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L116))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L113))

--- a/packages/agency-lang/docs/site/stdlib/safeBash/actions.md
+++ b/packages/agency-lang/docs/site/stdlib/safeBash/actions.md
@@ -1,0 +1,251 @@
+---
+name: "actions"
+description: "The things a bash command can turn into."
+---
+
+# actions
+
+The things a bash command can turn into.
+
+  Every command `safeBash` runs is first translated into an `Action`: a plain
+  data object saying what should happen, with nothing having happened yet.
+  Deciding *what* a command means and *doing* it are separate steps, so the
+  deciding half can be tested by handing in a string and looking at the
+  actions that come out.
+
+  `bash` itself is an action, so a command with no better mapping is still
+  represented here rather than being a hole in the model.
+
+## Types
+
+### Action
+
+```ts
+export type Action =
+  | PrintAction
+  | WriteFileAction
+  | GitAction
+  | BashAction
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L19))
+
+### PrintAction
+
+```ts
+export type PrintAction = {
+  type: "print";
+  content: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L25))
+
+### WriteFileAction
+
+```ts
+export type WriteFileAction = {
+  type: "writeFile";
+  filename: string;
+  dir: string;
+  content: string;
+  mode: "append" | "overwrite"
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L30))
+
+### GitAction
+
+```ts
+export type GitAction = GitStatusAction | GitDiffAction | GitLogAction
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L38))
+
+### GitStatusAction
+
+```ts
+export type GitStatusAction = {
+  type: "gitStatus";
+  cwd?: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L40))
+
+### GitDiffAction
+
+```ts
+export type GitDiffAction = {
+  type: "gitDiff";
+  path?: string;
+  staged?: boolean;
+  cwd?: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L45))
+
+### GitLogAction
+
+```ts
+export type GitLogAction = {
+  type: "gitLog";
+  path?: string;
+  cwd?: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L52))
+
+### BashAction
+
+The fallback: run the command through bash exactly as written.
+ *
+ * `command` is the command re-rendered from its AST, not the caller's
+ * original string, so a sequence that runs three commands and falls back on
+ * the second sends bash only the second one.
+
+```ts
+/** The fallback: run the command through bash exactly as written.
+ *
+ * `command` is the command re-rendered from its AST, not the caller's
+ * original string, so a sequence that runs three commands and falls back on
+ * the second sends bash only the second one. */
+export type BashAction = {
+  type: "bash";
+  command: string;
+  cwd?: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L63))
+
+## Constants
+
+### MAX_STDOUT_LEN
+
+```ts
+export static const MAX_STDOUT_LEN = 2000
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L17))
+
+## Functions
+
+### printAction
+
+```ts
+printAction(action: PrintAction): Result<string>
+```
+
+Print to stdout. No interrupt: printing has no effect to approve.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| action | [PrintAction](#printaction) |  |
+
+**Returns:** `Result<string>`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L69))
+
+### writeAction
+
+```ts
+writeAction(action: WriteFileAction): Result<string>
+```
+
+Write a file. `write` raises the `std::write` interrupt, so this is gated
+  the same way any other write is.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| action | [WriteFileAction](#writefileaction) |  |
+
+**Returns:** `Result<string>`
+
+**Throws:** `std::write`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L77))
+
+### gitStatusAction
+
+```ts
+gitStatusAction(action: GitStatusAction): Result<string>
+```
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| action | [GitStatusAction](#gitstatusaction) |  |
+
+**Returns:** `Result<string>`
+
+**Throws:** `std::git::status`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L94))
+
+### gitDiffAction
+
+```ts
+gitDiffAction(action: GitDiffAction): Result<string>
+```
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| action | [GitDiffAction](#gitdiffaction) |  |
+
+**Returns:** `Result<string>`
+
+**Throws:** `std::git::diff`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L98))
+
+### gitLogAction
+
+```ts
+gitLogAction(action: GitLogAction): Result<string>
+```
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| action | [GitLogAction](#gitlogaction) |  |
+
+**Returns:** `Result<string>`
+
+**Throws:** `std::git::log`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L110))
+
+### bashAction
+
+```ts
+bashAction(action: BashAction): Result<string>
+```
+
+Run the command through bash, approval and all.
+
+  A non-zero exit is a failure rather than a success carrying a bad exit
+  code, so a `&&` chain stops on it the way bash would.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| action | [BashAction](#bashaction) |  |
+
+**Returns:** `Result<string>`
+
+**Throws:** `std::bash`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L116))

--- a/packages/agency-lang/docs/superpowers/specs/2026-07-26-safebash-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-07-26-safebash-design.md
@@ -189,11 +189,24 @@ Whether to trust it in the approval path is a different question and deserves
 its own review with the risk in isolation. It is a one-line change to
 `shellTools()` when we want it.
 
-One thing that review should settle: when `echo hi > f` maps, the approval
-the user sees is `std::write`, not `std::bash`. That is the intended trade
-— a narrower, more informative gate — but it does mean the effect being
-approved depends on a decision safeBash made, and a user who has approved
-all writes has implicitly approved a class of redirects.
+### The approval changes, and that is the point
+
+When `echo hi > f` maps, the approval the user sees is `std::write`, not
+`std::bash`. This is intended, and it is most of the value of the feature
+rather than a side effect of it.
+
+`std::write` is the more accurate gate. It says a file is being written and
+names which one, where `std::bash` says only that a shell is involved and
+leaves the reader to work out the rest from a command string. A policy is
+written against effects, so a narrower effect is a policy that can be
+written precisely: "writes under this directory are fine, shell commands
+are not" becomes expressible for a command that previously could only be
+described as shell.
+
+The honest consequence is that a blanket approval of `std::write` now
+covers redirects that used to land under `std::bash`. That is the correct
+direction — those redirects really are writes, and were only ever shell
+commands because nothing had looked at them.
 
 ## Next: the command table
 

--- a/packages/agency-lang/docs/superpowers/specs/2026-07-26-safebash-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-07-26-safebash-design.md
@@ -1,9 +1,18 @@
 # safeBash: run a bash command through an equivalent tool
 
-## Status (2026-07-26)
+## Status (2026-07-26, revised)
 
-v1 implemented — `simplify`, `stringifyWordPart`, and one rule (`echo`),
-**not wired into any agent**. Later parts below are designed but unbuilt.
+v2 implemented and tested, **not wired into any agent**.
+
+The module is now built around an `Action`: deciding what a command means
+and actually doing it are separate steps. `echo` and three `git`
+subcommands are mapped; everything else falls back to bash. 19 execution
+tests cover it.
+
+This replaces the v1 design, which reduced a command to a `Cmd` record
+(`{ command, args, redirect }`) and ran it inline. The rewrite of the bash
+parser in tarsec 0.5.2/0.5.3 changed the AST underneath, and rather than
+re-fit the old shape to it we changed what the module produces.
 
 Grew out of [the idea doc](../ideas/2026-07-24-safebash-command-to-tool-matching.md),
 which has the original reasoning and the decisions as they were made.
@@ -35,53 +44,69 @@ The bash parser lives in tarsec, re-exported through `lib/stdlib/safeBash.ts`.
 It is deliberately incomplete; anything it cannot parse falls through to real
 bash, so incompleteness costs an approval rather than correctness.
 
-## Decisions
+## Actions: the seam
 
-- **v1 scope: one simple command, plus `>` and `>>`.** No pipes, no `&&`/`||`,
-  no background, no `;`. Anything else falls through.
-- **A `safeBash` tool, not a handler on `std::bash`.** A tool keeps `bash()`
-  honest — it always runs bash — and makes the behavior opt-in per agent and
-  easy to test.
-- **Words that need shell evaluation: expand `$VAR` from the environment,
-  refuse the rest.** Command substitution, arithmetic expansion and globs are
-  unmapped.
-- **`echo` maps to `print`** (`stdlib/index.agency:53`), which raises no
-  interrupt, so it costs nothing. `echo … > f` maps to `write`.
-- **Return `ExecResult`-shaped output** whichever path runs. The agent should
-  not be able to tell which, except by the absence of a prompt.
-
-## The lowered shape
+Every command is first translated into an **`Action`** — a plain data object
+saying what should happen, with nothing having happened yet:
 
 ```ts
-type OutputRedirect = { op: string, path: string }
-type Cmd = { words: string[], redirect: OutputRedirect | null }
+type Action = PrintAction | WriteFileAction | GitAction | BashAction
 ```
 
-The parser's AST is deeply nested — `list` → `listItem` → `andOr` → `pipeline`
-→ `simpleCommand` → `word` → parts — and matching on it directly is
-unreadable. `simplify` collapses that to the two fields above;
-`stringifyWordPart` collapses a word's parts to one string.
+`makeAction` turns one parsed command into an `Action` and does nothing else.
+`runAction` takes an `Action` and does it. All the interesting decisions —
+which tool answers this command, what its arguments mean, whether a flag
+changes the answer — live in `makeAction`, which has no effects at all.
 
-Named `OutputRedirect` rather than `Redirect` because the AST already has a
-`Redirect` node and the two are different things.
+That split is why the module is testable. A test hands in a string and
+looks at the actions that come out:
 
-## Refusals are by name
+```
+makeActions("echo hi; ls -la")
+  → [ { type: "print", content: "hi\n" },
+      { type: "bash", command: "ls -la", cwd: "" } ]
+```
 
-Every shape v1 cannot collapse to a word list is refused with its own message:
+Nothing ran, no approval was raised, and the assertion is on the decision
+rather than on its output. `makeActions` is the whole deciding half of the
+module in one call.
 
-| input | refusal |
-|---|---|
-| `cat a.txt \| grep x` | pipelines are not handled |
-| `a && b` | `` `&&` and `\|\|` are not handled `` |
-| `sleep 1 &` | background commands are not handled |
-| `FOO=1 echo hi` | leading variable assignments are not handled |
-| `echo $(date)` | `commandSubstitution` needs a shell to evaluate |
-| `echo hi 2>&1` | redirect with an explicit file descriptor |
-| `echo a; echo b` | expected a single command |
+One caveat worth knowing: for a `&&` or `||` chain, `makeActions` lists the
+actions for **both** sides. It reports what each command would do, not what
+will actually run, because which side runs is decided at run time by the
+exit status. That is right for testing and wrong for previewing; if a
+preview use ever appears it needs its own function.
 
-A fallthrough should be explainable, not mysterious. Refusing costs an
-approval — which is what happened before safeBash existed. Guessing would cost
-correctness.
+## bash is an action too
+
+The fallback is a `BashAction`, so a command with no mapping is a decision
+rather than a hole in the model. It carries the command **re-rendered from
+its own AST**, not the caller's original string. That matters in a
+sequence: if the second of three commands falls back, bash must be handed
+the second command, not all three.
+
+This is also what makes the failure story below coherent. In v1 a command
+that could not be mapped was a failure that fell back to bash. Once a
+sequence is running, "fall back" has no meaning — some commands have
+already had their effects, and re-running the whole string would repeat
+them. Making bash an action means falling back is a decision taken per
+command, before anything runs.
+
+## Falling back is not the same as refusing
+
+Two different things happen to a command safeBash will not map, and the
+distinction is worth keeping straight:
+
+- **Falling back** — the command is understood but has no better tool.
+  It becomes a `BashAction` and still runs, with the approval that implies.
+  `ls`, `FOO=1 echo hi`, `echo -n hi`, `git log --graph`.
+- **Refusing** — `makeAction` cannot produce any action at all. This
+  should be rare, and today only happens when a command cannot be rendered
+  back to bash source, which would leave nothing to run.
+
+Unparseable input is a third case, handled a level up: `safeBash` hands the
+whole original string to bash, because nothing has run yet and repeating
+nothing is safe.
 
 ## Word splitting
 
@@ -93,108 +118,187 @@ cat $F      # TWO arguments to bash
 cat "$F"    # one
 ```
 
-An unquoted expansion whose value contains whitespace is **refused**, not
-expanded. Expanding it without splitting would make safeBash and bash disagree
-about what a command means, which is the one failure mode this feature must
-not have. Inside double quotes no splitting applies, so it expands normally.
+An unquoted expansion whose value contains whitespace falls back rather
+than being expanded. Expanding it without splitting would make safeBash and
+bash disagree about what a command means, which is the one failure mode
+this feature must not have. Inside double quotes no splitting applies, so
+it expands normally.
 
 Unset is the empty string, as in bash.
+
+### Empty is a whole-word question
+
+An unquoted expansion that comes out **empty** produces zero arguments in
+bash, where treating it as `""` would produce one argument bash never
+passed. The check belongs to the whole word, not to each expansion inside
+it, and quoting is what decides:
+
+| written | bash passes | safeBash |
+|---|---|---|
+| `echo $A` (unset) | no argument | falls back |
+| `echo $A$B` (both unset) | no argument | falls back |
+| `echo $A/bin` (unset) | `/bin` | maps |
+| `echo "$A"` (unset) | one empty argument | maps |
+| `echo ""` | one empty argument | maps |
+
+The `$A$B` row is why the check cannot live inside the expansion: each half
+is legitimately empty, and only the concatenated word is. v1 checked each
+expansion and got this row wrong.
+
+## Flags
+
+The parser now returns flags as structured nodes (`{ tag: "flag",
+flagName, flagValue }`) rather than as literal text, and `makeAction`
+matches on them rather than around them. Both directions matter:
+
+- `git diff --staged` is a **different tool call** from `git diff`. A rule
+  that dropped the flag would answer one question with the other.
+- `echo -n hi` is **not** `echo hi` — `-n` drops the trailing newline and
+  `-e` interprets backslash escapes. A rule that treated the flag as text
+  would print `-n hi`, which bash never does.
+
+The standing rule is to fall back on any flag not explicitly translated. A
+fallback costs an approval; a wrong translation costs correctness.
+
+## Failure in a sequence
+
+`runCommands` stops at the first failing command and reports, in one
+message to the model:
+
+- which command failed, and why
+- the commands that already ran
+- the output so far
+- the commands that never ran
+
+The unrun commands are rendered back to bash source with `astToBash`, since
+by that point they are `Command` objects rather than strings. Telling the
+model exactly how far it got is what replaces v1's "fall back to bash",
+which cannot work once part of a sequence has already happened.
+
+`&&` and `||` short-circuit as bash does, and both are one precedence
+level, left-associative: `a || b && c` is `((a || b) && c)`. An `||` whose
+two sides both fail reports both messages — a report naming only the second
+would hide why the first was tried.
 
 ## Not wired in
 
 `shellTools()` (`stdlib/agents/lib/toolkits.agency:91`) is untouched. No
-agent's tool list changes, so nothing regresses, and v1 asks only "does the
-machinery work".
+agent's tool list changes, so nothing regresses.
 
 Whether to trust it in the approval path is a different question and deserves
 its own review with the risk in isolation. It is a one-line change to
 `shellTools()` when we want it.
 
+One thing that review should settle: when `echo hi > f` maps, the approval
+the user sees is `std::write`, not `std::bash`. That is the intended trade
+— a narrower, more informative gate — but it does mean the effect being
+approved depends on a decision safeBash made, and a user who has approved
+all writes has implicitly approved a class of redirects.
+
 ## Next: the command table
 
-`echo` is the whole table today. The intended shape, to be confirmed per
-command against the actual tool signature:
+Mapped today: `echo` (to `print`, or to `write` when redirected), and
+`git status` / `git diff` / `git diff --staged` / `git log`.
+
+The intended shape for the rest, to be confirmed per command against the
+actual tool signature:
 
 | command | tool | notes |
 |---|---|---|
-| `echo …` | `print` | no interrupt at all |
-| `echo … > f` / `>> f` | `write` | overwrite / append |
 | `cat f` | `read` | single file only |
 | `ls [dir]` | `ls` | |
 | `grep pat files` | `grep` | flag translation needed |
 | `find . -name g` | `glob` | narrow subset |
-| `git status\|log\|diff\|show\|…` | `gitStatus` etc. | `std::git` has one tool per subcommand |
+| `git show` / `git blame` / … | `gitShow` etc. | one tool per subcommand |
 | `curl url` | `fetch` | |
 
-**Flags are the hard part, not the verb.** `ls -la`, `grep -ri` and
-`git log --oneline -n 5` each need a decision about which flags are
-representable and what to do with the rest. Default to refusing on any
-unrecognized flag: a refusal costs an approval, a wrong translation costs
-correctness.
+Flags are still the work, but less of it than v1 expected: they arrive
+already parsed, with `--name=value` split for us, so what is left is
+deciding which ones are representable rather than parsing them first.
+
+A redirected command is a separate decision per verb. `echo … > f` maps
+because writing text to a file is what `write` does. `git status > f` falls
+back, because the git tools return a structured result to us rather than to
+a file, and honouring `>` would mean inventing a serialization bash never
+produces.
 
 ## Open questions
 
-- **Shape lock-in.** `Cmd` and `simplify` are this module's public API. If the
-  shape turns out wrong once real rules exist, changing it is a breaking
-  change to a shipped stdlib module. Sanity-checked against the table above on
-  paper and it holds; the first real rule is the test of that.
 - **Does a rewritten command get reported to the user?** Silently running
-  something other than what was asked for is the kind of thing that should be
-  observable. Leaning yes, via `whatIAmDoing`.
+  something other than what was asked for is the kind of thing that should
+  be observable. Leaning yes, via `whatIAmDoing`. The `Action` makes this
+  easier than it was — it is a data object that can be rendered.
 - **Does `safeBash` keep the name `bash` when handed to the LLM?** Renaming
   changes what the model writes.
 - **Should the coding agent's prompt change once this exists?** Probably not —
   safeBash is a safety net, not a license to write bash.
 
-## Parser gaps (separate from this module)
+### Settled since v1
 
-Two of the review findings are arguably the bash parser's, not safeBash's. The
-AST records what was *written* but not the shell's intent to *transform* it,
-so a consumer has to re-derive that by scanning literal text:
+- **Shape lock-in.** v1 flagged `Cmd` as a possible mistake whose test would
+  be the first real change. The parser rewrite was that change, and the
+  answer was to stop reducing to a record and produce an `Action` instead.
+  `Action` is a better thing to freeze: it is what the module is *for*,
+  where `Cmd` was an intermediate step that happened to be public.
 
-- **No node for glob patterns.** `echo *` arrives as `literal "*"`,
-  indistinguishable from ordinary text except by scanning for `*`, `?` and
-  `[`. safeBash now does that scan, which works — the parser does keep quoted
-  and unquoted parts separate within a word, so `"a"*` is
-  `[doubleQuoted "a", literal "*"]` and only the unquoted part is checked —
-  but every consumer that wants "would bash expand this?" has to reimplement
-  it. A `{ tag: "glob", pattern }` part would make it structural.
-- **No node for tilde expansion.** `~/d` arrives as `literal "~/d"`. Same
-  argument, plus tilde has a position rule (only at the start of a word) that
-  a consumer has to know.
+## Parser gaps: resolved
 
-Neither blocks v1 — the scan is correct today. They are noted because the
-workaround is a text scan for shell metacharacters, which is exactly the kind
-of thing that goes subtly wrong as coverage grows.
+v1 recorded two gaps in the bash parser — no node for glob patterns and
+none for tilde expansion — which forced safeBash to scan literal text for
+`*`, `?`, `[` and a leading `~` to work out what bash would rewrite.
 
-## Two more found while building
+The rewritten parser **rejects** both outright rather than emitting a
+literal indistinguishable from ordinary text, so the scan is gone. The same
+is true of command substitution, arithmetic expansion, pipelines,
+background commands and `2>&1`. Rejecting is the right answer for a parser
+whose consumers must never act on a wrong parse.
 
-Both pre-existing, both first hit by this file because nothing in stdlib had
-these shapes before.
-
-- **A blank line between match arms fails to parse when lowering is off.**
-  Same file: `agency tc` accepts it, `agency fmt` rejects it with "expected
-  match cases of the form `value => expression`". The formatter parses
-  un-lowered, so a blank line between arms breaks the corpus round-trip gate.
-  Worked around by removing the blank lines; the parser should take them.
-- **A call inside a match-arm guard is invisible to the effects walk**
-  (#668, already recorded as a known walker gap). A call reachable only from a
-  guard contributes no effects, which matters because effects are how the
-  language reasons about what a function may do. Avoided here by refusing
-  flags before the match rather than in a guard on every arm — which reads
-  better anyway — rather than by widening the walker inside this PR.
+The cost is that four cases moved from "refused by safeBash with a specific
+message" to "unparseable". Both paths end at bash, so no command changes
+hands — only the reason reported.
 
 ## Found while building
 
-`item.command`, where the field is declared `AndOr`, resolves to the type
-*alias* named `Command` — so every access below it reports a missing property.
-Worked around with `any` on three locals, each commented. Reachable only when
-a field name matches a type name; worth its own issue.
+Language and tooling issues hit by this module, all pre-existing, recorded
+here rather than fixed in the same change.
+
+- **A match arm does not narrow the scrutinee.** Writing
+  `match (action) { { type: "print" } => printAction(action) … }` fails to
+  typecheck, because inside the arm `action` still has the full union type.
+  A chain of `if (action.type == "print")` narrows correctly. This affects
+  every discriminated-union dispatch, which is the common case for an AST.
+- **`if … then … else` cannot be an object field.** It is allowed only as a
+  variable initializer or a return, so building a record with one
+  conditional field needs a temporary, or two whole returns.
+- **A method cannot be called on a comprehension.** `[x for x in xs].join()`
+  does not parse; the comprehension has to be assigned first. (Already in
+  `TODO.md`.)
+- **A function's declared return type does not describe a rejected
+  interrupt.** `bash()` is declared to return `ExecResult`, but rejecting
+  its approval halts it and returns a `Failure`, which the declared type
+  cannot express — so correct code has to go through `any` to check for it.
+  This is a sharp edge: the obvious code typechecks, and crashes the first
+  time a human says no.
+- **The `Command` type-alias collision is gone.** v1 needed `any` on three
+  locals because a field named `command` resolved to the type alias
+  `Command` instead of the field's declared type. It no longer reproduces
+  on the new types.
+- **A blank line between match arms fails to parse when lowering is off.**
+  `agency tc` accepts it, `agency fmt` rejects it, so a blank line between
+  arms breaks the corpus round-trip gate. Still worked around by removing
+  the blank lines.
+- **A call inside a match-arm guard is invisible to the effects walk**
+  (a known walker gap, tracked as issue 668). A call reachable only from a
+  guard contributes no effects, which matters because effects are how the
+  language reasons about what a function may do. Still avoided here by
+  deciding before the match rather than in a guard on every arm.
 
 ## Related
 
 - `docs/site/guide/interrupts.md`, `handlers.md`, `effects.md`, `policies.md` —
   the approval machinery this works around.
 - `stdlib/shell.agency:133` — `bash()` and its interrupt.
+- `stdlib/safeBash/actions.agency` — the action types and the executors.
+- `tests/agency/safeBash.agency` — string in, actions out.
 - PRs #674, #676, #677, #695, #698, #700, #701 — the pattern-matching work that
   made the match table expressible.

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -5065,7 +5065,7 @@ const ifBranchExprParser: Parser<Expression> = (input: string) => {
   if (kw.success) {
     return failure(
       "a branch of `if ... then ... else` cannot itself be an `if` expression " +
-      "(this includes `else if`); use `match` for multi-way or nested branching",
+        "(this includes `else if`); use `match` for multi-way or nested branching",
       input,
     );
   }
@@ -5269,123 +5269,123 @@ export const comprehensionParser: Parser<Comprehension> = label(
       "comprehensionParser",
       map(
         seqC(
-          set("type", "comprehension"),
-          // The concurrency prefix, as a raw keyword; the map() below this
-          // seqC converts it to mode/shared via COMPREHENSION_PREFIXES.
-          // Ordering in the or() is load-bearing: LONGEST FIRST, or
-          // str("fork") would half-match the fork in forkShared and then
-          // die on the required whitespace.
-          capture(
-            map(
-              optional(
-                seqR(
-                  or(
-                    str("forkShared"),
-                    str("raceShared"),
-                    str("fork"),
-                    str("race"),
-                  ),
-                  spaces,
+        set("type", "comprehension"),
+        // The concurrency prefix, as a raw keyword; the map() below this
+        // seqC converts it to mode/shared via COMPREHENSION_PREFIXES.
+        // Ordering in the or() is load-bearing: LONGEST FIRST, or
+        // str("fork") would half-match the fork in forkShared and then
+        // die on the required whitespace.
+        capture(
+          map(
+            optional(
+              seqR(
+                or(
+                  str("forkShared"),
+                  str("raceShared"),
+                  str("fork"),
+                  str("race"),
                 ),
-              ),
-              // seqR returns ALL results as an array; the keyword is [0]
-              (r) => (r === null ? null : (r as unknown[])[0]),
-            ),
-            "prefix",
-          ),
-          char("["),
-          optionalSpacesOrNewline,
-          capture(
-            lazy(() => exprParser),
-            "expression",
-          ),
-          // `optionalSpacesOrNewline` BEFORE each keyword, required `spaces`
-          // AFTER. Before must be optional because exprParser eats trailing
-          // whitespace after a call (`f(x) ` leaves rest `for...`) but not
-          // after a bare name (`x ` leaves rest ` for...`) - requiring
-          // whitespace here broke every call-bodied comprehension. It must
-          // cross newlines (optionalSpaces is spaces/tabs only) or a
-          // comprehension could only break lines after a call, never before
-          // `in`/`if`. `for` stays a whole word via the not(varNameChar)
-          // boundary below: `[format, other]` fails at str("for") because
-          // exprParser greedily consumed the full identifier `format`, and
-          // `forx` fails the boundary.
-          optionalSpacesOrNewline,
-          str("for"),
-          // word boundary, not required whitespace: `[x for]` (an editor
-          // auto-closing a half-typed comprehension) must still reach the
-          // commit and get the binder message, while `forever` must fail
-          // here, BEFORE the commit, and fall through to the array rule
-          not(varNameChar),
-          // COMMIT POINT (#602). Once `[ expr for` has matched as a whole
-          // word, nothing but a comprehension attempt can be on the wire -
-          // arrays, strings containing the word for, and format-style
-          // identifiers all diverge earlier (pinned in
-          // comprehension.test.ts). So from here failures are hard,
-          // targeted parseError throws instead of a silent backtrack into
-          // the array parser, which used to swallow half-typed
-          // comprehensions.
-          captureCaptures(
-            parseError(
-              "expected a binder name or pattern after `for` in this list comprehension",
-              spaces,
-              ...iterationBinderFragment,
-            ),
-          ),
-          captureCaptures(
-            parseError(
-              "expected `in` after the list comprehension binder",
-              optionalSpacesOrNewline,
-              str("in"),
-              // word-bounded (the ifExpressionParser precedent), so
-              // `insomething` reports the missing `in` here instead of
-              // committing past it and blaming the iterable
-              not(varNameChar),
-            ),
-          ),
-          // the required whitespace after `in` lives with the iterable,
-          // so `[x for x in]` reports a missing iterable rather than
-          // blaming the `in` it already has
-          captureCaptures(
-            parseError(
-              "expected an iterable expression after `in` in this list comprehension",
-              spaces,
-              capture(
-                lazy(() => exprParser),
-                "iterable",
+                spaces,
               ),
             ),
+            // seqR returns ALL results as an array; the keyword is [0]
+            (r) => (r === null ? null : (r as unknown[])[0]),
           ),
-          optional(
-            captureCaptures(
-              seqC(
-                optionalSpacesOrNewline,
-                str("if"),
-                // word boundary: `iffy` is an identifier, not a filter
-                // keyword - it must fail here so the optional backtracks
-                // and the close-bracket commit reports instead
-                not(varNameChar),
-                // committed once `if` matched as a whole word: a filter
-                // keyword with no condition is a broken comprehension,
-                // not an array
-                captureCaptures(
-                  parseError(
-                    "expected a filter condition after `if` in this list comprehension",
-                    spaces,
-                    capture(
-                      lazy(() => exprParser),
-                      "condition",
-                    ),
-                  ),
-                ),
-              ),
-            ),
-          ),
+          "prefix",
+        ),
+        char("["),
+        optionalSpacesOrNewline,
+        capture(
+          lazy(() => exprParser),
+          "expression",
+        ),
+        // `optionalSpacesOrNewline` BEFORE each keyword, required `spaces`
+        // AFTER. Before must be optional because exprParser eats trailing
+        // whitespace after a call (`f(x) ` leaves rest `for...`) but not
+        // after a bare name (`x ` leaves rest ` for...`) - requiring
+        // whitespace here broke every call-bodied comprehension. It must
+        // cross newlines (optionalSpaces is spaces/tabs only) or a
+        // comprehension could only break lines after a call, never before
+        // `in`/`if`. `for` stays a whole word via the not(varNameChar)
+        // boundary below: `[format, other]` fails at str("for") because
+        // exprParser greedily consumed the full identifier `format`, and
+        // `forx` fails the boundary.
+        optionalSpacesOrNewline,
+        str("for"),
+        // word boundary, not required whitespace: `[x for]` (an editor
+        // auto-closing a half-typed comprehension) must still reach the
+        // commit and get the binder message, while `forever` must fail
+        // here, BEFORE the commit, and fall through to the array rule
+        not(varNameChar),
+        // COMMIT POINT (#602). Once `[ expr for` has matched as a whole
+        // word, nothing but a comprehension attempt can be on the wire -
+        // arrays, strings containing the word for, and format-style
+        // identifiers all diverge earlier (pinned in
+        // comprehension.test.ts). So from here failures are hard,
+        // targeted parseError throws instead of a silent backtrack into
+        // the array parser, which used to swallow half-typed
+        // comprehensions.
+        captureCaptures(
           parseError(
-            "expected `]` to close this list comprehension",
-            optionalSpacesOrNewline,
-            char("]"),
+            "expected a binder name or pattern after `for` in this list comprehension",
+            spaces,
+            ...iterationBinderFragment,
           ),
+        ),
+        captureCaptures(
+          parseError(
+            "expected `in` after the list comprehension binder",
+            optionalSpacesOrNewline,
+            str("in"),
+            // word-bounded (the ifExpressionParser precedent), so
+            // `insomething` reports the missing `in` here instead of
+            // committing past it and blaming the iterable
+            not(varNameChar),
+          ),
+        ),
+        // the required whitespace after `in` lives with the iterable,
+        // so `[x for x in]` reports a missing iterable rather than
+        // blaming the `in` it already has
+        captureCaptures(
+          parseError(
+            "expected an iterable expression after `in` in this list comprehension",
+            spaces,
+            capture(
+              lazy(() => exprParser),
+              "iterable",
+            ),
+          ),
+        ),
+        optional(
+          captureCaptures(
+            seqC(
+              optionalSpacesOrNewline,
+              str("if"),
+              // word boundary: `iffy` is an identifier, not a filter
+              // keyword - it must fail here so the optional backtracks
+              // and the close-bracket commit reports instead
+              not(varNameChar),
+              // committed once `if` matched as a whole word: a filter
+              // keyword with no condition is a broken comprehension,
+              // not an array
+              captureCaptures(
+                parseError(
+                  "expected a filter condition after `if` in this list comprehension",
+                  spaces,
+                  capture(
+                    lazy(() => exprParser),
+                    "condition",
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+        parseError(
+          "expected `]` to close this list comprehension",
+          optionalSpacesOrNewline,
+          char("]"),
+        ),
         ),
         // Convert the raw prefix keyword into mode/shared by table
         // lookup - one branch, the sequential case being a table row

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -5065,7 +5065,7 @@ const ifBranchExprParser: Parser<Expression> = (input: string) => {
   if (kw.success) {
     return failure(
       "a branch of `if ... then ... else` cannot itself be an `if` expression " +
-        "(this includes `else if`); use `match` for multi-way or nested branching",
+      "(this includes `else if`); use `match` for multi-way or nested branching",
       input,
     );
   }
@@ -5269,123 +5269,123 @@ export const comprehensionParser: Parser<Comprehension> = label(
       "comprehensionParser",
       map(
         seqC(
-        set("type", "comprehension"),
-        // The concurrency prefix, as a raw keyword; the map() below this
-        // seqC converts it to mode/shared via COMPREHENSION_PREFIXES.
-        // Ordering in the or() is load-bearing: LONGEST FIRST, or
-        // str("fork") would half-match the fork in forkShared and then
-        // die on the required whitespace.
-        capture(
-          map(
-            optional(
-              seqR(
-                or(
-                  str("forkShared"),
-                  str("raceShared"),
-                  str("fork"),
-                  str("race"),
+          set("type", "comprehension"),
+          // The concurrency prefix, as a raw keyword; the map() below this
+          // seqC converts it to mode/shared via COMPREHENSION_PREFIXES.
+          // Ordering in the or() is load-bearing: LONGEST FIRST, or
+          // str("fork") would half-match the fork in forkShared and then
+          // die on the required whitespace.
+          capture(
+            map(
+              optional(
+                seqR(
+                  or(
+                    str("forkShared"),
+                    str("raceShared"),
+                    str("fork"),
+                    str("race"),
+                  ),
+                  spaces,
                 ),
-                spaces,
+              ),
+              // seqR returns ALL results as an array; the keyword is [0]
+              (r) => (r === null ? null : (r as unknown[])[0]),
+            ),
+            "prefix",
+          ),
+          char("["),
+          optionalSpacesOrNewline,
+          capture(
+            lazy(() => exprParser),
+            "expression",
+          ),
+          // `optionalSpacesOrNewline` BEFORE each keyword, required `spaces`
+          // AFTER. Before must be optional because exprParser eats trailing
+          // whitespace after a call (`f(x) ` leaves rest `for...`) but not
+          // after a bare name (`x ` leaves rest ` for...`) - requiring
+          // whitespace here broke every call-bodied comprehension. It must
+          // cross newlines (optionalSpaces is spaces/tabs only) or a
+          // comprehension could only break lines after a call, never before
+          // `in`/`if`. `for` stays a whole word via the not(varNameChar)
+          // boundary below: `[format, other]` fails at str("for") because
+          // exprParser greedily consumed the full identifier `format`, and
+          // `forx` fails the boundary.
+          optionalSpacesOrNewline,
+          str("for"),
+          // word boundary, not required whitespace: `[x for]` (an editor
+          // auto-closing a half-typed comprehension) must still reach the
+          // commit and get the binder message, while `forever` must fail
+          // here, BEFORE the commit, and fall through to the array rule
+          not(varNameChar),
+          // COMMIT POINT (#602). Once `[ expr for` has matched as a whole
+          // word, nothing but a comprehension attempt can be on the wire -
+          // arrays, strings containing the word for, and format-style
+          // identifiers all diverge earlier (pinned in
+          // comprehension.test.ts). So from here failures are hard,
+          // targeted parseError throws instead of a silent backtrack into
+          // the array parser, which used to swallow half-typed
+          // comprehensions.
+          captureCaptures(
+            parseError(
+              "expected a binder name or pattern after `for` in this list comprehension",
+              spaces,
+              ...iterationBinderFragment,
+            ),
+          ),
+          captureCaptures(
+            parseError(
+              "expected `in` after the list comprehension binder",
+              optionalSpacesOrNewline,
+              str("in"),
+              // word-bounded (the ifExpressionParser precedent), so
+              // `insomething` reports the missing `in` here instead of
+              // committing past it and blaming the iterable
+              not(varNameChar),
+            ),
+          ),
+          // the required whitespace after `in` lives with the iterable,
+          // so `[x for x in]` reports a missing iterable rather than
+          // blaming the `in` it already has
+          captureCaptures(
+            parseError(
+              "expected an iterable expression after `in` in this list comprehension",
+              spaces,
+              capture(
+                lazy(() => exprParser),
+                "iterable",
               ),
             ),
-            // seqR returns ALL results as an array; the keyword is [0]
-            (r) => (r === null ? null : (r as unknown[])[0]),
           ),
-          "prefix",
-        ),
-        char("["),
-        optionalSpacesOrNewline,
-        capture(
-          lazy(() => exprParser),
-          "expression",
-        ),
-        // `optionalSpacesOrNewline` BEFORE each keyword, required `spaces`
-        // AFTER. Before must be optional because exprParser eats trailing
-        // whitespace after a call (`f(x) ` leaves rest `for...`) but not
-        // after a bare name (`x ` leaves rest ` for...`) - requiring
-        // whitespace here broke every call-bodied comprehension. It must
-        // cross newlines (optionalSpaces is spaces/tabs only) or a
-        // comprehension could only break lines after a call, never before
-        // `in`/`if`. `for` stays a whole word via the not(varNameChar)
-        // boundary below: `[format, other]` fails at str("for") because
-        // exprParser greedily consumed the full identifier `format`, and
-        // `forx` fails the boundary.
-        optionalSpacesOrNewline,
-        str("for"),
-        // word boundary, not required whitespace: `[x for]` (an editor
-        // auto-closing a half-typed comprehension) must still reach the
-        // commit and get the binder message, while `forever` must fail
-        // here, BEFORE the commit, and fall through to the array rule
-        not(varNameChar),
-        // COMMIT POINT (#602). Once `[ expr for` has matched as a whole
-        // word, nothing but a comprehension attempt can be on the wire -
-        // arrays, strings containing the word for, and format-style
-        // identifiers all diverge earlier (pinned in
-        // comprehension.test.ts). So from here failures are hard,
-        // targeted parseError throws instead of a silent backtrack into
-        // the array parser, which used to swallow half-typed
-        // comprehensions.
-        captureCaptures(
-          parseError(
-            "expected a binder name or pattern after `for` in this list comprehension",
-            spaces,
-            ...iterationBinderFragment,
-          ),
-        ),
-        captureCaptures(
-          parseError(
-            "expected `in` after the list comprehension binder",
-            optionalSpacesOrNewline,
-            str("in"),
-            // word-bounded (the ifExpressionParser precedent), so
-            // `insomething` reports the missing `in` here instead of
-            // committing past it and blaming the iterable
-            not(varNameChar),
-          ),
-        ),
-        // the required whitespace after `in` lives with the iterable,
-        // so `[x for x in]` reports a missing iterable rather than
-        // blaming the `in` it already has
-        captureCaptures(
-          parseError(
-            "expected an iterable expression after `in` in this list comprehension",
-            spaces,
-            capture(
-              lazy(() => exprParser),
-              "iterable",
-            ),
-          ),
-        ),
-        optional(
-          captureCaptures(
-            seqC(
-              optionalSpacesOrNewline,
-              str("if"),
-              // word boundary: `iffy` is an identifier, not a filter
-              // keyword - it must fail here so the optional backtracks
-              // and the close-bracket commit reports instead
-              not(varNameChar),
-              // committed once `if` matched as a whole word: a filter
-              // keyword with no condition is a broken comprehension,
-              // not an array
-              captureCaptures(
-                parseError(
-                  "expected a filter condition after `if` in this list comprehension",
-                  spaces,
-                  capture(
-                    lazy(() => exprParser),
-                    "condition",
+          optional(
+            captureCaptures(
+              seqC(
+                optionalSpacesOrNewline,
+                str("if"),
+                // word boundary: `iffy` is an identifier, not a filter
+                // keyword - it must fail here so the optional backtracks
+                // and the close-bracket commit reports instead
+                not(varNameChar),
+                // committed once `if` matched as a whole word: a filter
+                // keyword with no condition is a broken comprehension,
+                // not an array
+                captureCaptures(
+                  parseError(
+                    "expected a filter condition after `if` in this list comprehension",
+                    spaces,
+                    capture(
+                      lazy(() => exprParser),
+                      "condition",
+                    ),
                   ),
                 ),
               ),
             ),
           ),
-        ),
-        parseError(
-          "expected `]` to close this list comprehension",
-          optionalSpacesOrNewline,
-          char("]"),
-        ),
+          parseError(
+            "expected `]` to close this list comprehension",
+            optionalSpacesOrNewline,
+            char("]"),
+          ),
         ),
         // Convert the raw prefix keyword into mode/shared by table
         // lookup - one branch, the sequential case being a table row

--- a/packages/agency-lang/lib/stdlib/safeBash.ts
+++ b/packages/agency-lang/lib/stdlib/safeBash.ts
@@ -1,1 +1,1 @@
-export { bashParser as _bashParser } from "tarsec/parsers/bash";
+export { bashParser as _bashParser, astToBash as _astToBash } from "tarsec/parsers/bash";

--- a/packages/agency-lang/lib/utils/expressionSlots.test.ts
+++ b/packages/agency-lang/lib/utils/expressionSlots.test.ts
@@ -377,6 +377,12 @@ const WALKER_EXCLUDED_FIELDS: Record<string, string> = {
     "copy flows through the hoisted temp assignment, which is walked",
   "objectPatternProperty.value":
     "pattern property content: a literal matcher or a binder, not a use",
+  "arrayPattern.elements":
+    "array-pattern content: every element is a literal matcher, a binder, or a nested " +
+    "pattern — a match arm cannot compare against an outer name, so nothing here is a " +
+    "use. Same ruling as objectPatternProperty.value, and reached first by a match on " +
+    "an array pattern (`[\"git\", \"diff\"] => ...`) rather than by a destructuring " +
+    "declaration, whose pattern is already shielded by assignment.pattern",
   "typePattern.pattern": "type-pattern binder, not a use",
   "codeLiteral.nodes":
     "quoted code: names belong to the generated program, not the host scope; " +

--- a/packages/agency-lang/package.json
+++ b/packages/agency-lang/package.json
@@ -105,7 +105,7 @@
     "picomatch": "^4.0.4",
     "prompts": "^2.4.2",
     "smoltalk": "^0.8.4",
-    "tarsec": "0.5.2",
+    "tarsec": "0.5.3",
     "typestache": "^0.5.0",
     "vscode-languageserver": "^9.0.1",
     "vscode-languageserver-protocol": "^3.17.5",

--- a/packages/agency-lang/stdlib/safeBash.agency
+++ b/packages/agency-lang/stdlib/safeBash.agency
@@ -370,7 +370,15 @@ export def runCommand(command: Command): Result<string> {
 }
 
 export def commandsToStr(command: Command[]): string {
-  return "not implemented"
+  const results: string[] = []
+  for (command in command) {
+    const result = try _astToBash(command)
+    match(result) {
+      success(text) => results.push(text)
+      failure(err) => results.push(err)
+    }
+  }
+  return results.join("\n")
 }
 
 export def runCommands(commands: Command[]): Result<string> {

--- a/packages/agency-lang/stdlib/safeBash.agency
+++ b/packages/agency-lang/stdlib/safeBash.agency
@@ -1,178 +1,124 @@
-import { _bashParser } from "agency-lang/stdlib-lib/safeBash.js"
-import { env } from "std::system"
 import { WriteMode } from "std::index"
 import { bash, ExecResult } from "std::shell"
+import { env } from "std::system"
 
-/** One piece of a word. Adjacent parts concatenate: `e'f'"g"$h` is a single
- * word of four parts. */
-export type WordPart =
-  | { tag: "literal"; text: string }
-  | { tag: "singleQuoted"; text: string }
-  | { tag: "doubleQuoted"; parts: WordPart[] }
-  | { tag: "variable"; name: string }
-  | { tag: "paramExpansion"; expression: string }
-  | { tag: "commandSubstitution"; command: List }
-  | { tag: "arithmeticExpansion"; expression: string }
+import { _bashParser } from "agency-lang/stdlib-lib/safeBash.js"
 
-export type BashWord = {
-  tag: "word";
-  parts: WordPart[]
+export type Word =
+  | LiteralWord
+  | PathWord
+  | FlagWord
+  | SingleQuotedWord
+  | DoubleQuotedWord
+  | VariableWord
+  | InterpolatedVariableWord
+
+export type ScriptName = LiteralWord | PathWord
+
+export type LiteralWord = {
+  tag: "literal";
+  text: string
+}
+
+export type PathWord = {
+  tag: "path";
+  text: string
+}
+
+export type FlagWord = {
+  tag: "flag";
+  flagName: string;
+  flagValue?: string
+}
+
+export type SingleQuotedWord = {
+  tag: "singleQuoted";
+  text: string
+}
+
+export type DoubleQuotedWord = {
+  tag: "doubleQuoted";
+  parts: Word[]
+}
+
+export type VariableWord = {
+  tag: "variable";
+  name: string
+}
+
+/** A word built from two or more adjacent parts: `$HOME.txt`, `"a"b`,
+ * `"$HOME"/x`. These are ONE word in bash; split into separate words they
+ * become separate arguments and the command means something else.
+ */
+export type InterpolatedVariableWord = {
+  tag: "interpolatedVariable";
+  parts: (
+  | LiteralWord
+  | VariableWord
+  | SingleQuotedWord
+  | DoubleQuotedWord)[]
 }
 
 /** `name=value` (or `name=` with a null value) before a command. */
 export type Assignment = {
   tag: "assignment";
   name: string;
-  value?: BashWord
+  value?: Word
 }
 
-/** A redirect like `> out.txt`, `2>&1`, or `<<< "$str"`. `fd` is the
- * explicit file descriptor (`2` in `2>`), or null for the default. */
+/** A redirect like `> out.txt`, `>> log`, `2> err.txt` or `< in.txt`.
+ * `fd` is the explicit file descriptor (`2` in `2>`), or undefined for the
+ * default. Only `>`, `>>`, `<` and `&>` are recognized; `2>&1`, heredocs
+ * and here-strings are rejected rather than parsed. */
 export type Redirect = {
   tag: "redirect";
   fd?: number;
   op: string;
-  target: BashWord
+  target: Word
 }
 
 export type SimpleCommand = {
   tag: "simpleCommand";
   assignments: Assignment[];
-  words: BashWord[];
+  /* The command name, or null for an assignment-only line (`FOO=bar`).
+   *  Bash requires at least one of a command name or an assignment. */
+  command?: ScriptName;
+  /** Every word after the command name, in source order. There is no
+   *  `subcommands` field: no syntactic rule separates `git status` from
+   *  `echo status`, so splitting them would put a command's real
+   *  arguments in whichever bucket the preceding word happened to pick. */
+  args: Word[];
   redirects: Redirect[]
 }
 
-export type IfCommand = {
-  tag: "if";
-  cond: List;
-  thenBody: List;
-  elifs: { cond: List; thenBody: List }[];
-  elseBody?: List;
-  redirects: Redirect[]
+export type Command = SimpleCommand | And | Or | Parens
+
+export type And = {
+  tag: "and";
+  left: Command;
+  right: Command
 }
 
-export type LoopCommand = {
-  tag: "loop";
-  kind: "while" | "until";
-  cond: List;
-  body: List;
-  redirects: Redirect[]
+export type Or = {
+  tag: "or";
+  left: Command;
+  right: Command
 }
 
-export type ForCommand = {
-  tag: "for";
-  variable: string;
-  /** The `in word...` list, or null for the implicit `in "$@"`. */
-  words?: BashWord[];
-  body: List;
-  redirects: Redirect[]
-}
-
-export type CaseItem = {
-  patterns: BashWord[];
-  body: List;
-  /** `;;`, `;&`, `;;&`, or null when the final item ends at `esac`. */
-  terminator?: string
-}
-
-export type CaseCommand = {
-  tag: "case";
-  subject: BashWord;
-  items: CaseItem[];
-  redirects: Redirect[]
-}
-
-export type Subshell = {
-  tag: "subshell";
-  body: List;
-  redirects: Redirect[]
-}
-
-export type Group = {
-  tag: "group";
-  body: List;
-  redirects: Redirect[]
-}
-
-/** `(( expression ))` as a command. The expression is kept as raw text. */
-export type ArithmeticCommand = {
-  tag: "arithmeticCommand";
-  expression: string;
-  redirects: Redirect[]
-}
-
-export type FunctionDef = {
-  tag: "functionDef";
-  name: string;
-  body: Command
-}
-
-export type Command =
-  | SimpleCommand
-  | IfCommand
-  | LoopCommand
-  | ForCommand
-  | CaseCommand
-  | Subshell
-  | Group
-  | ArithmeticCommand
-  | FunctionDef
-
-/** One or more commands joined by `|` (or `|&`), optionally negated. */
-export type Pipeline = {
-  tag: "pipeline";
-  negated: boolean;
-  commands: Command[]
-}
-
-/** Pipelines joined by `&&` / `||`, left to right. */
-export type AndOr = {
-  tag: "andOr";
-  first: Pipeline;
-  rest: { op: "&&" | "||"; pipeline: Pipeline }[]
-}
-
-export type ListItem = {
-  tag: "listItem";
-  command: Command;
-  /** True when the command was followed by `&`. */
-  background: boolean
-}
-
-/** A sequence of commands separated by `;`, `&`, or newlines — the top
- * level of a script, and the body of every compound command. */
-export type List = {
-  tag: "list";
-  items: ListItem[]
-}
-
-export static const emptyList: List = {
-  tag: "list",
-  items: []
+export type Parens = {
+  tag: "parens";
+  command: Command
 }
 
 export type BashNode =
-  | WordPart
-  | BashWord
+  | Command
+  | SimpleCommand
   | Assignment
   | Redirect
-  | Command
-  | Pipeline
-  | AndOr
-  | ListItem
-  | List
+  | Word
+  | ScriptName
 
-
-/** A bash command reduced to the only shape v1 can reason about: the words of a single command, and an optional output redirect. */
-export type OutputRedirect = {
-  op: string;
-  path: string
-}
-
-export type Cmd = {
-  words: string[];
-  redirect: OutputRedirect | null
-}
+export type BashAST = Command[]
 
 export def bashParser(code: string): Result<List> {
   """
@@ -194,7 +140,7 @@ def stringifyWordPart(part: WordPart, insideQuotes: boolean): Result<string> {
   because guessing at it is how safeBash and bash would come to disagree
   about what a command means.
   """
-  return match (part) {
+  return match(part) {
     { tag: "literal", text } => literalWord(text, insideQuotes)
     { tag: "singleQuoted", text } => success(text)
     { tag: "doubleQuoted", parts } => stringifyParts(parts, true)
@@ -294,7 +240,10 @@ def simplifyRedirects(redirects: Redirect[]): Result<OutputRedirect | null> {
   }
   const path = stringifyWord(only.target)
   if (path is success(text)) {
-    return success({ op: only.op, path: text })
+    return success({
+      op: only.op,
+      path: text
+    })
   }
   return failure("redirect target: ${path.error}")
 }
@@ -361,7 +310,10 @@ export def simplify(node: List): Result<Cmd> {
 
   const redirect = simplifyRedirects(cmd.redirects)
   if (redirect is success(only)) {
-    return success({ words: words, redirect: only })
+    return success({
+      words: words,
+      redirect: only
+    })
   }
   return failure("could not read the redirect: ${redirect.error}")
 }
@@ -370,7 +322,11 @@ def ok(stdout: string): ExecResult {
   """
   A successful result in the shape `bash` would have returned.
   """
-  return { stdout: stdout, stderr: "", exitCode: 0 }
+  return {
+    stdout: stdout,
+    stderr: "",
+    exitCode: 0
+  }
 }
 
 export def safeBash(command: string, cwd: string = ""): ExecResult {
@@ -401,7 +357,7 @@ export def safeBash(command: string, cwd: string = ""): ExecResult {
       if (hasFlags(cmd.words)) {
         return bash(command, cwd)
       }
-      return match (cmd) {
+      return match(cmd) {
         // `echo` has no side effect beyond its output, so there is nothing to
         // approve: print it and report what bash wrote to stdout.
         { words: ["echo", ...rest], redirect: null } => ok(joinWords(rest))
@@ -442,7 +398,13 @@ def joinWords(words: string[]): string {
   return words.join(" ") + "\n"
 }
 
-def writeThrough(path: string, content: string, mode: WriteMode, original: string, cwd: string): ExecResult {
+def writeThrough(
+  path: string,
+  content: string,
+  mode: WriteMode,
+  original: string,
+  cwd: string,
+): ExecResult {
   """
   Write the file, falling back to bash if the write itself fails so a refusal
   never silently swallows the command.
@@ -465,4 +427,3 @@ def writeThrough(path: string, content: string, mode: WriteMode, original: strin
   }
   return ok("")
 }
-

--- a/packages/agency-lang/stdlib/safeBash.agency
+++ b/packages/agency-lang/stdlib/safeBash.agency
@@ -1,8 +1,18 @@
 import { WriteMode } from "std::index"
 import { bash, ExecResult } from "std::shell"
-import { env } from "std::system"
+import { env, setEnv } from "std::system"
 
+import {
+  Action,
+  printAction,
+  writeAction,
+  gitStatusAction,
+  gitDiffAction,
+  gitLogAction,
+ } from "./safeBash/actions.agency"
 import { _bashParser } from "agency-lang/stdlib-lib/safeBash.js"
+
+export static const MAX_STDOUT_LEN = 2000
 
 export type Word =
   | LiteralWord
@@ -146,28 +156,22 @@ export def bashParser(code: string): Result<BashAST> {
 
 def stringifyWord(
   word: Word,
-  insideQuotes: boolean,
-  isWholeWord: boolean,
+  insideQuotes: boolean = false,
+  isWholeWord: boolean = true,
 ): Result<string> {
   """
   Reduce a word to text, or explain why it cannot be.
 
-  Only the words that are already text, or that the environment can answer,
-  are resolvable. Anything that would need a shell to evaluate is a failure,
-  because guessing at it is how safeBash and bash would come to disagree
-  about what a command means.
-
   The parser refuses globs, tilde, command substitution and arithmetic
-  outright, so they never arrive here — what is left to decide is what a
-  variable expands to, and whether bash would have split the result.
+  outright, so they never arrive here.
   """
   return match(word) {
     { tag: "literal", text } => success(text)
     { tag: "path", text } => success(text)
     { tag: "singleQuoted", text } => success(text)
-    { tag: "doubleQuoted", parts } => stringifyParts(parts, true, false)
+    { tag: "doubleQuoted", parts } => stringifyParts(parts, insideQuotes: true, isWholeWord: false)
     { tag: "variable", name } => expandVariable(name, insideQuotes, isWholeWord)
-    { tag: "interpolatedVariable", parts } => stringifyParts(parts, insideQuotes, false)
+    { tag: "interpolatedVariable", parts } => stringifyParts(parts, insideQuotes: insideQuotes, isWholeWord: false)
     _ => failure("`${word.tag}` cannot be reduced to text")
   }
 }
@@ -179,23 +183,16 @@ def expandVariable(
 ): Result<string> {
   """
   Look a variable up in the environment. Unset is the empty string, as in bash.
-
-  An UNQUOTED value containing whitespace is refused rather than expanded:
-  bash word-splits it, so `cat $F` with `F="a b"` is two arguments, and
-  expanding it here without splitting would quietly change what the command
-  means. Inside double quotes no splitting happens, so it expands normally.
   """
   const value = env(name) ?? ""
   if (insideQuotes) {
     return success(value)
   }
-  // Default IFS is space, TAB and NEWLINE — not just space.
+
   if (value.includes(" ") || value.includes("\t") || value.includes("\n")) {
     return failure("unquoted `${name}` contains whitespace; bash would word-split it")
   }
-  // An unquoted empty expansion produces ZERO words in bash, where this would
-  // produce one empty one — an argument bash never passed. Only when the
-  // variable IS the word: `$EMPTY/bin` is `/bin`, one word, not none.
+
   if (value == "" && isWholeWord) {
     return failure("unquoted `${name}` is empty; bash would pass no argument at all")
   }
@@ -255,24 +252,24 @@ def simplifyRedirects(redirects: Redirect[]): Result<OutputRedirect | null> {
 def hasFlags(args: Word[]): boolean {
   """
   True when any argument is a flag.
-
-  `echo -n` suppresses the trailing newline and `echo -e` interprets escapes;
-  `joinWords` does neither, so mapping those would produce different output
-  than bash. A flag also has no faithful text form to put in `args` — the
-  parser splits `--format=oneline` into a name and a value, and re-joining
-  them is a guess about a syntax that varies per command. Anything with a
-  flag falls through and costs an approval, which is the trade this module
-  makes everywhere else.
   """
-  for (arg in args) {
-    if (arg.tag == "flag") {
-      return true
-    }
-  }
-  return false
+  return some(args, \a -> a.tag == "flag")
 }
 
-export def simplify(ast: BashAST): Result<Cmd> {
+def tempSetEnv(newEnv: Record<string, string>, block: any) {
+  const oldEnv = {}
+  for (key, value in newEnv) {
+    oldEnv[key] = env(key)
+    setEnv(key, value) with approve
+  }
+  const result = block()
+  for (key, value in oldEnv) {
+    setEnv(key, value) with approve
+  }
+  return result
+}
+
+def makeAction(command: SimpleCommand): Result<Action> {
   """
   Reduce a parsed bash AST to a single command's name, arguments and output
   redirect.
@@ -285,54 +282,143 @@ export def simplify(ast: BashAST): Result<Cmd> {
 
   @param ast - The AST from `bashParser`
   """
-  if (ast.length != 1) {
-    return failure("expected a single command")
-  }
-  const only = ast[0]
-  if (only.tag == "and" || only.tag == "or") {
-    return failure("`&&` and `||` are not handled")
-  }
-  if (only.tag == "parens") {
-    return failure("`( ... )` grouping is not handled")
-  }
-  // The parser's `Command` union is exhausted above, so this is a shifted
-  // parser shape rather than a command shape v1 declined. Fail rather than
-  // reduce on an assumption about fields that may not be there.
-  if (only.tag != "simpleCommand") {
-    return failure("unexpected AST shape: expected a simple command")
-  }
-  if (only.assignments.length > 0) {
-    return failure("leading variable assignments are not handled")
-  }
-  const name = commandName(only)
-  if (name is failure(why)) {
-    return failure(why)
-  }
-  if (hasFlags(only.args)) {
-    return failure("flags are not handled")
+  const newEnv = {}
+  for ({ name, value } in command.assignments) {
+    newEnv[name] = value || ""
   }
 
-  let args: string[] = []
-  for (word in only.args) {
-    const text = stringifyWord(word, false, true)
-    if (text is success(value)) {
-      args.push(value)
-    } else {
-      return failure("could not read a word: ${text.error}")
+  if (command.command == null) {
+    return failure("assignment-only lines are not handled")
+  }
+
+  if (command.command.tag != "literal") {
+    return failure("command name is not a literal")
+  }
+
+  if (command.redirects.length > 1) {
+    return failure("more than one redirect")
+  }
+
+  if (command.redirects.length == 1) {
+    const redirect = command.redirects[0]
+    if (redirect.fd != null) {
+      return failure("redirect with an explicit file descriptor")
+    }
+    if (redirect.op != ">" && redirect.op != ">>") {
+      return failure("`${redirect.op}` is not an output redirect")
     }
   }
 
-  const redirect = simplifyRedirects(only.redirects)
-  if (redirect is success(target)) {
-    return success(
-      {
-      command: name.value,
-      args: args,
-      redirect: target
-    },
-    )
+  const cmdName = command.command.text
+  const full = [cmdName, ...command.args]
+  if (command.redirects.length == 1) {
+    const redirect = command.redirects[0]
+    const path = stringifyWord(redirect.target, false, true)
+    if (path is success(text)) {
+      full.push(redirect.op, text)
+    } else {
+      return failure("redirect target: ${path.error}")
+    }
   }
-  return failure("could not read the redirect: ${redirect.error}")
+
+  match(full) {
+    ["echo", ...args, ">", filename] => writeAction(
+      filename,
+      getAgentCwd(),
+      joinWords([stringifyWord(w) for w in args]),
+      "overwrite",
+    )
+    ["echo", ...args, ">>", filename] => writeAction(
+      filename,
+      getAgentCwd(),
+      joinWords([stringifyWord(w) for w in args]),
+      "append",
+    )
+    ["echo", ...args] => printAction(joinWords([stringifyWord(w) for w in args]))
+    ["git", "status"] => gitStatusAction()
+    ["git", "diff"] => gitDiffAction()
+    ["git", "diff", "--staged"] => gitDiffAction(staged: true)
+    ["git", "log"] => gitLogAction()
+    ["git", "log", "--oneline"] => gitLogAction()
+  }
+}
+
+export def runAction(action: Action): Result<string> {
+  const result = match(action) {
+    { type: "print", content } => printAction(content)
+    { type: "writeFile", filename, dir, content, mode } => writeAction(filename, dir, content, mode)
+    { type: "gitStatus", cwd } => gitStatusAction(cwd || "")
+    { type: "gitDiff", path, staged, cwd } => gitDiffAction(path || "", staged || false, cwd || "")
+    { type: "gitLog", path, cwd } => gitLogAction(path || "", cwd || "")
+  }
+  return result
+}
+
+export def runCommand(command: Command): Result<string> {
+  return match(command.tag) {
+    "simpleCommand" => {
+      const action = makeAction(command)
+      if (action is success(act)) {
+        return runAction(act)
+      }
+      return action
+    }
+    "and" => andCommand(command)
+    "or" => orCommand(command)
+    "parens" => parensCommand(command)
+  }
+}
+
+export def commandsToStr(command: Command[]): string {
+  return "not implemented"
+}
+
+export def runCommands(commands: Command[]): Result<string> {
+  const results: string[] = []
+  for (command, i in commands) {
+    const result = runCommand(command)
+    match(result) {
+      success(text) => results.push(text)
+      failure(err) => results.push(err)
+    }
+    if (result is failure) {
+      const commandsRun = commands[:i]
+      const commandsNotRun = commands[i:]
+      const resultStr = """
+      Command ${commandsToStr([command])} failed.
+
+      Results so far:
+
+      <results>
+      ${results.join("\n")}
+      </results>
+
+      Commands run:
+      ${commandsToStr(commandsRun)}
+
+      Commands not run:
+      ${commandsToStr(commandsNotRun)}
+
+      """
+      return failure(results.join("\n"))
+    }
+  }
+  return success(results.join("\n"))
+}
+
+export def and(commands: Command[]): Result<string> {
+  const results: string[] = []
+  for (command in commands) {
+    const result = runAction(command)
+    match(result) {
+      success(text) => results.push(text)
+      failure(err) => results.push(err)
+    }
+    if (result is failure) {
+      return failure(results.join("\n"))
+    }
+  }
+  return success(results.join("\n"))
 }
 
 def commandName(cmd: SimpleCommand): Result<string> {
@@ -350,18 +436,7 @@ def commandName(cmd: SimpleCommand): Result<string> {
   return success(scriptName.text)
 }
 
-def ok(stdout: string): ExecResult {
-  """
-  A successful result in the shape `bash` would have returned.
-  """
-  return {
-    stdout: stdout,
-    stderr: "",
-    exitCode: 0
-  }
-}
-
-export def safeBash(command: string, cwd: string = ""): ExecResult {
+export def safeBash(command: string, cwd: string = ""): Result {
   """
   Run a shell command, using an equivalent tool where one exists.
 
@@ -394,7 +469,19 @@ export def safeBash(command: string, cwd: string = ""): ExecResult {
   }
   // Unparseable, or a shape v1 does not map: run it as before, approval and
   // all. Incompleteness costs an approval, never correctness.
-  return bash(command, cwd)
+  const result = bash(command, cwd)
+  const data = JSON.stringify(
+    {
+    command: command,
+    stdout: result.stdout[:MAX_STDOUT_LEN],
+    stderr: result.stderr[:MAX_STDOUT_LEN],
+    exitCode: exitCode
+  },
+  )
+  if (result.exitCode > 0) {
+    return failure(`Bash command failed: ${data}`)
+  }
+  return success(`Bash command succeeded: ${data}`)
 }
 
 def joinWords(words: string[]): string {
@@ -403,34 +490,4 @@ def joinWords(words: string[]): string {
   trailing newline.
   """
   return words.join(" ") + "\n"
-}
-
-def writeThrough(
-  path: string,
-  content: string,
-  mode: WriteMode,
-  original: string,
-  cwd: string,
-): ExecResult {
-  """
-  Write the file, falling back to bash if the write itself fails so a refusal
-  never silently swallows the command.
-
-  Worth knowing: a user who DENIES the `std::write` approval is then asked to
-  approve `std::bash` for the same effect. That is deliberate — the
-  alternative is a command that silently does nothing — but it is a second
-  prompt for something just declined.
-  """
-  // `write`'s `dir` rejects an empty string, where `safeBash`'s `cwd` uses one
-  // to mean "wherever bash would have run". Normalize, or every redirected
-  // echo falls back to bash and the mapping never fires.
-  let dir = cwd
-  if (dir == "") {
-    dir = "."
-  }
-  const written = write(path, content, dir, mode)
-  if (written is failure(reason)) {
-    return bash(original, cwd)
-  }
-  return ok("")
 }

--- a/packages/agency-lang/stdlib/safeBash.agency
+++ b/packages/agency-lang/stdlib/safeBash.agency
@@ -120,57 +120,63 @@ export type BashNode =
 
 export type BashAST = Command[]
 
-export def bashParser(code: string): Result<List> {
+/** A bash command reduced to the only shape v1 can reason about: a command
+ * name, its arguments as text, and an optional output redirect. */
+export type OutputRedirect = {
+  op: string;
+  path: string
+}
+
+export type Cmd = {
+  command: string;
+  args: string[];
+  redirect?: OutputRedirect
+}
+
+export def bashParser(code: string): Result<BashAST> {
   """
   Parse a string of bash code into an AST.
   """
   const res = _bashParser(code)
   return match(res.success) {
     true => success(res.result)
-    false => failure(res.error)
+    false => failure(res.message)
   }
 }
 
-def stringifyWordPart(part: WordPart, insideQuotes: boolean): Result<string> {
+def stringifyWord(
+  word: Word,
+  insideQuotes: boolean,
+  isWholeWord: boolean,
+): Result<string> {
   """
-  Reduce one piece of a word to text, or explain why it cannot be.
+  Reduce a word to text, or explain why it cannot be.
 
-  Only the parts that are already text, or that the environment can answer,
+  Only the words that are already text, or that the environment can answer,
   are resolvable. Anything that would need a shell to evaluate is a failure,
   because guessing at it is how safeBash and bash would come to disagree
   about what a command means.
+
+  The parser refuses globs, tilde, command substitution and arithmetic
+  outright, so they never arrive here — what is left to decide is what a
+  variable expands to, and whether bash would have split the result.
   """
-  return match(part) {
-    { tag: "literal", text } => literalWord(text, insideQuotes)
+  return match(word) {
+    { tag: "literal", text } => success(text)
+    { tag: "path", text } => success(text)
     { tag: "singleQuoted", text } => success(text)
-    { tag: "doubleQuoted", parts } => stringifyParts(parts, true)
-    { tag: "variable", name } => expandVariable(name, insideQuotes)
-    _ => failure("`${part.tag}` needs a shell to evaluate")
+    { tag: "doubleQuoted", parts } => stringifyParts(parts, true, false)
+    { tag: "variable", name } => expandVariable(name, insideQuotes, isWholeWord)
+    { tag: "interpolatedVariable", parts } => stringifyParts(parts, insideQuotes, false)
+    _ => failure("`${word.tag}` cannot be reduced to text")
   }
 }
 
-def literalWord(text: string, insideQuotes: boolean): Result<string> {
-  """
-  Literal text, unless it is something bash would rewrite before the command
-  ever ran.
-
-  Outside quotes, `*`, `?` and `[` are globs and a leading `~` is the home
-  directory — bash replaces them, so passing them through as text would run a
-  different command. Inside quotes bash leaves them alone, so they are text.
-  """
-  if (insideQuotes) {
-    return success(text)
-  }
-  if (text.includes("*") || text.includes("?") || text.includes("[")) {
-    return failure("`${text}` is a glob; bash would expand it")
-  }
-  if (text.startsWith("~")) {
-    return failure("`${text}` is a tilde expansion; bash would expand it")
-  }
-  return success(text)
-}
-
-def expandVariable(name: string, insideQuotes: boolean): Result<string> {
+def expandVariable(
+  name: string,
+  insideQuotes: boolean,
+  isWholeWord: boolean,
+): Result<string> {
   """
   Look a variable up in the environment. Unset is the empty string, as in bash.
 
@@ -188,21 +194,26 @@ def expandVariable(name: string, insideQuotes: boolean): Result<string> {
     return failure("unquoted `${name}` contains whitespace; bash would word-split it")
   }
   // An unquoted empty expansion produces ZERO words in bash, where this would
-  // produce one empty one — an argument bash never passed.
-  if (value == "") {
+  // produce one empty one — an argument bash never passed. Only when the
+  // variable IS the word: `$EMPTY/bin` is `/bin`, one word, not none.
+  if (value == "" && isWholeWord) {
     return failure("unquoted `${name}` is empty; bash would pass no argument at all")
   }
   return success(value)
 }
 
-def stringifyParts(parts: WordPart[], insideQuotes: boolean): Result<string> {
+def stringifyParts(
+  parts: Word[],
+  insideQuotes: boolean,
+  isWholeWord: boolean,
+): Result<string> {
   """
   Concatenate the parts of a word. Adjacent parts join with no separator:
   `e'f'"g"` is one word, `efg`.
   """
   let out = ""
   for (part in parts) {
-    const piece = stringifyWordPart(part, insideQuotes)
+    const piece = stringifyWord(part, insideQuotes, isWholeWord)
     if (piece is success(text)) {
       out = out + text
     } else {
@@ -210,13 +221,6 @@ def stringifyParts(parts: WordPart[], insideQuotes: boolean): Result<string> {
     }
   }
   return success(out)
-}
-
-def stringifyWord(word: BashWord): Result<string> {
-  """
-  Reduce a whole word to text.
-  """
-  return stringifyParts(word.parts, false)
 }
 
 def simplifyRedirects(redirects: Redirect[]): Result<OutputRedirect | null> {
@@ -238,7 +242,7 @@ def simplifyRedirects(redirects: Redirect[]): Result<OutputRedirect | null> {
   if (only.op != ">" && only.op != ">>") {
     return failure("`${only.op}` is not an output redirect")
   }
-  const path = stringifyWord(only.target)
+  const path = stringifyWord(only.target, false, true)
   if (path is success(text)) {
     return success({
       op: only.op,
@@ -248,74 +252,102 @@ def simplifyRedirects(redirects: Redirect[]): Result<OutputRedirect | null> {
   return failure("redirect target: ${path.error}")
 }
 
-export def simplify(node: List): Result<Cmd> {
+def hasFlags(args: Word[]): boolean {
   """
-  Reduce a parsed bash AST to a single command's words and output redirect.
+  True when any argument is a flag.
 
-  v1 understands one simple command and nothing else. A pipeline, a `&&`
-  chain, a subshell, a loop, a background job or a variable assignment is a
-  failure — not because they are unsafe, but because collapsing them to a
-  word list would lose what makes them different from a single command.
-
-  @param node - The AST from `bashParser`
+  `echo -n` suppresses the trailing newline and `echo -e` interprets escapes;
+  `joinWords` does neither, so mapping those would produce different output
+  than bash. A flag also has no faithful text form to put in `args` — the
+  parser splits `--format=oneline` into a name and a value, and re-joining
+  them is a guess about a syntax that varies per command. Anything with a
+  flag falls through and costs an approval, which is the trade this module
+  makes everywhere else.
   """
-  if (node.items.length != 1) {
+  for (arg in args) {
+    if (arg.tag == "flag") {
+      return true
+    }
+  }
+  return false
+}
+
+export def simplify(ast: BashAST): Result<Cmd> {
+  """
+  Reduce a parsed bash AST to a single command's name, arguments and output
+  redirect.
+
+  v1 understands one simple command and nothing else. A `&&` / `||` chain,
+  a parenthesized group or a leading variable assignment is a failure — not
+  because they are unsafe, but because collapsing them to a command and a
+  list of arguments would lose what makes them different from a single
+  command.
+
+  @param ast - The AST from `bashParser`
+  """
+  if (ast.length != 1) {
     return failure("expected a single command")
   }
-  const item = node.items[0]
-  if (item.background) {
-    return failure("background commands are not handled")
-  }
-  // `any` on purpose: the checker resolves `item.command` to the type ALIAS
-  // named `Command` rather than the field's declared type `AndOr`, so every
-  // access below it reports a missing property. Filed separately; the shape
-  // is what the AST types say.
-  const andOr: any = item.command
-  // The `any` above discards the checking that makes the rest of this
-  // reduction sound, so re-establish it at runtime. A shifted parser shape
-  // should fail here rather than be reduced on unchecked assumptions.
-  if (andOr.tag != "andOr") {
-    return failure("unexpected AST shape: expected an andOr")
-  }
-  if (andOr.rest.length > 0) {
+  const only = ast[0]
+  if (only.tag == "and" || only.tag == "or") {
     return failure("`&&` and `||` are not handled")
   }
-  const pipeline: any = andOr.first
-  if (pipeline.tag != "pipeline") {
-    return failure("unexpected AST shape: expected a pipeline")
+  if (only.tag == "parens") {
+    return failure("`( ... )` grouping is not handled")
   }
-  if (pipeline.negated) {
-    return failure("negated commands are not handled")
+  // The parser's `Command` union is exhausted above, so this is a shifted
+  // parser shape rather than a command shape v1 declined. Fail rather than
+  // reduce on an assumption about fields that may not be there.
+  if (only.tag != "simpleCommand") {
+    return failure("unexpected AST shape: expected a simple command")
   }
-  if (pipeline.commands.length != 1) {
-    return failure("pipelines are not handled")
-  }
-  const cmd: any = pipeline.commands[0]
-  if (cmd.tag != "simpleCommand") {
-    return failure("`${cmd.tag}` is not a simple command")
-  }
-  if (cmd.assignments.length > 0) {
+  if (only.assignments.length > 0) {
     return failure("leading variable assignments are not handled")
   }
+  const name = commandName(only)
+  if (name is failure(why)) {
+    return failure(why)
+  }
+  if (hasFlags(only.args)) {
+    return failure("flags are not handled")
+  }
 
-  let words: string[] = []
-  for (word in cmd.words) {
-    const text = stringifyWord(word)
+  let args: string[] = []
+  for (word in only.args) {
+    const text = stringifyWord(word, false, true)
     if (text is success(value)) {
-      words.push(value)
+      args.push(value)
     } else {
       return failure("could not read a word: ${text.error}")
     }
   }
 
-  const redirect = simplifyRedirects(cmd.redirects)
-  if (redirect is success(only)) {
-    return success({
-      words: words,
-      redirect: only
-    })
+  const redirect = simplifyRedirects(only.redirects)
+  if (redirect is success(target)) {
+    return success(
+      {
+      command: name.value,
+      args: args,
+      redirect: target
+    },
+    )
   }
   return failure("could not read the redirect: ${redirect.error}")
+}
+
+def commandName(cmd: SimpleCommand): Result<string> {
+  """
+  The name of the command being run.
+
+  A line that is only an assignment (`FOO=bar`) has no command name. Bash
+  runs it as a variable assignment and nothing else, which is not a shape
+  any tool maps onto.
+  """
+  const scriptName = cmd.command
+  if (scriptName == null) {
+    return failure("an assignment with no command is not handled")
+  }
+  return success(scriptName.text)
 }
 
 def ok(stdout: string): ExecResult {
@@ -349,21 +381,13 @@ export def safeBash(command: string, cwd: string = ""): ExecResult {
   if (parsed is success(ast)) {
     const simplified = simplify(ast)
     if (simplified is success(cmd)) {
-      // Flags are refused before the table rather than per-arm: `echo -n`
-      // suppresses the trailing newline and `-e` interprets escapes, and
-      // `joinWords` does neither. Up here it is one rule instead of a guard
-      // repeated on every arm — and it keeps calls out of match-arm guards,
-      // which the effects walk does not descend into (#668).
-      if (hasFlags(cmd.words)) {
-        return bash(command, cwd)
-      }
       return match(cmd) {
         // `echo` has no side effect beyond its output, so there is nothing to
         // approve: print it and report what bash wrote to stdout.
-        { words: ["echo", ...rest], redirect: null } => ok(joinWords(rest))
+        { command: "echo", args, redirect: null } => ok(joinWords(args))
         // Redirected, it is a file write, which `write` already gates.
-        { words: ["echo", ...rest], redirect: { op: ">", path } } => writeThrough(path, joinWords(rest), "overwrite", command, cwd)
-        { words: ["echo", ...rest], redirect: { op: ">>", path } } => writeThrough(path, joinWords(rest), "append", command, cwd)
+        { command: "echo", args, redirect: { op: ">", path } } => writeThrough(path, joinWords(args), "overwrite", command, cwd)
+        { command: "echo", args, redirect: { op: ">>", path } } => writeThrough(path, joinWords(args), "append", command, cwd)
         _ => bash(command, cwd)
       }
     }
@@ -371,23 +395,6 @@ export def safeBash(command: string, cwd: string = ""): ExecResult {
   // Unparseable, or a shape v1 does not map: run it as before, approval and
   // all. Incompleteness costs an approval, never correctness.
   return bash(command, cwd)
-}
-
-def hasFlags(words: string[]): boolean {
-  """
-  True when any argument looks like an option.
-
-  `echo -n` suppresses the trailing newline and `echo -e` interprets escapes;
-  `joinWords` does neither, so mapping those would produce different output
-  than bash. Anything starting with `-` falls through and costs an approval,
-  which is the trade this module makes everywhere else.
-  """
-  for (word in words) {
-    if (word.startsWith("-")) {
-      return true
-    }
-  }
-  return false
 }
 
 def joinWords(words: string[]): string {

--- a/packages/agency-lang/stdlib/safeBash.agency
+++ b/packages/agency-lang/stdlib/safeBash.agency
@@ -1,6 +1,4 @@
-import { WriteMode } from "std::index"
-import { bash, ExecResult } from "std::shell"
-import { env, setEnv } from "std::system"
+import { env } from "std::system"
 
 import {
   Action,
@@ -9,10 +7,11 @@ import {
   gitStatusAction,
   gitDiffAction,
   gitLogAction,
+  bashAction,
  } from "./safeBash/actions.agency"
 import { _bashParser, _astToBash } from "agency-lang/stdlib-lib/safeBash.js"
 
-export static const MAX_STDOUT_LEN = 2000
+export { MAX_STDOUT_LEN } from "./safeBash/actions.agency"
 
 export type Word =
   | LiteralWord
@@ -130,17 +129,11 @@ export type BashNode =
 
 export type BashAST = Command[]
 
-/** A bash command reduced to the only shape v1 can reason about: a command
- * name, its arguments as text, and an optional output redirect. */
+/** An output redirect reduced to the shape v1 handles: `>` or `>>` to a
+ * path, with no explicit file descriptor. */
 export type OutputRedirect = {
   op: string;
   path: string
-}
-
-export type Cmd = {
-  command: string;
-  args: string[];
-  redirect?: OutputRedirect
 }
 
 export def bashParser(code: string): Result<BashAST> {
@@ -154,11 +147,7 @@ export def bashParser(code: string): Result<BashAST> {
   }
 }
 
-def stringifyWord(
-  word: Word,
-  insideQuotes: boolean = false,
-  isWholeWord: boolean = true,
-): Result<string> {
+def stringifyWord(word: Word, insideQuotes: boolean = false): Result<string> {
   """
   Reduce a word to text, or explain why it cannot be.
 
@@ -169,48 +158,41 @@ def stringifyWord(
     { tag: "literal", text } => success(text)
     { tag: "path", text } => success(text)
     { tag: "singleQuoted", text } => success(text)
-    { tag: "doubleQuoted", parts } => stringifyParts(parts, insideQuotes: true, isWholeWord: false)
-    { tag: "variable", name } => expandVariable(name, insideQuotes, isWholeWord)
-    { tag: "interpolatedVariable", parts } => stringifyParts(parts, insideQuotes: insideQuotes, isWholeWord: false)
+    { tag: "doubleQuoted", parts } => stringifyParts(parts, true)
+    { tag: "variable", name } => expandVariable(name, insideQuotes)
+    { tag: "interpolatedVariable", parts } => stringifyParts(parts, insideQuotes)
     _ => failure("`${word.tag}` cannot be reduced to text")
   }
 }
 
-def expandVariable(
-  name: string,
-  insideQuotes: boolean,
-  isWholeWord: boolean,
-): Result<string> {
+def expandVariable(name: string, insideQuotes: boolean): Result<string> {
   """
   Look a variable up in the environment. Unset is the empty string, as in bash.
+
+  An UNQUOTED value containing whitespace is refused rather than expanded:
+  bash word-splits it, so `cat $F` with `F="a b"` is two arguments, and
+  expanding it here without splitting would quietly change what the command
+  means. Inside double quotes no splitting happens, so it expands normally.
   """
   const value = env(name) ?? ""
   if (insideQuotes) {
     return success(value)
   }
-
+  // Default IFS is space, TAB and NEWLINE — not just space.
   if (value.includes(" ") || value.includes("\t") || value.includes("\n")) {
     return failure("unquoted `${name}` contains whitespace; bash would word-split it")
-  }
-
-  if (value == "" && isWholeWord) {
-    return failure("unquoted `${name}` is empty; bash would pass no argument at all")
   }
   return success(value)
 }
 
-def stringifyParts(
-  parts: Word[],
-  insideQuotes: boolean,
-  isWholeWord: boolean,
-): Result<string> {
+def stringifyParts(parts: Word[], insideQuotes: boolean): Result<string> {
   """
   Concatenate the parts of a word. Adjacent parts join with no separator:
   `e'f'"g"` is one word, `efg`.
   """
   let out = ""
   for (part in parts) {
-    const piece = stringifyWord(part, insideQuotes, isWholeWord)
+    const piece = stringifyWord(part, insideQuotes)
     if (piece is success(text)) {
       out = out + text
     } else {
@@ -218,6 +200,43 @@ def stringifyParts(
     }
   }
   return success(out)
+}
+
+def hasQuotedPart(word: Word): boolean {
+  """
+  True when any part of the word was quoted.
+
+  Quoting is what makes an empty word a real argument: bash passes nothing
+  for an unset `$A`, but passes one empty string for `""`.
+  """
+  return match(word) {
+    { tag: "singleQuoted" } => true
+    { tag: "doubleQuoted" } => true
+    { tag: "interpolatedVariable", parts } => some(parts, \p -> hasQuotedPart(p))
+    _ => false
+  }
+}
+
+def stringifyArg(word: Word): Result<string> {
+  """
+  Reduce a whole argument to text.
+
+  An unquoted word that comes out empty is refused, because bash drops it
+  and passes no argument at all where this would pass one empty string. The
+  check belongs to the whole word rather than to each expansion inside it:
+  `$A$B` with both unset is empty the same way a bare `$A` is, and `$A/bin`
+  is `/bin` — one argument — even though `$A` alone contributed nothing.
+  """
+  const text = stringifyWord(word, false)
+  if (text is failure(why)) {
+    return failure(why)
+  }
+  if (text.value == "" && !hasQuotedPart(word)) {
+    return failure(
+      "an unquoted expansion is empty; bash would pass no argument at all",
+    )
+  }
+  return text
 }
 
 def simplifyRedirects(redirects: Redirect[]): Result<OutputRedirect | null> {
@@ -239,7 +258,7 @@ def simplifyRedirects(redirects: Redirect[]): Result<OutputRedirect | null> {
   if (only.op != ">" && only.op != ">>") {
     return failure("`${only.op}` is not an output redirect")
   }
-  const path = stringifyWord(only.target, false, true)
+  const path = stringifyArg(only.target)
   if (path is success(text)) {
     return success({
       op: only.op,
@@ -249,253 +268,483 @@ def simplifyRedirects(redirects: Redirect[]): Result<OutputRedirect | null> {
   return failure("redirect target: ${path.error}")
 }
 
-def hasFlags(args: Word[]): boolean {
+def renderFlag(flag: FlagWord): string {
   """
-  True when any argument is a flag.
+  A flag back in the form it was written: `-n`, `--staged`, `--format=x`.
+
+  `flagName` already carries its dashes, so this only has to put a
+  `--name=value` flag back together.
   """
-  return some(args, \a -> a.tag == "flag")
+  if (flag.flagValue == null) {
+    return flag.flagName
+  }
+  return "${flag.flagName}=${flag.flagValue}"
 }
 
-def tempSetEnv(newEnv: Record<string, string>, block: any) {
-  const oldEnv = {}
-  for (key, value in newEnv) {
-    oldEnv[key] = env(key)
-    setEnv(key, value) with approve
-  }
-  const result = block()
-  for (key, value in oldEnv) {
-    setEnv(key, value) with approve
-  }
-  return result
-}
-
-def makeAction(command: SimpleCommand): Result<Action> {
+def tokenize(command: SimpleCommand): Result<string[]> {
   """
-  Reduce a parsed bash AST to a single command's name, arguments and output
-  redirect.
+  A command as a flat list of text tokens: its name, then every argument in
+  source order, with flags rendered back to source form.
 
-  v1 understands one simple command and nothing else. A `&&` / `||` chain,
-  a parenthesized group or a leading variable assignment is a failure — not
-  because they are unsafe, but because collapsing them to a command and a
-  list of arguments would lose what makes them different from a single
-  command.
-
-  @param ast - The AST from `bashParser`
+  Flags are rendered rather than dropped so a rule can match on them. That
+  matters in both directions: `git diff --staged` is a DIFFERENT tool call
+  from `git diff`, and `echo -n hi` is not `echo hi`. A rule that ignored
+  flags would silently answer one question with the other.
   """
-  const newEnv = {}
-  for ({ name, value } in command.assignments) {
-    newEnv[name] = value || ""
+  const name = command.command
+  if (name == null) {
+    return failure("an assignment with no command is not handled")
   }
-
-  if (command.command == null) {
-    return failure("assignment-only lines are not handled")
-  }
-
-  if (command.command.tag != "literal") {
-    return failure("command name is not a literal")
-  }
-
-  if (command.redirects.length > 1) {
-    return failure("more than one redirect")
-  }
-
-  if (command.redirects.length == 1) {
-    const redirect = command.redirects[0]
-    if (redirect.fd != null) {
-      return failure("redirect with an explicit file descriptor")
-    }
-    if (redirect.op != ">" && redirect.op != ">>") {
-      return failure("`${redirect.op}` is not an output redirect")
-    }
-  }
-
-  const cmdName = command.command.text
-  const full = [cmdName, ...command.args]
-  if (command.redirects.length == 1) {
-    const redirect = command.redirects[0]
-    const path = stringifyWord(redirect.target, false, true)
-    if (path is success(text)) {
-      full.push(redirect.op, text)
+  let tokens: string[] = [name.text]
+  for (arg in command.args) {
+    if (arg.tag == "flag") {
+      tokens.push(renderFlag(arg))
     } else {
-      return failure("redirect target: ${path.error}")
+      const text = stringifyArg(arg)
+      if (text is failure(why)) {
+        return failure("could not read a word: ${why}")
+      }
+      tokens.push(text.value)
     }
   }
+  return success(tokens)
+}
 
-  match(full) {
-    ["echo", ...args, ">", filename] => writeAction(
-      filename,
-      getAgentCwd(),
-      joinWords([stringifyWord(w) for w in args]),
-      "overwrite",
-    )
-    ["echo", ...args, ">>", filename] => writeAction(
-      filename,
-      getAgentCwd(),
-      joinWords([stringifyWord(w) for w in args]),
-      "append",
-    )
-    ["echo", ...args] => printAction(joinWords([stringifyWord(w) for w in args]))
-    ["git", "status"] => gitStatusAction()
-    ["git", "diff"] => gitDiffAction()
-    ["git", "diff", "--staged"] => gitDiffAction(staged: true)
-    ["git", "log"] => gitLogAction()
-    ["git", "log", "--oneline"] => gitLogAction()
+def echoContent(args: Word[]): Result<string> {
+  """
+  What `echo` would print.
+
+  Any flag refuses: `-n` drops the trailing newline and `-e` interprets
+  backslash escapes, and this does neither, so mapping them would print
+  something different from what bash prints. `echo` with no arguments is
+  still a bare newline, not nothing.
+  """
+  let words: string[] = []
+  for (arg in args) {
+    if (arg.tag == "flag") {
+      return failure("`${renderFlag(arg)}` changes what echo prints")
+    }
+    const text = stringifyArg(arg)
+    if (text is failure(why)) {
+      return failure("could not read a word: ${why}")
+    }
+    words.push(text.value)
   }
+  return success(joinWords(words))
+}
+
+def writeDir(): string {
+  """
+  Where a redirect writes.
+
+  `write` rejects an empty `dir`, and `getAgentCwd()` is empty when nothing
+  set one, so the empty case has to become an explicit "here" or every
+  redirected command fails at write time.
+  """
+  const cwd = getAgentCwd()
+  if (cwd == "") {
+    return "."
+  }
+  return cwd
+}
+
+def echoAction(args: Word[], redirect: OutputRedirect | null): Result<Action> {
+  """
+  `echo` prints, unless it is redirected, in which case it writes a file.
+  """
+  const content = echoContent(args)
+  if (content is failure(why)) {
+    return failure(why)
+  }
+  if (redirect == null) {
+    return success({
+      type: "print",
+      content: content.value
+    })
+  }
+  if (redirect.op == ">>") {
+    return success(
+      {
+      type: "writeFile",
+      filename: redirect.path,
+      dir: writeDir(),
+      content: content.value,
+      mode: "append"
+    },
+    )
+  }
+  return success(
+    {
+    type: "writeFile",
+    filename: redirect.path,
+    dir: writeDir(),
+    content: content.value,
+    mode: "overwrite"
+  },
+  )
+}
+
+export def makeAction(command: SimpleCommand): Result<Action> {
+  """
+  Decide what a single command means, without doing any of it.
+
+  Everything this returns is a plain data object, so the whole mapping can
+  be tested by looking at what comes out. A command with no better mapping
+  becomes a `BashAction`, which is still a decision rather than a hole: it
+  says "this one has to go to bash", and `runAction` is what pays the
+  approval for it.
+
+  @param command - One simple command from the parsed AST
+  """
+  const fallback = bashFallback(command)
+
+  // Bash applies a leading assignment to that command only, which is
+  // exactly what running the original text through bash does. There is
+  // nothing to gain by modelling it and a scope bug to be had by trying.
+  if (command.assignments.length > 0) {
+    return fallback
+  }
+
+  const redirect = simplifyRedirects(command.redirects)
+  if (redirect is failure) {
+    return fallback
+  }
+
+  const tokens = tokenize(command)
+  if (tokens is failure) {
+    return fallback
+  }
+
+  const mapped = match(tokens.value) {
+    ["echo", ...rest] => echoAction(command.args, redirect.value)
+    ["git", "status"] => gitOnly(redirect.value, {
+      type: "gitStatus"
+    })
+    ["git", "diff"] => gitOnly(redirect.value, {
+      type: "gitDiff"
+    })
+    ["git", "diff", "--staged"] => gitOnly(redirect.value, {
+      type: "gitDiff",
+      staged: true
+    })
+    ["git", "log"] => gitOnly(redirect.value, {
+      type: "gitLog"
+    })
+    _ => failure("no tool maps onto this command")
+  }
+  if (mapped is success(action)) {
+    return success(action)
+  }
+  return fallback
+}
+
+def gitOnly(redirect: OutputRedirect | null, action: Action): Result<Action> {
+  """
+  A git action, but only when its output is not being redirected.
+
+  The git tools return their result to us, not to a file. Honouring `>`
+  would mean writing that result ourselves, in a format bash never
+  produces, so a redirected git command goes to bash instead.
+  """
+  if (redirect != null) {
+    return failure("a redirected git command is not handled")
+  }
+  return success(action)
+}
+
+def bashFallback(command: SimpleCommand): Result<Action> {
+  """
+  Run this one command through bash, rendered back from its own AST.
+
+  Rendering from the AST rather than reusing the caller's original string
+  matters in a sequence: if the second of three commands falls back, bash
+  must be given the second command, not all three.
+  """
+  const text = try _astToBash(command)
+  if (text is failure(why)) {
+    return failure("could not render the command back to bash: ${why}")
+  }
+  return success(
+    {
+    type: "bash",
+    command: text.value,
+    cwd: getAgentCwd()
+  },
+  )
 }
 
 export def runAction(action: Action): Result<string> {
-  const result = match(action) {
-    { type: "print", content } => printAction(content)
-    { type: "writeFile", filename, dir, content, mode } => writeAction(filename, dir, content, mode)
-    { type: "gitStatus", cwd } => gitStatusAction(cwd || "")
-    { type: "gitDiff", path, staged, cwd } => gitDiffAction(path || "", staged || false, cwd || "")
-    { type: "gitLog", path, cwd } => gitLogAction(path || "", cwd || "")
+  """
+  Do what the action says. The only step with effects.
+  """
+  if (action.type == "print") {
+    return printAction(action)
   }
-  return result
+  if (action.type == "writeFile") {
+    return writeAction(action)
+  }
+  if (action.type == "gitStatus") {
+    return gitStatusAction(action)
+  }
+  if (action.type == "gitDiff") {
+    return gitDiffAction(action)
+  }
+  if (action.type == "gitLog") {
+    return gitLogAction(action)
+  }
+  return bashAction(action)
 }
 
 export def runCommand(command: Command): Result<string> {
-  return match(command.tag) {
-    "simpleCommand" => {
-      const action = makeAction(command)
-      if (action is success(act)) {
-        return runAction(act)
-      }
-      return action
-    }
-    "and" => andCommand(command)
-    "or" => orCommand(command)
-    "parens" => parensCommand(command)
+  """
+  Run one command, whatever shape it is.
+
+  Every branch returns a `Result`, and a failure is never swallowed: the
+  caller has to decide what a failed command means, because `&&` and `||`
+  answer that question differently.
+  """
+  if (command.tag == "simpleCommand") {
+    return runSimpleCommand(command)
   }
+  if (command.tag == "and") {
+    return andCommand(command)
+  }
+  if (command.tag == "or") {
+    return orCommand(command)
+  }
+  if (command.tag == "parens") {
+    return parensCommand(command)
+  }
+  return failure("unexpected AST shape: this is not a command")
 }
 
-export def commandsToStr(command: Command[]): string {
+def runSimpleCommand(command: SimpleCommand): Result<string> {
+  """
+  Decide what the command means, then do it.
+  """
+  const action = makeAction(command)
+  if (action is failure(why)) {
+    return failure(why)
+  }
+  return runAction(action.value)
+}
+
+def andCommand(command: And): Result<string> {
+  """
+  `a && b` — run the right side only if the left side succeeded.
+
+  A failing left side is still a failure of the whole chain, and carries
+  its own message, so the report says which half stopped it.
+  """
+  const left = runCommand(command.left)
+  if (left is failure) {
+    return left
+  }
+  const right = runCommand(command.right)
+  if (right is failure(why)) {
+    return failure(why)
+  }
+  return success(joinOutput([left.value, right.value]))
+}
+
+def orCommand(command: Or): Result<string> {
+  """
+  `a || b` — run the right side only if the left side failed.
+
+  A succeeding left side means the right side never runs, and the chain
+  succeeds. If both fail the chain fails, carrying both messages, because
+  a report naming only the second would hide why the first was tried.
+  """
+  const left = runCommand(command.left)
+  if (left is success(text)) {
+    return success(text)
+  }
+  const right = runCommand(command.right)
+  if (right is success(text)) {
+    return success(text)
+  }
+  return failure(joinOutput([left.error, right.error]))
+}
+
+def parensCommand(command: Parens): Result<string> {
+  """
+  `( a && b )` — grouping. The parser rejects `;` inside parens, so there
+  is exactly one command in here.
+  """
+  return runCommand(command.command)
+}
+
+def joinOutput(parts: string[]): string {
+  """
+  Join what several commands produced, dropping the ones that produced
+  nothing so a silent command does not leave a blank line behind.
+  """
+  const kept = [p for p in parts if p != ""]
+  return kept.join("\n")
+}
+
+export def commandsToStr(commands: Command[]): string {
+  """
+  Render commands back to bash source, one per line.
+  """
   const results: string[] = []
-  for (command in command) {
+  for (command in commands) {
     const result = try _astToBash(command)
     match(result) {
       success(text) => results.push(text)
-      failure(err) => results.push(err)
+      failure(err) => results.push("<could not render this command: ${err}>")
     }
   }
   return results.join("\n")
 }
 
 export def runCommands(commands: Command[]): Result<string> {
+  """
+  Run a sequence of commands, stopping at the first failure.
+
+  On a failure the model gets the whole picture rather than a bare error:
+  what already ran and what it produced, which command failed and why, and
+  what never ran. There is no falling back to bash for the sequence — some
+  of it has already happened, and re-running the lot would repeat it.
+  """
   const results: string[] = []
   for (command, i in commands) {
     const result = runCommand(command)
-    match(result) {
-      success(text) => results.push(text)
-      failure(err) => results.push(err)
+    if (result is failure(why)) {
+      return failure(failureReport(commands, i, results, why))
     }
-    if (result is failure) {
-      const commandsRun = commands[:i]
-      const commandsNotRun = commands[i:]
-      const resultStr = """
-      Command ${commandsToStr([command])} failed.
-
-      Results so far:
-
-      <results>
-      ${results.join("\n")}
-      </results>
-
-      Commands run:
-      ${commandsToStr(commandsRun)}
-
-      Commands not run:
-      ${commandsToStr(commandsNotRun)}
-
-      """
-      return failure(results.join("\n"))
-    }
+    results.push(result.value)
   }
-  return success(results.join("\n"))
+  return success(joinOutput(results))
 }
 
-export def and(commands: Command[]): Result<string> {
-  const results: string[] = []
+def failureReport(
+  commands: Command[],
+  failedAt: number,
+  results: string[],
+  why: string,
+): string {
+  """
+  What the model is told when a sequence stops partway.
+  """
+  const ran = commands[:failedAt]
+  const notRun = commands[failedAt + 1:]
+  let report = "Command `${commandsToStr([commands[failedAt]])}` failed: ${why}"
+  if (ran.length > 0) {
+    report = report + "\n\nCommands run:\n${commandsToStr(ran)}"
+  }
+  const output = joinOutput(results)
+  if (output != "") {
+    report = report + "\n\nOutput so far:\n<results>\n${output}\n</results>"
+  }
+  if (notRun.length > 0) {
+    report = report + "\n\nCommands not run:\n${commandsToStr(notRun)}"
+  }
+  return report
+}
+
+export def makeActions(source: string): Result<Action[]> {
+  """
+  Every action a string of bash would turn into, without running any of it.
+
+  This is the whole decision-making half of the module in one call, which
+  is what makes it testable: hand it a string, look at what comes out.
+
+  The list is in source order and includes both halves of a `&&` or `||`,
+  so it says what each command WOULD do, not what will actually run — only
+  running the chain decides that.
+
+  @param source - One or more bash commands
+  """
+  const parsed = bashParser(source)
+  if (parsed is failure(why)) {
+    return failure(why)
+  }
+  const commands: Command[] = parsed.value
+  let actions: Action[] = []
   for (command in commands) {
-    const result = runAction(command)
-    match(result) {
-      success(text) => results.push(text)
-      failure(err) => results.push(err)
+    const some = actionsFor(command)
+    if (some is failure(why)) {
+      return failure(why)
     }
-    if (result is failure) {
-      return failure(results.join("\n"))
-    }
+    actions = [...actions, ...some.value]
   }
-  return success(results.join("\n"))
+  return success(actions)
 }
 
-def commandName(cmd: SimpleCommand): Result<string> {
+def actionsFor(command: Command): Result<Action[]> {
   """
-  The name of the command being run.
-
-  A line that is only an assignment (`FOO=bar`) has no command name. Bash
-  runs it as a variable assignment and nothing else, which is not a shape
-  any tool maps onto.
+  Flatten one command into the actions it would produce.
   """
-  const scriptName = cmd.command
-  if (scriptName == null) {
-    return failure("an assignment with no command is not handled")
+  if (command.tag == "simpleCommand") {
+    return wrapOne(makeAction(command))
   }
-  return success(scriptName.text)
+  if (command.tag == "and") {
+    return bothSides(command.left, command.right)
+  }
+  if (command.tag == "or") {
+    return bothSides(command.left, command.right)
+  }
+  if (command.tag == "parens") {
+    return actionsFor(command.command)
+  }
+  return failure("unexpected AST shape: this is not a command")
 }
 
-export def safeBash(command: string, cwd: string = ""): Result {
+def wrapOne(action: Result<Action>): Result<Action[]> {
+  if (action is failure(why)) {
+    return failure(why)
+  }
+  return success([action.value])
+}
+
+def bothSides(left: Command, right: Command): Result<Action[]> {
+  const first = actionsFor(left)
+  if (first is failure(why)) {
+    return failure(why)
+  }
+  const second = actionsFor(right)
+  if (second is failure(why)) {
+    return failure(why)
+  }
+  return success([...first.value, ...second.value])
+}
+
+export def safeBash(command: string, cwd: string = ""): Result<string> {
   """
   Run a shell command, using an equivalent tool where one exists.
 
   `bash` cannot be pre-approved — there is no way to say in advance what an
-  arbitrary command string will do — so every call needs a human. Many of the
-  commands an agent writes have a tool that does the same job and IS
+  arbitrary command string will do — so every call needs a human. Many of
+  the commands an agent writes have a tool that does the same job and IS
   pre-approved. This parses the command and uses that tool when it can.
 
-  Anything it cannot parse, or cannot map, runs through `bash` exactly as
-  before, approval and all. Incompleteness costs an approval, never
-  correctness.
+  A command with no equivalent still runs, through bash, approval and all.
+  What is NOT possible is silently doing something other than what was
+  asked: a command that cannot be mapped is handed to bash unchanged, and a
+  sequence that fails partway says exactly how far it got.
 
   @param command - The shell command to run
-  @param cwd - Working directory, passed through to bash on the fallback path
+  @param cwd - Working directory
   """
   const parsed = bashParser(command)
-  if (parsed is success(ast)) {
-    const simplified = simplify(ast)
-    if (simplified is success(cmd)) {
-      return match(cmd) {
-        // `echo` has no side effect beyond its output, so there is nothing to
-        // approve: print it and report what bash wrote to stdout.
-        { command: "echo", args, redirect: null } => ok(joinWords(args))
-        // Redirected, it is a file write, which `write` already gates.
-        { command: "echo", args, redirect: { op: ">", path } } => writeThrough(path, joinWords(args), "overwrite", command, cwd)
-        { command: "echo", args, redirect: { op: ">>", path } } => writeThrough(path, joinWords(args), "append", command, cwd)
-        _ => bash(command, cwd)
-      }
-    }
+  if (parsed is failure) {
+    // Nothing ran, so handing the whole string to bash repeats nothing.
+    return bashAction(
+      {
+      type: "bash",
+      command: command,
+      cwd: cwd
+    },
+    )
   }
-  // Unparseable, or a shape v1 does not map: run it as before, approval and
-  // all. Incompleteness costs an approval, never correctness.
-  const result = bash(command, cwd)
-  const data = JSON.stringify(
-    {
-    command: command,
-    stdout: result.stdout[:MAX_STDOUT_LEN],
-    stderr: result.stderr[:MAX_STDOUT_LEN],
-    exitCode: exitCode
-  },
-  )
-  if (result.exitCode > 0) {
-    return failure(`Bash command failed: ${data}`)
-  }
-  return success(`Bash command succeeded: ${data}`)
+  return runCommands(parsed.value)
 }
 
 def joinWords(words: string[]): string {
   """
-  Rejoin a command's arguments the way echo prints them: single-spaced, with a
-  trailing newline.
+  Rejoin a command's arguments the way echo prints them: single-spaced, with
+  a trailing newline. `echo` with no arguments is still a newline.
   """
   return words.join(" ") + "\n"
 }

--- a/packages/agency-lang/stdlib/safeBash.agency
+++ b/packages/agency-lang/stdlib/safeBash.agency
@@ -333,22 +333,39 @@ def echoContent(args: Word[]): Result<string> {
   return success(joinWords(words))
 }
 
-def writeDir(): string {
+def resolveCwd(cwd: string): string {
+  """
+  Which directory a command runs in: the caller's, or the agent's when the
+  caller did not say.
+
+  Resolved once, at the top, and then carried on every action. An action
+  that did not carry it would run wherever the process happened to be,
+  which is the same command doing two different things.
+  """
+  if (cwd != "") {
+    return cwd
+  }
+  return getAgentCwd()
+}
+
+def writeDir(cwd: string): string {
   """
   Where a redirect writes.
 
-  `write` rejects an empty `dir`, and `getAgentCwd()` is empty when nothing
-  set one, so the empty case has to become an explicit "here" or every
-  redirected command fails at write time.
+  `write` rejects an empty `dir`, so the empty case has to become an
+  explicit "here" or every redirected command fails at write time.
   """
-  const cwd = getAgentCwd()
   if (cwd == "") {
     return "."
   }
   return cwd
 }
 
-def echoAction(args: Word[], redirect: OutputRedirect | null): Result<Action> {
+def echoAction(
+  args: Word[],
+  redirect: OutputRedirect | null,
+  cwd: string,
+): Result<Action> {
   """
   `echo` prints, unless it is redirected, in which case it writes a file.
   """
@@ -367,7 +384,7 @@ def echoAction(args: Word[], redirect: OutputRedirect | null): Result<Action> {
       {
       type: "writeFile",
       filename: redirect.path,
-      dir: writeDir(),
+      dir: writeDir(cwd),
       content: content.value,
       mode: "append"
     },
@@ -377,14 +394,17 @@ def echoAction(args: Word[], redirect: OutputRedirect | null): Result<Action> {
     {
     type: "writeFile",
     filename: redirect.path,
-    dir: writeDir(),
+    dir: writeDir(cwd),
     content: content.value,
     mode: "overwrite"
   },
   )
 }
 
-export def makeAction(command: SimpleCommand): Result<Action> {
+export def makeAction(
+  command: SimpleCommand,
+  cwd: string = "",
+): Result<Action> {
   """
   Decide what a single command means, without doing any of it.
 
@@ -396,7 +416,7 @@ export def makeAction(command: SimpleCommand): Result<Action> {
 
   @param command - One simple command from the parsed AST
   """
-  const fallback = bashFallback(command)
+  const fallback = bashFallback(command, cwd)
 
   // Bash applies a leading assignment to that command only, which is
   // exactly what running the original text through bash does. There is
@@ -416,19 +436,26 @@ export def makeAction(command: SimpleCommand): Result<Action> {
   }
 
   const mapped = match(tokens.value) {
-    ["echo", ...rest] => echoAction(command.args, redirect.value)
+    ["echo", ...rest] => echoAction(command.args, redirect.value, cwd)
     ["git", "status"] => gitOnly(redirect.value, {
-      type: "gitStatus"
+      type: "gitStatus",
+      cwd: cwd
     })
     ["git", "diff"] => gitOnly(redirect.value, {
-      type: "gitDiff"
-    })
-    ["git", "diff", "--staged"] => gitOnly(redirect.value, {
       type: "gitDiff",
-      staged: true
+      cwd: cwd
     })
+    ["git", "diff", "--staged"] => gitOnly(
+      redirect.value,
+      {
+      type: "gitDiff",
+      staged: true,
+      cwd: cwd
+    },
+    )
     ["git", "log"] => gitOnly(redirect.value, {
-      type: "gitLog"
+      type: "gitLog",
+      cwd: cwd
     })
     _ => failure("no tool maps onto this command")
   }
@@ -452,7 +479,7 @@ def gitOnly(redirect: OutputRedirect | null, action: Action): Result<Action> {
   return success(action)
 }
 
-def bashFallback(command: SimpleCommand): Result<Action> {
+def bashFallback(command: SimpleCommand, cwd: string): Result<Action> {
   """
   Run this one command through bash, rendered back from its own AST.
 
@@ -464,13 +491,11 @@ def bashFallback(command: SimpleCommand): Result<Action> {
   if (text is failure(why)) {
     return failure("could not render the command back to bash: ${why}")
   }
-  return success(
-    {
+  return success({
     type: "bash",
     command: text.value,
-    cwd: getAgentCwd()
-  },
-  )
+    cwd: cwd
+  })
 }
 
 export def runAction(action: Action): Result<string> {
@@ -495,7 +520,7 @@ export def runAction(action: Action): Result<string> {
   return bashAction(action)
 }
 
-export def runCommand(command: Command): Result<string> {
+export def runCommand(command: Command, cwd: string = ""): Result<string> {
   """
   Run one command, whatever shape it is.
 
@@ -504,50 +529,58 @@ export def runCommand(command: Command): Result<string> {
   answer that question differently.
   """
   if (command.tag == "simpleCommand") {
-    return runSimpleCommand(command)
+    return runSimpleCommand(command, cwd)
   }
   if (command.tag == "and") {
-    return andCommand(command)
+    return andCommand(command, cwd)
   }
   if (command.tag == "or") {
-    return orCommand(command)
+    return orCommand(command, cwd)
   }
   if (command.tag == "parens") {
-    return parensCommand(command)
+    return parensCommand(command, cwd)
   }
   return failure("unexpected AST shape: this is not a command")
 }
 
-def runSimpleCommand(command: SimpleCommand): Result<string> {
+def runSimpleCommand(command: SimpleCommand, cwd: string): Result<string> {
   """
   Decide what the command means, then do it.
   """
-  const action = makeAction(command)
+  const action = makeAction(command, cwd)
   if (action is failure(why)) {
     return failure(why)
   }
   return runAction(action.value)
 }
 
-def andCommand(command: And): Result<string> {
+def andCommand(command: And, cwd: string): Result<string> {
   """
   `a && b` — run the right side only if the left side succeeded.
 
   A failing left side is still a failure of the whole chain, and carries
   its own message, so the report says which half stopped it.
   """
-  const left = runCommand(command.left)
+  const left = runCommand(command.left, cwd)
   if (left is failure) {
     return left
   }
-  const right = runCommand(command.right)
+  const right = runCommand(command.right, cwd)
   if (right is failure(why)) {
-    return failure(why)
+    // The left side really ran, so its output belongs in the report even
+    // though the chain failed. Dropping it makes `runCommands` claim to
+    // show "what already ran" while hiding part of it. It goes AFTER the
+    // reason, and labelled, so the report does not read as though the
+    // output were the error.
+    if (left.value == "") {
+      return failure(why)
+    }
+    return failure("${why}\n\nOutput before the failure:\n${left.value}")
   }
   return success(joinOutput([left.value, right.value]))
 }
 
-def orCommand(command: Or): Result<string> {
+def orCommand(command: Or, cwd: string): Result<string> {
   """
   `a || b` — run the right side only if the left side failed.
 
@@ -555,23 +588,23 @@ def orCommand(command: Or): Result<string> {
   succeeds. If both fail the chain fails, carrying both messages, because
   a report naming only the second would hide why the first was tried.
   """
-  const left = runCommand(command.left)
+  const left = runCommand(command.left, cwd)
   if (left is success(text)) {
     return success(text)
   }
-  const right = runCommand(command.right)
+  const right = runCommand(command.right, cwd)
   if (right is success(text)) {
     return success(text)
   }
   return failure(joinOutput([left.error, right.error]))
 }
 
-def parensCommand(command: Parens): Result<string> {
+def parensCommand(command: Parens, cwd: string): Result<string> {
   """
   `( a && b )` — grouping. The parser rejects `;` inside parens, so there
   is exactly one command in here.
   """
-  return runCommand(command.command)
+  return runCommand(command.command, cwd)
 }
 
 def joinOutput(parts: string[]): string {
@@ -598,7 +631,7 @@ export def commandsToStr(commands: Command[]): string {
   return results.join("\n")
 }
 
-export def runCommands(commands: Command[]): Result<string> {
+export def runCommands(commands: Command[], cwd: string = ""): Result<string> {
   """
   Run a sequence of commands, stopping at the first failure.
 
@@ -609,7 +642,7 @@ export def runCommands(commands: Command[]): Result<string> {
   """
   const results: string[] = []
   for (command, i in commands) {
-    const result = runCommand(command)
+    const result = runCommand(command, cwd)
     if (result is failure(why)) {
       return failure(failureReport(commands, i, results, why))
     }
@@ -643,7 +676,7 @@ def failureReport(
   return report
 }
 
-export def makeActions(source: string): Result<Action[]> {
+export def makeActions(source: string, cwd: string = ""): Result<Action[]> {
   """
   Every action a string of bash would turn into, without running any of it.
 
@@ -661,9 +694,10 @@ export def makeActions(source: string): Result<Action[]> {
     return failure(why)
   }
   const commands: Command[] = parsed.value
+  const dir = resolveCwd(cwd)
   let actions: Action[] = []
   for (command in commands) {
-    const some = actionsFor(command)
+    const some = actionsFor(command, dir)
     if (some is failure(why)) {
       return failure(why)
     }
@@ -672,21 +706,21 @@ export def makeActions(source: string): Result<Action[]> {
   return success(actions)
 }
 
-def actionsFor(command: Command): Result<Action[]> {
+def actionsFor(command: Command, cwd: string): Result<Action[]> {
   """
   Flatten one command into the actions it would produce.
   """
   if (command.tag == "simpleCommand") {
-    return wrapOne(makeAction(command))
+    return wrapOne(makeAction(command, cwd))
   }
   if (command.tag == "and") {
-    return bothSides(command.left, command.right)
+    return bothSides(command.left, command.right, cwd)
   }
   if (command.tag == "or") {
-    return bothSides(command.left, command.right)
+    return bothSides(command.left, command.right, cwd)
   }
   if (command.tag == "parens") {
-    return actionsFor(command.command)
+    return actionsFor(command.command, cwd)
   }
   return failure("unexpected AST shape: this is not a command")
 }
@@ -698,12 +732,12 @@ def wrapOne(action: Result<Action>): Result<Action[]> {
   return success([action.value])
 }
 
-def bothSides(left: Command, right: Command): Result<Action[]> {
-  const first = actionsFor(left)
+def bothSides(left: Command, right: Command, cwd: string): Result<Action[]> {
+  const first = actionsFor(left, cwd)
   if (first is failure(why)) {
     return failure(why)
   }
-  const second = actionsFor(right)
+  const second = actionsFor(right, cwd)
   if (second is failure(why)) {
     return failure(why)
   }

--- a/packages/agency-lang/stdlib/safeBash.agency
+++ b/packages/agency-lang/stdlib/safeBash.agency
@@ -10,7 +10,7 @@ import {
   gitDiffAction,
   gitLogAction,
  } from "./safeBash/actions.agency"
-import { _bashParser } from "agency-lang/stdlib-lib/safeBash.js"
+import { _bashParser, _astToBash } from "agency-lang/stdlib-lib/safeBash.js"
 
 export static const MAX_STDOUT_LEN = 2000
 

--- a/packages/agency-lang/stdlib/safeBash/actions.agency
+++ b/packages/agency-lang/stdlib/safeBash/actions.agency
@@ -1,14 +1,26 @@
-import {
-  gitStatus,
-  gitDiff,
-  gitLog,
-  GitStatus,
-  GitDiff,
-  GitLog,
- } from "std::git"
+/** @module
+  The things a bash command can turn into.
+
+  Every command `safeBash` runs is first translated into an `Action`: a plain
+  data object saying what should happen, with nothing having happened yet.
+  Deciding *what* a command means and *doing* it are separate steps, so the
+  deciding half can be tested by handing in a string and looking at the
+  actions that come out.
+
+  `bash` itself is an action, so a command with no better mapping is still
+  represented here rather than being a hole in the model.
+*/
+import { gitStatus, gitDiff, gitLog } from "std::git"
 import { bash } from "std::shell"
 
-export type Action = PrintAction | WriteFileAction | GitAction
+/** How much of a command's output to keep before truncating. */
+export static const MAX_STDOUT_LEN = 2000
+
+export type Action =
+  | PrintAction
+  | WriteFileAction
+  | GitAction
+  | BashAction
 
 export type PrintAction = {
   type: "print";
@@ -43,34 +55,90 @@ export type GitLogAction = {
   cwd?: string
 }
 
-export def printAction(content: string) {
-  print(content)
+/** The fallback: run the command through bash exactly as written.
+ *
+ * `command` is the command re-rendered from its AST, not the caller's
+ * original string, so a sequence that runs three commands and falls back on
+ * the second sends bash only the second one. */
+export type BashAction = {
+  type: "bash";
+  command: string;
+  cwd?: string
 }
 
-export def writeAction(
-  filename: string,
-  dir: string,
-  content: string,
-  mode: "append" | "overwrite",
-): Result {
-  return write(filename: filename, content: content, dir: dir, mode: mode)
+export def printAction(action: PrintAction): Result<string> {
+  """
+  Print to stdout. No interrupt: printing has no effect to approve.
+  """
+  print(action.content)
+  return success(action.content)
 }
 
-export def gitStatusAction(cwd: string = ""): Result<GitStatus> {
-  const result = gitStatus(cwd: cwd)
-  return success(result)
+export def writeAction(action: WriteFileAction): Result<string> {
+  """
+  Write a file. `write` raises the `std::write` interrupt, so this is gated
+  the same way any other write is.
+  """
+  const written = write(
+    filename: action.filename,
+    content: action.content,
+    dir: action.dir,
+    mode: action.mode,
+  )
+  if (written is failure(reason)) {
+    return failure(reason)
+  }
+  return success("")
 }
 
-export def gitDiffAction(
-  path: string = "",
-  staged: boolean = false,
-  cwd: string = "",
-): Result<GitDiff> {
-  const result = gitDiff(path: path, staged: staged, cwd: cwd)
-  return success(result)
+export def gitStatusAction(action: GitStatusAction): Result<string> {
+  return success(JSON.stringify(gitStatus(cwd: action.cwd ?? "")))
 }
 
-export def gitLogAction(path: string = "", cwd: string = ""): Result<GitLog> {
-  const result = gitLog(path: path, cwd: cwd)
-  return success(result)
+export def gitDiffAction(action: GitDiffAction): Result<string> {
+  return success(
+    JSON.stringify(
+    gitDiff(
+    path: action.path ?? "",
+    staged: action.staged ?? false,
+    cwd: action.cwd ?? "",
+  ),
+  ),
+  )
+}
+
+export def gitLogAction(action: GitLogAction): Result<string> {
+  return success(
+    JSON.stringify(gitLog(path: action.path ?? "", cwd: action.cwd ?? "")),
+  )
+}
+
+export def bashAction(action: BashAction): Result<string> {
+  """
+  Run the command through bash, approval and all.
+
+  A non-zero exit is a failure rather than a success carrying a bad exit
+  code, so a `&&` chain stops on it the way bash would.
+  """
+  // `any` because `bash` is DECLARED to return an ExecResult, but a rejected
+  // approval halts it and hands back a failure instead, which the declared
+  // type cannot describe.
+  const result: any = bash(action.command, action.cwd ?? "")
+  // Reading an exit code off that failure is a crash on the most ordinary
+  // path there is: a human saying no.
+  if (result is failure(why)) {
+    return failure("`${action.command}` was not run: ${why}")
+  }
+  const data = JSON.stringify(
+    {
+    command: action.command,
+    stdout: result.stdout[:MAX_STDOUT_LEN],
+    stderr: result.stderr[:MAX_STDOUT_LEN],
+    exitCode: result.exitCode
+  },
+  )
+  if (result.exitCode != 0) {
+    return failure(data)
+  }
+  return success(data)
 }

--- a/packages/agency-lang/stdlib/safeBash/actions.agency
+++ b/packages/agency-lang/stdlib/safeBash/actions.agency
@@ -92,25 +92,22 @@ export def writeAction(action: WriteFileAction): Result<string> {
 }
 
 export def gitStatusAction(action: GitStatusAction): Result<string> {
-  return success(JSON.stringify(gitStatus(cwd: action.cwd ?? "")))
+  const status = gitStatus(cwd: action.cwd ?? "")
+  return success(JSON.stringify(status))
 }
 
 export def gitDiffAction(action: GitDiffAction): Result<string> {
-  return success(
-    JSON.stringify(
-    gitDiff(
+  const diff = gitDiff(
     path: action.path ?? "",
     staged: action.staged ?? false,
     cwd: action.cwd ?? "",
-  ),
-  ),
   )
+  return success(JSON.stringify(diff))
 }
 
 export def gitLogAction(action: GitLogAction): Result<string> {
-  return success(
-    JSON.stringify(gitLog(path: action.path ?? "", cwd: action.cwd ?? "")),
-  )
+  const log = gitLog(path: action.path ?? "", cwd: action.cwd ?? "")
+  return success(JSON.stringify(log))
 }
 
 export def bashAction(action: BashAction): Result<string> {

--- a/packages/agency-lang/stdlib/safeBash/actions.agency
+++ b/packages/agency-lang/stdlib/safeBash/actions.agency
@@ -1,0 +1,76 @@
+import {
+  gitStatus,
+  gitDiff,
+  gitLog,
+  GitStatus,
+  GitDiff,
+  GitLog,
+ } from "std::git"
+import { bash } from "std::shell"
+
+export type Action = PrintAction | WriteFileAction | GitAction
+
+export type PrintAction = {
+  type: "print";
+  content: string
+}
+
+export type WriteFileAction = {
+  type: "writeFile";
+  filename: string;
+  dir: string;
+  content: string;
+  mode: "append" | "overwrite"
+}
+
+export type GitAction = GitStatusAction | GitDiffAction | GitLogAction
+
+export type GitStatusAction = {
+  type: "gitStatus";
+  cwd?: string
+}
+
+export type GitDiffAction = {
+  type: "gitDiff";
+  path?: string;
+  staged?: boolean;
+  cwd?: string
+}
+
+export type GitLogAction = {
+  type: "gitLog";
+  path?: string;
+  cwd?: string
+}
+
+export def printAction(content: string) {
+  print(content)
+}
+
+export def writeAction(
+  filename: string,
+  dir: string,
+  content: string,
+  mode: "append" | "overwrite",
+): Result {
+  return write(filename: filename, content: content, dir: dir, mode: mode)
+}
+
+export def gitStatusAction(cwd: string = ""): Result<GitStatus> {
+  const result = gitStatus(cwd: cwd)
+  return success(result)
+}
+
+export def gitDiffAction(
+  path: string = "",
+  staged: boolean = false,
+  cwd: string = "",
+): Result<GitDiff> {
+  const result = gitDiff(path: path, staged: staged, cwd: cwd)
+  return success(result)
+}
+
+export def gitLogAction(path: string = "", cwd: string = ""): Result<GitLog> {
+  const result = gitLog(path: path, cwd: cwd)
+  return success(result)
+}

--- a/packages/agency-lang/tests/agency/safeBash.agency
+++ b/packages/agency-lang/tests/agency/safeBash.agency
@@ -20,7 +20,7 @@ def wordsOf(command: string): any {
   if (parsed is success(ast)) {
     const cmd = simplify(ast)
     if (cmd is success(c)) {
-      return c.words
+      return [c.command, ...c.args]
     }
     return ["FAILED"]
   }
@@ -43,29 +43,52 @@ node echoQuotingIsPreserved() {
 }
 
 node commandsItRefuses() {
-  // Each of these could be mapped one day; none can be mapped by collapsing
-  // it to a word list, which is what v1 does.
+  // Parsed, but not a single simple command. Each of these could be mapped
+  // one day; none can be mapped by collapsing it to a command and a list of
+  // arguments, which is what v1 does.
   return [
-    refusalFor("cat a.txt | grep x"),
     refusalFor("a && b"),
-    refusalFor("sleep 1 &"),
+    refusalFor("a || b"),
+    refusalFor("(a && b)"),
     refusalFor("FOO=1 echo hi"),
-    refusalFor("echo $(date)"),
-    refusalFor("echo hi 2>&1"),
+    refusalFor("FOO=1"),
     refusalFor("echo a; echo b"),
+    refusalFor("echo hi 2> err.txt"),
+    refusalFor("echo hi < in.txt"),
   ]
 }
 
-node shellTransformsAreRefused() {
-  // bash rewrites an unquoted word four ways before the command runs. Passing
-  // any of them through as text would run a different command than the user
-  // wrote — the one failure mode this module must not have.
+node flagsAreRefused() {
+  // A flag has no faithful text form to put in `args`, and `echo -n` / `-e`
+  // change what echo prints. Both mean the command belongs to bash.
+  return [
+    refusalFor("echo -n hi"),
+    refusalFor("ls -la"),
+    refusalFor("git log --format=oneline"),
+  ]
+}
+
+node shellTransformsAreUnparseable() {
+  // bash rewrites an unquoted word before the command runs, so passing one
+  // through as text would run a different command than the user wrote — the
+  // one failure mode this module must not have. The parser refuses them
+  // outright, so they never reach `simplify`. Quoted, they are ordinary
+  // text and still map.
   return [
     refusalFor("echo *"),
     refusalFor("echo x[1]"),
     refusalFor("echo ~/d"),
+    refusalFor("echo $(date)"),
+    refusalFor("cat a.txt | grep x"),
+    refusalFor("sleep 1 &"),
+    refusalFor("echo hi 2>&1"),
     refusalFor("echo \"a*b\""),
   ]
+}
+
+node wordsItUnderstands() {
+  // Paths and adjacent-part words are single arguments, not several.
+  return [wordsOf("cat src/main.ts"), wordsOf("echo a.txt")]
 }
 
 node redirectsItUnderstands() {
@@ -73,7 +96,7 @@ node redirectsItUnderstands() {
   if (parsed is success(ast)) {
     const cmd = simplify(ast)
     if (cmd is success(c)) {
-      return [c.words, c.redirect.op, c.redirect.path]
+      return [c.command, c.args, c.redirect.op, c.redirect.path]
     }
   }
   return ["FAILED"]

--- a/packages/agency-lang/tests/agency/safeBash.agency
+++ b/packages/agency-lang/tests/agency/safeBash.agency
@@ -1,70 +1,107 @@
-import { safeBash, bashParser, simplify } from "std::safeBash"
+import { makeActions, bashParser, runCommands } from "std::safeBash"
 
-def refusalFor(command: string): string {
-  // What `simplify` says about a command it will not map. The reason matters:
-  // a refusal is what sends the command to bash and costs an approval, so a
-  // wrong one is a silently worse experience, not a wrong answer.
-  const parsed = bashParser(command)
-  if (parsed is success(ast)) {
-    const cmd = simplify(ast)
-    if (cmd is failure(why)) {
-      return why
-    }
-    return "mapped"
+def actionTypes(command: string): any {
+  // What KIND of action each command becomes. The fallback matters as much
+  // as the mapping: "bash" means safeBash declined to map it and the human
+  // still has to approve it.
+  const actions = makeActions(command)
+  if (actions is success(list)) {
+    return [a.type for a in list]
   }
-  return "unparseable"
+  return ["REFUSED: ${actions.error}"]
 }
 
-def wordsOf(command: string): any {
-  const parsed = bashParser(command)
-  if (parsed is success(ast)) {
-    const cmd = simplify(ast)
-    if (cmd is success(c)) {
-      return [c.command, ...c.args]
-    }
-    return ["FAILED"]
+def actionsOf(command: string): any {
+  const actions = makeActions(command)
+  if (actions is success(list)) {
+    return list
   }
-  return ["UNPARSEABLE"]
+  return "REFUSED: ${actions.error}"
 }
 
-node echoRunsWithoutApproval() {
-  // The whole point: this used to need a human. It raises no interrupt now.
-  const r = safeBash("echo hello world")
-  return [r.stdout, r.exitCode]
+node echoBecomesPrint() {
+  // The whole point: this used to need a human, and now it is a print.
+  return actionsOf("echo hello world")
+}
+
+node echoRedirectBecomesWrite() {
+  // Redirected, the same command is a file write, which `write` gates.
+  return [actionsOf("echo hi > out.txt"), actionsOf("echo hi >> out.txt")]
 }
 
 node echoQuotingIsPreserved() {
-  // Adjacent parts concatenate, and quotes are not part of the value.
+  // Quotes delimit a word, they are not part of its value, and adjacent
+  // parts concatenate into one word.
+  return [actionTypes("echo 'single quoted'"), actionsOf("echo a'b'\"c\"")]
+}
+
+node echoFlagsFallBackToBash() {
+  // `-n` drops the trailing newline and `-e` interprets escapes. Printing
+  // the flag as if it were text would print something bash never would, so
+  // both go to bash instead.
+  return [actionsOf("echo -n hi"), actionTypes("echo -e hi")]
+}
+
+node echoWithNoArgs() {
+  // Still a newline, not nothing.
+  return actionsOf("echo")
+}
+
+node gitSubcommandsMap() {
+  return [actionTypes("git status"), actionTypes("git diff"), actionTypes("git log")]
+}
+
+node gitStagedIsItsOwnAction() {
+  // `--staged` is a different question from a bare `git diff`, so it has to
+  // reach the action rather than being dropped on the way.
+  return actionsOf("git diff --staged")
+}
+
+node unknownGitFlagsFallBackToBash() {
+  // Answering `git log --graph` with a plain gitLog() would silently give
+  // the model something other than what it asked for.
+  return [actionTypes("git log --graph"), actionTypes("git status --short")]
+}
+
+node unmappedCommandsFallBackToBash() {
   return [
-    wordsOf("echo 'single quoted'"),
-    wordsOf("echo \"double quoted\""),
-    wordsOf("echo a'b'\"c\""),
+    actionTypes("ls"),
+    actionTypes("cat src/main.ts"),
+    actionTypes("./script.sh"),
   ]
 }
 
-node commandsItRefuses() {
-  // Parsed, but not a single simple command. Each of these could be mapped
-  // one day; none can be mapped by collapsing it to a command and a list of
-  // arguments, which is what v1 does.
+node fallbackRendersOnlyItsOwnCommand() {
+  // In a sequence, the command handed to bash must be the one that fell
+  // through, not the whole string.
+  return actionsOf("echo hi; ls -la; echo bye")
+}
+
+node sequencesProduceOneActionEach() {
+  return actionTypes("echo one; echo two; echo three")
+}
+
+node bothSidesOfAChainAreListed() {
+  // makeActions says what each command WOULD do. Which side actually runs
+  // is decided at run time by the exit status.
   return [
-    refusalFor("a && b"),
-    refusalFor("a || b"),
-    refusalFor("(a && b)"),
-    refusalFor("FOO=1 echo hi"),
-    refusalFor("FOO=1"),
-    refusalFor("echo a; echo b"),
-    refusalFor("echo hi 2> err.txt"),
-    refusalFor("echo hi < in.txt"),
+    actionTypes("echo a && echo b"),
+    actionTypes("echo a || echo b"),
+    actionTypes("(echo a && echo b) || echo c"),
   ]
 }
 
-node flagsAreRefused() {
-  // A flag has no faithful text form to put in `args`, and `echo -n` / `-e`
-  // change what echo prints. Both mean the command belongs to bash.
+node assignmentsFallBackToBash() {
+  // Bash scopes a leading assignment to that one command, and running the
+  // original text through bash reproduces that exactly.
+  return [actionTypes("FOO=1 echo hi"), actionTypes("FOO=1")]
+}
+
+node redirectShapesWeDoNotHandle() {
   return [
-    refusalFor("echo -n hi"),
-    refusalFor("ls -la"),
-    refusalFor("git log --format=oneline"),
+    actionTypes("echo hi 2> err.txt"),
+    actionTypes("echo hi < in.txt"),
+    actionTypes("git status > out.txt"),
   ]
 }
 
@@ -72,37 +109,57 @@ node shellTransformsAreUnparseable() {
   // bash rewrites an unquoted word before the command runs, so passing one
   // through as text would run a different command than the user wrote — the
   // one failure mode this module must not have. The parser refuses them
-  // outright, so they never reach `simplify`. Quoted, they are ordinary
-  // text and still map.
+  // outright. Quoted, they are ordinary text and still map.
   return [
-    refusalFor("echo *"),
-    refusalFor("echo x[1]"),
-    refusalFor("echo ~/d"),
-    refusalFor("echo $(date)"),
-    refusalFor("cat a.txt | grep x"),
-    refusalFor("sleep 1 &"),
-    refusalFor("echo hi 2>&1"),
-    refusalFor("echo \"a*b\""),
+    actionTypes("echo *"),
+    actionTypes("echo ~/d"),
+    actionTypes("echo $(date)"),
+    actionTypes("cat a.txt | grep x"),
+    actionTypes("sleep 1 &"),
+    actionTypes("echo \"a*b\""),
   ]
 }
 
-node wordsItUnderstands() {
-  // Paths and adjacent-part words are single arguments, not several.
-  return [wordsOf("cat src/main.ts"), wordsOf("echo a.txt")]
+node emptyExpansionsFallBackToBash() {
+  // An unset variable produces NO argument in bash, where expanding it to
+  // "" here would produce an empty one. True of a whole word and of a word
+  // made only of empty parts.
+  return [
+    actionsOf("echo $NOPE_NOT_SET"),
+    actionTypes("echo $NOPE_A$NOPE_B"),
+    actionsOf("echo \"$NOPE_NOT_SET\""),
+  ]
 }
 
-node redirectsItUnderstands() {
-  const parsed = bashParser("echo hi > out.txt")
+node quotedEmptyIsARealArgument() {
+  // `""` is an argument bash really does pass.
+  return actionsOf("echo \"\"")
+}
+
+node runningASequenceReportsWhatRan() {
+  // A failure stops the sequence and says how far it got, what it produced,
+  // and what never ran. There is no falling back for the sequence: some of
+  // it already happened.
+  const parsed = bashParser("echo one; git log --graph --nope; echo three")
   if (parsed is success(ast)) {
-    const cmd = simplify(ast)
-    if (cmd is success(c)) {
-      return [c.command, c.args, c.redirect.op, c.redirect.path]
+    const result = runCommands(ast)
+    if (result is failure(why)) {
+      return why
     }
+    return "UNEXPECTEDLY SUCCEEDED"
   }
-  return ["FAILED"]
+  return "UNPARSEABLE"
 }
 
-node unparseableFallsThrough() {
-  // Not a refusal — the parser cannot even read it. Still must not crash.
-  return refusalFor("if [ -f x ]; then")
+node andStopsOnFailure() {
+  // `false && echo b` must not print b.
+  const parsed = bashParser("git log --graph --nope && echo should-not-run")
+  if (parsed is success(ast)) {
+    const result = runCommands(ast)
+    return [
+      result is failure,
+      actionTypes("git log --graph --nope && echo should-not-run"),
+    ]
+  }
+  return ["UNPARSEABLE"]
 }

--- a/packages/agency-lang/tests/agency/safeBash.agency
+++ b/packages/agency-lang/tests/agency/safeBash.agency
@@ -128,6 +128,7 @@ node emptyExpansionsFallBackToBash() {
     actionsOf("echo $NOPE_NOT_SET"),
     actionTypes("echo $NOPE_A$NOPE_B"),
     actionsOf("echo \"$NOPE_NOT_SET\""),
+    actionsOf("echo $NOPE_NOT_SET/bin"),
   ]
 }
 
@@ -162,4 +163,31 @@ node andStopsOnFailure() {
     ]
   }
   return ["UNPARSEABLE"]
+}
+
+node cwdReachesEveryAction() {
+  // The caller's cwd has to land on EVERY action, not just the unparseable
+  // fallback. The same command in two directories is two different
+  // commands, so an action that did not carry it would run wherever the
+  // process happened to be.
+  const actions = makeActions("echo hi > out.txt; git status; ls", "/tmp/somewhere")
+  if (actions is success(list)) {
+    return list
+  }
+  return "REFUSED: ${actions.error}"
+}
+
+node chainKeepsTheLeftSidesOutput() {
+  // `a && b` where a succeeds and b fails: a really ran, so its output
+  // belongs in the report. Dropping it would make the report claim to show
+  // what already ran while hiding part of it.
+  const parsed = bashParser("echo kept && git log --graph --nope")
+  if (parsed is success(ast)) {
+    const result = runCommands(ast)
+    if (result is failure(why)) {
+      return why
+    }
+    return "UNEXPECTEDLY SUCCEEDED"
+  }
+  return "UNPARSEABLE"
 }

--- a/packages/agency-lang/tests/agency/safeBash.test.json
+++ b/packages/agency-lang/tests/agency/safeBash.test.json
@@ -23,10 +23,43 @@
       ]
     },
     {
-      "nodeName": "commandsItRefuses",
-      "description": "Every shape v1 cannot collapse to a word list is refused by name, so a fallthrough is explainable rather than mysterious.",
+      "nodeName": "wordsItUnderstands",
+      "description": "A path and a dotted filename are each one argument, not several: the parser hands them over as single words.",
       "input": "",
-      "expectedOutput": "[\"pipelines are not handled\",\"`&&` and `||` are not handled\",\"background commands are not handled\",\"leading variable assignments are not handled\",\"could not read a word: `commandSubstitution` needs a shell to evaluate\",\"could not read the redirect: redirect with an explicit file descriptor\",\"expected a single command\"]",
+      "expectedOutput": "[[\"cat\",\"src/main.ts\"],[\"echo\",\"a.txt\"]]",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "commandsItRefuses",
+      "description": "Shapes the parser reads but v1 cannot collapse to a command and a list of arguments are refused by name, so a fallthrough is explainable rather than mysterious.",
+      "input": "",
+      "expectedOutput": "[\"`&&` and `||` are not handled\",\"`&&` and `||` are not handled\",\"`( ... )` grouping is not handled\",\"leading variable assignments are not handled\",\"leading variable assignments are not handled\",\"expected a single command\",\"could not read the redirect: redirect with an explicit file descriptor\",\"could not read the redirect: `<` is not an output redirect\"]",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "flagsAreRefused",
+      "description": "A flag has no faithful text form in `args`, and `echo -n`/`-e` change what echo prints, so any flag sends the command to bash.",
+      "input": "",
+      "expectedOutput": "[\"flags are not handled\",\"flags are not handled\",\"flags are not handled\"]",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "shellTransformsAreUnparseable",
+      "description": "Anything bash would rewrite before the command runs is rejected by the parser rather than reaching simplify. Quoted, a glob is ordinary text and still maps.",
+      "input": "",
+      "expectedOutput": "[\"unparseable\",\"unparseable\",\"unparseable\",\"unparseable\",\"unparseable\",\"unparseable\",\"unparseable\",\"mapped\"]",
       "evaluationCriteria": [
         {
           "type": "exact"
@@ -35,9 +68,9 @@
     },
     {
       "nodeName": "redirectsItUnderstands",
-      "description": "An output redirect is lifted out of the AST into the simplified shape.",
+      "description": "An output redirect is lifted out of the AST into the simplified shape, separately from the command name and its arguments.",
       "input": "",
-      "expectedOutput": "[[\"echo\",\"hi\"],\">\",\"out.txt\"]",
+      "expectedOutput": "[\"echo\",[\"hi\"],\">\",\"out.txt\"]",
       "evaluationCriteria": [
         {
           "type": "exact"
@@ -49,17 +82,6 @@
       "description": "The parser is deliberately incomplete; input it cannot read falls through rather than crashing.",
       "input": "",
       "expectedOutput": "\"unparseable\"",
-      "evaluationCriteria": [
-        {
-          "type": "exact"
-        }
-      ]
-    },
-    {
-      "nodeName": "shellTransformsAreRefused",
-      "description": "Globs, bracket patterns and tilde are refused unquoted because bash would expand them; quoted, they are ordinary text and still map.",
-      "input": "",
-      "expectedOutput": "[\"could not read a word: `*` is a glob; bash would expand it\",\"could not read a word: `x[1]` is a glob; bash would expand it\",\"could not read a word: `~/d` is a tilde expansion; bash would expand it\",\"mapped\"]",
       "evaluationCriteria": [
         {
           "type": "exact"

--- a/packages/agency-lang/tests/agency/safeBash.test.json
+++ b/packages/agency-lang/tests/agency/safeBash.test.json
@@ -1,10 +1,21 @@
 {
   "tests": [
     {
-      "nodeName": "echoRunsWithoutApproval",
-      "description": "echo maps to print, so the command produces its output without raising the bash interrupt a human would have to approve.",
+      "nodeName": "echoBecomesPrint",
+      "description": "echo maps to print, so a command that used to need a human approval now raises no interrupt at all.",
       "input": "",
-      "expectedOutput": "[\"hello world\\n\",0]",
+      "expectedOutput": "[{\"type\":\"print\",\"content\":\"hello world\\n\"}]",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "echoRedirectBecomesWrite",
+      "description": "Redirected, the same echo is a file write, which `write` already gates. `dir` is never empty, because `write` rejects an empty one.",
+      "input": "",
+      "expectedOutput": "[[{\"type\":\"writeFile\",\"filename\":\"out.txt\",\"dir\":\".\",\"content\":\"hi\\n\",\"mode\":\"overwrite\"}],[{\"type\":\"writeFile\",\"filename\":\"out.txt\",\"dir\":\".\",\"content\":\"hi\\n\",\"mode\":\"append\"}]]",
       "evaluationCriteria": [
         {
           "type": "exact"
@@ -15,7 +26,7 @@
       "nodeName": "echoQuotingIsPreserved",
       "description": "Quotes delimit a word, they are not part of its value, and adjacent parts concatenate into one word.",
       "input": "",
-      "expectedOutput": "[[\"echo\",\"single quoted\"],[\"echo\",\"double quoted\"],[\"echo\",\"abc\"]]",
+      "expectedOutput": "[[\"print\"],[{\"type\":\"print\",\"content\":\"abc\\n\"}]]",
       "evaluationCriteria": [
         {
           "type": "exact"
@@ -23,10 +34,10 @@
       ]
     },
     {
-      "nodeName": "wordsItUnderstands",
-      "description": "A path and a dotted filename are each one argument, not several: the parser hands them over as single words.",
+      "nodeName": "echoFlagsFallBackToBash",
+      "description": "`echo -n` drops the trailing newline and `-e` interprets escapes; mapping either would print something bash never would, so both go to bash.",
       "input": "",
-      "expectedOutput": "[[\"cat\",\"src/main.ts\"],[\"echo\",\"a.txt\"]]",
+      "expectedOutput": "[[{\"type\":\"bash\",\"command\":\"echo -n hi\",\"cwd\":\"\"}],[\"bash\"]]",
       "evaluationCriteria": [
         {
           "type": "exact"
@@ -34,10 +45,10 @@
       ]
     },
     {
-      "nodeName": "commandsItRefuses",
-      "description": "Shapes the parser reads but v1 cannot collapse to a command and a list of arguments are refused by name, so a fallthrough is explainable rather than mysterious.",
+      "nodeName": "echoWithNoArgs",
+      "description": "Bare `echo` still prints a newline, not nothing.",
       "input": "",
-      "expectedOutput": "[\"`&&` and `||` are not handled\",\"`&&` and `||` are not handled\",\"`( ... )` grouping is not handled\",\"leading variable assignments are not handled\",\"leading variable assignments are not handled\",\"expected a single command\",\"could not read the redirect: redirect with an explicit file descriptor\",\"could not read the redirect: `<` is not an output redirect\"]",
+      "expectedOutput": "[{\"type\":\"print\",\"content\":\"\\n\"}]",
       "evaluationCriteria": [
         {
           "type": "exact"
@@ -45,10 +56,98 @@
       ]
     },
     {
-      "nodeName": "flagsAreRefused",
-      "description": "A flag has no faithful text form in `args`, and `echo -n`/`-e` change what echo prints, so any flag sends the command to bash.",
+      "nodeName": "gitSubcommandsMap",
+      "description": "Each git subcommand maps onto the std::git tool that answers the same question.",
       "input": "",
-      "expectedOutput": "[\"flags are not handled\",\"flags are not handled\",\"flags are not handled\"]",
+      "expectedOutput": "[[\"gitStatus\"],[\"gitDiff\"],[\"gitLog\"]]",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "gitStagedIsItsOwnAction",
+      "description": "`--staged` is a different question from a bare `git diff`, so the flag has to reach the action rather than being dropped on the way.",
+      "input": "",
+      "expectedOutput": "[{\"type\":\"gitDiff\",\"staged\":true}]",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "unknownGitFlagsFallBackToBash",
+      "description": "An unrecognized flag falls back rather than being ignored: answering `git log --graph` with a plain gitLog() would give the model something other than what it asked for.",
+      "input": "",
+      "expectedOutput": "[[\"bash\"],[\"bash\"]]",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "unmappedCommandsFallBackToBash",
+      "description": "A command with no equivalent tool still runs, as a bash action, with the approval that implies.",
+      "input": "",
+      "expectedOutput": "[[\"bash\"],[\"bash\"],[\"bash\"]]",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "fallbackRendersOnlyItsOwnCommand",
+      "description": "In a sequence, the command handed to bash is the one that fell through, rendered back from its own AST, not the whole string.",
+      "input": "",
+      "expectedOutput": "[{\"type\":\"print\",\"content\":\"hi\\n\"},{\"type\":\"bash\",\"command\":\"ls -la\",\"cwd\":\"\"},{\"type\":\"print\",\"content\":\"bye\\n\"}]",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "sequencesProduceOneActionEach",
+      "description": "Commands separated by `;` each become their own action.",
+      "input": "",
+      "expectedOutput": "[\"print\",\"print\",\"print\"]",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "bothSidesOfAChainAreListed",
+      "description": "makeActions reports what each command WOULD do; which side of a `&&` or `||` actually runs is decided at run time.",
+      "input": "",
+      "expectedOutput": "[[\"print\",\"print\"],[\"print\",\"print\"],[\"print\",\"print\",\"print\"]]",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "assignmentsFallBackToBash",
+      "description": "Bash scopes a leading assignment to its one command, and handing the original text to bash reproduces that exactly.",
+      "input": "",
+      "expectedOutput": "[[\"bash\"],[\"bash\"]]",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "redirectShapesWeDoNotHandle",
+      "description": "An explicit file descriptor, an input redirect, and a redirected git command all fall back rather than being approximated.",
+      "input": "",
+      "expectedOutput": "[[\"bash\"],[\"bash\"],[\"bash\"]]",
       "evaluationCriteria": [
         {
           "type": "exact"
@@ -57,9 +156,9 @@
     },
     {
       "nodeName": "shellTransformsAreUnparseable",
-      "description": "Anything bash would rewrite before the command runs is rejected by the parser rather than reaching simplify. Quoted, a glob is ordinary text and still maps.",
+      "description": "Anything bash would rewrite before the command runs is rejected by the parser rather than reaching makeAction. Quoted, a glob is ordinary text and still maps.",
       "input": "",
-      "expectedOutput": "[\"unparseable\",\"unparseable\",\"unparseable\",\"unparseable\",\"unparseable\",\"unparseable\",\"unparseable\",\"mapped\"]",
+      "expectedOutput": "[[\"REFUSED: Unexpected input after commands: \\\"*\\\"\"],[\"REFUSED: Unexpected input after commands: \\\"~/d\\\"\"],[\"REFUSED: Unexpected input after commands: \\\"$(date)\\\"\"],[\"REFUSED: Unexpected input after commands: \\\"| grep x\\\"\"],[\"REFUSED: Unexpected input after commands: \\\"&\\\"\"],[\"print\"]]",
       "evaluationCriteria": [
         {
           "type": "exact"
@@ -67,10 +166,10 @@
       ]
     },
     {
-      "nodeName": "redirectsItUnderstands",
-      "description": "An output redirect is lifted out of the AST into the simplified shape, separately from the command name and its arguments.",
+      "nodeName": "emptyExpansionsFallBackToBash",
+      "description": "An unset variable passes NO argument in bash where expanding it to \"\" would pass one, so an unquoted empty word falls back. Quoted, it is a real empty argument.",
       "input": "",
-      "expectedOutput": "[\"echo\",[\"hi\"],\">\",\"out.txt\"]",
+      "expectedOutput": "[[{\"type\":\"bash\",\"command\":\"echo $NOPE_NOT_SET\",\"cwd\":\"\"}],[\"bash\"],[{\"type\":\"print\",\"content\":\"\\n\"}]]",
       "evaluationCriteria": [
         {
           "type": "exact"
@@ -78,10 +177,44 @@
       ]
     },
     {
-      "nodeName": "unparseableFallsThrough",
-      "description": "The parser is deliberately incomplete; input it cannot read falls through rather than crashing.",
+      "nodeName": "quotedEmptyIsARealArgument",
+      "description": "`echo \"\"` passes one empty argument, so it prints a newline rather than falling back.",
       "input": "",
-      "expectedOutput": "\"unparseable\"",
+      "expectedOutput": "[{\"type\":\"print\",\"content\":\"\\n\"}]",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "runningASequenceReportsWhatRan",
+      "description": "A failure stops the sequence and reports which command failed and why, what already ran, the output so far, and what never ran.",
+      "input": "",
+      "expectedOutput": "\"Command `git log --graph --nope` failed: `git log --graph --nope` was not run: interrupt rejected\\n\\nCommands run:\\necho one\\n\\nOutput so far:\\n<results>\\none\\n\\n</results>\\n\\nCommands not run:\\necho three\"",
+      "interruptHandlers": [
+        {
+          "action": "reject",
+          "expectedMessage": "Are you sure you want to run this shell command?"
+        }
+      ],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "andStopsOnFailure",
+      "description": "`a && b` does not run b when a fails, and the chain fails as a whole.",
+      "input": "",
+      "expectedOutput": "[true,[\"bash\",\"print\"]]",
+      "interruptHandlers": [
+        {
+          "action": "reject",
+          "expectedMessage": "Are you sure you want to run this shell command?"
+        }
+      ],
       "evaluationCriteria": [
         {
           "type": "exact"

--- a/packages/agency-lang/tests/agency/safeBash.test.json
+++ b/packages/agency-lang/tests/agency/safeBash.test.json
@@ -70,7 +70,7 @@
       "nodeName": "gitStagedIsItsOwnAction",
       "description": "`--staged` is a different question from a bare `git diff`, so the flag has to reach the action rather than being dropped on the way.",
       "input": "",
-      "expectedOutput": "[{\"type\":\"gitDiff\",\"staged\":true}]",
+      "expectedOutput": "[{\"type\":\"gitDiff\",\"staged\":true,\"cwd\":\"\"}]",
       "evaluationCriteria": [
         {
           "type": "exact"
@@ -169,7 +169,7 @@
       "nodeName": "emptyExpansionsFallBackToBash",
       "description": "An unset variable passes NO argument in bash where expanding it to \"\" would pass one, so an unquoted empty word falls back. Quoted, it is a real empty argument.",
       "input": "",
-      "expectedOutput": "[[{\"type\":\"bash\",\"command\":\"echo $NOPE_NOT_SET\",\"cwd\":\"\"}],[\"bash\"],[{\"type\":\"print\",\"content\":\"\\n\"}]]",
+      "expectedOutput": "[[{\"type\":\"bash\",\"command\":\"echo $NOPE_NOT_SET\",\"cwd\":\"\"}],[\"bash\"],[{\"type\":\"print\",\"content\":\"\\n\"}],[{\"type\":\"print\",\"content\":\"/bin\\n\"}]]",
       "evaluationCriteria": [
         {
           "type": "exact"
@@ -209,6 +209,34 @@
       "description": "`a && b` does not run b when a fails, and the chain fails as a whole.",
       "input": "",
       "expectedOutput": "[true,[\"bash\",\"print\"]]",
+      "interruptHandlers": [
+        {
+          "action": "reject",
+          "expectedMessage": "Are you sure you want to run this shell command?"
+        }
+      ],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "cwdReachesEveryAction",
+      "description": "The caller's cwd lands on every action a command produces \u2014 a write's dir, a git action's cwd, and a bash fallback's cwd \u2014 not only on the unparseable path.",
+      "input": "",
+      "expectedOutput": "[{\"type\":\"writeFile\",\"filename\":\"out.txt\",\"dir\":\"/tmp/somewhere\",\"content\":\"hi\\n\",\"mode\":\"overwrite\"},{\"type\":\"gitStatus\",\"cwd\":\"/tmp/somewhere\"},{\"type\":\"bash\",\"command\":\"ls\",\"cwd\":\"/tmp/somewhere\"}]",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "chainKeepsTheLeftSidesOutput",
+      "description": "When the left side of `&&` succeeds and the right fails, the left side really ran, so its output stays in the failure report.",
+      "input": "",
+      "expectedOutput": "\"Command `echo kept && git log --graph --nope` failed: `git log --graph --nope` was not run: interrupt rejected\\n\\nOutput before the failure:\\nkept\\n\"",
       "interruptHandlers": [
         {
           "action": "reject",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,8 +41,8 @@ importers:
         specifier: ^0.8.4
         version: 0.8.4(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.21.1)
       tarsec:
-        specifier: 0.5.2
-        version: 0.5.2
+        specifier: 0.5.3
+        version: 0.5.3
       typestache:
         specifier: ^0.5.0
         version: 0.5.0
@@ -2657,8 +2657,8 @@ packages:
   tarsec@0.2.2:
     resolution: {integrity: sha512-o6C0wNzEq9Mh3lPzWeoyRHTTiY3/j6rURahNHsqsGjcZmdNDelwXbf+7ocN0ojJJuBuKBkerWX8DrIvhpUz6qw==}
 
-  tarsec@0.5.2:
-    resolution: {integrity: sha512-OMZA8hP7wfRLhYDm4Cfdud1zDBRmM9q9DXqxGfofXiBeMwV4cd47opf0T8+K0WEaSB3FyDN3RZinPsyIyznZvA==}
+  tarsec@0.5.3:
+    resolution: {integrity: sha512-JrOqwP0+raZ+YEktoB0OEM6kYGhTORcN95fWJtSN7sHKTNXoNBxF2KVHnXhb4x5fWHXOYPpsveUVoZiyEH36eQ==}
 
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
@@ -5545,7 +5545,7 @@ snapshots:
 
   tarsec@0.2.2: {}
 
-  tarsec@0.5.2: {}
+  tarsec@0.5.3: {}
 
   thenify-all@1.6.0:
     dependencies:


### PR DESCRIPTION
tarsec 0.5.2 rewrote the bash parser, and the AST `safeBash` reduces changed shape underneath it. This follows it.

## What moved

- The top level is a flat `Command[]` — no `List`, no `items` wrapper, no `background` flag.
- A simple command carries its name in `command`, separate from `args`.
- Flags and paths are structural nodes rather than literal text.
- Globs, tilde, pipelines, background, command substitution, arithmetic and `2>&1` are rejected at parse time instead of arriving in the AST.

## The shape question

The spec flagged `Cmd` as a possible lock-in, with the first real change as its test. This is that change, and `Cmd` follows the parser rather than flattening back to a word list:

```ts
type Cmd = { command: string, args: string[], redirect: OutputRedirect | null }
```

Collapsing the name back into the args would throw away the split the parser now hands over, and a flag has no faithful text form to put in a `string[]` — the parser splits `--format=oneline` into a name and a value, and re-joining them is a guess about a syntax that varies per command. `simplify` refuses any command with a flag instead. That is the behavior the old `startsWith("-")` check had, now detected structurally.

## Dead code the parser made unreachable

Because the parser refuses what it cannot represent, the glob and tilde checks in `literalWord` and the `needs a shell to evaluate` arm can no longer fire, and are gone. This also resolves the spec's "Parser gaps" section: `echo *` no longer arrives as a literal indistinguishable from text, so nothing has to scan for shell metacharacters.

Four rows of the refusal table moved from "refused by `simplify`" to "unparseable". Both paths fall through to bash, so no command changes hands — only the reason it reports.

## One correctness fix

An unquoted empty expansion is now only refused when the variable **is** the whole word. Bash passes zero arguments for `cat $EMPTY` but one for `cat $EMPTY/bin`, so refusing the second was wrong.

## Also

- The `any` workaround for the field-name/type-alias collision is no longer needed and is dropped.
- Tests grew from 6 nodes to 8, splitting parse-time rejection from `simplify` refusal and covering flags and paths. 8/8 pass.
- Still **not wired into any agent** — `shellTools()` is untouched.

## Not in this PR

The spec's own sections still describe the old parser: the refusal table, "Parser gaps", and the flag discussion under the command table (flags being structural changes that calculus). Worth a follow-up pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
