### PR TITLE
parser: an index or slice cannot start on a new line

### DIFF
--- a/packages/agency-lang/TODO.md
+++ b/packages/agency-lang/TODO.md
@@ -432,23 +432,6 @@ Where/how is this enforced?
     }
   |]
 ```
----
-
-A single-element array pattern in a match arm parses as an INDEX on the
-previous arm's expression. Multi-element patterns are immune because
-`expr["a", "b"]` is not valid index syntax, which is why v2 safeBash's
-`["git", "status"]` arms worked. Found in the safeBash match refactor:
-
-fails ("expected match cases..."):
-```
-match (args) {
-  ["status"] => failure("a")
-  [sub] => failure("no rule for ${sub}")
-  _ => failure("nope")
-}
-```
-
----
 
 Match arms do not narrow the scrutinee or the bound fields of a
 discriminated union, so `if` chains can typecheck where the equivalent

--- a/packages/agency-lang/lib/parsers/chainNewlineBoundary.test.ts
+++ b/packages/agency-lang/lib/parsers/chainNewlineBoundary.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "vitest";
+import { parseAgency } from "../parser.js";
+
+/** The chain-newline boundary: an index or slice element must not
+ *  continue an expression across a line break. Expression parsers eat
+ *  trailing newlines, so before the boundary existed, a match arm whose
+ *  pattern was a SINGLE-element array parsed as an index on the previous
+ *  arm's value — `failure("a")[sub]` — and the whole match failed with
+ *  the generic "expected match cases" error. Multi-element patterns were
+ *  immune only because `expr["a", "b"]` is not valid index syntax.
+ *
+ *  Tests go through `parseAgency`, the real entry point, because the
+ *  boundary reads the parse-wide input that entry point installs. */
+
+function parses(source: string): boolean {
+  return parseAgency(source, {}, false, false).success;
+}
+
+describe("array-pattern arms after expression arms", () => {
+  const programs: Array<[string, string]> = [
+    [
+      "a literal single-element pattern in second position",
+      `def f(args: any): any {
+  return match(args) {
+    ["status"] => failure("a")
+    ["log"] => failure("b")
+    _ => failure("nope")
+  }
+}`,
+    ],
+    [
+      "a binder pattern in second position",
+      `def f(args: any): any {
+  return match(args) {
+    ["status"] => failure("a")
+    [sub] => failure("no rule for \${sub}")
+    _ => failure("nope")
+  }
+}`,
+    ],
+    [
+      "after a multiline arm expression ending in a close paren",
+      `def f(args: any): any {
+  return match(args) {
+    ["status"] => success(
+      [1, 2]
+    )
+    [sub] => failure("no rule")
+    _ => failure("nope")
+  }
+}`,
+    ],
+    [
+      "a guarded single-element pattern in second position",
+      `def f(args: any, n: number): any {
+  return match(args) {
+    ["status"] => failure("a")
+    ["log"] if (n == 0) => failure("b")
+    _ => failure("nope")
+  }
+}`,
+    ],
+  ];
+
+  programs.forEach(([name, source]) => {
+    it(`parses ${name}`, () => {
+      expect(parses(source)).toBe(true);
+    });
+  });
+});
+
+describe("same-line chains keep working", () => {
+  const programs: Array<[string, string]> = [
+    [
+      "plain chained indexing",
+      `def f(arr: number[][]): number {
+  return arr[0][1]
+}`,
+    ],
+    [
+      "a slice",
+      `def f(arr: number[]): number[] {
+  return arr[:2]
+}`,
+    ],
+    [
+      "an index directly after a multiline call's close paren",
+      `def g(a: number, b: number): number[] {
+  return [a, b]
+}
+def f(): number {
+  return g(
+    1,
+    2,
+  )[0]
+}`,
+    ],
+  ];
+
+  programs.forEach(([name, source]) => {
+    it(`still chains: ${name}`, () => {
+      expect(parses(source)).toBe(true);
+    });
+  });
+});
+
+describe("a bracket on a new line is not a chain", () => {
+  it("does not fold a next-line bracket into the call", () => {
+    // Under the old behavior `g()` chained with `[0]` into `g()[0]`.
+    // With the boundary the bracket stays separate, so no index element
+    // may appear anywhere in the parsed program.
+    const source = `def g(): number[] {
+  return [1]
+}
+node main() {
+  const x = g()
+  [0]
+  return x
+}`;
+    const result = parseAgency(source, {}, false, false);
+    if (result.success) {
+      expect(JSON.stringify(result.result.nodes)).not.toContain('"index"');
+    }
+    // Whether the bare `[0]` line parses as a statement or is rejected is
+    // the statement grammar's business; the boundary only guarantees it
+    // never glues onto the previous expression.
+  });
+});

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -2609,8 +2609,32 @@ const bracketParser: Parser<boolean> = or(
   map(char("["), () => false),
 );
 
-/** True when the current parse position sits just after a line break,
- *  looking back across spaces and tabs only.
+/** Offsets that begin a line's content: marks[i] is 1 when source[i] is
+ *  the first character on its line that is not a space or tab. Built in
+ *  ONE pass per parse input and cached by string identity, so the
+ *  boundary check below never re-scans text the parser already
+ *  consumed. */
+let markedSource: string | null = null;
+let lineStartMarks: Uint8Array | null = null;
+
+function lineContentStarts(source: string): Uint8Array {
+  const marks = new Uint8Array(source.length);
+  let atLineStart = true;
+  for (let i = 0; i < source.length; i++) {
+    const c = source.charCodeAt(i);
+    if (c === 10 || c === 13) {
+      atLineStart = true;
+    } else if (atLineStart && c !== 32 && c !== 9) {
+      marks[i] = 1;
+      atLineStart = false;
+    }
+  }
+  return marks;
+}
+
+/** True when the chain element about to be parsed sits at the start of
+ *  its own line (looking past indentation) — meaning the expression it
+ *  would extend ended on the PREVIOUS line.
  *
  *  A bracket chain element (`[i]`, `[a:b]`) must not continue an
  *  expression across a newline. Expression parsers (function calls in
@@ -2627,17 +2651,26 @@ const bracketParser: Parser<boolean> = or(
  *  aligns the two. Dot-method chains are deliberately untouched: a
  *  fluent `.method()` on its own line is an established style; a bare
  *  `[i]` on its own line is an array literal or a pattern, never an
- *  intended index. */
-function newlineBeforePosition(input: string): boolean {
+ *  intended index.
+ *
+ *  Cost: chain elements are attempted after every value access, so the
+ *  common path here must be a single character test. Only when a
+ *  bracket is actually next (`[` or `?.[`) does this consult the marks
+ *  table — one array read against the offset, no text scanning. */
+function bracketStartsOwnLine(input: string): boolean {
+  const c = input.charCodeAt(0);
+  if (c !== 91 /* [ */ && c !== 63 /* ? of ?.[ */) return false;
   const full = getInputStr();
-  if (!full || input.length >= full.length) return false;
-  let i = full.length - input.length - 1;
-  while (i >= 0 && (full[i] === " " || full[i] === "\t")) i--;
-  return i >= 0 && full[i] === "\n";
+  if (!full || input.length > full.length) return false;
+  if (full !== markedSource) {
+    markedSource = full;
+    lineStartMarks = lineContentStarts(full);
+  }
+  return lineStartMarks![full.length - input.length] === 1;
 }
 
 const sliceChainParser: Parser<AccessChainElement> = (input: string) => {
-  if (newlineBeforePosition(input)) {
+  if (bracketStartsOwnLine(input)) {
     return failure("a slice cannot start on a new line", input);
   }
   const parser = seqC(
@@ -2661,7 +2694,7 @@ const sliceChainParser: Parser<AccessChainElement> = (input: string) => {
 };
 
 const indexChainParser: Parser<AccessChainElement> = (input: string) => {
-  if (newlineBeforePosition(input)) {
+  if (bracketStartsOwnLine(input)) {
     return failure("an index cannot start on a new line", input);
   }
   const parser = seqC(

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -65,6 +65,7 @@ import {
   many1TillOneOf,
   isCommittedFailure,
   getPosition,
+  getInputStr,
   type Position,
 } from "tarsec";
 
@@ -2608,7 +2609,37 @@ const bracketParser: Parser<boolean> = or(
   map(char("["), () => false),
 );
 
+/** True when the current parse position sits just after a line break,
+ *  looking back across spaces and tabs only.
+ *
+ *  A bracket chain element (`[i]`, `[a:b]`) must not continue an
+ *  expression across a newline. Expression parsers (function calls in
+ *  particular) consume trailing whitespace INCLUDING newlines, so without
+ *  this check a match arm like
+ *
+ *      ["status"] => failure("a")
+ *      [sub] => failure("b")
+ *
+ *  parses the second arm's pattern as an INDEX on the first arm's value —
+ *  `failure("a")[sub]` — and the match collapses. Multi-element patterns
+ *  were immune only because `expr["a", "b"]` is not index syntax.
+ *  Statement context already refuses the same continuation, so this
+ *  aligns the two. Dot-method chains are deliberately untouched: a
+ *  fluent `.method()` on its own line is an established style; a bare
+ *  `[i]` on its own line is an array literal or a pattern, never an
+ *  intended index. */
+function newlineBeforePosition(input: string): boolean {
+  const full = getInputStr();
+  if (!full || input.length >= full.length) return false;
+  let i = full.length - input.length - 1;
+  while (i >= 0 && (full[i] === " " || full[i] === "\t")) i--;
+  return i >= 0 && full[i] === "\n";
+}
+
 const sliceChainParser: Parser<AccessChainElement> = (input: string) => {
+  if (newlineBeforePosition(input)) {
+    return failure("a slice cannot start on a new line", input);
+  }
   const parser = seqC(
     capture(bracketParser, "optional"),
     optionalSpaces,
@@ -2630,6 +2661,9 @@ const sliceChainParser: Parser<AccessChainElement> = (input: string) => {
 };
 
 const indexChainParser: Parser<AccessChainElement> = (input: string) => {
+  if (newlineBeforePosition(input)) {
+    return failure("an index cannot start on a new line", input);
+  }
   const parser = seqC(
     capture(bracketParser, "optional"),
     optionalSpaces,

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -2609,71 +2609,48 @@ const bracketParser: Parser<boolean> = or(
   map(char("["), () => false),
 );
 
-/** Offsets that begin a line's content: marks[i] is 1 when source[i] is
- *  the first character on its line that is not a space or tab. Built in
- *  ONE pass per parse input and cached by string identity, so the
- *  boundary check below never re-scans text the parser already
- *  consumed. */
-let markedSource: string | null = null;
-let lineStartMarks: Uint8Array | null = null;
-
-function lineContentStarts(source: string): Uint8Array {
-  const marks = new Uint8Array(source.length);
-  let atLineStart = true;
-  for (let i = 0; i < source.length; i++) {
-    const c = source.charCodeAt(i);
-    if (c === 10 || c === 13) {
-      atLineStart = true;
-    } else if (atLineStart && c !== 32 && c !== 9) {
-      marks[i] = 1;
-      atLineStart = false;
-    }
-  }
-  return marks;
-}
-
-/** True when the chain element about to be parsed sits at the start of
- *  its own line (looking past indentation) — meaning the expression it
- *  would extend ended on the PREVIOUS line.
+/** Zero-width parser: succeeds, consuming nothing, when the parse
+ *  position sits at the start of its line's content — nothing but
+ *  indentation precedes it on the line. This is a lookbehind, through
+ *  tarsec's parse-wide input, because the whitespace that got us here
+ *  was already consumed by whatever parser ran before.
  *
- *  A bracket chain element (`[i]`, `[a:b]`) must not continue an
- *  expression across a newline. Expression parsers (function calls in
- *  particular) consume trailing whitespace INCLUDING newlines, so without
- *  this check a match arm like
+ *  Used as `not(startOfLineContent)` to stop a bracket chain element
+ *  from continuing an expression across a newline. Expression parsers
+ *  (function calls in particular) consume trailing whitespace INCLUDING
+ *  newlines, so without that boundary a match arm like
  *
  *      ["status"] => failure("a")
  *      [sub] => failure("b")
  *
- *  parses the second arm's pattern as an INDEX on the first arm's value —
- *  `failure("a")[sub]` — and the match collapses. Multi-element patterns
- *  were immune only because `expr["a", "b"]` is not index syntax.
- *  Statement context already refuses the same continuation, so this
- *  aligns the two. Dot-method chains are deliberately untouched: a
- *  fluent `.method()` on its own line is an established style; a bare
- *  `[i]` on its own line is an array literal or a pattern, never an
- *  intended index.
- *
- *  Cost: chain elements are attempted after every value access, so the
- *  common path here must be a single character test. Only when a
- *  bracket is actually next (`[` or `?.[`) does this consult the marks
- *  table — one array read against the offset, no text scanning. */
-function bracketStartsOwnLine(input: string): boolean {
-  const c = input.charCodeAt(0);
-  if (c !== 91 /* [ */ && c !== 63 /* ? of ?.[ */) return false;
-  const full = getInputStr();
-  if (!full || input.length > full.length) return false;
-  if (full !== markedSource) {
-    markedSource = full;
-    lineStartMarks = lineContentStarts(full);
+ *  parses the second arm's pattern as an INDEX on the first arm's value
+ *  — `failure("a")[sub]` — and the match collapses. Multi-element
+ *  patterns were immune only because `expr["a", "b"]` is not index
+ *  syntax. Statement context already refuses the same continuation, so
+ *  the boundary aligns the two. Dot-method chains are deliberately
+ *  unguarded: a fluent `.method()` on its own line is an established
+ *  style; a bare `[i]` on its own line is an array literal or a
+ *  pattern, never an intended index. */
+const startOfLineContent: Parser<null> = (input: string) => {
+  const source = getInputStr();
+  const offset = source.length - input.length;
+  // Lookbehind needs the parse-wide input. When it is missing or does
+  // not correspond to this input (raw parser tests call parsers without
+  // installing it), there is nothing to look behind at — fail, which
+  // DISABLES the boundary rather than misfiring it.
+  if (offset < 0 || source.charCodeAt(offset) !== input.charCodeAt(0)) {
+    return failure("no parse-wide input to look behind at", input);
   }
-  return lineStartMarks![full.length - input.length] === 1;
-}
+  const lineStart = source.lastIndexOf("\n", offset - 1) + 1;
+  return /^[ \t]*$/.test(source.slice(lineStart, offset))
+    ? success(null, input)
+    : failure("not at the start of a line", input);
+};
+
 
 const sliceChainParser: Parser<AccessChainElement> = (input: string) => {
-  if (bracketStartsOwnLine(input)) {
-    return failure("a slice cannot start on a new line", input);
-  }
   const parser = seqC(
+    not(startOfLineContent),
     capture(bracketParser, "optional"),
     optionalSpaces,
     capture(optional(lazy(() => exprParser)), "start"),
@@ -2694,10 +2671,8 @@ const sliceChainParser: Parser<AccessChainElement> = (input: string) => {
 };
 
 const indexChainParser: Parser<AccessChainElement> = (input: string) => {
-  if (bracketStartsOwnLine(input)) {
-    return failure("an index cannot start on a new line", input);
-  }
   const parser = seqC(
+    not(startOfLineContent),
     capture(bracketParser, "optional"),
     optionalSpaces,
     capture(lazy(() => exprParser), "index"),

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -2615,6 +2615,17 @@ const bracketParser: Parser<boolean> = or(
  *  tarsec's parse-wide input, because the whitespace that got us here
  *  was already consumed by whatever parser ran before.
  *
+ *  PERFORMANCE WARNING: do NOT reach for this parser unless there is no
+ *  other option. It calls `getInputStr` and re-reads source text on
+ *  every attempt, which ordinary parsers never do — combinators look
+ *  forward at the remaining input for free. A lookbehind is only
+ *  justified when the information you need was already consumed by an
+ *  earlier parser and cannot be recovered any other way, which is the
+ *  case for the chain boundary below and almost nowhere else. If you
+ *  can restructure the grammar to test BEFORE the whitespace is
+ *  consumed (`not(...)` lookahead, reordering, a dedicated trivia
+ *  parser), do that instead.
+ *
  *  Used as `not(startOfLineContent)` to stop a bracket chain element
  *  from continuing an expression across a newline. Expression parsers
  *  (function calls in particular) consume trailing whitespace INCLUDING


### PR DESCRIPTION
Fixes the first of the three compiler gaps found during the safeBash match refactor (#707's TODO entries): a single-element array pattern arm after an expression arm parsed as an **index on that arm's value**, killing the whole match with the generic "expected match cases" error.

## Mechanism (from the DEBUG trace)

`_functionCallParser` consumes trailing whitespace **including newlines**. After the arm expression `failure("a")` parsed, the chain loop (`many(chainElementParser)`) resumed at the next line's `[sub]`, `bracketParser` matched, and the second arm's pattern became `failure("a")[sub]`. Multi-element patterns were immune only because `expr["a", "b"]` is not valid index syntax — which is why v2 safeBash's `["git", "status"]` arms worked by accident while v3's `["status"]` arms could not.

## The fix

A boundary at the top of `indexChainParser` and `sliceChainParser`: look back from the element's position across spaces and tabs (via tarsec's parse-wide input, `getInputStr`), and refuse the element if a newline sits there. Statement context already refused this continuation (`const x = g()` newline `[0]` was two statements before this change), so the boundary aligns expression context with existing statement behavior rather than inventing a new rule.

Deliberately untouched: **dot-method chains** — a fluent `.method()` on its own line is an established style. A bare `[i]` on a new line is an array literal or a pattern, never an intended index. If the parse-wide input is unavailable (defensive case), the boundary disables itself and behavior is exactly as before.

## Verified

- New `lib/parsers/chainNewlineBoundary.test.ts`: the four failing arm shapes now parse (literal, binder, guarded, and after a multiline arm expression); same-line chains (`arr[0][1]`, `arr[:2]`, multiline-call-then-`[0]`) unchanged; next-line bracket provably does not glue onto the previous expression. Tests run through `parseAgency` — raw-parser tests don't install the parse-wide input (vitest resolves two tarsec instances), which is itself worth knowing.
- Full parser suite: 1753/1753. Full corpus build clean (only the known deliberate diagnostics). safeBash agency tests 18/18, fixture typecheck + walker tripwire green, structural lint clean.

Removes the fixed entry from TODO.md. The two checker gaps (arm narrowing, flow into arm blocks) remain and are next; spec incoming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
