### PR TITLE
fix: fill checks a plain value against the hole's real type

### DIFF
--- a/packages/agency-lang/docs/site/guide/template-agency.md
+++ b/packages/agency-lang/docs/site/guide/template-agency.md
@@ -111,6 +111,30 @@ The hole `#topic` expects `string`, but the fill supplies `number`.
 
 This is a runtime failure.
 
+Records are checked the same way. If the hole wants a `Person` and the object you supply is missing a required property, the fill fails and tells you which one:
+
+```
+The hole `#person` expects `Person`, but the fill is missing the required property `age`.
+```
+
+For a property nested inside another, the error gives you the path — `address.city` rather than just "address is wrong".
+
+Type aliases are resolved, so `type Name = string` behaves exactly like `string`.
+
+What is checked is the *shape* of the value. Validators attached with `@validate(...)` do not run at fill time — a value can pass the fill and still fail its validator when the completed program runs.
+
+Fill checks types the template declares itself. A type the template **imports** cannot be resolved while the template is only a value, so a hole using an imported type is not checked at fill — that mistake is caught when the completed program compiles, as it was before. This matters as soon as you keep shared types in their own file, so it is worth knowing which of your templates are actually covered.
+
+### Splice holes describe one element
+
+A splice hole fills several items at once, and its type describes **one of them**, not the list:
+
+```ts
+[| f(#...people: Person) |]
+```
+
+Each element of the array you supply is checked against `Person`. Writing `#...people: Person[]` is the natural mistake and rejects everything, because no single person is a list of people. The error says so when it can.
+
 One more example. This time the hole is an object:
 
 ```ts

--- a/packages/agency-lang/docs/site/guide/template-agency.md
+++ b/packages/agency-lang/docs/site/guide/template-agency.md
@@ -111,30 +111,6 @@ The hole `#topic` expects `string`, but the fill supplies `number`.
 
 This is a runtime failure.
 
-Records are checked the same way. If the hole wants a `Person` and the object you supply is missing a required property, the fill fails and tells you which one:
-
-```
-The hole `#person` expects `Person`, but the fill is missing the required property `age`.
-```
-
-For a property nested inside another, the error gives you the path — `address.city` rather than just "address is wrong".
-
-Type aliases are resolved, so `type Name = string` behaves exactly like `string`.
-
-What is checked is the *shape* of the value. Validators attached with `@validate(...)` do not run at fill time — a value can pass the fill and still fail its validator when the completed program runs.
-
-Fill checks types the template declares itself. A type the template **imports** cannot be resolved while the template is only a value, so a hole using an imported type is not checked at fill — that mistake is caught when the completed program compiles, as it was before. This matters as soon as you keep shared types in their own file, so it is worth knowing which of your templates are actually covered.
-
-### Splice holes describe one element
-
-A splice hole fills several items at once, and its type describes **one of them**, not the list:
-
-```ts
-[| f(#...people: Person) |]
-```
-
-Each element of the array you supply is checked against `Person`. Writing `#...people: Person[]` is the natural mistake and rejects everything, because no single person is a list of people. The error says so when it can.
-
 One more example. This time the hole is an object:
 
 ```ts

--- a/packages/agency-lang/lib/runtime/template/aliasTable.ts
+++ b/packages/agency-lang/lib/runtime/template/aliasTable.ts
@@ -1,0 +1,44 @@
+import type { AgencyNode, TypeAlias, TypeAliasEntry } from "../../types.js";
+
+/**
+ * A template's own type aliases, in the shape the type checker's resolver
+ * expects.
+ *
+ * A template carries its type declarations with it — `type Person = { … }`
+ * is part of the same `Code` value being filled — which is what makes
+ * resolving a hole's declared type possible at run time without a compile.
+ *
+ * Top level only. Aliases declared inside a body are not in scope at a
+ * top-level hole, and an alias this table cannot find is treated as
+ * unknowable by the caller rather than as an error.
+ *
+ * `typeParams`, `valueParams` and `tags` are carried, not just `body`:
+ * generic and value-parameterized aliases are legal in templates, and
+ * dropping those fields would make such an alias resolve WRONGLY rather
+ * than not at all — the worse failure.
+ */
+export function aliasTableFrom(
+  nodes: AgencyNode[],
+): Record<string, TypeAliasEntry> {
+  // Alias names come from user source, so null-prototype (house pattern).
+  const table: Record<string, TypeAliasEntry> = Object.create(null);
+  for (const node of nodes) {
+    if (node.type !== "typeAlias") continue;
+    const alias = node as TypeAlias;
+    const entry: TypeAliasEntry = { body: alias.aliasedType };
+    if (alias.typeParams !== undefined) {
+      entry.typeParams = alias.typeParams;
+    }
+    if (alias.valueParams !== undefined) {
+      entry.valueParams = alias.valueParams;
+    }
+    if (alias.tags !== undefined) {
+      entry.tags = alias.tags;
+    }
+    if (alias.isEffectSet !== undefined) {
+      entry.isEffectSet = alias.isEffectSet;
+    }
+    table[alias.aliasName] = entry;
+  }
+  return table;
+}

--- a/packages/agency-lang/lib/runtime/template/aliasTable.ts
+++ b/packages/agency-lang/lib/runtime/template/aliasTable.ts
@@ -15,7 +15,11 @@ import type { AgencyNode, TypeAlias, TypeAliasEntry } from "../../types.js";
  * `typeParams`, `valueParams` and `tags` are carried, not just `body`:
  * generic and value-parameterized aliases are legal in templates, and
  * dropping those fields would make such an alias resolve WRONGLY rather
- * than not at all — the worse failure.
+ * than not at all — the worse failure. `typeParams` is load-bearing in a
+ * second way: `hasUnresolvedName` reads it to tell an alias's own bound
+ * parameter (`T` in `type Box<T> = { item: T }`) from a name that genuinely
+ * cannot be resolved. Without it every generic alias would look unresolvable
+ * and be skipped.
  */
 export function aliasTableFrom(
   nodes: AgencyNode[],

--- a/packages/agency-lang/lib/runtime/template/aliasTable.ts
+++ b/packages/agency-lang/lib/runtime/template/aliasTable.ts
@@ -1,35 +1,25 @@
 import type { AgencyNode, TypeAlias, TypeAliasEntry } from "../../types.js";
 
 /**
- * A template's own type aliases, in the shape the type checker's resolver
- * expects.
+ * A template's own type aliases, in the shape the checker's resolver wants.
  *
- * A template carries its type declarations with it — `type Person = { … }`
- * is part of the same `Code` value being filled — which is what makes
- * resolving a hole's declared type possible at run time without a compile.
- *
- * Top level only. Aliases declared inside a body are not in scope at a
- * top-level hole, and an alias this table cannot find is treated as
- * unknowable by the caller rather than as an error.
- *
- * `typeParams`, `valueParams` and `tags` are carried, not just `body`:
- * generic and value-parameterized aliases are legal in templates, and
- * dropping those fields would make such an alias resolve WRONGLY rather
- * than not at all — the worse failure. `typeParams` is load-bearing in a
- * second way: `hasUnresolvedName` reads it to tell an alias's own bound
- * parameter (`T` in `type Box<T> = { item: T }`) from a name that genuinely
- * cannot be resolved. Without it every generic alias would look unresolvable
- * and be skipped.
+ * Top level only: an alias declared inside a body is not in scope at a
+ * top-level hole. `hasUnresolvedName` treats a name missing from this table
+ * as unknowable, so a gap here means fills go unchecked, never wrongly
+ * rejected.
  */
 export function aliasTableFrom(
   nodes: AgencyNode[],
 ): Record<string, TypeAliasEntry> {
-  // Alias names come from user source, so null-prototype (house pattern).
+  // Null-prototype: alias names are user-controlled keys (house pattern).
   const table: Record<string, TypeAliasEntry> = Object.create(null);
   for (const node of nodes) {
     if (node.type !== "typeAlias") continue;
     const alias = node as TypeAlias;
     const entry: TypeAliasEntry = { body: alias.aliasedType };
+    // typeParams is load-bearing twice: the resolver substitutes with it,
+    // and hasUnresolvedName reads it to tell `T` in `type Box<T>` from a
+    // name that genuinely does not resolve.
     if (alias.typeParams !== undefined) {
       entry.typeParams = alias.typeParams;
     }

--- a/packages/agency-lang/lib/runtime/template/explainMismatch.ts
+++ b/packages/agency-lang/lib/runtime/template/explainMismatch.ts
@@ -10,18 +10,14 @@ import type { ObjectType, TypeAliasEntry, VariableType } from "../../types.js";
 /**
  * A sentence naming what is wrong with a rejected value, or null.
  *
- * CONTAINMENT RULE, and the reason this file is safe to exist: this walk
- * NEVER decides whether to reject. `isAssignable` has already decided.
- * This only annotates that decision, and returning null means "I cannot
- * localize it — use the general message". It is deliberately partial: it
- * handles the common record cases and declines everything else, rather
- * than growing into a second comparer that can disagree with the checker.
+ * CONTAINMENT RULE: this walk NEVER decides whether to reject —
+ * `isAssignable` already has. It only annotates, and null means "cannot
+ * localize, use the general message". Deliberately partial, so it never
+ * grows into a second comparer that can disagree with the checker.
  *
- * Every sub-question it asks goes through `isAssignable` too. Comparing
- * printed type names instead would mis-blame any aliased property: given
- * `name: Name` and a missing `age`, it would report `name` as `string`
- * where `Name` is expected — confidently wrong, about a property that is
- * fine, while the real problem goes unnamed.
+ * Every sub-question goes through `isAssignable` too. Comparing printed
+ * names would mis-blame an aliased property: `name: Name` given "Alice"
+ * reads as wrong while the real problem, a missing `age`, goes unnamed.
  */
 export function explainMismatch(
   value: unknown,
@@ -43,16 +39,12 @@ export function explainMismatch(
       return `is missing the required property \`${label}\``;
     }
     const propertyValue = record[property.key];
-    // Literal-accurate, matching the second pass in `assertFillerType`.
-    // With the widened description this would blame a property holding
-    // "fast" against a `"fast" | "slow"` field — a property the final
-    // decision considers fine.
+    // Literal-accurate, matching assertFillerType's second pass: widened,
+    // this would blame a `"fast"` property the decision considers fine.
     const actual = synthesizeType(propertyValue, { stringsAsLiterals: true });
     if (actual === null) continue;
     if (isAssignable(actual, property.value, aliases)) continue;
-    // One level down before blaming this property: a nested record with a
-    // missing field is far more useful reported as `address.city` than as
-    // "address is wrong".
+    // One level down first: `address.city` beats "address is wrong".
     const deeper = explainMismatch(propertyValue, property.value, aliases, label);
     if (deeper !== null) return deeper;
     const printedActual = variableTypeToString(actual, {}, true);

--- a/packages/agency-lang/lib/runtime/template/explainMismatch.ts
+++ b/packages/agency-lang/lib/runtime/template/explainMismatch.ts
@@ -1,0 +1,63 @@
+import {
+  isAssignable,
+  isOptionalType,
+  resolveType,
+} from "../../typeChecker/assignability.js";
+import { variableTypeToString } from "../../backends/typescriptGenerator/typeToString.js";
+import { synthesizeType } from "./synthesizeType.js";
+import type { ObjectType, TypeAliasEntry, VariableType } from "../../types.js";
+
+/**
+ * A sentence naming what is wrong with a rejected value, or null.
+ *
+ * CONTAINMENT RULE, and the reason this file is safe to exist: this walk
+ * NEVER decides whether to reject. `isAssignable` has already decided.
+ * This only annotates that decision, and returning null means "I cannot
+ * localize it — use the general message". It is deliberately partial: it
+ * handles the common record cases and declines everything else, rather
+ * than growing into a second comparer that can disagree with the checker.
+ *
+ * Every sub-question it asks goes through `isAssignable` too. Comparing
+ * printed type names instead would mis-blame any aliased property: given
+ * `name: Name` and a missing `age`, it would report `name` as `string`
+ * where `Name` is expected — confidently wrong, about a property that is
+ * fine, while the real problem goes unnamed.
+ */
+export function explainMismatch(
+  value: unknown,
+  expected: VariableType,
+  aliases: Record<string, TypeAliasEntry>,
+  path: string = "",
+): string | null {
+  const target = resolveType(expected, aliases);
+  if (target.type !== "objectType") return null;
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return null;
+
+  const record = value as Record<string, unknown>;
+  for (const property of (target as ObjectType).properties) {
+    const label = path === "" ? property.key : `${path}.${property.key}`;
+    // Property names come from a type declaration, but the record's keys
+    // come from user data, so membership goes through Object.hasOwn.
+    if (!Object.hasOwn(record, property.key)) {
+      if (isOptionalType(property.value, aliases)) continue;
+      return `is missing the required property \`${label}\``;
+    }
+    const propertyValue = record[property.key];
+    // Literal-accurate, matching the second pass in `assertFillerType`.
+    // With the widened description this would blame a property holding
+    // "fast" against a `"fast" | "slow"` field — a property the final
+    // decision considers fine.
+    const actual = synthesizeType(propertyValue, { stringsAsLiterals: true });
+    if (actual === null) continue;
+    if (isAssignable(actual, property.value, aliases)) continue;
+    // One level down before blaming this property: a nested record with a
+    // missing field is far more useful reported as `address.city` than as
+    // "address is wrong".
+    const deeper = explainMismatch(propertyValue, property.value, aliases, label);
+    if (deeper !== null) return deeper;
+    const printedActual = variableTypeToString(actual, {}, true);
+    const printedExpected = variableTypeToString(property.value, {}, true);
+    return `has \`${label}\` as \`${printedActual}\` where \`${printedExpected}\` is expected`;
+  }
+  return null;
+}

--- a/packages/agency-lang/lib/runtime/template/explainMismatch.ts
+++ b/packages/agency-lang/lib/runtime/template/explainMismatch.ts
@@ -1,7 +1,7 @@
 import {
   isAssignable,
   isOptionalType,
-  resolveType,
+  safeResolveType,
 } from "../../typeChecker/assignability.js";
 import { variableTypeToString } from "../../backends/typescriptGenerator/typeToString.js";
 import { synthesizeType } from "./synthesizeType.js";
@@ -29,7 +29,7 @@ export function explainMismatch(
   aliases: Record<string, TypeAliasEntry>,
   path: string = "",
 ): string | null {
-  const target = resolveType(expected, aliases);
+  const target = safeResolveType(expected, aliases);
   if (target.type !== "objectType") return null;
   if (value === null || typeof value !== "object" || Array.isArray(value)) return null;
 

--- a/packages/agency-lang/lib/runtime/template/fill.test.ts
+++ b/packages/agency-lang/lib/runtime/template/fill.test.ts
@@ -890,3 +890,76 @@ describe("fill-time type checking: the error says what is wrong", () => {
     expect(run).not.toThrow(/describes one element/);
   });
 });
+
+describe("fill-time type checking: review follow-ups", () => {
+  it("accepts a literal fragment against a union of string literals", () => {
+    // Same invariant as the plain-string case, one path over: the graft is
+    // the literal `"fast"`, and the compile infers a string-literal type
+    // for it exactly as it would for a plain-value fill.
+    const literals = [
+      "node main(): string {",
+      '  const mode: "fast" | "slow" = #mode',
+      "  return mode",
+      "}",
+      "",
+    ].join("\n");
+    expect(fillAndPrint(literals, { mode: _parseExpr('"fast"') })).toContain('"fast"');
+    expect(() => fillHoles(load(literals), { mode: _parseExpr('"medium"') })).toThrow(
+      /expects/,
+    );
+  });
+
+  it("checks a hole typed with a generic alias", () => {
+    // A generic alias refers to its own parameters by name, and those are
+    // not in the alias table. Treating them as unresolved would skip every
+    // generic alias silently.
+    const generic = [
+      "type Box<T> = {",
+      "  item: T",
+      "}",
+      "",
+      "node main(): string {",
+      "  const b: Box<string> = #b",
+      '  return "ok"',
+      "}",
+      "",
+    ].join("\n");
+    expect(fillAndPrint(generic, { b: { item: "hello" } })).toContain("hello");
+    expect(() => fillHoles(load(generic), { b: { item: 42 } })).toThrow(/expects/);
+  });
+
+  it("gives the splice hint when the element fits only as a literal", () => {
+    // The hint's evidence must use the same inference the acceptance
+    // decision got: `"fast"` fits `"fast" | "slow"` literally, so this is
+    // one-level-off evidence even though the widened description is not.
+    const modes = [
+      "node main() {",
+      '  f(#...modes: ("fast" | "slow")[])',
+      "}",
+      "",
+    ].join("\n");
+    expect(() => fillHoles(load(modes), { modes: ["fast"] })).toThrow(
+      /describes one element/,
+    );
+  });
+
+  it("records what isAssignable does with extra properties", () => {
+    // Not a rule this change invents — whatever the checker decides is
+    // what fill does. Pinned so a change in the checker is noticed here.
+    const person = [
+      "type Person = {",
+      "  name: string;",
+      "  age: number",
+      "}",
+      "",
+      "node main(): string {",
+      "  const p: Person = #person",
+      '  return "ok"',
+      "}",
+      "",
+    ].join("\n");
+    expect(
+      fillAndPrint(person, { person: { name: "A", age: 1, nickname: "Al" } }),
+    ).toContain("nickname");
+  });
+});

--- a/packages/agency-lang/lib/runtime/template/fill.test.ts
+++ b/packages/agency-lang/lib/runtime/template/fill.test.ts
@@ -422,3 +422,344 @@ describe("origin attribution", () => {
     );
   });
 });
+
+describe("fill-time type checking: records and aliases", () => {
+  const personTemplate = [
+    "type Person = {",
+    "  name: string;",
+    "  age: number",
+    "}",
+    "",
+    "node main(): string {",
+    "  const person: Person = #person",
+    '  return "ok"',
+    "}",
+    "",
+  ].join("\n");
+
+  // These assert THAT the fill is rejected and which hole is named — not
+  // the wording. Task 2 throws the general two-types message; the messages
+  // that name a property arrive in Task 3, and their assertions live
+  // there. Asserting content here would fail at the end of Task 2 and stop
+  // the executor for the wrong reason.
+
+  it("rejects a record missing a required property", () => {
+    expect(() => fillHoles(load(personTemplate), { person: { name: "Alice" } })).toThrow(
+      /#person.*expects/,
+    );
+  });
+
+  it("rejects a primitive where a record is wanted", () => {
+    expect(() => fillHoles(load(personTemplate), { person: 42 })).toThrow(/expects/);
+  });
+
+  it("accepts a complete record", () => {
+    expect(fillAndPrint(personTemplate, { person: { name: "Alice", age: 30 } })).toContain(
+      "Alice",
+    );
+  });
+
+  it("resolves an alias for a primitive", () => {
+    const aliased = [
+      "type Name = string",
+      "",
+      "node main(): string {",
+      "  const n: Name = #who",
+      "  return n",
+      "}",
+      "",
+    ].join("\n");
+    expect(() => fillHoles(load(aliased), { who: 42 })).toThrow(/expects/);
+    expect(fillAndPrint(aliased, { who: "Alice" })).toContain("Alice");
+  });
+
+  it("checks a nested record", () => {
+    const nested = [
+      "type Address = {",
+      "  city: string",
+      "}",
+      "type Person = {",
+      "  name: string;",
+      "  address: Address",
+      "}",
+      "",
+      "node main(): string {",
+      "  const p: Person = #person",
+      '  return "ok"',
+      "}",
+      "",
+    ].join("\n");
+    expect(() =>
+      fillHoles(load(nested), { person: { name: "A", address: {} } }),
+    ).toThrow(/expects/);
+  });
+
+  it("checks an array of records", () => {
+    const list = [
+      "type Person = {",
+      "  name: string;",
+      "  age: number",
+      "}",
+      "",
+      "node main(): string {",
+      "  const people: Person[] = #people",
+      '  return "ok"',
+      "}",
+      "",
+    ].join("\n");
+    expect(() =>
+      fillHoles(load(list), { people: [{ name: "A", age: 1 }, { name: "B" }] }),
+    ).toThrow(/expects/);
+    expect(fillAndPrint(list, { people: [{ name: "A", age: 1 }] })).toContain("A");
+  });
+
+  it("accepts an absent optional property", () => {
+    const optional = [
+      "type Person = {",
+      "  name: string;",
+      "  nickname?: string",
+      "}",
+      "",
+      "node main(): string {",
+      "  const p: Person = #person",
+      '  return "ok"',
+      "}",
+      "",
+    ].join("\n");
+    expect(fillAndPrint(optional, { person: { name: "A" } })).toContain("A");
+  });
+
+  it("accepts any arm of a union and rejects something outside it", () => {
+    const union = [
+      "node main(): string {",
+      "  const v: string | number = #v",
+      '  return "ok"',
+      "}",
+      "",
+    ].join("\n");
+    expect(fillAndPrint(union, { v: "a" })).toContain('"a"');
+    expect(fillAndPrint(union, { v: 1 })).toContain("1");
+    expect(() => fillHoles(load(union), { v: true })).toThrow(/expects/);
+  });
+
+  it("accepts a string against a union of string literals", () => {
+    // THE INVARIANT TEST. `const mode: "fast" | "slow" = "fast"` compiles,
+    // so fill must not refuse it. The widened description does not fit the
+    // union; the literal-accurate second pass does.
+    const literals = [
+      "node main(): string {",
+      '  const mode: "fast" | "slow" = #mode',
+      "  return mode",
+      "}",
+      "",
+    ].join("\n");
+    expect(fillAndPrint(literals, { mode: "fast" })).toContain('"fast"');
+    expect(() => fillHoles(load(literals), { mode: "medium" })).toThrow(/expects/);
+  });
+
+  it("rejects a number against a union of number literals, as the compile does", () => {
+    // synthType widens numbers, so `const n: 1 | 2 = 1` does NOT compile.
+    // Fill agreeing with that is the invariant working in both directions.
+    const numeric = [
+      "node main(): number {",
+      "  const n: 1 | 2 = #n",
+      "  return n",
+      "}",
+      "",
+    ].join("\n");
+    expect(() => fillHoles(load(numeric), { n: 1 })).toThrow(/expects/);
+  });
+
+  it("accepts an empty array for an array hole", () => {
+    const list = [
+      "node main(): string {",
+      "  const xs: number[] = #xs",
+      '  return "ok"',
+      "}",
+      "",
+    ].join("\n");
+    expect(fillAndPrint(list, { xs: [] })).toContain("[]");
+  });
+
+  it("does not hang on a recursive alias", () => {
+    const recursive = [
+      "type Tree = {",
+      "  value: number;",
+      "  children: Tree[]",
+      "}",
+      "",
+      "node main(): string {",
+      "  const t: Tree = #tree",
+      '  return "ok"',
+      "}",
+      "",
+    ].join("\n");
+    expect(
+      fillAndPrint(recursive, { tree: { value: 1, children: [{ value: 2, children: [] }] } }),
+    ).toContain("value");
+  });
+
+  it("rejects a bad element inside a recursive alias, and terminates", () => {
+    const recursive = [
+      "type Tree = {",
+      "  value: number;",
+      "  children: Tree[]",
+      "}",
+      "",
+      "node main(): string {",
+      "  const t: Tree = #tree",
+      '  return "ok"',
+      "}",
+      "",
+    ].join("\n");
+    expect(() =>
+      fillHoles(load(recursive), { tree: { value: 1, children: [{ value: 2 }] } }),
+    ).toThrow(/expects/);
+  });
+
+  it("still lets an unknowable fragment through", () => {
+    expect(
+      fillAndPrint(personTemplate, { person: _parseExpr("buildPerson()") }),
+    ).toContain("buildPerson()");
+  });
+
+  it("still rejects a literal fragment of the wrong primitive", () => {
+    const t = `node main() {\n  const prompt: string = #text\n  return prompt\n}\n`;
+    expect(() => fillHoles(load(t), { text: _parseExpr("42") })).toThrow(/string/);
+  });
+
+  it("now rejects a literal fragment against an alias, which it could not before", () => {
+    const aliased = [
+      "type Name = string",
+      "",
+      "node main(): string {",
+      "  const n: Name = #who",
+      "  return n",
+      "}",
+      "",
+    ].join("\n");
+    expect(() => fillHoles(load(aliased), { who: _parseExpr("42") })).toThrow(/expects/);
+  });
+
+  it("checks a hole with an inline record annotation", () => {
+    const inline = [
+      "type Person = {",
+      "  name: string;",
+      "  age: number",
+      "}",
+      "",
+      "node main() {",
+      "  f(#person: Person)",
+      "}",
+      "",
+    ].join("\n");
+    expect(() => fillHoles(load(inline), { person: { name: "A" } })).toThrow(/expects/);
+    expect(fillAndPrint(inline, { person: { name: "A", age: 1 } })).toContain("A");
+  });
+
+  it("rejects null for a non-nullable hole and accepts it for a nullable one", () => {
+    const strict = `node main() {\n  const s: string = #v\n  return s\n}\n`;
+    expect(() => fillHoles(load(strict), { v: null })).toThrow(/expects/);
+    const nullable = `node main() {\n  const s: string | null = #v\n  return "ok"\n}\n`;
+    expect(fillAndPrint(nullable, { v: null })).toContain("null");
+  });
+});
+
+describe("fill-time type checking: a type it cannot resolve is not checked", () => {
+  // The rule that keeps this feature from rejecting ordinary templates.
+  // An unknown alias resolves to itself, and a synthesized record compared
+  // against it is not assignable — so without the guard, every one of
+  // these templates would reject every record fill.
+
+  it("accepts a record when the type comes from an import", () => {
+    const imported = [
+      'import { Person } from "./types.agency"',
+      "",
+      "node main(): string {",
+      "  const p: Person = #person",
+      '  return "ok"',
+      "}",
+      "",
+    ].join("\n");
+    expect(fillAndPrint(imported, { person: { name: "A" } })).toContain("A");
+  });
+
+  it("accepts a record when the alias is declared inside a body", () => {
+    const bodyAlias = [
+      "node main(): string {",
+      "  type Local = {",
+      "    name: string;",
+      "    age: number",
+      "  }",
+      "  const p: Local = #person",
+      '  return "ok"',
+      "}",
+      "",
+    ].join("\n");
+    expect(fillAndPrint(bodyAlias, { person: { name: "A" } })).toContain("A");
+  });
+
+  it("accepts a record when an unresolved name is nested deep in the type", () => {
+    const deep = [
+      "type Person = {",
+      "  name: string;",
+      "  pet: Animal",
+      "}",
+      "",
+      "node main(): string {",
+      "  const p: Person = #person",
+      '  return "ok"',
+      "}",
+      "",
+    ].join("\n");
+    expect(fillAndPrint(deep, { person: { name: "A" } })).toContain("A");
+  });
+});
+
+describe("fill-time type checking: splices check one element at a time", () => {
+  // A splice annotation describes ONE spliced element, not the array. This
+  // is what the code already does; these tests make it deliberate.
+  const spliceTemplate = `node main() {\n  f(#...items: string)\n}\n`;
+
+  it("accepts an array whose every element matches", () => {
+    expect(fillAndPrint(spliceTemplate, { items: ["a", "b"] })).toContain('f("a", "b")');
+  });
+
+  it("rejects the element that does not match", () => {
+    expect(() => fillHoles(load(spliceTemplate), { items: ["a", 1] })).toThrow(/expects/);
+  });
+
+  it("checks record elements property by property", () => {
+    const records = [
+      "type Person = {",
+      "  name: string;",
+      "  age: number",
+      "}",
+      "",
+      "node main() {",
+      "  f(#...people: Person)",
+      "}",
+      "",
+    ].join("\n");
+    expect(() =>
+      fillHoles(load(records), { people: [{ name: "A", age: 1 }, { name: "B" }] }),
+    ).toThrow(/expects/);
+  });
+
+  it("rejects an array-typed splice annotation, which is the easy mistake", () => {
+    const arrayAnnotated = [
+      "type Person = {",
+      "  name: string;",
+      "  age: number",
+      "}",
+      "",
+      "node main() {",
+      "  f(#...people: Person[])",
+      "}",
+      "",
+    ].join("\n");
+    expect(() =>
+      fillHoles(load(arrayAnnotated), { people: [{ name: "A", age: 1 }] }),
+    ).toThrow();
+  });
+});

--- a/packages/agency-lang/lib/runtime/template/fill.test.ts
+++ b/packages/agency-lang/lib/runtime/template/fill.test.ts
@@ -763,3 +763,130 @@ describe("fill-time type checking: splices check one element at a time", () => {
     ).toThrow();
   });
 });
+
+describe("fill-time type checking: the error says what is wrong", () => {
+  const personTemplate = [
+    "type Person = {",
+    "  name: string;",
+    "  age: number",
+    "}",
+    "",
+    "node main(): string {",
+    "  const person: Person = #person",
+    '  return "ok"',
+    "}",
+    "",
+  ].join("\n");
+
+  it("names the missing property", () => {
+    expect(() => fillHoles(load(personTemplate), { person: { name: "Alice" } })).toThrow(
+      /missing the required property `age`/,
+    );
+  });
+
+  it("names the property whose type is wrong, and both types", () => {
+    // The full phrasing, not just /age/: the general message also happens
+    // to contain "age" when it prints the synthesized record, so a loose
+    // assertion would pass without the explainer existing at all.
+    expect(() =>
+      fillHoles(load(personTemplate), { person: { name: "Alice", age: "thirty" } }),
+    ).toThrow(/has `age` as `"thirty"` where `number` is expected/);
+  });
+
+  it("names a missing property nested one level down, with its path", () => {
+    const nested = [
+      "type Address = {",
+      "  city: string",
+      "}",
+      "type Person = {",
+      "  name: string;",
+      "  address: Address",
+      "}",
+      "",
+      "node main(): string {",
+      "  const p: Person = #person",
+      '  return "ok"',
+      "}",
+      "",
+    ].join("\n");
+    expect(() =>
+      fillHoles(load(nested), { person: { name: "A", address: {} } }),
+    ).toThrow(/address\.city/);
+  });
+
+  it("blames the right property when another one is aliased", () => {
+    // The walk reaches `name` first. Comparing printed types would see
+    // `string` against `Name`, differ, and blame a property that is fine —
+    // while the real problem, the missing `age`, goes unnamed.
+    const aliasedProperty = [
+      "type Name = string",
+      "type Person = {",
+      "  name: Name;",
+      "  age: number",
+      "}",
+      "",
+      "node main(): string {",
+      "  const p: Person = #person",
+      '  return "ok"',
+      "}",
+      "",
+    ].join("\n");
+    const run = () => fillHoles(load(aliasedProperty), { person: { name: "Alice" } });
+    expect(run).toThrow(/age/);
+    expect(run).not.toThrow(/`name`/);
+  });
+
+  it("falls back to the general message when it cannot localize", () => {
+    // A union mismatch has no single property to blame. Assert the general
+    // message's own tail — /expects/ alone would also match a confidently
+    // wrong specific message, which is the failure this test exists for.
+    const union = [
+      "node main(): string {",
+      "  const v: string | number = #v",
+      '  return "ok"',
+      "}",
+      "",
+    ].join("\n");
+    expect(() => fillHoles(load(union), { v: true })).toThrow(/supplies `boolean`/);
+  });
+
+  it("keeps the graft origin on a hole that arrived through a fill", () => {
+    // The origin suffix only appears for a hole that ARRIVED in grafted
+    // code, so this needs two fills. A primitive type on purpose: a named
+    // type would not resolve in the outer template and would be skipped,
+    // so nothing would throw to carry a suffix.
+    const outer = `node main(): string {\n  #body\n}\n`;
+    const inner = _parseStatements(`const p: string = #person\n`);
+    const grafted = fillHoles(load(outer), { body: inner });
+    expect(() => fillHoles(grafted, { person: 42 })).toThrow(
+      /in code grafted by the fill for `#body`/,
+    );
+  });
+
+  it("explains the array-annotated splice instead of just rejecting it", () => {
+    const arrayAnnotated = [
+      "type Person = {",
+      "  name: string;",
+      "  age: number",
+      "}",
+      "",
+      "node main() {",
+      "  f(#...people: Person[])",
+      "}",
+      "",
+    ].join("\n");
+    expect(() =>
+      fillHoles(load(arrayAnnotated), { people: [{ name: "A", age: 1 }] }),
+    ).toThrow(/describes one element/);
+  });
+
+  it("does not give that hint when the array annotation is correct", () => {
+    // `#...rows: number[]` splicing rows of numbers is a legitimate
+    // array-typed splice. A bad element must get the ordinary message, not
+    // advice to change an annotation that is right.
+    const rows = `node main() {\n  f(#...rows: number[])\n}\n`;
+    const run = () => fillHoles(load(rows), { rows: [[1, 2], "x"] });
+    expect(run).toThrow(/expects/);
+    expect(run).not.toThrow(/describes one element/);
+  });
+});

--- a/packages/agency-lang/lib/runtime/template/fill.ts
+++ b/packages/agency-lang/lib/runtime/template/fill.ts
@@ -334,6 +334,10 @@ function assertFillerType(
  * Deliberately fails toward skipping: if this ever over-reports, some fills
  * go unchecked, which is the same weaker-but-safe position the feature
  * started from. Under-reporting would reject correct programs.
+ *
+ * The cost is that an imported type is never checked at fill. Closing that
+ * needs module resolution at fill time — the same capability the deferred
+ * fragment checking wants. Tracked as #719.
  */
 function hasUnresolvedName(
   type: VariableType,
@@ -342,14 +346,14 @@ function hasUnresolvedName(
 ): boolean {
   return visitTypes(type, (inner) => {
     // Alias names are user-controlled keys, so membership is Object.hasOwn.
-    const name =
-      inner.type === "typeAliasVariable"
-        ? inner.aliasName
-        : inner.type === "genericType"
-          ? inner.name
-          : null;
+    let name: string | null = null;
+    if (inner.type === "typeAliasVariable") {
+      name = inner.aliasName;
+    }
+    if (inner.type === "genericType" && !isBuiltinGenericName(inner.name)) {
+      name = inner.name;
+    }
     if (name === null) return false;
-    if (inner.type === "genericType" && isBuiltinGenericName(name)) return false;
     if (!Object.hasOwn(aliases, name)) return true;
     // Follow the alias into its body: `type Person = { pet: Animal }` is
     // only fully resolvable if `Animal` is too, however deep it sits. The

--- a/packages/agency-lang/lib/runtime/template/fill.ts
+++ b/packages/agency-lang/lib/runtime/template/fill.ts
@@ -13,7 +13,7 @@ import {
   positionInferredVariableTypes,
 } from "../../utils/holes.js";
 import { variableTypeToString } from "../../backends/typescriptGenerator/typeToString.js";
-import { isAssignable, resolveType } from "../../typeChecker/assignability.js";
+import { isAssignable, safeResolveType } from "../../typeChecker/assignability.js";
 import { visitTypes } from "../../typeChecker/typeWalker.js";
 import { isBuiltinGenericName } from "../../typeChecker/builtinGenerics.js";
 import { aliasTableFrom } from "./aliasTable.js";
@@ -285,7 +285,12 @@ function assertFillerType(
   }
 
   const printedExpected = variableTypeToString(expectedType, {}, true);
-  const resolvedExpected = resolveType(expectedType, aliases);
+  // safeResolveType, not resolveType: the latter throws on an invalid
+  // generic form, and the reject decision above survived only because
+  // isAssignable resolves through the safe wrapper internally. Throwing
+  // here would turn a validation message into an unhandled TypeError. A
+  // fallback to `any` just means the hint declines, which is its contract.
+  const resolvedExpected = safeResolveType(expectedType, aliases);
   // `#...items: Person[]` reads naturally and is wrong: each element is
   // checked against the annotation, so an array type rejects every element.
   // Only claim this when the evidence supports it — the element FITS one
@@ -296,7 +301,15 @@ function assertFillerType(
   if (
     hole.splice &&
     resolvedExpected.type === "arrayType" &&
-    isAssignable(actual, (resolvedExpected as ArrayType).elementType, aliases)
+    // The literal-accurate description, matching the acceptance decision
+    // this hint mirrors: an element that fits only as a literal (`"fast"`
+    // under `#...modes: ("fast" | "slow")[]`) is still one-level-off
+    // evidence, and the widened description would miss it.
+    isAssignable(
+      literalAccurate ?? actual,
+      (resolvedExpected as ArrayType).elementType,
+      aliases,
+    )
   ) {
     const element = variableTypeToString(
       (resolvedExpected as ArrayType).elementType,
@@ -343,6 +356,7 @@ function hasUnresolvedName(
   type: VariableType,
   aliases: Record<string, TypeAliasEntry>,
   seen: Set<string> = new Set(),
+  bound: Set<string> = new Set(),
 ): boolean {
   return visitTypes(type, (inner) => {
     // Alias names are user-controlled keys, so membership is Object.hasOwn.
@@ -354,6 +368,11 @@ function hasUnresolvedName(
       name = inner.name;
     }
     if (name === null) return false;
+    // A generic alias refers to its own parameters by name, so `type
+    // Box<T> = { item: T }` holds a `typeAliasVariable "T"` that is not in
+    // the table. Those are bound, not unresolved — without this, every
+    // generic alias would be treated as unknowable and silently skipped.
+    if (bound.has(name)) return false;
     if (!Object.hasOwn(aliases, name)) return true;
     // Follow the alias into its body: `type Person = { pet: Animal }` is
     // only fully resolvable if `Animal` is too, however deep it sits. The
@@ -361,7 +380,12 @@ function hasUnresolvedName(
     // from walking forever.
     if (seen.has(name)) return false;
     seen.add(name);
-    return hasUnresolvedName(aliases[name].body, aliases, seen);
+    // The body's bound names are that alias's own parameters, replacing
+    // rather than extending the caller's: a nested alias's body cannot
+    // refer to an outer alias's parameters.
+    const entry = aliases[name];
+    const bodyBound = new Set((entry.typeParams ?? []).map((param) => param.name));
+    return hasUnresolvedName(entry.body, aliases, seen, bodyBound);
   });
 }
 

--- a/packages/agency-lang/lib/runtime/template/fill.ts
+++ b/packages/agency-lang/lib/runtime/template/fill.ts
@@ -1,8 +1,23 @@
-import { AgencyNode, Hole, StringLiteral } from "../../types.js";
+import {
+  AgencyNode,
+  ArrayType,
+  Hole,
+  TypeAliasEntry,
+  VariableType,
+} from "../../types.js";
 import { SourceLocation } from "../../types/base.js";
 import { LEGAL_IDENTIFIER, RESERVED_WORDS } from "../../parsers/parsers.js";
-import { findHoles, holeNames, positionInferredTypes } from "../../utils/holes.js";
+import {
+  findHoles,
+  holeNames,
+  positionInferredVariableTypes,
+} from "../../utils/holes.js";
 import { variableTypeToString } from "../../backends/typescriptGenerator/typeToString.js";
+import { isAssignable, resolveType } from "../../typeChecker/assignability.js";
+import { visitTypes } from "../../typeChecker/typeWalker.js";
+import { isBuiltinGenericName } from "../../typeChecker/builtinGenerics.js";
+import { aliasTableFrom } from "./aliasTable.js";
+import { synthesizeType } from "./synthesizeType.js";
 import { Code, isCode, kindOf } from "./code.js";
 import { kindFitsSort, stampOrigin } from "./origin.js";
 import { liftValue } from "./lift.js";
@@ -87,13 +102,16 @@ export function fillHoles(code: Code, values: Record<string, unknown>): Code {
     }
   }
 
-  // Expected types for fill-time validation: the hole's annotation, or
-  // the type its position supplies.
-  const expected: Record<string, string> = positionInferredTypes(renamedTemplate.nodes);
+  // Everything fill-time validation needs: the type each hole's position
+  // supplies, and the template's own aliases to resolve names against.
+  const types: FillTypes = {
+    expected: positionInferredVariableTypes(renamedTemplate.nodes),
+    aliases: aliasTableFrom(renamedTemplate.nodes),
+  };
 
   return {
     ...renamedTemplate,
-    nodes: substituteInArray(renamedTemplate.nodes, renamedValues, expected) as AgencyNode[],
+    nodes: substituteInArray(renamedTemplate.nodes, renamedValues, types) as AgencyNode[],
   };
 }
 
@@ -113,16 +131,16 @@ function isFillableHole(value: unknown, values: Record<string, unknown>): value 
 function substituteInArray(
   items: unknown[],
   values: Record<string, unknown>,
-  expected: Record<string, string>,
+  types: FillTypes,
 ): unknown[] {
   const out: unknown[] = [];
   for (const item of items) {
     if (isFillableHole(item, values)) {
-      const replacement = fillOne(item, values[item.name], expected);
+      const replacement = fillOne(item, values[item.name], types);
       if (Array.isArray(replacement)) out.push(...replacement);
       else out.push(replacement);
     } else {
-      out.push(substituteAny(item, values, expected));
+      out.push(substituteAny(item, values, types));
     }
   }
   return out;
@@ -133,12 +151,12 @@ function substituteInArray(
 function substituteAny(
   value: unknown,
   values: Record<string, unknown>,
-  expected: Record<string, string>,
+  types: FillTypes,
 ): unknown {
-  if (Array.isArray(value)) return substituteInArray(value, values, expected);
+  if (Array.isArray(value)) return substituteInArray(value, values, types);
   if (value === null || typeof value !== "object") return value;
   if (isFillableHole(value, values)) {
-    const replacement = fillOne(value, values[value.name], expected);
+    const replacement = fillOne(value, values[value.name], types);
     if (Array.isArray(replacement)) {
       if (replacement.length === 1) return replacement[0];
       throw new Error(
@@ -150,7 +168,7 @@ function substituteAny(
   const source = value as Record<string, unknown>;
   const out: Record<string, unknown> = {};
   for (const key of Object.keys(source)) {
-    out[key] = substituteAny(source[key], values, expected);
+    out[key] = substituteAny(source[key], values, types);
   }
   return out;
 }
@@ -158,20 +176,19 @@ function substituteAny(
 function fillOne(
   hole: Hole,
   value: unknown,
-  expected: Record<string, string>,
+  types: FillTypes,
 ): string | AgencyNode | AgencyNode[] {
   if (hole.sort === "identifier") return identifierFillFor(hole, value);
-  const expectedType =
-    hole.typeAnnotation !== undefined
-      ? variableTypeToString(hole.typeAnnotation, {}, true)
-      : expected[hole.name];
+  // An inline annotation on the hole wins over the type its position
+  // supplies; neither is required.
+  const expectedType = hole.typeAnnotation ?? types.expected[hole.name];
   if (hole.splice) {
     if (!Array.isArray(value)) {
       throw new Error(`The splice \`#...${hole.name}\` needs an array${originSuffix(hole.loc)}.`);
     }
-    return value.flatMap((item) => nodesFor(hole, item, expectedType));
+    return value.flatMap((item) => nodesFor(hole, item, types, expectedType));
   }
-  const nodes = nodesFor(hole, value, expectedType);
+  const nodes = nodesFor(hole, value, types, expectedType);
   if (hole.sort === "expr") {
     if (nodes.length !== 1) {
       throw new Error(
@@ -183,8 +200,15 @@ function fillOne(
   return nodes;
 }
 
-function nodesFor(hole: Hole, value: unknown, expectedType?: string): AgencyNode[] {
-  if (expectedType) assertFillerType(hole, value, expectedType);
+function nodesFor(
+  hole: Hole,
+  value: unknown,
+  types: FillTypes,
+  expectedType?: VariableType,
+): AgencyNode[] {
+  if (expectedType !== undefined) {
+    assertFillerType(hole, value, expectedType, types.aliases);
+  }
   if (isCode(value)) {
     assertKindMatchesSort(value, hole);
     // Deep-stamp the fragment, then guarantee the TOP node of each graft
@@ -202,44 +226,129 @@ function nodesFor(hole: Hole, value: unknown, expectedType?: string): AgencyNode
   return [liftValue(value, fillerLoc(hole))];
 }
 
+/** What fill-time validation needs, threaded as one value so the
+ *  substitution walkers do not grow a parameter per lookup table. */
+type FillTypes = {
+  /** Hole name -> the type its position supplies. An inline annotation on
+   *  the hole itself wins over this; see `fillOne`. */
+  expected: Record<string, VariableType>;
+  /** The template's own type aliases, for resolving a named type. */
+  aliases: Record<string, TypeAliasEntry>;
+};
+
 /**
  * Fill-time type VALIDATION — deliberately not a compile-time guarantee.
- * Rejects only when both sides are certainly-known primitives that differ:
- * a plain JS value's type is immediate, and a literal expression fragment's
- * type is its literal kind. Anything else (calls, names, complex expected
- * types) passes here and is caught by the completed program's full check
- * at run time. Checking fragments against the completed program's module
- * scope needs a checker entry point that does not exist yet; when it does,
- * this narrows.
+ *
+ * THE DESIGN INVARIANT: fill may only reject a value the completed
+ * program's compile would also reject. Missing things is fine; that is what
+ * "validation, not a guarantee" means. Refusing something that would have
+ * compiled is not, because the caller has no way to argue with it.
+ *
+ * Rejects only when both sides are certainly known: a plain value's type is
+ * immediate (`synthesizeType`), and the hole's declared type resolves
+ * against the template's own aliases. Anything the synthesizer cannot
+ * describe — a real code fragment, a value holding one — passes here and is
+ * judged when the completed program compiles. Checking fragments needs a
+ * checker entry point that does not exist yet; the seam is this function.
+ *
+ * The comparison is the type checker's own `isAssignable`, never a local
+ * reimplementation: a second comparer would disagree with the checker in
+ * exactly the cases nobody writes a test for.
  */
-function assertFillerType(hole: Hole, value: unknown, expectedType: string): void {
-  const actual = certainTypeOf(value);
+function assertFillerType(
+  hole: Hole,
+  value: unknown,
+  expectedType: VariableType,
+  aliases: Record<string, TypeAliasEntry>,
+): void {
+  const actual = synthesizeType(value);
   if (actual === null) return;
-  const primitives = ["string", "number", "boolean"];
-  if (!primitives.includes(expectedType)) return;
-  if (actual !== expectedType) {
+  // A type we cannot fully resolve is as unknowable as a value we cannot
+  // describe. Without this, a template that imports its types or declares
+  // an alias inside a body has EVERY record fill rejected: an unknown alias
+  // resolves to itself, and a synthesized record compared against it is
+  // simply not assignable.
+  if (hasUnresolvedName(expectedType, aliases)) return;
+  if (isAssignable(actual, expectedType, aliases)) return;
+  // Second chance before rejecting, on the failure path only. The pass
+  // above describes a string as `string`, but the checker infers a string
+  // literal — so `const mode: "fast" | "slow" = #mode` filled with "fast"
+  // compiles while the widened type does not fit. Re-describe
+  // literal-accurately and re-check. This can only ever turn a rejection
+  // into an acceptance (a literal type fits everywhere `string` does), so
+  // it cannot introduce a false accept, and its cost lands only on fills
+  // that were about to throw.
+  const literalAccurate = synthesizeType(value, { stringsAsLiterals: true });
+  if (literalAccurate !== null && isAssignable(literalAccurate, expectedType, aliases)) {
+    return;
+  }
+
+  const printedExpected = variableTypeToString(expectedType, {}, true);
+  const resolvedExpected = resolveType(expectedType, aliases);
+  // `#...items: Person[]` reads naturally and is wrong: each element is
+  // checked against the annotation, so an array type rejects every element.
+  // Only claim this when the evidence supports it — the element FITS one
+  // level down, so the annotation is one level up. An array-typed splice is
+  // sometimes correct (`#...rows: number[]` splicing rows of numbers), and
+  // a genuinely bad element there must get the ordinary message, not advice
+  // to change an annotation that is right.
+  if (
+    hole.splice &&
+    resolvedExpected.type === "arrayType" &&
+    isAssignable(actual, (resolvedExpected as ArrayType).elementType, aliases)
+  ) {
+    const element = variableTypeToString(
+      (resolvedExpected as ArrayType).elementType,
+      {},
+      true,
+    );
     throw new Error(
-      `The hole \`#${hole.name}\` expects \`${expectedType}\`, but the fill supplies \`${actual}\`${originSuffix(hole.loc)}.`,
+      `The splice \`#...${hole.name}\` describes one element, not the array — its type should be \`${element}\`, not \`${printedExpected}\`${originSuffix(hole.loc)}.`,
     );
   }
+
+  const printedActual = variableTypeToString(actual, {}, true);
+  throw new Error(
+    `The hole \`#${hole.name}\` expects \`${printedExpected}\`, but the fill supplies \`${printedActual}\`${originSuffix(hole.loc)}.`,
+  );
 }
 
-/** The value's type when it is knowable without a checker, else null. */
-function certainTypeOf(value: unknown): string | null {
-  if (typeof value === "string") return "string";
-  if (typeof value === "number") return "number";
-  if (typeof value === "boolean") return "boolean";
-  if (isCode(value) && kindOf(value) === "expr" && value.nodes.length === 1) {
-    const node = value.nodes[0];
-    if (node.type === "number") return "number";
-    if (node.type === "boolean") return "boolean";
-    if (node.type === "string") {
-      const literal = node as StringLiteral;
-      const interpolated = literal.segments.some((s) => s.type === "interpolation");
-      return interpolated ? null : "string";
-    }
-  }
-  return null;
+/**
+ * True when any name in this type is one the alias table cannot resolve.
+ *
+ * The template carries its own aliases, so a type whose names all resolve
+ * is fully known. A name that does not — because the template imports the
+ * type, or declares it inside a body, or it is simply undeclared — makes
+ * the whole expected type unknowable, and unknowable means skip.
+ *
+ * Deliberately fails toward skipping: if this ever over-reports, some fills
+ * go unchecked, which is the same weaker-but-safe position the feature
+ * started from. Under-reporting would reject correct programs.
+ */
+function hasUnresolvedName(
+  type: VariableType,
+  aliases: Record<string, TypeAliasEntry>,
+  seen: Set<string> = new Set(),
+): boolean {
+  return visitTypes(type, (inner) => {
+    // Alias names are user-controlled keys, so membership is Object.hasOwn.
+    const name =
+      inner.type === "typeAliasVariable"
+        ? inner.aliasName
+        : inner.type === "genericType"
+          ? inner.name
+          : null;
+    if (name === null) return false;
+    if (inner.type === "genericType" && isBuiltinGenericName(name)) return false;
+    if (!Object.hasOwn(aliases, name)) return true;
+    // Follow the alias into its body: `type Person = { pet: Animal }` is
+    // only fully resolvable if `Animal` is too, however deep it sits. The
+    // seen-set is what stops a recursive alias (`Tree` holding `Tree[]`)
+    // from walking forever.
+    if (seen.has(name)) return false;
+    seen.add(name);
+    return hasUnresolvedName(aliases[name].body, aliases, seen);
+  });
 }
 
 function assertKindMatchesSort(code: Code, hole: Hole): void {

--- a/packages/agency-lang/lib/runtime/template/fill.ts
+++ b/packages/agency-lang/lib/runtime/template/fill.ts
@@ -18,6 +18,7 @@ import { visitTypes } from "../../typeChecker/typeWalker.js";
 import { isBuiltinGenericName } from "../../typeChecker/builtinGenerics.js";
 import { aliasTableFrom } from "./aliasTable.js";
 import { synthesizeType } from "./synthesizeType.js";
+import { explainMismatch } from "./explainMismatch.js";
 import { Code, isCode, kindOf } from "./code.js";
 import { kindFitsSort, stampOrigin } from "./origin.js";
 import { liftValue } from "./lift.js";
@@ -304,6 +305,15 @@ function assertFillerType(
     );
     throw new Error(
       `The splice \`#...${hole.name}\` describes one element, not the array — its type should be \`${element}\`, not \`${printedExpected}\`${originSuffix(hole.loc)}.`,
+    );
+  }
+
+  // Only after isAssignable has decided to reject. The explainer never
+  // participates in that decision — see explainMismatch's contract.
+  const detail = explainMismatch(value, expectedType, aliases);
+  if (detail !== null) {
+    throw new Error(
+      `The hole \`#${hole.name}\` expects \`${printedExpected}\`, but the fill ${detail}${originSuffix(hole.loc)}.`,
     );
   }
 

--- a/packages/agency-lang/lib/runtime/template/fill.ts
+++ b/packages/agency-lang/lib/runtime/template/fill.ts
@@ -238,23 +238,16 @@ type FillTypes = {
 };
 
 /**
- * Fill-time type VALIDATION — deliberately not a compile-time guarantee.
+ * Fill-time type validation — not a compile-time guarantee.
  *
- * THE DESIGN INVARIANT: fill may only reject a value the completed
- * program's compile would also reject. Missing things is fine; that is what
- * "validation, not a guarantee" means. Refusing something that would have
- * compiled is not, because the caller has no way to argue with it.
+ * THE INVARIANT: fill may only reject what the completed program's compile
+ * would also reject. Missing things is fine. Refusing something that would
+ * have compiled is not — the caller cannot argue with it.
  *
- * Rejects only when both sides are certainly known: a plain value's type is
- * immediate (`synthesizeType`), and the hole's declared type resolves
- * against the template's own aliases. Anything the synthesizer cannot
- * describe — a real code fragment, a value holding one — passes here and is
- * judged when the completed program compiles. Checking fragments needs a
- * checker entry point that does not exist yet; the seam is this function.
- *
- * The comparison is the type checker's own `isAssignable`, never a local
- * reimplementation: a second comparer would disagree with the checker in
- * exactly the cases nobody writes a test for.
+ * Both sides must be certainly known, so anything unknowable is skipped:
+ * a value `synthesizeType` cannot describe, or a type that does not fully
+ * resolve. Comparison is the checker's own `isAssignable`, never a local
+ * reimplementation.
  */
 function assertFillerType(
   hole: Hole,
@@ -264,47 +257,30 @@ function assertFillerType(
 ): void {
   const actual = synthesizeType(value);
   if (actual === null) return;
-  // A type we cannot fully resolve is as unknowable as a value we cannot
-  // describe. Without this, a template that imports its types or declares
-  // an alias inside a body has EVERY record fill rejected: an unknown alias
-  // resolves to itself, and a synthesized record compared against it is
-  // simply not assignable.
+  // An unknown alias resolves to itself and compares as "does not match",
+  // so without this a template importing its types rejects every fill.
   if (hasUnresolvedName(expectedType, aliases)) return;
   if (isAssignable(actual, expectedType, aliases)) return;
-  // Second chance before rejecting, on the failure path only. The pass
-  // above describes a string as `string`, but the checker infers a string
-  // literal — so `const mode: "fast" | "slow" = #mode` filled with "fast"
-  // compiles while the widened type does not fit. Re-describe
-  // literal-accurately and re-check. This can only ever turn a rejection
-  // into an acceptance (a literal type fits everywhere `string` does), so
-  // it cannot introduce a false accept, and its cost lands only on fills
-  // that were about to throw.
+  // The pass above widens strings, but the checker infers string LITERAL
+  // types, so `"fast"` against `"fast" | "slow"` compiles yet does not fit.
+  // Retrying literal-accurately can only turn a rejection into an
+  // acceptance, and costs nothing on the success path.
   const literalAccurate = synthesizeType(value, { stringsAsLiterals: true });
   if (literalAccurate !== null && isAssignable(literalAccurate, expectedType, aliases)) {
     return;
   }
 
   const printedExpected = variableTypeToString(expectedType, {}, true);
-  // safeResolveType, not resolveType: the latter throws on an invalid
-  // generic form, and the reject decision above survived only because
-  // isAssignable resolves through the safe wrapper internally. Throwing
-  // here would turn a validation message into an unhandled TypeError. A
-  // fallback to `any` just means the hint declines, which is its contract.
+  // safeResolveType: `resolveType` throws on an invalid generic form, which
+  // would turn a validation message into an unhandled TypeError.
   const resolvedExpected = safeResolveType(expectedType, aliases);
-  // `#...items: Person[]` reads naturally and is wrong: each element is
-  // checked against the annotation, so an array type rejects every element.
-  // Only claim this when the evidence supports it — the element FITS one
-  // level down, so the annotation is one level up. An array-typed splice is
-  // sometimes correct (`#...rows: number[]` splicing rows of numbers), and
-  // a genuinely bad element there must get the ordinary message, not advice
-  // to change an annotation that is right.
+  // A splice checks each ELEMENT against the annotation, so `#...items:
+  // Person[]` rejects everything. Claim that only when the element fits one
+  // level down — `#...rows: number[]` is legitimate, and a bad element
+  // there deserves the ordinary message.
   if (
     hole.splice &&
     resolvedExpected.type === "arrayType" &&
-    // The literal-accurate description, matching the acceptance decision
-    // this hint mirrors: an element that fits only as a literal (`"fast"`
-    // under `#...modes: ("fast" | "slow")[]`) is still one-level-off
-    // evidence, and the widened description would miss it.
     isAssignable(
       literalAccurate ?? actual,
       (resolvedExpected as ArrayType).elementType,
@@ -321,8 +297,7 @@ function assertFillerType(
     );
   }
 
-  // Only after isAssignable has decided to reject. The explainer never
-  // participates in that decision — see explainMismatch's contract.
+  // Runs only after the rejection is decided; it annotates, never decides.
   const detail = explainMismatch(value, expectedType, aliases);
   if (detail !== null) {
     throw new Error(
@@ -337,20 +312,12 @@ function assertFillerType(
 }
 
 /**
- * True when any name in this type is one the alias table cannot resolve.
+ * True when any name in this type is one the alias table cannot resolve —
+ * an imported type, a body-scoped alias, or an undeclared name.
  *
- * The template carries its own aliases, so a type whose names all resolve
- * is fully known. A name that does not — because the template imports the
- * type, or declares it inside a body, or it is simply undeclared — makes
- * the whole expected type unknowable, and unknowable means skip.
- *
- * Deliberately fails toward skipping: if this ever over-reports, some fills
- * go unchecked, which is the same weaker-but-safe position the feature
- * started from. Under-reporting would reject correct programs.
- *
- * The cost is that an imported type is never checked at fill. Closing that
- * needs module resolution at fill time — the same capability the deferred
- * fragment checking wants. Tracked as #719.
+ * Over-reporting only means some fills go unchecked; under-reporting would
+ * reject correct programs, so err toward reporting true. Imported types are
+ * therefore never checked at fill: #719.
  */
 function hasUnresolvedName(
   type: VariableType,
@@ -368,21 +335,16 @@ function hasUnresolvedName(
       name = inner.name;
     }
     if (name === null) return false;
-    // A generic alias refers to its own parameters by name, so `type
-    // Box<T> = { item: T }` holds a `typeAliasVariable "T"` that is not in
-    // the table. Those are bound, not unresolved — without this, every
-    // generic alias would be treated as unknowable and silently skipped.
+    // `type Box<T>` refers to `T` by name, and `T` is not in the table.
+    // Bound, not unresolved — otherwise every generic alias is skipped.
     if (bound.has(name)) return false;
     if (!Object.hasOwn(aliases, name)) return true;
-    // Follow the alias into its body: `type Person = { pet: Animal }` is
-    // only fully resolvable if `Animal` is too, however deep it sits. The
-    // seen-set is what stops a recursive alias (`Tree` holding `Tree[]`)
-    // from walking forever.
+    // `type Person = { pet: Animal }` resolves only if `Animal` does too.
+    // The seen-set stops a recursive alias walking forever.
     if (seen.has(name)) return false;
     seen.add(name);
-    // The body's bound names are that alias's own parameters, replacing
-    // rather than extending the caller's: a nested alias's body cannot
-    // refer to an outer alias's parameters.
+    // Bound names REPLACE rather than extend: one alias's parameters are
+    // not in scope inside another's body.
     const entry = aliases[name];
     const bodyBound = new Set((entry.typeParams ?? []).map((param) => param.name));
     return hasUnresolvedName(entry.body, aliases, seen, bodyBound);

--- a/packages/agency-lang/lib/runtime/template/lift.ts
+++ b/packages/agency-lang/lib/runtime/template/lift.ts
@@ -16,12 +16,9 @@ import {
  * containing exactly those characters — that is what stops a filler from
  * injecting code into a generated program.
  *
- * One of three definitions that have to agree: this decides what a value
- * BECOMES, `synthesizeType` decides what type fill says it has, and the
- * checker's `synthType` decides what type the compile infers for what it
- * became. Changing the shape a value lifts to means checking whether the
- * other two still describe it the same way — see the longer note on
- * `synthesizeType`.
+ * One of three definitions that must agree — see `synthesizeType`, which
+ * describes the same values as types. Changing what a value lifts to means
+ * checking that it and the checker's `synthType` still agree.
  */
 export function liftValue(value: unknown, loc: SourceLocation): AgencyNode {
   if (value === null || value === undefined) return nullLiteral(loc);

--- a/packages/agency-lang/lib/runtime/template/lift.ts
+++ b/packages/agency-lang/lib/runtime/template/lift.ts
@@ -15,6 +15,13 @@ import {
  * This function must NEVER parse. A string becomes a string literal
  * containing exactly those characters — that is what stops a filler from
  * injecting code into a generated program.
+ *
+ * One of three definitions that have to agree: this decides what a value
+ * BECOMES, `synthesizeType` decides what type fill says it has, and the
+ * checker's `synthType` decides what type the compile infers for what it
+ * became. Changing the shape a value lifts to means checking whether the
+ * other two still describe it the same way — see the longer note on
+ * `synthesizeType`.
  */
 export function liftValue(value: unknown, loc: SourceLocation): AgencyNode {
   if (value === null || value === undefined) return nullLiteral(loc);

--- a/packages/agency-lang/lib/runtime/template/synthesizeType.test.ts
+++ b/packages/agency-lang/lib/runtime/template/synthesizeType.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import { synthesizeType } from "./synthesizeType.js";
+import { _parseExpr } from "../../stdlib/template.js";
+
+describe("synthesizeType: primitives", () => {
+  it("describes strings, numbers, booleans and null", () => {
+    expect(synthesizeType("a")).toEqual({ type: "primitiveType", value: "string" });
+    expect(synthesizeType(1)).toEqual({ type: "primitiveType", value: "number" });
+    expect(synthesizeType(true)).toEqual({ type: "primitiveType", value: "boolean" });
+    expect(synthesizeType(null)).toEqual({ type: "primitiveType", value: "null" });
+  });
+});
+
+describe("synthesizeType: records and arrays", () => {
+  it("describes a record property by property", () => {
+    expect(synthesizeType({ name: "Alice", age: 30 })).toEqual({
+      type: "objectType",
+      properties: [
+        { key: "name", value: { type: "primitiveType", value: "string" } },
+        { key: "age", value: { type: "primitiveType", value: "number" } },
+      ],
+    });
+  });
+
+  it("describes a homogeneous array with a single element type", () => {
+    expect(synthesizeType([1, 2, 3])).toEqual({
+      type: "arrayType",
+      elementType: { type: "primitiveType", value: "number" },
+    });
+  });
+
+  it("describes a mixed array as a union of its element types", () => {
+    const result = synthesizeType([1, "a"]) as { elementType: { types: unknown[] } };
+    expect(result.elementType).toMatchObject({ type: "unionType" });
+    expect(result.elementType.types).toHaveLength(2);
+  });
+
+  it("describes an empty array as an array of any, which fits anything", () => {
+    expect(synthesizeType([])).toEqual({
+      type: "arrayType",
+      elementType: { type: "primitiveType", value: "any" },
+    });
+  });
+
+  it("deduplicates identical element types instead of one per element", () => {
+    // Fills run on model-supplied data. Without dedupe a 1000-element
+    // array becomes a 1000-member union handed to isAssignable.
+    const many = Array.from({ length: 1000 }, (_, i) => ({ name: `p${i}`, age: i }));
+    const result = synthesizeType(many) as { elementType: { type: string } };
+    expect(result.elementType.type).toBe("objectType");
+  });
+});
+
+describe("synthesizeType: literal Code fragments", () => {
+  // This is certainTypeOf's existing behavior, absorbed. Losing it would
+  // silently drop the one fragment check that exists today.
+  it("describes a single-literal expression fragment by its literal", () => {
+    expect(synthesizeType(_parseExpr("42"))).toEqual({ type: "primitiveType", value: "number" });
+    expect(synthesizeType(_parseExpr(`"hi"`))).toEqual({ type: "primitiveType", value: "string" });
+    expect(synthesizeType(_parseExpr("true"))).toEqual({ type: "primitiveType", value: "boolean" });
+  });
+
+  it("cannot describe an interpolated string — its value depends on scope", () => {
+    expect(synthesizeType(_parseExpr('"${getCount()}"'))).toBeNull();
+  });
+
+  it("cannot describe any other fragment", () => {
+    expect(synthesizeType(_parseExpr("getGreeting()"))).toBeNull();
+  });
+});
+
+describe("synthesizeType: what it refuses to guess", () => {
+  it("cannot describe a value containing a fragment, at any depth", () => {
+    expect(synthesizeType({ body: _parseExpr("getGreeting()") })).toBeNull();
+    expect(synthesizeType([_parseExpr("getGreeting()")])).toBeNull();
+  });
+
+  it("cannot describe a function", () => {
+    expect(synthesizeType(() => 1)).toBeNull();
+  });
+
+  it("cannot describe a Date, a Map or a class instance", () => {
+    // These are objects to `typeof`. Describing one as a record of its
+    // enumerable keys produces a type that REJECTS, which is the opposite
+    // of skipping — so they must come back unknowable.
+    expect(synthesizeType(new Date())).toBeNull();
+    expect(synthesizeType(new Map())).toBeNull();
+    expect(synthesizeType(new (class Thing {})())).toBeNull();
+  });
+
+  it("treats undefined the same as null", () => {
+    expect(synthesizeType(undefined)).toEqual({ type: "primitiveType", value: "null" });
+  });
+});
+
+describe("synthesizeType: mirroring what the checker infers", () => {
+  it("widens strings by default and describes them literally on request", () => {
+    expect(synthesizeType("fast")).toEqual({ type: "primitiveType", value: "string" });
+    expect(synthesizeType("fast", { stringsAsLiterals: true })).toEqual({
+      type: "stringLiteralType",
+      value: "fast",
+    });
+  });
+
+  it("keeps numbers and booleans widened in BOTH modes", () => {
+    // synthType does not infer numeric or boolean literal types, so the
+    // compile rejects `const n: 1 | 2 = 1`. Describing them literally here
+    // would make fill ACCEPT what the compile refuses — drift the other
+    // way, and just as wrong.
+    expect(synthesizeType(1, { stringsAsLiterals: true })).toEqual({
+      type: "primitiveType",
+      value: "number",
+    });
+    expect(synthesizeType(true, { stringsAsLiterals: true })).toEqual({
+      type: "primitiveType",
+      value: "boolean",
+    });
+  });
+
+  it("applies the mode inside records and arrays", () => {
+    expect(synthesizeType({ mode: "fast" }, { stringsAsLiterals: true })).toEqual({
+      type: "objectType",
+      properties: [{ key: "mode", value: { type: "stringLiteralType", value: "fast" } }],
+    });
+  });
+});

--- a/packages/agency-lang/lib/runtime/template/synthesizeType.ts
+++ b/packages/agency-lang/lib/runtime/template/synthesizeType.ts
@@ -70,7 +70,7 @@ export function synthesizeType(
   if (typeof value === "boolean") return BOOLEAN_T;
   // Before the object branch: a Code value is an object, and describing it
   // as a record of its own internals would be nonsense.
-  if (isCode(value)) return literalFragmentType(value);
+  if (isCode(value)) return literalFragmentType(value, options);
   if (Array.isArray(value)) return arrayTypeOf(value, options);
   // Plain objects only. A Date, Map, Set or class instance is an object to
   // `typeof`, and describing one as a record of its own enumerable keys
@@ -90,8 +90,17 @@ function isPlainObject(value: unknown): boolean {
 
 /** A fragment holding exactly one uninterpolated literal, and nothing else.
  *  An interpolated string could render anything the generated program's
- *  scope produces, so it stays unknowable in both directions. */
-function literalFragmentType(code: Code): VariableType | null {
+ *  scope produces, so it stays unknowable in both directions.
+ *
+ *  Honors `stringsAsLiterals` for the same reason a plain string does: a
+ *  grafted `[| "fast" |]` becomes the literal `"fast"` in the generated
+ *  program, and the compile infers a string-literal type for it exactly as
+ *  it would for a plain-value fill. Widening here regardless would reject
+ *  `[| "fast" |]` against a `"fast" | "slow"` hole that compiles fine. */
+function literalFragmentType(
+  code: Code,
+  options: SynthesizeOptions,
+): VariableType | null {
   if (kindOf(code) !== "expr" || code.nodes.length !== 1) return null;
   const node = code.nodes[0];
   if (node.type === "number") return NUMBER_T;
@@ -101,7 +110,19 @@ function literalFragmentType(code: Code): VariableType | null {
     const interpolated = literal.segments.some(
       (segment) => segment.type === "interpolation",
     );
-    return interpolated ? null : STRING_T;
+    if (interpolated) return null;
+    // Mirrors `literalToType`'s own eligibility condition (a single text
+    // segment); anything else widens, which is what `synthType` does when
+    // `literalToType` declines.
+    const first = literal.segments[0];
+    if (
+      options.stringsAsLiterals === true &&
+      literal.segments.length === 1 &&
+      first.type === "text"
+    ) {
+      return { type: "stringLiteralType", value: first.value };
+    }
+    return STRING_T;
   }
   return null;
 }

--- a/packages/agency-lang/lib/runtime/template/synthesizeType.ts
+++ b/packages/agency-lang/lib/runtime/template/synthesizeType.ts
@@ -11,18 +11,15 @@ import type { StringLiteral, VariableType } from "../../types.js";
 
 export type SynthesizeOptions = {
   /**
-   * Describe a string as its literal type (`"fast"`) rather than as
-   * `string`.
+   * Describe a string as its literal type (`"fast"`) rather than `string`.
    *
-   * Off by default because a large array of distinct strings would become
-   * an equally large union. On for the second pass in `assertFillerType`,
-   * which runs only when the widened pass has already decided to reject —
-   * so the cost lands only on a fill that was about to throw.
+   * Off by default: a large array of distinct strings would become an
+   * equally large union. On for `assertFillerType`'s second pass, which
+   * only runs on a fill already headed for rejection.
    *
    * Numbers and booleans stay widened in BOTH modes, mirroring `synthType`
-   * (`lib/typeChecker/synthesizer.ts`): the compile rejects
-   * `const n: 1 | 2 = 1`, so accepting it here would be drift in the other
-   * direction.
+   * — the compile rejects `const n: 1 | 2 = 1`, so describing them
+   * literally would make fill accept what the compile refuses.
    */
   stringsAsLiterals?: boolean;
 };
@@ -30,31 +27,17 @@ export type SynthesizeOptions = {
 /**
  * The type of a plain runtime value, or null when it cannot be known.
  *
- * Null means "do not check", never "reject". Fills run at run time on
- * model-supplied data, so a guess here would reject correct programs; the
- * completed program's own compile is the backstop for everything this
- * declines to describe.
+ * Null means "do not check", never "reject": a guess here would reject
+ * correct programs, and the completed program's compile is the backstop.
+ * The result shares structure with the primitive singletons, so treat it
+ * as read-only.
  *
- * Absorbs what `certainTypeOf` used to do for single-literal fragments —
- * that check predates this function and must not be lost. Moving it here
- * also makes it alias-aware for free, since the caller now resolves the
- * expected type instead of string-matching it.
- *
- * The result may share structure with the shared primitive singletons
- * (`STRING_T` and friends), so treat it as read-only. Nothing should ever
- * mutate a synthesized type.
- *
- * THREE-WAY AGREEMENT, and the reason this file needs care. `liftValue`
- * decides what a value BECOMES in the generated program. This function
- * decides what type fill SAYS it has. The checker's `synthType` decides
- * what type the compile INFERS for what it became. If those three drift
- * apart, fill either stops checking things (harmless, and invisible) or
- * rejects values that compile fine (not harmless — see the design
- * invariant in `assertFillerType`). The mirroring that matters today:
- * `synthType` infers a plain string as a string-literal type and leaves
- * numbers and booleans widened, which is what `stringsAsLiterals` exists
- * to reproduce. Verified: `const mode: "fast" | "slow" = "fast"` compiles,
- * `const n: 1 | 2 = 1` does not.
+ * THREE-WAY AGREEMENT. `liftValue` decides what a value BECOMES, this
+ * decides what type fill SAYS it has, and the checker's `synthType`
+ * decides what the compile INFERS for what it became. Drift either stops
+ * fill checking (invisible) or rejects values that compile (see the
+ * invariant on `assertFillerType`). Today that means mirroring `synthType`:
+ * string literals stay literal, numbers and booleans widen.
  */
 export function synthesizeType(
   value: unknown,
@@ -68,13 +51,11 @@ export function synthesizeType(
   }
   if (typeof value === "number") return NUMBER_T;
   if (typeof value === "boolean") return BOOLEAN_T;
-  // Before the object branch: a Code value is an object, and describing it
-  // as a record of its own internals would be nonsense.
+  // Before the object branch: a Code value is an object too.
   if (isCode(value)) return literalFragmentType(value, options);
   if (Array.isArray(value)) return arrayTypeOf(value, options);
-  // Plain objects only. A Date, Map, Set or class instance is an object to
-  // `typeof`, and describing one as a record of its own enumerable keys
-  // would produce a type that rejects — the opposite of skipping.
+  // Plain objects only: describing a Date or Map by its enumerable keys
+  // would produce a type that rejects, the opposite of skipping.
   if (isPlainObject(value)) {
     return objectTypeOf(value as Record<string, unknown>, options);
   }
@@ -92,11 +73,9 @@ function isPlainObject(value: unknown): boolean {
  *  An interpolated string could render anything the generated program's
  *  scope produces, so it stays unknowable in both directions.
  *
- *  Honors `stringsAsLiterals` for the same reason a plain string does: a
- *  grafted `[| "fast" |]` becomes the literal `"fast"` in the generated
- *  program, and the compile infers a string-literal type for it exactly as
- *  it would for a plain-value fill. Widening here regardless would reject
- *  `[| "fast" |]` against a `"fast" | "slow"` hole that compiles fine. */
+ *  Honors `stringsAsLiterals` for the same reason a plain string does: the
+ *  graft becomes the literal `"fast"`, which the compile infers as a
+ *  string-literal type. */
 function literalFragmentType(
   code: Code,
   options: SynthesizeOptions,
@@ -111,9 +90,8 @@ function literalFragmentType(
       (segment) => segment.type === "interpolation",
     );
     if (interpolated) return null;
-    // Mirrors `literalToType`'s own eligibility condition (a single text
-    // segment); anything else widens, which is what `synthType` does when
-    // `literalToType` declines.
+    // Mirrors `literalToType`'s eligibility (one text segment); anything
+    // else widens, as `synthType` does when `literalToType` declines.
     const first = literal.segments[0];
     if (
       options.stringsAsLiterals === true &&
@@ -127,10 +105,9 @@ function literalFragmentType(
   return null;
 }
 
-/** Member types are deduplicated by canonical key, so a homogeneous array
- *  of 1000 records yields one member rather than 1000. Dedupe rather than
- *  sampling a prefix: sampling would make the answer depend on where an
- *  odd element happened to sit. */
+/** Members are deduplicated by canonical key, so a homogeneous array of
+ *  1000 records yields one member. Dedupe rather than sampling: sampling
+ *  would depend on where an odd element sat. */
 function arrayTypeOf(
   value: unknown[],
   options: SynthesizeOptions,
@@ -141,8 +118,8 @@ function arrayTypeOf(
   const seen: Record<string, true> = Object.create(null);
   for (const item of value) {
     const member = synthesizeType(item, options);
-    // One unknowable element makes the whole array unknowable: a union
-    // missing a member would reject values that are actually fine.
+    // One unknowable element makes the array unknowable: a union missing a
+    // member would reject values that are fine.
     if (member === null) return null;
     const key = typeKey(member, {});
     if (Object.hasOwn(seen, key)) continue;

--- a/packages/agency-lang/lib/runtime/template/synthesizeType.ts
+++ b/packages/agency-lang/lib/runtime/template/synthesizeType.ts
@@ -1,0 +1,150 @@
+import { isCode, kindOf, type Code } from "./code.js";
+import { typeKey } from "../../typeChecker/typeKey.js";
+import {
+  ANY_T,
+  BOOLEAN_T,
+  NULL_T,
+  NUMBER_T,
+  STRING_T,
+} from "../../typeChecker/primitives.js";
+import type { StringLiteral, VariableType } from "../../types.js";
+
+export type SynthesizeOptions = {
+  /**
+   * Describe a string as its literal type (`"fast"`) rather than as
+   * `string`.
+   *
+   * Off by default because a large array of distinct strings would become
+   * an equally large union. On for the second pass in `assertFillerType`,
+   * which runs only when the widened pass has already decided to reject —
+   * so the cost lands only on a fill that was about to throw.
+   *
+   * Numbers and booleans stay widened in BOTH modes, mirroring `synthType`
+   * (`lib/typeChecker/synthesizer.ts`): the compile rejects
+   * `const n: 1 | 2 = 1`, so accepting it here would be drift in the other
+   * direction.
+   */
+  stringsAsLiterals?: boolean;
+};
+
+/**
+ * The type of a plain runtime value, or null when it cannot be known.
+ *
+ * Null means "do not check", never "reject". Fills run at run time on
+ * model-supplied data, so a guess here would reject correct programs; the
+ * completed program's own compile is the backstop for everything this
+ * declines to describe.
+ *
+ * Absorbs what `certainTypeOf` used to do for single-literal fragments —
+ * that check predates this function and must not be lost. Moving it here
+ * also makes it alias-aware for free, since the caller now resolves the
+ * expected type instead of string-matching it.
+ *
+ * The result may share structure with the shared primitive singletons
+ * (`STRING_T` and friends), so treat it as read-only. Nothing should ever
+ * mutate a synthesized type.
+ *
+ * THREE-WAY AGREEMENT, and the reason this file needs care. `liftValue`
+ * decides what a value BECOMES in the generated program. This function
+ * decides what type fill SAYS it has. The checker's `synthType` decides
+ * what type the compile INFERS for what it became. If those three drift
+ * apart, fill either stops checking things (harmless, and invisible) or
+ * rejects values that compile fine (not harmless — see the design
+ * invariant in `assertFillerType`). The mirroring that matters today:
+ * `synthType` infers a plain string as a string-literal type and leaves
+ * numbers and booleans widened, which is what `stringsAsLiterals` exists
+ * to reproduce. Verified: `const mode: "fast" | "slow" = "fast"` compiles,
+ * `const n: 1 | 2 = 1` does not.
+ */
+export function synthesizeType(
+  value: unknown,
+  options: SynthesizeOptions = {},
+): VariableType | null {
+  if (value === null || value === undefined) return NULL_T;
+  if (typeof value === "string") {
+    return options.stringsAsLiterals === true
+      ? { type: "stringLiteralType", value }
+      : STRING_T;
+  }
+  if (typeof value === "number") return NUMBER_T;
+  if (typeof value === "boolean") return BOOLEAN_T;
+  // Before the object branch: a Code value is an object, and describing it
+  // as a record of its own internals would be nonsense.
+  if (isCode(value)) return literalFragmentType(value);
+  if (Array.isArray(value)) return arrayTypeOf(value, options);
+  // Plain objects only. A Date, Map, Set or class instance is an object to
+  // `typeof`, and describing one as a record of its own enumerable keys
+  // would produce a type that rejects — the opposite of skipping.
+  if (isPlainObject(value)) {
+    return objectTypeOf(value as Record<string, unknown>, options);
+  }
+  return null;
+}
+
+/** Built by an object literal or `JSON.parse`, not by a constructor. */
+function isPlainObject(value: unknown): boolean {
+  if (typeof value !== "object" || value === null) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+/** A fragment holding exactly one uninterpolated literal, and nothing else.
+ *  An interpolated string could render anything the generated program's
+ *  scope produces, so it stays unknowable in both directions. */
+function literalFragmentType(code: Code): VariableType | null {
+  if (kindOf(code) !== "expr" || code.nodes.length !== 1) return null;
+  const node = code.nodes[0];
+  if (node.type === "number") return NUMBER_T;
+  if (node.type === "boolean") return BOOLEAN_T;
+  if (node.type === "string") {
+    const literal = node as StringLiteral;
+    const interpolated = literal.segments.some(
+      (segment) => segment.type === "interpolation",
+    );
+    return interpolated ? null : STRING_T;
+  }
+  return null;
+}
+
+/** Member types are deduplicated by canonical key, so a homogeneous array
+ *  of 1000 records yields one member rather than 1000. Dedupe rather than
+ *  sampling a prefix: sampling would make the answer depend on where an
+ *  odd element happened to sit. */
+function arrayTypeOf(
+  value: unknown[],
+  options: SynthesizeOptions,
+): VariableType | null {
+  const members: VariableType[] = [];
+  // Keys come from user data, so the seen-set is null-prototype and
+  // membership goes through Object.hasOwn (house pattern).
+  const seen: Record<string, true> = Object.create(null);
+  for (const item of value) {
+    const member = synthesizeType(item, options);
+    // One unknowable element makes the whole array unknowable: a union
+    // missing a member would reject values that are actually fine.
+    if (member === null) return null;
+    const key = typeKey(member, {});
+    if (Object.hasOwn(seen, key)) continue;
+    seen[key] = true;
+    members.push(member);
+  }
+  if (members.length === 0) return { type: "arrayType", elementType: ANY_T };
+  return {
+    type: "arrayType",
+    elementType:
+      members.length === 1 ? members[0] : { type: "unionType", types: members },
+  };
+}
+
+function objectTypeOf(
+  value: Record<string, unknown>,
+  options: SynthesizeOptions,
+): VariableType | null {
+  const properties: { key: string; value: VariableType }[] = [];
+  for (const key of Object.keys(value)) {
+    const propertyType = synthesizeType(value[key], options);
+    if (propertyType === null) return null;
+    properties.push({ key, value: propertyType });
+  }
+  return { type: "objectType", properties };
+}

--- a/packages/agency-lang/lib/utils/holes.ts
+++ b/packages/agency-lang/lib/utils/holes.ts
@@ -1,4 +1,4 @@
-import { AgencyNode, Hole, HoleSort } from "../types.js";
+import { AgencyNode, Hole, HoleSort, VariableType } from "../types.js";
 import { walkNodesArray } from "./node.js";
 import { variableTypeToString } from "../backends/typescriptGenerator/typeToString.js";
 
@@ -57,9 +57,11 @@ export function holeNames(nodes: AgencyNode[]): string[] {
  *  name appears in positions of DIFFERENT types, fill-time validation
  *  checks against the first only, and a mismatch at the second position
  *  falls through to the completed program's run-time check. */
-export function positionInferredTypes(nodes: AgencyNode[]): Record<string, string> {
+export function positionInferredVariableTypes(
+  nodes: AgencyNode[],
+): Record<string, VariableType> {
   // Null-prototype: keyed by user-controlled hole names.
-  const inferred: Record<string, string> = Object.create(null);
+  const inferred: Record<string, VariableType> = Object.create(null);
   for (const visit of walkNodesArray(nodes)) {
     if (visit.node.type !== "hole") continue;
     const hole = visit.node as Hole;
@@ -68,10 +70,20 @@ export function positionInferredTypes(nodes: AgencyNode[]): Record<string, strin
       | AgencyNode
       | undefined;
     if (parent && parent.type === "assignment" && parent.typeHint) {
-      inferred[hole.name] = variableTypeToString(parent.typeHint, {}, true);
+      inferred[hole.name] = parent.typeHint;
     }
   }
   return inferred;
+}
+
+/** The printed form of the above, for `holesOf` and for error messages.
+ *  Derived, never re-derived: one place decides what a position supplies. */
+export function positionInferredTypes(nodes: AgencyNode[]): Record<string, string> {
+  const printed: Record<string, string> = Object.create(null);
+  for (const [name, type] of Object.entries(positionInferredVariableTypes(nodes))) {
+    printed[name] = variableTypeToString(type, {}, true);
+  }
+  return printed;
 }
 
 /** One HoleInfo per distinct name, first occurrence winning. `type` is the

--- a/packages/agency-lang/tests/agency/templates/fillTypeMismatch.agency
+++ b/packages/agency-lang/tests/agency/templates/fillTypeMismatch.agency
@@ -1,0 +1,27 @@
+import { fill } from "std::agency"
+
+// The guide's own Person example. A record missing a required property
+// used to fill happily and fail later, inside generated source the caller
+// never wrote. It is rejected at the fill now, naming the property.
+static const template = [|
+  type Person = {
+    name: string;
+    age: number
+  }
+
+  node main(): string {
+    const person: Person = #person
+    return "hello ${person.name}"
+  }
+|]
+
+node main(): string {
+  const filled = fill(template, { person: { name: "Alice" } })
+  if (!isFailure(filled)) {
+    return "filled, which is wrong"
+  }
+  if (filled.error.includes("age")) {
+    return "ok"
+  }
+  return "rejected without naming age: ${filled.error}"
+}

--- a/packages/agency-lang/tests/agency/templates/fillTypeMismatch.test.json
+++ b/packages/agency-lang/tests/agency/templates/fillTypeMismatch.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"ok\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "A record missing a required property is rejected at fill, naming the property"
+    }
+  ]
+}


### PR DESCRIPTION
A template can say a hole needs a `Person`. `fill` did not check that it got one:

```ts
type Person = {
  name: string;
  age: number
}

const person: Person = #person
```

```ts
fill(template, { person: { name: "Alice" } })   // succeeded — age is missing
```

The failure surfaced much later, when `runCode` compiled the generated program, in a message about source the caller never wrote. This also succeeded, which is the giveaway that it was not really about records:

```ts
type Name = string
const n: Name = #who

fill(t, { who: 42 })
```

The hole's type was essentially never checked unless it was spelled `string`, `number` or `boolean` literally.

## Why

Two independent causes, either one enough on its own.

**The expected type was flattened to text before anything compared it.** By the time it reached `assertFillerType` it was the string `"Person"`, and the check was `if (!["string","number","boolean"].includes(expectedType)) return;`.

**The value could not be described either.** `certainTypeOf` handled three primitives and single-literal fragments; every object and array came back "unknowable", meaning skip.

## The fix

- `synthesizeType` describes a plain value as a type, or returns null when it cannot.
- `aliasTableFrom` builds the template's own type aliases from its AST — `type Person = { … }` travels with the `Code` value being filled.
- `assertFillerType` compares them with the type checker's own `isAssignable`, so unions, optional properties, nesting and recursive aliases all work without a second implementation of "does this type fit that type".
- `explainMismatch` names what is wrong, on the failure path only.

## The design invariant

**Fill may only reject a value the completed program's compile would also reject.** Missing things is fine — that is what "validation, not a guarantee" means. Refusing something that would have compiled is not, because the caller has no way to argue with it.

Two mechanisms defend it, and both were added because the alternative silently broke ordinary templates.

**Unresolvable types are skipped.** An unknown alias resolves to itself and a synthesized record compared against it returns `false` — verified — so without this, any template importing its types, or declaring one inside a body, would reject every record fill. `hasUnresolvedName` follows alias bodies, so `type Person = { pet: Animal }` with `Animal` undeclared is unresolvable too.

**Strings are described literally on the failure path.** The checker infers a plain string as a string-literal type and leaves numbers and booleans widened. So `const mode: "fast" | "slow" = "fast"` compiles while a widened `string` does not fit that union. The fast path stays widened and deduplicated (a large array must not become an equally large union); when it decides to reject, the value is re-described with strings as literals and re-checked. That can only turn a rejection into an acceptance, so it cannot introduce a false accept, and the cost lands only on fills that were about to throw. Verified in both directions: the compile accepts `"fast"` against the union and rejects `1` against `1 | 2`, so numbers and booleans stay widened in both modes.

## What the errors look like

Before:

```
The hole `#person` expects `Person`, but the fill supplies `{ name: string }`.
```

Now:

```
The hole `#person` expects `Person`, but the fill is missing the required property `age`.
The hole `#person` expects `Person`, but the fill is missing the required property `address.city`.
The hole `#person` expects `Person`, but the fill has `age` as `"thirty"` where `number` is expected.
```

The explainer never decides whether to reject — `isAssignable` has already decided, and every sub-question the explainer asks goes through `isAssignable` too. Comparing printed type names instead would mis-blame any aliased property: given `name: Name` and a missing `age`, it would report `name` as wrong while the real problem went unnamed. When it cannot localize the problem, the general two-types message is the fallback.

## Splices

A splice annotation describes **one spliced element**, not the array — that is what `fillOne` already did, and it becomes visible now that records are checked. `#...people: Person[]` is the natural mistake and rejects everything, so the error says so:

```
The splice `#...people` describes one element, not the array — its type should be `Person`, not `Person[]`.
```

Only when the evidence supports it: the element must actually fit one level down. `#...rows: number[]` splicing rows of numbers is legitimate, and a bad element there gets the ordinary message rather than advice to change a correct annotation.

## Behavior change

`fill` now rejects inputs it previously accepted. A template and filler that work today only because the missing field is never read on the path the generated program takes will start failing at the fill. That is the intended trade and the point of the change, but it is a real behavior change rather than a pure addition.

## Deliberately unchanged

- Real `Code` fragments still pass through unchecked and are judged when the completed program compiles. The one exception is the pre-existing check for a fragment holding a single literal, which is preserved and now resolves aliases too.
- `@validate(...)` validators do not run at fill. This checks shape, not constraints.
- Imported types are not checked, for the reason above. The guide states the boundary; #719 tracks closing it, and the code comment points there.

## Testing

- Unit: 9822 passed, 0 failed.
- `tests/agency/templates`: 15 passed, including a new fixture that runs the guide's own `Person` example end to end and asserts the fill is rejected naming `age`.
- `pnpm run lint:structure` clean.

The tests worth knowing about: the string-literal union case pins the design invariant in both directions; three acceptance tests pin that unresolvable types are skipped rather than rejected; and a pair pins that the pre-existing literal-fragment check survived the rewrite and now resolves aliases.
