### PR TITLE
safeBash v3: classify the command, then let bash do the work

### DIFF
--- a/packages/agency-lang/docs/site/stdlib/safeBash.md
+++ b/packages/agency-lang/docs/site/stdlib/safeBash.md
@@ -19,7 +19,7 @@ export type Word =
   | InterpolatedVariableWord
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L21))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L22))
 
 ### ScriptName
 
@@ -27,7 +27,7 @@ export type Word =
 export type ScriptName = LiteralWord | PathWord
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L30))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L31))
 
 ### LiteralWord
 
@@ -38,7 +38,7 @@ export type LiteralWord = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L32))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L33))
 
 ### PathWord
 
@@ -49,7 +49,7 @@ export type PathWord = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L37))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L38))
 
 ### FlagWord
 
@@ -61,7 +61,7 @@ export type FlagWord = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L42))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L43))
 
 ### SingleQuotedWord
 
@@ -72,7 +72,7 @@ export type SingleQuotedWord = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L48))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L49))
 
 ### DoubleQuotedWord
 
@@ -83,7 +83,7 @@ export type DoubleQuotedWord = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L53))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L54))
 
 ### VariableWord
 
@@ -94,7 +94,7 @@ export type VariableWord = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L58))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L59))
 
 ### InterpolatedVariableWord
 
@@ -117,7 +117,7 @@ export type InterpolatedVariableWord = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L67))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L68))
 
 ### Assignment
 
@@ -132,7 +132,7 @@ export type Assignment = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L77))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L78))
 
 ### Redirect
 
@@ -154,7 +154,7 @@ export type Redirect = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L87))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L88))
 
 ### SimpleCommand
 
@@ -174,7 +174,7 @@ export type SimpleCommand = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L94))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L95))
 
 ### Command
 
@@ -182,7 +182,7 @@ export type SimpleCommand = {
 export type Command = SimpleCommand | And | Or | Parens
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L108))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L109))
 
 ### And
 
@@ -194,7 +194,7 @@ export type And = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L110))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L111))
 
 ### Or
 
@@ -206,7 +206,7 @@ export type Or = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L116))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L117))
 
 ### Parens
 
@@ -217,7 +217,7 @@ export type Parens = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L122))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L123))
 
 ### BashNode
 
@@ -231,7 +231,7 @@ export type BashNode =
   | ScriptName
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L127))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L128))
 
 ### BashAST
 
@@ -239,7 +239,7 @@ export type BashNode =
 export type BashAST = Command[]
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L135))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L136))
 
 ## Functions
 
@@ -267,7 +267,7 @@ Which interrupts this one command needs raised.
 
 **Returns:** `Result<Effect[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L241))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L245))
 
 ### planFor
 
@@ -293,7 +293,7 @@ Decide everything about a call before any of it happens.
 
 **Returns:** [Plan](safeBash/actions.md#plan)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L646))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L650))
 
 ### isRefused
 
@@ -318,7 +318,7 @@ True when this command must not run, whatever anyone approves.
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L735))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L739))
 
 ### bashParser
 
@@ -336,7 +336,7 @@ Parse a string of bash code into an AST.
 
 **Returns:** `Result<BashAST>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L816))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L820))
 
 ### resolveCwd
 
@@ -359,7 +359,7 @@ Which directory a command runs in: the caller's, or the agent's when the
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L840))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L844))
 
 ### safeBash
 
@@ -395,4 +395,4 @@ Run a shell command, asking the narrowest question that describes it.
 
 **Throws:** `std::bash`, `std::write`, `std::git::status`, `std::git::log`, `std::git::diff`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L861))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L865))

--- a/packages/agency-lang/docs/site/stdlib/safeBash.md
+++ b/packages/agency-lang/docs/site/stdlib/safeBash.md
@@ -19,7 +19,7 @@ export type Word =
   | InterpolatedVariableWord
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L16))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L21))
 
 ### ScriptName
 
@@ -27,7 +27,7 @@ export type Word =
 export type ScriptName = LiteralWord | PathWord
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L25))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L30))
 
 ### LiteralWord
 
@@ -38,7 +38,7 @@ export type LiteralWord = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L27))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L32))
 
 ### PathWord
 
@@ -49,7 +49,7 @@ export type PathWord = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L32))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L37))
 
 ### FlagWord
 
@@ -61,7 +61,7 @@ export type FlagWord = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L37))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L42))
 
 ### SingleQuotedWord
 
@@ -72,7 +72,7 @@ export type SingleQuotedWord = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L43))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L48))
 
 ### DoubleQuotedWord
 
@@ -83,7 +83,7 @@ export type DoubleQuotedWord = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L48))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L53))
 
 ### VariableWord
 
@@ -94,7 +94,7 @@ export type VariableWord = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L53))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L58))
 
 ### InterpolatedVariableWord
 
@@ -117,7 +117,7 @@ export type InterpolatedVariableWord = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L62))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L67))
 
 ### Assignment
 
@@ -132,7 +132,7 @@ export type Assignment = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L72))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L77))
 
 ### Redirect
 
@@ -154,7 +154,7 @@ export type Redirect = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L82))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L87))
 
 ### SimpleCommand
 
@@ -174,7 +174,7 @@ export type SimpleCommand = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L89))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L94))
 
 ### Command
 
@@ -182,7 +182,7 @@ export type SimpleCommand = {
 export type Command = SimpleCommand | And | Or | Parens
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L103))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L108))
 
 ### And
 
@@ -194,7 +194,7 @@ export type And = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L105))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L110))
 
 ### Or
 
@@ -206,7 +206,7 @@ export type Or = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L111))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L116))
 
 ### Parens
 
@@ -217,7 +217,7 @@ export type Parens = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L117))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L122))
 
 ### BashNode
 
@@ -231,7 +231,7 @@ export type BashNode =
   | ScriptName
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L122))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L127))
 
 ### BashAST
 
@@ -239,25 +239,86 @@ export type BashNode =
 export type BashAST = Command[]
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L130))
-
-### OutputRedirect
-
-An output redirect reduced to the shape v1 handles: `>` or `>>` to a
- * path, with no explicit file descriptor.
-
-```ts
-/** An output redirect reduced to the shape v1 handles: `>` or `>>` to a
- * path, with no explicit file descriptor. */
-export type OutputRedirect = {
-  op: string;
-  path: string
-}
-```
-
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L134))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L135))
 
 ## Functions
+
+### effectsFor
+
+```ts
+effectsFor(command: SimpleCommand, cwd: string): Result<Effect[]>
+```
+
+Which interrupts this one command needs raised.
+
+  A failure means the command is not recognized. The caller turns that
+  into a `std::bash` question for the whole string rather than trying to
+  ask a narrow question about part of it.
+
+  @param command - One simple command from the parsed AST
+  @param cwd - The resolved working directory, for payloads that need it
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| command | [SimpleCommand](#simplecommand) |  |
+| cwd | `string` |  |
+
+**Returns:** `Result<Effect[]>`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L241))
+
+### planFor
+
+```ts
+planFor(source: string, cwd: string): Plan
+```
+
+Decide everything about a call before any of it happens.
+
+  Parses the string, classifies every command, and works out which
+  interrupts to raise and what to run. Nothing here has an effect, which
+  is what makes the decision testable: hand in a string, look at the plan.
+
+  @param source - One or more bash commands
+  @param cwd - The resolved working directory
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| source | `string` |  |
+| cwd | `string` |  |
+
+**Returns:** [Plan](safeBash/actions.md#plan)
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L646))
+
+### isRefused
+
+```ts
+isRefused(command: SimpleCommand): boolean
+```
+
+True when this command must not run, whatever anyone approves.
+
+  Matches the command word, including the last part of a path, so `rm`,
+  `/bin/rm` and `./rm` are all refused.
+
+  This wall is friction against the obvious spelling, not a guarantee.
+  `find . -delete` and `xargs rm` get past it and are approvable under
+  `std::bash`, which is where the actual control lives.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| command | [SimpleCommand](#simplecommand) |  |
+
+**Returns:** `boolean`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L735))
 
 ### bashParser
 
@@ -275,172 +336,53 @@ Parse a string of bash code into an AST.
 
 **Returns:** `Result<BashAST>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L139))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L816))
 
-### makeAction
+### resolveCwd
 
 ```ts
-makeAction(command: SimpleCommand, cwd: string = ""): Result<Action>
+resolveCwd(cwd: string): string
 ```
 
-Decide what a single command means, without doing any of it.
+Which directory a command runs in: the caller's, or the agent's when the
+  caller did not say.
 
-  Everything this returns is a plain data object, so the whole mapping can
-  be tested by looking at what comes out. A command with no better mapping
-  becomes a `BashAction`, which is still a decision rather than a hole: it
-  says "this one has to go to bash", and `runAction` is what pays the
-  approval for it.
-
-  @param command - One simple command from the parsed AST
+  Resolved once, at the top, and then carried on every action. An action
+  that did not carry it would run wherever the process happened to be,
+  which is the same command doing two different things.
 
 **Parameters:**
 
 | Name | Type | Default |
 |---|---|---|
-| command | [SimpleCommand](#simplecommand) |  |
-| cwd | `string` | "" |
-
-**Returns:** `Result<Action>`
-
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L404))
-
-### runAction
-
-```ts
-runAction(action: Action): Result<string>
-```
-
-Do what the action says. The only step with effects.
-
-**Parameters:**
-
-| Name | Type | Default |
-|---|---|---|
-| action | [Action](safeBash/actions.md#action) |  |
-
-**Returns:** `Result<string>`
-
-**Throws:** `std::write`, `std::git::status`, `std::git::diff`, `std::git::log`, `std::bash`
-
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L501))
-
-### runCommand
-
-```ts
-runCommand(command: Command, cwd: string = ""): Result<string>
-```
-
-Run one command, whatever shape it is.
-
-  Every branch returns a `Result`, and a failure is never swallowed: the
-  caller has to decide what a failed command means, because `&&` and `||`
-  answer that question differently.
-
-**Parameters:**
-
-| Name | Type | Default |
-|---|---|---|
-| command | [Command](#command) |  |
-| cwd | `string` | "" |
-
-**Returns:** `Result<string>`
-
-**Throws:** `std::write`, `std::git::status`, `std::git::diff`, `std::git::log`, `std::bash`
-
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L523))
-
-### commandsToStr
-
-```ts
-commandsToStr(commands: Command[]): string
-```
-
-Render commands back to bash source, one per line.
-
-**Parameters:**
-
-| Name | Type | Default |
-|---|---|---|
-| commands | `Command[]` |  |
+| cwd | `string` |  |
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L619))
-
-### runCommands
-
-```ts
-runCommands(commands: Command[], cwd: string = ""): Result<string>
-```
-
-Run a sequence of commands, stopping at the first failure.
-
-  On a failure the model gets the whole picture rather than a bare error:
-  what already ran and what it produced, which command failed and why, and
-  what never ran. There is no falling back to bash for the sequence — some
-  of it has already happened, and re-running the lot would repeat it.
-
-**Parameters:**
-
-| Name | Type | Default |
-|---|---|---|
-| commands | `Command[]` |  |
-| cwd | `string` | "" |
-
-**Returns:** `Result<string>`
-
-**Throws:** `std::write`, `std::git::status`, `std::git::diff`, `std::git::log`, `std::bash`
-
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L634))
-
-### makeActions
-
-```ts
-makeActions(source: string, cwd: string = ""): Result<Action[]>
-```
-
-Every action a string of bash would turn into, without running any of it.
-
-  This is the whole decision-making half of the module in one call, which
-  is what makes it testable: hand it a string, look at what comes out.
-
-  The list is in source order and includes both halves of a `&&` or `||`,
-  so it says what each command WOULD do, not what will actually run — only
-  running the chain decides that.
-
-  @param source - One or more bash commands
-
-**Parameters:**
-
-| Name | Type | Default |
-|---|---|---|
-| source | `string` |  |
-| cwd | `string` | "" |
-
-**Returns:** `Result<Action[]>`
-
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L679))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L840))
 
 ### safeBash
 
 ```ts
-safeBash(command: string, cwd: string = ""): Result<string>
+safeBash(
+  command: string,
+  cwd: string = "",
+): Result<string> raises <std::bash, std::write, std::git::status, std::git::diff, std::git::log>
 ```
 
-Run a shell command, using an equivalent tool where one exists.
+Run a shell command, asking the narrowest question that describes it.
 
-  `bash` cannot be pre-approved — there is no way to say in advance what an
-  arbitrary command string will do — so every call needs a human. Many of
-  the commands an agent writes have a tool that does the same job and IS
-  pre-approved. This parses the command and uses that tool when it can.
+  `bash` cannot be pre-approved, because a command is a string and a
+  string could do anything, so every call needs a human. Many of the
+  commands an agent writes can be identified, and for those we ask a more
+  specific question — one a policy can answer in advance.
 
-  A command with no equivalent still runs, through bash, approval and all.
-  What is NOT possible is silently doing something other than what was
-  asked: a command that cannot be mapped is handed to bash unchanged, and a
-  sequence that fails partway says exactly how far it got.
+  Nothing runs until every question is answered. If everything is
+  approved, the whole string goes to bash in one call, so bash does the
+  control flow and produces the output.
 
-  @param command - The shell command to run
-  @param cwd - Working directory
+  @param command - One or more bash commands
+  @param cwd - Working directory. Defaults to the agent working directory.
 
 **Parameters:**
 
@@ -451,6 +393,6 @@ Run a shell command, using an equivalent tool where one exists.
 
 **Returns:** `Result<string>`
 
-**Throws:** `std::bash`, `std::write`, `std::git::status`, `std::git::diff`, `std::git::log`
+**Throws:** `std::bash`, `std::write`, `std::git::status`, `std::git::log`, `std::git::diff`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L747))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L861))

--- a/packages/agency-lang/docs/site/stdlib/safeBash/actions.md
+++ b/packages/agency-lang/docs/site/stdlib/safeBash/actions.md
@@ -1,126 +1,107 @@
 ---
 name: "actions"
-description: "The things a bash command can turn into."
+description: "What safeBash decides, and the three ways it can carry that out."
 ---
 
 # actions
 
-The things a bash command can turn into.
+What safeBash decides, and the three ways it can carry that out.
 
-  Every command `safeBash` runs is first translated into an `Action`: a plain
-  data object saying what should happen, with nothing having happened yet.
-  Deciding *what* a command means and *doing* it are separate steps, so the
-  deciding half can be tested by handing in a string and looking at the
-  actions that come out.
+  A `Plan` is the whole decision about one call, made before anything
+  happens: which interrupts to raise, and what to run if they are all
+  approved. Deciding and doing are separate steps so the deciding half can
+  be tested by handing in a string and looking at the plan.
 
-  `bash` itself is an action, so a command with no better mapping is still
-  represented here rather than being a hole in the model.
+  The executors call the NON-RAISING internals (`_bash`, `_write`) rather
+  than the `bash` and `write` tools, because those raise their own
+  interrupts and the caller has already raised a narrower one. See the
+  comment on `runBash`.
 
 ## Types
 
-### Action
+### Effect
+
+One interrupt a command needs raised before it may run.
+ *
+ * A discriminated union rather than a bag of `any`: the effect set is
+ * closed, so each payload can be typed, and typing them is what makes the
+ * raise sites check that every payload satisfies its effect's contract.
 
 ```ts
-export type Action =
-  | PrintAction
-  | WriteFileAction
-  | GitAction
-  | BashAction
-```
-
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L19))
-
-### PrintAction
-
-```ts
-export type PrintAction = {
-  type: "print";
-  content: string
-}
+/** One interrupt a command needs raised before it may run.
+ *
+ * A discriminated union rather than a bag of `any`: the effect set is
+ * closed, so each payload can be typed, and typing them is what makes the
+ * raise sites check that every payload satisfies its effect's contract. */
+export type Effect =
+  | { name: "std::bash" }
+  | { name: "std::write"; payload: WritePayload }
+  | { name: "std::git::status"; payload: { cwd: string } }
+  | { name: "std::git::log"; payload: { cwd: string; ref: string; path: string } }
+  | { name: "std::git::diff"; payload: GitDiffPayload }
 ```
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L25))
 
-### WriteFileAction
+### WritePayload
 
 ```ts
-export type WriteFileAction = {
-  type: "writeFile";
+export type WritePayload = {
+  dir: string;
+  filename: string;
+  content: string;
+  mode: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L32))
+
+### GitDiffPayload
+
+```ts
+export type GitDiffPayload = {
+  cwd: string;
+  ref: string;
+  ref2: string;
+  staged: boolean;
+  path: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L39))
+
+### Execution
+
+What happens if every effect in the plan is approved.
+
+```ts
+/** What happens if every effect in the plan is approved. */
+export type Execution = {
+  kind: string;
+  command: string;
+  content: string;
   filename: string;
   dir: string;
-  content: string;
-  mode: "append" | "overwrite"
+  mode: string;
+  reason: string
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L30))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L48))
 
-### GitAction
+### Plan
 
-```ts
-export type GitAction = GitStatusAction | GitDiffAction | GitLogAction
-```
-
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L38))
-
-### GitStatusAction
+The whole decision about one call to safeBash, made before anything runs.
 
 ```ts
-export type GitStatusAction = {
-  type: "gitStatus";
-  cwd?: string
+/** The whole decision about one call to safeBash, made before anything runs. */
+export type Plan = {
+  effects: Effect[];
+  execution: Execution
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L40))
-
-### GitDiffAction
-
-```ts
-export type GitDiffAction = {
-  type: "gitDiff";
-  path?: string;
-  staged?: boolean;
-  cwd?: string
-}
-```
-
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L45))
-
-### GitLogAction
-
-```ts
-export type GitLogAction = {
-  type: "gitLog";
-  path?: string;
-  cwd?: string
-}
-```
-
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L52))
-
-### BashAction
-
-The fallback: run the command through bash exactly as written.
- *
- * `command` is the command re-rendered from its AST, not the caller's
- * original string, so a sequence that runs three commands and falls back on
- * the second sends bash only the second one.
-
-```ts
-/** The fallback: run the command through bash exactly as written.
- *
- * `command` is the command re-rendered from its AST, not the caller's
- * original string, so a sequence that runs three commands and falls back on
- * the second sends bash only the second one. */
-export type BashAction = {
-  type: "bash";
-  command: string;
-  cwd?: string
-}
-```
-
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L63))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L59))
 
 ## Constants
 
@@ -130,122 +111,77 @@ export type BashAction = {
 export static const MAX_STDOUT_LEN = 2000
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L17))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L18))
 
 ## Functions
 
-### printAction
+### runBash
 
 ```ts
-printAction(action: PrintAction): Result<string>
+runBash(command: string, cwd: string): Result<string>
 ```
 
-Print to stdout. No interrupt: printing has no effect to approve.
+Run a command string through bash and return what it printed.
+
+  On success the value is bash's stdout, raw — nothing added, nothing
+  stripped. stderr is discarded on success and reported on failure: two
+  captured pipes cannot interleave the way a terminal does, so this is a
+  policy either way, and discarding on success keeps the value exactly
+  equal to bash's stdout.
+
+  A non-zero exit is a failure, which `&&` and `||` require. The known
+  cost: `grep` exits 1 when it finds nothing and `diff` exits 1 when files
+  differ, and neither is an error.
 
 **Parameters:**
 
 | Name | Type | Default |
 |---|---|---|
-| action | [PrintAction](#printaction) |  |
+| command | `string` |  |
+| cwd | `string` |  |
 
 **Returns:** `Result<string>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L69))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L64))
 
-### writeAction
+### truncate
 
 ```ts
-writeAction(action: WriteFileAction): Result<string>
+truncate(text: string): string
 ```
 
-Write a file. `write` raises the `std::write` interrupt, so this is gated
-  the same way any other write is.
+Cap output length. Raw output with no bound is a context-window hazard,
+  and a visible loss of fidelity beats an invisible one.
 
 **Parameters:**
 
 | Name | Type | Default |
 |---|---|---|
-| action | [WriteFileAction](#writefileaction) |  |
+| text | `string` |  |
 
-**Returns:** `Result<string>`
-
-**Throws:** `std::write`
-
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L77))
-
-### gitStatusAction
-
-```ts
-gitStatusAction(action: GitStatusAction): Result<string>
-```
-
-**Parameters:**
-
-| Name | Type | Default |
-|---|---|---|
-| action | [GitStatusAction](#gitstatusaction) |  |
-
-**Returns:** `Result<string>`
-
-**Throws:** `std::git::status`
-
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L94))
-
-### gitDiffAction
-
-```ts
-gitDiffAction(action: GitDiffAction): Result<string>
-```
-
-**Parameters:**
-
-| Name | Type | Default |
-|---|---|---|
-| action | [GitDiffAction](#gitdiffaction) |  |
-
-**Returns:** `Result<string>`
-
-**Throws:** `std::git::diff`
-
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L99))
-
-### gitLogAction
-
-```ts
-gitLogAction(action: GitLogAction): Result<string>
-```
-
-**Parameters:**
-
-| Name | Type | Default |
-|---|---|---|
-| action | [GitLogAction](#gitlogaction) |  |
-
-**Returns:** `Result<string>`
-
-**Throws:** `std::git::log`
-
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L108))
-
-### bashAction
-
-```ts
-bashAction(action: BashAction): Result<string>
-```
-
-Run the command through bash, approval and all.
-
-  A non-zero exit is a failure rather than a success carrying a bad exit
-  code, so a `&&` chain stops on it the way bash would.
-
-**Parameters:**
-
-| Name | Type | Default |
-|---|---|---|
-| action | [BashAction](#bashaction) |  |
-
-**Returns:** `Result<string>`
-
-**Throws:** `std::bash`
+**Returns:** `string`
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L113))
+
+### runWrite
+
+```ts
+runWrite(exec: Execution): Result<string>
+```
+
+Perform the write a redirected echo asked for. Returns the empty string,
+  which is what bash's stdout for `echo hi > f` is.
+
+  `_write`, NOT `write`, for the same reason `runBash` uses `_bash`: the
+  `write` tool raises its own `std::write`, and the caller already raised
+  one carrying the content.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| exec | [Execution](#execution) |  |
+
+**Returns:** `Result<string>`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L124))

--- a/packages/agency-lang/docs/site/stdlib/safeBash/actions.md
+++ b/packages/agency-lang/docs/site/stdlib/safeBash/actions.md
@@ -41,7 +41,7 @@ export type Effect =
   | { name: "std::git::diff"; payload: GitDiffPayload }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L25))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L27))
 
 ### WritePayload
 
@@ -50,11 +50,11 @@ export type WritePayload = {
   dir: string;
   filename: string;
   content: string;
-  mode: string
+  mode: WriteMode
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L32))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L34))
 
 ### GitDiffPayload
 
@@ -68,7 +68,7 @@ export type GitDiffPayload = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L39))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L41))
 
 ### Execution
 
@@ -82,12 +82,12 @@ export type Execution = {
   content: string;
   filename: string;
   dir: string;
-  mode: string;
+  mode: WriteMode;
   reason: string
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L48))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L50))
 
 ### Plan
 
@@ -101,7 +101,7 @@ export type Plan = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L59))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L61))
 
 ## Constants
 
@@ -111,7 +111,7 @@ export type Plan = {
 export static const MAX_STDOUT_LEN = 2000
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L18))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L20))
 
 ## Functions
 
@@ -142,7 +142,7 @@ Run a command string through bash and return what it printed.
 
 **Returns:** `Result<string>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L64))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L66))
 
 ### truncate
 
@@ -161,7 +161,7 @@ Cap output length. Raw output with no bound is a context-window hazard,
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L113))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L115))
 
 ### runWrite
 
@@ -184,4 +184,4 @@ Perform the write a redirected echo asked for. Returns the empty string,
 
 **Returns:** `Result<string>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L124))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L126))

--- a/packages/agency-lang/docs/superpowers/plans/2026-07-27-safebash-v3-classifier.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-07-27-safebash-v3-classifier.md
@@ -75,6 +75,7 @@ node refuseWall() {
     refusedFor("git restore src"),
     refusedFor("git reset HEAD~1"),
     refusedFor("git checkout main"),
+    refusedFor("git checkout ."),
     refusedFor("git log reset"),
     refusedFor("git status"),
     refusedFor("echo hi"),
@@ -89,7 +90,7 @@ Add to `tests/agency/safeBash.test.json` inside `"tests"`:
   "nodeName": "refuseWall",
   "description": "Commands we decline to run even with approval, matched by command word and by the last part of a path. Only the destructive spellings of git subcommands are refused, and only in the first argument position.",
   "input": "",
-  "expectedOutput": "[true,true,true,true,true,true,true,false,false,false,false,false]",
+  "expectedOutput": "[true,true,true,true,true,true,true,false,false,true,false,false,false]",
   "evaluationCriteria": [{ "type": "exact" }]
 }
 ```
@@ -176,11 +177,14 @@ def isDestructiveGit(command: SimpleCommand): boolean {
     return hasFlag(command, "--hard")
   }
   if (first.text == "checkout") {
-    // `git checkout -- path` and `git checkout .` discard working-tree
-    // changes. `git checkout branch` does not.
-    if (hasFlag(command, "--")) {
-      return true
-    }
+    // `git checkout .` discards working-tree changes; `git checkout main`
+    // does not.
+    //
+    // `git checkout -- .` is NOT handled here, and cannot be: the parser
+    // rejects a bare `--` ("Unexpected input after commands"), so that
+    // string never reaches classification at all. It falls through as
+    // unparseable and is approvable under `std::bash`. Verified against
+    // the parser; the spec's refuse table is corrected to match.
     return hasLiteralArg(command, ".")
   }
   return false
@@ -270,10 +274,11 @@ node classifyOneCommand() {
     effectNamesFor("echo hi"),
     effectNamesFor("ls"),
     effectNamesFor("git log --graph"),
-    effectNamesFor("$CMD status"),
+    effectNamesFor("/bin/git status"),
     effectNamesFor("FOO=1 git status"),
     effectNamesFor("echo -n hi"),
     effectNamesFor("echo \"quoted\""),
+    effectNamesFor("git diff --staged --stat"),
   ]
 }
 ```
@@ -283,9 +288,9 @@ Add to `tests/agency/safeBash.test.json`:
 ```json
 {
   "nodeName": "classifyOneCommand",
-  "description": "Each recognized command contributes its own effects. An unrecognized command, an unknown flag, a non-literal command word and a leading assignment are all unrecognized. In a sequence, echo contributes nothing whatever its arguments, because bash runs it.",
+  "description": "Each recognized command contributes its own effects. An unrecognized command, an unknown flag, a non-literal command word and a leading assignment are all unrecognized. In a sequence, echo contributes nothing whatever its arguments, because bash runs it.\n\nThe `/bin/git status` row is the one that fails if the literal-command-word rule is deleted: it parses cleanly with a `path` command word and would otherwise classify as a git read. (`$CMD status` does NOT parse, so it cannot cover this rule.)",
   "input": "",
-  "expectedOutput": "[[\"std::git::status\"],[\"std::git::diff\"],[\"std::git::diff\"],[\"std::git::log\"],[],\"UNRECOGNIZED\",\"UNRECOGNIZED\",\"UNRECOGNIZED\",\"UNRECOGNIZED\",[],[]]",
+  "expectedOutput": "[[\"std::git::status\"],[\"std::git::diff\"],[\"std::git::diff\"],[\"std::git::log\"],[],\"UNRECOGNIZED\",\"UNRECOGNIZED\",\"UNRECOGNIZED\",\"UNRECOGNIZED\",[],[],\"UNRECOGNIZED\"]",
   "evaluationCriteria": [{ "type": "exact" }]
 }
 ```
@@ -408,10 +413,6 @@ export def effectsFor(command: SimpleCommand, cwd: string): Result<Effect[]> {
   if (command.assignments.length > 0) {
     return failure("a leading assignment changes what the command does")
   }
-  const args = literalArgs(command)
-  if (args is failure(why)) {
-    return failure(why)
-  }
   const flags = flagNames(command)
 
   if (name.text == "echo") {
@@ -428,6 +429,14 @@ export def effectsFor(command: SimpleCommand, cwd: string): Result<Effect[]> {
 
   if (name.text != "git") {
     return failure("no rule for `${name.text}`")
+  }
+  // Only the git rules need the arguments as text, so this runs AFTER the
+  // echo branch. Above it, a quoted `echo "hi"` would fail here and be
+  // demoted before the branch that says echo is fine whatever its
+  // arguments ever ran.
+  const args = literalArgs(command)
+  if (args is failure(why)) {
+    return failure(why)
   }
   return gitEffects(args.value, flags, cwd)
 }
@@ -513,6 +522,7 @@ node redirectsContribute() {
     effectNamesFor("echo hi > $F"),
     effectNamesFor("echo hi < in.txt"),
     effectNamesFor("echo hi 2> err.txt"),
+    effectNamesFor("echo hi > a.txt > b.txt"),
   ]
 }
 ```
@@ -524,7 +534,7 @@ Add to `tests/agency/safeBash.test.json`:
   "nodeName": "redirectsContribute",
   "description": "A redirect writes a file whatever the verb is, so it contributes std::write independently. A variable target or any other redirect kind is unrecognized.",
   "input": "",
-  "expectedOutput": "[[\"std::git::status\",\"std::write\"],[\"std::write\"],[\"std::write\"],\"UNRECOGNIZED\",\"UNRECOGNIZED\",\"UNRECOGNIZED\"]",
+  "expectedOutput": "[[\"std::git::status\",\"std::write\"],[\"std::write\"],[\"std::write\"],\"UNRECOGNIZED\",\"UNRECOGNIZED\",\"UNRECOGNIZED\",\"UNRECOGNIZED\"]",
   "evaluationCriteria": [{ "type": "exact" }]
 }
 ```
@@ -607,6 +617,10 @@ Then in `effectsFor`, compute the redirect contribution first and add it to ever
 
   if (name.text != "git") {
     return failure("no rule for `${name.text}`")
+  }
+  const args = literalArgs(command)
+  if (args is failure(why)) {
+    return failure(why)
   }
   const git = gitEffects(args.value, flags, cwd)
   if (git is failure(why)) {
@@ -808,6 +822,11 @@ export def planFor(source: string, cwd: string): Plan {
   // Narrow questions were asked, so run the tree we classified.
   const rebuilt = rebuild(commands)
   if (rebuilt is failure(why)) {
+    // We cannot produce the text we classified, so we must not ask narrow
+    // questions about it. Demote to the broad question and the original
+    // text. Doing this AFTER raising would break the design's first hard
+    // rule: a narrow approval must never be followed by text we only
+    // assumed matched it.
     return bashPlan(source, [BASH_EFFECT])
   }
   return bashPlan(rebuilt.value, narrow)
@@ -868,21 +887,6 @@ def rebuild(commands: Command[]): Result<string> {
 }
 ```
 
-Then make `planFor` handle a render failure **before anything is raised**:
-
-```ts
-  // Narrow questions were asked, so run the tree we classified.
-  const rebuilt = rebuild(commands)
-  if (rebuilt is failure(why)) {
-    // We cannot produce the text we classified, so we must not ask narrow
-    // questions about it. Demote to the broad question and the original
-    // text. Doing this AFTER raising would break the design's first hard
-    // rule: a narrow approval must never be followed by text we only
-    // assumed matched it.
-    return bashPlan(source, [BASH_EFFECT])
-  }
-  return bashPlan(rebuilt.value, narrow)
-
 - [ ] **Step 4: Run test to verify it passes**
 
 ```bash
@@ -927,6 +931,8 @@ node shellFreeEcho() {
     planDetail("echo"),
     planDetail("echo 'a  b'"),
     planDetail("echo $HOME"),
+    planDetail("echo \"$HOME\""),
+    planDetail("echo \"a b\" c"),
     planDetail("echo -n hi"),
     planDetail("echo hi; echo bye"),
   ]
@@ -940,7 +946,7 @@ Add to `tests/agency/safeBash.test.json`:
   "nodeName": "shellFreeEcho",
   "description": "A single fully-literal echo computes its own output and never touches a shell. An expansion, a flag, or a sequence sends it to bash.",
   "input": "",
-  "expectedOutput": "[[\"echo\",\"hello world\\n\",[]],[\"echo\",\"\\n\",[]],[\"echo\",\"a  b\\n\",[]],[\"bash\",\"\",[\"std::bash\"]],[\"bash\",\"\",[\"std::bash\"]],[\"bash\",\"\",[\"std::bash\"]]]",
+  "expectedOutput": "[[\"echo\",\"hello world\\n\",[]],[\"echo\",\"\\n\",[]],[\"echo\",\"a  b\\n\",[]],[\"bash\",\"\",[\"std::bash\"]],[\"bash\",\"\",[\"std::bash\"]],[\"echo\",\"a b c\\n\",[]],[\"bash\",\"\",[\"std::bash\"]],[\"bash\",\"\",[\"std::bash\"]]]",
   "evaluationCriteria": [{ "type": "exact" }]
 }
 ```
@@ -1085,7 +1091,10 @@ Add to `tests/agency/safeBash.agency`:
 def writePlanDetail(source: string): any {
   const plan = planFor(source, "/repo")
   const exec = plan.execution
-  return [exec.kind, exec.content, exec.filename, exec.dir, [e.name for e in plan.effects]]
+  // `mode` is in the tuple deliberately. Without it, a `writeMode` that
+  // always returned "overwrite" survives the whole suite, and
+  // `echo hi >> notes.txt` silently TRUNCATES the file.
+  return [exec.kind, exec.content, exec.filename, exec.dir, exec.mode, [e.name for e in plan.effects]]
 }
 
 node shellFreeWrite() {
@@ -1094,6 +1103,36 @@ node shellFreeWrite() {
     writePlanDetail("echo hi >> out.txt"),
     writePlanDetail("echo hi > $F"),
     writePlanDetail("echo $HOME > out.txt"),
+  ]
+}
+
+node payloadValuesAreCorrect() {
+  // Every other classification test asserts effect NAMES. The name of a
+  // staged diff and an unstaged diff is the same, so a dropped
+  // `staged: true` would answer the wrong question with a green suite.
+  // This also pins cwd threading into git payloads.
+  const staged = planFor("git diff --staged", "/repo")
+  const redirected = planFor("git status > out.txt", "/repo")
+  const writeEffect = redirected.effects[1]
+  return [
+    staged.effects[0].payload.staged,
+    staged.effects[0].payload.cwd,
+    writeEffect.name,
+    writeEffect.payload.filename,
+    writeEffect.payload.dir,
+    writeEffect.payload.mode,
+  ]
+}
+
+node rebuiltVersusOriginal() {
+  // Hard rule #1, which nothing else pins. Multi-space input makes it
+  // observable: re-rendering normalizes whitespace, so on the narrow path
+  // `execution.command` must be the NORMALIZED form (the tree we
+  // classified), and on the broad path it must be the caller's text
+  // VERBATIM (what the human read and approved).
+  return [
+    planFor("git    status", "/repo").execution.command,
+    planFor("ls    -la", "/repo").execution.command,
   ]
 }
 
@@ -1112,7 +1151,21 @@ Add to `tests/agency/safeBash.test.json`:
   "nodeName": "shellFreeWrite",
   "description": "A single literal redirected echo computes its content and writes it, with no shell. A variable in the target or the arguments sends it to bash.",
   "input": "",
-  "expectedOutput": "[[\"write\",\"hi\\n\",\"out.txt\",\"/repo\",[\"std::write\"]],[\"write\",\"hi\\n\",\"out.txt\",\"/repo\",[\"std::write\"]],[\"bash\",\"\",\"\",\"\",[\"std::bash\"]],[\"bash\",\"\",\"\",\"\",[\"std::bash\"]]]",
+  "expectedOutput": "[[\"write\",\"hi\\n\",\"out.txt\",\"/repo\",\"overwrite\",[\"std::write\"]],[\"write\",\"hi\\n\",\"out.txt\",\"/repo\",\"append\",[\"std::write\"]],[\"bash\",\"\",\"\",\"\",\"\",[\"std::bash\"]],[\"bash\",\"\",\"\",\"\",\"\",[\"std::bash\"]]]",
+  "evaluationCriteria": [{ "type": "exact" }]
+},
+{
+  "nodeName": "payloadValuesAreCorrect",
+  "description": "Payload values, not just effect names. A staged diff and an unstaged diff raise the same effect name, so only the payload distinguishes them.",
+  "input": "",
+  "expectedOutput": "[true,\"/repo\",\"std::write\",\"out.txt\",\"/repo\",\"overwrite\"]",
+  "evaluationCriteria": [{ "type": "exact" }]
+},
+{
+  "nodeName": "rebuiltVersusOriginal",
+  "description": "A narrow plan runs the tree it classified (whitespace normalized); a broad plan runs the caller's text verbatim.",
+  "input": "",
+  "expectedOutput": "[\"git status\",\"ls    -la\"]",
   "evaluationCriteria": [{ "type": "exact" }]
 },
 {
@@ -1124,7 +1177,7 @@ Add to `tests/agency/safeBash.test.json`:
 }
 ```
 
-Note the append case plans the same way; `mode` is carried separately in Task 7's executor via the redirect operator, which `writePlanDetail` does not surface.
+The `>` and `>>` rows differ only in `mode`, which is the point: that field is the difference between overwriting a file and appending to it, and nothing else in the suite would notice if it were wrong.
 
 - [ ] **Step 2: Run test to verify it fails**
 
@@ -1278,6 +1331,46 @@ node refusedNeverRuns() {
   return "UNEXPECTEDLY RAN"
 }
 
+node sequenceRunsThroughBash() {
+  // The measured divergence that motivated the whole redesign:
+  // v2 returned "hi\n\nbye\n" where bash returns "hi\nbye\n". Nothing
+  // else in the suite runs a sequence through bash at all.
+  const result = safeBash("echo hi && echo bye")
+  if (result is failure(why)) {
+    return "FAILED: ${why}"
+  }
+  return result.value
+}
+
+node nonZeroExitIsAFailure() {
+  const result = safeBash("false")
+  if (result is failure(why)) {
+    return "FAILED"
+  }
+  return "UNEXPECTEDLY SUCCEEDED"
+}
+
+node appendReallyAppends() {
+  // The executor is called positionally — `_write(dir, filename, content,
+  // mode)` — and no other test runs it, so a swapped argument order
+  // survives everything else. This also proves `>>` appends rather than
+  // truncating.
+  safeBash("echo one > safebash-append-probe.txt")
+  safeBash("echo two >> safebash-append-probe.txt")
+  const back = read("safebash-append-probe.txt") with approve
+  if (back is failure(why)) {
+    return "READ FAILED"
+  }
+  return back.value
+}
+
+node defaultCwdIsNeverEmpty() {
+  // `resolveCwd`'s "" -> "." mapping exists because `write` rejects an
+  // empty dir, and the tests run in exactly that environment.
+  const plan = planFor("echo hi > out.txt", "")
+  return plan.execution.dir
+}
+
 node exactlyOneQuestion() {
   // The test that actually pins the feature. It APPROVES the narrow
   // question and asserts the command ran. A test that only ever rejects
@@ -1323,6 +1416,45 @@ Add to `tests/agency/safeBash.test.json`:
   "interruptHandlers": [
     { "action": "approve", "expectedMessage": "Show git status" }
   ],
+  "evaluationCriteria": [{ "type": "exact" }]
+},
+{
+  "nodeName": "sequenceRunsThroughBash",
+  "description": "A sequence runs in one bash call, so its output is bash's — including the newline behavior that v2 got wrong.",
+  "input": "",
+  "expectedOutput": "\"hi\\nbye\\n\"",
+  "interruptHandlers": [
+    { "action": "approve", "expectedMessage": "Are you sure you want to run this shell command?" }
+  ],
+  "evaluationCriteria": [{ "type": "exact" }]
+},
+{
+  "nodeName": "nonZeroExitIsAFailure",
+  "description": "A non-zero exit is a failure, which `&&` and `||` semantics depend on.",
+  "input": "",
+  "expectedOutput": "\"FAILED\"",
+  "interruptHandlers": [
+    { "action": "approve", "expectedMessage": "Are you sure you want to run this shell command?" }
+  ],
+  "evaluationCriteria": [{ "type": "exact" }]
+},
+{
+  "nodeName": "appendReallyAppends",
+  "description": "The write executor runs for real: `>` then `>>` leaves both lines, proving the append mode reaches _write and the positional arguments are in the right order.",
+  "input": "",
+  "expectedOutput": "\"one\\ntwo\\n\"",
+  "interruptHandlers": [
+    { "action": "approve", "expectedMessage": "Are you sure you want to write to this file?" },
+    { "action": "approve", "expectedMessage": "Are you sure you want to write to this file?" },
+    { "action": "approve", "expectedMessage": "Are you sure you want to read this file?" }
+  ],
+  "evaluationCriteria": [{ "type": "exact" }]
+},
+{
+  "nodeName": "defaultCwdIsNeverEmpty",
+  "description": "resolveCwd maps an empty caller cwd and an empty agent cwd to \".\", because write rejects an empty dir.",
+  "input": "",
+  "expectedOutput": "\".\"",
   "evaluationCriteria": [{ "type": "exact" }]
 },
 {
@@ -1374,10 +1506,14 @@ export def runBash(command: string, cwd: string): Result<string> {
   // `raiseAll` that raised every effect in the plan and returned success.
   // Every plan raises at least one effect, so no classification bug can
   // turn into an ungated shell call.
-  const result: any = try _bash(command, cwd, 0, "", {})
-  if (result is failure(why)) {
+  const attempt = try _bash(command, cwd, 0, "", {})
+  if (attempt is failure(why)) {
     return failure("`${command}` was not run: ${why}")
   }
+  // `try` WRAPS the call in a Result, so the ExecResult is inside
+  // `.value`. Reading `attempt.stdout` directly is undefined and every
+  // successful run returns garbage.
+  const result: any = attempt.value
   const out = truncate(result.stdout)
   if (result.exitCode != 0) {
     return failure(JSON.stringify({
@@ -1410,19 +1546,48 @@ export def runWrite(exec: Execution): Result<string> {
   `write` tool raises its own `std::write`, and `raiseAll` already raised
   one carrying the content. Calling the tool would ask twice.
   """
-  const written = try _write(exec.dir, exec.filename, exec.content, exec.mode)
-  if (written is failure(why)) {
-    return failure(why)
+  // `destructive { }` because `write()` wraps `_write` in one, and that
+  // marker feeds the tool-loop retry rules. Calling `_write` directly
+  // without it would give this write a different retry classification
+  // from the tool it replaces.
+  destructive {
+    const written = try _write(exec.dir, exec.filename, exec.content, exec.mode)
+    if (written is failure(why)) {
+      return failure(why)
+    }
   }
   return success("")
 }
 ```
 
-Add these imports to `stdlib/safeBash/actions.agency`, and remove the now-unused `bash` and `write` imports:
+Add these imports to `stdlib/safeBash/actions.agency`:
 
 ```ts
 import { _bash } from "agency-lang/stdlib-lib/shell.js"
 import { _write } from "agency-lang/stdlib-lib/builtins.js"
+```
+
+**Keep an import from `std::shell` and `std::git` in
+`stdlib/safeBash.agency`, even though nothing calls them.** Effect
+declarations travel with imports, and without them a raise compiles with
+its payload contract *unenforced* — measured:
+
+```
+raise std::git::status("...", { wrongField: d })   // no std::git import → compiles clean
+raise std::git::status("...", { wrongField: d })   // with std::git import → AG3006: field 'cwd' is missing
+```
+
+`std::write` is enforced through the auto-imported prelude and needs no
+import. `std::bash` and the git effects do. Write the reason next to
+them, or someone removes an unused import and silently loses every
+payload check:
+
+```ts
+// These imports are NOT unused. Effect declarations come with imports,
+// and without them the `raise std::bash(...)` and `raise std::git::*(...)`
+// sites below compile with their payload contracts unenforced.
+import { bash } from "std::shell"
+import { gitStatus } from "std::git"
 ```
 
 Then replace `safeBash` in `stdlib/safeBash.agency`:
@@ -1460,7 +1625,10 @@ export def safeBash(
   }
 
   if (plan.execution.kind == "echo") {
-    return success(plan.execution.content)
+    // Truncated like every other path. A long echo returning in full
+    // while a long `ls` came back capped would be exactly the
+    // distinguishability this design exists to remove.
+    return success(truncate(plan.execution.content))
   }
   if (plan.execution.kind == "write") {
     return runWrite(plan.execution)
@@ -1556,7 +1724,24 @@ make && pnpm run a test tests/agency/safeBash.agency 2>&1 | tail -30
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 5: Prove the payload contracts are actually enforced**
+
+The imports above are load-bearing and invisible. Confirm they work by
+breaking a payload on purpose:
+
+```bash
+# Temporarily change one raise site, e.g. drop `cwd` from the
+# std::git::status payload, then:
+pnpm run a tc stdlib/safeBash.agency 2>&1 | grep AG3006
+```
+
+Expected: `AG3006: Effect 'std::git::status' data field 'cwd' is missing.`
+
+If that error does **not** appear, the effect declaration is not in scope
+and every payload in this task is unchecked. Restore the payload before
+committing.
+
+- [ ] **Step 6: Commit**
 
 ```bash
 pnpm run a fmt -i stdlib/safeBash.agency stdlib/safeBash/actions.agency tests/agency/safeBash.agency
@@ -1800,7 +1985,7 @@ Implemented. See `docs/superpowers/plans/2026-07-27-safebash-v3-classifier.md`.
 git diff main...HEAD --stat
 ```
 
-Read `docs/dev/anti-patterns.md` and check the diff against it. The ones most likely to bite here: comments that restate the code rather than explaining why, and `any` used where a real type would work. The two deliberate `any` uses in this plan — `bash()`'s return, and `Effect.payload` — each have a comment saying why.
+Read `docs/dev/anti-patterns.md` and check the diff against it. The ones most likely to bite here: comments that restate the code rather than explaining why, and `any` used where a real type would work. There is exactly one deliberate `any` in this plan — the unwrapped result of `_bash`, whose declared type cannot describe a rejected approval — and it has a comment saying why. `Effect` is a typed union precisely so payloads are not `any`.
 
 - [ ] **Step 5: Commit**
 
@@ -1810,6 +1995,26 @@ git commit -m "safeBash: regenerate docs and mark the spec implemented"
 ```
 
 ---
+
+## Verified harness behavior
+
+Several tests here prove a negative — "no extra question was asked" — and
+that only works if the harness is strict. It is, in both directions
+(`lib/templates/cli/evaluate.mustache`):
+
+```
+more interrupts than handlers  →  throw "Unexpected interrupt #N ... No handler provided."
+more handlers than interrupts  →  throw "Expected N interrupts but only M occurred."
+```
+
+And a node with **no** `interruptHandlers` at all gets no response loop,
+so an interrupt leaves the raw interrupt array as the result and the
+exact-match comparison fails.
+
+So `exactlyOneQuestion`, `echoRunsWithoutApproval` and `refusedNeverRuns`
+are not vacuous: a second, unlisted prompt fails the run. This was checked
+rather than assumed, because if unlisted interrupts were absorbed silently
+every one of those tests would pass whether or not the feature worked.
 
 ## Notes for the implementer
 

--- a/packages/agency-lang/docs/superpowers/plans/2026-07-27-safebash-v3-classifier.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-07-27-safebash-v3-classifier.md
@@ -20,6 +20,7 @@
 - **Agency test command:** `pnpm run a test <path>` — not `pnpm test:run`, which is the vitest suite.
 - **Format before committing:** `pnpm run a fmt -i <file>` on every `.agency` file touched.
 - **Never edit `CHANGELOG.md`.**
+- **Execute through the non-raising internals.** `bash()` raises `std::bash` itself and `write()` raises `std::write`; calling them after `raiseAll` would ask the question twice and make the narrow path pointless. Use `_bash` (`agency-lang/stdlib-lib/shell.js`) and `_write` (`agency-lang/stdlib-lib/builtins.js`). Bypassing a tool's interrupt is normally forbidden — the reasoning that makes it correct here is in the spec, and it depends on every plan raising at least one effect first.
 
 ## File Structure
 
@@ -71,6 +72,10 @@ node refuseWall() {
     refusedFor("dd if=a of=b"),
     refusedFor("git clean -fd"),
     refusedFor("git reset --hard"),
+    refusedFor("git restore src"),
+    refusedFor("git reset HEAD~1"),
+    refusedFor("git checkout main"),
+    refusedFor("git log reset"),
     refusedFor("git status"),
     refusedFor("echo hi"),
   ]
@@ -82,9 +87,9 @@ Add to `tests/agency/safeBash.test.json` inside `"tests"`:
 ```json
 {
   "nodeName": "refuseWall",
-  "description": "Commands we decline to run even with approval, matched by command word and by the last part of a path.",
+  "description": "Commands we decline to run even with approval, matched by command word and by the last part of a path. Only the destructive spellings of git subcommands are refused, and only in the first argument position.",
   "input": "",
-  "expectedOutput": "[true,true,true,true,true,true,false,false]",
+  "expectedOutput": "[true,true,true,true,true,true,true,false,false,false,false,false]",
   "evaluationCriteria": [{ "type": "exact" }]
 }
 ```
@@ -107,10 +112,8 @@ static const REFUSED_COMMANDS: string[] = [
   "rm", "rmdir", "dd", "shred", "mkfs", "truncate",
 ]
 
-/** `git` subcommands that destroy work, matched on the first argument. */
-static const REFUSED_GIT_SUBCOMMANDS: string[] = [
-  "clean", "reset", "checkout", "restore",
-]
+/** `git` subcommands that always destroy work. */
+static const REFUSED_GIT_ALWAYS: string[] = ["clean", "restore"]
 
 def baseName(text: string): string {
   """
@@ -142,11 +145,59 @@ export def isRefused(command: SimpleCommand): boolean {
   if (word != "git") {
     return false
   }
-  // `git reset --hard` destroys work; `git reset` alone does not, but
-  // telling them apart needs flag inspection, and refusing the whole
-  // subcommand costs a fallback where guessing costs a lost tree.
+  return isDestructiveGit(command)
+}
+
+def isDestructiveGit(command: SimpleCommand): boolean {
+  """
+  The git subcommands that throw work away.
+
+  Only the FIRST argument is the subcommand. `git log reset` is a log,
+  not a reset, and matching a subcommand name anywhere in the arguments
+  would refuse it.
+
+  `clean` and `restore` are destructive by purpose. `reset` and
+  `checkout` are only destructive in particular spellings, and refusing
+  the whole subcommand would refuse `git checkout main`, which agents do
+  constantly. So those two are matched on the spelling that discards
+  work.
+  """
+  if (command.args.length == 0) {
+    return false
+  }
+  const first = command.args[0]
+  if (first.tag != "literal") {
+    return false
+  }
+  if (REFUSED_GIT_ALWAYS.includes(first.text)) {
+    return true
+  }
+  if (first.text == "reset") {
+    return hasFlag(command, "--hard")
+  }
+  if (first.text == "checkout") {
+    // `git checkout -- path` and `git checkout .` discard working-tree
+    // changes. `git checkout branch` does not.
+    if (hasFlag(command, "--")) {
+      return true
+    }
+    return hasLiteralArg(command, ".")
+  }
+  return false
+}
+
+def hasFlag(command: SimpleCommand, name: string): boolean {
   for (arg in command.args) {
-    if (arg.tag == "literal" && REFUSED_GIT_SUBCOMMANDS.includes(arg.text)) {
+    if (arg.tag == "flag" && arg.flagName == name) {
+      return true
+    }
+  }
+  return false
+}
+
+def hasLiteralArg(command: SimpleCommand, text: string): boolean {
+  for (arg in command.args) {
+    if (arg.tag == "literal" && arg.text == text) {
       return true
     }
   }
@@ -220,6 +271,9 @@ node classifyOneCommand() {
     effectNamesFor("ls"),
     effectNamesFor("git log --graph"),
     effectNamesFor("$CMD status"),
+    effectNamesFor("FOO=1 git status"),
+    effectNamesFor("echo -n hi"),
+    effectNamesFor("echo \"quoted\""),
   ]
 }
 ```
@@ -229,9 +283,9 @@ Add to `tests/agency/safeBash.test.json`:
 ```json
 {
   "nodeName": "classifyOneCommand",
-  "description": "Each recognized command contributes its own effects; an unrecognized command, an unknown flag, and a non-literal command word are all unrecognized.",
+  "description": "Each recognized command contributes its own effects. An unrecognized command, an unknown flag, a non-literal command word and a leading assignment are all unrecognized. In a sequence, echo contributes nothing whatever its arguments, because bash runs it.",
   "input": "",
-  "expectedOutput": "[[\"std::git::status\"],[\"std::git::diff\"],[\"std::git::diff\"],[\"std::git::log\"],[],\"UNRECOGNIZED\",\"UNRECOGNIZED\",\"UNRECOGNIZED\"]",
+  "expectedOutput": "[[\"std::git::status\"],[\"std::git::diff\"],[\"std::git::diff\"],[\"std::git::log\"],[],\"UNRECOGNIZED\",\"UNRECOGNIZED\",\"UNRECOGNIZED\",\"UNRECOGNIZED\",[],[]]",
   "evaluationCriteria": [{ "type": "exact" }]
 }
 ```
@@ -289,15 +343,22 @@ Add to `stdlib/safeBash.agency` (import `Effect` from `./safeBash/actions.agency
 ```ts
 def literalArgs(command: SimpleCommand): Result<string[]> {
   """
-  A command's arguments as text, but only when every one is a plain
-  literal.
+  A command's non-flag arguments as text, but only when every one is a
+  plain literal.
 
-  Anything else — a variable, a quoted string, a path, a flag — makes this
-  fail, because classification must never depend on a value we would have
-  to expand or interpret ourselves.
+  Flags are SKIPPED, not rejected: they are collected separately by
+  `flagNames`, and rejecting them here would make `git diff --staged`
+  unrecognized before any rule saw it.
+
+  A variable, a quoted string or a path is a failure, because
+  classification must never depend on a value we would have to expand or
+  interpret ourselves.
   """
   let out: string[] = []
   for (arg in command.args) {
+    if (arg.tag == "flag") {
+      continue
+    }
     if (arg.tag != "literal") {
       return failure("`${arg.tag}` is not a literal argument")
     }
@@ -340,6 +401,13 @@ export def effectsFor(command: SimpleCommand, cwd: string): Result<Effect[]> {
   if (name.tag != "literal") {
     return failure("the command word is not a literal")
   }
+  // `GIT_DIR=/elsewhere git status` reads a DIFFERENT repository than the
+  // payload would claim. Rather than model what each assignment means,
+  // any command carrying one is unrecognized; bash applies it correctly
+  // and the human sees the whole command.
+  if (command.assignments.length > 0) {
+    return failure("a leading assignment changes what the command does")
+  }
   const args = literalArgs(command)
   if (args is failure(why)) {
     return failure(why)
@@ -347,11 +415,14 @@ export def effectsFor(command: SimpleCommand, cwd: string): Result<Effect[]> {
   const flags = flagNames(command)
 
   if (name.text == "echo") {
-    // `echo` contributes nothing on its own. A string of nothing but
-    // echoes still raises `std::bash` — see the audit rule in the caller.
-    if (flags.length > 0) {
-      return failure("`echo` with flags prints differently")
-    }
+    // `echo` contributes nothing on its own, whatever its arguments. Bash
+    // runs it and expands anything in it, so `echo $HOME` and `echo -n hi`
+    // are both fine HERE — the flag and literal-argument restrictions
+    // belong to the shell-free path in Task 5, which computes the output
+    // itself and therefore cannot tolerate either.
+    //
+    // A string of nothing but echoes still raises `std::bash`, by the
+    // audit rule in the caller.
     return success([])
   }
 
@@ -531,9 +602,6 @@ Then in `effectsFor`, compute the redirect contribution first and add it to ever
   }
 
   if (name.text == "echo") {
-    if (flags.length > 0) {
-      return failure("`echo` with flags prints differently")
-    }
     return success(redirect.value)
   }
 
@@ -600,6 +668,10 @@ node wholeStringPlans() {
     planSummary("rm -rf build"),
     planSummary("git status; rm -rf build"),
     planSummary("cat a.txt | grep x"),
+    planSummary("git status && git log"),
+    planSummary("true && rm -rf /tmp/x"),
+    planSummary("(git status && git log)"),
+    planSummary("git status && ls"),
   ]
 }
 ```
@@ -609,9 +681,9 @@ Add to `tests/agency/safeBash.test.json`:
 ```json
 {
   "nodeName": "wholeStringPlans",
-  "description": "The whole string gets one plan: refused if any command is refused, one std::bash if any command is unrecognized, otherwise the union of narrow effects. A shell spawn always raises at least one effect.",
+  "description": "The whole string gets one plan: refused if any command anywhere is refused, one std::bash if any command is unrecognized, otherwise the union of narrow effects. Chains are walked, so `true && rm -rf /tmp/x` is refused rather than approvable, and `git status && git log` keeps its narrow questions.",
   "input": "",
-  "expectedOutput": "[[\"bash\",[\"std::git::status\"]],[\"bash\",[\"std::git::status\",\"std::git::log\"]],[\"bash\",[\"std::bash\"]],[\"bash\",[\"std::bash\"]],[\"bash\",[\"std::bash\"]],[\"refuse\",[]],[\"refuse\",[]],[\"bash\",[\"std::bash\"]]]",
+  "expectedOutput": "[[\"bash\",[\"std::git::status\"]],[\"bash\",[\"std::git::status\",\"std::git::log\"]],[\"bash\",[\"std::bash\"]],[\"bash\",[\"std::bash\"]],[\"bash\",[\"std::bash\"]],[\"refuse\",[]],[\"refuse\",[]],[\"bash\",[\"std::bash\"]],[\"bash\",[\"std::git::status\",\"std::git::log\"]],[\"refuse\",[]],[\"bash\",[\"std::git::status\",\"std::git::log\"]],[\"bash\",[\"std::bash\"]]]",
   "evaluationCriteria": [{ "type": "exact" }]
 }
 ```
@@ -651,7 +723,7 @@ export type Plan = {
 Add to `stdlib/safeBash.agency`:
 
 ```ts
-static const BASH_EFFECT: Effect = { name: "std::bash", payload: {} }
+static const BASH_EFFECT: Effect = { name: "std::bash" }
 
 def emptyExecution(): Execution {
   return { kind: "", command: "", content: "", filename: "", dir: "", reason: "" }
@@ -696,27 +768,27 @@ export def planFor(source: string, cwd: string): Plan {
   }
   const commands: Command[] = parsed.value
 
+  // Flatten first. A chain hides its halves inside `and`/`or`/`parens`
+  // nodes, and `true && rm -rf /` has no top-level simple command at all —
+  // without this walk the wall never sees the `rm` and the string plans as
+  // an APPROVABLE std::bash.
+  const simple = flatten(commands)
+
   let narrow: Effect[] = []
   let allRecognized = true
-  for (command in commands) {
-    if (command.tag != "simpleCommand") {
-      // `&&`, `||` and parens: bash runs these, and their halves are not
-      // separately classified in this version.
+  for (command in simple) {
+    if (isRefused(command)) {
+      const name = command.command
+      if (name == null) {
+        return refusePlan("this command is not allowed")
+      }
+      return refusePlan("`${name.text}` is not allowed")
+    }
+    const effects = effectsFor(command, cwd)
+    if (effects is failure(why)) {
       allRecognized = false
     } else {
-      if (isRefused(command)) {
-        const name = command.command
-        if (name == null) {
-          return refusePlan("this command is not allowed")
-        }
-        return refusePlan("`${name.text}` is not allowed")
-      }
-      const effects = effectsFor(command, cwd)
-      if (effects is failure(why)) {
-        allRecognized = false
-      } else {
-        narrow = [...narrow, ...effects.value]
-      }
+      narrow = [...narrow, ...effects.value]
     }
   }
 
@@ -734,10 +806,45 @@ export def planFor(source: string, cwd: string): Plan {
     return bashPlan(source, [BASH_EFFECT])
   }
   // Narrow questions were asked, so run the tree we classified.
-  return bashPlan(rebuild(commands), narrow)
+  const rebuilt = rebuild(commands)
+  if (rebuilt is failure(why)) {
+    return bashPlan(source, [BASH_EFFECT])
+  }
+  return bashPlan(rebuilt.value, narrow)
 }
 
-def rebuild(commands: Command[]): string {
+def flatten(commands: Command[]): SimpleCommand[] {
+  """
+  Every simple command in the string, including the halves of a chain.
+
+  `a && b` and `a || b` contribute both sides; `( a )` contributes its
+  inner command. Used for BOTH the refuse wall and classification, because
+  a wall that only looks at the top level is bypassed by two characters,
+  and a classifier that only looks at the top level demotes every chained
+  invocation to the broad question — and agents chain with `&&`
+  constantly.
+  """
+  let out: SimpleCommand[] = []
+  for (command in commands) {
+    out = [...out, ...flattenOne(command)]
+  }
+  return out
+}
+
+def flattenOne(command: Command): SimpleCommand[] {
+  if (command.tag == "simpleCommand") {
+    return [command]
+  }
+  if (command.tag == "and" || command.tag == "or") {
+    return [...flattenOne(command.left), ...flattenOne(command.right)]
+  }
+  if (command.tag == "parens") {
+    return flattenOne(command.command)
+  }
+  return []
+}
+
+def rebuild(commands: Command[]): Result<string> {
   """
   The command string, rendered back from the tree we classified.
 
@@ -753,15 +860,28 @@ def rebuild(commands: Command[]): string {
   for (command in commands) {
     const text = try _astToBash(command)
     if (text is failure(why)) {
-      return ""
+      return failure("could not render `${why}`")
     }
     parts.push(text.value)
   }
-  return parts.join("; ")
+  return success(parts.join("; "))
 }
 ```
 
-Note: `rebuild` returning `""` on a render failure is handled in Task 7, which treats an empty rebuilt command as a reason to use the original string.
+Then make `planFor` handle a render failure **before anything is raised**:
+
+```ts
+  // Narrow questions were asked, so run the tree we classified.
+  const rebuilt = rebuild(commands)
+  if (rebuilt is failure(why)) {
+    // We cannot produce the text we classified, so we must not ask narrow
+    // questions about it. Demote to the broad question and the original
+    // text. Doing this AFTER raising would break the design's first hard
+    // rule: a narrow approval must never be followed by text we only
+    // assumed matched it.
+    return bashPlan(source, [BASH_EFFECT])
+  }
+  return bashPlan(rebuilt.value, narrow)
 
 - [ ] **Step 4: Run test to verify it passes**
 
@@ -1157,6 +1277,22 @@ node refusedNeverRuns() {
   }
   return "UNEXPECTEDLY RAN"
 }
+
+node exactlyOneQuestion() {
+  // The test that actually pins the feature. It APPROVES the narrow
+  // question and asserts the command ran. A test that only ever rejects
+  // the first interrupt passes whether or not a second `std::bash` prompt
+  // would have appeared — which is precisely how calling `bash()` instead
+  // of `_bash()` hides itself.
+  //
+  // The test.json lists exactly one interrupt handler. If execution asks
+  // a second question, the harness fails on the unmatched message.
+  const result = safeBash("git status")
+  if (result is failure(why)) {
+    return "FAILED: ${why}"
+  }
+  return "RAN"
+}
 ```
 
 Add to `tests/agency/safeBash.test.json`:
@@ -1176,6 +1312,16 @@ Add to `tests/agency/safeBash.test.json`:
   "expectedOutput": "\"REJECTED\"",
   "interruptHandlers": [
     { "action": "reject", "expectedMessage": "Are you sure you want to run this shell command?" }
+  ],
+  "evaluationCriteria": [{ "type": "exact" }]
+},
+{
+  "nodeName": "exactlyOneQuestion",
+  "description": "The narrow question REPLACES the broad one. Approving std::git::status runs the command; a second std::bash prompt would fail the run on an unmatched interrupt.",
+  "input": "",
+  "expectedOutput": "\"RAN\"",
+  "interruptHandlers": [
+    { "action": "approve", "expectedMessage": "Show git status" }
   ],
   "evaluationCriteria": [{ "type": "exact" }]
 },
@@ -1216,10 +1362,19 @@ export def runBash(command: string, cwd: string): Result<string> {
   differ, and neither is an error, so an agent sees a failure where bash
   would have shown an empty result.
   """
-  // `any` because `bash` is DECLARED to return an ExecResult, but a
-  // rejected approval halts it and hands back a failure instead, which
-  // the declared type cannot describe.
-  const result: any = bash(command, cwd)
+  // `_bash`, NOT `bash`. The `bash` tool raises `std::bash` itself, so
+  // calling it here would ask the broad question again — after the human
+  // already answered a narrower one — and the entire feature would be a
+  // no-op. On the broad path they would be asked twice.
+  //
+  // Bypassing a tool's interrupt is normally forbidden: handlers are
+  // safety infrastructure. It is correct here for one specific reason,
+  // and only while that reason holds: the narrow interrupt REPLACES the
+  // broad one, and the only path into this function runs through a
+  // `raiseAll` that raised every effect in the plan and returned success.
+  // Every plan raises at least one effect, so no classification bug can
+  // turn into an ungated shell call.
+  const result: any = try _bash(command, cwd, 0, "", {})
   if (result is failure(why)) {
     return failure("`${command}` was not run: ${why}")
   }
@@ -1250,18 +1405,24 @@ export def runWrite(exec: Execution): Result<string> {
   """
   Perform the write a redirected echo asked for. Returns the empty string,
   which is what bash's stdout for `echo hi > f` is.
+
+  `_write`, NOT `write`, for the same reason `runBash` uses `_bash`: the
+  `write` tool raises its own `std::write`, and `raiseAll` already raised
+  one carrying the content. Calling the tool would ask twice.
   """
-  const written = write(
-    filename: exec.filename,
-    content: exec.content,
-    dir: exec.dir,
-    mode: exec.mode,
-  )
+  const written = try _write(exec.dir, exec.filename, exec.content, exec.mode)
   if (written is failure(why)) {
     return failure(why)
   }
   return success("")
 }
+```
+
+Add these imports to `stdlib/safeBash/actions.agency`, and remove the now-unused `bash` and `write` imports:
+
+```ts
+import { _bash } from "agency-lang/stdlib-lib/shell.js"
+import { _write } from "agency-lang/stdlib-lib/builtins.js"
 ```
 
 Then replace `safeBash` in `stdlib/safeBash.agency`:
@@ -1304,8 +1465,11 @@ export def safeBash(
   if (plan.execution.kind == "write") {
     return runWrite(plan.execution)
   }
-  const text = if plan.execution.command == "" then command else plan.execution.command
-  return runBash(text, dir)
+  // `planFor` already decided which text to run — rebuilt when it asked
+  // narrow questions, original when it asked the broad one. There is no
+  // fallback here: choosing the original AFTER raising narrow effects
+  // would break the design's first hard rule.
+  return runBash(plan.execution.command, dir)
 }
 
 def raiseAll(effects: Effect[], fullCommand: string, cwd: string): Result {
@@ -1322,7 +1486,7 @@ def raiseAll(effects: Effect[], fullCommand: string, cwd: string): Result {
   fragment.
   """
   for (effect in effects) {
-    const why = raiseOne(effect, fullCommand)
+    const why = raiseOne(effect, fullCommand, cwd)
     if (why is failure(reason)) {
       return failure(reason)
     }
@@ -1330,10 +1494,16 @@ def raiseAll(effects: Effect[], fullCommand: string, cwd: string): Result {
   return success(null)
 }
 
-def raiseOne(effect: Effect, fullCommand: string): Result {
+def raiseOne(effect: Effect, fullCommand: string, cwd: string): Result {
   if (effect.name == "std::bash") {
+    // The contract is `effect std::bash { command, cwd, timeout, stdin }`
+    // and payload contracts are enforced at the raise site, so all four
+    // fields are required even though we only vary the first two.
     raise std::bash("Are you sure you want to run this shell command?", {
-      command: fullCommand
+      command: fullCommand,
+      cwd: cwd,
+      timeout: 0,
+      stdin: ""
     })
     return success(null)
   }
@@ -1428,7 +1598,29 @@ Remove these definitions from `stdlib/safeBash.agency`. Bash does control flow n
 Remove from `stdlib/safeBash.agency`:
 
 - `stringifyWord`, `expandVariable`, `stringifyParts`, `hasQuotedPart`, `stringifyArg`
-- `simplifyRedirects`, `writeDir`, `joinWords` (replaced by `echoOutput`)
+- `simplifyRedirects`, `joinWords` (replaced by `echoOutput`)
+
+Keep `writeDir`'s behavior by folding it into `resolveCwd`, which must
+never return `""`: `write` rejects an empty `dir`, and `getAgentCwd()` is
+empty whenever nothing set one — which is the case the tests run in.
+
+```ts
+def resolveCwd(cwd: string): string {
+  """
+  Which directory a command runs in: the caller's, or the agent's, or
+  here. Never empty — `write` rejects an empty `dir`, so an empty result
+  would make every redirected echo fail at write time.
+  """
+  if (cwd != "") {
+    return cwd
+  }
+  const agent = getAgentCwd()
+  if (agent != "") {
+    return agent
+  }
+  return "."
+}
+```
 - the `OutputRedirect` type
 - the `env` import from `std::system`, which now has no user
 
@@ -1472,6 +1664,20 @@ Create `lib/stdlib/safeBash.test.ts`:
 import { describe, it, expect } from "vitest";
 import { _bashParser, _astToBash } from "./safeBash.js";
 
+/** Drop `loc` fields so two trees compare on structure, not on where the
+ *  text happened to sit. Rendering re-flows whitespace, so positions
+ *  legitimately differ between the original and the re-parsed form. */
+function strip(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(strip);
+  if (value === null || typeof value !== "object") return value;
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    if (k === "loc") continue;
+    out[k] = strip(v);
+  }
+  return out;
+}
+
 // Every command family the classifier recognizes, plus the hostile
 // quoting cases that would turn one command into two if rendering lost a
 // quote.
@@ -1513,9 +1719,14 @@ describe("astToBash round-trips every command family the classifier sees", () =>
       expect(second.success, `rendered form did not re-parse: ${rendered}`).toBe(true);
       if (!second.success) return;
 
-      // Re-rendering the re-parsed tree must be a fixed point. Comparing
-      // rendered strings rather than trees keeps the failure message
-      // readable, and any tree difference shows up as a text difference.
+      // Compare the TREES, not the rendered strings. A string fixed point
+      // passes on exactly the failure this test exists to catch: if
+      // rendering lost the quotes, `echo "a; b"` renders to `echo a; b`,
+      // which re-parses as TWO commands, which re-render (joined with
+      // "; ") to the same string. Green test, one command became two.
+      expect(strip(second.result)).toEqual(strip(first.result));
+
+      // Kept only as a readability aid on failure.
       const again = second.result.map((c: unknown) => _astToBash(c)).join("; ");
       expect(again).toBe(rendered);
     });

--- a/packages/agency-lang/docs/superpowers/plans/2026-07-27-safebash-v3-classifier.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-07-27-safebash-v3-classifier.md
@@ -1,0 +1,1614 @@
+# safeBash v3 Classifier Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rewrite `std::safeBash` so it classifies a bash command, raises the narrowest interrupt that describes it, and then hands the whole command string to bash — instead of substituting Agency functions for commands.
+
+**Architecture:** Parse the string into commands. Classify each one to work out which interrupts it needs. Raise all of them up front. If everything is approved, run the *whole original string* in **one** bash call, so bash does the control flow and produces the output. Two single-command cases never touch a shell: a fully-literal `echo`, and a fully-literal `echo` with a `>`/`>>` redirect.
+
+**Tech Stack:** Agency (`stdlib/*.agency`), TypeScript for the parser shim and property test (`lib/stdlib/*.ts`), tarsec 0.5.3 bash parser, vitest for TS tests, the Agency test runner for `.agency` tests.
+
+**Spec:** `docs/superpowers/specs/2026-07-26-safebash-classifier-design.md`
+
+## Global Constraints
+
+- **No new commands.** The classification table covers exactly what v2 covers: `git status`, `git diff`, `git diff --staged`, `git log`, and `echo`. Do not add `cat`, `ls`, `grep`, `curl`, or anything else.
+- **We resolve a variable nowhere.** Not for classification, not for an interrupt payload, not for content. If a value depends on expansion, the string goes to bash.
+- **The command word must be a literal.** A `PathWord` command name (`./script.sh`, `/bin/git`) is never classified as a recognized command.
+- **Spawning a shell always raises at least one effect.** If classification produced none and we are going to bash, raise `std::bash`.
+- **Run `make` before running any `.agency` test.** Changing a stdlib file requires a full build; `pnpm run build` is not enough.
+- **Agency test command:** `pnpm run a test <path>` — not `pnpm test:run`, which is the vitest suite.
+- **Format before committing:** `pnpm run a fmt -i <file>` on every `.agency` file touched.
+- **Never edit `CHANGELOG.md`.**
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `stdlib/safeBash.agency` | AST types (unchanged), classification, plan assembly, effect raising, execution |
+| `stdlib/safeBash/actions.agency` | The plan/action data types and the three executors (`bash`, `echo` content, `write`) |
+| `lib/stdlib/safeBash.ts` | Unchanged — re-exports `bashParser` and `astToBash` from tarsec |
+| `lib/stdlib/safeBash.test.ts` | **New.** The `astToBash` round-trip property test |
+| `tests/agency/safeBash.agency` | Classification tests: string in, plan out |
+| `tests/agency/safeBash.test.json` | Expected plans |
+
+---
+
+### Task 1: The refuse wall
+
+**Files:**
+- Modify: `stdlib/safeBash.agency`
+- Test: `tests/agency/safeBash.agency`, `tests/agency/safeBash.test.json`
+
+**Interfaces:**
+- Consumes: `SimpleCommand`, `ScriptName`, `FlagWord` (existing types, `stdlib/safeBash.agency:16-130`)
+- Produces: `export def isRefused(command: SimpleCommand): boolean`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/agency/safeBash.agency`:
+
+```ts
+import { bashParser, isRefused } from "std::safeBash"
+
+def refusedFor(source: string): any {
+  const parsed = bashParser(source)
+  if (parsed is failure(why)) {
+    return "UNPARSEABLE"
+  }
+  const first = parsed.value[0]
+  if (first.tag != "simpleCommand") {
+    return "NOT-SIMPLE"
+  }
+  return isRefused(first)
+}
+
+node refuseWall() {
+  return [
+    refusedFor("rm -rf build"),
+    refusedFor("/bin/rm -rf build"),
+    refusedFor("./rm thing"),
+    refusedFor("dd if=a of=b"),
+    refusedFor("git clean -fd"),
+    refusedFor("git reset --hard"),
+    refusedFor("git status"),
+    refusedFor("echo hi"),
+  ]
+}
+```
+
+Add to `tests/agency/safeBash.test.json` inside `"tests"`:
+
+```json
+{
+  "nodeName": "refuseWall",
+  "description": "Commands we decline to run even with approval, matched by command word and by the last part of a path.",
+  "input": "",
+  "expectedOutput": "[true,true,true,true,true,true,false,false]",
+  "evaluationCriteria": [{ "type": "exact" }]
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+make && pnpm run a test tests/agency/safeBash.agency 2>&1 | tail -20
+```
+
+Expected: FAIL — `isRefused` is not exported from `std::safeBash`.
+
+- [ ] **Step 3: Write the implementation**
+
+Add to `stdlib/safeBash.agency`:
+
+```ts
+/** Commands we decline to run even when a human approves. */
+static const REFUSED_COMMANDS: string[] = [
+  "rm", "rmdir", "dd", "shred", "mkfs", "truncate",
+]
+
+/** `git` subcommands that destroy work, matched on the first argument. */
+static const REFUSED_GIT_SUBCOMMANDS: string[] = [
+  "clean", "reset", "checkout", "restore",
+]
+
+def baseName(text: string): string {
+  """
+  The last part of a path. `/bin/rm` is `rm`.
+  """
+  const parts = text.split("/")
+  return parts[parts.length - 1]
+}
+
+export def isRefused(command: SimpleCommand): boolean {
+  """
+  True when this command must not run, whatever anyone approves.
+
+  Matches the command word, including the last part of a path, so `rm`,
+  `/bin/rm` and `./rm` are all refused.
+
+  This wall is friction against the obvious spelling, not a guarantee.
+  `find . -delete` and `xargs rm` get past it and are approvable under
+  `std::bash`, which is where the actual control lives.
+  """
+  const name = command.command
+  if (name == null) {
+    return false
+  }
+  const word = baseName(name.text)
+  if (REFUSED_COMMANDS.includes(word)) {
+    return true
+  }
+  if (word != "git") {
+    return false
+  }
+  // `git reset --hard` destroys work; `git reset` alone does not, but
+  // telling them apart needs flag inspection, and refusing the whole
+  // subcommand costs a fallback where guessing costs a lost tree.
+  for (arg in command.args) {
+    if (arg.tag == "literal" && REFUSED_GIT_SUBCOMMANDS.includes(arg.text)) {
+      return true
+    }
+  }
+  return false
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+make && pnpm run a test tests/agency/safeBash.agency 2>&1 | tail -20
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+pnpm run a fmt -i stdlib/safeBash.agency tests/agency/safeBash.agency
+git add stdlib/safeBash.agency tests/agency/safeBash.agency tests/agency/safeBash.test.json
+git commit -m "safeBash: add the refuse wall"
+```
+
+---
+
+### Task 2: Classify one command into effects
+
+**Files:**
+- Modify: `stdlib/safeBash.agency`, `stdlib/safeBash/actions.agency`
+- Test: `tests/agency/safeBash.agency`, `tests/agency/safeBash.test.json`
+
+**Interfaces:**
+- Consumes: `isRefused` (Task 1)
+- Produces:
+  - `export type Effect` — a discriminated union over the five effect names, with a typed payload per name (defined in Step 3)
+  - `export type WritePayload = { dir: string; filename: string; content: string; mode: string }`
+  - `export type GitDiffPayload = { cwd: string; ref: string; ref2: string; staged: boolean; path: string }`
+  - `export def effectsFor(command: SimpleCommand, cwd: string): Result<Effect[]>`
+  - A `failure` return means "this command is not recognized" — the caller demotes the whole string to `std::bash`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/agency/safeBash.agency`:
+
+```ts
+import { effectsFor } from "std::safeBash"
+
+def effectNamesFor(source: string): any {
+  const parsed = bashParser(source)
+  if (parsed is failure(why)) {
+    return "UNPARSEABLE"
+  }
+  const first = parsed.value[0]
+  if (first.tag != "simpleCommand") {
+    return "NOT-SIMPLE"
+  }
+  const effects = effectsFor(first, "/repo")
+  if (effects is failure(why)) {
+    return "UNRECOGNIZED"
+  }
+  return [e.name for e in effects.value]
+}
+
+node classifyOneCommand() {
+  return [
+    effectNamesFor("git status"),
+    effectNamesFor("git diff"),
+    effectNamesFor("git diff --staged"),
+    effectNamesFor("git log"),
+    effectNamesFor("echo hi"),
+    effectNamesFor("ls"),
+    effectNamesFor("git log --graph"),
+    effectNamesFor("$CMD status"),
+  ]
+}
+```
+
+Add to `tests/agency/safeBash.test.json`:
+
+```json
+{
+  "nodeName": "classifyOneCommand",
+  "description": "Each recognized command contributes its own effects; an unrecognized command, an unknown flag, and a non-literal command word are all unrecognized.",
+  "input": "",
+  "expectedOutput": "[[\"std::git::status\"],[\"std::git::diff\"],[\"std::git::diff\"],[\"std::git::log\"],[],\"UNRECOGNIZED\",\"UNRECOGNIZED\",\"UNRECOGNIZED\"]",
+  "evaluationCriteria": [{ "type": "exact" }]
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+make && pnpm run a test tests/agency/safeBash.agency 2>&1 | tail -20
+```
+
+Expected: FAIL — `effectsFor` is not defined.
+
+- [ ] **Step 3: Write the implementation**
+
+Add to `stdlib/safeBash/actions.agency`:
+
+```ts
+/** One interrupt a command needs raised before it may run.
+ *
+ * A discriminated union rather than a bag of `any`: the effect set is
+ * closed, so each payload can be typed, and typing them is what makes the
+ * raise sites in Task 7 check that every payload satisfies its effect's
+ * contract. */
+export type Effect =
+  | { name: "std::bash" }
+  | { name: "std::write"; payload: WritePayload }
+  | { name: "std::git::status"; payload: { cwd: string } }
+  | { name: "std::git::log"; payload: { cwd: string; ref: string; path: string } }
+  | { name: "std::git::diff"; payload: GitDiffPayload }
+
+export type WritePayload = {
+  dir: string;
+  filename: string;
+  content: string;
+  mode: string
+}
+
+export type GitDiffPayload = {
+  cwd: string;
+  ref: string;
+  ref2: string;
+  staged: boolean;
+  path: string
+}
+```
+
+If the typechecker fights the union when these are built dynamically —
+narrowing on `effect.name` in Task 7 has to work for the payload accesses
+to check — fall back to `{ name: string; payload: any }` and record the
+deviation in the commit message. Do not spend more than one attempt on it;
+the union is an improvement, not a requirement of the design.
+
+Add to `stdlib/safeBash.agency` (import `Effect` from `./safeBash/actions.agency`):
+
+```ts
+def literalArgs(command: SimpleCommand): Result<string[]> {
+  """
+  A command's arguments as text, but only when every one is a plain
+  literal.
+
+  Anything else — a variable, a quoted string, a path, a flag — makes this
+  fail, because classification must never depend on a value we would have
+  to expand or interpret ourselves.
+  """
+  let out: string[] = []
+  for (arg in command.args) {
+    if (arg.tag != "literal") {
+      return failure("`${arg.tag}` is not a literal argument")
+    }
+    out.push(arg.text)
+  }
+  return success(out)
+}
+
+def flagNames(command: SimpleCommand): string[] {
+  """
+  Every flag on the command, in source form (`--staged`, `-n`).
+  """
+  let out: string[] = []
+  for (arg in command.args) {
+    if (arg.tag == "flag") {
+      out.push(renderFlag(arg))
+    }
+  }
+  return out
+}
+
+export def effectsFor(command: SimpleCommand, cwd: string): Result<Effect[]> {
+  """
+  Which interrupts this one command needs raised.
+
+  A failure means the command is not recognized. The caller turns that
+  into a `std::bash` question for the whole string rather than trying to
+  ask a narrow question about part of it.
+
+  @param command - One simple command from the parsed AST
+  @param cwd - The resolved working directory, for payloads that need it
+  """
+  const name = command.command
+  if (name == null) {
+    return failure("an assignment with no command")
+  }
+  // A path word is never a recognized command: `$CMD` and `./git` must
+  // not become git reads. The wall may look at path words, because a
+  // wall match can only ever cause a refusal.
+  if (name.tag != "literal") {
+    return failure("the command word is not a literal")
+  }
+  const args = literalArgs(command)
+  if (args is failure(why)) {
+    return failure(why)
+  }
+  const flags = flagNames(command)
+
+  if (name.text == "echo") {
+    // `echo` contributes nothing on its own. A string of nothing but
+    // echoes still raises `std::bash` — see the audit rule in the caller.
+    if (flags.length > 0) {
+      return failure("`echo` with flags prints differently")
+    }
+    return success([])
+  }
+
+  if (name.text != "git") {
+    return failure("no rule for `${name.text}`")
+  }
+  return gitEffects(args.value, flags, cwd)
+}
+
+def gitEffects(args: string[], flags: string[], cwd: string): Result<Effect[]> {
+  """
+  The four git reads we recognize.
+
+  An unrecognized flag is a failure rather than something to ignore.
+  Answering `git log --graph` with a plain `std::git::log` would tell the
+  model it asked one question when it asked another.
+  """
+  if (args.length != 1) {
+    return failure("only a bare git subcommand is recognized")
+  }
+  const sub = args[0]
+  if (sub == "status" && flags.length == 0) {
+    return success([{ name: "std::git::status", payload: { cwd: cwd } }])
+  }
+  if (sub == "log" && flags.length == 0) {
+    return success([
+      { name: "std::git::log", payload: { cwd: cwd, ref: "", path: "" } }
+    ])
+  }
+  if (sub == "diff" && flags.length == 0) {
+    return success([
+      { name: "std::git::diff", payload: {
+        cwd: cwd, ref: "", ref2: "", staged: false, path: ""
+      } }
+    ])
+  }
+  if (sub == "diff" && flags.length == 1 && flags[0] == "--staged") {
+    return success([
+      { name: "std::git::diff", payload: {
+        cwd: cwd, ref: "", ref2: "", staged: true, path: ""
+      } }
+    ])
+  }
+  return failure("no rule for `git ${sub}`")
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+make && pnpm run a test tests/agency/safeBash.agency 2>&1 | tail -20
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+pnpm run a fmt -i stdlib/safeBash.agency stdlib/safeBash/actions.agency tests/agency/safeBash.agency
+git add stdlib/safeBash.agency stdlib/safeBash/actions.agency tests/agency/safeBash.agency tests/agency/safeBash.test.json
+git commit -m "safeBash: classify one command into effects"
+```
+
+---
+
+### Task 3: Redirects contribute on their own
+
+**Files:**
+- Modify: `stdlib/safeBash.agency`
+- Test: `tests/agency/safeBash.agency`, `tests/agency/safeBash.test.json`
+
+**Interfaces:**
+- Consumes: `effectsFor` (Task 2)
+- Produces: `effectsFor` now also accounts for redirects. Same signature.
+
+This is the security-critical task. Without it, `echo pwned >> .bashrc; git status` classifies as a git read only, and a policy that approves git reads has approved appending to a shell startup file.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/agency/safeBash.agency`:
+
+```ts
+node redirectsContribute() {
+  return [
+    effectNamesFor("git status > out.txt"),
+    effectNamesFor("echo hi > out.txt"),
+    effectNamesFor("echo hi >> out.txt"),
+    effectNamesFor("echo hi > $F"),
+    effectNamesFor("echo hi < in.txt"),
+    effectNamesFor("echo hi 2> err.txt"),
+  ]
+}
+```
+
+Add to `tests/agency/safeBash.test.json`:
+
+```json
+{
+  "nodeName": "redirectsContribute",
+  "description": "A redirect writes a file whatever the verb is, so it contributes std::write independently. A variable target or any other redirect kind is unrecognized.",
+  "input": "",
+  "expectedOutput": "[[\"std::git::status\",\"std::write\"],[\"std::write\"],[\"std::write\"],\"UNRECOGNIZED\",\"UNRECOGNIZED\",\"UNRECOGNIZED\"]",
+  "evaluationCriteria": [{ "type": "exact" }]
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+make && pnpm run a test tests/agency/safeBash.agency 2>&1 | tail -20
+```
+
+Expected: FAIL — redirects are ignored, so `git status > out.txt` returns only `["std::git::status"]`.
+
+- [ ] **Step 3: Write the implementation**
+
+Add to `stdlib/safeBash.agency`:
+
+```ts
+def redirectEffect(redirects: Redirect[], cwd: string): Result<Effect[]> {
+  """
+  What a command's redirects contribute, independently of its verb.
+
+  A redirect writes a file whatever the command is, so it has to be
+  accounted for on its own. Without this, `echo pwned >> .bashrc; git
+  status` would classify as a git read and ride along under whatever
+  approves git reads.
+
+  Anything other than a plain `>` or `>>` to a literal target is a
+  failure, which sends the whole string to `std::bash`. An input redirect
+  is a read the effect set would otherwise never mention, and a variable
+  target cannot fill the payload without expanding it ourselves.
+  """
+  if (redirects.length == 0) {
+    return success([])
+  }
+  if (redirects.length > 1) {
+    return failure("more than one redirect")
+  }
+  const only = redirects[0]
+  if (only.fd != null) {
+    return failure("redirect with an explicit file descriptor")
+  }
+  if (only.op != ">" && only.op != ">>") {
+    return failure("`${only.op}` is not an output redirect")
+  }
+  if (only.target.tag != "literal" && only.target.tag != "path") {
+    return failure("the redirect target is not a literal")
+  }
+  const mode = writeMode(only.op)
+  return success([
+    { name: "std::write", payload: {
+      dir: cwd, filename: only.target.text, content: "", mode: mode
+    } }
+  ])
+}
+
+def writeMode(op: string): string {
+  """
+  `>` truncates, `>>` appends. A statement rather than an `if` expression,
+  because an `if ... then ... else` is only allowed as a variable value or
+  a return, not as an object field or a member assignment.
+  """
+  if (op == ">>") {
+    return "append"
+  }
+  return "overwrite"
+}
+```
+
+Then in `effectsFor`, compute the redirect contribution first and add it to every return. Replace the body after the `flags` line with:
+
+```ts
+  const redirect = redirectEffect(command.redirects, cwd)
+  if (redirect is failure(why)) {
+    return failure(why)
+  }
+
+  if (name.text == "echo") {
+    if (flags.length > 0) {
+      return failure("`echo` with flags prints differently")
+    }
+    return success(redirect.value)
+  }
+
+  if (name.text != "git") {
+    return failure("no rule for `${name.text}`")
+  }
+  const git = gitEffects(args.value, flags, cwd)
+  if (git is failure(why)) {
+    return failure(why)
+  }
+  return success([...git.value, ...redirect.value])
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+make && pnpm run a test tests/agency/safeBash.agency 2>&1 | tail -20
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+pnpm run a fmt -i stdlib/safeBash.agency tests/agency/safeBash.agency
+git add stdlib/safeBash.agency tests/agency/safeBash.agency tests/agency/safeBash.test.json
+git commit -m "safeBash: redirects contribute std::write on their own"
+```
+
+---
+
+### Task 4: Assemble the whole-string plan
+
+**Files:**
+- Modify: `stdlib/safeBash.agency`, `stdlib/safeBash/actions.agency`
+- Test: `tests/agency/safeBash.agency`, `tests/agency/safeBash.test.json`
+
+**Interfaces:**
+- Consumes: `isRefused` (Task 1), `effectsFor` (Tasks 2–3), `resolveCwd` (existing, `stdlib/safeBash.agency:336`)
+- Produces:
+  - `export type Plan = { effects: Effect[]; execution: Execution }`
+  - `export type Execution = { kind: string; command: string; content: string; filename: string; dir: string; reason: string }` — one flat record; `kind` is `"bash"`, `"echo"`, `"write"` or `"refuse"`, and the other fields are filled per kind. A flat record rather than a union because a union of object shapes is awkward to assert on in a test fixture.
+  - `export def planFor(source: string, cwd: string): Plan`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/agency/safeBash.agency`:
+
+```ts
+import { planFor } from "std::safeBash"
+
+def planSummary(source: string): any {
+  const plan = planFor(source, "/repo")
+  return [plan.execution.kind, [e.name for e in plan.effects]]
+}
+
+node wholeStringPlans() {
+  return [
+    planSummary("git status"),
+    planSummary("git status; git log"),
+    planSummary("git status; ls"),
+    planSummary("ls"),
+    planSummary("echo hi; echo bye"),
+    planSummary("rm -rf build"),
+    planSummary("git status; rm -rf build"),
+    planSummary("cat a.txt | grep x"),
+  ]
+}
+```
+
+Add to `tests/agency/safeBash.test.json`:
+
+```json
+{
+  "nodeName": "wholeStringPlans",
+  "description": "The whole string gets one plan: refused if any command is refused, one std::bash if any command is unrecognized, otherwise the union of narrow effects. A shell spawn always raises at least one effect.",
+  "input": "",
+  "expectedOutput": "[[\"bash\",[\"std::git::status\"]],[\"bash\",[\"std::git::status\",\"std::git::log\"]],[\"bash\",[\"std::bash\"]],[\"bash\",[\"std::bash\"]],[\"bash\",[\"std::bash\"]],[\"refuse\",[]],[\"refuse\",[]],[\"bash\",[\"std::bash\"]]]",
+  "evaluationCriteria": [{ "type": "exact" }]
+}
+```
+
+Note `git status` alone plans as `kind: "bash"` — the shell-free paths are `echo` only and arrive in Tasks 5 and 6.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+make && pnpm run a test tests/agency/safeBash.agency 2>&1 | tail -20
+```
+
+Expected: FAIL — `planFor` is not defined.
+
+- [ ] **Step 3: Write the implementation**
+
+Add to `stdlib/safeBash/actions.agency`:
+
+```ts
+/** What happens if every effect in the plan is approved. */
+export type Execution = {
+  kind: string;
+  command: string;
+  content: string;
+  filename: string;
+  dir: string;
+  reason: string
+}
+
+/** The whole decision about one call to safeBash, made before anything runs. */
+export type Plan = {
+  effects: Effect[];
+  execution: Execution
+}
+```
+
+Add to `stdlib/safeBash.agency`:
+
+```ts
+static const BASH_EFFECT: Effect = { name: "std::bash", payload: {} }
+
+def emptyExecution(): Execution {
+  return { kind: "", command: "", content: "", filename: "", dir: "", reason: "" }
+}
+
+def refusePlan(reason: string): Plan {
+  let exec = emptyExecution()
+  exec.kind = "refuse"
+  exec.reason = reason
+  return { effects: [], execution: exec }
+}
+
+def bashPlan(command: string, effects: Effect[]): Plan {
+  let exec = emptyExecution()
+  exec.kind = "bash"
+  exec.command = command
+  // Spawning a shell always raises at least one effect, so a log of
+  // effects is a complete audit of shell invocations. A string of nothing
+  // but echoes would otherwise raise nothing and still start a shell.
+  if (effects.length == 0) {
+    return { effects: [BASH_EFFECT], execution: exec }
+  }
+  return { effects: effects, execution: exec }
+}
+
+export def planFor(source: string, cwd: string): Plan {
+  """
+  Decide everything about a call before any of it happens.
+
+  Parses the string, classifies every command, and works out which
+  interrupts to raise and what to run. Nothing here has an effect, which
+  is what makes the decision testable: hand in a string, look at the plan.
+
+  @param source - One or more bash commands
+  @param cwd - The resolved working directory
+  """
+  const parsed = bashParser(source)
+  if (parsed is failure(why)) {
+    // Unparseable: nothing was understood, so ask the broad question and
+    // hand bash the text the human will have seen.
+    return bashPlan(source, [])
+  }
+  const commands: Command[] = parsed.value
+
+  let narrow: Effect[] = []
+  let allRecognized = true
+  for (command in commands) {
+    if (command.tag != "simpleCommand") {
+      // `&&`, `||` and parens: bash runs these, and their halves are not
+      // separately classified in this version.
+      allRecognized = false
+    } else {
+      if (isRefused(command)) {
+        const name = command.command
+        if (name == null) {
+          return refusePlan("this command is not allowed")
+        }
+        return refusePlan("`${name.text}` is not allowed")
+      }
+      const effects = effectsFor(command, cwd)
+      if (effects is failure(why)) {
+        allRecognized = false
+      } else {
+        narrow = [...narrow, ...effects.value]
+      }
+    }
+  }
+
+  if (!allRecognized) {
+    // We have to ask the broad question anyway, so asking narrow ones
+    // first adds prompts without adding information — and a human
+    // approving std::bash should see the whole command, not a fragment.
+    // The ORIGINAL text runs, because that is what they read.
+    return bashPlan(source, [BASH_EFFECT])
+  }
+  if (narrow.length == 0) {
+    // Everything was recognized but nothing contributed an effect — a
+    // string of nothing but echoes. The audit rule makes this a std::bash
+    // question, so by the same rule it runs the original text.
+    return bashPlan(source, [BASH_EFFECT])
+  }
+  // Narrow questions were asked, so run the tree we classified.
+  return bashPlan(rebuild(commands), narrow)
+}
+
+def rebuild(commands: Command[]): string {
+  """
+  The command string, rendered back from the tree we classified.
+
+  Used only when every command was recognized. We claimed the string is
+  `git status`, so we must run what we classified rather than text we only
+  assumed matched it. A parser bug then degrades to running what we
+  thought we read.
+
+  When the plan is a broad `std::bash` question the caller passes the
+  ORIGINAL text instead, because that is what the human read and approved.
+  """
+  let parts: string[] = []
+  for (command in commands) {
+    const text = try _astToBash(command)
+    if (text is failure(why)) {
+      return ""
+    }
+    parts.push(text.value)
+  }
+  return parts.join("; ")
+}
+```
+
+Note: `rebuild` returning `""` on a render failure is handled in Task 7, which treats an empty rebuilt command as a reason to use the original string.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+make && pnpm run a test tests/agency/safeBash.agency 2>&1 | tail -20
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+pnpm run a fmt -i stdlib/safeBash.agency stdlib/safeBash/actions.agency tests/agency/safeBash.agency
+git add stdlib/safeBash.agency stdlib/safeBash/actions.agency tests/agency/safeBash.agency tests/agency/safeBash.test.json
+git commit -m "safeBash: assemble one plan for the whole string"
+```
+
+---
+
+### Task 5: The shell-free echo path
+
+**Files:**
+- Modify: `stdlib/safeBash.agency`
+- Test: `tests/agency/safeBash.agency`, `tests/agency/safeBash.test.json`
+
+**Interfaces:**
+- Consumes: `planFor` (Task 4)
+- Produces: `planFor` returns `execution.kind == "echo"` with `execution.content` set, for a single fully-literal `echo` with no redirect.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/agency/safeBash.agency`:
+
+```ts
+def planDetail(source: string): any {
+  const plan = planFor(source, "/repo")
+  return [plan.execution.kind, plan.execution.content, [e.name for e in plan.effects]]
+}
+
+node shellFreeEcho() {
+  return [
+    planDetail("echo hello world"),
+    planDetail("echo"),
+    planDetail("echo 'a  b'"),
+    planDetail("echo $HOME"),
+    planDetail("echo -n hi"),
+    planDetail("echo hi; echo bye"),
+  ]
+}
+```
+
+Add to `tests/agency/safeBash.test.json`:
+
+```json
+{
+  "nodeName": "shellFreeEcho",
+  "description": "A single fully-literal echo computes its own output and never touches a shell. An expansion, a flag, or a sequence sends it to bash.",
+  "input": "",
+  "expectedOutput": "[[\"echo\",\"hello world\\n\",[]],[\"echo\",\"\\n\",[]],[\"echo\",\"a  b\\n\",[]],[\"bash\",\"\",[\"std::bash\"]],[\"bash\",\"\",[\"std::bash\"]],[\"bash\",\"\",[\"std::bash\"]]]",
+  "evaluationCriteria": [{ "type": "exact" }]
+}
+```
+
+Note `echo 'a  b'` keeps its two spaces: a single-quoted word is fully literal, and its text is the value between the quotes.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+make && pnpm run a test tests/agency/safeBash.agency 2>&1 | tail -20
+```
+
+Expected: FAIL — every case plans as `"bash"`.
+
+- [ ] **Step 3: Write the implementation**
+
+Add to `stdlib/safeBash.agency`:
+
+```ts
+def echoWords(command: SimpleCommand): Result<string[]> {
+  """
+  `echo`'s arguments as text, but only when every one is fully literal.
+
+  A plain word or a single-quoted string qualifies. A variable does not,
+  and neither does a double-quoted string containing one: this path never
+  invokes a shell, so there is nothing here to expand a variable, and
+  expanding it ourselves is where v2's divergence bugs lived.
+  """
+  let out: string[] = []
+  for (arg in command.args) {
+    if (arg.tag == "literal" || arg.tag == "path") {
+      out.push(arg.text)
+    } else if (arg.tag == "singleQuoted") {
+      out.push(arg.text)
+    } else if (arg.tag == "doubleQuoted") {
+      const flat = literalDoubleQuoted(arg)
+      if (flat is failure(why)) {
+        return failure(why)
+      }
+      out.push(flat.value)
+    } else {
+      return failure("`${arg.tag}` is not fully literal")
+    }
+  }
+  return success(out)
+}
+
+def literalDoubleQuoted(word: DoubleQuotedWord): Result<string> {
+  """
+  The text of a double-quoted word, when it contains no expansions.
+  """
+  let out = ""
+  for (part in word.parts) {
+    if (part.tag != "literal") {
+      return failure("a double-quoted word contains `${part.tag}`")
+    }
+    out = out + part.text
+  }
+  return success(out)
+}
+
+def echoOutput(words: string[]): string {
+  """
+  What `echo` prints: its arguments joined by single spaces, then a
+  newline. Bare `echo` is still a newline, not nothing.
+  """
+  return words.join(" ") + "\n"
+}
+
+def echoPlan(command: SimpleCommand): Result<Plan> {
+  """
+  A single `echo` with nothing else in the string and no redirect.
+
+  Nothing here can write a file or reach the network no matter how wrong
+  the classifier is, because all it does is build a string. That is the
+  one place v2's structural safety was free, and it is worth keeping.
+  """
+  if (command.redirects.length > 0) {
+    return failure("a redirected echo is handled elsewhere")
+  }
+  if (flagNames(command).length > 0) {
+    return failure("`echo` with flags prints differently")
+  }
+  const words = echoWords(command)
+  if (words is failure(why)) {
+    return failure(why)
+  }
+  let exec = emptyExecution()
+  exec.kind = "echo"
+  exec.content = echoOutput(words.value)
+  return success({ effects: [], execution: exec })
+}
+```
+
+Then in `planFor`, immediately after `const commands: Command[] = parsed.value`, add the single-command check:
+
+```ts
+  if (commands.length == 1 && commands[0].tag == "simpleCommand") {
+    const only = commands[0]
+    if (!isRefused(only) && only.command != null && only.command.tag == "literal" && only.command.text == "echo") {
+      const shellFree = echoPlan(only)
+      if (shellFree is success(plan)) {
+        return plan
+      }
+    }
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+make && pnpm run a test tests/agency/safeBash.agency 2>&1 | tail -20
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+pnpm run a fmt -i stdlib/safeBash.agency tests/agency/safeBash.agency
+git add stdlib/safeBash.agency tests/agency/safeBash.agency tests/agency/safeBash.test.json
+git commit -m "safeBash: a single literal echo never touches a shell"
+```
+
+---
+
+### Task 6: The shell-free write path
+
+**Files:**
+- Modify: `stdlib/safeBash.agency`
+- Test: `tests/agency/safeBash.agency`, `tests/agency/safeBash.test.json`
+
+**Interfaces:**
+- Consumes: `echoWords`, `echoOutput`, `emptyExecution` (Task 5)
+- Produces: `planFor` returns `execution.kind == "write"` with `content`, `filename` and `dir` set, and a `std::write` effect whose payload includes `content`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/agency/safeBash.agency`:
+
+```ts
+def writePlanDetail(source: string): any {
+  const plan = planFor(source, "/repo")
+  const exec = plan.execution
+  return [exec.kind, exec.content, exec.filename, exec.dir, [e.name for e in plan.effects]]
+}
+
+node shellFreeWrite() {
+  return [
+    writePlanDetail("echo hi > out.txt"),
+    writePlanDetail("echo hi >> out.txt"),
+    writePlanDetail("echo hi > $F"),
+    writePlanDetail("echo $HOME > out.txt"),
+  ]
+}
+
+node writeContentIsInThePayload() {
+  // The bytes are in the approval payload BEFORE anyone approves, which
+  // is more than v2 managed.
+  const plan = planFor("echo hi > out.txt", "/repo")
+  return plan.effects[0].payload.content
+}
+```
+
+Add to `tests/agency/safeBash.test.json`:
+
+```json
+{
+  "nodeName": "shellFreeWrite",
+  "description": "A single literal redirected echo computes its content and writes it, with no shell. A variable in the target or the arguments sends it to bash.",
+  "input": "",
+  "expectedOutput": "[[\"write\",\"hi\\n\",\"out.txt\",\"/repo\",[\"std::write\"]],[\"write\",\"hi\\n\",\"out.txt\",\"/repo\",[\"std::write\"]],[\"bash\",\"\",\"\",\"\",[\"std::bash\"]],[\"bash\",\"\",\"\",\"\",[\"std::bash\"]]]",
+  "evaluationCriteria": [{ "type": "exact" }]
+},
+{
+  "nodeName": "writeContentIsInThePayload",
+  "description": "The std::write interrupt carries the bytes, so a policy that inspects what is being written still can.",
+  "input": "",
+  "expectedOutput": "\"hi\\n\"",
+  "evaluationCriteria": [{ "type": "exact" }]
+}
+```
+
+Note the append case plans the same way; `mode` is carried separately in Task 7's executor via the redirect operator, which `writePlanDetail` does not surface.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+make && pnpm run a test tests/agency/safeBash.agency 2>&1 | tail -20
+```
+
+Expected: FAIL — the redirected cases plan as `"bash"`.
+
+- [ ] **Step 3: Write the implementation**
+
+Add to `stdlib/safeBash.agency`. First add a `mode` field to `Execution` in `stdlib/safeBash/actions.agency`:
+
+```ts
+export type Execution = {
+  kind: string;
+  command: string;
+  content: string;
+  filename: string;
+  dir: string;
+  mode: string;
+  reason: string
+}
+```
+
+and add `mode: ""` to `emptyExecution`. Then:
+
+```ts
+def writePlan(command: SimpleCommand, cwd: string): Result<Plan> {
+  """
+  A single `echo` redirected to a literal file.
+
+  The content is computed rather than produced by running anything, so no
+  shell is spawned and the bytes are in the approval payload before anyone
+  approves. An earlier design ran `echo` through bash with the redirect
+  stripped and only then asked — a shell spawn with nothing raised before
+  it, and an awkward argument about why running before approval was fine.
+
+  If the equivalence claim is good enough to say what `echo` prints, it is
+  good enough to say what `echo` writes.
+  """
+  if (command.redirects.length != 1) {
+    return failure("not a single redirect")
+  }
+  if (flagNames(command).length > 0) {
+    return failure("`echo` with flags prints differently")
+  }
+  const only = command.redirects[0]
+  if (only.fd != null) {
+    return failure("redirect with an explicit file descriptor")
+  }
+  if (only.op != ">" && only.op != ">>") {
+    return failure("`${only.op}` is not an output redirect")
+  }
+  if (only.target.tag != "literal" && only.target.tag != "path") {
+    return failure("the redirect target is not a literal")
+  }
+  const words = echoWords(command)
+  if (words is failure(why)) {
+    return failure(why)
+  }
+  const content = echoOutput(words.value)
+
+  let exec = emptyExecution()
+  exec.kind = "write"
+  exec.content = content
+  exec.filename = only.target.text
+  exec.dir = cwd
+  exec.mode = writeMode(only.op)
+
+  const effect: Effect = {
+    name: "std::write",
+    payload: {
+      dir: cwd,
+      filename: only.target.text,
+      content: content,
+      mode: exec.mode
+    }
+  }
+  return success({ effects: [effect], execution: exec })
+}
+```
+
+Then extend the single-command branch in `planFor` to try `writePlan` when `echoPlan` declines:
+
+```ts
+      const shellFree = echoPlan(only)
+      if (shellFree is success(plan)) {
+        return plan
+      }
+      const written = writePlan(only, cwd)
+      if (written is success(plan)) {
+        return plan
+      }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+make && pnpm run a test tests/agency/safeBash.agency 2>&1 | tail -20
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+pnpm run a fmt -i stdlib/safeBash.agency stdlib/safeBash/actions.agency tests/agency/safeBash.agency
+git add stdlib/safeBash.agency stdlib/safeBash/actions.agency tests/agency/safeBash.agency tests/agency/safeBash.test.json
+git commit -m "safeBash: a single redirected echo writes without a shell"
+```
+
+---
+
+### Task 7: Raise the effects and execute
+
+**Files:**
+- Modify: `stdlib/safeBash.agency`, `stdlib/safeBash/actions.agency`
+- Test: `tests/agency/safeBash.agency`, `tests/agency/safeBash.test.json`
+
+**Interfaces:**
+- Consumes: `planFor` (Tasks 4–6)
+- Produces: `export def safeBash(command: string, cwd: string = ""): Result<string>` with the new behavior, and `raises <std::bash, std::write, std::git::status, std::git::diff, std::git::log>`
+
+- [ ] **Step 1: Write the failing test**
+
+Replace the old execution tests in `tests/agency/safeBash.agency` with:
+
+```ts
+import { safeBash } from "std::safeBash"
+
+node echoRunsWithoutApproval() {
+  // The whole point: this raises no interrupt and spawns no shell.
+  return safeBash("echo hello world")
+}
+
+node unrecognizedAsksForBash() {
+  // Rejecting the approval means nothing ran at all.
+  const result = safeBash("ls")
+  if (result is failure(why)) {
+    return "REJECTED"
+  }
+  return "RAN"
+}
+
+node refusedNeverRuns() {
+  const result = safeBash("rm -rf build")
+  if (result is failure(why)) {
+    return why
+  }
+  return "UNEXPECTEDLY RAN"
+}
+```
+
+Add to `tests/agency/safeBash.test.json`:
+
+```json
+{
+  "nodeName": "echoRunsWithoutApproval",
+  "description": "A literal echo returns its text with no interrupt and no shell.",
+  "input": "",
+  "expectedOutput": "\"hello world\\n\"",
+  "evaluationCriteria": [{ "type": "exact" }]
+},
+{
+  "nodeName": "unrecognizedAsksForBash",
+  "description": "An unrecognized command asks for std::bash; rejecting it means nothing ran.",
+  "input": "",
+  "expectedOutput": "\"REJECTED\"",
+  "interruptHandlers": [
+    { "action": "reject", "expectedMessage": "Are you sure you want to run this shell command?" }
+  ],
+  "evaluationCriteria": [{ "type": "exact" }]
+},
+{
+  "nodeName": "refusedNeverRuns",
+  "description": "A refused command fails without raising anything, so there is nothing to approve.",
+  "input": "",
+  "expectedOutput": "\"`rm` is not allowed\"",
+  "evaluationCriteria": [{ "type": "exact" }]
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+make && pnpm run a test tests/agency/safeBash.agency 2>&1 | tail -30
+```
+
+Expected: FAIL — `safeBash` still has the v2 body.
+
+- [ ] **Step 3: Write the implementation**
+
+Replace `bashAction` in `stdlib/safeBash/actions.agency` with the v3 return contract, and delete `printAction`, `writeAction`'s old signature, `gitStatusAction`, `gitDiffAction`, `gitLogAction`, and the `PrintAction` / `GitAction` / `GitStatusAction` / `GitDiffAction` / `GitLogAction` types:
+
+```ts
+export def runBash(command: string, cwd: string): Result<string> {
+  """
+  Run a command string through bash and return what it printed.
+
+  On success the value is bash's stdout, raw — nothing added, nothing
+  stripped. stderr is discarded on success and reported on failure: two
+  captured pipes cannot interleave the way a terminal does, so this is a
+  policy either way, and discarding on success keeps the value exactly
+  equal to bash's stdout.
+
+  A non-zero exit is a failure, which `&&` and `||` require. The known
+  cost: `grep` exits 1 when it finds nothing and `diff` exits 1 when files
+  differ, and neither is an error, so an agent sees a failure where bash
+  would have shown an empty result.
+  """
+  // `any` because `bash` is DECLARED to return an ExecResult, but a
+  // rejected approval halts it and hands back a failure instead, which
+  // the declared type cannot describe.
+  const result: any = bash(command, cwd)
+  if (result is failure(why)) {
+    return failure("`${command}` was not run: ${why}")
+  }
+  const out = truncate(result.stdout)
+  if (result.exitCode != 0) {
+    return failure(JSON.stringify({
+      command: command,
+      exitCode: result.exitCode,
+      stderr: truncate(result.stderr),
+      stdout: out
+    }))
+  }
+  return success(out)
+}
+
+def truncate(text: string): string {
+  """
+  Cap output length. Raw output with no bound is a context-window hazard,
+  and a visible loss of fidelity beats an invisible one.
+  """
+  if (text.length <= MAX_STDOUT_LEN) {
+    return text
+  }
+  return text[:MAX_STDOUT_LEN] + "\n[truncated]"
+}
+
+export def runWrite(exec: Execution): Result<string> {
+  """
+  Perform the write a redirected echo asked for. Returns the empty string,
+  which is what bash's stdout for `echo hi > f` is.
+  """
+  const written = write(
+    filename: exec.filename,
+    content: exec.content,
+    dir: exec.dir,
+    mode: exec.mode,
+  )
+  if (written is failure(why)) {
+    return failure(why)
+  }
+  return success("")
+}
+```
+
+Then replace `safeBash` in `stdlib/safeBash.agency`:
+
+```ts
+export def safeBash(
+  command: string,
+  cwd: string = "",
+): Result<string> raises <std::bash, std::write, std::git::status, std::git::diff, std::git::log> {
+  """
+  Run a shell command, asking the narrowest question that describes it.
+
+  `bash` cannot be pre-approved, because a command is a string and a
+  string could do anything, so every call needs a human. Many of the
+  commands an agent writes can be identified, and for those we ask a more
+  specific question — one a policy can answer in advance.
+
+  Nothing runs until every question is answered. If everything is
+  approved, the whole string goes to bash in one call, so bash does the
+  control flow and produces the output.
+
+  @param command - One or more bash commands
+  @param cwd - Working directory. Defaults to the agent working directory.
+  """
+  const dir = resolveCwd(cwd)
+  const plan = planFor(command, dir)
+
+  if (plan.execution.kind == "refuse") {
+    return failure(plan.execution.reason)
+  }
+
+  const raised = raiseAll(plan.effects, command, dir)
+  if (raised is failure(why)) {
+    return failure(why)
+  }
+
+  if (plan.execution.kind == "echo") {
+    return success(plan.execution.content)
+  }
+  if (plan.execution.kind == "write") {
+    return runWrite(plan.execution)
+  }
+  const text = if plan.execution.command == "" then command else plan.execution.command
+  return runBash(text, dir)
+}
+
+def raiseAll(effects: Effect[], fullCommand: string, cwd: string): Result {
+  """
+  Ask every question the plan needs answered, before anything happens.
+
+  An effect is raised at a named site, not by name-as-data, so this is a
+  closed dispatch with one arm per effect. That is also why safeBash
+  declares them all in its `raises` clause: it is how an agent author
+  discovers which handlers to write.
+
+  Every payload carries the full command string. A human approving a git
+  read inside `echo hi; git status` needs to see the whole thing, not the
+  fragment.
+  """
+  for (effect in effects) {
+    const why = raiseOne(effect, fullCommand)
+    if (why is failure(reason)) {
+      return failure(reason)
+    }
+  }
+  return success(null)
+}
+
+def raiseOne(effect: Effect, fullCommand: string): Result {
+  if (effect.name == "std::bash") {
+    raise std::bash("Are you sure you want to run this shell command?", {
+      command: fullCommand
+    })
+    return success(null)
+  }
+  if (effect.name == "std::write") {
+    raise std::write("Are you sure you want to write to this file?", {
+      dir: effect.payload.dir,
+      filename: effect.payload.filename,
+      content: effect.payload.content,
+      mode: effect.payload.mode,
+      command: fullCommand
+    })
+    return success(null)
+  }
+  if (effect.name == "std::git::status") {
+    raise std::git::status("Show git status", {
+      cwd: effect.payload.cwd,
+      command: fullCommand
+    })
+    return success(null)
+  }
+  if (effect.name == "std::git::log") {
+    raise std::git::log("Show git log", {
+      cwd: effect.payload.cwd,
+      ref: effect.payload.ref,
+      path: effect.payload.path,
+      command: fullCommand
+    })
+    return success(null)
+  }
+  if (effect.name == "std::git::diff") {
+    raise std::git::diff("Show git diff", {
+      cwd: effect.payload.cwd,
+      ref: effect.payload.ref,
+      ref2: effect.payload.ref2,
+      staged: effect.payload.staged,
+      path: effect.payload.path,
+      command: fullCommand
+    })
+    return success(null)
+  }
+  return failure("no raise site for `${effect.name}`")
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+make && pnpm run a test tests/agency/safeBash.agency 2>&1 | tail -30
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+pnpm run a fmt -i stdlib/safeBash.agency stdlib/safeBash/actions.agency tests/agency/safeBash.agency
+git add stdlib/safeBash.agency stdlib/safeBash/actions.agency tests/agency/safeBash.agency tests/agency/safeBash.test.json
+git commit -m "safeBash: raise the plan effects, then run the whole string"
+```
+
+---
+
+### Task 8: Delete the v2 machinery
+
+**Files:**
+- Modify: `stdlib/safeBash.agency`
+
+**Interfaces:**
+- Consumes: nothing new
+- Produces: nothing new. This task only removes code that is now unreachable.
+
+- [ ] **Step 1: Confirm the current tests pass before deleting**
+
+```bash
+make && pnpm run a test tests/agency/safeBash.agency 2>&1 | tail -5
+```
+
+Expected: PASS. This is the baseline the deletion must preserve.
+
+- [ ] **Step 2: Delete the runner**
+
+Remove these definitions from `stdlib/safeBash.agency`. Bash does control flow now, so none of them has a caller:
+
+- `runAction`, `runCommand`, `runSimpleCommand`
+- `andCommand`, `orCommand`, `parensCommand`
+- `joinOutput`, `commandsToStr`, `runCommands`, `failureReport`
+- `makeActions`, `actionsFor`, `wrapOne`, `bothSides`
+- `makeAction`, `echoAction`, `gitOnly`, `bashFallback`, `echoContent`, `tokenize`
+
+- [ ] **Step 3: Delete the expansion machinery**
+
+Remove from `stdlib/safeBash.agency`:
+
+- `stringifyWord`, `expandVariable`, `stringifyParts`, `hasQuotedPart`, `stringifyArg`
+- `simplifyRedirects`, `writeDir`, `joinWords` (replaced by `echoOutput`)
+- the `OutputRedirect` type
+- the `env` import from `std::system`, which now has no user
+
+Bash expands variables in the child process, so the word-splitting and empty-value refusals these implemented are not needed and cannot diverge.
+
+- [ ] **Step 4: Verify nothing broke**
+
+```bash
+make && pnpm run a tc stdlib/safeBash.agency 2>&1 | tail -10
+pnpm run a test tests/agency/safeBash.agency 2>&1 | tail -5
+```
+
+Expected: no type errors, all tests still pass. If `tc` reports an unused import or an undefined function, that names something the deletion missed or over-reached.
+
+- [ ] **Step 5: Commit**
+
+```bash
+pnpm run a fmt -i stdlib/safeBash.agency
+git add stdlib/safeBash.agency
+git commit -m "safeBash: delete the runner and the expansion machinery"
+```
+
+---
+
+### Task 9: The astToBash round-trip property test
+
+**Files:**
+- Create: `lib/stdlib/safeBash.test.ts`
+
+**Interfaces:**
+- Consumes: `_bashParser`, `_astToBash` from `lib/stdlib/safeBash.ts`
+- Produces: nothing the Agency code uses. This pins a claim the design rests on.
+
+`astToBash` became security-critical in this design: when every command is recognized, bash receives a string rendered from the tree rather than the agent's text. If rendering is lossy, we run something other than what we classified.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `lib/stdlib/safeBash.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { _bashParser, _astToBash } from "./safeBash.js";
+
+// Every command family the classifier recognizes, plus the hostile
+// quoting cases that would turn one command into two if rendering lost a
+// quote.
+const CORPUS = [
+  "echo hello",
+  "echo hello world",
+  "echo 'a  b'",
+  'echo "a b" c',
+  "echo a'b'\"c\"",
+  'echo "a; rm -rf /tmp/x"',
+  'echo "a\\"b"',
+  "echo $HOME",
+  'echo "$HOME"/bin',
+  "echo hi > out.txt",
+  "echo hi >> out.txt",
+  'echo hi > "my file.txt"',
+  "git status",
+  "git log",
+  "git diff",
+  "git diff --staged",
+  "git log --format=oneline",
+  "ls -la",
+  "cat src/main.ts",
+  "git status; git log",
+  "git status && git log",
+  "git status || git log",
+  "(git status && git log)",
+];
+
+describe("astToBash round-trips every command family the classifier sees", () => {
+  for (const source of CORPUS) {
+    it(`round-trips ${JSON.stringify(source)}`, () => {
+      const first = _bashParser(source);
+      expect(first.success, `corpus entry did not parse: ${source}`).toBe(true);
+      if (!first.success) return;
+
+      const rendered = first.result.map((c: unknown) => _astToBash(c)).join("; ");
+      const second = _bashParser(rendered);
+      expect(second.success, `rendered form did not re-parse: ${rendered}`).toBe(true);
+      if (!second.success) return;
+
+      // Re-rendering the re-parsed tree must be a fixed point. Comparing
+      // rendered strings rather than trees keeps the failure message
+      // readable, and any tree difference shows up as a text difference.
+      const again = second.result.map((c: unknown) => _astToBash(c)).join("; ");
+      expect(again).toBe(rendered);
+    });
+  }
+});
+```
+
+- [ ] **Step 2: Run test to verify it runs and passes**
+
+```bash
+npx vitest run lib/stdlib/safeBash.test.ts 2>&1 | tail -15
+```
+
+Expected: PASS for every entry. A failure here is a real finding — it means the design's rebuilt-string rule is unsound for that command shape, and the classifier must not recognize it until the renderer is fixed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/stdlib/safeBash.test.ts
+git commit -m "safeBash: pin the astToBash round-trip property"
+```
+
+---
+
+### Task 10: Documentation and the full sweep
+
+**Files:**
+- Modify: `docs/site/stdlib/safeBash.md`, `docs/site/stdlib/safeBash/actions.md` (both regenerated)
+- Modify: `docs/superpowers/specs/2026-07-26-safebash-classifier-design.md` (status line only)
+
+- [ ] **Step 1: Regenerate the stdlib documentation**
+
+```bash
+make doc
+git status --short -- docs/site/stdlib/
+```
+
+Expected: `docs/site/stdlib/safeBash.md` and `docs/site/stdlib/safeBash/actions.md` show as modified.
+
+If `make doc` also modifies files unrelated to safeBash — `docs/site/guide/pattern-matching.md` has done this before — revert those with `git checkout --` and mention it. They are pre-existing generator drift, not part of this change.
+
+- [ ] **Step 2: Run every test that touches this module**
+
+```bash
+make
+pnpm run a test tests/agency/safeBash.agency 2>&1 | tail -5
+npx vitest run lib/stdlib/safeBash.test.ts 2>&1 | tail -5
+npx vitest run lib/utils/expressionSlots.test.ts 2>&1 | tail -5
+pnpm run lint:structure 2>&1 | tail -3
+```
+
+Expected: all pass. The third is the walker-completeness tripwire, which fires when a `.agency` file in the corpus uses an AST shape the walker does not reach. This plan adds `match`-free code and array patterns are already ruled on, but run it because a new shape would fail the whole build.
+
+- [ ] **Step 3: Update the spec's status line**
+
+In `docs/superpowers/specs/2026-07-26-safebash-classifier-design.md`, change the Status section's first line from:
+
+```
+Design, not yet built.
+```
+
+to:
+
+```
+Implemented. See `docs/superpowers/plans/2026-07-27-safebash-v3-classifier.md`.
+```
+
+- [ ] **Step 4: Audit the diff against the anti-patterns list**
+
+```bash
+git diff main...HEAD --stat
+```
+
+Read `docs/dev/anti-patterns.md` and check the diff against it. The ones most likely to bite here: comments that restate the code rather than explaining why, and `any` used where a real type would work. The two deliberate `any` uses in this plan — `bash()`'s return, and `Effect.payload` — each have a comment saying why.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/site/stdlib docs/superpowers/specs/2026-07-26-safebash-classifier-design.md
+git commit -m "safeBash: regenerate docs and mark the spec implemented"
+```
+
+---
+
+## Notes for the implementer
+
+**What is deliberately not in this plan.** No new commands. If you find yourself adding a row for `cat`, `ls`, `grep` or `curl`, stop — that is a separate change with its own effect-signature consequences, because adding a row changes `safeBash`'s public `raises` clause.
+
+**The two rules that carry the safety argument.** If a change seems to require breaking one of these, it is the wrong change:
+
+1. Bash receives a string rendered from the validated tree when we asked narrow questions, and the agent's original text when we asked for `std::bash`. Never the other way round.
+2. We resolve a variable nowhere — not for classification, not for a payload, not for content.
+
+**The hole this design closes.** `echo pwned >> .bashrc; git status` must classify as needing `std::write`, not just `std::git::status`. Task 3 is what makes that true. If you refactor `effectsFor`, keep a test that pins it.
+
+**Known gaps that are not bugs.** `grep` and `diff` exit non-zero for ordinary results, and the blanket "non-zero is a failure" rule reports those as failures. Echo-only sequences (`echo a; echo b`) now cost a `std::bash` approval that was free in v2. Both are recorded in the spec as accepted costs.

--- a/packages/agency-lang/docs/superpowers/specs/2026-07-26-safebash-classifier-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-07-26-safebash-classifier-design.md
@@ -223,7 +223,14 @@ below.
 
 Some commands we decline to run at all, even with approval: `rm`, `rmdir`,
 `dd`, `shred`, `mkfs`, `truncate`, and the destructive git subcommands
-(`git clean`, `git reset --hard`, `git checkout -- .`, `git restore`).
+(`git clean`, `git restore`, `git reset --hard`, `git checkout .`).
+
+An earlier draft listed `git checkout -- .` here. **It cannot be
+refused**, because the parser rejects a bare `--` outright, so that string
+never reaches classification and falls through as unparseable — under an
+approvable `std::bash`. Checked against the parser rather than assumed.
+Only the destructive *spellings* are refused, so `git checkout main` and
+`git reset HEAD~1` are ordinary commands.
 
 A refusal anywhere in the string refuses the **whole string**.
 

--- a/packages/agency-lang/docs/superpowers/specs/2026-07-26-safebash-classifier-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-07-26-safebash-classifier-design.md
@@ -123,8 +123,14 @@ not persist, and neither do variable assignments. `cd foo && git status`
 would run `git status` in the wrong directory.
 
 Up front avoids all three. The cost is that we ask about effects that may
-never happen — `false && git status` still raises `std::git::status` — and
-that is a much smaller problem than a half-run sequence.
+never happen: `git status && git log` raises both questions before
+anything runs, even though the second command only runs if the first
+succeeds. That is a much smaller problem than a half-run sequence.
+
+(The example has to be an all-recognized chain to make the point.
+Something like `false && git status` never gets there — `false` is
+unrecognized, so the whole string collapses to one `std::bash` and the
+narrow question is never asked.)
 
 ### Why one bash call
 
@@ -155,44 +161,61 @@ The reasoning: we have to ask the broad question anyway, so asking the
 narrow one first adds a prompt without adding information. And a human
 approving `std::bash` should see the entire command, not a fragment of it.
 
-## The single-command fast paths
+## The two shell-free paths
 
-Two cases skip bash entirely, and both apply **only when the whole input
-is one command.** Once there is a sequence, the whole thing goes to bash.
+Two cases never invoke a shell at all. Both apply **only when the whole
+input is one command**, and both require **every argument to be fully
+literal** — a plain word, a single-quoted string, or a double-quoted
+string with no variables inside.
 
-**A bare `echo`** goes to `print`:
+Both rest on one claim: `echo` prints its arguments joined by single
+spaces followed by a newline, and we can compute that ourselves, exactly.
+That is a small enough behavior to be provable and is already what the
+existing code produces.
+
+**A bare `echo` computes its own output.**
 
 ```
-safeBash("echo hello")     → print("hello\n")   no shell, no interrupt
-safeBash("echo -n hi")     → flags change what echo prints → bash
-safeBash("echo hi; ls")    → a sequence → bash
+safeBash("echo hello")     → returns "hello\n"    no shell, no interrupt
+safeBash("echo -n hi")     → flags change what echo prints  → bash
+safeBash("echo $HOME")     → not fully literal             → bash
+safeBash("echo hi; ls")    → a sequence                    → bash
 ```
 
 This is the one place v2's structural safety was free, and it is worth
-keeping: `print` cannot write a file or reach the network no matter how
-wrong the classifier is. The output is provably identical — `echo a b`
-prints its arguments joined by single spaces plus a newline, which is
-exactly what the existing code produces.
+keeping: nothing here can write a file or reach the network no matter how
+wrong the classifier is, because all it does is build a string.
 
-**A single redirected `echo`** goes to `write`:
+Note it **returns** the text rather than printing it. `bash()` captures
+stdout into its result, so safeBash does too; a shell-free path that wrote
+to the console would be an observable seam between the two paths, and the
+whole point is that an agent cannot tell them apart.
+
+**A single redirected `echo` computes its content, then writes it.**
 
 ```
 safeBash("echo hi > out.txt")
+   compute "hi\n"
+   raise std::write { dir, filename: "out.txt", content: "hi\n" }
+   if approved → write
 ```
 
-We run `echo hi` through bash with the redirect stripped, capture what it
-printed, and hand those bytes to `write`. Bash makes the text so fidelity
-holds; `write` does the writing so it can enforce which directory you
-allowed, and the `std::write` interrupt carries `content`, so a policy
-that inspects what is being written still can.
+No shell is spawned here either. An earlier draft ran `echo hi` through
+bash with the redirect stripped and only then raised `std::write` — a
+shell spawn with nothing raised before it, contradicting the audit rule
+below, and forcing an awkward argument about why running before approval
+was tolerable.
 
-This is only sound because `echo` has no effects of its own — the command
-runs before the write is approved, so a rejected write must not leave
-anything behind. Any other command with a redirect goes to bash.
+Computing the content instead makes the path strictly better: the bytes
+are in the approval payload **before** anyone approves, which is more
+than v2 managed, and nothing runs if the write is rejected. It also
+resolves an inconsistency — if the provable-equivalence claim is good
+enough to generate what `echo` prints, it is good enough to generate what
+`echo` writes. The earlier draft trusted it in one place and not the
+other.
 
-Two exclusions: a redirect whose **target contains a variable**
-(`echo hi > $F`) cannot substitute, because `write` needs a known filename
-at approval time. And any `echo` with flags goes to bash.
+Everything else with a redirect goes to bash, under the redirect rules
+below.
 
 ## Three outcomes
 
@@ -222,7 +245,7 @@ mechanism does not make.
 
 ### Ask, then delegate to bash
 
-Everything recognized that is not refused and not a fast path.
+Everything recognized that is not refused and not shell-free.
 
 | command | effect raised |
 |---|---|
@@ -241,6 +264,39 @@ all.
 The default is always `std::bash`. Classification is an allowlist — a
 command earns a narrower question by matching a rule, and everything else
 gets the broad one.
+
+### Redirects contribute on their own
+
+A command's *verb* is not the only thing that decides what it can do. A
+redirect writes a file whatever the verb is, so it has to contribute
+independently of the table above. Without this rule there is a hole:
+
+```
+echo pwned >> .bashrc; git status
+```
+
+`echo` contributes nothing on its own and `git status` contributes a git
+read, so the string would classify as `{ std::git::status }` — and a
+policy that blanket-approves git reads would have silently approved
+appending to a shell startup file. That must not be a possible reading.
+
+Three rules:
+
+1. **Any `>` or `>>` on any command contributes `std::write`**, with
+   `{ dir, filename }` filled from the parse tree, regardless of what the
+   command itself contributes.
+2. **A redirect whose target contains a variable demotes the whole string
+   to `std::bash`.** `std::write` cannot be raised without a filename, and
+   the filename is not known without expanding the variable ourselves —
+   which is exactly what the classification rule forbids. This is the same
+   restriction the shell-free write path has, one level up.
+3. **Any other redirect demotes the whole string to `std::bash`.** Input
+   redirects (`< in.txt`) and explicit file descriptors (`2> err.txt`,
+   `&>`) both reach classification, because the parser represents them.
+   `< secret.txt` on an otherwise-recognized command is a read that the
+   effect set would never otherwise mention, and rather than growing a
+   table row per redirect kind, anything that is not a plain `>`/`>>`
+   asks the broad question.
 
 ### The rule that closes the audit hole
 
@@ -292,8 +348,9 @@ correctly — which is a much smaller and more reviewable surface.
 This makes `astToBash` security-critical, which it was not before. It
 earns a property test: for every command in the corpus, re-parsing the
 rendered string must produce the same tree, and the corpus must cover
-every command family in the table, plus the redirect-stripped form the
-`write` fast path renders (the same command with an empty redirect list).
+every command family in the table. (An earlier draft also rendered a
+redirect-stripped form, for a write path that ran `echo` through bash.
+That path is gone, and so is the extra rendering mode it needed.)
 
 Checked before adopting this design, `astToBash` preserves quoting on
 every hostile input tried:
@@ -352,9 +409,21 @@ right of the plain-command-word rule:
 pass through untouched — `echo $HOME` is still an echo, because the
 question we are asking does not depend on what it expands to.
 
-The only place we still resolve a variable ourselves is a redirect target
-on the `write` fast path, and a target that *is* a variable disqualifies
-the fast path (above).
+**The shell-free paths need the same rule, more strictly.** They never
+invoke bash, so nothing else is there to expand anything: for
+`safeBash("echo $HOME")` we would have to produce the text ourselves, with
+machinery this section just deleted. So a shell-free path requires every
+argument to be **fully literal** — a plain word, a single-quoted string,
+or a double-quoted string containing no variables. An `echo` with any
+expansion in it is not a shell-free path; as a single command it goes to
+bash, and by the audit rule that raises `std::bash`.
+
+The cost is that a bare `echo $HOME` now needs one broad approval. That is
+honest: we genuinely do not know what it prints without expanding it, and
+expanding it ourselves is where the divergence bugs lived.
+
+We therefore never resolve a variable anywhere. Not for classification,
+not for a payload, not for content.
 
 **The wall and the classifier match differently, on purpose.** The refuse
 wall looks at path words and at flag and path arguments (`git reset
@@ -494,7 +563,7 @@ than silent. Raw output with no bound is a context-window hazard that v2's
 envelope quietly protected against; a visible loss of fidelity is a much
 better failure than an invisible one.
 
-**The `write` fast path returns the empty string on success**, which is
+**The shell-free write path returns the empty string on success**, which is
 what bash's stdout for `echo hi > f` is. The invariant holds there by
 construction, not by accident.
 
@@ -521,9 +590,10 @@ function would ask.
 
 The clearest case is a write. When the `write` function raises
 `std::write`, its payload includes `content`, so a policy can inspect the
-bytes. The `write` fast path preserves that, because we run the command
-first and hand over real bytes. But a `std::write` raised for a redirect
-that goes to bash cannot: the content does not exist yet.
+bytes. The shell-free write path preserves that, because it computes the
+content before raising anything. But a `std::write` raised for a redirect
+that goes to bash cannot: bash has not run, so the content does not exist
+yet.
 
 > A relabeled effect is approval of the **question**, not of the bytes. It
 > says what kind of thing is about to happen and to what target, not what
@@ -540,11 +610,20 @@ blast radius is whatever the string does.
 
 Three things narrow this: the rebuilt-string rule means parser bugs
 degrade safely, the plain-command-word rule stops a variable smuggling in
-a different command, and the single-`echo` fast path keeps the structural
+a different command, and the shell-free `echo` path keeps the structural
 bound exactly where it was free.
 
 The second weakness is the refuse wall, which stops the common spelling of
 a destructive command and not the idea of one.
+
+The third is small but real, and it is the one case where v3 asks a
+*broader* question than v2 did. In v2, `echo a; echo b` was two `print`
+calls and cost nothing. In v3 the shell-free path only covers a single
+command, so a sequence of echoes goes to bash, and the audit rule means it
+raises `std::bash`. Two harmless echoes now need an approval that used to
+be free. That is the right trade — the alternative is a shell spawn with
+no effect raised — but it is a regression and belongs on this list rather
+than being discovered.
 
 The judgment is that both are worth it. v2's structural bound only applied
 to the handful of commands it could faithfully reimplement, and the
@@ -583,7 +662,7 @@ foundation for it.
 - **Does `write` need `allowedPaths`?** It takes `dir` but, unlike
   `mkdir`, `copy` and `applyPatch`, has no path allowlist, so binding
   `dir` sets a base without checking whether `filename` climbs out with
-  `../`. If that is right, the `write` fast path enforces less than it
+  `../`. If that is right, the shell-free write path enforces less than it
   appears to.
 - **A developer-supplied function table** — letting someone route a
   command to *their* bound tool — is deferred. It overlaps an existing

--- a/packages/agency-lang/docs/superpowers/specs/2026-07-26-safebash-classifier-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-07-26-safebash-classifier-design.md
@@ -228,8 +228,20 @@ v2's `echo` never spawned a shell and v3's does, so a silent `echo` would
 be the one path where an agent reaches a shell with no effect raised. That
 breaks an invariant worth keeping: *every shell spawn was preceded by a
 raised effect*, which is what makes a statelog of effects a complete audit
-of shell invocations. `std::echo` ships blanket-approved in the default
-policy, so it costs a user nothing.
+of shell invocations.
+
+**How `std::echo` costs an unattended run nothing.** There is no default
+policy file — `lib/runtime/builtinPolicies.ts` defines named policies
+(`recommended`, `minimal`, `with-writes`, `approve-all`) but none applies
+unless `--policy` is passed. So "ships approved by default" has to be a
+mechanism, not a file. The mechanism already exists: **an inner
+`with approve` is non-authoritative.** Every handler up the chain runs,
+and any rejection wins, so safeBash raising `std::echo` under
+`with approve` means approved-unless-someone-says-otherwise — an
+unattended run is never prompted, and a policy or handler that wants to
+see echoes still overrides it. `std::echo` should also be added to the
+`recommended` built-in policy, so the effect is discoverable to anyone
+reading what that policy allows.
 
 ## How an effect actually gets raised
 
@@ -285,17 +297,32 @@ type Action = {
   effects: Effect[]      // what this command asks permission for
   outcome: Outcome
 }
+```
 
-type Effect = {
-  name: string           // "std::git::diff"
-  payload: any           // the typed payload that effect's contract requires
-}
+`Effect` and `Outcome` are **discriminated unions, not bags of `any`**.
+The effect set is a closed enum — that is forced by the raise mechanism
+above — so the payloads can be typed, and typing them is what makes the
+raise-site `match` arms check that each payload satisfies its effect's
+contract:
+
+```ts
+type Effect =
+  | { name: "std::echo" }
+  | { name: "std::bash",        payload: { command: string, cwd: string } }
+  | { name: "std::write",       payload: { dir: string, filename: string, content?: string } }
+  | { name: "std::git::status", payload: { cwd: string } }
+  | { name: "std::git::log",    payload: { cwd: string, ref: string, path: string } }
+  | { name: "std::git::diff",   payload: { cwd, ref, ref2, staged, path } }
 
 type Outcome =
-  | { kind: "run" }                                   // bash executes it
-  | { kind: "substitute", tool: string, args: any }   // a tool executes it
+  | { kind: "run" }
+  | { kind: "substitute", tool: "write", args: WriteArgs }
   | { kind: "refuse", reason: string }
 ```
+
+Naming the tool and its arguments in `substitute` is also what keeps the
+testing seam's "look at what comes out" property — an action that said
+only "substitute" would hide the interesting half.
 
 The interrupts alone would not be enough for testing, which answers the
 question directly: an interrupt is raised at run time and is not an
@@ -348,6 +375,90 @@ stating. The handling is to fall back: a sequence that needs shell state
 to persist goes to bash as one string under one `std::bash` approval. Less
 precise gating, correct behavior.
 
+## The return contract
+
+One of the two bugs motivating v3 was that the return *shape* depended on
+which path ran. "Every path returns bash's output" fixes the
+inconsistency, but it does not by itself say what the shape is, and the
+v2 code shows how much is packed into that: `bashAction` returns a JSON
+envelope of `{ command, stdout, stderr, exitCode }` with both streams
+truncated to `MAX_STDOUT_LEN`, while the echo path returned raw text.
+
+The v3 contract:
+
+**On success, the value is bash's stdout, raw.** Nothing added, nothing
+stripped, concatenated across commands in a sequence. That is the whole
+point of the redesign, and it is what makes safeBash's output
+indistinguishable from bash's.
+
+**stderr is discarded on success and reported on failure.** Two captured
+pipes cannot faithfully interleave the way a terminal does, so this is a
+policy either way and the choice should be deliberate. Discarding it on
+success keeps the success value exactly equal to bash's stdout, which is
+the property we are buying; including it on failure is what a model needs
+to debug the command it just ran.
+
+**A non-zero exit is a failure**, carrying the command, the exit code and
+stderr. This is required rather than aesthetic: `&&` and `||` are defined
+in terms of it.
+
+The known cost: **exit status is not the same as "went wrong"** for every
+command. `grep` exits 1 when it finds nothing and `diff` exits 1 when
+files differ, and neither is an error. Both fall back to `std::bash`
+today, so both get the blanket rule, and an agent will see a failure where
+bash would have shown it an empty result. Fixing that means per-command
+exit-code semantics, which is a table this change deliberately does not
+grow.
+
+**Output is capped.** Raw concatenated streams with no bound is a
+context-window hazard that the v2 envelope quietly protected against.
+The cap stays, and truncation is marked in the returned text rather than
+silent — a visible loss of fidelity is a much better failure than an
+invisible one.
+
+**The substituted redirect returns the empty string on success**, which
+is what bash's stdout for `echo hi > f` is. The indistinguishability
+invariant holds there, but by construction rather than by accident, so it
+is worth stating.
+
+## Expansion: bash does it now
+
+v2 expanded variables itself. `expandVariable` read the environment,
+refused an unquoted value containing whitespace because bash would
+word-split it, and `stringifyArg` refused an unquoted expansion that came
+out empty because bash would pass no argument at all. Those rules existed
+because v2 had to reconstruct argv, and each of them was a place where
+safeBash and bash could disagree — one of them shipped as a bug.
+
+**Under v3's relabel path all of that goes away.** The re-rendered command
+contains `$FOO`, and the bash child expands it: real word-splitting, real
+empty-drop, real `IFS`. Fidelity is perfect because the shell is doing its
+own job. A whole class of refusal rules, and the divergence bugs that came
+with them, is deleted rather than fixed.
+
+What it costs is a decision the spec has to record, because it is a safety
+boundary one position to the right of the literal-command-word rule:
+
+> **Classification matches on literal and flag words only.** If any word
+> in a *matched* position is an expansion, the command falls back to
+> `std::bash`.
+
+`git status $X` must not classify as `std::git::status` on the strength of
+us expanding `$X` — for the same reason `$CMD status` must not classify as
+git. An expansion in an *unmatched* argument position is fine to pass
+through untouched, because the effect does not depend on it: `echo $HOME`
+is still `std::echo`, since the approval is of the question, not the
+bytes.
+
+**One edge needs its own rule.** A redirect whose target contains an
+expansion — `echo hi > $F` — cannot be substituted, because `write` needs
+a known filename at approval time and `std::write`'s payload requires
+`filename`. Fall back to `std::bash` and let bash do the redirect.
+
+The one place expansion still gets resolved by us is a redirect target
+that is *not* an expansion, because the filename has to go into the
+`std::write` payload and the `write` call.
+
 ## Working directory
 
 `cwd` reaches everything, resolved once:
@@ -385,6 +496,13 @@ earns a property test: for every command in the corpus, re-parsing the
 rendered string must produce the same tree, and the corpus must include
 every command family in the classification table.
 
+**The substitution path renders a second form**, and it needs the same
+coverage. For `echo hi > f`, bash is handed the command *with the redirect
+stripped* — which is not a new rendering mode in `astToBash`, but a render
+of a modified tree: the same `SimpleCommand` with an empty `redirects`
+list. That rendered string is one of the ones bash actually receives, so
+the round-trip corpus has to include redirect-stripped forms too.
+
 Checked before adopting this design, `astToBash` preserves quoting on
 every hostile input tried:
 
@@ -417,10 +535,18 @@ interrupt gets raised. So v3 **adds** the check, and the test plan pins
 it, because a rule the spec believes already exists is a rule nobody
 implements.
 
-(The one place a path word is still inspected is the refuse wall, which
-checks a path's basename so `/bin/rm` is refused. That is a deliberate
-exception in the safe direction: it can only cause a refusal, never a
-narrower effect.)
+**The wall and the classifier match differently, on purpose.** The refuse
+wall looks at path words (it checks a basename, so `/bin/rm` is refused)
+and at flag and path arguments (`git reset --hard`, `git checkout -- .`).
+Classification refuses to look at anything that is not a literal or a
+flag. The asymmetry is sound because the two matchers can only fail in
+opposite directions: a wall match can only ever cause a *refusal*, so
+looking at more is free, while a classification match causes a *narrower
+effect*, so looking at anything the shell could reinterpret is dangerous.
+
+This is worth stating because the natural implementation instinct is to
+share one matcher between them, and sharing it would either blind the wall
+or widen the classifier.
 
 ## What approval means here
 

--- a/packages/agency-lang/docs/superpowers/specs/2026-07-26-safebash-classifier-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-07-26-safebash-classifier-design.md
@@ -1,21 +1,20 @@
-# safeBash v3: classify the command, don't reimplement it
+# safeBash v3: ask a better question, then let bash do the work
 
 ## Status
 
-Design, not yet built. Revised 2026-07-27 after
-[review](./2026-07-26-safebash-classifier-design-REVIEW.md).
+Design, not yet built. Rewritten 2026-07-27 around whole-string execution,
+after two rounds of
+[review](./2026-07-26-safebash-classifier-design-REVIEW.md) and a design
+discussion that changed the execution model.
 
 Replaces the mapping design in
 [the v2 spec](./2026-07-26-safebash-design.md), which shipped and is on
-`main`. That spec stays as the record of how we got here.
+`main`.
 
-Scope for this change is deliberately narrow: **no new commands**. The
-classification table covers exactly what v2 covers — `echo` and four git
-reads — and everything else keeps falling back. This is a change to *how*
-safeBash decides and executes, not to *what* it recognizes.
-
-The integration test plan targets this design and is written separately,
-after this settles.
+Scope is deliberately narrow: **no new commands.** The classification
+table covers exactly what v2 covers, and everything else keeps falling
+back. This changes *how* safeBash decides and runs, not *what* it
+recognizes.
 
 ## Background: what this module is for
 
@@ -23,51 +22,42 @@ An agent gets file, git, search and http tools, and a prompt telling it to
 prefer them over the shell. It reaches for the shell anyway.
 
 That costs autonomy, not safety. The read-only tools are pre-approved and
-run without asking. `bash()` cannot be, because there is no way to say in
-advance what an arbitrary command string will do, so it raises an
-interrupt on every call. A run that could have gone unattended turns into
-a human approving a stream of `ls`, `cat` and `git status` by hand.
+run without asking. `bash()` cannot be, because a command is a string and
+a string could do anything, so it raises an interrupt every time. A run
+that could have gone unattended becomes one you have to sit through,
+approving `ls`, `cat` and `git status` by hand.
 
-`safeBash` exists to close that gap: look at the command the agent
-actually wrote, and if we can tell what it does, ask a narrower question
-than "may I run a shell command?"
+`safeBash` exists to close that gap: read the command the agent wrote,
+and if we can tell what it is, **ask a more specific question** than "may
+I run a shell command?" A specific question is one a policy can answer in
+advance. The generic one never is.
 
-## How v2 tried to do it, and what went wrong
+## How v2 tried to do it, and why it broke
 
 v2 parsed the command and, when it recognized one, **called an equivalent
-Agency tool instead of the shell**. `echo hi` became `print("hi\n")`.
-`git status` became `gitStatus()`. Anything unrecognized fell back to
-`bash()`.
+Agency function instead of the shell.** `echo hi` became `print("hi\n")`.
+`git status` became `gitStatus()`.
 
-The appeal was that the tool's own interrupt policy applied. `print`
-raises nothing, so `echo` became free. `write` raises `std::write`, so a
-redirect asked a narrower question than `std::bash`.
+The appeal was that the function's own interrupt policy applied. The
+problem is that a substituted function has to produce the same output as
+the command it replaced, and past `echo` that is very hard.
 
-The problem is that a substituted tool has to produce the same output as
-the command it replaced, and for anything more complicated than `echo`
-that turns out to be very hard.
-
-`std::git` was where this became clear. It does not run the command a user
-types. It runs machine-readable variants and deletes environment
+`std::git` is where it became obvious. It does not run the command a user
+types. It runs machine-readable variants, and deletes environment
 variables before spawning:
 
-| tool | actual argv |
+| function | actual argv |
 |---|---|
 | `gitStatus` | `git status --porcelain=v2 --branch -z` |
 | `gitLog` | `git log --format=%H␟%an␟%ae␟%aI␟%s␟%b␞ --end-of-options` |
 | `gitDiff` | `git diff --patch -M --end-of-options` |
 
-All of that is deliberate and good: machine formats parse reliably, and
-scrubbing the environment stops it influencing what git does. But it means
-there is no raw text lying around that matches what `git status` prints.
-
-To match `bash -c 'git status'` byte for byte you would have to reproduce
-everything that shapes git's human output: the same arguments, the user's
-locale (git translates status output), the user's `~/.gitconfig` (advice
-hints and untracked-file handling are configurable), and the user's git
-version (hint wording changes between releases). Which is to say: the only
-way to produce exactly what bash produces is to run exactly what bash
-runs, in the environment bash runs it in.
+All of that is deliberate and good — machine formats parse reliably, and
+scrubbing the environment stops it influencing git. But it means there is
+no text lying around that matches what `git status` prints. Matching bash
+byte for byte would mean matching the user's locale (git translates status
+output), their `~/.gitconfig` (advice hints are configurable), and their
+git version (hint wording changes between releases).
 
 Measured, v2 does not match:
 
@@ -76,432 +66,234 @@ safeBash("echo hi && echo bye")  →  "hi\n\nbye\n"
 bash     "echo hi && echo bye"   →  "hi\nbye\n"
 ```
 
-and the shape of the return value depends on which path ran — raw text for
-`echo`, one JSON object for git, a different JSON envelope for the bash
-fallback — so an agent can tell which decision safeBash made by looking at
-what it got back. The v2 spec had explicitly decided it should not be able
+and the *shape* of the return value depended on which path ran — raw text
+for `echo`, one JSON object for git, a different envelope for the bash
+fallback — so an agent could tell which decision safeBash had made by
+looking at what came back. The v2 spec had decided it should not be able
 to.
 
 ## The idea
 
-Stop reproducing the command. Identify it, raise the interrupt that
-describes it, and then run it through bash.
+Stop reproducing commands. Identify them, raise the interrupts that
+describe them, and hand the whole thing to bash.
 
 ```
-parse → classify each command → raise its effects → run it → return bash's output
+parse → classify every command → raise the effects → run the whole string in bash
 ```
 
-The insight is that **substituting a tool was never what made this safe**.
-`gitStatus` spawns `git` either way. What made it safe was the narrower
-interrupt — `std::git::status` instead of `std::bash`, so a policy can say
-"git reads are fine, arbitrary shell is not". That benefit survives
+The insight is that **substituting a function was never what made this
+safe.** `gitStatus` spawns `git` either way. What made it safe was the
+narrower question — `std::git::status` instead of `std::bash`, so a policy
+can say "git reads are fine, arbitrary shell is not." That survives
 without the substitution, and output fidelity comes free, because the
 thing producing the output *is* bash.
 
-## Three outcomes
+## Execution: one bash call for the whole string
 
-Classification produces one of three results.
+This is the centre of the design, and everything else follows from it.
+
+```
+1. Parse the string into commands.
+2. Classify every command.
+3. If any command is refused        → refuse the whole string. Nothing runs.
+4. If any command needs std::bash   → raise ONE std::bash for the whole string.
+5. Otherwise                        → raise every narrow effect, up front.
+6. If everything was approved       → run the WHOLE string in one bash call.
+```
+
+Nothing executes until everything is approved.
+
+### Why up front rather than command by command
+
+The alternative is to approve and run each command in turn. It sounds more
+precise and it is worse in three ways.
+
+**It creates a half-executed state.** Approve the first command, reject
+the second, and the first has already happened. There is no way to undo
+it, and the model has to be told a complicated story about what did and
+did not run.
+
+**It asks silly questions.** `cd foo && git status` splits into an
+unrecognized `cd` and a recognized `git status`. Command by command, a
+human gets asked to approve a bare `cd`, which tells them nothing about
+what is actually going on.
+
+**It breaks the shell.** Each command in its own process means `cd` does
+not persist, and neither do variable assignments. `cd foo && git status`
+would run `git status` in the wrong directory.
+
+Up front avoids all three. The cost is that we ask about effects that may
+never happen — `false && git status` still raises `std::git::status` — and
+that is a much smaller problem than a half-run sequence.
+
+### Why one bash call
+
+Because once everything is approved, splitting execution buys nothing and
+costs a lot.
+
+**Bash does the control flow.** We do not implement `&&`, `||` or `;`.
+That is not a simplification for its own sake: our implementations of them
+were where the divergences lived.
+
+**There is nothing to join.** One process produces one stream, so the
+extra-newline bug from v2 has nowhere to live. It is deleted rather than
+fixed.
+
+**Shell state works.** `cd foo && git status` behaves the way it does in a
+terminal, because it *is* one shell.
+
+**Fidelity is exact by construction.** The output is bash's, because bash
+produced it in one go.
+
+### If any part needs plain bash approval, the whole string does
+
+`git status; curl evil.com` classifies as one recognized command and one
+unrecognized one. Rather than raising `std::git::status` and then
+`std::bash`, it raises **one** `std::bash` for the whole string.
+
+The reasoning: we have to ask the broad question anyway, so asking the
+narrow one first adds a prompt without adding information. And a human
+approving `std::bash` should see the entire command, not a fragment of it.
+
+## The single-command fast paths
+
+Two cases skip bash entirely, and both apply **only when the whole input
+is one command.** Once there is a sequence, the whole thing goes to bash.
+
+**A bare `echo`** goes to `print`:
+
+```
+safeBash("echo hello")     → print("hello\n")   no shell, no interrupt
+safeBash("echo -n hi")     → flags change what echo prints → bash
+safeBash("echo hi; ls")    → a sequence → bash
+```
+
+This is the one place v2's structural safety was free, and it is worth
+keeping: `print` cannot write a file or reach the network no matter how
+wrong the classifier is. The output is provably identical — `echo a b`
+prints its arguments joined by single spaces plus a newline, which is
+exactly what the existing code produces.
+
+**A single redirected `echo`** goes to `write`:
+
+```
+safeBash("echo hi > out.txt")
+```
+
+We run `echo hi` through bash with the redirect stripped, capture what it
+printed, and hand those bytes to `write`. Bash makes the text so fidelity
+holds; `write` does the writing so it can enforce which directory you
+allowed, and the `std::write` interrupt carries `content`, so a policy
+that inspects what is being written still can.
+
+This is only sound because `echo` has no effects of its own — the command
+runs before the write is approved, so a rejected write must not leave
+anything behind. Any other command with a redirect goes to bash.
+
+Two exclusions: a redirect whose **target contains a variable**
+(`echo hi > $F`) cannot substitute, because `write` needs a known filename
+at approval time. And any `echo` with flags goes to bash.
+
+## Three outcomes
 
 ### Refuse
 
-Some commands we decline to run at all, even if a human approves: `rm`,
-`rmdir`, `dd`, `shred`, `mkfs`, `truncate`, and the destructive git
-subcommands (`git clean`, `git reset --hard`, `git checkout -- .`,
-`git restore`).
+Some commands we decline to run at all, even with approval: `rm`, `rmdir`,
+`dd`, `shred`, `mkfs`, `truncate`, and the destructive git subcommands
+(`git clean`, `git reset --hard`, `git checkout -- .`, `git restore`).
+
+A refusal anywhere in the string refuses the **whole string**.
 
 The reason for a wall rather than a prompt: an approval is a judgment made
-in a hurry, often by an automated policy rather than a person, and the
-cost of getting it wrong for this set is unrecoverable. A refusal is
-recoverable — the human can run the command themselves.
+quickly, often by an automated policy rather than a person, and for this
+set the cost of getting it wrong cannot be undone. A refusal can be — the
+human can run the command themselves.
 
-**What the wall actually reaches.** It matches the command word, so it
-catches the common spelling and a path whose basename matches
-(`/bin/rm`, `./rm` — v3 checks the basename of a path word for exactly
-this reason). It does **not** catch `find . -delete`, `xargs rm`,
-`python -c "os.unlink(...)"`, or `env rm`. Those classify as unrecognized,
-raise `std::bash`, and are approvable like any other shell command.
+**What the wall actually reaches.** It matches the command word, including
+the last part of a path, so `rm`, `/bin/rm` and `./rm` are all refused. It
+does **not** catch `find . -delete`, `xargs rm`, `python -c "os.unlink(…)"`
+or `env rm`. Those classify as unrecognized, raise `std::bash`, and are
+approvable like any other shell command.
 
 So the wall is friction against the obvious spelling, not a guarantee. The
-guarantee for everything else is that it asks for `std::bash` approval
-first. This is worth stating plainly because the rationale above — "the
-cost of getting it wrong is unrecoverable" — would otherwise read as a
-promise the mechanism does not make.
+guarantee for everything else is that it asks first. This is worth saying
+plainly, because the rationale above would otherwise read as a promise the
+mechanism does not make.
 
-### Substitute a tool
+### Ask, then delegate to bash
 
-For a small set of commands, call an Agency tool instead of letting bash
-do the work. The rule:
+Everything recognized that is not refused and not a fast path.
 
-> **Substitute a tool when the tool can enforce a constraint the shell
-> cannot. Relabel the effect when the tool is only another way to run the
-> same program.**
-
-Substitution buys enforcement and costs fidelity — a tool's output is its
-own, not the command's — so the rule is about whether the enforcement
-earns that.
-
-Which stdlib tools can enforce something, checked against their
-signatures:
-
-| tool | constraint parameter |
+| command | effect raised |
 |---|---|
-| `fetch` | `allowedDomains` |
-| `mkdir`, `copy`, `applyPatch` | `allowedPaths` |
-| `ls`, `grep` | `allowedPaths` |
-| `write`, `read` | `dir` only — no `allowedPaths` |
-| `gitStatus`, `gitLog`, `gitDiff`, `gitShow` | none |
-
-Git reads clearly do not qualify: `gitStatus` shells out to git and
-enforces nothing a shell would not, so substituting buys no constraint and
-costs exact output.
-
-**In this change, the table has one member: output redirection.**
-
-Every other command where substitution would help — `curl` to `fetch`,
-`mkdir -p` to `mkdir`, `cp` to `copy`, `patch` to `applyPatch` — is a
-command safeBash does not recognize today, and adding them is out of
-scope. The mechanism is specified here so that adding one later is a table
-entry rather than a shape change.
-
-**How a redirect substitutes without reimplementing anything.** For
-`echo hi > f`, producing the content ourselves would be reimplementing
-`echo`, which is the v2 trap. Instead, invert it:
-
-1. Run the left-hand command through bash with the redirect stripped, and
-   capture stdout. Bash produces the bytes, so fidelity holds.
-2. Hand those bytes to `write`, which performs the write.
-
-This keeps what v2's redirect handling was actually good at: `write`
-enforces its `dir`, and the `std::write` interrupt carries **`content`**,
-so a policy that inspects what is being written still can.
-
-The ordering constraint: the command runs before the write is approved, so
-a rejected write means the left-hand command already ran. That is only
-acceptable when the left-hand command has no effects of its own. Today
-that means **`echo` and nothing else** — any other command with a redirect
-relabels and lets bash do the whole thing. A future command added to the
-"effect-free" set must be justified on that basis specifically.
-
-**Deferred: a developer-supplied substitution table.** The natural
-extension is handing `safeBash` a map of bound tools, so a developer who
-built `fetch.partial(allowedDomains: [...])` routes `curl` to *their*
-constrained tool. Two reasons it is not in this change: there are no
-commands to route yet, and the shape overlaps an existing design thread
-for tool rebinding (`provide { tool: impl }`). Before building it, check
-whether it should be that mechanism rather than a second one, since two
-ways to swap an implementation under a name will eventually disagree about
-scoping and precedence.
-
-**One policy for whenever substitution grows:** when a tool cannot express
-something the command asked for — a curl flag with no `fetch` parameter —
-the command **falls back to relabel-and-run under `std::bash`**. It never
-drops the flag and calls the tool anyway. That is v2's `git log --graph`
-mistake, and it is the one failure mode this module must not have.
-
-### Relabel and run
-
-Everything else we recognize. Raise the effects that describe the command,
-then hand the re-rendered command to bash.
-
-| command shape | effects raised |
-|---|---|
-| `echo …` | `std::echo` |
-| `echo … > f`, `>> f` | `std::echo`, then `std::write` (substituted — see above) |
 | `git status` | `std::git::status` |
 | `git diff` | `std::git::diff` |
-| `git diff --staged` | `std::git::diff` (with `staged: true` in the payload) |
+| `git diff --staged` | `std::git::diff` (with `staged: true`) |
 | `git log` | `std::git::log` |
-| anything else, recognized or not | `std::bash` |
+| `echo …` in a sequence | *(contributes nothing on its own)* |
+| anything else | `std::bash` |
 
-Effects **compose**: a command can raise more than one, and each is a
-separate question. v2 could not express that, so a redirected git read
-fell back to a single `std::bash`.
+Effects **compose**: a string raises the union of what its commands
+contribute, and each is a separate question. `git status > out.txt` asks
+about the git read and the write separately, which v2 could not express at
+all.
 
 The default is always `std::bash`. Classification is an allowlist — a
-command earns a narrower effect by matching a rule, and everything else
-gets the widest one. No shape gets a narrower effect by failing to match
-something.
+command earns a narrower question by matching a rule, and everything else
+gets the broad one.
 
-**`std::echo` is new, and it is why every shell spawn is auditable.** It
-would be tempting to let `echo` raise nothing, since it is harmless. But
-v2's `echo` never spawned a shell and v3's does, so a silent `echo` would
-be the one path where an agent reaches a shell with no effect raised. That
-breaks an invariant worth keeping: *every shell spawn was preceded by a
-raised effect*, which is what makes a statelog of effects a complete audit
-of shell invocations.
+### The rule that closes the audit hole
 
-**How `std::echo` costs an unattended run nothing.** There is no default
-policy file — `lib/runtime/builtinPolicies.ts` defines named policies
-(`recommended`, `minimal`, `with-writes`, `approve-all`) but none applies
-unless `--policy` is passed. So "ships approved by default" has to be a
-mechanism, not a file. The mechanism already exists: **an inner
-`with approve` is non-authoritative.** Every handler up the chain runs,
-and any rejection wins, so safeBash raising `std::echo` under
-`with approve` means approved-unless-someone-says-otherwise — an
-unattended run is never prompted, and a policy or handler that wants to
-see echoes still overrides it. `std::echo` should also be added to the
-`recommended` built-in policy, so the effect is discoverable to anyone
-reading what that policy allows.
+`echo` contributes no effect. So a string of nothing but echoes —
+`echo hi; echo bye` — would classify as fully recognized, raise nothing,
+and spawn a shell unwatched. That is the one hole worth closing:
 
-## How an effect actually gets raised
-
-This is the part that constrains the implementation, and v3 has to be
-built around it rather than discovering it.
-
-**An effect is raised at a named raise site**, not by name-as-data:
-`interrupt std::read("...", { dir, filename })`. There is no "raise this
-string" primitive, and if there were, safeBash's effects would be
-invisible to `getEffects` and to the effect-propagation walk, which read
-raise sites out of the source.
-
-Two consequences:
-
-**The dispatch is closed.** The implementation is a `match` over the
-effect enum with one `interrupt std::x(...)` arm per effect, and
-`safeBash`'s signature grows a wide clause:
-
-```
-raises <std::bash, std::echo, std::write,
-        std::git::status, std::git::diff, std::git::log>
-```
-
-That clause is a feature — it is how an agent author discovers which
-handlers to write — but it also means **adding a row to the
-classification table changes safeBash's public effect signature.** Anyone
-adding a command has to expect that.
-
-**Effects carry typed payloads, so a plan cannot hold bare names.** The
-contracts are enforced at the raise site:
-
-```
-effect std::read           { dir, filename }
-effect std::write          { dir, filename }
-effect std::git::status    { cwd }
-effect std::git::log       { cwd, ref, path }
-effect std::git::diff      { cwd, ref, ref2, staged, path }
-```
-
-Classification is where `filename`, `cwd` and `staged` are known, so the
-plan carries them.
-
-## The plan type, and why Action stays
-
-v2's `Action` was a plain data object describing what would happen, with
-nothing having happened yet. That is what made the module testable — hand
-in a string, look at what comes out — and it stays for exactly that
-reason. What changes is what it describes.
-
-```ts
-type Action = {
-  command: string        // re-rendered from the AST, never the original text
-  effects: Effect[]      // what this command asks permission for
-  outcome: Outcome
-}
-```
-
-`Effect` and `Outcome` are **discriminated unions, not bags of `any`**.
-The effect set is a closed enum — that is forced by the raise mechanism
-above — so the payloads can be typed, and typing them is what makes the
-raise-site `match` arms check that each payload satisfies its effect's
-contract:
-
-```ts
-type Effect =
-  | { name: "std::echo" }
-  | { name: "std::bash",        payload: { command: string, cwd: string } }
-  | { name: "std::write",       payload: { dir: string, filename: string, content?: string } }
-  | { name: "std::git::status", payload: { cwd: string } }
-  | { name: "std::git::log",    payload: { cwd: string, ref: string, path: string } }
-  | { name: "std::git::diff",   payload: { cwd, ref, ref2, staged, path } }
-
-type Outcome =
-  | { kind: "run" }
-  | { kind: "substitute", tool: "write", args: WriteArgs }
-  | { kind: "refuse", reason: string }
-```
-
-Naming the tool and its arguments in `substitute` is also what keeps the
-testing seam's "look at what comes out" property — an action that said
-only "substitute" would hide the interesting half.
-
-The interrupts alone would not be enough for testing, which answers the
-question directly: an interrupt is raised at run time and is not an
-inspectable artifact, whereas `actionsFor(source) → Action[]` is pure and
-returns data. The action is strictly richer than v2's, because it now
-carries the effects and their payloads — so the testing seam gets better,
-not worse.
-
-`stdlib/safeBash/actions.agency` keeps its executors. The set shrinks:
-`bashAction` for the `run` outcome and `writeAction` for the one
-substitution, with `printAction` and the git executors deleted because
-those commands now relabel.
-
-## Execution model
-
-**Per command.** The parser produces a list of commands; each one is
-classified, gated and run separately, in its own bash process. That keeps
-each approval about the command it belongs to, and it keeps the
-partial-failure report: when a sequence stops, the model is told which
-command failed, what already ran and what it produced, and what never ran.
-
-**Effects are raised lazily**, immediately before their command runs — not
-up front for the whole sequence. For `a && b`, `b`'s interrupt is raised
-only if `a` succeeded. Up-front approval would ask a human about effects
-that may never happen, and would have to be revoked when the chain
-short-circuits.
-
-**Output is concatenated, and this is a joining policy we own.** The
-review caught a contradiction in an earlier draft, which claimed the v2
-extra-newline bug "disappears because bash produces one stream". It does
-not: with per-command processes, bash produces one stream per command and
-the module joins them. So the policy has to be stated rather than assumed:
-
-> Concatenate the raw streams. Add nothing, strip nothing. Bash's output
-> already carries its own trailing newline.
-
-That is what fixes the v2 bug — `joinOutput` inserted a separator between
-strings that already ended in one. It is a fix, not an absence.
-
-**Shell state does not carry between commands**, because each runs in its
-own process:
-
-- `cd sub && ls` will not see the directory change
-- `FOO=1; echo $FOO` will not see the assignment
-
-Neither works today either — `cd` is outside the parser's supported
-subset, and a leading assignment already falls back. But v3 makes bash the
-executor for everything, so the limitation is more visible and needs
-stating. The handling is to fall back: a sequence that needs shell state
-to persist goes to bash as one string under one `std::bash` approval. Less
-precise gating, correct behavior.
-
-## The return contract
-
-One of the two bugs motivating v3 was that the return *shape* depended on
-which path ran. "Every path returns bash's output" fixes the
-inconsistency, but it does not by itself say what the shape is, and the
-v2 code shows how much is packed into that: `bashAction` returns a JSON
-envelope of `{ command, stdout, stderr, exitCode }` with both streams
-truncated to `MAX_STDOUT_LEN`, while the echo path returned raw text.
-
-The v3 contract:
-
-**On success, the value is bash's stdout, raw.** Nothing added, nothing
-stripped, concatenated across commands in a sequence. That is the whole
-point of the redesign, and it is what makes safeBash's output
-indistinguishable from bash's.
-
-**stderr is discarded on success and reported on failure.** Two captured
-pipes cannot faithfully interleave the way a terminal does, so this is a
-policy either way and the choice should be deliberate. Discarding it on
-success keeps the success value exactly equal to bash's stdout, which is
-the property we are buying; including it on failure is what a model needs
-to debug the command it just ran.
-
-**A non-zero exit is a failure**, carrying the command, the exit code and
-stderr. This is required rather than aesthetic: `&&` and `||` are defined
-in terms of it.
-
-The known cost: **exit status is not the same as "went wrong"** for every
-command. `grep` exits 1 when it finds nothing and `diff` exits 1 when
-files differ, and neither is an error. Both fall back to `std::bash`
-today, so both get the blanket rule, and an agent will see a failure where
-bash would have shown it an empty result. Fixing that means per-command
-exit-code semantics, which is a table this change deliberately does not
-grow.
-
-**Output is capped.** Raw concatenated streams with no bound is a
-context-window hazard that the v2 envelope quietly protected against.
-The cap stays, and truncation is marked in the returned text rather than
-silent — a visible loss of fidelity is a much better failure than an
-invisible one.
-
-**The substituted redirect returns the empty string on success**, which
-is what bash's stdout for `echo hi > f` is. The indistinguishability
-invariant holds there, but by construction rather than by accident, so it
-is worth stating.
-
-## Expansion: bash does it now
-
-v2 expanded variables itself. `expandVariable` read the environment,
-refused an unquoted value containing whitespace because bash would
-word-split it, and `stringifyArg` refused an unquoted expansion that came
-out empty because bash would pass no argument at all. Those rules existed
-because v2 had to reconstruct argv, and each of them was a place where
-safeBash and bash could disagree — one of them shipped as a bug.
-
-**Under v3's relabel path all of that goes away.** The re-rendered command
-contains `$FOO`, and the bash child expands it: real word-splitting, real
-empty-drop, real `IFS`. Fidelity is perfect because the shell is doing its
-own job. A whole class of refusal rules, and the divergence bugs that came
-with them, is deleted rather than fixed.
-
-What it costs is a decision the spec has to record, because it is a safety
-boundary one position to the right of the literal-command-word rule:
-
-> **Classification matches on literal and flag words only.** If any word
-> in a *matched* position is an expansion, the command falls back to
+> **Spawning a shell always raises at least one effect.** If
+> classification produced none and we are going to bash, raise
 > `std::bash`.
 
-`git status $X` must not classify as `std::git::status` on the strength of
-us expanding `$X` — for the same reason `$CMD status` must not classify as
-git. An expansion in an *unmatched* argument position is fine to pass
-through untouched, because the effect does not depend on it: `echo $HOME`
-is still `std::echo`, since the approval is of the question, not the
-bytes.
+This keeps the invariant that *every shell spawn was preceded by a raised
+effect*, which is what makes a log of effects a complete audit of shell
+invocations.
 
-**One edge needs its own rule.** A redirect whose target contains an
-expansion — `echo hi > $F` — cannot be substituted, because `write` needs
-a known filename at approval time and `std::write`'s payload requires
-`filename`. Fall back to `std::bash` and let bash do the redirect.
+An earlier draft solved this with a new `std::echo` effect. That was the
+wrong shape: a new effect needs an entry in
+`lib/runtime/builtinPolicies.ts`, a decision about where it sits in
+`std::capabilities` (and there is no good home — `Shell` is documented as
+"the sharpest edge, grant with care", which `echo` is not), and every node
+declaring `raises <FileRead, Network>` would break the moment it echoed.
+A lot of blast radius for the most harmless command there is.
 
-The one place expansion still gets resolved by us is a redirect target
-that is *not* an expansion, because the filename has to go into the
-`std::write` payload and the `write` call.
+## Original text or rebuilt text?
 
-## Working directory
+The module parses the command, so it can hand bash either the agent's
+original string or one rendered back out of the parse tree. Which it uses
+depends on which question was asked:
 
-`cwd` reaches everything, resolved once:
+> **If we asked narrow questions, run the string rebuilt from the parse
+> tree.** We claimed the command is `git status`. We must run what we
+> classified, not text we only assumed matched it.
+>
+> **If we asked for plain bash approval, run the original.** That is the
+> text the human read and approved. Running something else — even a
+> harmlessly re-spaced version — means they approved one string and we ran
+> another.
 
-> The caller's `cwd` if non-empty, otherwise `getAgentCwd()`. Resolved at
-> the top of `safeBash` and stamped into every action.
+Unparseable input is already in the second case, since there is no tree to
+render.
 
-From there it flows to the bash invocation, to substituted tool calls, and
-into effect payloads that require it — `std::git::status { cwd }` and the
-other git effects all do.
-
-This gets its own section because it is precisely what silently regressed
-in the v2 pull request: `cwd` was honoured only when the command failed to
-parse, so the same call behaved differently depending on whether the
-string parsed. One resolution rule, applied once, prevents the repeat.
-
-## Two hard rules
-
-These carry the safety argument, and neither is negotiable.
-
-### Bash receives a string re-rendered from the validated AST
-
-Never the agent's original text. The module parses, classifies the tree,
-and renders that same tree back to shell source with `astToBash`.
-
-This means a **parser** bug degrades to "we ran what we thought we read"
-rather than to arbitrary execution. If the parser misreads
-`rm -rf / ; echo hi` as just `echo hi`, the renderer produces `echo hi`
-and that is what runs. What is left is **classification** bugs — the
-effect table being wrong about a command it read correctly — which is a
-far smaller and more reviewable surface.
+This is why the rebuilt string matters where it matters: a **parser** bug
+degrades to "we ran what we thought we read" rather than to arbitrary
+execution. If the parser misread `rm -rf / ; echo hi` as just `echo hi`,
+the renderer produces `echo hi` and that is what runs. What is left is
+**classification** bugs — the table being wrong about a command it read
+correctly — which is a much smaller and more reviewable surface.
 
 This makes `astToBash` security-critical, which it was not before. It
 earns a property test: for every command in the corpus, re-parsing the
-rendered string must produce the same tree, and the corpus must include
-every command family in the classification table.
-
-**The substitution path renders a second form**, and it needs the same
-coverage. For `echo hi > f`, bash is handed the command *with the redirect
-stripped* — which is not a new rendering mode in `astToBash`, but a render
-of a modified tree: the same `SimpleCommand` with an empty `redirects`
-list. That rendered string is one of the ones bash actually receives, so
-the round-trip corpus has to include redirect-stripped forms too.
+rendered string must produce the same tree, and the corpus must cover
+every command family in the table, plus the redirect-stripped form the
+`write` fast path renders (the same command with an empty redirect list).
 
 Checked before adopting this design, `astToBash` preserves quoting on
 every hostile input tried:
@@ -516,112 +308,288 @@ echo hi > "my file.txt"   →  echo hi > "my file.txt"
 so the obvious injection route — losing the quotes and turning one command
 into two — does not open. The property test is what keeps it closed.
 
-### The command word must be a literal — and v3 has to add this
+## The command word must be a plain word, and v3 has to add this
 
 `$CMD status` with `CMD=git` must never classify as a git read. The
-command name has to be a literal word in the source: not a variable
-expansion, not a path.
+command name has to be a literal word in the source: not a variable, not a
+path.
 
 **This check does not exist today.** An earlier draft of this spec claimed
-the current code enforces it; it does not. `tokenize` reads
-`command.command` and uses `name.text` with no tag check, and `ScriptName`
-is `LiteralWord | PathWord`, so a path word is accepted and classified by
-its text. Safety currently holds *incidentally* — a path word contains a
-`/`, so it cannot spell `git` — rather than because anything checks.
+it did. `tokenize` reads `command.command` and uses `name.text` with no
+tag check, and `ScriptName` is `LiteralWord | PathWord`, so a path word is
+accepted and classified by its text. Safety currently holds
+*incidentally* — a path contains a `/` so it cannot spell `git` — rather
+than because anything checks.
 
-That incidental safety is fine while classification only affects which
-tool gets called. It is not fine once classification decides which
-interrupt gets raised. So v3 **adds** the check, and the test plan pins
-it, because a rule the spec believes already exists is a rule nobody
-implements.
+That is fine while classification only picks a function to call. It stops
+being fine once classification picks which question a human gets asked.
+So v3 **adds** the check, and the test plan pins it, because a rule the
+spec believes already exists is a rule nobody implements.
+
+## Expansion: bash does it now
+
+v2 expanded variables itself. `expandVariable` read the environment and
+refused an unquoted value containing whitespace because bash would
+word-split it; `stringifyArg` refused an unquoted expansion that came out
+empty because bash would pass no argument at all. Those rules existed
+because v2 had to reconstruct arguments, and each was a place where
+safeBash and bash could disagree. One of them shipped as a bug.
+
+**All of it goes away.** The string handed to bash contains `$FOO`, and
+bash expands it: real word-splitting, real empty-drop, real `IFS`. A whole
+class of refusal rules, and the divergence bugs that came with them, is
+deleted rather than fixed.
+
+What it costs is one rule, and it is a safety boundary one position to the
+right of the plain-command-word rule:
+
+> **Classification looks only at literal and flag words.** If a word in a
+> position the table matches on is a variable, the command is not
+> recognized and the string falls to `std::bash`.
+
+`git status $X` must not become a git read on the strength of us expanding
+`$X`. A variable in a position the table does *not* match on is fine to
+pass through untouched — `echo $HOME` is still an echo, because the
+question we are asking does not depend on what it expands to.
+
+The only place we still resolve a variable ourselves is a redirect target
+on the `write` fast path, and a target that *is* a variable disqualifies
+the fast path (above).
 
 **The wall and the classifier match differently, on purpose.** The refuse
-wall looks at path words (it checks a basename, so `/bin/rm` is refused)
-and at flag and path arguments (`git reset --hard`, `git checkout -- .`).
-Classification refuses to look at anything that is not a literal or a
-flag. The asymmetry is sound because the two matchers can only fail in
-opposite directions: a wall match can only ever cause a *refusal*, so
-looking at more is free, while a classification match causes a *narrower
-effect*, so looking at anything the shell could reinterpret is dangerous.
+wall looks at path words and at flag and path arguments (`git reset
+--hard`). Classification refuses to look at anything but literals and
+flags. The asymmetry is sound because the two can only fail in opposite
+directions: a wall match causes a *refusal*, so looking at more is free,
+while a classification match causes a *narrower question*, so looking at
+anything the shell could reinterpret is dangerous. Worth stating, because
+the instinct is to share one matcher, and sharing it would either blind
+the wall or widen the classifier.
 
-This is worth stating because the natural implementation instinct is to
-share one matcher between them, and sharing it would either blind the wall
-or widen the classifier.
+## How an effect actually gets raised
+
+An effect is raised at a **named raise site**, not by name-as-data:
+`interrupt std::git::status("…", { cwd })`. There is no "raise this
+string" primitive, and if there were, safeBash's effects would be
+invisible to `getEffects` and to the effect-propagation walk, both of
+which read raise sites out of the source.
+
+Two consequences:
+
+**The dispatch is closed.** One `interrupt std::x(…)` arm per effect, and
+`safeBash` grows a wide clause:
+
+```
+raises <std::bash, std::write,
+        std::git::status, std::git::diff, std::git::log>
+```
+
+That clause is a feature — it is how an agent author discovers which
+handlers to write — but it also means **adding a row to the table changes
+safeBash's public effect signature.**
+
+**Effects carry typed payloads.** The contracts are enforced at the raise
+site:
+
+```
+effect std::write          { dir, filename }
+effect std::git::status    { cwd }
+effect std::git::log       { cwd, ref, path }
+effect std::git::diff      { cwd, ref, ref2, staged, path }
+```
+
+Classification is where `filename`, `cwd` and `staged` are known, so the
+plan carries them.
+
+**Every payload also carries the full original string.** A payload may
+have fields beyond its contract, and it should: a human approving
+`std::git::status` for one part of `echo hi; git status` needs to see the
+whole command, not the fragment. The prompt should read as "here is what
+is about to run, and here is the part I need you to approve."
+
+## The plan type, and why Action stays
+
+v2's `Action` was a plain data object describing what would happen with
+nothing having happened yet. That is what made the module testable — hand
+in a string, look at what comes out — and it stays for that reason.
+
+Interrupts alone would not be enough, which answers the question directly:
+an interrupt is raised at run time and is not an inspectable artifact,
+whereas `actionsFor(source)` is pure and returns data.
+
+```ts
+type Plan = {
+  commands: Action[]     // one per parsed command — classification stays per command
+  effects: Effect[]      // the union, which is what actually gets raised
+  execution: Execution   // what happens if it is all approved
+}
+
+type Action = {
+  command: string        // this command, rendered from the tree
+  effects: Effect[]
+  refused: boolean
+}
+
+type Execution =
+  | { kind: "bash",      command: string }   // rebuilt or original, per the rule above
+  | { kind: "print",     content: string }   // single bare echo
+  | { kind: "write",     args: WriteArgs }   // single redirected echo
+  | { kind: "refuse",    reason: string }
+```
+
+`Effect` is a discriminated union, not a bag of `any` — the effect set is
+closed, so the payloads can be typed, and typing them is what makes the
+raise-site arms check that each payload satisfies its contract.
+
+**Classification stays per command even though execution does not.** That
+is deliberate: it is what keeps the door open (see below), and it is what
+the tests assert against.
+
+`stdlib/safeBash/actions.agency` keeps `bashAction`, `printAction` and
+`writeAction`. The git executors go, because git commands now relabel.
+
+## What gets deleted
+
+The runner. `runCommands`, `runCommand`, `andCommand`, `orCommand`,
+`parensCommand`, `commandsToStr`, `failureReport`, `joinOutput` — all of
+it. Bash does control flow, so we do not.
+
+The expansion rules: `expandVariable`'s whitespace and empty-value
+refusals, and `stringifyArg`'s whole-word emptiness check. Bash expands
+now.
+
+The v2 output-joining bug, which had no separate fix because the code that
+caused it is gone.
+
+The partial-failure report, and with it the "what ran, what didn't"
+message. There is no half-executed state to report on any more.
+
+## The return contract
+
+One of the two motivating bugs was that the return shape depended on which
+path ran. With one bash call the shape is simple, but it still has to be
+stated:
+
+**On success, the value is bash's stdout, raw.** Nothing added, nothing
+stripped, nothing joined. This is the property the whole redesign buys.
+
+**stderr is discarded on success and reported on failure.** Two captured
+pipes cannot interleave the way a terminal does, so this is a policy
+either way. Discarding on success keeps the success value exactly equal to
+bash's stdout; including it on failure is what a model needs to debug what
+it just ran.
+
+**A non-zero exit is a failure**, carrying the command, the exit code and
+stderr.
+
+The known cost: **exit status is not the same as "went wrong"** for every
+command. `grep` exits 1 when it finds nothing, `diff` exits 1 when files
+differ, and neither is an error. Both fall back to `std::bash`, so both
+get the blanket rule, and an agent sees a failure where bash would have
+shown an empty result. Fixing that needs per-command exit semantics, which
+is a table this change deliberately does not grow.
+
+**Output is capped**, and truncation is marked in the returned text rather
+than silent. Raw output with no bound is a context-window hazard that v2's
+envelope quietly protected against; a visible loss of fidelity is a much
+better failure than an invisible one.
+
+**The `write` fast path returns the empty string on success**, which is
+what bash's stdout for `echo hi > f` is. The invariant holds there by
+construction, not by accident.
+
+**A rejected approval is not a failed command.** Nothing ran, and the
+message should say so rather than implying the command was attempted.
+
+## Working directory
+
+Resolved once:
+
+> The caller's `cwd` if non-empty, otherwise `getAgentCwd()`. Resolved at
+> the top of `safeBash` and used for the bash call, the fast-path function
+> calls, and every effect payload that requires it.
+
+This gets its own section because it is exactly what silently regressed in
+the v2 pull request: `cwd` was honoured only when the command failed to
+parse, so the same call behaved differently depending on whether the
+string parsed.
 
 ## What approval means here
 
-A relabeled effect asks a **narrower question**, but not always the *same*
-question the corresponding tool would ask.
+A narrower question is not always the *same* question the corresponding
+function would ask.
 
-The clearest case is a write. When the `write` tool raises `std::write`,
-its payload includes `content` — a policy can inspect the bytes. The
-declared contract only requires `{ dir, filename }`, so a relabeled raise
-without content is legal, but any policy reading content would silently
-see a thinner payload.
+The clearest case is a write. When the `write` function raises
+`std::write`, its payload includes `content`, so a policy can inspect the
+bytes. The `write` fast path preserves that, because we run the command
+first and hand over real bytes. But a `std::write` raised for a redirect
+that goes to bash cannot: the content does not exist yet.
 
-For redirects this is why the substitution above exists: running the
-command first and handing the bytes to `write` keeps `content` in the
-payload. For anything that relabels rather than substitutes, the general
-shape holds and should be stated to handler authors:
-
-> A relabeled effect is approval of the *question*, not of the bytes. It
+> A relabeled effect is approval of the **question**, not of the bytes. It
 > says what kind of thing is about to happen and to what target, not what
-> the result will contain — because bash has not run yet.
+> the result will contain, because bash has not run.
 
-## What is checked, and when
+## What is weaker than v2
 
-1. **Parse time.** The parser either reads a command correctly or rejects
-   it; it never silently mis-parses. Globs, tilde, command substitution,
-   pipelines, background commands and file-descriptor redirection are
-   rejected rather than represented, so they never reach classification.
-   This is a claim about tarsec, not about this module — the round-trip
-   property test is what keeps us honest about relying on it.
-2. **Classification time.** The command word is checked for being a
-   literal, the refuse list is checked first, effects and payloads are
-   computed. Nothing has run.
-3. **Approval time.** Each effect is raised, lazily, immediately before
-   its command runs. Handlers and policies decide.
-4. **Run time.** The re-rendered command goes to bash, or to a substituted
-   tool.
+v2's gate was **structural**. `echo hi` called `print`, and `print` cannot
+write a file or reach the network no matter how wrong the analysis was.
 
-## What is weaker than v2, honestly
-
-v2's gate was **structural**. `echo hi` called `print`, and `print` has no
-capability to write a file or reach the network. If the analysis was
-wrong, the blast radius was bounded by what `print` could do, which is
-nothing.
-
-v3's gate is **analytical**. We parse, conclude what the command is, and
+v3's gate is **analytical**. We read the command, decide what it is, and
 hand it to a shell that can do anything. If the analysis is wrong, the
 blast radius is whatever the string does.
 
-The two hard rules narrow this most of the way back — a parser bug
-degrades safely, and the command word cannot be smuggled in through an
-expansion — and `astToBash`'s measured behavior closes the obvious
-injection route. But it is a real change in the kind of guarantee being
-made.
+Three things narrow this: the rebuilt-string rule means parser bugs
+degrade safely, the plain-command-word rule stops a variable smuggling in
+a different command, and the single-`echo` fast path keeps the structural
+bound exactly where it was free.
 
-The second weakness is the refuse wall: it stops the common spelling of a
-destructive command, not the concept. `find . -delete` and `xargs rm`
-reach the approvable path. The wall is friction, and `std::bash` approval
-is the actual control.
+The second weakness is the refuse wall, which stops the common spelling of
+a destructive command and not the idea of one.
 
-The judgment is that both trades are worth it. v2's structural bound only
-applied to the handful of commands it could faithfully reimplement, and
-the reimplementation was itself a source of divergence. A correct
-classifier over many commands is more useful than a structural guarantee
-over three.
+The judgment is that both are worth it. v2's structural bound only applied
+to the handful of commands it could faithfully reimplement, and the
+reimplementation was itself a source of divergence.
+
+## What this design forecloses, and what it keeps open
+
+Whole-string execution means safeBash is an **approval optimizer**: bash
+executes everything, and what we contribute is deciding which question to
+ask first. It is not a **capability layer** — it cannot route a command
+inside a sequence to a constrained implementation, so it cannot make an
+agent structurally unable to do something.
+
+That is consistent with what the module has always been for. Every version
+has been trying to fix prompting, not capability; the v1 spec's own
+framing was "the cost is autonomy, not safety."
+
+**What stays open.** Classification remains per command, so the
+information a future per-command executor would need is already produced.
+Going the other way later is additive:
+
+> If every command is independently executable — no `cd`, no assignment
+> feeding a later command — and at least one has a constrained
+> implementation worth routing to, run per-command instead.
+
+We would be adding a runner back knowing exactly which cases need it,
+rather than building one now on the guess that we will.
+
+**When to revisit.** If the goal becomes pointing safeBash at untrusted
+output and relying on it to constrain what runs, that is the capability
+layer, it needs per-command routing, and this design is the wrong
+foundation for it.
 
 ## Open questions
 
 - **Does `write` need `allowedPaths`?** It takes `dir` but, unlike
   `mkdir`, `copy` and `applyPatch`, has no path allowlist, so binding
   `dir` sets a base without checking whether `filename` climbs out with
-  `../`. If that is right, the redirect substitution enforces less than it
-  appears to. `read` has the same shape and the same question.
-- **Should the substitution map be `provide { tool: impl }`?** See the
-  deferred note above. Worth settling before building a second rebinding
-  mechanism.
+  `../`. If that is right, the `write` fast path enforces less than it
+  appears to.
+- **A developer-supplied function table** — letting someone route a
+  command to *their* bound tool — is deferred. It overlaps an existing
+  design thread for tool rebinding (`provide { tool: impl }`), and two
+  mechanisms for swapping an implementation under a name will eventually
+  disagree about scoping. Settle that before building a second one.
 - **Still not wired in.** `shellTools()` remains untouched. Whether to put
   this in an agent's approval path is a separate decision, and the thing
   that review should weigh is the analytical-versus-structural trade
@@ -630,23 +598,24 @@ over three.
 ## Follow-on
 
 The integration test plan targets this design and is written separately.
-Its shape, in brief: a pure layer asserting classification
-(`actionsFor`), cheap enough for every pull request; a property test that
-`astToBash` round-trips across every command family in the table; and a
-small sandboxed layer, gated behind an acknowledgement environment
+Its shape: a pure layer asserting classification (`actionsFor`), cheap
+enough for every pull request; a property test that `astToBash`
+round-trips across every command family and the redirect-stripped form;
+and a small sandboxed layer, gated behind an acknowledgement environment
 variable and restricted to an allowlist of command names, that runs real
 commands in a temporary directory and compares against real bash.
 
 ## Related
 
 - [`2026-07-26-safebash-classifier-design-REVIEW.md`](./2026-07-26-safebash-classifier-design-REVIEW.md) —
-  the review this revision answers
+  the two review rounds this answers
 - [`2026-07-26-safebash-design.md`](./2026-07-26-safebash-design.md) —
   the v2 mapping design this replaces
 - [`../ideas/2026-07-24-safebash-command-to-tool-matching.md`](../ideas/2026-07-24-safebash-command-to-tool-matching.md) —
   the original reasoning
-- `docs/site/guide/interrupts.md`, `handlers.md`, `effects.md`,
-  `policies.md` — the approval machinery this works with
-- `stdlib/shell.agency` — `bash()` and its interrupt
+- `docs/site/guide/handlers.md`, `effects-and-raises.md`, `policies.md` —
+  the approval machinery this works with
+- `stdlib/capabilities.agency`, `lib/runtime/builtinPolicies.ts` — the
+  effect sets and named policies a new effect would have to join
 - `stdlib/git.agency`, `lib/stdlib/gitCore.ts` — the machine-format argv
   and environment scrubbing described above

--- a/packages/agency-lang/docs/superpowers/specs/2026-07-26-safebash-classifier-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-07-26-safebash-classifier-design.md
@@ -2,8 +2,9 @@
 
 ## Status
 
-Design, not yet built. Rewritten 2026-07-27 around whole-string execution,
-after two rounds of
+**Implemented.** See
+[the implementation plan](../plans/2026-07-27-safebash-v3-classifier.md).
+Rewritten 2026-07-27 around whole-string execution, after two rounds of
 [review](./2026-07-26-safebash-classifier-design-REVIEW.md) and a design
 discussion that changed the execution model.
 
@@ -657,6 +658,31 @@ yet.
 > A relabeled effect is approval of the **question**, not of the bytes. It
 > says what kind of thing is about to happen and to what target, not what
 > the result will contain, because bash has not run.
+
+### Approving `std::write` can authorize a shell spawn
+
+This one is easy to miss, and policy authors should learn it here rather
+than from a test fixture.
+
+A redirect contributes `std::write` whatever the verb is. So a command
+that is *recognized* but not shell-free raises `std::write` alone — and
+then runs through bash:
+
+```
+echo $HOME > out.txt
+   the variable means this is not shell-free …
+   … but echo is recognized, and the redirect contributes std::write
+   → raises std::write ONLY, then runs the string in bash
+```
+
+That is within the rules, and the audit invariant holds: an effect was
+raised before the shell started. But it means **a policy that
+blanket-approves `std::write` is also approving shell execution of any
+recognized command carrying a redirect.**
+
+If that is not what you want, approve `std::write` conditionally on its
+payload rather than wholesale. The payload names the directory and the
+file, so a rule matching on `dir` is the natural way to bound it.
 
 ## What is weaker than v2
 

--- a/packages/agency-lang/docs/superpowers/specs/2026-07-26-safebash-classifier-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-07-26-safebash-classifier-design.md
@@ -1,0 +1,392 @@
+# safeBash v3: classify the command, don't reimplement it
+
+## Status
+
+Design, not yet built. Replaces the mapping design described in
+[the v2 spec](./2026-07-26-safebash-design.md), which shipped and is on
+`main`. That spec stays as the record of how we got here; this one
+describes what the module becomes.
+
+An integration test plan exists in draft and is deliberately **not** part
+of this spec. It targets the shape described here, so it is written after
+this settles.
+
+## Background: what this module is for
+
+An agent gets file, git, search and http tools, and a prompt telling it to
+prefer them over the shell. It reaches for the shell anyway.
+
+That costs autonomy, not safety. The read-only tools are pre-approved and
+run without asking. `bash()` cannot be, because there is no way to say in
+advance what an arbitrary command string will do, so it raises an
+interrupt on every call. A run that could have gone unattended turns into
+a human approving a stream of `ls`, `cat` and `git status` by hand.
+
+`safeBash` exists to close that gap: look at the command the agent
+actually wrote, and if we can tell what it does, ask a narrower question
+than "may I run a shell command?"
+
+## How v2 tried to do it, and what went wrong
+
+v2 parsed the command and, when it recognized one, **called an equivalent
+Agency tool instead of the shell**. `echo hi` became `print("hi\n")`.
+`git status` became `gitStatus()`. Anything unrecognized fell back to
+`bash()`.
+
+The appeal was that the tool's own interrupt policy applied. `print`
+raises nothing, so `echo` became free. `write` raises `std::write`, so a
+redirect asked a narrower question than `std::bash`.
+
+The problem is that a substituted tool has to produce the same output as
+the command it replaced, and for anything more complicated than `echo`
+that turns out to be very hard.
+
+`std::git` was where this became clear. It does not run the command a user
+types. It runs machine-readable variants and deletes environment
+variables before spawning:
+
+| tool | actual argv |
+|---|---|
+| `gitStatus` | `git status --porcelain=v2 --branch -z` |
+| `gitLog` | `git log --format=%H␟%an␟%ae␟%aI␟%s␟%b␞ --end-of-options` |
+| `gitDiff` | `git diff --patch -M --end-of-options` |
+
+All of that is deliberate and good: machine formats parse reliably, and
+scrubbing the environment stops it influencing what git does. But it means
+there is no raw text lying around that matches what `git status` prints.
+
+To match `bash -c 'git status'` byte for byte you would have to reproduce
+everything that shapes git's human output: the same arguments, the user's
+locale (git translates status output), the user's `~/.gitconfig` (the
+advice hints and untracked-file handling are configurable), and the user's
+git version (hint wording changes between releases). Which is to say: the
+only way to produce exactly what bash produces is to run exactly what bash
+runs, in the environment bash runs it in.
+
+Measured, v2 does not match. Two examples:
+
+```
+safeBash("echo hi && echo bye")  →  "hi\n\nbye\n"
+bash     "echo hi && echo bye"   →  "hi\nbye\n"
+```
+
+The extra blank line comes from joining outputs that already end in a
+newline. And the shape of the return value depends on which path ran —
+raw text for `echo`, one JSON object for git, a different JSON envelope
+for the bash fallback — so an agent can tell which decision safeBash made
+by looking at what it got back. The v2 spec had explicitly decided it
+should not be able to.
+
+## The idea
+
+Stop reproducing the command. Identify it, raise the interrupt that
+describes it, and then run it through bash.
+
+```
+parse → classify each command → raise its effects → run it → return bash's output
+```
+
+The insight is that **substituting a tool was never what made this safe**.
+`gitStatus` spawns `git` either way. What made it safe was the narrower
+interrupt — `std::git::status` instead of `std::bash`, so a policy can say
+"git reads are fine, arbitrary shell is not". That benefit survives
+without the substitution, and fidelity comes free, because the thing
+producing the output *is* bash.
+
+## Three outcomes
+
+Classification produces one of three results.
+
+### Refuse
+
+Some commands we decline to run at all, even if a human approves. This is
+not a gate; it is a wall. `rm`, `rmdir`, `dd`, `shred`, `mkfs`,
+`truncate`, and the destructive git subcommands (`git clean`,
+`git reset --hard`, `git checkout -- .`, `git restore`).
+
+The reason for a wall rather than a prompt: an approval is a judgment made
+in a hurry, often by an automated policy rather than a person, and the
+cost of getting it wrong for this set is unrecoverable. A refusal is
+recoverable — the human can run the command themselves.
+
+### Substitute a constraining tool
+
+For a small set of commands, call an Agency tool instead of the shell.
+
+The rule for when this is worth doing:
+
+> **Substitute a tool when the tool can enforce a constraint the shell
+> cannot. Relabel the effect when the tool is only another way to run the
+> same program.**
+
+Substitution buys enforcement and costs fidelity — a tool's output is its
+own, not the command's — so the rule is really about whether the
+enforcement is worth that.
+
+Which stdlib tools can enforce something, checked against their
+signatures:
+
+| tool | constraint parameter |
+|---|---|
+| `fetch` | `allowedDomains` |
+| `mkdir`, `copy`, `applyPatch` | `allowedPaths` |
+| `ls`, `grep` | `allowedPaths` |
+| `write` | `dir` only — no `allowedPaths` |
+| `read` | `dir` only — no `allowedPaths` |
+| `gitStatus`, `gitLog`, `gitDiff`, `gitShow` | none |
+
+This is the language's own capability story. A developer who writes
+`readFile.partial(dir: "/tmp")` has built a tool that *cannot* read
+elsewhere. Relabelling an effect cannot participate in that: it asks "may
+I write?", where a bound tool enforces "you may only write here."
+
+**The clear cases.** `curl` and `wget` substitute to `fetch`: the domain
+allowlist is the whole point, and curl is not really a network command
+anyway — it writes files with `-o` and reads local ones through `file://`,
+so `std::bash` is closer to honest than any single narrower effect would
+be. `mkdir -p`, `cp`, `patch` and `git apply` substitute for the same
+reason: their tools take `allowedPaths` and their output is uninteresting.
+
+Git reads clearly do **not** qualify. `gitStatus` shells out to git and
+enforces nothing a shell would not, so substituting buys no constraint and
+costs exact output.
+
+**The genuinely contested cases are `ls` and `grep`.** Both tools take
+`allowedPaths`, which by the rule argues for substitution. Both also
+return structured results that look nothing like what the commands print,
+which argues for relabelling. The rule does not settle it, because the
+trade is real in both directions: a developer running an agent over one
+directory wants the path constraint enforced, and a developer whose agent
+parses command output wants the output to be the command's.
+
+**So the substitution table should be the developer's, not ours.** Rather
+than picking for everyone, `safeBash` takes a map of bound tools:
+
+```
+safeBash.partial(tools: {
+  curl: fetch.partial(allowedDomains: ["api.example.com"]),
+  ls:   ls.partial(allowedPaths: [projectRoot]),
+})
+```
+
+A command with an entry substitutes to that tool; a command without one
+relabels and runs. This puts the constraint-versus-fidelity decision with
+the person who knows which they need, and it means the enforcement is a
+tool *they* bound rather than a default we chose. The built-in default
+table stays small — `curl`, `wget`, `mkdir`, `cp`, `patch`, `git apply` —
+and `ls`, `grep`, `cat` and redirects relabel unless a developer says
+otherwise.
+
+One thing to confirm during implementation: `write` takes a `dir` but no
+`allowedPaths`, so binding `dir` sets a base directory without checking
+whether `filename` climbs out of it with `../`. If that is right, a
+redirect substituted to `write` is a weaker enforcement point than it
+looks, and `write` either needs the parameter or needs the containment
+check doing somewhere. `read` has the same shape and the same question.
+
+### Relabel and run
+
+Everything else we recognize. Raise the effect that describes the command,
+then hand the command to bash.
+
+| command shape | effects raised |
+|---|---|
+| `echo …` | *(none)* |
+| `git status`, `git log`, `git diff`, `git show` | `std::git::status`, `std::git::log`, `std::git::diff`, `std::git::show` |
+| `cat f` | `std::read` |
+| `ls [dir]` | `std::ls` |
+| `grep …` | `std::grep` |
+| anything recognized but not listed | `std::bash` |
+| anything unrecognized | `std::bash` |
+
+Effects **compose**. `git status > out.txt` raises `std::git::status`
+*and* `std::write` — two precise questions about one command. v2 could not
+express that and fell back to a single `std::bash`.
+
+The default is always `std::bash`. Classification is an allowlist: a
+command earns a narrower effect by matching a rule, and everything else
+gets the widest one. There is no shape that gets a narrower effect by
+failing to match something.
+
+## Two hard rules
+
+These are the reason the design is defensible, and neither is negotiable.
+
+### Bash receives a string re-rendered from the validated AST
+
+Never the agent's original text. The module parses, classifies the tree,
+and then renders that same tree back to shell source with `astToBash`.
+
+Why it matters: it means a **parser** bug degrades to "we ran what we
+thought we read" rather than to arbitrary execution. If the parser
+misreads `rm -rf / ; echo hi` as just `echo hi`, the renderer produces
+`echo hi` and that is what runs. What is left is **classification** bugs —
+the effect table being wrong about a command it did read correctly — which
+is a much smaller and more reviewable surface than "the shell did
+something we did not see".
+
+This makes `astToBash` security-critical, which it was not before. It
+earns a property test: for every command in the corpus, re-parsing the
+rendered string must produce the same tree.
+
+Checked before adopting this design, `astToBash` preserves quoting on
+every hostile input tried:
+
+```
+echo "a; rm -rf /tmp/x"   →  echo "a; rm -rf /tmp/x"
+echo 'a; b'               →  echo 'a; b'
+echo "a\"b"               →  echo "a\"b"
+echo hi > "my file.txt"   →  echo hi > "my file.txt"
+```
+
+so the obvious injection route — losing the quotes and turning one command
+into two — does not open. The property test is what keeps it that way.
+
+### The command word must be a literal
+
+`$CMD status` with `CMD=git` must never classify as a git read. The
+command name has to be a literal word in the source: not a variable
+expansion, not a path, not a quoted string that happens to expand to one.
+
+This changed status between v2 and v3. In v2, expansion fed the *argument
+list*, so getting it wrong was a correctness problem — the wrong text got
+printed. In v3, expansion could feed *classification*, so getting it wrong
+is a safety problem: the wrong question gets asked about the command that
+runs.
+
+The current code already requires the command word to be a `literal` tag,
+which rejects both expansions and path words. This rule records why that
+line has to stay.
+
+## Execution model
+
+**Per command.** The parser produces a list of commands; each one is
+classified, gated and run separately. That preserves the property that
+each command's approval is about that command, and it preserves the
+partial-failure report from v2: when a sequence stops, the model is told
+which command failed, what already ran and what it produced, and what
+never ran.
+
+The cost is that **shell state does not carry between commands**, because
+each runs in its own bash process:
+
+- `cd sub && ls` will not see the directory change
+- `FOO=1; echo $FOO` will not see the assignment
+
+Neither works today either — `cd` is not in the parser's supported subset,
+and a leading assignment already falls back. But under v3 bash is the
+executor for everything, so the limitation becomes much more visible and
+needs stating plainly rather than being discovered.
+
+The handling is to fall back: a command sequence that needs shell state to
+persist is not something we classify per command, so it goes to bash as
+one string, under one `std::bash` approval. That is the honest trade —
+less precise gating, correct behavior.
+
+## What happens to the v2 machinery
+
+`Action` and its executors go away. `stdlib/safeBash/actions.agency`
+mostly disappears; what survives is the substitution set (`fetch`,
+`write`, `mkdir`, `copy`, `applyPatch`), which is much smaller.
+
+`makeAction` becomes `classify`, returning a plan rather than an
+instruction:
+
+```ts
+type Plan = {
+  command: string      // re-rendered from the AST, never the original text
+  effects: string[]    // the interrupts this command must raise
+  outcome: "run" | "substitute" | "refuse"
+}
+```
+
+The testing seam is unchanged in shape and slightly better in substance:
+`plansFor(source) → Plan[]` is pure, takes a string, and returns data,
+exactly as `makeActions` did. The existing tests move across nearly
+one-for-one, asserting effects where they asserted action types.
+
+Two pieces of v2 die usefully rather than being fixed:
+
+- `joinOutput`'s extra-newline bug disappears, because we no longer join
+  outputs — bash produces one stream.
+- The return-shape inconsistency disappears, because every path returns
+  bash's stdout.
+
+## What is checked, and when
+
+1. **Parse time.** The parser either reads a command correctly or rejects
+   it; it never silently mis-parses. Globs, tilde, command substitution,
+   pipelines, background commands and file-descriptor redirection are all
+   rejected rather than represented, so they never reach classification.
+2. **Classification time.** The command word is checked for being a
+   literal, the refuse list is checked first, and effects are computed.
+   Nothing has run.
+3. **Approval time.** Each effect is raised as an interrupt. Handlers and
+   policies decide.
+4. **Run time.** The re-rendered command goes to bash, or to the
+   substituted tool.
+
+## What is weaker than v2, honestly
+
+v2's gate was **structural**. `echo hi` called `print`, and `print` has no
+capability to write a file or reach the network. If the analysis was
+wrong, the blast radius was bounded by what `print` could do, which is
+nothing.
+
+v3's gate is **analytical**. We parse, conclude the command is harmless,
+and hand it to a shell that can do anything. If the analysis is wrong, the
+blast radius is whatever the string does.
+
+The two hard rules narrow this most of the way back — a parser bug
+degrades safely, and the command word cannot be smuggled in through an
+expansion — and the measured behavior of `astToBash` closes the obvious
+injection route. But it is a real change in the kind of guarantee being
+made, and anyone reviewing this should know they are trading a structural
+bound for a reviewable analysis.
+
+The judgment is that the trade is worth it: v2's structural bound only
+applied to the handful of commands it could faithfully reimplement, and
+the reimplementation was itself a source of divergence. A correct
+classifier over many commands is more useful than a structural guarantee
+over three.
+
+## Open questions
+
+- **Does `write` need `allowedPaths`?** See the substitution section. If
+  binding `dir` does not prevent `../` traversal, the write substitution
+  is weaker than it looks.
+- **How big is the default substitution table?** The design says
+  developers supply their own map and keeps the built-in set to the
+  commands where substitution is uncontested. Whether `ls` and `grep`
+  should be in that default set, given they have `allowedPaths` but very
+  different output, is the specific call to make.
+- **Is `echo` really effect-free?** Raising nothing means an agent can
+  spawn a shell unattended on the strength of the classifier alone. The
+  alternative is a very low-friction effect that a policy blanket-approves
+  once. Currently resolved as: raise nothing, because the residual risk is
+  a classifier bug rather than an injection, and a classifier bug is
+  reviewable.
+- **Still not wired in.** `shellTools()` remains untouched. Whether to put
+  this in an agent's approval path is a separate decision.
+
+## Follow-on
+
+The integration test plan targets this design and is written separately.
+Its shape, in brief: a pure layer asserting classification (`plansFor`),
+which is cheap enough for every pull request; a property test that
+`astToBash` round-trips; and a small sandboxed layer, gated behind an
+acknowledgement environment variable and restricted to an allowlist of
+command names, that runs real commands in a temporary directory and
+compares against real bash.
+
+## Related
+
+- [`docs/superpowers/specs/2026-07-26-safebash-design.md`](./2026-07-26-safebash-design.md) —
+  the v2 mapping design this replaces
+- [`docs/superpowers/ideas/2026-07-24-safebash-command-to-tool-matching.md`](../ideas/2026-07-24-safebash-command-to-tool-matching.md) —
+  the original reasoning
+- `docs/site/guide/interrupts.md`, `handlers.md`, `effects.md`,
+  `policies.md` — the approval machinery this works with
+- `stdlib/shell.agency` — `bash()` and its interrupt
+- `stdlib/git.agency`, `lib/stdlib/gitCore.ts` — the machine-format argv
+  and environment scrubbing described above

--- a/packages/agency-lang/docs/superpowers/specs/2026-07-26-safebash-classifier-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-07-26-safebash-classifier-design.md
@@ -533,6 +533,58 @@ caused it is gone.
 The partial-failure report, and with it the "what ran, what didn't"
 message. There is no half-executed state to report on any more.
 
+## Executing without asking twice
+
+There is a trap here that defeats the whole design if it is missed.
+
+`bash()` in `std::shell` raises `std::bash` itself, every time, and then
+calls an internal `_bash`. `write()` does the same with `std::write`. So
+if safeBash raises `std::git::status`, gets approval, and then calls
+`bash()`, the human is asked "are you sure you want to run this shell
+command?" anyway — and the narrow question they just answered bought them
+nothing. On the broad path they would be asked twice.
+
+So after every effect in the plan is approved, safeBash executes through
+the **non-raising internals**: `_bash` from
+`agency-lang/stdlib-lib/shell.js`, and `_write` from
+`agency-lang/stdlib-lib/builtins.js`. These are the same functions
+`shell.agency` and `index.agency` call themselves once their own
+interrupts return.
+
+**This needs saying loudly, because bypassing a tool's interrupt is
+normally forbidden.** Handlers are safety infrastructure and must never be
+skipped by accident. Here it is not an accident, and the reasoning is
+specific:
+
+> The narrow interrupt **replaces** the broad one rather than preceding
+> it. The only path to `_bash` runs through a raise of every effect in the
+> plan, and any rejection returns before execution. So the command is
+> never less gated than `bash()` would have made it — it is gated by a
+> question that describes it better.
+
+Two things have to hold for that argument to be true, and both are
+testable:
+
+1. **Every plan raises at least one effect before reaching `_bash`.** That
+   is the audit rule above, and it is what stops a classification bug
+   turning into an ungated shell call.
+2. **Exactly one question is asked per effect.** A test has to *approve* a
+   narrow effect and assert the command ran, not merely reject it — a test
+   that only ever rejects the first interrupt passes whether or not a
+   second one would have appeared.
+
+## Leading assignments are not recognized
+
+A command may carry variable assignments that apply to it alone:
+`GIT_DIR=/elsewhere git status`. The assignment changes which repository
+git reads, so classifying that as `std::git::status { cwd }` would
+describe one read while bash performs another — the payload would lie.
+
+Rather than model what each assignment might mean, **any command with a
+leading assignment is not recognized** and the string falls to
+`std::bash`. Bash applies the assignment itself, correctly, and the human
+sees the whole command including the assignment.
+
 ## The return contract
 
 One of the two motivating bugs was that the return shape depended on which

--- a/packages/agency-lang/docs/superpowers/specs/2026-07-26-safebash-classifier-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-07-26-safebash-classifier-design.md
@@ -2,14 +2,20 @@
 
 ## Status
 
-Design, not yet built. Replaces the mapping design described in
-[the v2 spec](./2026-07-26-safebash-design.md), which shipped and is on
-`main`. That spec stays as the record of how we got here; this one
-describes what the module becomes.
+Design, not yet built. Revised 2026-07-27 after
+[review](./2026-07-26-safebash-classifier-design-REVIEW.md).
 
-An integration test plan exists in draft and is deliberately **not** part
-of this spec. It targets the shape described here, so it is written after
-this settles.
+Replaces the mapping design in
+[the v2 spec](./2026-07-26-safebash-design.md), which shipped and is on
+`main`. That spec stays as the record of how we got here.
+
+Scope for this change is deliberately narrow: **no new commands**. The
+classification table covers exactly what v2 covers — `echo` and four git
+reads — and everything else keeps falling back. This is a change to *how*
+safeBash decides and executes, not to *what* it recognizes.
+
+The integration test plan targets this design and is written separately,
+after this settles.
 
 ## Background: what this module is for
 
@@ -57,25 +63,24 @@ there is no raw text lying around that matches what `git status` prints.
 
 To match `bash -c 'git status'` byte for byte you would have to reproduce
 everything that shapes git's human output: the same arguments, the user's
-locale (git translates status output), the user's `~/.gitconfig` (the
-advice hints and untracked-file handling are configurable), and the user's
-git version (hint wording changes between releases). Which is to say: the
-only way to produce exactly what bash produces is to run exactly what bash
+locale (git translates status output), the user's `~/.gitconfig` (advice
+hints and untracked-file handling are configurable), and the user's git
+version (hint wording changes between releases). Which is to say: the only
+way to produce exactly what bash produces is to run exactly what bash
 runs, in the environment bash runs it in.
 
-Measured, v2 does not match. Two examples:
+Measured, v2 does not match:
 
 ```
 safeBash("echo hi && echo bye")  →  "hi\n\nbye\n"
 bash     "echo hi && echo bye"   →  "hi\nbye\n"
 ```
 
-The extra blank line comes from joining outputs that already end in a
-newline. And the shape of the return value depends on which path ran —
-raw text for `echo`, one JSON object for git, a different JSON envelope
-for the bash fallback — so an agent can tell which decision safeBash made
-by looking at what it got back. The v2 spec had explicitly decided it
-should not be able to.
+and the shape of the return value depends on which path ran — raw text for
+`echo`, one JSON object for git, a different JSON envelope for the bash
+fallback — so an agent can tell which decision safeBash made by looking at
+what it got back. The v2 spec had explicitly decided it should not be able
+to.
 
 ## The idea
 
@@ -90,8 +95,8 @@ The insight is that **substituting a tool was never what made this safe**.
 `gitStatus` spawns `git` either way. What made it safe was the narrower
 interrupt — `std::git::status` instead of `std::bash`, so a policy can say
 "git reads are fine, arbitrary shell is not". That benefit survives
-without the substitution, and fidelity comes free, because the thing
-producing the output *is* bash.
+without the substitution, and output fidelity comes free, because the
+thing producing the output *is* bash.
 
 ## Three outcomes
 
@@ -99,29 +104,41 @@ Classification produces one of three results.
 
 ### Refuse
 
-Some commands we decline to run at all, even if a human approves. This is
-not a gate; it is a wall. `rm`, `rmdir`, `dd`, `shred`, `mkfs`,
-`truncate`, and the destructive git subcommands (`git clean`,
-`git reset --hard`, `git checkout -- .`, `git restore`).
+Some commands we decline to run at all, even if a human approves: `rm`,
+`rmdir`, `dd`, `shred`, `mkfs`, `truncate`, and the destructive git
+subcommands (`git clean`, `git reset --hard`, `git checkout -- .`,
+`git restore`).
 
 The reason for a wall rather than a prompt: an approval is a judgment made
 in a hurry, often by an automated policy rather than a person, and the
 cost of getting it wrong for this set is unrecoverable. A refusal is
 recoverable — the human can run the command themselves.
 
-### Substitute a constraining tool
+**What the wall actually reaches.** It matches the command word, so it
+catches the common spelling and a path whose basename matches
+(`/bin/rm`, `./rm` — v3 checks the basename of a path word for exactly
+this reason). It does **not** catch `find . -delete`, `xargs rm`,
+`python -c "os.unlink(...)"`, or `env rm`. Those classify as unrecognized,
+raise `std::bash`, and are approvable like any other shell command.
 
-For a small set of commands, call an Agency tool instead of the shell.
+So the wall is friction against the obvious spelling, not a guarantee. The
+guarantee for everything else is that it asks for `std::bash` approval
+first. This is worth stating plainly because the rationale above — "the
+cost of getting it wrong is unrecoverable" — would otherwise read as a
+promise the mechanism does not make.
 
-The rule for when this is worth doing:
+### Substitute a tool
+
+For a small set of commands, call an Agency tool instead of letting bash
+do the work. The rule:
 
 > **Substitute a tool when the tool can enforce a constraint the shell
 > cannot. Relabel the effect when the tool is only another way to run the
 > same program.**
 
 Substitution buys enforcement and costs fidelity — a tool's output is its
-own, not the command's — so the rule is really about whether the
-enforcement is worth that.
+own, not the command's — so the rule is about whether the enforcement
+earns that.
 
 Which stdlib tools can enforce something, checked against their
 signatures:
@@ -131,103 +148,242 @@ signatures:
 | `fetch` | `allowedDomains` |
 | `mkdir`, `copy`, `applyPatch` | `allowedPaths` |
 | `ls`, `grep` | `allowedPaths` |
-| `write` | `dir` only — no `allowedPaths` |
-| `read` | `dir` only — no `allowedPaths` |
+| `write`, `read` | `dir` only — no `allowedPaths` |
 | `gitStatus`, `gitLog`, `gitDiff`, `gitShow` | none |
 
-This is the language's own capability story. A developer who writes
-`readFile.partial(dir: "/tmp")` has built a tool that *cannot* read
-elsewhere. Relabelling an effect cannot participate in that: it asks "may
-I write?", where a bound tool enforces "you may only write here."
-
-**The clear cases.** `curl` and `wget` substitute to `fetch`: the domain
-allowlist is the whole point, and curl is not really a network command
-anyway — it writes files with `-o` and reads local ones through `file://`,
-so `std::bash` is closer to honest than any single narrower effect would
-be. `mkdir -p`, `cp`, `patch` and `git apply` substitute for the same
-reason: their tools take `allowedPaths` and their output is uninteresting.
-
-Git reads clearly do **not** qualify. `gitStatus` shells out to git and
+Git reads clearly do not qualify: `gitStatus` shells out to git and
 enforces nothing a shell would not, so substituting buys no constraint and
 costs exact output.
 
-**The genuinely contested cases are `ls` and `grep`.** Both tools take
-`allowedPaths`, which by the rule argues for substitution. Both also
-return structured results that look nothing like what the commands print,
-which argues for relabelling. The rule does not settle it, because the
-trade is real in both directions: a developer running an agent over one
-directory wants the path constraint enforced, and a developer whose agent
-parses command output wants the output to be the command's.
+**In this change, the table has one member: output redirection.**
 
-**So the substitution table should be the developer's, not ours.** Rather
-than picking for everyone, `safeBash` takes a map of bound tools:
+Every other command where substitution would help — `curl` to `fetch`,
+`mkdir -p` to `mkdir`, `cp` to `copy`, `patch` to `applyPatch` — is a
+command safeBash does not recognize today, and adding them is out of
+scope. The mechanism is specified here so that adding one later is a table
+entry rather than a shape change.
 
-```
-safeBash.partial(tools: {
-  curl: fetch.partial(allowedDomains: ["api.example.com"]),
-  ls:   ls.partial(allowedPaths: [projectRoot]),
-})
-```
+**How a redirect substitutes without reimplementing anything.** For
+`echo hi > f`, producing the content ourselves would be reimplementing
+`echo`, which is the v2 trap. Instead, invert it:
 
-A command with an entry substitutes to that tool; a command without one
-relabels and runs. This puts the constraint-versus-fidelity decision with
-the person who knows which they need, and it means the enforcement is a
-tool *they* bound rather than a default we chose. The built-in default
-table stays small — `curl`, `wget`, `mkdir`, `cp`, `patch`, `git apply` —
-and `ls`, `grep`, `cat` and redirects relabel unless a developer says
-otherwise.
+1. Run the left-hand command through bash with the redirect stripped, and
+   capture stdout. Bash produces the bytes, so fidelity holds.
+2. Hand those bytes to `write`, which performs the write.
 
-One thing to confirm during implementation: `write` takes a `dir` but no
-`allowedPaths`, so binding `dir` sets a base directory without checking
-whether `filename` climbs out of it with `../`. If that is right, a
-redirect substituted to `write` is a weaker enforcement point than it
-looks, and `write` either needs the parameter or needs the containment
-check doing somewhere. `read` has the same shape and the same question.
+This keeps what v2's redirect handling was actually good at: `write`
+enforces its `dir`, and the `std::write` interrupt carries **`content`**,
+so a policy that inspects what is being written still can.
+
+The ordering constraint: the command runs before the write is approved, so
+a rejected write means the left-hand command already ran. That is only
+acceptable when the left-hand command has no effects of its own. Today
+that means **`echo` and nothing else** — any other command with a redirect
+relabels and lets bash do the whole thing. A future command added to the
+"effect-free" set must be justified on that basis specifically.
+
+**Deferred: a developer-supplied substitution table.** The natural
+extension is handing `safeBash` a map of bound tools, so a developer who
+built `fetch.partial(allowedDomains: [...])` routes `curl` to *their*
+constrained tool. Two reasons it is not in this change: there are no
+commands to route yet, and the shape overlaps an existing design thread
+for tool rebinding (`provide { tool: impl }`). Before building it, check
+whether it should be that mechanism rather than a second one, since two
+ways to swap an implementation under a name will eventually disagree about
+scoping and precedence.
+
+**One policy for whenever substitution grows:** when a tool cannot express
+something the command asked for — a curl flag with no `fetch` parameter —
+the command **falls back to relabel-and-run under `std::bash`**. It never
+drops the flag and calls the tool anyway. That is v2's `git log --graph`
+mistake, and it is the one failure mode this module must not have.
 
 ### Relabel and run
 
-Everything else we recognize. Raise the effect that describes the command,
-then hand the command to bash.
+Everything else we recognize. Raise the effects that describe the command,
+then hand the re-rendered command to bash.
 
 | command shape | effects raised |
 |---|---|
-| `echo …` | *(none)* |
-| `git status`, `git log`, `git diff`, `git show` | `std::git::status`, `std::git::log`, `std::git::diff`, `std::git::show` |
-| `cat f` | `std::read` |
-| `ls [dir]` | `std::ls` |
-| `grep …` | `std::grep` |
-| anything recognized but not listed | `std::bash` |
-| anything unrecognized | `std::bash` |
+| `echo …` | `std::echo` |
+| `echo … > f`, `>> f` | `std::echo`, then `std::write` (substituted — see above) |
+| `git status` | `std::git::status` |
+| `git diff` | `std::git::diff` |
+| `git diff --staged` | `std::git::diff` (with `staged: true` in the payload) |
+| `git log` | `std::git::log` |
+| anything else, recognized or not | `std::bash` |
 
-Effects **compose**. `git status > out.txt` raises `std::git::status`
-*and* `std::write` — two precise questions about one command. v2 could not
-express that and fell back to a single `std::bash`.
+Effects **compose**: a command can raise more than one, and each is a
+separate question. v2 could not express that, so a redirected git read
+fell back to a single `std::bash`.
 
-The default is always `std::bash`. Classification is an allowlist: a
+The default is always `std::bash`. Classification is an allowlist — a
 command earns a narrower effect by matching a rule, and everything else
-gets the widest one. There is no shape that gets a narrower effect by
-failing to match something.
+gets the widest one. No shape gets a narrower effect by failing to match
+something.
+
+**`std::echo` is new, and it is why every shell spawn is auditable.** It
+would be tempting to let `echo` raise nothing, since it is harmless. But
+v2's `echo` never spawned a shell and v3's does, so a silent `echo` would
+be the one path where an agent reaches a shell with no effect raised. That
+breaks an invariant worth keeping: *every shell spawn was preceded by a
+raised effect*, which is what makes a statelog of effects a complete audit
+of shell invocations. `std::echo` ships blanket-approved in the default
+policy, so it costs a user nothing.
+
+## How an effect actually gets raised
+
+This is the part that constrains the implementation, and v3 has to be
+built around it rather than discovering it.
+
+**An effect is raised at a named raise site**, not by name-as-data:
+`interrupt std::read("...", { dir, filename })`. There is no "raise this
+string" primitive, and if there were, safeBash's effects would be
+invisible to `getEffects` and to the effect-propagation walk, which read
+raise sites out of the source.
+
+Two consequences:
+
+**The dispatch is closed.** The implementation is a `match` over the
+effect enum with one `interrupt std::x(...)` arm per effect, and
+`safeBash`'s signature grows a wide clause:
+
+```
+raises <std::bash, std::echo, std::write,
+        std::git::status, std::git::diff, std::git::log>
+```
+
+That clause is a feature — it is how an agent author discovers which
+handlers to write — but it also means **adding a row to the
+classification table changes safeBash's public effect signature.** Anyone
+adding a command has to expect that.
+
+**Effects carry typed payloads, so a plan cannot hold bare names.** The
+contracts are enforced at the raise site:
+
+```
+effect std::read           { dir, filename }
+effect std::write          { dir, filename }
+effect std::git::status    { cwd }
+effect std::git::log       { cwd, ref, path }
+effect std::git::diff      { cwd, ref, ref2, staged, path }
+```
+
+Classification is where `filename`, `cwd` and `staged` are known, so the
+plan carries them.
+
+## The plan type, and why Action stays
+
+v2's `Action` was a plain data object describing what would happen, with
+nothing having happened yet. That is what made the module testable — hand
+in a string, look at what comes out — and it stays for exactly that
+reason. What changes is what it describes.
+
+```ts
+type Action = {
+  command: string        // re-rendered from the AST, never the original text
+  effects: Effect[]      // what this command asks permission for
+  outcome: Outcome
+}
+
+type Effect = {
+  name: string           // "std::git::diff"
+  payload: any           // the typed payload that effect's contract requires
+}
+
+type Outcome =
+  | { kind: "run" }                                   // bash executes it
+  | { kind: "substitute", tool: string, args: any }   // a tool executes it
+  | { kind: "refuse", reason: string }
+```
+
+The interrupts alone would not be enough for testing, which answers the
+question directly: an interrupt is raised at run time and is not an
+inspectable artifact, whereas `actionsFor(source) → Action[]` is pure and
+returns data. The action is strictly richer than v2's, because it now
+carries the effects and their payloads — so the testing seam gets better,
+not worse.
+
+`stdlib/safeBash/actions.agency` keeps its executors. The set shrinks:
+`bashAction` for the `run` outcome and `writeAction` for the one
+substitution, with `printAction` and the git executors deleted because
+those commands now relabel.
+
+## Execution model
+
+**Per command.** The parser produces a list of commands; each one is
+classified, gated and run separately, in its own bash process. That keeps
+each approval about the command it belongs to, and it keeps the
+partial-failure report: when a sequence stops, the model is told which
+command failed, what already ran and what it produced, and what never ran.
+
+**Effects are raised lazily**, immediately before their command runs — not
+up front for the whole sequence. For `a && b`, `b`'s interrupt is raised
+only if `a` succeeded. Up-front approval would ask a human about effects
+that may never happen, and would have to be revoked when the chain
+short-circuits.
+
+**Output is concatenated, and this is a joining policy we own.** The
+review caught a contradiction in an earlier draft, which claimed the v2
+extra-newline bug "disappears because bash produces one stream". It does
+not: with per-command processes, bash produces one stream per command and
+the module joins them. So the policy has to be stated rather than assumed:
+
+> Concatenate the raw streams. Add nothing, strip nothing. Bash's output
+> already carries its own trailing newline.
+
+That is what fixes the v2 bug — `joinOutput` inserted a separator between
+strings that already ended in one. It is a fix, not an absence.
+
+**Shell state does not carry between commands**, because each runs in its
+own process:
+
+- `cd sub && ls` will not see the directory change
+- `FOO=1; echo $FOO` will not see the assignment
+
+Neither works today either — `cd` is outside the parser's supported
+subset, and a leading assignment already falls back. But v3 makes bash the
+executor for everything, so the limitation is more visible and needs
+stating. The handling is to fall back: a sequence that needs shell state
+to persist goes to bash as one string under one `std::bash` approval. Less
+precise gating, correct behavior.
+
+## Working directory
+
+`cwd` reaches everything, resolved once:
+
+> The caller's `cwd` if non-empty, otherwise `getAgentCwd()`. Resolved at
+> the top of `safeBash` and stamped into every action.
+
+From there it flows to the bash invocation, to substituted tool calls, and
+into effect payloads that require it — `std::git::status { cwd }` and the
+other git effects all do.
+
+This gets its own section because it is precisely what silently regressed
+in the v2 pull request: `cwd` was honoured only when the command failed to
+parse, so the same call behaved differently depending on whether the
+string parsed. One resolution rule, applied once, prevents the repeat.
 
 ## Two hard rules
 
-These are the reason the design is defensible, and neither is negotiable.
+These carry the safety argument, and neither is negotiable.
 
 ### Bash receives a string re-rendered from the validated AST
 
 Never the agent's original text. The module parses, classifies the tree,
-and then renders that same tree back to shell source with `astToBash`.
+and renders that same tree back to shell source with `astToBash`.
 
-Why it matters: it means a **parser** bug degrades to "we ran what we
-thought we read" rather than to arbitrary execution. If the parser
-misreads `rm -rf / ; echo hi` as just `echo hi`, the renderer produces
-`echo hi` and that is what runs. What is left is **classification** bugs —
-the effect table being wrong about a command it did read correctly — which
-is a much smaller and more reviewable surface than "the shell did
-something we did not see".
+This means a **parser** bug degrades to "we ran what we thought we read"
+rather than to arbitrary execution. If the parser misreads
+`rm -rf / ; echo hi` as just `echo hi`, the renderer produces `echo hi`
+and that is what runs. What is left is **classification** bugs — the
+effect table being wrong about a command it read correctly — which is a
+far smaller and more reviewable surface.
 
 This makes `astToBash` security-critical, which it was not before. It
 earns a property test: for every command in the corpus, re-parsing the
-rendered string must produce the same tree.
+rendered string must produce the same tree, and the corpus must include
+every command family in the classification table.
 
 Checked before adopting this design, `astToBash` preserves quoting on
 every hostile input tried:
@@ -240,91 +396,67 @@ echo hi > "my file.txt"   →  echo hi > "my file.txt"
 ```
 
 so the obvious injection route — losing the quotes and turning one command
-into two — does not open. The property test is what keeps it that way.
+into two — does not open. The property test is what keeps it closed.
 
-### The command word must be a literal
+### The command word must be a literal — and v3 has to add this
 
 `$CMD status` with `CMD=git` must never classify as a git read. The
 command name has to be a literal word in the source: not a variable
-expansion, not a path, not a quoted string that happens to expand to one.
+expansion, not a path.
 
-This changed status between v2 and v3. In v2, expansion fed the *argument
-list*, so getting it wrong was a correctness problem — the wrong text got
-printed. In v3, expansion could feed *classification*, so getting it wrong
-is a safety problem: the wrong question gets asked about the command that
-runs.
+**This check does not exist today.** An earlier draft of this spec claimed
+the current code enforces it; it does not. `tokenize` reads
+`command.command` and uses `name.text` with no tag check, and `ScriptName`
+is `LiteralWord | PathWord`, so a path word is accepted and classified by
+its text. Safety currently holds *incidentally* — a path word contains a
+`/`, so it cannot spell `git` — rather than because anything checks.
 
-The current code already requires the command word to be a `literal` tag,
-which rejects both expansions and path words. This rule records why that
-line has to stay.
+That incidental safety is fine while classification only affects which
+tool gets called. It is not fine once classification decides which
+interrupt gets raised. So v3 **adds** the check, and the test plan pins
+it, because a rule the spec believes already exists is a rule nobody
+implements.
 
-## Execution model
+(The one place a path word is still inspected is the refuse wall, which
+checks a path's basename so `/bin/rm` is refused. That is a deliberate
+exception in the safe direction: it can only cause a refusal, never a
+narrower effect.)
 
-**Per command.** The parser produces a list of commands; each one is
-classified, gated and run separately. That preserves the property that
-each command's approval is about that command, and it preserves the
-partial-failure report from v2: when a sequence stops, the model is told
-which command failed, what already ran and what it produced, and what
-never ran.
+## What approval means here
 
-The cost is that **shell state does not carry between commands**, because
-each runs in its own bash process:
+A relabeled effect asks a **narrower question**, but not always the *same*
+question the corresponding tool would ask.
 
-- `cd sub && ls` will not see the directory change
-- `FOO=1; echo $FOO` will not see the assignment
+The clearest case is a write. When the `write` tool raises `std::write`,
+its payload includes `content` — a policy can inspect the bytes. The
+declared contract only requires `{ dir, filename }`, so a relabeled raise
+without content is legal, but any policy reading content would silently
+see a thinner payload.
 
-Neither works today either — `cd` is not in the parser's supported subset,
-and a leading assignment already falls back. But under v3 bash is the
-executor for everything, so the limitation becomes much more visible and
-needs stating plainly rather than being discovered.
+For redirects this is why the substitution above exists: running the
+command first and handing the bytes to `write` keeps `content` in the
+payload. For anything that relabels rather than substitutes, the general
+shape holds and should be stated to handler authors:
 
-The handling is to fall back: a command sequence that needs shell state to
-persist is not something we classify per command, so it goes to bash as
-one string, under one `std::bash` approval. That is the honest trade —
-less precise gating, correct behavior.
-
-## What happens to the v2 machinery
-
-`Action` and its executors go away. `stdlib/safeBash/actions.agency`
-mostly disappears; what survives is the substitution set (`fetch`,
-`write`, `mkdir`, `copy`, `applyPatch`), which is much smaller.
-
-`makeAction` becomes `classify`, returning a plan rather than an
-instruction:
-
-```ts
-type Plan = {
-  command: string      // re-rendered from the AST, never the original text
-  effects: string[]    // the interrupts this command must raise
-  outcome: "run" | "substitute" | "refuse"
-}
-```
-
-The testing seam is unchanged in shape and slightly better in substance:
-`plansFor(source) → Plan[]` is pure, takes a string, and returns data,
-exactly as `makeActions` did. The existing tests move across nearly
-one-for-one, asserting effects where they asserted action types.
-
-Two pieces of v2 die usefully rather than being fixed:
-
-- `joinOutput`'s extra-newline bug disappears, because we no longer join
-  outputs — bash produces one stream.
-- The return-shape inconsistency disappears, because every path returns
-  bash's stdout.
+> A relabeled effect is approval of the *question*, not of the bytes. It
+> says what kind of thing is about to happen and to what target, not what
+> the result will contain — because bash has not run yet.
 
 ## What is checked, and when
 
 1. **Parse time.** The parser either reads a command correctly or rejects
    it; it never silently mis-parses. Globs, tilde, command substitution,
-   pipelines, background commands and file-descriptor redirection are all
+   pipelines, background commands and file-descriptor redirection are
    rejected rather than represented, so they never reach classification.
+   This is a claim about tarsec, not about this module — the round-trip
+   property test is what keeps us honest about relying on it.
 2. **Classification time.** The command word is checked for being a
-   literal, the refuse list is checked first, and effects are computed.
-   Nothing has run.
-3. **Approval time.** Each effect is raised as an interrupt. Handlers and
-   policies decide.
-4. **Run time.** The re-rendered command goes to bash, or to the
-   substituted tool.
+   literal, the refuse list is checked first, effects and payloads are
+   computed. Nothing has run.
+3. **Approval time.** Each effect is raised, lazily, immediately before
+   its command runs. Handlers and policies decide.
+4. **Run time.** The re-rendered command goes to bash, or to a substituted
+   tool.
 
 ## What is weaker than v2, honestly
 
@@ -333,18 +465,22 @@ capability to write a file or reach the network. If the analysis was
 wrong, the blast radius was bounded by what `print` could do, which is
 nothing.
 
-v3's gate is **analytical**. We parse, conclude the command is harmless,
-and hand it to a shell that can do anything. If the analysis is wrong, the
+v3's gate is **analytical**. We parse, conclude what the command is, and
+hand it to a shell that can do anything. If the analysis is wrong, the
 blast radius is whatever the string does.
 
 The two hard rules narrow this most of the way back — a parser bug
 degrades safely, and the command word cannot be smuggled in through an
-expansion — and the measured behavior of `astToBash` closes the obvious
+expansion — and `astToBash`'s measured behavior closes the obvious
 injection route. But it is a real change in the kind of guarantee being
-made, and anyone reviewing this should know they are trading a structural
-bound for a reviewable analysis.
+made.
 
-The judgment is that the trade is worth it: v2's structural bound only
+The second weakness is the refuse wall: it stops the common spelling of a
+destructive command, not the concept. `find . -delete` and `xargs rm`
+reach the approvable path. The wall is friction, and `std::bash` approval
+is the actual control.
+
+The judgment is that both trades are worth it. v2's structural bound only
 applied to the handful of commands it could faithfully reimplement, and
 the reimplementation was itself a source of divergence. A correct
 classifier over many commands is more useful than a structural guarantee
@@ -352,38 +488,36 @@ over three.
 
 ## Open questions
 
-- **Does `write` need `allowedPaths`?** See the substitution section. If
-  binding `dir` does not prevent `../` traversal, the write substitution
-  is weaker than it looks.
-- **How big is the default substitution table?** The design says
-  developers supply their own map and keeps the built-in set to the
-  commands where substitution is uncontested. Whether `ls` and `grep`
-  should be in that default set, given they have `allowedPaths` but very
-  different output, is the specific call to make.
-- **Is `echo` really effect-free?** Raising nothing means an agent can
-  spawn a shell unattended on the strength of the classifier alone. The
-  alternative is a very low-friction effect that a policy blanket-approves
-  once. Currently resolved as: raise nothing, because the residual risk is
-  a classifier bug rather than an injection, and a classifier bug is
-  reviewable.
+- **Does `write` need `allowedPaths`?** It takes `dir` but, unlike
+  `mkdir`, `copy` and `applyPatch`, has no path allowlist, so binding
+  `dir` sets a base without checking whether `filename` climbs out with
+  `../`. If that is right, the redirect substitution enforces less than it
+  appears to. `read` has the same shape and the same question.
+- **Should the substitution map be `provide { tool: impl }`?** See the
+  deferred note above. Worth settling before building a second rebinding
+  mechanism.
 - **Still not wired in.** `shellTools()` remains untouched. Whether to put
-  this in an agent's approval path is a separate decision.
+  this in an agent's approval path is a separate decision, and the thing
+  that review should weigh is the analytical-versus-structural trade
+  above.
 
 ## Follow-on
 
 The integration test plan targets this design and is written separately.
-Its shape, in brief: a pure layer asserting classification (`plansFor`),
-which is cheap enough for every pull request; a property test that
-`astToBash` round-trips; and a small sandboxed layer, gated behind an
-acknowledgement environment variable and restricted to an allowlist of
-command names, that runs real commands in a temporary directory and
-compares against real bash.
+Its shape, in brief: a pure layer asserting classification
+(`actionsFor`), cheap enough for every pull request; a property test that
+`astToBash` round-trips across every command family in the table; and a
+small sandboxed layer, gated behind an acknowledgement environment
+variable and restricted to an allowlist of command names, that runs real
+commands in a temporary directory and compares against real bash.
 
 ## Related
 
-- [`docs/superpowers/specs/2026-07-26-safebash-design.md`](./2026-07-26-safebash-design.md) —
+- [`2026-07-26-safebash-classifier-design-REVIEW.md`](./2026-07-26-safebash-classifier-design-REVIEW.md) —
+  the review this revision answers
+- [`2026-07-26-safebash-design.md`](./2026-07-26-safebash-design.md) —
   the v2 mapping design this replaces
-- [`docs/superpowers/ideas/2026-07-24-safebash-command-to-tool-matching.md`](../ideas/2026-07-24-safebash-command-to-tool-matching.md) —
+- [`../ideas/2026-07-24-safebash-command-to-tool-matching.md`](../ideas/2026-07-24-safebash-command-to-tool-matching.md) —
   the original reasoning
 - `docs/site/guide/interrupts.md`, `handlers.md`, `effects.md`,
   `policies.md` — the approval machinery this works with

--- a/packages/agency-lang/lib/stdlib/safeBash.test.ts
+++ b/packages/agency-lang/lib/stdlib/safeBash.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { _bashParser, _astToBash } from "./safeBash.js";
+
+/** Drop `loc` fields so two trees compare on structure, not on where the
+ *  text happened to sit. Rendering re-flows whitespace, so positions
+ *  legitimately differ between the original and the re-parsed form. */
+function strip(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(strip);
+  if (value === null || typeof value !== "object") return value;
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    if (k === "loc") continue;
+    out[k] = strip(v);
+  }
+  return out;
+}
+
+// Every command family the classifier recognizes, plus the hostile
+// quoting cases that would turn one command into two if rendering lost a
+// quote.
+const CORPUS = [
+  "echo hello",
+  "echo hello world",
+  "echo 'a  b'",
+  'echo "a b" c',
+  "echo a'b'\"c\"",
+  'echo "a; rm -rf /tmp/x"',
+  'echo "a\\"b"',
+  "echo $HOME",
+  'echo "$HOME"/bin',
+  "echo hi > out.txt",
+  "echo hi >> out.txt",
+  'echo hi > "my file.txt"',
+  "git status",
+  "git log",
+  "git diff",
+  "git diff --staged",
+  "git log --format=oneline",
+  "git checkout .",
+  "ls -la",
+  "cat src/main.ts",
+  "git status; git log",
+  "git status && git log",
+  "git status || git log",
+  "(git status && git log)",
+];
+
+describe("astToBash round-trips every command family the classifier sees", () => {
+  // This is security-critical: when every command is recognized, bash is
+  // handed a string rendered from the tree rather than the agent's text.
+  // If rendering is lossy, we run something other than what we classified.
+  for (const source of CORPUS) {
+    it(`round-trips ${JSON.stringify(source)}`, () => {
+      const first = _bashParser(source);
+      expect(first.success, `corpus entry did not parse: ${source}`).toBe(true);
+      if (!first.success) return;
+
+      const rendered = first.result.map((c: unknown) => _astToBash(c)).join("; ");
+      const second = _bashParser(rendered);
+      expect(second.success, `rendered form did not re-parse: ${rendered}`).toBe(true);
+      if (!second.success) return;
+
+      // Compare the TREES, not the rendered strings. A string fixed point
+      // passes on exactly the failure this test exists to catch: if
+      // rendering lost the quotes, `echo "a; b"` renders to `echo a; b`,
+      // which re-parses as TWO commands, which re-render (joined with
+      // "; ") to the same string. Green test, one command became two.
+      expect(strip(second.result)).toEqual(strip(first.result));
+    });
+  }
+});

--- a/packages/agency-lang/stdlib/safeBash.agency
+++ b/packages/agency-lang/stdlib/safeBash.agency
@@ -1,13 +1,18 @@
-import { env } from "std::system"
+// These imports are NOT unused. Effect declarations come with imports,
+// and without them the `raise std::bash(...)` and `raise std::git::*(...)`
+// sites below compile with their payload contracts UNENFORCED. Measured:
+// dropping them makes `raise std::git::status("...", { wrongField: x })`
+// typecheck clean. `std::write` is covered by the auto-imported prelude.
+import { gitStatus } from "std::git"
+import { bash } from "std::shell"
 
 import {
-  Action,
-  printAction,
-  writeAction,
-  gitStatusAction,
-  gitDiffAction,
-  gitLogAction,
-  bashAction,
+  Effect,
+  Plan,
+  Execution,
+  runBash,
+  runWrite,
+  truncate,
  } from "./safeBash/actions.agency"
 import { _bashParser, _astToBash } from "agency-lang/stdlib-lib/safeBash.js"
 
@@ -129,124 +134,57 @@ export type BashNode =
 
 export type BashAST = Command[]
 
-/** An output redirect reduced to the shape v1 handles: `>` or `>>` to a
- * path, with no explicit file descriptor. */
-export type OutputRedirect = {
-  op: string;
-  path: string
-}
+def literalArgs(command: SimpleCommand): Result<string[]> {
+  """
+  A command's non-flag arguments as text, but only when every one is a
+  plain literal.
 
-export def bashParser(code: string): Result<BashAST> {
+  Flags are SKIPPED, not rejected: they are collected separately by
+  `flagNames`, and rejecting them here would make `git diff --staged`
+  unrecognized before any rule saw it.
   """
-  Parse a string of bash code into an AST.
-  """
-  const res = _bashParser(code)
-  return match(res.success) {
-    true => success(res.result)
-    false => failure(res.message)
-  }
-}
-
-def stringifyWord(word: Word, insideQuotes: boolean = false): Result<string> {
-  """
-  Reduce a word to text, or explain why it cannot be.
-
-  The parser refuses globs, tilde, command substitution and arithmetic
-  outright, so they never arrive here.
-  """
-  return match(word) {
-    { tag: "literal", text } => success(text)
-    { tag: "path", text } => success(text)
-    { tag: "singleQuoted", text } => success(text)
-    { tag: "doubleQuoted", parts } => stringifyParts(parts, true)
-    { tag: "variable", name } => expandVariable(name, insideQuotes)
-    { tag: "interpolatedVariable", parts } => stringifyParts(parts, insideQuotes)
-    _ => failure("`${word.tag}` cannot be reduced to text")
-  }
-}
-
-def expandVariable(name: string, insideQuotes: boolean): Result<string> {
-  """
-  Look a variable up in the environment. Unset is the empty string, as in bash.
-
-  An UNQUOTED value containing whitespace is refused rather than expanded:
-  bash word-splits it, so `cat $F` with `F="a b"` is two arguments, and
-  expanding it here without splitting would quietly change what the command
-  means. Inside double quotes no splitting happens, so it expands normally.
-  """
-  const value = env(name) ?? ""
-  if (insideQuotes) {
-    return success(value)
-  }
-  // Default IFS is space, TAB and NEWLINE — not just space.
-  if (value.includes(" ") || value.includes("\t") || value.includes("\n")) {
-    return failure("unquoted `${name}` contains whitespace; bash would word-split it")
-  }
-  return success(value)
-}
-
-def stringifyParts(parts: Word[], insideQuotes: boolean): Result<string> {
-  """
-  Concatenate the parts of a word. Adjacent parts join with no separator:
-  `e'f'"g"` is one word, `efg`.
-  """
-  let out = ""
-  for (part in parts) {
-    const piece = stringifyWord(part, insideQuotes)
-    if (piece is success(text)) {
-      out = out + text
-    } else {
-      return failure(piece.error)
+  let out: string[] = []
+  for (arg in command.args) {
+    if (arg.tag == "flag") {
+      continue
     }
+    if (arg.tag != "literal") {
+      return failure("`${arg.tag}` is not a literal argument")
+    }
+    out.push(arg.text)
   }
   return success(out)
 }
 
-def hasQuotedPart(word: Word): boolean {
+def flagNames(command: SimpleCommand): string[] {
   """
-  True when any part of the word was quoted.
-
-  Quoting is what makes an empty word a real argument: bash passes nothing
-  for an unset `$A`, but passes one empty string for `""`.
+  Every flag on the command, in source form (`--staged`, `-n`).
   """
-  return match(word) {
-    { tag: "singleQuoted" } => true
-    { tag: "doubleQuoted" } => true
-    { tag: "interpolatedVariable", parts } => some(parts, \p -> hasQuotedPart(p))
-    _ => false
+  let out: string[] = []
+  for (arg in command.args) {
+    if (arg.tag == "flag") {
+      out.push(renderFlag(arg))
+    }
   }
+  return out
 }
 
-def stringifyArg(word: Word): Result<string> {
+def redirectEffect(redirects: Redirect[], cwd: string): Result<Effect[]> {
   """
-  Reduce a whole argument to text.
+  What a command's redirects contribute, independently of its verb.
 
-  An unquoted word that comes out empty is refused, because bash drops it
-  and passes no argument at all where this would pass one empty string. The
-  check belongs to the whole word rather than to each expansion inside it:
-  `$A$B` with both unset is empty the same way a bare `$A` is, and `$A/bin`
-  is `/bin` — one argument — even though `$A` alone contributed nothing.
-  """
-  const text = stringifyWord(word, false)
-  if (text is failure(why)) {
-    return failure(why)
-  }
-  if (text.value == "" && !hasQuotedPart(word)) {
-    return failure(
-      "an unquoted expansion is empty; bash would pass no argument at all",
-    )
-  }
-  return text
-}
+  A redirect writes a file whatever the command is, so it has to be
+  accounted for on its own. Without this, `echo pwned >> .bashrc; git
+  status` would classify as a git read and ride along under whatever
+  approves git reads.
 
-def simplifyRedirects(redirects: Redirect[]): Result<OutputRedirect | null> {
-  """
-  Reduce a command's redirects to the one shape v1 handles: a single `>` or
-  `>>` to a file, with no explicit file descriptor. Everything else — `2>&1`,
-  heredocs, input redirects, more than one — is refused.
+  Anything other than a plain `>` or `>>` to a literal target is a
+  failure, which sends the whole string to `std::bash`. An input redirect
+  is a read the effect set would otherwise never mention, and a variable
+  target cannot fill the payload without expanding it ourselves.
   """
   if (redirects.length == 0) {
-    return success(null)
+    return success([])
   }
   if (redirects.length > 1) {
     return failure("more than one redirect")
@@ -258,14 +196,632 @@ def simplifyRedirects(redirects: Redirect[]): Result<OutputRedirect | null> {
   if (only.op != ">" && only.op != ">>") {
     return failure("`${only.op}` is not an output redirect")
   }
-  const path = stringifyArg(only.target)
-  if (path is success(text)) {
-    return success({
-      op: only.op,
-      path: text
-    })
+  const target = literalTarget(only.target)
+  if (target is failure(why)) {
+    return failure(why)
   }
-  return failure("redirect target: ${path.error}")
+  const mode = writeMode(only.op)
+  return success(
+    [
+    {
+    name: "std::write",
+    payload: {
+      dir: cwd,
+      filename: target.value,
+      content: "",
+      mode: mode
+    }
+  },
+  ],
+  )
+}
+
+def literalTarget(word: Word): Result<string> {
+  """
+  A redirect target's text, when the target is fully literal.
+
+  A variable target cannot fill the `std::write` payload without expanding
+  it ourselves, which is the one thing this module never does. A quoted
+  target with no variable in it is fine — `> "my file.txt"` names a real
+  file — so this is the same question `echoWords` asks of an argument.
+  """
+  return literalWordText(word)
+}
+
+def writeMode(op: string): string {
+  """
+  `>` truncates, `>>` appends.
+  """
+  if (op == ">>") {
+    return "append"
+  }
+  return "overwrite"
+}
+
+export def effectsFor(command: SimpleCommand, cwd: string): Result<Effect[]> {
+  """
+  Which interrupts this one command needs raised.
+
+  A failure means the command is not recognized. The caller turns that
+  into a `std::bash` question for the whole string rather than trying to
+  ask a narrow question about part of it.
+
+  @param command - One simple command from the parsed AST
+  @param cwd - The resolved working directory, for payloads that need it
+  """
+  const name = command.command
+  if (name == null) {
+    return failure("an assignment with no command")
+  }
+  // A path word is never a recognized command: `/bin/git` must not become
+  // a git read. The wall may look at path words, because a wall match can
+  // only ever cause a refusal.
+  if (name.tag != "literal") {
+    return failure("the command word is not a literal")
+  }
+  // `GIT_DIR=/elsewhere git status` reads a DIFFERENT repository than the
+  // payload would claim. Rather than model what each assignment means,
+  // any command carrying one is unrecognized.
+  if (command.assignments.length > 0) {
+    return failure("a leading assignment changes what the command does")
+  }
+  const flags = flagNames(command)
+  const redirect = redirectEffect(command.redirects, cwd)
+  if (redirect is failure(why)) {
+    return failure(why)
+  }
+
+  if (name.text == "echo") {
+    // `echo` contributes nothing on its own, whatever its arguments. Bash
+    // runs it and expands anything in it, so `echo $HOME` and `echo -n hi`
+    // are both fine HERE — the flag and literal-argument restrictions
+    // belong to the shell-free path, which computes the output itself.
+    return success(redirect.value)
+  }
+
+  if (name.text != "git") {
+    return failure("no rule for `${name.text}`")
+  }
+  // Only the git rules need the arguments as text, so this runs AFTER the
+  // echo branch. Above it, a quoted `echo "hi"` would fail here and be
+  // demoted before the branch that says echo is fine whatever its
+  // arguments ever ran.
+  const args = literalArgs(command)
+  if (args is failure(why)) {
+    return failure(why)
+  }
+  const git = gitEffects(args.value, flags, cwd)
+  if (git is failure(why)) {
+    return failure(why)
+  }
+  return success([...git.value, ...redirect.value])
+}
+
+def gitEffects(args: string[], flags: string[], cwd: string): Result<Effect[]> {
+  """
+  The four git reads we recognize.
+
+  An unrecognized flag is a failure rather than something to ignore.
+  Answering `git log --graph` with a plain `std::git::log` would tell the
+  model it asked one question when it asked another.
+  """
+  if (args.length != 1) {
+    return failure("only a bare git subcommand is recognized")
+  }
+  const sub = args[0]
+  if (sub == "status" && flags.length == 0) {
+    return success(
+      [
+      {
+      name: "std::git::status",
+      payload: {
+        cwd: cwd
+      }
+    },
+    ],
+    )
+  }
+  if (sub == "log" && flags.length == 0) {
+    return success(
+      [
+      {
+      name: "std::git::log",
+      payload: {
+        cwd: cwd,
+        ref: "",
+        path: ""
+      }
+    },
+    ],
+    )
+  }
+  if (sub == "diff" && flags.length == 0) {
+    return success(
+      [
+      {
+      name: "std::git::diff",
+      payload: {
+        cwd: cwd,
+        ref: "",
+        ref2: "",
+        staged: false,
+        path: ""
+      }
+    },
+    ],
+    )
+  }
+  if (sub == "diff" && flags.length == 1 && flags[0] == "--staged") {
+    return success(
+      [
+      {
+      name: "std::git::diff",
+      payload: {
+        cwd: cwd,
+        ref: "",
+        ref2: "",
+        staged: true,
+        path: ""
+      }
+    },
+    ],
+    )
+  }
+  return failure("no rule for `git ${sub}`")
+}
+
+static const BASH_EFFECT: Effect = {
+  name: "std::bash"
+}
+
+def emptyExecution(): Execution {
+  return {
+    kind: "",
+    command: "",
+    content: "",
+    filename: "",
+    dir: "",
+    mode: "",
+    reason: ""
+  }
+}
+
+def refusePlan(reason: string): Plan {
+  let exec = emptyExecution()
+  exec.kind = "refuse"
+  exec.reason = reason
+  return {
+    effects: [],
+    execution: exec
+  }
+}
+
+def bashPlan(command: string, effects: Effect[]): Plan {
+  let exec = emptyExecution()
+  exec.kind = "bash"
+  exec.command = command
+  // Spawning a shell always raises at least one effect, so a log of
+  // effects is a complete audit of shell invocations. A string of nothing
+  // but echoes would otherwise raise nothing and still start a shell.
+  if (effects.length == 0) {
+    return {
+      effects: [BASH_EFFECT],
+      execution: exec
+    }
+  }
+  return {
+    effects: effects,
+    execution: exec
+  }
+}
+
+def flattenCommands(commands: Command[]): SimpleCommand[] {
+  """
+  Every simple command in the string, including the halves of a chain.
+
+  Used for BOTH the refuse wall and classification, because a wall that
+  only looks at the top level is bypassed by two characters
+  (`true && rm -rf /`), and a classifier that only looks at the top level
+  demotes every chained invocation to the broad question.
+  """
+  let out: SimpleCommand[] = []
+  for (command in commands) {
+    out = [...out, ...flattenOne(command)]
+  }
+  return out
+}
+
+def flattenOne(command: Command): SimpleCommand[] {
+  if (command.tag == "simpleCommand") {
+    return [command]
+  }
+  if (command.tag == "and") {
+    return [...flattenOne(command.left), ...flattenOne(command.right)]
+  }
+  if (command.tag == "or") {
+    return [...flattenOne(command.left), ...flattenOne(command.right)]
+  }
+  if (command.tag == "parens") {
+    return flattenOne(command.command)
+  }
+  return []
+}
+
+def rebuild(commands: Command[]): Result<string> {
+  """
+  The command string, rendered back from the tree we classified.
+
+  Used only when every command was recognized. We claimed the string is
+  `git status`, so we must run what we classified rather than text we only
+  assumed matched it. A parser bug then degrades to running what we
+  thought we read.
+  """
+  let parts: string[] = []
+  for (command in commands) {
+    const text = try _astToBash(command)
+    if (text is failure(why)) {
+      return failure("could not render `${why}`")
+    }
+    parts.push(text.value)
+  }
+  return success(parts.join("; "))
+}
+
+def trySeeIfShellFree(command: SimpleCommand, cwd: string): Result<Plan> {
+  """
+  A shell-free path applies only to a single `echo`, and only when the
+  wall has nothing to say about it.
+  """
+  if (isRefused(command)) {
+    return failure("refused")
+  }
+  const name = command.command
+  if (name == null) {
+    return failure("no command")
+  }
+  if (name.tag != "literal") {
+    return failure("the command word is not a literal")
+  }
+  if (name.text != "echo") {
+    return failure("not echo")
+  }
+  if (command.assignments.length > 0) {
+    return failure("a leading assignment changes what the command does")
+  }
+  return shellFreePlan(command, cwd)
+}
+
+def echoWords(command: SimpleCommand): Result<string[]> {
+  """
+  `echo`'s arguments as text, but only when every one is fully literal.
+
+  A plain word, a path, or a single-quoted string qualifies. A variable
+  does not, and neither does a double-quoted string containing one: this
+  path never invokes a shell, so there is nothing here to expand a
+  variable, and expanding it ourselves is where v2's divergence bugs
+  lived.
+  """
+  let out: string[] = []
+  for (arg in command.args) {
+    const text = literalWordText(arg)
+    if (text is failure(why)) {
+      return failure(why)
+    }
+    out.push(text.value)
+  }
+  return success(out)
+}
+
+def literalWordText(word: Word): Result<string> {
+  if (word.tag == "literal") {
+    return success(word.text)
+  }
+  if (word.tag == "path") {
+    return success(word.text)
+  }
+  if (word.tag == "singleQuoted") {
+    return success(word.text)
+  }
+  if (word.tag == "doubleQuoted") {
+    return literalDoubleQuoted(word)
+  }
+  return failure("`${word.tag}` is not fully literal")
+}
+
+def literalDoubleQuoted(word: DoubleQuotedWord): Result<string> {
+  """
+  The text of a double-quoted word, when it contains no expansions.
+  """
+  let out = ""
+  for (part in word.parts) {
+    if (part.tag != "literal") {
+      return failure("a double-quoted word contains `${part.tag}`")
+    }
+    out = out + part.text
+  }
+  return success(out)
+}
+
+def echoOutput(words: string[]): string {
+  """
+  What `echo` prints: its arguments joined by single spaces, then a
+  newline. Bare `echo` is still a newline, not nothing.
+  """
+  return words.join(" ") + "\n"
+}
+
+def echoPlan(command: SimpleCommand): Result<Plan> {
+  """
+  A single `echo` with nothing else in the string and no redirect.
+
+  Nothing here can write a file or reach the network no matter how wrong
+  the classifier is, because all it does is build a string. That is the
+  one place v2's structural safety was free.
+  """
+  if (command.redirects.length > 0) {
+    return failure("a redirected echo is handled elsewhere")
+  }
+  if (flagNames(command).length > 0) {
+    return failure("`echo` with flags prints differently")
+  }
+  const words = echoWords(command)
+  if (words is failure(why)) {
+    return failure(why)
+  }
+  let exec = emptyExecution()
+  exec.kind = "echo"
+  exec.content = echoOutput(words.value)
+  return success({
+    effects: [],
+    execution: exec
+  })
+}
+
+def writePlan(command: SimpleCommand, cwd: string): Result<Plan> {
+  """
+  A single `echo` redirected to a literal file.
+
+  The content is computed rather than produced by running anything, so no
+  shell is spawned and the bytes are in the approval payload before anyone
+  approves. If the equivalence claim is good enough to say what `echo`
+  prints, it is good enough to say what `echo` writes.
+  """
+  if (command.redirects.length != 1) {
+    return failure("not a single redirect")
+  }
+  if (flagNames(command).length > 0) {
+    return failure("`echo` with flags prints differently")
+  }
+  const only = command.redirects[0]
+  if (only.fd != null) {
+    return failure("redirect with an explicit file descriptor")
+  }
+  if (only.op != ">" && only.op != ">>") {
+    return failure("`${only.op}` is not an output redirect")
+  }
+  const target = literalTarget(only.target)
+  if (target is failure(why)) {
+    return failure(why)
+  }
+  const words = echoWords(command)
+  if (words is failure(why)) {
+    return failure(why)
+  }
+  const content = echoOutput(words.value)
+  const mode = writeMode(only.op)
+
+  let exec = emptyExecution()
+  exec.kind = "write"
+  exec.content = content
+  exec.filename = target.value
+  exec.dir = cwd
+  exec.mode = mode
+
+  const effect: Effect = {
+    name: "std::write",
+    payload: {
+      dir: cwd,
+      filename: target.value,
+      content: content,
+      mode: mode
+    }
+  }
+  return success({
+    effects: [effect],
+    execution: exec
+  })
+}
+
+def shellFreePlan(command: SimpleCommand, cwd: string): Result<Plan> {
+  """
+  The two paths that never invoke a shell, tried in order.
+  """
+  const bare = echoPlan(command)
+  if (bare is success(plan)) {
+    return bare
+  }
+  return writePlan(command, cwd)
+}
+
+export def planFor(source: string, cwd: string): Plan {
+  """
+  Decide everything about a call before any of it happens.
+
+  Parses the string, classifies every command, and works out which
+  interrupts to raise and what to run. Nothing here has an effect, which
+  is what makes the decision testable: hand in a string, look at the plan.
+
+  @param source - One or more bash commands
+  @param cwd - The resolved working directory
+  """
+  const parsed = bashParser(source)
+  if (parsed is failure(why)) {
+    // Unparseable: nothing was understood, so ask the broad question and
+    // hand bash the text the human will have seen.
+    return bashPlan(source, [])
+  }
+  const commands: Command[] = parsed.value
+
+  if (commands.length == 1) {
+    const only = commands[0]
+    if (only.tag == "simpleCommand") {
+      const shellFree = trySeeIfShellFree(only, cwd)
+      if (shellFree is success(plan)) {
+        return plan
+      }
+    }
+  }
+
+  // Flatten first. A chain hides its halves inside `and`/`or`/`parens`
+  // nodes, and `true && rm -rf /` has no top-level simple command at all —
+  // without this walk the wall never sees the `rm`.
+  const simple = flattenCommands(commands)
+
+  let narrow: Effect[] = []
+  let allRecognized = true
+  for (command in simple) {
+    if (isRefused(command)) {
+      const name = command.command
+      if (name == null) {
+        return refusePlan("this command is not allowed")
+      }
+      return refusePlan("`${name.text}` is not allowed")
+    }
+    const effects = effectsFor(command, cwd)
+    if (effects is failure(why)) {
+      allRecognized = false
+    } else {
+      narrow = [...narrow, ...effects.value]
+    }
+  }
+
+  if (!allRecognized) {
+    // We have to ask the broad question anyway, so asking narrow ones
+    // first adds prompts without adding information. The ORIGINAL text
+    // runs, because that is what the human read.
+    return bashPlan(source, [BASH_EFFECT])
+  }
+  if (narrow.length == 0) {
+    // Everything recognized but nothing contributed an effect — a string
+    // of nothing but echoes. The audit rule makes this a std::bash
+    // question, so by the same rule it runs the original text.
+    return bashPlan(source, [BASH_EFFECT])
+  }
+  // Narrow questions were asked, so run the tree we classified.
+  const rebuilt = rebuild(commands)
+  if (rebuilt is failure(why)) {
+    // We cannot produce the text we classified, so we must not ask narrow
+    // questions about it. Doing this AFTER raising would break the first
+    // hard rule.
+    return bashPlan(source, [BASH_EFFECT])
+  }
+  return bashPlan(rebuilt.value, narrow)
+}
+
+/** Commands we decline to run even when a human approves. */
+static const REFUSED_COMMANDS: string[] = ["rm", "rmdir", "dd", "shred", "mkfs", "truncate"]
+
+/** `git` subcommands that always destroy work. */
+static const REFUSED_GIT_ALWAYS: string[] = ["clean", "restore"]
+
+def baseName(text: string): string {
+  """
+  The last part of a path. `/bin/rm` is `rm`.
+  """
+  const parts = text.split("/")
+  return parts[parts.length - 1]
+}
+
+export def isRefused(command: SimpleCommand): boolean {
+  """
+  True when this command must not run, whatever anyone approves.
+
+  Matches the command word, including the last part of a path, so `rm`,
+  `/bin/rm` and `./rm` are all refused.
+
+  This wall is friction against the obvious spelling, not a guarantee.
+  `find . -delete` and `xargs rm` get past it and are approvable under
+  `std::bash`, which is where the actual control lives.
+  """
+  const name = command.command
+  if (name == null) {
+    return false
+  }
+  const word = baseName(name.text)
+  if (REFUSED_COMMANDS.includes(word)) {
+    return true
+  }
+  if (word != "git") {
+    return false
+  }
+  return isDestructiveGit(command)
+}
+
+def isDestructiveGit(command: SimpleCommand): boolean {
+  """
+  The git subcommands that throw work away.
+
+  Only the FIRST argument is the subcommand. `git log reset` is a log, not
+  a reset, and matching a subcommand name anywhere in the arguments would
+  refuse it.
+
+  `clean` and `restore` are destructive by purpose. `reset` and `checkout`
+  are only destructive in particular spellings, and refusing the whole
+  subcommand would refuse `git checkout main`, which agents do constantly.
+  """
+  if (command.args.length == 0) {
+    return false
+  }
+  const first = command.args[0]
+  if (first.tag != "literal") {
+    return false
+  }
+  if (REFUSED_GIT_ALWAYS.includes(first.text)) {
+    return true
+  }
+  if (first.text == "reset") {
+    return hasFlag(command, "--hard")
+  }
+  if (first.text == "checkout") {
+    // `git checkout .` discards working-tree changes; `git checkout main`
+    // does not.
+    //
+    // `git checkout -- .` is NOT handled here, and cannot be: the parser
+    // rejects a bare `--`, so that string never reaches classification at
+    // all. It falls through as unparseable and is approvable under
+    // `std::bash`.
+    return hasLiteralArg(command, ".")
+  }
+  return false
+}
+
+def hasFlag(command: SimpleCommand, name: string): boolean {
+  for (arg in command.args) {
+    if (arg.tag == "flag" && arg.flagName == name) {
+      return true
+    }
+  }
+  return false
+}
+
+def hasLiteralArg(command: SimpleCommand, text: string): boolean {
+  for (arg in command.args) {
+    if (arg.tag == "literal" && arg.text == text) {
+      return true
+    }
+  }
+  return false
+}
+
+export def bashParser(code: string): Result<BashAST> {
+  """
+  Parse a string of bash code into an AST.
+  """
+  const res = _bashParser(code)
+  return match(res.success) {
+    true => success(res.result)
+    false => failure(res.message)
+  }
 }
 
 def renderFlag(flag: FlagWord): string {
@@ -281,59 +837,7 @@ def renderFlag(flag: FlagWord): string {
   return "${flag.flagName}=${flag.flagValue}"
 }
 
-def tokenize(command: SimpleCommand): Result<string[]> {
-  """
-  A command as a flat list of text tokens: its name, then every argument in
-  source order, with flags rendered back to source form.
-
-  Flags are rendered rather than dropped so a rule can match on them. That
-  matters in both directions: `git diff --staged` is a DIFFERENT tool call
-  from `git diff`, and `echo -n hi` is not `echo hi`. A rule that ignored
-  flags would silently answer one question with the other.
-  """
-  const name = command.command
-  if (name == null) {
-    return failure("an assignment with no command is not handled")
-  }
-  let tokens: string[] = [name.text]
-  for (arg in command.args) {
-    if (arg.tag == "flag") {
-      tokens.push(renderFlag(arg))
-    } else {
-      const text = stringifyArg(arg)
-      if (text is failure(why)) {
-        return failure("could not read a word: ${why}")
-      }
-      tokens.push(text.value)
-    }
-  }
-  return success(tokens)
-}
-
-def echoContent(args: Word[]): Result<string> {
-  """
-  What `echo` would print.
-
-  Any flag refuses: `-n` drops the trailing newline and `-e` interprets
-  backslash escapes, and this does neither, so mapping them would print
-  something different from what bash prints. `echo` with no arguments is
-  still a bare newline, not nothing.
-  """
-  let words: string[] = []
-  for (arg in args) {
-    if (arg.tag == "flag") {
-      return failure("`${renderFlag(arg)}` changes what echo prints")
-    }
-    const text = stringifyArg(arg)
-    if (text is failure(why)) {
-      return failure("could not read a word: ${why}")
-    }
-    words.push(text.value)
-  }
-  return success(joinWords(words))
-}
-
-def resolveCwd(cwd: string): string {
+export def resolveCwd(cwd: string): string {
   """
   Which directory a command runs in: the caller's, or the agent's when the
   caller did not say.
@@ -345,440 +849,133 @@ def resolveCwd(cwd: string): string {
   if (cwd != "") {
     return cwd
   }
-  return getAgentCwd()
+  const agent = getAgentCwd()
+  if (agent != "") {
+    return agent
+  }
+  // `write` rejects an empty dir, and `getAgentCwd()` is empty whenever
+  // nothing set one — which is the case the tests run in.
+  return "."
 }
 
-def writeDir(cwd: string): string {
-  """
-  Where a redirect writes.
-
-  `write` rejects an empty `dir`, so the empty case has to become an
-  explicit "here" or every redirected command fails at write time.
-  """
-  if (cwd == "") {
-    return "."
-  }
-  return cwd
-}
-
-def echoAction(
-  args: Word[],
-  redirect: OutputRedirect | null,
-  cwd: string,
-): Result<Action> {
-  """
-  `echo` prints, unless it is redirected, in which case it writes a file.
-  """
-  const content = echoContent(args)
-  if (content is failure(why)) {
-    return failure(why)
-  }
-  if (redirect == null) {
-    return success({
-      type: "print",
-      content: content.value
-    })
-  }
-  if (redirect.op == ">>") {
-    return success(
-      {
-      type: "writeFile",
-      filename: redirect.path,
-      dir: writeDir(cwd),
-      content: content.value,
-      mode: "append"
-    },
-    )
-  }
-  return success(
-    {
-    type: "writeFile",
-    filename: redirect.path,
-    dir: writeDir(cwd),
-    content: content.value,
-    mode: "overwrite"
-  },
-  )
-}
-
-export def makeAction(
-  command: SimpleCommand,
+export def safeBash(
+  command: string,
   cwd: string = "",
-): Result<Action> {
+): Result<string> raises <std::bash, std::write, std::git::status, std::git::diff, std::git::log> {
   """
-  Decide what a single command means, without doing any of it.
+  Run a shell command, asking the narrowest question that describes it.
 
-  Everything this returns is a plain data object, so the whole mapping can
-  be tested by looking at what comes out. A command with no better mapping
-  becomes a `BashAction`, which is still a decision rather than a hole: it
-  says "this one has to go to bash", and `runAction` is what pays the
-  approval for it.
+  `bash` cannot be pre-approved, because a command is a string and a
+  string could do anything, so every call needs a human. Many of the
+  commands an agent writes can be identified, and for those we ask a more
+  specific question — one a policy can answer in advance.
 
-  @param command - One simple command from the parsed AST
+  Nothing runs until every question is answered. If everything is
+  approved, the whole string goes to bash in one call, so bash does the
+  control flow and produces the output.
+
+  @param command - One or more bash commands
+  @param cwd - Working directory. Defaults to the agent working directory.
   """
-  const fallback = bashFallback(command, cwd)
-
-  // Bash applies a leading assignment to that command only, which is
-  // exactly what running the original text through bash does. There is
-  // nothing to gain by modelling it and a scope bug to be had by trying.
-  if (command.assignments.length > 0) {
-    return fallback
-  }
-
-  const redirect = simplifyRedirects(command.redirects)
-  if (redirect is failure) {
-    return fallback
-  }
-
-  const tokens = tokenize(command)
-  if (tokens is failure) {
-    return fallback
-  }
-
-  const mapped = match(tokens.value) {
-    ["echo", ...rest] => echoAction(command.args, redirect.value, cwd)
-    ["git", "status"] => gitOnly(redirect.value, {
-      type: "gitStatus",
-      cwd: cwd
-    })
-    ["git", "diff"] => gitOnly(redirect.value, {
-      type: "gitDiff",
-      cwd: cwd
-    })
-    ["git", "diff", "--staged"] => gitOnly(
-      redirect.value,
-      {
-      type: "gitDiff",
-      staged: true,
-      cwd: cwd
-    },
-    )
-    ["git", "log"] => gitOnly(redirect.value, {
-      type: "gitLog",
-      cwd: cwd
-    })
-    _ => failure("no tool maps onto this command")
-  }
-  if (mapped is success(action)) {
-    return success(action)
-  }
-  return fallback
-}
-
-def gitOnly(redirect: OutputRedirect | null, action: Action): Result<Action> {
-  """
-  A git action, but only when its output is not being redirected.
-
-  The git tools return their result to us, not to a file. Honouring `>`
-  would mean writing that result ourselves, in a format bash never
-  produces, so a redirected git command goes to bash instead.
-  """
-  if (redirect != null) {
-    return failure("a redirected git command is not handled")
-  }
-  return success(action)
-}
-
-def bashFallback(command: SimpleCommand, cwd: string): Result<Action> {
-  """
-  Run this one command through bash, rendered back from its own AST.
-
-  Rendering from the AST rather than reusing the caller's original string
-  matters in a sequence: if the second of three commands falls back, bash
-  must be given the second command, not all three.
-  """
-  const text = try _astToBash(command)
-  if (text is failure(why)) {
-    return failure("could not render the command back to bash: ${why}")
-  }
-  return success({
-    type: "bash",
-    command: text.value,
-    cwd: cwd
-  })
-}
-
-export def runAction(action: Action): Result<string> {
-  """
-  Do what the action says. The only step with effects.
-  """
-  if (action.type == "print") {
-    return printAction(action)
-  }
-  if (action.type == "writeFile") {
-    return writeAction(action)
-  }
-  if (action.type == "gitStatus") {
-    return gitStatusAction(action)
-  }
-  if (action.type == "gitDiff") {
-    return gitDiffAction(action)
-  }
-  if (action.type == "gitLog") {
-    return gitLogAction(action)
-  }
-  return bashAction(action)
-}
-
-export def runCommand(command: Command, cwd: string = ""): Result<string> {
-  """
-  Run one command, whatever shape it is.
-
-  Every branch returns a `Result`, and a failure is never swallowed: the
-  caller has to decide what a failed command means, because `&&` and `||`
-  answer that question differently.
-  """
-  if (command.tag == "simpleCommand") {
-    return runSimpleCommand(command, cwd)
-  }
-  if (command.tag == "and") {
-    return andCommand(command, cwd)
-  }
-  if (command.tag == "or") {
-    return orCommand(command, cwd)
-  }
-  if (command.tag == "parens") {
-    return parensCommand(command, cwd)
-  }
-  return failure("unexpected AST shape: this is not a command")
-}
-
-def runSimpleCommand(command: SimpleCommand, cwd: string): Result<string> {
-  """
-  Decide what the command means, then do it.
-  """
-  const action = makeAction(command, cwd)
-  if (action is failure(why)) {
-    return failure(why)
-  }
-  return runAction(action.value)
-}
-
-def andCommand(command: And, cwd: string): Result<string> {
-  """
-  `a && b` — run the right side only if the left side succeeded.
-
-  A failing left side is still a failure of the whole chain, and carries
-  its own message, so the report says which half stopped it.
-  """
-  const left = runCommand(command.left, cwd)
-  if (left is failure) {
-    return left
-  }
-  const right = runCommand(command.right, cwd)
-  if (right is failure(why)) {
-    // The left side really ran, so its output belongs in the report even
-    // though the chain failed. Dropping it makes `runCommands` claim to
-    // show "what already ran" while hiding part of it. It goes AFTER the
-    // reason, and labelled, so the report does not read as though the
-    // output were the error.
-    if (left.value == "") {
-      return failure(why)
-    }
-    return failure("${why}\n\nOutput before the failure:\n${left.value}")
-  }
-  return success(joinOutput([left.value, right.value]))
-}
-
-def orCommand(command: Or, cwd: string): Result<string> {
-  """
-  `a || b` — run the right side only if the left side failed.
-
-  A succeeding left side means the right side never runs, and the chain
-  succeeds. If both fail the chain fails, carrying both messages, because
-  a report naming only the second would hide why the first was tried.
-  """
-  const left = runCommand(command.left, cwd)
-  if (left is success(text)) {
-    return success(text)
-  }
-  const right = runCommand(command.right, cwd)
-  if (right is success(text)) {
-    return success(text)
-  }
-  return failure(joinOutput([left.error, right.error]))
-}
-
-def parensCommand(command: Parens, cwd: string): Result<string> {
-  """
-  `( a && b )` — grouping. The parser rejects `;` inside parens, so there
-  is exactly one command in here.
-  """
-  return runCommand(command.command, cwd)
-}
-
-def joinOutput(parts: string[]): string {
-  """
-  Join what several commands produced, dropping the ones that produced
-  nothing so a silent command does not leave a blank line behind.
-  """
-  const kept = [p for p in parts if p != ""]
-  return kept.join("\n")
-}
-
-export def commandsToStr(commands: Command[]): string {
-  """
-  Render commands back to bash source, one per line.
-  """
-  const results: string[] = []
-  for (command in commands) {
-    const result = try _astToBash(command)
-    match(result) {
-      success(text) => results.push(text)
-      failure(err) => results.push("<could not render this command: ${err}>")
-    }
-  }
-  return results.join("\n")
-}
-
-export def runCommands(commands: Command[], cwd: string = ""): Result<string> {
-  """
-  Run a sequence of commands, stopping at the first failure.
-
-  On a failure the model gets the whole picture rather than a bare error:
-  what already ran and what it produced, which command failed and why, and
-  what never ran. There is no falling back to bash for the sequence — some
-  of it has already happened, and re-running the lot would repeat it.
-  """
-  const results: string[] = []
-  for (command, i in commands) {
-    const result = runCommand(command, cwd)
-    if (result is failure(why)) {
-      return failure(failureReport(commands, i, results, why))
-    }
-    results.push(result.value)
-  }
-  return success(joinOutput(results))
-}
-
-def failureReport(
-  commands: Command[],
-  failedAt: number,
-  results: string[],
-  why: string,
-): string {
-  """
-  What the model is told when a sequence stops partway.
-  """
-  const ran = commands[:failedAt]
-  const notRun = commands[failedAt + 1:]
-  let report = "Command `${commandsToStr([commands[failedAt]])}` failed: ${why}"
-  if (ran.length > 0) {
-    report = report + "\n\nCommands run:\n${commandsToStr(ran)}"
-  }
-  const output = joinOutput(results)
-  if (output != "") {
-    report = report + "\n\nOutput so far:\n<results>\n${output}\n</results>"
-  }
-  if (notRun.length > 0) {
-    report = report + "\n\nCommands not run:\n${commandsToStr(notRun)}"
-  }
-  return report
-}
-
-export def makeActions(source: string, cwd: string = ""): Result<Action[]> {
-  """
-  Every action a string of bash would turn into, without running any of it.
-
-  This is the whole decision-making half of the module in one call, which
-  is what makes it testable: hand it a string, look at what comes out.
-
-  The list is in source order and includes both halves of a `&&` or `||`,
-  so it says what each command WOULD do, not what will actually run — only
-  running the chain decides that.
-
-  @param source - One or more bash commands
-  """
-  const parsed = bashParser(source)
-  if (parsed is failure(why)) {
-    return failure(why)
-  }
-  const commands: Command[] = parsed.value
   const dir = resolveCwd(cwd)
-  let actions: Action[] = []
-  for (command in commands) {
-    const some = actionsFor(command, dir)
-    if (some is failure(why)) {
-      return failure(why)
+  const plan = planFor(command, dir)
+
+  if (plan.execution.kind == "refuse") {
+    return failure(plan.execution.reason)
+  }
+
+  const raised = raiseAll(plan.effects, command, dir)
+  if (raised is failure(why)) {
+    return failure(why)
+  }
+
+  if (plan.execution.kind == "echo") {
+    // Truncated like every other path. A long echo returning in full
+    // while a long `ls` came back capped would be exactly the
+    // distinguishability this design exists to remove.
+    return success(truncate(plan.execution.content))
+  }
+  if (plan.execution.kind == "write") {
+    return runWrite(plan.execution)
+  }
+  // `planFor` already decided which text to run — rebuilt when it asked
+  // narrow questions, original when it asked the broad one. There is no
+  // fallback here: choosing the original AFTER raising narrow effects
+  // would break the design's first hard rule.
+  return runBash(plan.execution.command, dir)
+}
+
+def raiseAll(effects: Effect[], fullCommand: string, cwd: string): Result {
+  """
+  Ask every question the plan needs answered, before anything happens.
+  """
+  for (effect in effects) {
+    const answered = raiseOne(effect, fullCommand, cwd)
+    if (answered is failure(reason)) {
+      return failure(reason)
     }
-    actions = [...actions, ...some.value]
   }
-  return success(actions)
+  return success(null)
 }
 
-def actionsFor(command: Command, cwd: string): Result<Action[]> {
+def raiseOne(effect: Effect, fullCommand: string, cwd: string): Result {
   """
-  Flatten one command into the actions it would produce.
+  Raise one effect.
+
+  An effect is raised at a named site, not by name-as-data, so this is a
+  closed dispatch with one arm per effect. That is also why safeBash
+  declares them all in its `raises` clause: it is how an agent author
+  discovers which handlers to write.
+
+  Every payload carries the full command string. A human approving a git
+  read inside `echo hi; git status` needs to see the whole thing, not the
+  fragment.
   """
-  if (command.tag == "simpleCommand") {
-    return wrapOne(makeAction(command, cwd))
+  if (effect.name == "std::bash") {
+    raise std::bash("Are you sure you want to run this shell command?", {
+      command: fullCommand,
+      cwd: cwd,
+      timeout: 0,
+      stdin: ""
+    })
+    return success(null)
   }
-  if (command.tag == "and") {
-    return bothSides(command.left, command.right, cwd)
+  if (effect.name == "std::write") {
+    raise std::write("Are you sure you want to write to this file?", {
+      dir: effect.payload.dir,
+      filename: effect.payload.filename,
+      content: effect.payload.content,
+      mode: effect.payload.mode,
+      command: fullCommand
+    })
+    return success(null)
   }
-  if (command.tag == "or") {
-    return bothSides(command.left, command.right, cwd)
+  if (effect.name == "std::git::status") {
+    raise std::git::status("Show git status", {
+      cwd: effect.payload.cwd,
+      command: fullCommand
+    })
+    return success(null)
   }
-  if (command.tag == "parens") {
-    return actionsFor(command.command, cwd)
+  if (effect.name == "std::git::log") {
+    raise std::git::log("Show git log", {
+      cwd: effect.payload.cwd,
+      ref: effect.payload.ref,
+      path: effect.payload.path,
+      command: fullCommand
+    })
+    return success(null)
   }
-  return failure("unexpected AST shape: this is not a command")
-}
-
-def wrapOne(action: Result<Action>): Result<Action[]> {
-  if (action is failure(why)) {
-    return failure(why)
+  if (effect.name == "std::git::diff") {
+    raise std::git::diff("Show git diff", {
+      cwd: effect.payload.cwd,
+      ref: effect.payload.ref,
+      ref2: effect.payload.ref2,
+      staged: effect.payload.staged,
+      path: effect.payload.path,
+      command: fullCommand
+    })
+    return success(null)
   }
-  return success([action.value])
-}
-
-def bothSides(left: Command, right: Command, cwd: string): Result<Action[]> {
-  const first = actionsFor(left, cwd)
-  if (first is failure(why)) {
-    return failure(why)
-  }
-  const second = actionsFor(right, cwd)
-  if (second is failure(why)) {
-    return failure(why)
-  }
-  return success([...first.value, ...second.value])
-}
-
-export def safeBash(command: string, cwd: string = ""): Result<string> {
-  """
-  Run a shell command, using an equivalent tool where one exists.
-
-  `bash` cannot be pre-approved — there is no way to say in advance what an
-  arbitrary command string will do — so every call needs a human. Many of
-  the commands an agent writes have a tool that does the same job and IS
-  pre-approved. This parses the command and uses that tool when it can.
-
-  A command with no equivalent still runs, through bash, approval and all.
-  What is NOT possible is silently doing something other than what was
-  asked: a command that cannot be mapped is handed to bash unchanged, and a
-  sequence that fails partway says exactly how far it got.
-
-  @param command - The shell command to run
-  @param cwd - Working directory
-  """
-  const parsed = bashParser(command)
-  if (parsed is failure) {
-    // Nothing ran, so handing the whole string to bash repeats nothing.
-    return bashAction(
-      {
-      type: "bash",
-      command: command,
-      cwd: cwd
-    },
-    )
-  }
-  return runCommands(parsed.value)
-}
-
-def joinWords(words: string[]): string {
-  """
-  Rejoin a command's arguments the way echo prints them: single-spaced, with
-  a trailing newline. `echo` with no arguments is still a newline.
-  """
-  return words.join(" ") + "\n"
+  return failure("no raise site for `${effect.name}`")
 }

--- a/packages/agency-lang/stdlib/safeBash.agency
+++ b/packages/agency-lang/stdlib/safeBash.agency
@@ -4,6 +4,7 @@
 // dropping them makes `raise std::git::status("...", { wrongField: x })`
 // typecheck clean. `std::write` is covered by the auto-imported prelude.
 import { gitStatus } from "std::git"
+import { WriteMode } from "std::index"
 import { bash } from "std::shell"
 
 import {
@@ -228,9 +229,12 @@ def literalTarget(word: Word): Result<string> {
   return literalWordText(word)
 }
 
-def writeMode(op: string): string {
+def writeMode(op: string): WriteMode {
   """
   `>` truncates, `>>` appends.
+
+  The return type is narrowed rather than `string` so an invalid mode
+  cannot reach the `std::write` payload or the `_write` call.
   """
   if (op == ">>") {
     return "append"
@@ -381,7 +385,7 @@ def emptyExecution(): Execution {
     content: "",
     filename: "",
     dir: "",
-    mode: "",
+    mode: "overwrite",
     reason: ""
   }
 }

--- a/packages/agency-lang/stdlib/safeBash/actions.agency
+++ b/packages/agency-lang/stdlib/safeBash/actions.agency
@@ -11,6 +11,8 @@
   interrupts and the caller has already raised a narrower one. See the
   comment on `runBash`.
 */
+import { WriteMode } from "std::index"
+
 import { _write } from "agency-lang/stdlib-lib/builtins.js"
 import { _bash } from "agency-lang/stdlib-lib/shell.js"
 
@@ -33,7 +35,7 @@ export type WritePayload = {
   dir: string;
   filename: string;
   content: string;
-  mode: string
+  mode: WriteMode
 }
 
 export type GitDiffPayload = {
@@ -51,7 +53,7 @@ export type Execution = {
   content: string;
   filename: string;
   dir: string;
-  mode: string;
+  mode: WriteMode;
   reason: string
 }
 

--- a/packages/agency-lang/stdlib/safeBash/actions.agency
+++ b/packages/agency-lang/stdlib/safeBash/actions.agency
@@ -1,141 +1,144 @@
 /** @module
-  The things a bash command can turn into.
+  What safeBash decides, and the three ways it can carry that out.
 
-  Every command `safeBash` runs is first translated into an `Action`: a plain
-  data object saying what should happen, with nothing having happened yet.
-  Deciding *what* a command means and *doing* it are separate steps, so the
-  deciding half can be tested by handing in a string and looking at the
-  actions that come out.
+  A `Plan` is the whole decision about one call, made before anything
+  happens: which interrupts to raise, and what to run if they are all
+  approved. Deciding and doing are separate steps so the deciding half can
+  be tested by handing in a string and looking at the plan.
 
-  `bash` itself is an action, so a command with no better mapping is still
-  represented here rather than being a hole in the model.
+  The executors call the NON-RAISING internals (`_bash`, `_write`) rather
+  than the `bash` and `write` tools, because those raise their own
+  interrupts and the caller has already raised a narrower one. See the
+  comment on `runBash`.
 */
-import { gitStatus, gitDiff, gitLog } from "std::git"
-import { bash } from "std::shell"
+import { _write } from "agency-lang/stdlib-lib/builtins.js"
+import { _bash } from "agency-lang/stdlib-lib/shell.js"
 
 /** How much of a command's output to keep before truncating. */
 export static const MAX_STDOUT_LEN = 2000
 
-export type Action =
-  | PrintAction
-  | WriteFileAction
-  | GitAction
-  | BashAction
+/** One interrupt a command needs raised before it may run.
+ *
+ * A discriminated union rather than a bag of `any`: the effect set is
+ * closed, so each payload can be typed, and typing them is what makes the
+ * raise sites check that every payload satisfies its effect's contract. */
+export type Effect =
+  | { name: "std::bash" }
+  | { name: "std::write"; payload: WritePayload }
+  | { name: "std::git::status"; payload: { cwd: string } }
+  | { name: "std::git::log"; payload: { cwd: string; ref: string; path: string } }
+  | { name: "std::git::diff"; payload: GitDiffPayload }
 
-export type PrintAction = {
-  type: "print";
-  content: string
+export type WritePayload = {
+  dir: string;
+  filename: string;
+  content: string;
+  mode: string
 }
 
-export type WriteFileAction = {
-  type: "writeFile";
+export type GitDiffPayload = {
+  cwd: string;
+  ref: string;
+  ref2: string;
+  staged: boolean;
+  path: string
+}
+
+/** What happens if every effect in the plan is approved. */
+export type Execution = {
+  kind: string;
+  command: string;
+  content: string;
   filename: string;
   dir: string;
-  content: string;
-  mode: "append" | "overwrite"
+  mode: string;
+  reason: string
 }
 
-export type GitAction = GitStatusAction | GitDiffAction | GitLogAction
-
-export type GitStatusAction = {
-  type: "gitStatus";
-  cwd?: string
+/** The whole decision about one call to safeBash, made before anything runs. */
+export type Plan = {
+  effects: Effect[];
+  execution: Execution
 }
 
-export type GitDiffAction = {
-  type: "gitDiff";
-  path?: string;
-  staged?: boolean;
-  cwd?: string
-}
-
-export type GitLogAction = {
-  type: "gitLog";
-  path?: string;
-  cwd?: string
-}
-
-/** The fallback: run the command through bash exactly as written.
- *
- * `command` is the command re-rendered from its AST, not the caller's
- * original string, so a sequence that runs three commands and falls back on
- * the second sends bash only the second one. */
-export type BashAction = {
-  type: "bash";
-  command: string;
-  cwd?: string
-}
-
-export def printAction(action: PrintAction): Result<string> {
+export def runBash(command: string, cwd: string): Result<string> {
   """
-  Print to stdout. No interrupt: printing has no effect to approve.
+  Run a command string through bash and return what it printed.
+
+  On success the value is bash's stdout, raw — nothing added, nothing
+  stripped. stderr is discarded on success and reported on failure: two
+  captured pipes cannot interleave the way a terminal does, so this is a
+  policy either way, and discarding on success keeps the value exactly
+  equal to bash's stdout.
+
+  A non-zero exit is a failure, which `&&` and `||` require. The known
+  cost: `grep` exits 1 when it finds nothing and `diff` exits 1 when files
+  differ, and neither is an error.
   """
-  print(action.content)
-  return success(action.content)
+  // `_bash`, NOT `bash`. The `bash` tool raises `std::bash` itself, so
+  // calling it here would ask the broad question again — after the human
+  // already answered a narrower one — and the entire feature would be a
+  // no-op.
+  //
+  // Bypassing a tool's interrupt is normally forbidden: handlers are
+  // safety infrastructure. It is correct here for one specific reason,
+  // and only while that reason holds: the narrow interrupt REPLACES the
+  // broad one, and the only path into this function runs through a
+  // `raiseAll` that raised every effect in the plan and returned success.
+  // Every plan raises at least one effect, so no classification bug can
+  // turn into an ungated shell call.
+  const attempt = try _bash(command, cwd, 0, "", {})
+  if (attempt is failure(why)) {
+    return failure("`${command}` was not run: ${why}")
+  }
+  // `try` WRAPS the call in a Result, so the ExecResult is inside
+  // `.value`. Reading `attempt.stdout` directly is undefined.
+  const result: any = attempt.value
+  const out = truncate(result.stdout)
+  if (result.exitCode != 0) {
+    return failure(
+      JSON.stringify(
+      {
+      command: command,
+      exitCode: result.exitCode,
+      stderr: truncate(result.stderr),
+      stdout: out
+    },
+    ),
+    )
+  }
+  return success(out)
 }
 
-export def writeAction(action: WriteFileAction): Result<string> {
+export def truncate(text: string): string {
   """
-  Write a file. `write` raises the `std::write` interrupt, so this is gated
-  the same way any other write is.
+  Cap output length. Raw output with no bound is a context-window hazard,
+  and a visible loss of fidelity beats an invisible one.
   """
-  const written = write(
-    filename: action.filename,
-    content: action.content,
-    dir: action.dir,
-    mode: action.mode,
-  )
-  if (written is failure(reason)) {
-    return failure(reason)
+  if (text.length <= MAX_STDOUT_LEN) {
+    return text
+  }
+  return text[:MAX_STDOUT_LEN] + "\n[truncated]"
+}
+
+export def runWrite(exec: Execution): Result<string> {
+  """
+  Perform the write a redirected echo asked for. Returns the empty string,
+  which is what bash's stdout for `echo hi > f` is.
+
+  `_write`, NOT `write`, for the same reason `runBash` uses `_bash`: the
+  `write` tool raises its own `std::write`, and the caller already raised
+  one carrying the content.
+  """
+  // `destructive { }` because `write()` wraps `_write` in one, and that
+  // marker feeds the tool-loop retry rules. Calling `_write` directly
+  // without it would give this write a different retry classification
+  // from the tool it replaces.
+  destructive {
+    const written = try _write(exec.dir, exec.filename, exec.content, exec.mode)
+    if (written is failure(why)) {
+      return failure(why)
+    }
   }
   return success("")
-}
-
-export def gitStatusAction(action: GitStatusAction): Result<string> {
-  const status = gitStatus(cwd: action.cwd ?? "")
-  return success(JSON.stringify(status))
-}
-
-export def gitDiffAction(action: GitDiffAction): Result<string> {
-  const diff = gitDiff(
-    path: action.path ?? "",
-    staged: action.staged ?? false,
-    cwd: action.cwd ?? "",
-  )
-  return success(JSON.stringify(diff))
-}
-
-export def gitLogAction(action: GitLogAction): Result<string> {
-  const log = gitLog(path: action.path ?? "", cwd: action.cwd ?? "")
-  return success(JSON.stringify(log))
-}
-
-export def bashAction(action: BashAction): Result<string> {
-  """
-  Run the command through bash, approval and all.
-
-  A non-zero exit is a failure rather than a success carrying a bad exit
-  code, so a `&&` chain stops on it the way bash would.
-  """
-  // `any` because `bash` is DECLARED to return an ExecResult, but a rejected
-  // approval halts it and hands back a failure instead, which the declared
-  // type cannot describe.
-  const result: any = bash(action.command, action.cwd ?? "")
-  // Reading an exit code off that failure is a crash on the most ordinary
-  // path there is: a human saying no.
-  if (result is failure(why)) {
-    return failure("`${action.command}` was not run: ${why}")
-  }
-  const data = JSON.stringify(
-    {
-    command: action.command,
-    stdout: result.stdout[:MAX_STDOUT_LEN],
-    stderr: result.stderr[:MAX_STDOUT_LEN],
-    exitCode: result.exitCode
-  },
-  )
-  if (result.exitCode != 0) {
-    return failure(data)
-  }
-  return success(data)
 }

--- a/packages/agency-lang/tests/agency/safeBash.agency
+++ b/packages/agency-lang/tests/agency/safeBash.agency
@@ -1,193 +1,258 @@
-import { makeActions, bashParser, runCommands } from "std::safeBash"
+import {
+  bashParser,
+  isRefused,
+  effectsFor,
+  planFor,
+  safeBash,
+  resolveCwd,
+ } from "std::safeBash"
 
-def actionTypes(command: string): any {
-  // What KIND of action each command becomes. The fallback matters as much
-  // as the mapping: "bash" means safeBash declined to map it and the human
-  // still has to approve it.
-  const actions = makeActions(command)
-  if (actions is success(list)) {
-    return [a.type for a in list]
+def refusedFor(source: string): any {
+  const parsed = bashParser(source)
+  if (parsed is failure(why)) {
+    return "UNPARSEABLE"
   }
-  return ["REFUSED: ${actions.error}"]
-}
-
-def actionsOf(command: string): any {
-  const actions = makeActions(command)
-  if (actions is success(list)) {
-    return list
+  const first = parsed.value[0]
+  if (first.tag != "simpleCommand") {
+    return "NOT-SIMPLE"
   }
-  return "REFUSED: ${actions.error}"
+  return isRefused(first)
 }
 
-node echoBecomesPrint() {
-  // The whole point: this used to need a human, and now it is a print.
-  return actionsOf("echo hello world")
-}
-
-node echoRedirectBecomesWrite() {
-  // Redirected, the same command is a file write, which `write` gates.
-  return [actionsOf("echo hi > out.txt"), actionsOf("echo hi >> out.txt")]
-}
-
-node echoQuotingIsPreserved() {
-  // Quotes delimit a word, they are not part of its value, and adjacent
-  // parts concatenate into one word.
-  return [actionTypes("echo 'single quoted'"), actionsOf("echo a'b'\"c\"")]
-}
-
-node echoFlagsFallBackToBash() {
-  // `-n` drops the trailing newline and `-e` interprets escapes. Printing
-  // the flag as if it were text would print something bash never would, so
-  // both go to bash instead.
-  return [actionsOf("echo -n hi"), actionTypes("echo -e hi")]
-}
-
-node echoWithNoArgs() {
-  // Still a newline, not nothing.
-  return actionsOf("echo")
-}
-
-node gitSubcommandsMap() {
-  return [actionTypes("git status"), actionTypes("git diff"), actionTypes("git log")]
-}
-
-node gitStagedIsItsOwnAction() {
-  // `--staged` is a different question from a bare `git diff`, so it has to
-  // reach the action rather than being dropped on the way.
-  return actionsOf("git diff --staged")
-}
-
-node unknownGitFlagsFallBackToBash() {
-  // Answering `git log --graph` with a plain gitLog() would silently give
-  // the model something other than what it asked for.
-  return [actionTypes("git log --graph"), actionTypes("git status --short")]
-}
-
-node unmappedCommandsFallBackToBash() {
+node refuseWall() {
   return [
-    actionTypes("ls"),
-    actionTypes("cat src/main.ts"),
-    actionTypes("./script.sh"),
+    refusedFor("rm -rf build"),
+    refusedFor("/bin/rm -rf build"),
+    refusedFor("./rm thing"),
+    refusedFor("dd if=a of=b"),
+    refusedFor("git clean -fd"),
+    refusedFor("git reset --hard"),
+    refusedFor("git restore src"),
+    refusedFor("git reset HEAD"),
+    refusedFor("git checkout main"),
+    refusedFor("git checkout ."),
+    refusedFor("git log reset"),
+    refusedFor("git status"),
+    refusedFor("echo hi"),
   ]
 }
 
-node fallbackRendersOnlyItsOwnCommand() {
-  // In a sequence, the command handed to bash must be the one that fell
-  // through, not the whole string.
-  return actionsOf("echo hi; ls -la; echo bye")
+def effectNamesFor(source: string): any {
+  const parsed = bashParser(source)
+  if (parsed is failure(why)) {
+    return "UNPARSEABLE"
+  }
+  const first = parsed.value[0]
+  if (first.tag != "simpleCommand") {
+    return "NOT-SIMPLE"
+  }
+  const effects = effectsFor(first, "/repo")
+  if (effects is failure(why)) {
+    return "UNRECOGNIZED"
+  }
+  return [e.name for e in effects.value]
 }
 
-node sequencesProduceOneActionEach() {
-  return actionTypes("echo one; echo two; echo three")
-}
-
-node bothSidesOfAChainAreListed() {
-  // makeActions says what each command WOULD do. Which side actually runs
-  // is decided at run time by the exit status.
+node classifyOneCommand() {
   return [
-    actionTypes("echo a && echo b"),
-    actionTypes("echo a || echo b"),
-    actionTypes("(echo a && echo b) || echo c"),
+    effectNamesFor("git status"),
+    effectNamesFor("git diff"),
+    effectNamesFor("git diff --staged"),
+    effectNamesFor("git log"),
+    effectNamesFor("echo hi"),
+    effectNamesFor("ls"),
+    effectNamesFor("git log --graph"),
+    effectNamesFor("/bin/git status"),
+    effectNamesFor("FOO=1 git status"),
+    effectNamesFor("echo -n hi"),
+    effectNamesFor("echo \"quoted\""),
+    effectNamesFor("git diff --staged --stat"),
   ]
 }
 
-node assignmentsFallBackToBash() {
-  // Bash scopes a leading assignment to that one command, and running the
-  // original text through bash reproduces that exactly.
-  return [actionTypes("FOO=1 echo hi"), actionTypes("FOO=1")]
-}
-
-node redirectShapesWeDoNotHandle() {
+node redirectsContribute() {
   return [
-    actionTypes("echo hi 2> err.txt"),
-    actionTypes("echo hi < in.txt"),
-    actionTypes("git status > out.txt"),
+    effectNamesFor("git status > out.txt"),
+    effectNamesFor("echo hi > out.txt"),
+    effectNamesFor("echo hi >> out.txt"),
+    effectNamesFor("echo hi > $F"),
+    effectNamesFor("echo hi < in.txt"),
+    effectNamesFor("echo hi 2> err.txt"),
+    effectNamesFor("echo hi > a.txt > b.txt"),
   ]
 }
 
-node shellTransformsAreUnparseable() {
-  // bash rewrites an unquoted word before the command runs, so passing one
-  // through as text would run a different command than the user wrote — the
-  // one failure mode this module must not have. The parser refuses them
-  // outright. Quoted, they are ordinary text and still map.
+def planSummary(source: string): any {
+  const plan = planFor(source, "/repo")
+  return [plan.execution.kind, [e.name for e in plan.effects]]
+}
+
+node wholeStringPlans() {
   return [
-    actionTypes("echo *"),
-    actionTypes("echo ~/d"),
-    actionTypes("echo $(date)"),
-    actionTypes("cat a.txt | grep x"),
-    actionTypes("sleep 1 &"),
-    actionTypes("echo \"a*b\""),
+    planSummary("git status"),
+    planSummary("git status; git log"),
+    planSummary("git status; ls"),
+    planSummary("ls"),
+    planSummary("echo hi; echo bye"),
+    planSummary("rm -rf build"),
+    planSummary("git status; rm -rf build"),
+    planSummary("cat a.txt | grep x"),
+    planSummary("git status && git log"),
+    planSummary("true && rm -rf /tmp/x"),
+    planSummary("(git status && git log)"),
+    planSummary("git status && ls"),
   ]
 }
 
-node emptyExpansionsFallBackToBash() {
-  // An unset variable produces NO argument in bash, where expanding it to
-  // "" here would produce an empty one. True of a whole word and of a word
-  // made only of empty parts.
+node rebuiltVersusOriginal() {
+  // Hard rule #1. Multi-space input makes it observable: re-rendering
+  // normalizes whitespace, so on the narrow path `execution.command` must
+  // be the NORMALIZED form, and on the broad path it must be the caller's
+  // text VERBATIM.
   return [
-    actionsOf("echo $NOPE_NOT_SET"),
-    actionTypes("echo $NOPE_A$NOPE_B"),
-    actionsOf("echo \"$NOPE_NOT_SET\""),
-    actionsOf("echo $NOPE_NOT_SET/bin"),
+    planFor("git    status", "/repo").execution.command,
+    planFor("ls    -la", "/repo").execution.command,
   ]
 }
 
-node quotedEmptyIsARealArgument() {
-  // `""` is an argument bash really does pass.
-  return actionsOf("echo \"\"")
+def planDetail(source: string): any {
+  const plan = planFor(source, "/repo")
+  return [plan.execution.kind, plan.execution.content, [e.name for e in plan.effects]]
 }
 
-node runningASequenceReportsWhatRan() {
-  // A failure stops the sequence and says how far it got, what it produced,
-  // and what never ran. There is no falling back for the sequence: some of
-  // it already happened.
-  const parsed = bashParser("echo one; git log --graph --nope; echo three")
-  if (parsed is success(ast)) {
-    const result = runCommands(ast)
-    if (result is failure(why)) {
-      return why
-    }
-    return "UNEXPECTEDLY SUCCEEDED"
-  }
-  return "UNPARSEABLE"
+node shellFreeEcho() {
+  return [
+    planDetail("echo hello world"),
+    planDetail("echo"),
+    planDetail("echo 'a  b'"),
+    planDetail("echo $HOME"),
+    planDetail("echo \"$HOME\""),
+    planDetail("echo \"a b\" c"),
+    planDetail("echo -n hi"),
+    planDetail("echo hi; echo bye"),
+  ]
 }
 
-node andStopsOnFailure() {
-  // `false && echo b` must not print b.
-  const parsed = bashParser("git log --graph --nope && echo should-not-run")
-  if (parsed is success(ast)) {
-    const result = runCommands(ast)
-    return [
-      result is failure,
-      actionTypes("git log --graph --nope && echo should-not-run"),
-    ]
-  }
-  return ["UNPARSEABLE"]
+def writePlanDetail(source: string): any {
+  const plan = planFor(source, "/repo")
+  const exec = plan.execution
+  // `mode` is in the tuple deliberately. Without it, a `writeMode` that
+  // always returned "overwrite" survives the whole suite, and
+  // `echo hi >> notes.txt` silently TRUNCATES the file.
+  return [
+    exec.kind,
+    exec.content,
+    exec.filename,
+    exec.dir,
+    exec.mode,
+    [e.name for e in plan.effects],
+  ]
 }
 
-node cwdReachesEveryAction() {
-  // The caller's cwd has to land on EVERY action, not just the unparseable
-  // fallback. The same command in two directories is two different
-  // commands, so an action that did not carry it would run wherever the
-  // process happened to be.
-  const actions = makeActions("echo hi > out.txt; git status; ls", "/tmp/somewhere")
-  if (actions is success(list)) {
-    return list
-  }
-  return "REFUSED: ${actions.error}"
+node shellFreeWrite() {
+  return [
+    writePlanDetail("echo hi > out.txt"),
+    writePlanDetail("echo hi >> out.txt"),
+    writePlanDetail("echo hi > $F"),
+    writePlanDetail("echo $HOME > out.txt"),
+  ]
 }
 
-node chainKeepsTheLeftSidesOutput() {
-  // `a && b` where a succeeds and b fails: a really ran, so its output
-  // belongs in the report. Dropping it would make the report claim to show
-  // what already ran while hiding part of it.
-  const parsed = bashParser("echo kept && git log --graph --nope")
-  if (parsed is success(ast)) {
-    const result = runCommands(ast)
-    if (result is failure(why)) {
-      return why
-    }
-    return "UNEXPECTEDLY SUCCEEDED"
+node payloadValuesAreCorrect() {
+  // Every other classification test asserts effect NAMES. A staged diff
+  // and an unstaged diff share a name, so only the payload tells them
+  // apart. This also pins cwd threading into git payloads.
+  const staged = planFor("git diff --staged", "/repo")
+  const redirected = planFor("git status > out.txt", "/repo")
+  // `any` here only. Effect is a discriminated union so the raise sites in
+  // the module typecheck their payloads; a test reading payloads
+  // generically would have to narrow five times to say nothing extra.
+  const diffPayload: any = staged.effects[0]
+  const writeEffect: any = redirected.effects[1]
+  return [
+    diffPayload.payload.staged,
+    diffPayload.payload.cwd,
+    writeEffect.name,
+    writeEffect.payload.filename,
+    writeEffect.payload.dir,
+    writeEffect.payload.mode,
+  ]
+}
+
+node writeContentIsInThePayload() {
+  const plan = planFor("echo hi > out.txt", "/repo")
+  const effect: any = plan.effects[0]
+  return effect.payload.content
+}
+
+node echoRunsWithoutApproval() {
+  // No interrupt and no shell. If this ever routed through bash, an
+  // unlisted interrupt would leave the raw interrupt array as the result
+  // and this comparison would fail.
+  const result = safeBash("echo hello world")
+  if (result is failure(why)) {
+    return "FAILED: ${why}"
   }
-  return "UNPARSEABLE"
+  return result.value
+}
+
+node exactlyOneQuestion() {
+  // The test that actually pins the feature. It APPROVES the narrow
+  // question and asserts the command ran. A test that only rejects the
+  // first interrupt passes whether or not a second std::bash prompt
+  // appears — which is how calling `bash()` instead of `_bash()` hides.
+  const result = safeBash("git status")
+  if (result is failure(why)) {
+    return "FAILED"
+  }
+  return "RAN"
+}
+
+node refusedNeverRuns() {
+  const result = safeBash("rm -rf build")
+  if (result is failure(why)) {
+    return why
+  }
+  return "UNEXPECTEDLY RAN"
+}
+
+node sequenceRunsThroughBash() {
+  // The measured divergence that motivated the redesign: v2 returned
+  // "hi\n\nbye\n" where bash returns "hi\nbye\n".
+  const result = safeBash("echo hi && echo bye")
+  if (result is failure(why)) {
+    return "FAILED: ${why}"
+  }
+  return result.value
+}
+
+node nonZeroExitIsAFailure() {
+  const result = safeBash("false")
+  if (result is failure(why)) {
+    return "FAILED"
+  }
+  return "UNEXPECTEDLY SUCCEEDED"
+}
+
+node appendReallyAppends() {
+  // The executor is called positionally, and no other test runs it, so a
+  // swapped argument order survives everything else.
+  safeBash("echo one > __safebash_append__.txt")
+  safeBash("echo two >> __safebash_append__.txt")
+  const back = read("__safebash_append__.txt") with approve
+  if (back is failure(why)) {
+    return "READ FAILED"
+  }
+  return back.value
+}
+
+node defaultCwdIsNeverEmpty() {
+  // `write` rejects an empty dir, and `getAgentCwd()` is empty whenever
+  // nothing set one — which is the case these tests run in.
+  return [resolveCwd(""), resolveCwd("/somewhere")]
+}
+
+node quotedRedirectTarget() {
+  // A quoted target with no variable is a real filename, so it maps.
+  return writePlanDetail("echo hi > \"my file.txt\"")
 }

--- a/packages/agency-lang/tests/agency/safeBash.agency
+++ b/packages/agency-lang/tests/agency/safeBash.agency
@@ -1,3 +1,4 @@
+import { remove } from "std::fs"
 import {
   bashParser,
   isRefused,
@@ -240,6 +241,7 @@ node appendReallyAppends() {
   safeBash("echo one > __safebash_append__.txt")
   safeBash("echo two >> __safebash_append__.txt")
   const back = read("__safebash_append__.txt") with approve
+  remove("__safebash_append__.txt") with approve
   if (back is failure(why)) {
     return "READ FAILED"
   }
@@ -255,4 +257,18 @@ node defaultCwdIsNeverEmpty() {
 node quotedRedirectTarget() {
   // A quoted target with no variable is a real filename, so it maps.
   return writePlanDetail("echo hi > \"my file.txt\"")
+}
+
+node longOutputIsTruncated() {
+  // The only new behavior with no coverage: deleting the cap, or the
+  // marker, survives every other test. A >2000-char literal goes through
+  // the shell-free path, which truncates too — so this also pins the
+  // consistency between that path and the bash path.
+  const chars = ["x" for i in range(2500)]
+  const long = chars.join("")
+  const result = safeBash("echo ${long}")
+  if (result is failure(why)) {
+    return "FAILED"
+  }
+  return [result.value.length, result.value.endsWith("\n[truncated]")]
 }

--- a/packages/agency-lang/tests/agency/safeBash.test.json
+++ b/packages/agency-lang/tests/agency/safeBash.test.json
@@ -70,7 +70,7 @@
       "nodeName": "shellFreeWrite",
       "description": "A single literal redirected echo computes its content and writes it, with no shell. The `>` and `>>` rows differ only in mode, which is the difference between overwriting and appending. A variable TARGET is unrecognized entirely; a variable in the ARGUMENTS is not shell-free but is still recognized, and goes to bash raising std::write with no content \u2014 approval of the destination, not the bytes, because bash has not run yet.",
       "input": "",
-      "expectedOutput": "[[\"write\",\"hi\\n\",\"out.txt\",\"/repo\",\"overwrite\",[\"std::write\"]],[\"write\",\"hi\\n\",\"out.txt\",\"/repo\",\"append\",[\"std::write\"]],[\"bash\",\"\",\"\",\"\",\"\",[\"std::bash\"]],[\"bash\",\"\",\"\",\"\",\"\",[\"std::write\"]]]",
+      "expectedOutput": "[[\"write\",\"hi\\n\",\"out.txt\",\"/repo\",\"overwrite\",[\"std::write\"]],[\"write\",\"hi\\n\",\"out.txt\",\"/repo\",\"append\",[\"std::write\"]],[\"bash\",\"\",\"\",\"\",\"overwrite\",[\"std::bash\"]],[\"bash\",\"\",\"\",\"\",\"overwrite\",[\"std::write\"]]]",
       "evaluationCriteria": [
         {
           "type": "exact"
@@ -209,6 +209,17 @@
       "description": "A quoted redirect target containing no variable names a real file, so it maps rather than falling back.",
       "input": "",
       "expectedOutput": "[\"write\",\"hi\\n\",\"my file.txt\",\"/repo\",\"overwrite\",[\"std::write\"]]",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "longOutputIsTruncated",
+      "description": "Output is capped, and truncation is marked rather than silent. The shell-free echo path truncates too, so a long echo and a long shell command return the same shape.",
+      "input": "",
+      "expectedOutput": "[2012,true]",
       "evaluationCriteria": [
         {
           "type": "exact"

--- a/packages/agency-lang/tests/agency/safeBash.test.json
+++ b/packages/agency-lang/tests/agency/safeBash.test.json
@@ -1,10 +1,10 @@
 {
   "tests": [
     {
-      "nodeName": "echoBecomesPrint",
-      "description": "echo maps to print, so a command that used to need a human approval now raises no interrupt at all.",
+      "nodeName": "refuseWall",
+      "description": "Commands we decline to run even with approval, matched by command word and by the last part of a path. Only the destructive spellings of git subcommands are refused, and only in the first argument position.",
       "input": "",
-      "expectedOutput": "[{\"type\":\"print\",\"content\":\"hello world\\n\"}]",
+      "expectedOutput": "[true,true,true,true,true,true,true,false,false,true,false,false,false]",
       "evaluationCriteria": [
         {
           "type": "exact"
@@ -12,10 +12,10 @@
       ]
     },
     {
-      "nodeName": "echoRedirectBecomesWrite",
-      "description": "Redirected, the same echo is a file write, which `write` already gates. `dir` is never empty, because `write` rejects an empty one.",
+      "nodeName": "classifyOneCommand",
+      "description": "Each recognized command contributes its own effects. An unrecognized command, an unknown flag, a non-literal command word and a leading assignment are all unrecognized. In a sequence, echo contributes nothing whatever its arguments, because bash runs it.",
       "input": "",
-      "expectedOutput": "[[{\"type\":\"writeFile\",\"filename\":\"out.txt\",\"dir\":\".\",\"content\":\"hi\\n\",\"mode\":\"overwrite\"}],[{\"type\":\"writeFile\",\"filename\":\"out.txt\",\"dir\":\".\",\"content\":\"hi\\n\",\"mode\":\"append\"}]]",
+      "expectedOutput": "[[\"std::git::status\"],[\"std::git::diff\"],[\"std::git::diff\"],[\"std::git::log\"],[],\"UNRECOGNIZED\",\"UNRECOGNIZED\",\"UNRECOGNIZED\",\"UNRECOGNIZED\",[],[],\"UNRECOGNIZED\"]",
       "evaluationCriteria": [
         {
           "type": "exact"
@@ -23,10 +23,10 @@
       ]
     },
     {
-      "nodeName": "echoQuotingIsPreserved",
-      "description": "Quotes delimit a word, they are not part of its value, and adjacent parts concatenate into one word.",
+      "nodeName": "redirectsContribute",
+      "description": "A redirect writes a file whatever the verb is, so it contributes std::write independently. A variable target or any other redirect kind is unrecognized.",
       "input": "",
-      "expectedOutput": "[[\"print\"],[{\"type\":\"print\",\"content\":\"abc\\n\"}]]",
+      "expectedOutput": "[[\"std::git::status\",\"std::write\"],[\"std::write\"],[\"std::write\"],\"UNRECOGNIZED\",\"UNRECOGNIZED\",\"UNRECOGNIZED\",\"UNRECOGNIZED\"]",
       "evaluationCriteria": [
         {
           "type": "exact"
@@ -34,10 +34,10 @@
       ]
     },
     {
-      "nodeName": "echoFlagsFallBackToBash",
-      "description": "`echo -n` drops the trailing newline and `-e` interprets escapes; mapping either would print something bash never would, so both go to bash.",
+      "nodeName": "wholeStringPlans",
+      "description": "The whole string gets one plan: refused if any command anywhere is refused, one std::bash if any command is unrecognized, otherwise the union of narrow effects. Chains are walked, so `true && rm -rf /tmp/x` is refused rather than approvable.",
       "input": "",
-      "expectedOutput": "[[{\"type\":\"bash\",\"command\":\"echo -n hi\",\"cwd\":\"\"}],[\"bash\"]]",
+      "expectedOutput": "[[\"bash\",[\"std::git::status\"]],[\"bash\",[\"std::git::status\",\"std::git::log\"]],[\"bash\",[\"std::bash\"]],[\"bash\",[\"std::bash\"]],[\"bash\",[\"std::bash\"]],[\"refuse\",[]],[\"refuse\",[]],[\"bash\",[\"std::bash\"]],[\"bash\",[\"std::git::status\",\"std::git::log\"]],[\"refuse\",[]],[\"bash\",[\"std::git::status\",\"std::git::log\"]],[\"bash\",[\"std::bash\"]]]",
       "evaluationCriteria": [
         {
           "type": "exact"
@@ -45,10 +45,10 @@
       ]
     },
     {
-      "nodeName": "echoWithNoArgs",
-      "description": "Bare `echo` still prints a newline, not nothing.",
+      "nodeName": "rebuiltVersusOriginal",
+      "description": "A narrow plan runs the tree it classified (whitespace normalized); a broad plan runs the caller's text verbatim.",
       "input": "",
-      "expectedOutput": "[{\"type\":\"print\",\"content\":\"\\n\"}]",
+      "expectedOutput": "[\"git status\",\"ls    -la\"]",
       "evaluationCriteria": [
         {
           "type": "exact"
@@ -56,10 +56,10 @@
       ]
     },
     {
-      "nodeName": "gitSubcommandsMap",
-      "description": "Each git subcommand maps onto the std::git tool that answers the same question.",
+      "nodeName": "shellFreeEcho",
+      "description": "A single fully-literal echo computes its own output and never touches a shell. An expansion, a flag, or a sequence sends it to bash.",
       "input": "",
-      "expectedOutput": "[[\"gitStatus\"],[\"gitDiff\"],[\"gitLog\"]]",
+      "expectedOutput": "[[\"echo\",\"hello world\\n\",[]],[\"echo\",\"\\n\",[]],[\"echo\",\"a  b\\n\",[]],[\"bash\",\"\",[\"std::bash\"]],[\"bash\",\"\",[\"std::bash\"]],[\"echo\",\"a b c\\n\",[]],[\"bash\",\"\",[\"std::bash\"]],[\"bash\",\"\",[\"std::bash\"]]]",
       "evaluationCriteria": [
         {
           "type": "exact"
@@ -67,10 +67,10 @@
       ]
     },
     {
-      "nodeName": "gitStagedIsItsOwnAction",
-      "description": "`--staged` is a different question from a bare `git diff`, so the flag has to reach the action rather than being dropped on the way.",
+      "nodeName": "shellFreeWrite",
+      "description": "A single literal redirected echo computes its content and writes it, with no shell. The `>` and `>>` rows differ only in mode, which is the difference between overwriting and appending. A variable TARGET is unrecognized entirely; a variable in the ARGUMENTS is not shell-free but is still recognized, and goes to bash raising std::write with no content \u2014 approval of the destination, not the bytes, because bash has not run yet.",
       "input": "",
-      "expectedOutput": "[{\"type\":\"gitDiff\",\"staged\":true,\"cwd\":\"\"}]",
+      "expectedOutput": "[[\"write\",\"hi\\n\",\"out.txt\",\"/repo\",\"overwrite\",[\"std::write\"]],[\"write\",\"hi\\n\",\"out.txt\",\"/repo\",\"append\",[\"std::write\"]],[\"bash\",\"\",\"\",\"\",\"\",[\"std::bash\"]],[\"bash\",\"\",\"\",\"\",\"\",[\"std::write\"]]]",
       "evaluationCriteria": [
         {
           "type": "exact"
@@ -78,10 +78,10 @@
       ]
     },
     {
-      "nodeName": "unknownGitFlagsFallBackToBash",
-      "description": "An unrecognized flag falls back rather than being ignored: answering `git log --graph` with a plain gitLog() would give the model something other than what it asked for.",
+      "nodeName": "payloadValuesAreCorrect",
+      "description": "Payload values, not just effect names. A staged diff and an unstaged diff raise the same effect name, so only the payload distinguishes them.",
       "input": "",
-      "expectedOutput": "[[\"bash\"],[\"bash\"]]",
+      "expectedOutput": "[true,\"/repo\",\"std::write\",\"out.txt\",\"/repo\",\"overwrite\"]",
       "evaluationCriteria": [
         {
           "type": "exact"
@@ -89,10 +89,10 @@
       ]
     },
     {
-      "nodeName": "unmappedCommandsFallBackToBash",
-      "description": "A command with no equivalent tool still runs, as a bash action, with the approval that implies.",
+      "nodeName": "writeContentIsInThePayload",
+      "description": "The std::write interrupt carries the bytes, so a policy that inspects what is being written still can.",
       "input": "",
-      "expectedOutput": "[[\"bash\"],[\"bash\"],[\"bash\"]]",
+      "expectedOutput": "\"hi\\n\"",
       "evaluationCriteria": [
         {
           "type": "exact"
@@ -100,10 +100,10 @@
       ]
     },
     {
-      "nodeName": "fallbackRendersOnlyItsOwnCommand",
-      "description": "In a sequence, the command handed to bash is the one that fell through, rendered back from its own AST, not the whole string.",
+      "nodeName": "echoRunsWithoutApproval",
+      "description": "A literal echo returns its text with no interrupt and no shell.",
       "input": "",
-      "expectedOutput": "[{\"type\":\"print\",\"content\":\"hi\\n\"},{\"type\":\"bash\",\"command\":\"ls -la\",\"cwd\":\"\"},{\"type\":\"print\",\"content\":\"bye\\n\"}]",
+      "expectedOutput": "\"hello world\\n\"",
       "evaluationCriteria": [
         {
           "type": "exact"
@@ -111,90 +111,41 @@
       ]
     },
     {
-      "nodeName": "sequencesProduceOneActionEach",
-      "description": "Commands separated by `;` each become their own action.",
+      "nodeName": "exactlyOneQuestion",
+      "description": "The narrow question REPLACES the broad one. Approving std::git::status runs the command; a second std::bash prompt would fail the run on an unmatched interrupt.",
       "input": "",
-      "expectedOutput": "[\"print\",\"print\",\"print\"]",
-      "evaluationCriteria": [
-        {
-          "type": "exact"
-        }
-      ]
-    },
-    {
-      "nodeName": "bothSidesOfAChainAreListed",
-      "description": "makeActions reports what each command WOULD do; which side of a `&&` or `||` actually runs is decided at run time.",
-      "input": "",
-      "expectedOutput": "[[\"print\",\"print\"],[\"print\",\"print\"],[\"print\",\"print\",\"print\"]]",
-      "evaluationCriteria": [
-        {
-          "type": "exact"
-        }
-      ]
-    },
-    {
-      "nodeName": "assignmentsFallBackToBash",
-      "description": "Bash scopes a leading assignment to its one command, and handing the original text to bash reproduces that exactly.",
-      "input": "",
-      "expectedOutput": "[[\"bash\"],[\"bash\"]]",
-      "evaluationCriteria": [
-        {
-          "type": "exact"
-        }
-      ]
-    },
-    {
-      "nodeName": "redirectShapesWeDoNotHandle",
-      "description": "An explicit file descriptor, an input redirect, and a redirected git command all fall back rather than being approximated.",
-      "input": "",
-      "expectedOutput": "[[\"bash\"],[\"bash\"],[\"bash\"]]",
-      "evaluationCriteria": [
-        {
-          "type": "exact"
-        }
-      ]
-    },
-    {
-      "nodeName": "shellTransformsAreUnparseable",
-      "description": "Anything bash would rewrite before the command runs is rejected by the parser rather than reaching makeAction. Quoted, a glob is ordinary text and still maps.",
-      "input": "",
-      "expectedOutput": "[[\"REFUSED: Unexpected input after commands: \\\"*\\\"\"],[\"REFUSED: Unexpected input after commands: \\\"~/d\\\"\"],[\"REFUSED: Unexpected input after commands: \\\"$(date)\\\"\"],[\"REFUSED: Unexpected input after commands: \\\"| grep x\\\"\"],[\"REFUSED: Unexpected input after commands: \\\"&\\\"\"],[\"print\"]]",
-      "evaluationCriteria": [
-        {
-          "type": "exact"
-        }
-      ]
-    },
-    {
-      "nodeName": "emptyExpansionsFallBackToBash",
-      "description": "An unset variable passes NO argument in bash where expanding it to \"\" would pass one, so an unquoted empty word falls back. Quoted, it is a real empty argument.",
-      "input": "",
-      "expectedOutput": "[[{\"type\":\"bash\",\"command\":\"echo $NOPE_NOT_SET\",\"cwd\":\"\"}],[\"bash\"],[{\"type\":\"print\",\"content\":\"\\n\"}],[{\"type\":\"print\",\"content\":\"/bin\\n\"}]]",
-      "evaluationCriteria": [
-        {
-          "type": "exact"
-        }
-      ]
-    },
-    {
-      "nodeName": "quotedEmptyIsARealArgument",
-      "description": "`echo \"\"` passes one empty argument, so it prints a newline rather than falling back.",
-      "input": "",
-      "expectedOutput": "[{\"type\":\"print\",\"content\":\"\\n\"}]",
-      "evaluationCriteria": [
-        {
-          "type": "exact"
-        }
-      ]
-    },
-    {
-      "nodeName": "runningASequenceReportsWhatRan",
-      "description": "A failure stops the sequence and reports which command failed and why, what already ran, the output so far, and what never ran.",
-      "input": "",
-      "expectedOutput": "\"Command `git log --graph --nope` failed: `git log --graph --nope` was not run: interrupt rejected\\n\\nCommands run:\\necho one\\n\\nOutput so far:\\n<results>\\none\\n\\n</results>\\n\\nCommands not run:\\necho three\"",
+      "expectedOutput": "\"RAN\"",
       "interruptHandlers": [
         {
-          "action": "reject",
+          "action": "approve",
+          "expectedMessage": "Show git status"
+        }
+      ],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "refusedNeverRuns",
+      "description": "A refused command fails without raising anything, so there is nothing to approve.",
+      "input": "",
+      "expectedOutput": "\"`rm` is not allowed\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "sequenceRunsThroughBash",
+      "description": "A sequence runs in one bash call, so its output is bash's \u2014 including the newline behavior v2 got wrong.",
+      "input": "",
+      "expectedOutput": "\"hi\\nbye\\n\"",
+      "interruptHandlers": [
+        {
+          "action": "approve",
           "expectedMessage": "Are you sure you want to run this shell command?"
         }
       ],
@@ -205,13 +156,13 @@
       ]
     },
     {
-      "nodeName": "andStopsOnFailure",
-      "description": "`a && b` does not run b when a fails, and the chain fails as a whole.",
+      "nodeName": "nonZeroExitIsAFailure",
+      "description": "A non-zero exit is a failure, which && and || semantics depend on.",
       "input": "",
-      "expectedOutput": "[true,[\"bash\",\"print\"]]",
+      "expectedOutput": "\"FAILED\"",
       "interruptHandlers": [
         {
-          "action": "reject",
+          "action": "approve",
           "expectedMessage": "Are you sure you want to run this shell command?"
         }
       ],
@@ -222,10 +173,20 @@
       ]
     },
     {
-      "nodeName": "cwdReachesEveryAction",
-      "description": "The caller's cwd lands on every action a command produces \u2014 a write's dir, a git action's cwd, and a bash fallback's cwd \u2014 not only on the unparseable path.",
+      "nodeName": "appendReallyAppends",
+      "description": "The write executor runs for real: > then >> leaves both lines, proving append mode reaches _write and the positional arguments are in the right order.",
       "input": "",
-      "expectedOutput": "[{\"type\":\"writeFile\",\"filename\":\"out.txt\",\"dir\":\"/tmp/somewhere\",\"content\":\"hi\\n\",\"mode\":\"overwrite\"},{\"type\":\"gitStatus\",\"cwd\":\"/tmp/somewhere\"},{\"type\":\"bash\",\"command\":\"ls\",\"cwd\":\"/tmp/somewhere\"}]",
+      "expectedOutput": "\"one\\ntwo\\n\"",
+      "interruptHandlers": [
+        {
+          "action": "approve",
+          "expectedMessage": "Are you sure you want to write to this file?"
+        },
+        {
+          "action": "approve",
+          "expectedMessage": "Are you sure you want to write to this file?"
+        }
+      ],
       "evaluationCriteria": [
         {
           "type": "exact"
@@ -233,16 +194,21 @@
       ]
     },
     {
-      "nodeName": "chainKeepsTheLeftSidesOutput",
-      "description": "When the left side of `&&` succeeds and the right fails, the left side really ran, so its output stays in the failure report.",
+      "nodeName": "defaultCwdIsNeverEmpty",
+      "description": "resolveCwd maps an empty caller cwd and an empty agent cwd to \".\", because write rejects an empty dir.",
       "input": "",
-      "expectedOutput": "\"Command `echo kept && git log --graph --nope` failed: `git log --graph --nope` was not run: interrupt rejected\\n\\nOutput before the failure:\\nkept\\n\"",
-      "interruptHandlers": [
+      "expectedOutput": "[\".\",\"/somewhere\"]",
+      "evaluationCriteria": [
         {
-          "action": "reject",
-          "expectedMessage": "Are you sure you want to run this shell command?"
+          "type": "exact"
         }
-      ],
+      ]
+    },
+    {
+      "nodeName": "quotedRedirectTarget",
+      "description": "A quoted redirect target containing no variable names a real file, so it maps rather than falling back.",
+      "input": "",
+      "expectedOutput": "[\"write\",\"hi\\n\",\"my file.txt\",\"/repo\",\"overwrite\",[\"std::write\"]]",
       "evaluationCriteria": [
         {
           "type": "exact"


### PR DESCRIPTION
Replaces the v2 mapping design for `std::safeBash`. Includes the spec, the review rounds it answers, the implementation plan, and the implementation.

## Why v2 had to go

v2 substituted an Agency function for a recognized command — `git status` became `gitStatus()`. That requires the function to produce what the command produces, and `std::git` cannot: it runs machine-format argv in a scrubbed environment, so there is no text matching what `git status` prints. Matching bash byte for byte would mean matching the user's locale, `~/.gitconfig` and git version.

Measured, it didn't match:

```
safeBash("echo hi && echo bye")  →  "hi\n\nbye\n"
bash     "echo hi && echo bye"   →  "hi\nbye\n"
```

and the *shape* of the return value depended on which path ran, so an agent could tell which decision safeBash had made — the one thing the v2 spec said it shouldn't be able to do.

## What v3 does instead

**Substituting a function was never what made this safe.** `gitStatus` spawns `git` either way. What made it safe was the narrower question. That survives without the substitution, and fidelity comes free because the thing producing the output *is* bash.

```
1. Parse the string into commands.
2. Classify every command.
3. Any refused        → refuse the whole string. Nothing runs.
4. Any needs bash     → one std::bash for the whole string.
5. Otherwise          → raise every narrow effect, up front.
6. All approved       → run the WHOLE string in one bash call.
```

Three problems dissolve rather than being managed. No half-executed state, because nothing runs before every approval is in. Nobody is asked to approve a bare `cd`, because if any part needs the broad question the whole string asks once. And `cd foo && git status` works, because it is one shell.

Two paths never spawn a shell: a single fully-literal `echo` computes its own output, and a single fully-literal redirected `echo` computes its content and hands the real bytes to `write` — so `content` is in the approval payload *before* anyone approves, which is more than v2 managed.

## The trap that would have made this a no-op

`bash()` raises `std::bash` itself before calling `_bash`. So raising `std::git::status`, getting approval, then calling `bash()` asks the broad question anyway — and the narrow one buys nothing.

Execution goes through `_bash` and `_write`, the non-raising internals. Bypassing a tool's interrupt is normally forbidden, so the reasoning is written at the call site, in the spec, and in the plan's constraints:

> The narrow interrupt **replaces** the broad one. The only path to `_bash` runs through a `raiseAll` that raised every effect in the plan and returned success.

`exactlyOneQuestion` pins it by **approving** the narrow question and asserting the command ran. A test that only rejects the first interrupt passes whether or not a second prompt appears — which is exactly how this bug hides.

## Deleted

The entire runner — `runCommands`, `runCommand`, `andCommand`, `orCommand`, `parensCommand`, `commandsToStr`, `failureReport`, `joinOutput`. Bash does control flow now.

All the expansion machinery — `expandVariable`, `stringifyArg`, `stringifyParts`, `hasQuotedPart`. Bash expands, with real word-splitting and real `IFS`, including the `$A$B` case v2 got wrong.

The v2 `Action` types and executors. The extra-newline bug went with the code that caused it.

## Safety notes worth reading

**This trades a structural bound for a reviewable analysis.** v2's `echo` called `print`, which *cannot* write a file however wrong the classifier was. v3 hands a shell a string. Three things narrow it: bash receives a string re-rendered from the validated tree when we asked narrow questions (so a parser bug degrades to "we ran what we thought we read"), the command word must be a literal (so `$CMD status` can never become a git read), and the shell-free `echo` path keeps the structural bound where it was free.

**The refuse wall stops the common spelling, not the idea.** `rm`, `/bin/rm` and `git checkout .` are refused; `find . -delete` and `xargs rm` reach the ordinary `std::bash` prompt. Stated plainly in the spec rather than implied to be a guarantee.

**Two "unused" imports are load-bearing.** Effect declarations travel with imports, and without them a raise compiles with its payload contract *unenforced* — verified by deliberately breaking a payload and confirming `AG3006` fires. There's a comment saying so, because the natural instinct is to delete them.

## Tests

- 17 agency tests: classification, the refuse wall through a chain, payload values, the rebuilt-vs-original rule, and real execution (a sequence, a non-zero exit, an append that reads the file back)
- 24 property-test cases pinning `astToBash` round-trips, comparing **trees** not rendered strings — a string fixed point passes on exactly the failure it exists to catch
- Full vitest suite: 9686 passing

## Reviews

Three rounds on the spec and three on the plan, in the `-REVIEW.md` files. The findings that changed the design: the executors would have re-raised the broad interrupt; chain halves were never walked, so `true && rm -rf /` bypassed the wall by two characters; a redirect contributed nothing, so `echo pwned >> .bashrc; git status` could have ridden along under a git-read approval; and three parser assumptions were empirically false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
