### PR TITLE
fix: one rule for what may sit at the top level of a file

### DIFF
--- a/packages/agency-lang/docs/site/diagnostics/effects.md
+++ b/packages/agency-lang/docs/site/diagnostics/effects.md
@@ -155,3 +155,23 @@ An interrupt pauses the program and waits for an answer. When the answer arrives
 The check follows calls into functions defined in your own files. It cannot see into imported functions. If an imported function interrupts inside a finalize at runtime, the finalize counts as failed and the scope falls back to its saved draft.
 
 **How to fix:** only compute values inside the finalize, using the variables you already have. If you need to ask the user something, ask in the normal body, before the work that can trip.
+
+<a id="ag3017"></a>
+
+## AG3017 — &#123;kind&#125; cannot sit at the top level of a file. Top-level code runs at initialization, which cannot branch, loop, or wait — move it inside a node or a function.
+
+*Default severity: error.*
+
+Code at the top level of a file runs when the module is initialized, not when a node executes. That phase has no way to branch, loop, or wait, so a statement that controls execution has nothing to control.
+
+**How to fix:** move it inside a node or a function. Top-level code may declare things (`node`, `def`, `type`, imports), bind values (`const x = 1`), and call functions for their effect (`print("ready")`) — nothing else.
+
+<a id="ag3018"></a>
+
+## AG3018 — A handler cannot be registered at the top level of a file. Handlers must be inside a node or a function, where there is execution for them to guard.
+
+*Default severity: error.*
+
+A handler guards the code it wraps. At the top level of a file there is no execution to guard: the module is only being initialized, and a handler registered there would never see the interrupts it was written for.
+
+**How to fix:** move the `handle` block inside the node or function whose work it should guard.

--- a/packages/agency-lang/docs/site/diagnostics/effects.md
+++ b/packages/agency-lang/docs/site/diagnostics/effects.md
@@ -158,7 +158,7 @@ The check follows calls into functions defined in your own files. It cannot see 
 
 <a id="ag3017"></a>
 
-## AG3017 — &#123;kind&#125; cannot sit at the top level of a file. Top-level code runs at initialization, which cannot branch, loop, or wait — move it inside a node or a function.
+## AG3017 — Cannot use &#123;kind&#125; at the top level of a file. Top-level code runs at initialization, which cannot branch, loop, or wait — move it inside a node or a function.
 
 *Default severity: error.*
 

--- a/packages/agency-lang/docs/site/diagnostics/index.md
+++ b/packages/agency-lang/docs/site/diagnostics/index.md
@@ -63,6 +63,8 @@ or suppress a type-checker one on the next line with `// @tc-ignore AG####`.
 | [AG3014](effects.md#ag3014) | &#123;who&#125; may raise any effect (its type has no 'raises' clause), which exceeds the 'raises &lt;&#123;allowed&#125;&gt;' allowed by type '&#123;type&#125;'. Add a 'raises' clause to the value's type. |
 | [AG3015](effects.md#ag3015) | &#123;who&#125; raises effect '&#123;effect&#125;', which exceeds the 'raises &lt;&#123;allowed&#125;&gt;' allowed by type '&#123;type&#125;'. Add '&#123;effect&#125;' to the clause, or use a target type that allows it. |
 | [AG3016](effects.md#ag3016) | '&#123;callee&#125;' can interrupt, and a finalize block cannot contain interrupts. A finalize runs while its scope shuts down, so there is nothing to resume. |
+| [AG3017](effects.md#ag3017) | &#123;kind&#125; cannot sit at the top level of a file. Top-level code runs at initialization, which cannot branch, loop, or wait — move it inside a node or a function. |
+| [AG3018](effects.md#ag3018) | A handler cannot be registered at the top level of a file. Handlers must be inside a node or a function, where there is execution for them to guard. |
 
 ## Names, scope, and reserved words
 

--- a/packages/agency-lang/docs/site/diagnostics/index.md
+++ b/packages/agency-lang/docs/site/diagnostics/index.md
@@ -159,6 +159,7 @@ or suppress a type-checker one on the next line with `// @tc-ignore AG####`.
 | [AG8011](templates.md#ag8011) | The splice argument `&#123;name&#125;` is declared in this file, so it does not exist yet when the generator runs. Splice arguments may be literals, code literals, or imported names. |
 | [AG8012](templates.md#ag8012) | The generator `&#123;name&#125;` declares `&#123;declared&#125;`, which this file already declares. Generated declarations may not replace existing ones. |
 | [AG8013](templates.md#ag8013) | The generator `&#123;name&#125;` produced an exported declaration (`&#123;declared&#125;`). Generated declarations cannot be exported yet, because other files resolve imports without running generators. Remove the `export`. |
+| [AG8014](templates.md#ag8014) | The generator `&#123;name&#125;` returned &#123;kind&#125;, which cannot sit at the top level of a file. Top-level code runs at initialization, which cannot branch, loop, or wait. |
 
 ## Lint
 

--- a/packages/agency-lang/docs/site/diagnostics/index.md
+++ b/packages/agency-lang/docs/site/diagnostics/index.md
@@ -63,7 +63,7 @@ or suppress a type-checker one on the next line with `// @tc-ignore AG####`.
 | [AG3014](effects.md#ag3014) | &#123;who&#125; may raise any effect (its type has no 'raises' clause), which exceeds the 'raises &lt;&#123;allowed&#125;&gt;' allowed by type '&#123;type&#125;'. Add a 'raises' clause to the value's type. |
 | [AG3015](effects.md#ag3015) | &#123;who&#125; raises effect '&#123;effect&#125;', which exceeds the 'raises &lt;&#123;allowed&#125;&gt;' allowed by type '&#123;type&#125;'. Add '&#123;effect&#125;' to the clause, or use a target type that allows it. |
 | [AG3016](effects.md#ag3016) | '&#123;callee&#125;' can interrupt, and a finalize block cannot contain interrupts. A finalize runs while its scope shuts down, so there is nothing to resume. |
-| [AG3017](effects.md#ag3017) | &#123;kind&#125; cannot sit at the top level of a file. Top-level code runs at initialization, which cannot branch, loop, or wait — move it inside a node or a function. |
+| [AG3017](effects.md#ag3017) | Cannot use &#123;kind&#125; at the top level of a file. Top-level code runs at initialization, which cannot branch, loop, or wait — move it inside a node or a function. |
 | [AG3018](effects.md#ag3018) | A handler cannot be registered at the top level of a file. Handlers must be inside a node or a function, where there is execution for them to guard. |
 
 ## Names, scope, and reserved words

--- a/packages/agency-lang/docs/site/diagnostics/templates.md
+++ b/packages/agency-lang/docs/site/diagnostics/templates.md
@@ -172,3 +172,13 @@ Other files find out what a module exports by reading its source, not by compili
 **How to fix:** drop the `export` from the generated declaration. If the name needs to be shared, write a hand-authored wrapper that calls it and export that.
 
 Lifting this restriction is tracked as issue #687.
+
+<a id="ag8014"></a>
+
+## AG8014 — The generator `&#123;name&#125;` returned &#123;kind&#125;, which cannot sit at the top level of a file. Top-level code runs at initialization, which cannot branch, loop, or wait.
+
+*Default severity: error.*
+
+A splice at the top level of a file adds the generator's output to the file, so that output is held to the same rule as anything you write there yourself: top-level code runs at initialization and cannot branch, loop, or wait.
+
+**How to fix:** have the generator return declarations (`node`, `def`, `type`), bindings, or plain calls. If it needs to branch, put the branching inside a `def` it declares, or splice it inside a node body instead.

--- a/packages/agency-lang/lib/backends/topLevelRefusal.test.ts
+++ b/packages/agency-lang/lib/backends/topLevelRefusal.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { parseAgency } from "../parser.js";
+import { TypeScriptBuilder } from "./typescriptBuilder.js";
+import { TypescriptPreprocessor } from "@/preprocessors/typescriptPreprocessor.js";
+import { buildCompilationUnit } from "@/compilationUnit.js";
+import { printTs } from "../ir/prettyPrint.js";
+import type { AgencyConfig } from "@/config.js";
+
+/**
+ * The builder's own refusal, exercised WITHOUT a type check in front of it.
+ *
+ * This is the only coverage the pre-pass has, and it needs to be: every
+ * compile path runs `typeCheck` before building, so the checker's AG3017
+ * fires first and nothing else in the suite ever reaches this throw. Delete
+ * the pre-pass and only these tests notice — which is the drift the pre-pass
+ * exists to prevent.
+ */
+function build(source: string): string {
+  const parseResult = parseAgency(source, {}, false);
+  if (!parseResult.success) throw new Error(`Failed to parse: ${parseResult.message}`);
+  const info = buildCompilationUnit(parseResult.result);
+  const preprocessor = new TypescriptPreprocessor(parseResult.result, {}, info);
+  const pre = preprocessor.preprocess();
+  const builder = new TypeScriptBuilder({} as AgencyConfig, info, "test.agency");
+  return printTs(builder.build(pre));
+}
+
+describe("the builder refuses a top-level statement before generating anything", () => {
+  const IF_AT_TOP = "if (true) {\n  print(1)\n}\n\nnode main() { print(2) }\n";
+
+  it("throws with the diagnostic code", () => {
+    expect(() => build(IF_AT_TOP)).toThrow(/AG3017/);
+  });
+
+  it("does not reach the step machinery", () => {
+    // The crash this replaces. If this assertion ever fails, the pre-pass
+    // has stopped running and the internal error is back.
+    expect(() => build(IF_AT_TOP)).not.toThrow(/StepPathTracker/);
+  });
+
+  it("still builds a program whose top level is legal", () => {
+    const output = build("const x = 1\n\nnode main() { print(x) }\n");
+    expect(output).toContain("main");
+  });
+});

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -3,6 +3,7 @@ import { declaredName } from "../types/hole.js";
 import { printCodeLiteralBody } from "./agencyGenerator.js";
 import { walkNodesArray } from "../utils/node.js";
 import { holeNames } from "../utils/holes.js";
+import { isLegalAtTopLevel } from "../utils/topLevel.js";
 import { DIAGNOSTICS, renderMessage } from "../typeChecker/diagnostics.js";
 import {
   AgencyComment,
@@ -509,6 +510,21 @@ export class TypeScriptBuilder {
         names: unfilled.map((name) => `#${name}`).join(", "),
       });
       throw new Error(`${DIAGNOSTICS.unfilledHoles.code}: ${rendered}`);
+    }
+
+    // Same reasoning as the refusal above: refuse before generating
+    // anything. A control-flow node routed into __initializeGlobals throws
+    // from inside the step machinery, with no location to report. The type
+    // checker reports this properly (AG3017); this is the guarantee that no
+    // codegen path can reach the crash without it.
+    const illegal = program.nodes.filter((node) => !isLegalAtTopLevel(node));
+    if (illegal.length > 0) {
+      const message = renderMessage(DIAGNOSTICS.topLevelStatementNotAllowed.message, {
+        kind: illegal.map((node) => node.type).join(", "),
+      });
+      throw new Error(
+        `${DIAGNOSTICS.topLevelStatementNotAllowed.code}: ${message}`,
+      );
     }
 
     // A tripwire. Expansion removes every splice before codegen, so one

--- a/packages/agency-lang/lib/backends/typescriptBuilder/nameClassifier.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder/nameClassifier.ts
@@ -22,7 +22,7 @@ export const DIRECT_CALL_FUNCTIONS: ReadonlySet<string> = new Set([
  * expressions, …) goes into the per-execution init function so it has
  * access to `__ctx`.
  */
-const TOP_LEVEL_DECLARATION_TYPES: ReadonlySet<string> = new Set([
+export const TOP_LEVEL_DECLARATION_TYPES: ReadonlySet<string> = new Set([
   "graphNode", "function", "typeAlias",
   "importStatement", "importNodeStatement",
   "comment", "multiLineComment", "newLine",

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -3268,6 +3268,14 @@ export const topLevelSpliceParser: Parser<Splice> = map(
   (splice) => ({ ...splice, position: "decl" as const }),
 );
 
+/** A splice occupying a whole statement in a body. Same shape as the
+ *  top-level form; this exists solely to stamp the position, which is what
+ *  lets a generator return statements here. */
+const statementSpliceParser: Parser<Splice> = map(
+  lazy(() => spliceParser),
+  (splice) => ({ ...splice, position: "statement" as const }),
+);
+
 const baseAtom: Parser<Expression> = or(
   // First: `#` cannot start any other expression, so this is a cheap
   // early exit. Being an operand alternative covers every expression
@@ -4783,9 +4791,8 @@ const _bodyNodeParser: Parser<AgencyNode> = memo("bodyNodeParser", or(
   // A bare `$( gen() )` occupying a whole statement needs its own entry:
   // binOpParser below rejects anything that is not a binOpExpression, and
   // the remaining alternatives (valueAccess, literal) do not start at `$`.
-  // So statement position never reaches baseAtom's spliceParser. Position
-  // stays "expr" — only the top-level parser stamps "decl".
-  lazy(() => spliceParser),
+  // So statement position never reaches baseAtom's spliceParser.
+  lazy(() => statementSpliceParser),
   binOpParser,
   booleanParser,
   valueAccessParser,

--- a/packages/agency-lang/lib/parsers/splice.test.ts
+++ b/packages/agency-lang/lib/parsers/splice.test.ts
@@ -43,9 +43,13 @@ describe("splice parsing", () => {
     expect(splice.position).toBe("expr");
   });
 
-  it("treats a bare splice inside a node body as an expression splice", () => {
+  it("treats a bare splice inside a node body as a statement splice", () => {
+    // CHANGED deliberately. This used to be "expr", which meant a
+    // generator returning statements was refused in the one place it is
+    // most useful. Statement position accepts the kinds a statements hole
+    // already accepts.
     const [splice] = splicesIn(`node main() {\n  $( makeThings() )\n  return 1\n}\n`);
-    expect(splice.position).toBe("expr");
+    expect(splice.position).toBe("statement");
   });
 
   it("parses a splice whose argument is a code literal", () => {
@@ -94,5 +98,28 @@ describe("splice parsing", () => {
     // fails immediately on a `splice: true` leaf ruling.
     const calls = nodesOfType(parseTemplate(`$( f(g(1)) )\n`).nodes, "functionCall");
     expect(calls.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe("splice positions", () => {
+  function spliceIn(source: string): Splice {
+    const found = [...walkNodesArray(parseTemplate(source).nodes)]
+      .map((visit) => visit.node)
+      .find((node) => node.type === "splice");
+    if (!found) throw new Error(`no splice in: ${source}`);
+    return found as Splice;
+  }
+
+  it("stamps statement position on a splice occupying a whole statement", () => {
+    expect(spliceIn("node main() {\n  $( gen() )\n}\n").position).toBe("statement");
+  });
+
+  it("leaves a splice inside an expression as expr", () => {
+    expect(spliceIn("node main() {\n  const x = $( gen() )\n}\n").position).toBe("expr");
+  });
+
+  it("still stamps decl on a top-level splice", () => {
+    // The new wrapper must not disturb the position it sits beside.
+    expect(spliceIn("$( gen() )\n\nnode main() { print(1) }\n").position).toBe("decl");
   });
 });

--- a/packages/agency-lang/lib/preprocessors/expandSplices.test.ts
+++ b/packages/agency-lang/lib/preprocessors/expandSplices.test.ts
@@ -385,3 +385,65 @@ describe("expandSplices", () => {
     expect(result.diagnostic.loc.line).toBeGreaterThan(1);
   });
 });
+
+describe("a declaration splice is held to the top-level rule", () => {
+  /** A generator whose fragment holds `body`, with the inferred kind left
+   *  to kind inference — which is the point of several cases below. */
+  function writeGenerator(body: string): void {
+    write(
+      "gen.agency",
+      `import { Code } from "std::agency"\n\nexport def gen(): Code {\n  return [|\n${body}\n  |]\n}\n`,
+    );
+  }
+
+  function spliceAtTopLevel() {
+    return expand(`import { gen } from "./gen.agency"\n\n$( gen() )\n`);
+  }
+
+  it("accepts a statements fragment whose nodes are all legal", () => {
+    writeGenerator("    const apiKey = 1");
+    const result = spliceAtTopLevel();
+    expect(result.ok).toBe(true);
+  });
+
+  it("refuses a statements fragment containing an if, naming it", () => {
+    writeGenerator("    if (true) {\n      print(1)\n    }");
+    const result = spliceAtTopLevel();
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(JSON.stringify(result.diagnostic)).toMatch(/ifElse|if/);
+  });
+
+  it("refuses the mixed fragment, which is the case the rule exists for", () => {
+    // One fragment, one legal statement and one illegal one. No fragment
+    // KIND distinguishes these — only looking at each node does.
+    writeGenerator("    const apiKey = 1\n    if (true) {\n      print(1)\n    }");
+    const result = spliceAtTopLevel();
+    expect(result.ok).toBe(false);
+  });
+
+  it("refuses a fragment containing a body-only block", () => {
+    // A `guard` block cannot be parsed at the top level at all, so this
+    // path is the only way one reaches the check.
+    writeGenerator("    guard(maxTime: 100) {\n      print(1)\n    }");
+    const result = spliceAtTopLevel();
+    expect(result.ok).toBe(false);
+  });
+
+  it("refuses a program fragment containing an if", () => {
+    // The hole a statements-only check leaves: this fragment infers kind
+    // `program`, because the statements attempt fails on the `def`. It
+    // passed the kind gate unexamined and crashed the backend.
+    writeGenerator(
+      "    if (true) {\n      print(1)\n    }\n\n    def helper(): number {\n      return 1\n    }",
+    );
+    const result = spliceAtTopLevel();
+    expect(result.ok).toBe(false);
+  });
+
+  it("still accepts a program fragment whose declarations are legal", () => {
+    writeGenerator('    def helper(): string {\n      return "hi"\n    }');
+    const result = spliceAtTopLevel();
+    expect(result.ok).toBe(true);
+  });
+});

--- a/packages/agency-lang/lib/preprocessors/expandSplices.ts
+++ b/packages/agency-lang/lib/preprocessors/expandSplices.ts
@@ -462,8 +462,36 @@ function importedNamesIn(nodes: AgencyNode[]): string[] {
  * Requiring `program` would make generated constants impossible. At the
  * top level a statement is a declaration, so this costs nothing.
  */
+/** Exhaustive, not a ternary: a third position value silently described a
+ *  statement mismatch as "expression position needs an expr fragment". */
+function expectedKindFor(position: Splice["position"]): string {
+  switch (position) {
+    case "decl":
+      return "program";
+    case "statement":
+      return "statements";
+    case "expr":
+      return "expr";
+  }
+}
+
+function positionLabel(position: Splice["position"]): string {
+  switch (position) {
+    case "decl":
+      return "declaration";
+    case "statement":
+      return "statement";
+    case "expr":
+      return "expression";
+  }
+}
+
 const KINDS_FOR_POSITION: Record<Splice["position"], string[]> = {
   decl: [...KINDS_FOR_SORT.decl, "statements"],
+  // The same set a statements HOLE accepts, right for the same reason: an
+  // expression is a legal statement, and a program grafted into a body is
+  // judged when the completed program compiles.
+  statement: KINDS_FOR_SORT.statements,
   expr: KINDS_FOR_SORT.expr,
 };
 
@@ -553,8 +581,8 @@ function graft(
         params: {
           name: generatorName,
           actual: kindOf(code),
-          expected: splice.position === "decl" ? "program" : "expr",
-          position: splice.position === "decl" ? "declaration" : "expression",
+          expected: expectedKindFor(splice.position),
+          position: positionLabel(splice.position),
         },
         loc: splice.loc ?? ORIGIN_UNKNOWN,
       },

--- a/packages/agency-lang/lib/preprocessors/expandSplices.ts
+++ b/packages/agency-lang/lib/preprocessors/expandSplices.ts
@@ -8,6 +8,7 @@ import { BUILTIN_VARIABLES } from "../config.js";
 import { PRELUDE_NAMES } from "../prelude.js";
 import { BUILTIN_FUNCTION_TYPES } from "../typeChecker/builtins.js";
 import { KINDS_FOR_SORT, stampOrigin } from "../runtime/template/origin.js";
+import { isLegalAtTopLevel } from "../utils/topLevel.js";
 import { kindOf } from "../runtime/template/code.js";
 import {
   checkGeneratorEligible,
@@ -462,6 +463,24 @@ function importedNamesIn(nodes: AgencyNode[]): string[] {
  * Requiring `program` would make generated constants impossible. At the
  * top level a statement is a declaration, so this costs nothing.
  */
+/** How a node reads in a message: `ifElse` means nothing to a user. */
+function describeNodeKind(type: string): string {
+  // Null-prototype: keyed by node type strings (house pattern).
+  const names: Record<string, string> = Object.assign(Object.create(null), {
+    ifElse: "an `if` statement",
+    whileLoop: "a `while` loop",
+    forLoop: "a `for` loop",
+    matchBlock: "a `match` block",
+    messageThread: "a `thread` block",
+    guardBlock: "a `guard` block",
+    finalizeBlock: "a `finalize` block",
+    handleBlock: "a handler",
+    returnStatement: "a `return`",
+    interruptStatement: "an interrupt",
+  });
+  return Object.hasOwn(names, type) ? names[type] : `a \`${type}\``;
+}
+
 /** Exhaustive, not a ternary: a third position value silently described a
  *  statement mismatch as "expression position needs an expr fragment". */
 function expectedKindFor(position: Splice["position"]): string {
@@ -572,6 +591,24 @@ function graft(
   const captured = checkNoCapture(splice, code, generatorName);
   if (captured !== null) {
     return { ok: false, diagnostic: captured };
+  }
+  // Declaration position: the kind gate above admits both `program` and
+  // `statements`, and neither says whether the NODES may sit at the top
+  // level. One fragment can hold `const x = 1` and an `if` at once, so this
+  // is per-node or nothing. Same predicate the compile path uses, so
+  // generated code is held to the standard written code is held to.
+  if (splice.position === "decl") {
+    const illegal = code.nodes.find((node) => !isLegalAtTopLevel(node));
+    if (illegal !== undefined) {
+      return {
+        ok: false,
+        diagnostic: {
+          diagnostic: "spliceTopLevelStatement",
+          params: { name: generatorName, kind: describeNodeKind(illegal.type) },
+          loc: splice.loc ?? ORIGIN_UNKNOWN,
+        },
+      };
+    }
   }
   if (!KINDS_FOR_POSITION[splice.position].includes(kindOf(code))) {
     return {

--- a/packages/agency-lang/lib/preprocessors/expandSplices.ts
+++ b/packages/agency-lang/lib/preprocessors/expandSplices.ts
@@ -8,7 +8,7 @@ import { BUILTIN_VARIABLES } from "../config.js";
 import { PRELUDE_NAMES } from "../prelude.js";
 import { BUILTIN_FUNCTION_TYPES } from "../typeChecker/builtins.js";
 import { KINDS_FOR_SORT, stampOrigin } from "../runtime/template/origin.js";
-import { isLegalAtTopLevel } from "../utils/topLevel.js";
+import { describeNodeKind, isLegalAtTopLevel } from "../utils/topLevel.js";
 import { kindOf } from "../runtime/template/code.js";
 import {
   checkGeneratorEligible,
@@ -463,24 +463,6 @@ function importedNamesIn(nodes: AgencyNode[]): string[] {
  * Requiring `program` would make generated constants impossible. At the
  * top level a statement is a declaration, so this costs nothing.
  */
-/** How a node reads in a message: `ifElse` means nothing to a user. */
-function describeNodeKind(type: string): string {
-  // Null-prototype: keyed by node type strings (house pattern).
-  const names: Record<string, string> = Object.assign(Object.create(null), {
-    ifElse: "an `if` statement",
-    whileLoop: "a `while` loop",
-    forLoop: "a `for` loop",
-    matchBlock: "a `match` block",
-    messageThread: "a `thread` block",
-    guardBlock: "a `guard` block",
-    finalizeBlock: "a `finalize` block",
-    handleBlock: "a handler",
-    returnStatement: "a `return`",
-    interruptStatement: "an interrupt",
-  });
-  return Object.hasOwn(names, type) ? names[type] : `a \`${type}\``;
-}
-
 /** Exhaustive, not a ternary: a third position value silently described a
  *  statement mismatch as "expression position needs an expr fragment". */
 function expectedKindFor(position: Splice["position"]): string {

--- a/packages/agency-lang/lib/typeChecker.test.ts
+++ b/packages/agency-lang/lib/typeChecker.test.ts
@@ -29,6 +29,26 @@ function withImports(
 // that diagnostic.
 const SILENT_UNDEF = { typechecker: { undefinedFunctions: "silent" as const } };
 
+/**
+ * `typeCheck` minus the top-level-statement rule (AG3017 / AG3018).
+ *
+ * Several fixtures below place control flow — an `if`, a loop, a handler —
+ * directly in `program.nodes`, which a real program cannot do: top-level
+ * code runs at initialization and cannot branch, loop, or guard. Those
+ * fixtures exist to exercise type inference and scoping, and they count
+ * errors exactly, so the unrelated diagnostic is filtered out here. The rule
+ * itself is covered in `lib/typeChecker/topLevelStatements.test.ts`.
+ */
+function inferenceCheck(program: AgencyProgram) {
+  const result = typeCheck(program);
+  const topLevelRule = ["AG3017", "AG3018"];
+  return {
+    ...result,
+    errors: result.errors.filter((e) => !topLevelRule.includes(e.code)),
+  };
+}
+
+
 describe("TypeChecker", () => {
   describe("function call argument type matching", () => {
     it("should pass with correct argument types", () => {
@@ -1175,7 +1195,7 @@ describe("TypeChecker", () => {
         ],
       };
 
-      const { errors } = typeCheck(program);
+      const { errors } = inferenceCheck(program);
       expect(errors).toHaveLength(1);
       expect(errors[0].message).toContain("not assignable to parameter type");
       expect(errors[0].params?.actual).toBe("string");
@@ -1228,7 +1248,7 @@ describe("TypeChecker", () => {
         ],
       };
 
-      const { errors } = typeCheck(program);
+      const { errors } = inferenceCheck(program);
       expect(errors).toHaveLength(1);
       expect(errors[0].params?.actual).toBe("number");
       expect(errors[0].params?.expected).toBe("string");
@@ -1260,7 +1280,7 @@ describe("TypeChecker", () => {
         ],
       };
 
-      const { errors } = typeCheck(program);
+      const { errors } = inferenceCheck(program);
       expect(errors).toHaveLength(1);
       expect(errors[0].params?.actual).toBe("boolean");
     });
@@ -1993,7 +2013,7 @@ describe("TypeChecker", () => {
         ],
       };
 
-      const { errors } = typeCheck(program);
+      const { errors } = inferenceCheck(program);
       expect(errors).toHaveLength(1);
       expect(errors[0].message).toMatch(/For-loop iterable must be an array/);
     });
@@ -2040,7 +2060,7 @@ describe("TypeChecker", () => {
         ],
       };
 
-      const { errors } = typeCheck(program);
+      const { errors } = inferenceCheck(program);
       expect(errors).toHaveLength(0);
     });
 
@@ -2083,7 +2103,7 @@ describe("TypeChecker", () => {
         ],
       };
 
-      const { errors } = typeCheck(program);
+      const { errors } = inferenceCheck(program);
       expect(errors).toHaveLength(1);
       expect(errors[0].params?.actual).toBe("string");
       expect(errors[0].params?.expected).toBe("number");
@@ -2133,7 +2153,7 @@ describe("TypeChecker", () => {
         ],
       };
 
-      const { errors } = typeCheck(program);
+      const { errors } = inferenceCheck(program);
       expect(errors).toHaveLength(0);
     });
 
@@ -2178,7 +2198,7 @@ describe("TypeChecker", () => {
         ],
       };
 
-      const { errors } = typeCheck(program);
+      const { errors } = inferenceCheck(program);
       expect(errors).toHaveLength(1);
       expect(errors[0].params?.actual).toBe("number");
       expect(errors[0].params?.expected).toBe("string");
@@ -2231,7 +2251,7 @@ describe("TypeChecker", () => {
         ],
       };
 
-      const { errors } = typeCheck(program);
+      const { errors } = inferenceCheck(program);
       expect(errors).toHaveLength(1);
       expect(errors[0].params?.actual).toBe("number");
       expect(errors[0].params?.expected).toBe("string");
@@ -2293,7 +2313,7 @@ describe("TypeChecker", () => {
         ],
       };
 
-      const { errors } = typeCheck(program);
+      const { errors } = inferenceCheck(program);
       expect(errors).toHaveLength(1);
       expect(errors[0].params?.actual).toBe("number");
       expect(errors[0].params?.expected).toBe("string");
@@ -2330,7 +2350,7 @@ describe("TypeChecker", () => {
         ],
       };
 
-      const { errors } = typeCheck(program);
+      const { errors } = inferenceCheck(program);
       expect(errors).toHaveLength(0);
     });
   });
@@ -3211,7 +3231,7 @@ describe("TypeChecker", () => {
           },
         ],
       };
-      const { errors } = typeCheck(program);
+      const { errors } = inferenceCheck(program);
       expect(errors).toHaveLength(1);
       expect(errors[0].message).toMatch(/not assignable.*boolean/);
     });
@@ -3233,7 +3253,7 @@ describe("TypeChecker", () => {
           },
         ],
       };
-      expect(typeCheck(program).errors).toHaveLength(0);
+      expect(inferenceCheck(program).errors).toHaveLength(0);
     });
 
     it("flags non-boolean while condition", () => {
@@ -3253,7 +3273,7 @@ describe("TypeChecker", () => {
           },
         ],
       };
-      const { errors } = typeCheck(program);
+      const { errors } = inferenceCheck(program);
       expect(errors).toHaveLength(1);
       expect(errors[0].message).toMatch(/not assignable.*boolean/);
     });
@@ -3283,7 +3303,7 @@ describe("TypeChecker", () => {
           },
         ],
       };
-      expect(typeCheck(program).errors).toHaveLength(0);
+      expect(inferenceCheck(program).errors).toHaveLength(0);
     });
   });
 
@@ -3503,7 +3523,7 @@ describe("TypeChecker", () => {
           },
         ],
       };
-      expect(typeCheck(program).errors).toHaveLength(0);
+      expect(inferenceCheck(program).errors).toHaveLength(0);
     });
 
     it("declarations inside seq block are visible after", () => {
@@ -3536,7 +3556,7 @@ describe("TypeChecker", () => {
           },
         ],
       };
-      const errors = typeCheck(program).errors;
+      const errors = inferenceCheck(program).errors;
       expect(errors.length).toBeGreaterThanOrEqual(1);
       expect(errors[0].message).toMatch(/not assignable to parameter type 'string'/);
     });
@@ -3571,7 +3591,7 @@ describe("TypeChecker", () => {
           },
         ],
       };
-      expect(typeCheck(program).errors).toHaveLength(0);
+      expect(inferenceCheck(program).errors).toHaveLength(0);
     });
 
     it("imported function call uses imported signature for return type", () => {
@@ -3854,7 +3874,7 @@ describe("TypeChecker", () => {
           },
         ],
       };
-      const errors = typeCheck(program).errors;
+      const errors = inferenceCheck(program).errors;
       expect(errors.length).toBeGreaterThanOrEqual(1);
       expect(errors[0].message).toMatch(/not assignable to parameter type 'string'/);
     });

--- a/packages/agency-lang/lib/typeChecker/diagnosticExplanations.ts
+++ b/packages/agency-lang/lib/typeChecker/diagnosticExplanations.ts
@@ -481,6 +481,14 @@ def f(): string {
 **How to fix:** keep the one marker that describes the function and remove the other.`,
 
   // ---- AG8: code templates and holes ----
+  topLevelStatementNotAllowed: `Code at the top level of a file runs when the module is initialized, not when a node executes. That phase has no way to branch, loop, or wait, so a statement that controls execution has nothing to control.
+
+**How to fix:** move it inside a node or a function. Top-level code may declare things (\`node\`, \`def\`, \`type\`, imports), bind values (\`const x = 1\`), and call functions for their effect (\`print("ready")\`) — nothing else.`,
+
+  topLevelHandlerNotAllowed: `A handler guards the code it wraps. At the top level of a file there is no execution to guard: the module is only being initialized, and a handler registered there would never see the interrupts it was written for.
+
+**How to fix:** move the \`handle\` block inside the node or function whose work it should guard.`,
+
   unfilledHoles: `This file contains template holes (\`#name\`), which mark gaps for code or values to be filled in later. A file with unfilled holes is a template, not a program, so it cannot be compiled or run directly.
 
 **How to fix:** load the file with \`loadTemplate\`, fill every hole with \`fill\`, and run the completed program (for example with \`runCode(toSource(filled))\`). Use \`holesOf\` to list what still needs filling.`,

--- a/packages/agency-lang/lib/typeChecker/diagnosticExplanations.ts
+++ b/packages/agency-lang/lib/typeChecker/diagnosticExplanations.ts
@@ -481,6 +481,10 @@ def f(): string {
 **How to fix:** keep the one marker that describes the function and remove the other.`,
 
   // ---- AG8: code templates and holes ----
+  spliceTopLevelStatement: `A splice at the top level of a file adds the generator's output to the file, so that output is held to the same rule as anything you write there yourself: top-level code runs at initialization and cannot branch, loop, or wait.
+
+**How to fix:** have the generator return declarations (\`node\`, \`def\`, \`type\`), bindings, or plain calls. If it needs to branch, put the branching inside a \`def\` it declares, or splice it inside a node body instead.`,
+
   topLevelStatementNotAllowed: `Code at the top level of a file runs when the module is initialized, not when a node executes. That phase has no way to branch, loop, or wait, so a statement that controls execution has nothing to control.
 
 **How to fix:** move it inside a node or a function. Top-level code may declare things (\`node\`, \`def\`, \`type\`, imports), bind values (\`const x = 1\`), and call functions for their effect (\`print("ready")\`) — nothing else.`,

--- a/packages/agency-lang/lib/typeChecker/diagnostics.ts
+++ b/packages/agency-lang/lib/typeChecker/diagnostics.ts
@@ -620,6 +620,12 @@ export const DIAGNOSTICS = {
     message:
       "The generator `{name}` reaches non-Agency code through `{importPath}`. Compile-time generators may import only `std::` modules and relative `.agency` files, because JavaScript raises no interrupts and cannot be checked. Set `allowNonAgencyGenerators` in your config to permit it.",
   },
+  spliceTopLevelStatement: {
+    code: "AG8014",
+    severity: "error",
+    message:
+      "The generator `{name}` returned {kind}, which cannot sit at the top level of a file. Top-level code runs at initialization, which cannot branch, loop, or wait.",
+  },
   spliceFragmentKindMismatch: {
     code: "AG8007",
     severity: "error",

--- a/packages/agency-lang/lib/typeChecker/diagnostics.ts
+++ b/packages/agency-lang/lib/typeChecker/diagnostics.ts
@@ -441,6 +441,18 @@ export const DIAGNOSTICS = {
     message:
       "'{callee}' can interrupt, and a finalize block cannot contain interrupts. A finalize runs while its scope shuts down, so there is nothing to resume.",
   },
+  topLevelStatementNotAllowed: {
+    code: "AG3017",
+    severity: "error",
+    message:
+      "{kind} cannot sit at the top level of a file. Top-level code runs at initialization, which cannot branch, loop, or wait — move it inside a node or a function.",
+  },
+  topLevelHandlerNotAllowed: {
+    code: "AG3018",
+    severity: "error",
+    message:
+      "A handler cannot be registered at the top level of a file. Handlers must be inside a node or a function, where there is execution for them to guard.",
+  },
   undefinedFunction: {
     code: "AG4004",
     severity: "error",

--- a/packages/agency-lang/lib/typeChecker/diagnostics.ts
+++ b/packages/agency-lang/lib/typeChecker/diagnostics.ts
@@ -445,7 +445,7 @@ export const DIAGNOSTICS = {
     code: "AG3017",
     severity: "error",
     message:
-      "{kind} cannot sit at the top level of a file. Top-level code runs at initialization, which cannot branch, loop, or wait — move it inside a node or a function.",
+      "Cannot use {kind} at the top level of a file. Top-level code runs at initialization, which cannot branch, loop, or wait — move it inside a node or a function.",
   },
   topLevelHandlerNotAllowed: {
     code: "AG3018",

--- a/packages/agency-lang/lib/typeChecker/index.ts
+++ b/packages/agency-lang/lib/typeChecker/index.ts
@@ -47,6 +47,7 @@ import { computeMatchExprTypes } from "./matchExprTypes.js";
 import { checkDefiniteReturns } from "./definiteReturns.js";
 import { checkConflictingMarkers } from "./conflictingMarkers.js";
 import { checkTemplateHoles } from "./templateHoles.js";
+import { checkTopLevelStatements } from "./topLevelStatements.js";
 import { refineInlineHandlerParams } from "./handlerParamTyping.js";
 import { declareFinalizeBinders } from "./finalizeBinder.js";
 import { checkEffectPayloads, buildEffectRegistry } from "./effectPayloadCheck.js";
@@ -367,6 +368,10 @@ export class TypeChecker {
     // Template holes: an expression hole in a position that supplies no
     // type must carry an inline annotation (AG8002).
     checkTemplateHoles(ctx);
+
+    // Top-level code is initialization: it may establish something but not
+    // control anything (AG3017, AG3018).
+    checkTopLevelStatements(ctx);
 
     // Check for undefined function calls (config-controlled severity).
     checkUndefinedFunctions(scopes, ctx);

--- a/packages/agency-lang/lib/typeChecker/spliceDiagnostics.test.ts
+++ b/packages/agency-lang/lib/typeChecker/spliceDiagnostics.test.ts
@@ -31,6 +31,7 @@ const SPLICE_DIAGNOSTIC_PARAMS: Record<string, Record<string, string>> = {
     name: "makeGetters",
     reason: "it reaches helper.agency, which does not parse",
   },
+  spliceTopLevelStatement: { name: "makeGetters", kind: "an `if` statement" },
 };
 
 describe("splice diagnostics", () => {
@@ -58,6 +59,7 @@ describe("splice diagnostics", () => {
       "AG8011",
       "AG8012",
       "AG8013",
+      "AG8014",
     ]);
   });
 

--- a/packages/agency-lang/lib/typeChecker/topLevelStatements.test.ts
+++ b/packages/agency-lang/lib/typeChecker/topLevelStatements.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { typeCheckSource } from "../compiler/typecheck.js";
+
+/** Codes reported for `source`, errors and warnings alike. */
+function codesOf(source: string): string[] {
+  const report = typeCheckSource(source);
+  return [...report.errors, ...report.warnings].map((diag) => diag.code ?? "");
+}
+
+/** The first diagnostic carrying `code`, or undefined. */
+function diagFor(source: string, code: string) {
+  const report = typeCheckSource(source);
+  return [...report.errors, ...report.warnings].find((diag) => diag.code === code);
+}
+
+describe("AG3017: statements that cannot sit at the top level", () => {
+  const refused: [string, string, string][] = [
+    ["if", "if (true) {\n  print(1)\n}\n\nnode main() { print(2) }\n", "AG3017"],
+    ["while", "while (false) {\n  print(1)\n}\n\nnode main() { print(2) }\n", "AG3017"],
+    ["for", "for (x in [1, 2]) {\n  print(x)\n}\n\nnode main() { print(2) }\n", "AG3017"],
+    ["match", "match(1) {\n  1 => print(1)\n}\n\nnode main() { print(2) }\n", "AG3017"],
+    ["thread", "thread {\n  print(1)\n}\n\nnode main() { print(2) }\n", "AG3017"],
+    // The row the spec's first draft got wrong, and the one where a wrong
+    // fix is worst: a handler that compiles and never registers.
+    [
+      "handle",
+      "handle {\n  print(1)\n} with (e) {\n  return approve()\n}\n\nnode main() { print(2) }\n",
+      "AG3018",
+    ],
+    ["return", "return 1\n\nnode main() { print(2) }\n", "AG3017"],
+    ["interrupt", 'interrupt("x")\n\nnode main() { print(2) }\n', "AG3017"],
+    ["static interrupt", 'static interrupt("x")\n\nnode main() { print(2) }\n', "AG3017"],
+    ["debugger(...)", 'debugger("x")\n\nnode main() { print(2) }\n', "AG3017"],
+  ];
+
+  for (const [label, source, code] of refused) {
+    it(`refuses ${label}`, () => {
+      expect(codesOf(source), label).toContain(code);
+    });
+  }
+
+  const allowed: [string, string][] = [
+    ["const", "const x = 1\n\nnode main() { print(x) }\n"],
+    ["bare call", "print(1)\n\nnode main() { print(2) }\n"],
+    ["static call", "static print(1)\n\nnode main() { print(2) }\n"],
+    ["assignment", "x = 1\n\nnode main() { print(2) }\n"],
+    ["bare debugger", "debugger\n\nnode main() { print(2) }\n"],
+    ["declarations", "def f(): number {\n  return 1\n}\n\nnode main() { print(2) }\n"],
+    ["goto, which is two bare names", "goto other\n\nnode main() { print(2) }\n"],
+  ];
+
+  for (const [label, source] of allowed) {
+    it(`allows ${label}`, () => {
+      const codes = codesOf(source).filter((c) => c === "AG3017" || c === "AG3018");
+      expect(codes, label).toEqual([]);
+    });
+  }
+
+  it("names the rule, not just the symptom", () => {
+    const found = diagFor("if (true) {\n  print(1)\n}\n\nnode main() { print(2) }\n", "AG3017");
+    expect(found?.message).toMatch(/top level/);
+    expect(found?.message).toMatch(/initializ/i);
+  });
+
+  it("describes the inner statement of a static, not the wrapper", () => {
+    const found = diagFor('static interrupt("x")\n\nnode main() { print(2) }\n', "AG3017");
+    expect(found?.message).toMatch(/interrupt/);
+    expect(found?.message).not.toMatch(/staticStatement/);
+  });
+
+  it("tells a handler author where handlers may live", () => {
+    const found = diagFor(
+      "handle {\n  print(1)\n} with (e) {\n  return approve()\n}\n\nnode main() { print(2) }\n",
+      "AG3018",
+    );
+    expect(found?.message).toMatch(/handler/i);
+  });
+
+  it("reports every offender, not just the first", () => {
+    const two =
+      "if (true) {\n  print(1)\n}\n\nif (false) {\n  print(2)\n}\n\nnode main() { print(3) }\n";
+    expect(codesOf(two).filter((c) => c === "AG3017")).toHaveLength(2);
+  });
+
+  it("carries a location, so the message can point at the statement", () => {
+    const found = diagFor("if (true) {\n  print(1)\n}\n\nnode main() { print(2) }\n", "AG3017");
+    expect(found?.loc).toBeDefined();
+    expect(found?.loc?.line).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/topLevelStatements.test.ts
+++ b/packages/agency-lang/lib/typeChecker/topLevelStatements.test.ts
@@ -56,6 +56,15 @@ describe("AG3017: statements that cannot sit at the top level", () => {
     });
   }
 
+  it("says nothing about a template's own declaration hole", () => {
+    // A top-level hole is a designed template feature. Reporting it here
+    // told the author to "move it inside a node or a function", which is
+    // wrong advice for a template; AG8001 refuses a holey program at
+    // compile with the right message.
+    const codes = codesOf("#helper\n\nnode main(): string {\n  return greet()\n}\n");
+    expect(codes).not.toContain("AG3017");
+  });
+
   it("names the rule, not just the symptom", () => {
     const found = diagFor("if (true) {\n  print(1)\n}\n\nnode main() { print(2) }\n", "AG3017");
     expect(found?.message).toMatch(/top level/);

--- a/packages/agency-lang/lib/typeChecker/topLevelStatements.ts
+++ b/packages/agency-lang/lib/typeChecker/topLevelStatements.ts
@@ -1,6 +1,6 @@
-import { isLegalAtTopLevel } from "../utils/topLevel.js";
+import { describeNodeKind, isLegalAtTopLevel } from "../utils/topLevel.js";
 import { diagnostic } from "./diagnostics.js";
-import type { AgencyNode, StaticStatement } from "../types.js";
+import type { StaticStatement } from "../types.js";
 import type { TypeCheckerContext } from "./types.js";
 
 /**
@@ -21,30 +21,9 @@ export function checkTopLevelStatements(ctx: TypeCheckerContext): void {
         offender.type === "handleBlock"
           ? "topLevelHandlerNotAllowed"
           : "topLevelStatementNotAllowed",
-        { kind: describeKind(offender.type) },
+        { kind: describeNodeKind(offender.type) },
         node.loc ?? null,
       ),
     );
   }
-}
-
-/** `ifElse` reads as "if statement" to a user, not as a node type. Unmapped
- *  types fall back to their own name, so this fails ugly rather than wrong.
- *  Each entry carries its own article so the message reads as English. */
-function describeKind(type: AgencyNode["type"]): string {
-  // Null-prototype: keyed by node type strings (house pattern).
-  const names: Record<string, string> = Object.assign(Object.create(null), {
-    ifElse: "An `if` statement",
-    whileLoop: "A `while` loop",
-    forLoop: "A `for` loop",
-    matchBlock: "A `match` block",
-    messageThread: "A `thread` block",
-    guardBlock: "A `guard` block",
-    finalizeBlock: "A `finalize` block",
-    returnStatement: "A `return`",
-    gotoStatement: "A `goto`",
-    interruptStatement: "An interrupt",
-    debuggerStatement: "A `debugger(...)` statement",
-  });
-  return Object.hasOwn(names, type) ? names[type] : `A \`${type}\``;
 }

--- a/packages/agency-lang/lib/typeChecker/topLevelStatements.ts
+++ b/packages/agency-lang/lib/typeChecker/topLevelStatements.ts
@@ -1,0 +1,50 @@
+import { isLegalAtTopLevel } from "../utils/topLevel.js";
+import { diagnostic } from "./diagnostics.js";
+import type { AgencyNode, StaticStatement } from "../types.js";
+import type { TypeCheckerContext } from "./types.js";
+
+/**
+ * AG3017 / AG3018 — the top-level rule, reported where the user can see it.
+ *
+ * Top level only: this walks `ctx.programNodes` directly rather than
+ * recursing, because a node's own body is a different context entirely.
+ */
+export function checkTopLevelStatements(ctx: TypeCheckerContext): void {
+  for (const node of ctx.programNodes) {
+    if (isLegalAtTopLevel(node)) continue;
+    // `static interrupt(...)` should say "interrupt", not "staticStatement":
+    // the predicate defers to the inner node, so the message must too.
+    const offender =
+      node.type === "staticStatement" ? (node as StaticStatement).statement : node;
+    ctx.errors.push(
+      diagnostic(
+        offender.type === "handleBlock"
+          ? "topLevelHandlerNotAllowed"
+          : "topLevelStatementNotAllowed",
+        { kind: describeKind(offender.type) },
+        node.loc ?? null,
+      ),
+    );
+  }
+}
+
+/** `ifElse` reads as "if statement" to a user, not as a node type. Unmapped
+ *  types fall back to their own name, so this fails ugly rather than wrong.
+ *  Each entry carries its own article so the message reads as English. */
+function describeKind(type: AgencyNode["type"]): string {
+  // Null-prototype: keyed by node type strings (house pattern).
+  const names: Record<string, string> = Object.assign(Object.create(null), {
+    ifElse: "An `if` statement",
+    whileLoop: "A `while` loop",
+    forLoop: "A `for` loop",
+    matchBlock: "A `match` block",
+    messageThread: "A `thread` block",
+    guardBlock: "A `guard` block",
+    finalizeBlock: "A `finalize` block",
+    returnStatement: "A `return`",
+    gotoStatement: "A `goto`",
+    interruptStatement: "An interrupt",
+    debuggerStatement: "A `debugger(...)` statement",
+  });
+  return Object.hasOwn(names, type) ? names[type] : `A \`${type}\``;
+}

--- a/packages/agency-lang/lib/types/splice.ts
+++ b/packages/agency-lang/lib/types/splice.ts
@@ -17,5 +17,5 @@ export type Splice = BaseNode & {
   type: "splice";
   expression: Expression;
   /** Derived from which parser matched, never written by the user. */
-  position: "decl" | "expr";
+  position: "decl" | "statement" | "expr";
 };

--- a/packages/agency-lang/lib/utils/topLevel.test.ts
+++ b/packages/agency-lang/lib/utils/topLevel.test.ts
@@ -34,6 +34,9 @@ describe("isLegalAtTopLevel: allowed", () => {
     "1 + 2",
     "true",
     "null",
+    // Supported deliberately: issue #229 made this work at module scope
+    // rather than refusing it.
+    "foo() with approve",
   ];
 
   for (const source of allowed) {

--- a/packages/agency-lang/lib/utils/topLevel.test.ts
+++ b/packages/agency-lang/lib/utils/topLevel.test.ts
@@ -70,6 +70,31 @@ describe("isLegalAtTopLevel: refused", () => {
   }
 });
 
+describe("isLegalAtTopLevel: template features are legal", () => {
+  // Both are designed top-level features, and both are handled by a better
+  // mechanism than this rule. Saying otherwise reported a template's own
+  // declaration hole as a user error advising "move it inside a node".
+  it("allows a declaration hole, which AG8001 refuses at compile with better advice", () => {
+    const parsed = parseAgency("#helper\n\nnode main(): string {\n  return greet()\n}\n", {}, false, false);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    const hole = parsed.result.nodes.find((n) => n.type === "hole");
+    expect(hole).toBeDefined();
+    expect(isLegalAtTopLevel(hole as AgencyNode)).toBe(true);
+  });
+
+  it("allows a splice, which expansion replaces before codegen", () => {
+    // A splice reaching the builder means a compile path skipped
+    // expandSplices — a maintainer bug that must not read as user error.
+    const parsed = parseAgency("$( gen() )\n\nnode main() { print(1) }\n", {}, false, false);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    const splice = parsed.result.nodes.find((n) => n.type === "splice");
+    expect(splice).toBeDefined();
+    expect(isLegalAtTopLevel(splice as AgencyNode)).toBe(true);
+  });
+});
+
 describe("isLegalAtTopLevel: goto is not reachable at the top level", () => {
   it("parses as two bare names, so it stays legal", () => {
     // `goto other` at file scope is NOT a gotoStatement — the grammar

--- a/packages/agency-lang/lib/utils/topLevel.test.ts
+++ b/packages/agency-lang/lib/utils/topLevel.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from "vitest";
+import { isLegalAtTopLevel } from "./topLevel.js";
+import { parseAgency } from "../parser.js";
+import { TOP_LEVEL_DECLARATION_TYPES } from "../backends/typescriptBuilder/nameClassifier.js";
+import type { AgencyNode } from "../types.js";
+
+/** The first non-trivia node of a program parsed from `source`. */
+function firstNode(source: string): AgencyNode {
+  const result = parseAgency(source, {}, false);
+  if (!result.success) throw new Error(`${source}: ${result.message}`);
+  // Skip trivia only. NOT importStatement — one allowed case IS an import.
+  const node = result.result.nodes.find(
+    (n) => n.type !== "newLine" && n.type !== "comment",
+  );
+  if (!node) throw new Error(`no node in: ${source}`);
+  return node;
+}
+
+describe("isLegalAtTopLevel: allowed", () => {
+  // Top-level code is initialization. It may ESTABLISH something.
+  const allowed: string[] = [
+    "node main() { print(1) }",
+    "def helper(): number { return 1 }",
+    "type Person = { name: string }",
+    "const x = 1",
+    "let y = 2",
+    "static const z = 3",
+    "x = 1",
+    "print(1)",
+    "foo.bar",
+    "static print(1)",
+    "debugger", // parses as a variableName, not a debuggerStatement
+    "someName",
+    "1 + 2",
+    "true",
+    "null",
+  ];
+
+  for (const source of allowed) {
+    it(`allows: ${source}`, () => {
+      expect(isLegalAtTopLevel(firstNode(source)), source).toBe(true);
+    });
+  }
+});
+
+describe("isLegalAtTopLevel: refused", () => {
+  // It may not CONTROL anything: the init phases have no step machinery.
+  const refused: string[] = [
+    "if (true) { print(1) }",
+    "while (false) { print(1) }",
+    "for (x in [1, 2]) { print(x) }",
+    "match(1) { 1 => print(1) }",
+    "thread { print(1) }",
+    "handle {\n  print(1)\n} with (e) {\n  return approve()\n}",
+    "return 1",
+    'interrupt("x")',
+    'static interrupt("x")',
+    // The parenthesized form, which is a real debuggerStatement and
+    // crashes today — the opposite side of the rule from bare `debugger`.
+    'debugger("x")',
+  ];
+
+  for (const source of refused) {
+    it(`refuses: ${source.split("\n")[0]}`, () => {
+      expect(isLegalAtTopLevel(firstNode(source)), source).toBe(false);
+    });
+  }
+});
+
+describe("isLegalAtTopLevel: goto is not reachable at the top level", () => {
+  it("parses as two bare names, so it stays legal", () => {
+    // `goto other` at file scope is NOT a gotoStatement — the grammar
+    // yields `variableName("goto")` and `variableName("other")`. So the
+    // gotoStatement row is unobservable here, and this spelling keeps
+    // compiling. Pinned because it looks like a refusal and is not one.
+    const result = parseAgency("goto other\n\nnode main() { print(1) }\n", {}, false);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const types = result.result.nodes.map((n) => n.type);
+    expect(types.filter((t) => t === "variableName")).toHaveLength(2);
+    expect(types).not.toContain("gotoStatement");
+  });
+});
+
+describe("isLegalAtTopLevel: body-only forms", () => {
+  // These cannot be parsed at the top level, so no whole-file test can
+  // reach them — but a statements FRAGMENT parses body grammar, so a
+  // top-level splice takes them straight to the per-node check. Pull them
+  // out of a body parse to exercise the table rows that path depends on.
+  function firstBodyNode(body: string): AgencyNode {
+    const node = firstNode(`node m() {\n${body}\n}\n`) as { body?: AgencyNode[] };
+    const inner = node.body?.[0];
+    if (!inner) throw new Error(`no body node in: ${body}`);
+    return inner;
+  }
+
+  const refused: [string, string][] = [
+    ["guard", "  guard(maxTime: 100) {\n    print(1)\n  }"],
+    ["finalize", "  finalize {\n    print(1)\n  }"],
+    ["if", "  if (true) {\n    print(1)\n  }"],
+  ];
+
+  for (const [label, body] of refused) {
+    it(`refuses a ${label} block`, () => {
+      expect(isLegalAtTopLevel(firstBodyNode(body)), label).toBe(false);
+    });
+  }
+});
+
+describe("isLegalAtTopLevel: static wraps its inner statement", () => {
+  it("judges the statement inside, not the `static`", () => {
+    expect(isLegalAtTopLevel(firstNode("static print(1)"))).toBe(true);
+    expect(isLegalAtTopLevel(firstNode('static interrupt("x")'))).toBe(false);
+  });
+});
+
+describe("placement can never route an illegal node", () => {
+  // Three things describe the top level after this change: the grammar
+  // (permissive), the placement set (where a node is emitted), and this
+  // predicate (whether it may be there). This closes the triangle.
+  it("every top-level declaration type is legal at the top level", () => {
+    // Reads the REAL set, never a copy — a copy is what this test exists
+    // to prevent.
+    for (const type of TOP_LEVEL_DECLARATION_TYPES) {
+      expect(isLegalAtTopLevel({ type } as AgencyNode), type).toBe(true);
+    }
+  });
+
+  it("a static assignment is legal too", () => {
+    // The placement set's other half: `isTopLevelDeclaration` special-cases
+    // a static-scoped assignment.
+    expect(isLegalAtTopLevel({ type: "assignment" } as AgencyNode)).toBe(true);
+  });
+});

--- a/packages/agency-lang/lib/utils/topLevel.ts
+++ b/packages/agency-lang/lib/utils/topLevel.ts
@@ -1,0 +1,116 @@
+import type { AgencyNode, StaticStatement } from "../types.js";
+
+/**
+ * May this node sit at the top level of a file?
+ *
+ * Top-level code is initialization, not execution: it runs in the init
+ * phases, which have no step machinery. So a node may ESTABLISH something —
+ * bind a name, call for effect — but may not CONTROL anything.
+ *
+ * The `Record<AgencyNode["type"], …>` is the point: a new node kind fails to
+ * compile until someone decides. The bug this exists to stop is a statement
+ * form nobody considered reaching the backend and crashing it.
+ *
+ * Answers legality only. Where a node is EMITTED is a different question,
+ * owned by `TOP_LEVEL_DECLARATION_TYPES` in the builder.
+ */
+const LEGAL_AT_TOP_LEVEL: Record<AgencyNode["type"], boolean> = {
+  // Declarations.
+  graphNode: true,
+  function: true,
+  typeAlias: true,
+  effectDeclaration: true,
+  importStatement: true,
+  importNodeStatement: true,
+  exportFromStatement: true,
+  skill: true,
+  tag: true,
+
+  // Bindings and expression statements.
+  assignment: true,
+  functionCall: true,
+  valueAccess: true,
+  binOpExpression: true,
+  keyword: true,
+
+  // `static <inner>` — judged by its inner statement, see below.
+  staticStatement: true,
+
+  // Trivia.
+  comment: true,
+  multiLineComment: true,
+  newLine: true,
+
+  // Literal forms, which the top-level grammar accepts unevenly. These
+  // follow what compiles today; refusing more would be a breaking change
+  // nobody asked for.
+  variableName: true, // bare `debugger` is one of these
+  boolean: true,
+  null: true,
+  number: false, // parse error at top level
+  string: false,
+  multiLineString: false,
+  unitLiteral: false,
+  regex: false,
+
+  // `debugger(...)` — the parenthesized form. Crashes today, unlike the
+  // bare word above, which is a `variableName`.
+  debuggerStatement: false,
+
+  // Control flow: the init phases cannot branch, loop, or wait.
+  ifElse: false,
+  whileLoop: false,
+  forLoop: false,
+  matchBlock: false,
+  matchYield: false,
+  messageThread: false,
+  handleBlock: false,
+  finalizeBlock: false,
+  guardBlock: false,
+  parallelBlock: false,
+  seqBlock: false,
+  tryExpression: false,
+  withModifier: false,
+
+  // Node-relative: there is no enclosing node at file scope.
+  returnStatement: false,
+  gotoStatement: false,
+
+  // Interrupts need a running node. Both spellings compile today and then
+  // crash with `__self is not defined`; refusing is the better error.
+  interruptStatement: false,
+
+  // Sub-expressions and patterns, which are not statements at all.
+  agencyObject: false,
+  agencyArray: false,
+  comprehension: false,
+  newExpression: false,
+  schemaExpression: false,
+  isExpression: false,
+  typeTestExpression: false,
+  blockArgument: false,
+  awaitPending: false,
+  markDestructiveRan: false,
+  rawCode: false,
+  objectPattern: false,
+  arrayPattern: false,
+  restPattern: false,
+  wildcardPattern: false,
+  resultPattern: false,
+  typePattern: false,
+
+  // Templates. A hole is refused earlier (AG8001); a code literal is a
+  // value, and a splice is replaced before this check runs.
+  hole: false,
+  codeLiteral: false,
+  splice: false,
+};
+
+export function isLegalAtTopLevel(node: AgencyNode): boolean {
+  // `static print(1)` is legal and `static interrupt(...)` is not, so the
+  // wrapper defers to what it wraps.
+  if (node.type === "staticStatement") {
+    return isLegalAtTopLevel((node as StaticStatement).statement);
+  }
+  return LEGAL_AT_TOP_LEVEL[node.type];
+}

--- a/packages/agency-lang/lib/utils/topLevel.ts
+++ b/packages/agency-lang/lib/utils/topLevel.ts
@@ -32,6 +32,10 @@ const LEGAL_AT_TOP_LEVEL: Record<AgencyNode["type"], boolean> = {
   valueAccess: true,
   binOpExpression: true,
   keyword: true,
+  // `foo() with approve` at module scope. This hit the same crash and was
+  // made to WORK rather than refused — partitionProgram special-cases it
+  // (issue #229), which is the other way to answer this question.
+  withModifier: true,
 
   // `static <inner>` — judged by its inner statement, see below.
   staticStatement: true,
@@ -70,7 +74,6 @@ const LEGAL_AT_TOP_LEVEL: Record<AgencyNode["type"], boolean> = {
   parallelBlock: false,
   seqBlock: false,
   tryExpression: false,
-  withModifier: false,
 
   // Node-relative: there is no enclosing node at file scope.
   returnStatement: false,

--- a/packages/agency-lang/lib/utils/topLevel.ts
+++ b/packages/agency-lang/lib/utils/topLevel.ts
@@ -80,7 +80,9 @@ const LEGAL_AT_TOP_LEVEL: Record<AgencyNode["type"], boolean> = {
   gotoStatement: false,
 
   // Interrupts need a running node. Both spellings compile today and then
-  // crash with `__self is not defined`; refusing is the better error.
+  // crash with `__self is not defined`; refusing is the better error. The
+  // parser advertises them (staticStatementParser's inner list) and the
+  // backend never implemented them — #728.
   interruptStatement: false,
 
   // Sub-expressions and patterns, which are not statements at all.

--- a/packages/agency-lang/lib/utils/topLevel.ts
+++ b/packages/agency-lang/lib/utils/topLevel.ts
@@ -104,12 +104,43 @@ const LEGAL_AT_TOP_LEVEL: Record<AgencyNode["type"], boolean> = {
   resultPattern: false,
   typePattern: false,
 
-  // Templates. A hole is refused earlier (AG8001); a code literal is a
-  // value, and a splice is replaced before this check runs.
-  hole: false,
+  // Templates. Both ARE legal top-level Agency, and both are handled by a
+  // better mechanism than this rule: a program with holes is refused by
+  // AG8001, which says so; a splice is replaced by expansion, and one that
+  // reaches codegen means a compile path skipped `expandSplices` — a
+  // maintainer bug that must not be reported as user error. Saying `false`
+  // here shadowed both with advice to "move it inside a node".
+  hole: true,
+  splice: true,
+  // A value, so it never appears as a top-level statement.
   codeLiteral: false,
-  splice: false,
 };
+
+/**
+ * How a node reads in a message: `ifElse` means nothing to a user.
+ *
+ * Lives here so the type checker and the splice checker describe the same
+ * node the same way. Lowercase, for use mid-sentence. Unmapped types fall
+ * back to their own name, so this fails ugly rather than wrong.
+ */
+export function describeNodeKind(type: AgencyNode["type"]): string {
+  // Null-prototype: keyed by node type strings (house pattern).
+  const names: Record<string, string> = Object.assign(Object.create(null), {
+    ifElse: "an `if` statement",
+    whileLoop: "a `while` loop",
+    forLoop: "a `for` loop",
+    matchBlock: "a `match` block",
+    messageThread: "a `thread` block",
+    guardBlock: "a `guard` block",
+    finalizeBlock: "a `finalize` block",
+    handleBlock: "a handler",
+    returnStatement: "a `return`",
+    gotoStatement: "a `goto`",
+    interruptStatement: "an interrupt",
+    debuggerStatement: "a `debugger(...)` statement",
+  });
+  return Object.hasOwn(names, type) ? names[type] : `a \`${type}\``;
+}
 
 export function isLegalAtTopLevel(node: AgencyNode): boolean {
   // `static print(1)` is legal and `static interrupt(...)` is not, so the

--- a/packages/agency-lang/tests/agency/templates/spliceInBody.agency
+++ b/packages/agency-lang/tests/agency/templates/spliceInBody.agency
@@ -1,0 +1,9 @@
+import { callFunc } from "./spliceInBodyGen.agency"
+
+// The original report: a generator returning statements, spliced into a
+// node body. Refused before this change, because a splice occupying a
+// whole statement was in expression position.
+node main(): string {
+  $( callFunc() )
+  return "ok"
+}

--- a/packages/agency-lang/tests/agency/templates/spliceInBody.test.json
+++ b/packages/agency-lang/tests/agency/templates/spliceInBody.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"ok\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "A generator returning statements can be spliced into a node body"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/templates/spliceInBodyGen.agency
+++ b/packages/agency-lang/tests/agency/templates/spliceInBodyGen.agency
@@ -1,0 +1,8 @@
+import { Code } from "std::agency"
+
+export def callFunc(): Code {
+  return [|
+    const spliced = "hello from a spliced statement"
+    print(spliced)
+  |]
+}


### PR DESCRIPTION
Three symptoms, one root: nothing in the compiler answered "may this statement sit at the top level of a file?", so the grammar, the backend and the splice checker each guessed differently.

## What was broken

**An `if` at file scope crashed the compiler** (#713):

```ts
if (true) { print(1) }

node main() { print(2) }
```

```
Error: StepPathTracker: currentId() called with empty path
    at TypeScriptBuilder.processIfElseWithSteps
    at TypeScriptBuilder.processNodeInGlobalInit
```

No file, no line, no column. Same for `while`, `for`, `match`, `thread`, a `handle` block, and `debugger("x")`.

**A splice on its own line inside a node body could not use a generator that returns statements:**

```ts
node main() {
  $( callFunc() )    // AG8007: needs an expr fragment
}
```

**The same splice at the top level was accepted** and produced TypeScript that esbuild could not parse.

Those last two are the same table, wrong in both directions: statements were refused where they are useful and accepted where they break.

## The rule

Top-level code is **initialization, not execution**. It runs in the init phases, which have no step machinery. A top-level statement may *establish* something — bind a name, call something for its effect — but may not *control* anything.

`staticStatementParser` already encoded a piece of this for `static <expression>`, enumerating an interrupt, a call, or a value access. This generalizes that answer.

## The fix

`isLegalAtTopLevel` (`lib/utils/topLevel.ts`) is one table keyed by node type, so **adding a node kind to the language fails to compile until someone classifies it**. Same enforcement `identifierSlots.ts` uses, and for a sharper reason: the bug being fixed is a statement form nobody considered reaching the backend and crashing it.

Two consumers with different jobs:

- **The type checker** reports `AG3017`, or `AG3018` for a handler, with a file, line and column.
- **A pre-pass in `TypeScriptBuilder.build()`**, beside the unfilled-holes refusal, guarantees no codegen path can reach the crash whatever else changes. It has its own test that calls the builder directly, because every compile path runs the type checker first and would otherwise never execute it.

Then the splice checker calls the same predicate, so generated code is held to the standard written code is held to — by construction, not by two lists agreeing.

## Splices

A splice position was `"decl" | "expr"`, and a splice occupying a whole statement inherited `"expr"`. Adding `"statement"` maps it to `KINDS_FOR_SORT.statements`, the set a statements *hole* already accepts. The kind-mismatch message is now built by exhaustive switch, so a future position cannot be silently described as an expression.

At the top level the check stopped asking about the fragment's kind alone. **Kind cannot answer the question** — one fragment holds both of these at once:

```ts
const apiKey = getKey()      // legal at the top level
if (debug) { log("hi") }     // crashes the backend
```

So every node of the fragment goes through the predicate. That also closes a hole a statements-only check would leave: a fragment holding an `if` and a `def` infers kind `program`, because the statements attempt fails on the `def`, and it sailed past the kind gate unexamined.

## Errors now

```
AG3017: An `if` statement cannot sit at the top level of a file. Top-level code
runs at initialization, which cannot branch, loop, or wait — move it inside a
node or a function.

AG3018: A handler cannot be registered at the top level of a file. Handlers must
be inside a node or a function, where there is execution for them to guard.

AG8014: The generator `gen` returned an `if` statement, which cannot sit at the
top level of a file.
```

Handlers get their own code deliberately: a top-level `handle` is a handler its author believes is registered, and the worst outcome of a careless fix here is not a crash but a handler that compiles and never registers.

## Two things the work turned up

**`withModifier` at top level was already made to work.** Issue #229 hit this exact `StepPathTracker` crash for `foo() with approve` at module scope and fixed it by special-casing the node in `partitionProgram` — the other way to answer this question. It stays legal, and the wider test suite is what caught my having refused it.

**Bare `debugger` and `debugger("x")` land on opposite sides.** The bare word parses as an ordinary name and compiles; the parenthesized form is a real `debuggerStatement` and crashed. Both are now classified explicitly.

## Breaking changes

Refusing code that compiles today, all of it meaningless or already broken:

- `return` at file scope — a `return` outside any function.
- `interrupt(...)` and `static interrupt(...)` — both compile today and then crash at run time with `__self is not defined`. A compile-time refusal is a better error, not a fix; the underlying gap is **#728**, where `staticStatementParser` advertises something the backend never implemented.
- `debugger("x")` at file scope, which crashed.

`goto other` is **not** affected, contrary to what the plan first assumed: at file scope it parses as two bare names rather than a `gotoStatement`, so it keeps compiling. Pinned by a test, because it looks like a refusal and is not one.

## Testing

- 9885 unit tests pass; 16/16 template fixtures; `lint:structure` clean; `make` exits 0.
- A new end-to-end fixture runs the original report's shape: a generator returning statements, spliced into a node body, compiled and run.
- The predicate's test reads as the rule, and one test ties the placement set (`TOP_LEVEL_DECLARATION_TYPES`, now exported) to the predicate, so emission can never route a node the rule would refuse.

One test-maintenance note: several type-checker fixtures place control flow directly in `program.nodes` to exercise inference, and count errors exactly. Those now filter the top-level diagnostic through a documented helper rather than pretending a bare top-level `if` is a real program.

Closes #713.
