### PR TITLE
feat(serve): export withRuntimeConfigOverrides for per-module log routing

### DIFF
--- a/packages/agency-lang/lib/runtime/configOverrides.test.ts
+++ b/packages/agency-lang/lib/runtime/configOverrides.test.ts
@@ -2,7 +2,9 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import {
   applyRuntimeConfigOverridesToContextArgs,
+  getRuntimeConfigOverrides,
   setRuntimeConfigOverrides,
+  withRuntimeConfigOverrides,
 } from "./configOverrides.js";
 import {
   CONFIG_OVERRIDES_ENV,
@@ -204,6 +206,40 @@ describe("writer→reader override contract", () => {
     const r = applyRuntimeConfigOverridesToContextArgs(base, overrides);
     expect(r.traceConfig?.traceFile).toBe("t.trace");
     expect(r.statelogConfig.logFile).toBe("l.jsonl");
+  });
+});
+
+describe("withRuntimeConfigOverrides", () => {
+  afterEach(() => setRuntimeConfigOverrides(undefined));
+
+  it("installs the overrides while fn runs and restores after", async () => {
+    let seen: unknown;
+    await withRuntimeConfigOverrides(
+      { observability: true, log: { projectId: "p1" } },
+      async () => {
+        seen = getRuntimeConfigOverrides();
+      },
+    );
+    expect(seen).toEqual({ observability: true, log: { projectId: "p1" } });
+    expect(getRuntimeConfigOverrides()).toBeUndefined();
+  });
+
+  it("restores the PREVIOUS value, not just undefined", async () => {
+    setRuntimeConfigOverrides({ maxCallDepth: 3 });
+    await withRuntimeConfigOverrides({ observability: true }, async () => {
+      expect(getRuntimeConfigOverrides()).toEqual({ observability: true });
+    });
+    expect(getRuntimeConfigOverrides()).toEqual({ maxCallDepth: 3 });
+  });
+
+  it("restores even when fn throws", async () => {
+    setRuntimeConfigOverrides({ maxCallDepth: 3 });
+    await expect(
+      withRuntimeConfigOverrides({ observability: true }, async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+    expect(getRuntimeConfigOverrides()).toEqual({ maxCallDepth: 3 });
   });
 });
 

--- a/packages/agency-lang/lib/runtime/configOverrides.ts
+++ b/packages/agency-lang/lib/runtime/configOverrides.ts
@@ -34,6 +34,35 @@ export function getRuntimeConfigOverrides(): Partial<AgencyConfig> | undefined {
 }
 
 /**
+ * Run `fn` with `overrides` installed as the active runtime config overrides,
+ * restoring whatever was set before when `fn` settles.
+ *
+ * A host that serves many compiled modules from one process uses this to bind
+ * per-module log/observability config at the moment it imports that module: the
+ * overrides are read by the `RuntimeContext` constructor, which runs while the
+ * module is importing, so the import must happen inside `fn`. The overrides only
+ * need to differ per module (not per request), because they are frozen into that
+ * module's `RuntimeContext` at import and every later invocation derives from it.
+ *
+ * The overrides live in a single process-global, so a host serving concurrently
+ * MUST serialize its imports (e.g. behind a mutex) — otherwise two overlapping
+ * `withRuntimeConfigOverrides` scopes would read each other's values. This helper
+ * does not lock; it only pairs set with restore.
+ */
+export async function withRuntimeConfigOverrides<T>(
+  overrides: Partial<AgencyConfig> | undefined,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const previous = activeRuntimeConfigOverrides;
+  activeRuntimeConfigOverrides = overrides;
+  try {
+    return await fn();
+  } finally {
+    activeRuntimeConfigOverrides = previous;
+  }
+}
+
+/**
  * Apply runtime config overrides — a `Partial<AgencyConfig>` — onto the args
  * used to construct a `RuntimeContext`. This is THE single runtime merge; it
  * serves two transports:

--- a/packages/agency-lang/lib/serve/public.ts
+++ b/packages/agency-lang/lib/serve/public.ts
@@ -4,6 +4,10 @@ export { createServeHandler } from "./createServeHandler.js";
 export type { ServeHandler, CreateServeHandlerOptions } from "./createServeHandler.js";
 export { collectServeMetadata } from "./metadata.js";
 export type { ServeMetadata } from "./metadata.js";
+// Bind per-module log/observability config at import time (see the helper's
+// doc comment): a host serving many compiled modules from one process wraps
+// each module's import in this so that module traces to its own destination.
+export { withRuntimeConfigOverrides } from "../runtime/configOverrides.js";
 export type { RouteResult, HandlerConfig } from "./http/adapter.js";
 export type { ExportedItem, ExportedFunction, ExportedNode } from "./types.js";
 export type { InterruptEffect } from "../symbolTable.js";


### PR DESCRIPTION
Closes #598.

## Why

The statelog host serves many compiled Agency modules from one process, and each hosted agent must auto-trace to its **own** statelog project (per-agent routing, decided with the owner). Config only reaches a run through the `RuntimeContext` constructor, and that constructor runs **once, at module-import time** (`context.ts:263-267`); `createExecutionContext` — the per-invocation path — just copies the frozen config. So there is no way to vary observability per run of an already-loaded module, and the two existing override seams (`AGENCY_CONFIG_OVERRIDES` env, `setRuntimeConfigOverrides` module-global) are process-global.

The saving grace: routing is **per-agent, not per-request**. An agent's project never changes, and each agent is a separately-cached module import. So the config only needs to be bound once, at each module's import — exactly when the existing override seam fires.

## What

`withRuntimeConfigOverrides(overrides, fn)` — a scoped helper that installs `overrides` as the active runtime config overrides, runs `fn` (which does the `import`), and restores the previous value in a `finally`. Re-exported from the public `./serve` surface next to `createServeHandler`.

This adds **no new mechanism**: it reuses the same `setRuntimeConfigOverrides` seam subprocess IPC already uses, and just wraps it in a misuse-resistant set/restore pair. The host (statelog) serializes its imports behind a mutex, since the override is a process-global — documented in the helper's doc comment.

### Caveat (documented in code)
This relies on the invariant that a `RuntimeContext` is only constructed at module import, never per-invocation. True today. A test in the statelog PR will pin the end-to-end routing behavior.

## Test
`lib/runtime/configOverrides.test.ts` — 3 new cases: installs-during/restores-after, restores the *previous* value (not just undefined), restores on throw. Full file: 16/16 pass. Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
