### PR TITLE
Fix flaky parallel-tools test: detect overlap instead of timing the run

### DIFF
--- a/packages/agency-lang/tests/agency-js/parallel-tools/agent.agency
+++ b/packages/agency-lang/tests/agency-js/parallel-tools/agent.agency
@@ -1,13 +1,35 @@
+// Both tools bump a shared counter on entry and drop it on exit. If the two
+// tool calls in one LLM round overlap, the counter reaches 2 while both are
+// sleeping. Running them one after the other can never get it above 1.
+let running: number = 0
+let sawOverlap: boolean = false
+
+def enter() {
+  running = running + 1
+  if (running > 1) {
+    sawOverlap = true
+  }
+}
+
+def leave() {
+  running = running - 1
+}
+
 def slowTool1(): string {
+  enter()
   sleep(200)
+  leave()
   return "tool1 done"
 }
 
 def slowTool2(): string {
+  enter()
   sleep(200)
+  leave()
   return "tool2 done"
 }
 
 node main() {
-  return llm("call both slowTool1 and slowTool2", { tools: [slowTool1, slowTool2] })
+  const data = llm("call both slowTool1 and slowTool2", { tools: [slowTool1, slowTool2] })
+  return { data: data, ranInParallel: sawOverlap }
 }

--- a/packages/agency-lang/tests/agency-js/parallel-tools/test.js
+++ b/packages/agency-lang/tests/agency-js/parallel-tools/test.js
@@ -2,22 +2,20 @@ import { main } from "./agent.js";
 import { writeFileSync } from "fs";
 
 // Two slow tools (200ms each) are called in one LLM round. Under
-// PromptRunner.parallel, both run concurrently, so total wall-clock for
-// the tool round is ~200ms — not ~400ms as it would be if the round
-// ran them sequentially.
-const start = performance.now();
+// PromptRunner.parallel, both run concurrently, so both sit inside their
+// sleep at the same moment and the agent's shared counter reaches 2. If the
+// round ran them one after the other, the counter would never exceed 1.
+//
+// The agent reports that overlap itself rather than the test timing the
+// call, so a slow or loaded CI runner cannot change the answer.
 const result = await main();
-const elapsed = performance.now() - start;
 
 writeFileSync(
   "__result.json",
   JSON.stringify(
     {
-      data: result.data,
-      // Use a coarse threshold to avoid CI flake. Sequential execution
-      // would be > 400ms; the parallel path comfortably finishes in
-      // < 350ms even on slow runners.
-      ranInParallel: elapsed < 350,
+      data: result.data.data,
+      ranInParallel: result.data.ranInParallel,
     },
     null,
     2,


### PR DESCRIPTION
## The problem

CI on main has been failing intermittently. Every failure is the same test in the same shard: `tests/agency-js/parallel-tools` in `agency-tests (2)`. It failed on 3 of the last 12 main runs (19b3d02b, 9835a54d, 5fae2d11) while everything else in the job passed. Nothing on main touched the test, so this is flake, not a regression.

The test decided whether the two tool calls ran at the same time by timing the whole run:

```js
const start = performance.now();
const result = await main();
const elapsed = performance.now() - start;
... ranInParallel: elapsed < 350
```

Two things go wrong with that measurement:

1. The stopwatch wraps all of `main()` -- module init, runtime context setup, the mock LLM client, graph setup -- not just the tool round it wants to test. The two 200ms sleeps are only part of what gets timed.
2. 350ms leaves about 150ms of headroom over the 200ms floor. The four `agency-tests` shards run at the same time on GitHub runners, so a loaded runner goes over it and the test reports `ranInParallel: false`.

## The fix

Stop timing anything. The agent answers the question itself.

Both tools bump a shared counter when they start and drop it when they finish. If the two calls overlap, the counter reaches 2 while both are inside their sleep. Running them one after the other can never get it above 1, because the first tool always drops back to 0 before the second one starts.

```
let running: number = 0
let sawOverlap: boolean = false

def enter() {
  running = running + 1
  if (running > 1) {
    sawOverlap = true
  }
}
```

`main()` returns that flag next to its data, and `test.js` just reports it. How fast or loaded the machine is cannot change the answer.

## What this does not change

`fixture.json` is untouched. The test asserts exactly what it asserted before:

```json
{ "data": "both done", "ranInParallel": true }
```

## Verification

- The test passes on this branch.
- It still catches the regression it exists for. With `runBatch`'s mode `"all"` temporarily patched to run its tasks one at a time instead of through `Promise.allSettled`, the test fails with `ranInParallel: false`. That patch was reverted before committing -- only the two test files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
