### PR TITLE
safeBash tests: fixture rows stop describing the retired flat record

### DIFF
--- a/packages/agency-lang/TODO.md
+++ b/packages/agency-lang/TODO.md
@@ -448,16 +448,6 @@ match cannot. Found in the safeBash match refactor:
 Exhaustiveness (AG5002) works well; arm narrowing is the missing half.
 safeBash's `raiseOne` and `flattenOne` are the motivating cases — both
 carry comments saying they want to be matches when this lands.
-
----
-
-safeBash test fixtures: the non-write rows in `shellFreeWrite` (and the
-`writePlanDetail` helper) still report the old flat-Execution sentinel
-fields ("", "", "", "overwrite") for bash plans, to keep the match/pipe
-refactor byte-identical. Follow-up: collapse those rows to what a
-BashExec actually carries, so the fixtures stop describing a record that
-no longer exists.
-
 ---
 
 Flow narrowing does not reach inside a match arm block. The identical

--- a/packages/agency-lang/tests/agency/safeBash.agency
+++ b/packages/agency-lang/tests/agency/safeBash.agency
@@ -148,13 +148,9 @@ def writePlanDetail(source: string): any {
   // `mode` is in the tuple deliberately. Without it, a `writeMode` that
   // always returned "overwrite" survives the whole suite, and
   // `echo hi >> notes.txt` silently TRUNCATES the file.
-  //
-  // The non-write arm reports the same sentinel fields the old flat
-  // Execution record carried, so the fixture rows for bash plans stay
-  // byte-identical across the union refactor.
   return match(plan.execution) {
     { kind: "write", content, filename, dir, mode } => return ["write", content, filename, dir, mode, names]
-    { kind } => [kind, "", "", "", "overwrite", names]
+    { kind } => [kind, names]
   }
 }
 

--- a/packages/agency-lang/tests/agency/safeBash.test.json
+++ b/packages/agency-lang/tests/agency/safeBash.test.json
@@ -68,9 +68,9 @@
     },
     {
       "nodeName": "shellFreeWrite",
-      "description": "A single literal redirected echo computes its content and writes it, with no shell. The `>` and `>>` rows differ only in mode, which is the difference between overwriting and appending. A variable TARGET is unrecognized entirely; a variable in the ARGUMENTS is not shell-free but is still recognized, and goes to bash raising std::write with no content \u2014 approval of the destination, not the bytes, because bash has not run yet.",
+      "description": "A single literal redirected echo computes its content and writes it, with no shell. The `>` and `>>` rows differ only in mode, which is the difference between overwriting and appending. A variable TARGET is unrecognized entirely; a variable in the ARGUMENTS is still recognized and goes to bash raising std::write with no content \u2014 approval of the destination, not the bytes. Non-write plans report only the fields their Execution variant carries.",
       "input": "",
-      "expectedOutput": "[[\"write\",\"hi\\n\",\"out.txt\",\"/repo\",\"overwrite\",[\"std::write\"]],[\"write\",\"hi\\n\",\"out.txt\",\"/repo\",\"append\",[\"std::write\"]],[\"bash\",\"\",\"\",\"\",\"overwrite\",[\"std::bash\"]],[\"bash\",\"\",\"\",\"\",\"overwrite\",[\"std::write\"]]]",
+      "expectedOutput": "[[\"write\",\"hi\\n\",\"out.txt\",\"/repo\",\"overwrite\",[\"std::write\"]],[\"write\",\"hi\\n\",\"out.txt\",\"/repo\",\"append\",[\"std::write\"]],[\"bash\",[\"std::bash\"]],[\"bash\",[\"std::write\"]]]",
       "evaluationCriteria": [
         {
           "type": "exact"


### PR DESCRIPTION
The small follow-up deferred from the #707 review: the `shellFreeWrite` fixture rows (and the `writePlanDetail` helper) still reported the old flat-Execution sentinel fields — `"", "", "", "overwrite"` — for bash plans, describing a filename, dir, and mode that a `BashExec` does not have. Keeping them byte-identical was the right call *in* the refactor PR (it was the proof nothing changed); after the merge it just teaches the reader a shape the code contradicts.

Non-write rows now report `[kind, effects]`; write rows keep all six fields, `mode` included — the row that catches a `writeMode` regression stays intact. Removes the corresponding TODO entry. 18/18 agency tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
