### PR TITLE
fix: node/def declarations no longer parse as a name plus a call, and toSource stops mutating its input

### DIFF
--- a/packages/agency-lang/docs/dev/template-agency.md
+++ b/packages/agency-lang/docs/dev/template-agency.md
@@ -1,6 +1,6 @@
 # Template Agency: implementation
 
-How templates (holes, `fill`, hygiene) work under the hood. The user-facing story is in `docs/site/guide/templates.md`; the design history is in `docs/superpowers/specs/2026-07-22-code-templates-design.md`. This doc is for changing the implementation without re-learning it. Shipped in #665.
+How templates (holes, `fill`, hygiene) work under the hood. The user-facing story is in `docs/site/guide/template-agency.md`; the design history is in `docs/superpowers/specs/2026-07-22-code-templates-design.md`. This doc is for changing the implementation without re-learning it. Shipped in #665.
 
 ## The one rule, stated first
 
@@ -141,7 +141,9 @@ Rename application is a bespoke rewriting walk, and that is documented rather th
 
 ## Code literals (`[| ... |]`)
 
-An inline template is a `codeLiteral` expression node — `{ nodes, kind }` — whose body parsed at parse time of the enclosing file (unlowered template mode, holes intact). Kind is inferred smallest-first by `parseCodeLiteralBody`: a lone expression, else a statement list, else a program; each attempt must consume the whole body. The expr-fills-statements admissibility relaxation (see `assertKindMatchesSort`) is what makes this inference lossless — anything inferred `expr` also works wherever statements go.
+An inline template is a `codeLiteral` expression node — `{ nodes, kind }` — whose body parsed at parse time of the enclosing file (unlowered template mode, holes intact). Kind is inferred smallest-first by `parseCodeLiteralBody`: a lone expression, else a statement list, else a program; each attempt must consume the whole body. The expr-fills-statements admissibility relaxation (see `assertKindMatchesSort`) is what makes the expression case lossless — anything inferred `expr` also works wherever statements go.
+
+Smallest-first is only correct because the statement grammar refuses to read a declaration. `node main() { … }` written without a return type is otherwise a legal statement list — the name `node`, then a call to `main` taking a trailing block, because a call may take a block and keywords are not reserved in expression position — so the statements attempt would win and the program attempt would never run. `bodyDeclarationParser` declines that shape in body position, which is what makes the fall-through happen; a return type annotation is what accidentally saved the annotated forms before it existed. Two details of it are load bearing. It returns `committedFailure`, not plain `failure`: `or` treats an ordinary failure as "try the next alternative", and the alternatives after it are the ones that read `node` as a name, so a plain failure makes the whole thing a no-op. And it registers that failure in `getParseState().committedFailure`, the slot `committed()` writes and both of `parseAgency`'s failure exits prefer — without it the message loses to the enclosing `parseError` throw and a user sees "expected node body" instead of what is wrong. Separately, `parseCodeLiteralBody` wraps its expr and statements attempts in `tryAttempt`, because a parser reached during an attempt may throw (`bodyReservedModifierParser` does, for `static const`) and a throw would abandon the attempts after it. Removing any of the three silently restores a mis-parse.
 
 The implementation rides on four tarsec ≥0.5.1 features that exist because this feature needed them (see `docs/superpowers/specs/2026-07-24-tarsec-nested-parsing-and-errors-design.md` for the war stories):
 

--- a/packages/agency-lang/docs/site/examples/generatedAgent.md
+++ b/packages/agency-lang/docs/site/examples/generatedAgent.md
@@ -19,8 +19,7 @@ Using [Template Agency](/guide/template-agency) to generate the code for a resea
 
 ```ts
   const template = [|
-    node
-    main() {
+    node main() {
       const topic = #topic
       const res = llm("Research the topic: ${topic} and provide a summary of findings.")
       return res

--- a/packages/agency-lang/lib/backends/agencyGenerator.roundtrip.test.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.roundtrip.test.ts
@@ -222,6 +222,24 @@ describe("formatter gate: code literals", () => {
     expect(generateAgency(parseTemplateMode(source))).toBe(expected);
   });
 
+  it("golden: an un-annotated node in a literal keeps its declaration", () => {
+    // The reported symptom of the mis-parse was formatting: `node` and
+    // `main() {` printed on separate lines, because the tree held a name
+    // and a call. A byte-exact golden is what stops that coming back.
+    const source = `node host() {\n  const t = [|\n    node main() {\n      print(1)\n    }\n  |]\n}\n`;
+    const expected = [
+      "node host() {",
+      "  const t = [|",
+      "    node main() {",
+      "      print(1)",
+      "    }",
+      "  |]",
+      "}",
+      "",
+    ].join("\n");
+    expect(generateAgency(parseTemplateMode(source))).toBe(expected);
+  });
+
   it("a body comment survives printing", () => {
     const source = `node main() {\n  const t = [|\n    // keep me\n    print(1)\n  |]\n}\n`;
     const printed = generateAgency(parseTemplateMode(source));

--- a/packages/agency-lang/lib/backends/agencyGenerator.test.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { AgencyGenerator } from "./agencyGenerator.js";
+import { AgencyGenerator, generateAgency } from "./agencyGenerator.js";
 import { parseAgency } from "../parser.js";
+import { deepFreeze } from "../runtime/utils.js";
 import { FunctionDefinition } from "../types.js";
 
 describe("AgencyGenerator - Function Parameter Type Hints", () => {
@@ -1128,5 +1129,53 @@ describe("finalize block formatting", () => {
     if (!reparsed.success) return;
     const regenerated = new AgencyGenerator().generate(reparsed.result).output;
     expect(regenerated).toContain("finalize {");
+  });
+});
+
+describe("AgencyGenerator - does not modify its input", () => {
+  // The import sits BELOW the declaration on purpose. Hoisting is what
+  // makes the printer want to rewrite the node list, so a source where the
+  // import is already at the top cannot tell you whether hoisting still
+  // happens after the fix.
+  const source = [
+    "// a header comment",
+    "node main(): string {",
+    '  return "x"',
+    "}",
+    "",
+    'import { read } from "std::fs"',
+    "",
+  ].join("\n");
+
+  function parseOk(text: string) {
+    const result = parseAgency(text, {}, false);
+    if (!result.success) throw new Error(result.message);
+    return result.result;
+  }
+
+  it("leaves the caller's program untouched", () => {
+    const program = parseOk(source);
+    // Whole-tree comparison, not a list of node types: a type list is
+    // blind to a mutation inside a node, or to a reorder among nodes of
+    // the same type. This asserts the invariant the fix is really about.
+    const before = JSON.stringify(program);
+    generateAgency(program);
+    expect(JSON.stringify(program)).toBe(before);
+  });
+
+  it("prints a deep-frozen program without throwing", () => {
+    // A `static const` Code value is deep-frozen at init, so this is the
+    // exact shape `toSource(someStaticLiteral)` hands the printer.
+    const program = deepFreeze(parseOk(source));
+    expect(() => generateAgency(program)).not.toThrow();
+  });
+
+  it("still hoists imports above declarations", () => {
+    // Order, not presence. A `toContain` pair would stay green if
+    // partitioning were deleted outright, which is the thing this guards.
+    const printed = generateAgency(parseOk(source));
+    expect(printed.indexOf('import { read } from "std::fs"')).toBeLessThan(
+      printed.indexOf("node main(): string {"),
+    );
   });
 });

--- a/packages/agency-lang/lib/backends/agencyGenerator.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.ts
@@ -163,7 +163,6 @@ export class AgencyGenerator {
   > = new Map();
   protected functionDefinitions: Record<string, FunctionDefinition> = {};
   protected currentScope: Scope[] = [{ type: "global" }];
-  protected program: AgencyProgram | null = null;
   protected agencyConfig: AgencyConfig = {};
 
   private indentLevel: number = 0;
@@ -198,7 +197,6 @@ export class AgencyGenerator {
   generate(program: AgencyProgram): {
     output: string;
   } {
-    this.program = program;
     // Pass 1: Collect all type aliases
     for (const node of program.nodes) {
       if (node.type === "typeAlias") {

--- a/packages/agency-lang/lib/backends/agencyGenerator.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.ts
@@ -219,19 +219,23 @@ export class AgencyGenerator {
     // while preserving `// @tc-ignore` / `// @tc-nocheck` placement.
     // Skipped in preserveOrder mode (literate weave) because the whole
     // point there is to leave nodes exactly where the author put them.
-    if (!this.preserveOrder) {
-      program.nodes = this.partitionImports(program.nodes);
-    }
+    // A local, never a write-back. The caller may own this tree — a `Code`
+    // value from a `static const` is deep-frozen, and assigning to
+    // `program.nodes` throws. Passes 3, 4 and 5 below read `nodes`; passes
+    // 1 and 2 above ran before the partition and read `program.nodes`.
+    const nodes = this.preserveOrder
+      ? program.nodes
+      : this.partitionImports(program.nodes);
 
     // Pass 3: Collect all node imports
-    for (const node of program.nodes) {
+    for (const node of nodes) {
       if (node.type === "importNodeStatement") {
         this.importedNodes.push(node);
       }
     }
 
     // Pass 4: Generate code for tools
-    for (const node of program.nodes) {
+    for (const node of nodes) {
       if (node.type === "function") {
         this.generatedStatements.push(this.processTool(node));
         this.collectFunctionSignature(node);
@@ -251,7 +255,7 @@ export class AgencyGenerator {
 
     // Pass 5: Process all nodes and generate code
     const stmtPairs: { type: string; code: string }[] = [];
-    for (const node of program.nodes) {
+    for (const node of nodes) {
       const result = this.processNode(node);
       if (result !== "" || node.type === "newLine") {
         // Collapse runs of blank lines to one. Import hoisting can leave

--- a/packages/agency-lang/lib/parsers/body.test.ts
+++ b/packages/agency-lang/lib/parsers/body.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { bodyParser } from "./parsers.js";
+import { parseAgency } from "../parser.js";
 
 describe("functionBodyParser", () => {
   const testCases = [
@@ -113,4 +114,92 @@ describe("functionBodyParser", () => {
       });
     }
   });
+});
+
+describe("declarations are not legal in a body", () => {
+  // These assert a FAILURE, not a partial success. The decline is a
+  // committed failure, and `many` fails the whole repetition when it meets
+  // one — which is exactly what a code literal needs, since kind inference
+  // only reaches the program parser if the statements attempt fails
+  // outright.
+  const declarations = [
+    "node inner() { print(1) }",
+    "def helper() { return 1 }",
+    "print(1)\nnode inner() { print(2) }",
+  ];
+
+  for (const source of declarations) {
+    it(`fails on: ${source.split("\n")[0]}`, () => {
+      const result = bodyParser(source);
+      expect(result.success, source).toBe(false);
+      if (result.success) return;
+      expect(result.message, source).toContain(
+        "only legal at the top level of a file",
+      );
+    });
+  }
+});
+
+describe("the body-declaration message reaches a whole-file parse", () => {
+  // At this level, not `bodyParser`: a block parser wraps its body in
+  // tarsec's `parseError`, which THROWS its own generic message over
+  // whatever failed inside. Only `parseAgency` catches that and consults
+  // the committed-failure slot, which is why `bodyDeclarationParser`
+  // registers itself there. Without that registration these report
+  // "expected node body" / "expected `{` to open if block body" and the
+  // user is told nothing useful.
+  const files: [string, string][] = [
+    ["a node body", "node main() {\n  node inner() {\n    print(1)\n  }\n}\n"],
+    ["a def body", "node main() {\n  def helper() {\n    return 1\n  }\n}\n"],
+    [
+      "inside an if",
+      "node main() {\n  if (true) {\n    node inner() {\n      print(1)\n    }\n  }\n}\n",
+    ],
+  ];
+
+  for (const [label, source] of files) {
+    it(`names the top-level rule for a declaration in ${label}`, () => {
+      const result = parseAgency(source, {}, false);
+      expect(result.success, label).toBe(false);
+      if (result.success) return;
+      expect(result.message, label).toContain(
+        "only legal at the top level of a file",
+      );
+    });
+  }
+});
+
+describe("keyword-as-variable statements still parse", () => {
+  // `node` is a legal variable name (`const node = 1` compiles today).
+  // Every one of these fails the declaration probe somewhere, which is
+  // what keeps them out of the decline.
+  const cases: { input: string; firstType: string }[] = [
+    { input: "node.run()", firstType: "valueAccess" },
+    { input: "node + 1", firstType: "binOpExpression" },
+    { input: "node(1)", firstType: "functionCall" },
+    { input: "node", firstType: "variableName" },
+    { input: "debugger", firstType: "variableName" },
+    { input: "nodeCount()", firstType: "functionCall" },
+    // Keyword followed by a word is the reason the probe requires a name
+    // AND a `(`. All three parse today, and a probe that stopped at
+    // "keyword, space, identifier" would decline them — which, being a
+    // committed failure, turns something that parses into a hard error.
+    // `node is string` is three bare-name statements, not an `is`
+    // expression; it is junk, but it is junk that parses, and this change
+    // is not the place to start rejecting it.
+    { input: "node is string", firstType: "variableName" },
+    { input: "node as Foo", firstType: "variableName" },
+    { input: "node in items", firstType: "binOpExpression" },
+  ];
+
+  for (const { input, firstType } of cases) {
+    it(`parses \`${input}\` as before`, () => {
+      const result = bodyParser(input);
+      expect(result.success, input).toBe(true);
+      if (!result.success) return;
+      expect(result.result.length, input).toBeGreaterThan(0);
+      expect(result.result[0].type, input).toBe(firstType);
+      expect(result.rest.trim(), input).toBe("");
+    });
+  }
 });

--- a/packages/agency-lang/lib/parsers/body.test.ts
+++ b/packages/agency-lang/lib/parsers/body.test.ts
@@ -140,6 +140,26 @@ describe("declarations are not legal in a body", () => {
   }
 });
 
+describe("known limitation: a keyword and a call on separate lines", () => {
+  it("declines `node` on one line and a call on the next, which parsed before", () => {
+    // ACCEPTED REGRESSION, pinned so a future probe change that un-declines
+    // it is a deliberate decision rather than an accident.
+    //
+    // Here `node` is an ordinary variable and `helper()` an ordinary call,
+    // and this file compiles on main. The probe's `many1(space)` matches a
+    // newline — the same whitespace the real declaration grammar accepts —
+    // so keyword-newline-name-paren is declined exactly like the one-line
+    // form. That text is indistinguishable from the bug being fixed, and
+    // anyone writing it almost certainly meant a declaration.
+    const source =
+      "def helper(): number {\n  return 1\n}\n\nnode main() {\n  const node = 1\n  node\n  helper()\n}\n";
+    const result = parseAgency(source, {}, false);
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.message).toContain("only legal at the top level of a file");
+  });
+});
+
 describe("the body-declaration message reaches a whole-file parse", () => {
   // At this level, not `bodyParser`: a block parser wraps its body in
   // tarsec's `parseError`, which THROWS its own generic message over

--- a/packages/agency-lang/lib/parsers/codeLiteral.test.ts
+++ b/packages/agency-lang/lib/parsers/codeLiteral.test.ts
@@ -306,3 +306,77 @@ describe("code literals: review-round pins", () => {
     expect(errorData!.line).toBeLessThanOrEqual(3);
   });
 });
+
+describe("declarations in a literal infer program", () => {
+  // `expects` lists node types the literal must hold. Order is not
+  // asserted — a leading comment is kept as a node of its own, so the
+  // declaration is not always first.
+  const cases: { body: string; expects: string[]; label: string }[] = [
+    { label: "un-annotated node", body: "node main() {\n  print(1)\n}", expects: ["graphNode"] },
+    { label: "un-annotated def", body: "def foo() {\n  return 1\n}", expects: ["function"] },
+    { label: "node with parameters", body: "node m(x: number) {\n  print(x)\n}", expects: ["graphNode"] },
+    { label: "two declarations", body: "node a() {\n  print(1)\n}\n\nnode b() {\n  print(2)\n}", expects: ["graphNode"] },
+    { label: "comment first", body: "// hi\nnode main() {\n  print(1)\n}", expects: ["comment", "graphNode"] },
+    { label: "statement then declaration", body: "print(1)\nnode main() {\n  print(2)\n}", expects: ["functionCall", "graphNode"] },
+  ];
+
+  for (const { label, body, expects } of cases) {
+    it(`infers program for a ${label}`, () => {
+      const lit = firstLiteral(`node host() {\n  const t = [|\n${body}\n  |]\n}\n`);
+      expect(lit.kind, label).toBe("program");
+      // The kind alone is not enough: it was already wrong for a reason
+      // only the node types reveal. Under the bug the declaration became a
+      // `variableName` plus a `functionCall`, so both halves of this
+      // matter — the declaration is present, and no stray name is.
+      const types = lit.nodes.map((node) => node.type);
+      for (const expected of expects) {
+        expect(types, `${label}: ${expected}`).toContain(expected);
+      }
+      expect(types, label).not.toContain("variableName");
+    });
+  }
+
+  it("still infers program for an annotated node", () => {
+    const lit = firstLiteral(`node host() {\n  const t = [|\n    node main(): string {\n      return "x"\n    }\n  |]\n}\n`);
+    expect(lit.kind).toBe("program");
+    expect(lit.nodes[0].type).toBe("graphNode");
+  });
+
+  it("still infers program for an annotated def", () => {
+    // `def` takes the other branch of the probe's `or`, so it needs its
+    // own annotated case, not just the un-annotated one above.
+    const lit = firstLiteral(`node host() {\n  const t = [|\n    def foo(): number {\n      return 1\n    }\n  |]\n}\n`);
+    expect(lit.kind).toBe("program");
+    expect(lit.nodes[0].type).toBe("function");
+  });
+
+  it("reports a broken declaration instead of silently reading two statements", () => {
+    // Before the fix this parsed as statements and produced junk. Now the
+    // statements attempt declines and the parse fails.
+    const source = `node host() {\n  const t = [|\n    node main( {\n      print(1)\n    }\n  |]\n}\n`;
+    const result = parseAgency(source, {}, true, false);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("bodies whose kind must not change", () => {
+  // Regression guards. Each begins with a word that a keyword-routing fix
+  // would have misread, and `type` / `effect` are legal in bodies so their
+  // statements answer is the correct one.
+  const cases: { body: string; kind: string }[] = [
+    { body: "node", kind: "expr" },
+    { body: "node.run()", kind: "expr" },
+    { body: "node + 1", kind: "expr" },
+    { body: "const x = 1", kind: "statements" },
+    { body: "print(1)", kind: "expr" },
+    { body: "type P = { n: number }", kind: "statements" },
+    { body: "effect Foo", kind: "statements" },
+  ];
+
+  for (const { body, kind } of cases) {
+    it(`keeps \`${body}\` as ${kind}`, () => {
+      const lit = firstLiteral(`node host() {\n  const node = 1\n  const t = [| ${body} |]\n  print("x")\n}\n`);
+      expect(lit.kind, body).toBe(kind);
+    });
+  }
+});

--- a/packages/agency-lang/lib/parsers/codeLiteral.test.ts
+++ b/packages/agency-lang/lib/parsers/codeLiteral.test.ts
@@ -352,10 +352,17 @@ describe("declarations in a literal infer program", () => {
 
   it("reports a broken declaration instead of silently reading two statements", () => {
     // Before the fix this parsed as statements and produced junk. Now the
-    // statements attempt declines and the parse fails.
+    // statements attempt declines, the program attempt runs, and its own
+    // declaration parser reports the real problem — the unclosed parameter
+    // list. Asserting the message matters as much as asserting the failure:
+    // a future change that keeps the failure but degrades the message to a
+    // generic one would still pass a success-only check while telling the
+    // user nothing.
     const source = `node host() {\n  const t = [|\n    node main( {\n      print(1)\n    }\n  |]\n}\n`;
     const result = parseAgency(source, {}, true, false);
     expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.message).toContain("parameter list");
   });
 });
 

--- a/packages/agency-lang/lib/parsers/codeLiteral.test.ts
+++ b/packages/agency-lang/lib/parsers/codeLiteral.test.ts
@@ -380,3 +380,20 @@ describe("bodies whose kind must not change", () => {
     });
   }
 });
+
+describe("a throwing attempt does not abandon the remaining attempts", () => {
+  // `static const` is rejected inside a function body by a parser that
+  // reports through tarsec's parseError, which THROWS. A literal body may
+  // legitimately be a whole program, where `static const` is correct.
+  it("parses a static const literal as a program", () => {
+    const lit = firstLiteral(`node host() {\n  const t = [|\n    static const x = 1\n  |]\n  print("y")\n}\n`);
+    expect(lit.kind).toBe("program");
+    expect(lit.nodes.map((node) => node.type)).toContain("assignment");
+  });
+
+  it("parses a static const written after another statement", () => {
+    const lit = firstLiteral(`node host() {\n  const t = [|\n    const a = 1\n    static const x = 2\n  |]\n  print("y")\n}\n`);
+    expect(lit.kind).toBe("program");
+    expect(lit.nodes.filter((node) => node.type === "assignment").length).toBe(2);
+  });
+});

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -3095,6 +3095,37 @@ function advancePositionOver(base: Position, text: string): Position {
  *  `base` is passed in USER coordinates (template offset already
  *  subtracted), and this file's own template offset is zeroed around the
  *  nested parses so withLoc does not subtract it a second time. */
+/**
+ * Run one kind attempt, treating a throw as a non-match.
+ *
+ * A parser reached during an attempt may throw rather than fail: tarsec's
+ * `parseError` does, and `bodyReservedModifierParser` uses it to explain
+ * `static const` written inside a function body. That message is right for a
+ * body and wrong for a literal, whose body may legitimately be a whole
+ * program. An attempt that dies is an attempt that did not match, so the
+ * remaining attempts must still run.
+ *
+ * Safe because `runNested` restores the enclosing parse's state in a
+ * `finally` — success, failure, or throw — so a caught throw leaves no
+ * corrupted state behind, and the committed-failure slot it swaps back is
+ * the enclosing parse's own. Only `TarsecError` is converted; anything else
+ * is a real bug and still propagates.
+ *
+ * Returns a `ParserResult` rather than null, so a caught throw IS a failure:
+ * the call sites keep their ordinary `.success` checks, and the thrown
+ * message survives instead of being discarded.
+ */
+function tryAttempt<T>(run: () => ParserResult<T>): ParserResult<T> {
+  try {
+    return run();
+  } catch (error) {
+    if (error instanceof TarsecError) {
+      return failure(error.message, "") as ParserResult<T>;
+    }
+    throw error;
+  }
+}
+
 export function parseCodeLiteralBody(body: string, base?: Position): ParsedLiteralBody {
   const sentineled = replaceBlankLines(body);
   // Strip whitespace AND blank-line sentinels: a sentinel is not JS
@@ -3110,11 +3141,15 @@ export function parseCodeLiteralBody(body: string, base?: Position): ParsedLiter
   const savedOffset = currentTemplateOffset;
   setTemplateOffset(0);
   try {
-    const asExpr = runNested(exprParser, trimmed, { basePosition: trimmedBase });
+    const asExpr = tryAttempt(() =>
+      runNested(exprParser, trimmed, { basePosition: trimmedBase }),
+    );
     if (asExpr.success && stripSentinels(asExpr.rest).trim() === "") {
       return { ok: true, nodes: [asExpr.result as AgencyNode], kind: "expr" };
     }
-    const asStatements = runNested(bodyParser, trimmed, { basePosition: trimmedBase });
+    const asStatements = tryAttempt(() =>
+      runNested(bodyParser, trimmed, { basePosition: trimmedBase }),
+    );
     if (asStatements.success && stripSentinels(asStatements.rest).trim() === "") {
       return { ok: true, nodes: asStatements.result as AgencyNode[], kind: "statements" };
     }

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -66,6 +66,7 @@ import {
   isCommittedFailure,
   getPosition,
   getInputStr,
+  getParseState,
   type Position,
 } from "tarsec";
 
@@ -4490,6 +4491,63 @@ export const modifiedAssignmentParser: Parser<Assignment> = withLoc((input: stri
   return success(out, result.rest);
 });
 
+const BODY_DECLARATION_MESSAGE =
+  "`node` and `def` declarations are only legal at the top level of a file.";
+
+/**
+ * Decline a statement that starts like a `node` or `def` declaration.
+ *
+ * A call may take a trailing block and keywords are not reserved in
+ * expression position, so `node main() { ... }` in a body otherwise parses
+ * as the name `node` followed by a call to `main`. That tree compiles and
+ * fails at run time with `node is not defined`. Declining removes the
+ * reading; inside a code literal it is also what lets kind inference fall
+ * through to the program parser, where a declaration belongs.
+ *
+ * The probe mirrors the real declaration prefix — keyword, whitespace,
+ * name, `(` — the same shape `graphNodeParser` and `_baseFunctionParser`
+ * consume, and it reuses `varNameChar`, this file's single definition of an
+ * identifier character. Requiring the `(` is what keeps ordinary uses of
+ * `node` as a variable out of the decline: `node.run()` and `node + 1` fail
+ * at the whitespace, `node (x)` and `node is string` fail for want of a
+ * name-then-paren, `nodeCount()` fails because `str("node")` is not
+ * followed by whitespace.
+ *
+ * `committedFailure`, never plain `failure` and never `parseError`. A plain
+ * failure means "try the next alternative", and the alternatives below
+ * include the parsers that read `node` as a name — the decline would do
+ * nothing at all. `parseError` throws, which escapes
+ * `parseCodeLiteralBody`'s statements attempt and abandons the program
+ * attempt, the bug `bodyReservedModifierParser` causes for `static const`.
+ * A committed failure stops backtracking without throwing, which is exactly
+ * the job; same pattern as the nested-literal directive above.
+ */
+const bodyDeclarationParser: Parser<never> = (input: string) => {
+  const probe = seqC(
+    or(str("node"), str("def")),
+    many1(space),
+    many1WithJoin(varNameChar),
+    optionalSpaces,
+    char("("),
+  );
+  const probed = probe(input);
+  if (!probed.success) {
+    return failure("", input);
+  }
+  const declined = committedFailure(BODY_DECLARATION_MESSAGE, probed.rest);
+  // Record it in the preferred-message slot, which is what `committed()`
+  // does for the failures it produces (tarsec combinators.js:226) and what
+  // both of `parseAgency`'s failure exits read. Marking the RESULT
+  // committed only stops `or` and `many` from backtracking; without the
+  // slot this message loses to the enclosing `parseError` throw — a node
+  // body is wrapped in one, so the user would get "expected node body"
+  // instead of being told what is actually wrong. Position comes from
+  // `probed.rest`, past the declaration name, so the squiggle lands on the
+  // declaration rather than at the start of the statement.
+  getParseState().committedFailure = declined;
+  return declined as ParserResult<never>;
+};
+
 const bodyOptimizeAssignmentParser: Parser<Assignment> = (input: string) => {
   const result = modifiedAssignmentParser(input);
   if (!result.success) return result;
@@ -4633,6 +4691,11 @@ const _bodyNodeParser: Parser<AgencyNode> = memo("bodyNodeParser", or(
   typeAliasParser,
   tagParser,
   bodyReservedModifierParser,
+  // Next to bodyReservedModifierParser because it does the same job: both
+  // decline a top-level-only declaration written inside a body. This one
+  // must sit ahead of assignmentParser / binOpParser / valueAccessParser,
+  // which are what would otherwise read `node` as a name.
+  bodyDeclarationParser,
   // withModifierParser must be tried before returnStatementParser/
   // assignmentParser so that `return foo() with approve` and
   // `const x = foo() with approve` don't get partially consumed by

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -3083,18 +3083,6 @@ function advancePositionOver(base: Position, text: string): Position {
   };
 }
 
-/** Smallest-first kind inference over a literal body: a lone expression,
- *  else a statement list, else a program. Each attempt must consume the
- *  whole body. EXPORTED and shared with the runtime constructor
- *  (__codeLiteral), so compile-time and runtime reconstruction cannot
- *  diverge by drift.
- *
- *  Each attempt runs in `runNested` — its own input string, rightmost
- *  record, and memo caches, restored on exit — with `basePosition` set
- *  so spans AND error messages come out in enclosing-file coordinates.
- *  `base` is passed in USER coordinates (template offset already
- *  subtracted), and this file's own template offset is zeroed around the
- *  nested parses so withLoc does not subtract it a second time. */
 /**
  * Run one kind attempt, treating a throw as a non-match.
  *
@@ -3126,6 +3114,18 @@ function tryAttempt<T>(run: () => ParserResult<T>): ParserResult<T> {
   }
 }
 
+/** Smallest-first kind inference over a literal body: a lone expression,
+ *  else a statement list, else a program. Each attempt must consume the
+ *  whole body. EXPORTED and shared with the runtime constructor
+ *  (__codeLiteral), so compile-time and runtime reconstruction cannot
+ *  diverge by drift.
+ *
+ *  Each attempt runs in `runNested` — its own input string, rightmost
+ *  record, and memo caches, restored on exit — with `basePosition` set
+ *  so spans AND error messages come out in enclosing-file coordinates.
+ *  `base` is passed in USER coordinates (template offset already
+ *  subtracted), and this file's own template offset is zeroed around the
+ *  nested parses so withLoc does not subtract it a second time. */
 export function parseCodeLiteralBody(body: string, base?: Position): ParsedLiteralBody {
   const sentineled = replaceBlankLines(body);
   // Strip whitespace AND blank-line sentinels: a sentinel is not JS

--- a/packages/agency-lang/tests/agency/templates/literalNodeDeclaration.agency
+++ b/packages/agency-lang/tests/agency/templates/literalNodeDeclaration.agency
@@ -1,0 +1,34 @@
+import { fill, toSource, runCode } from "std::agency"
+
+// A node declaration written without a return type used to parse as the
+// name `node` followed by a call. Nothing downstream caught it: the tree
+// printed and re-parsed stably, and only the generated program failed. This
+// runs the whole path — parse, fill, print, re-parse, compile, run — so the
+// stages have to agree.
+node main(): string {
+  const tpl = [|
+    export node main() {
+      const who: string = #who
+      return "hello " + who
+    }
+  |]
+  const filled = fill(tpl, { who: "world" })
+  if (isFailure(filled)) {
+    return "fill failed: ${filled.error}"
+  }
+  const source = toSource(filled.value)
+  if (!source.includes("node main() {")) {
+    return "bad source: ${source}"
+  }
+  handle {
+    const result = runCode(source)
+    if (isFailure(result)) {
+      return "run failed: ${result.error}"
+    }
+    return result.value
+  } with (e) {
+    if (e.effect == "std::run") {
+      return approve()
+    }
+  }
+}

--- a/packages/agency-lang/tests/agency/templates/literalNodeDeclaration.test.json
+++ b/packages/agency-lang/tests/agency/templates/literalNodeDeclaration.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"hello world\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "A node declaration without a return type survives a literal, a fill, and a run"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/templates/staticToSource.agency
+++ b/packages/agency-lang/tests/agency/templates/staticToSource.agency
@@ -1,0 +1,19 @@
+import { toSource } from "std::agency"
+
+// A `static const` Code value is deep-frozen at init. The printer used to
+// write its reordered node list back over the caller's `nodes` field, so
+// this threw. Every other fixture calls `fill` first, which clones, and so
+// never touched the frozen value.
+static const template = [|
+  node main() {
+    print("hi")
+  }
+|]
+
+node main(): string {
+  const source = toSource(template)
+  if (source.includes("node main() {")) {
+    return "ok"
+  }
+  return "unexpected: ${source}"
+}

--- a/packages/agency-lang/tests/agency/templates/staticToSource.test.json
+++ b/packages/agency-lang/tests/agency/templates/staticToSource.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"ok\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "toSource prints a static const literal without an intervening fill"
+    }
+  ]
+}


### PR DESCRIPTION
Two independent bugs found while working through the Template Agency guide. Spec and plan:

- `docs/superpowers/specs/2026-07-28-code-literal-parse-and-print-fixes-design.md`
- `docs/superpowers/plans/2026-07-28-code-literal-parse-and-print-fixes.md`

## Bug 1: a declaration parsed as a name followed by a call

This compiled, and died at run time with `ReferenceError: node is not defined`:

```ts
node main() {
  node inner() { print(1) }
  print("x")
}
```

A call may take a trailing block, and keywords are not reserved in expression position (`const node = 1` compiles today), so the body parser read `node` as a name and `main() { ... }` as a call with a block. A return type annotation makes the call reading fail, which is why `node main(): string { ... }` always worked and nobody noticed.

Inside a code literal it was worse. `parseCodeLiteralBody` tries expression, then statements, then program, taking the first that consumes the body — so the wrong statements reading won and the program parser was never consulted. `[| node main() { ... } |]` ended up holding a name and a call. Nothing downstream caught it: the tree printed and re-parsed stably, `fill` and `holesOf` worked fine, and only the generated program failed. The reported symptom was `agency fmt` printing `node` and `main() {` on separate lines — the formatter printing exactly what it was handed.

**Fix:** decline the declaration shape in body position (`bodyDeclarationParser`). Ordinary bodies now get a real error, and code literals fall through to the program parser and get the right tree. No routing, no peeking at literal bodies.

Three details are load bearing and are commented at the code:

- It returns `committedFailure`, not plain `failure`. `or` treats an ordinary failure as "try the next alternative", and the alternatives after it are the ones that read `node` as a name — a plain failure would have made the whole change a silent no-op.
- It registers that failure in `getParseState().committedFailure`, the slot `committed()` writes and both of `parseAgency`'s failure exits prefer. Without it the message loses to the enclosing `parseError` throw and the user gets "expected node body".
- It never uses `parseError`, which throws — see Bug 2.

The probe mirrors the real declaration prefix (keyword, whitespace, name, `(`) and reuses `varNameChar`. Requiring the `(` is what keeps ordinary uses of `node` as a variable out of it.

## Bug 2: `toSource` threw on a `static const` literal

```ts
static const s = [| print("hi") |]
node main() { print(toSource(s)) }
```

```
TypeError: Cannot assign to read only property 'nodes' of object
```

`AgencyGenerator.generate` assigned its partitioned node list back over the caller's `nodes` field. Statics are `__deepFreeze`d by design, so the write threw. Masked in the guide because every example calls `fill` first, and `fill` works on a clone. Fixed by keeping the partitioned list in a local.

Also fixed in the same area: `[| static const x = 1 |]` failed outright with a message about function bodies. The body-context diagnostic for `static const` reports through tarsec's `parseError`, which throws, and the throw escaped before the program attempt ran. `tryAttempt` now converts a thrown `TarsecError` into an ordinary attempt failure so kind inference continues.

## What changes for users

| Case | Before | After |
| --- | --- | --- |
| `[\| node main() {} \|]` | wrong tree, fails at run time | correct declaration |
| `[\| def foo() {} \|]` | wrong tree | correct declaration |
| statement, then a declaration | wrong tree | correct program |
| comment, then a declaration | wrong tree | correct program |
| `node inner() {}` in a node body | compiled, crashed at run time | parse error naming the rule |
| `[\| static const x = 1 \|]` | hard parse failure | correct program |
| `toSource(staticLiteral)` | TypeError | prints |

Deliberately unchanged, and pinned by tests: `[| node |]`, `[| node.run() |]`, `[| node + 1 |]` stay `expr`; `[| type P = ... |]` and `[| effect Foo |]` stay `statements` (both are legal in bodies, so that reading is correct); `debugger` still parses as a bare name.

One accepted regression, corrected from an earlier version of this description. A body with `node` on one line and a call on the next **does** compile on main:

```ts
def helper(): number { return 1 }

node main() {
  const node = 1
  node
  helper()
}
```

On this branch that is a hard parse error, because the probe's `many1(space)` matches a newline — the same whitespace the real declaration grammar accepts — so keyword-newline-name-paren is declined exactly like the one-line form. The regression is worth accepting: that text is indistinguishable from the bug being fixed, and anyone writing it almost certainly meant a declaration. It is now pinned by a known-limitation test so a future probe change that un-declines it is a deliberate decision.

## Testing

- Unit: 9741 passed, 0 failed.
- `tests/agency/templates`: 14 passed, including two new fixtures — one fills, prints, compiles and runs a generated un-annotated node declaration end to end; the other calls `toSource` on a `static const` literal with no `fill` in between.
- The whole-corpus formatter round-trip gate passes, plus a new byte-exact golden for an un-annotated node in a literal.
- `pnpm run lint:structure` clean.

The build regenerated `docs/site/examples/generatedAgent.md`, which shows the reported symptom disappearing:

```diff
   const template = [|
-    node
-    main() {
+    node main() {
```

## Pre-existing issue noticed, not fixed here

Committed-failure messages report a line number shifted by the prelude wrapper: the new message points at line 4 for a declaration on line 2. The existing unclosed-literal error is shifted the same way, so this is not introduced here — the position for committed failures is not adjusted by the template offset. Worth its own fix, since it affects every committed-failure diagnostic.

Related: #713 (top-level `if`/`while`/`for`/`match`/`thread` crash the builder), found while establishing which statements are legal at file scope.
