### PR TITLE
fix: node parameter defaults compile; goto may omit defaulted args

### DIFF
--- a/packages/agency-lang/docs/site/diagnostics/index.md
+++ b/packages/agency-lang/docs/site/diagnostics/index.md
@@ -130,6 +130,7 @@ or suppress a type-checker one on the next line with `// @tc-ignore AG####`.
 | [AG6036](tools.md#ag6036) | This scope has a finalize block, so a return expression cannot bury a call inside a bigger expression. If the call were stopped, the expression would consume its partial result before the finalize could run. Assign the call to a local first, then return the local. |
 | [AG6037](tools.md#ag6037) | finalize binder '&#123;name&#125;' collides with a variable that already exists in this scope. Pick a fresh name. The finalize body reads the scope's locals directly, so a colliding binder would silently shadow the local. |
 | [AG6038](tools.md#ag6038) | finalize yields a single value — the scope's saved draft. Use one binder: finalize as &#123;name&#125; &#123; ... &#125;. |
+| [AG6039](tools.md#ag6039) | Parameter '&#123;name&#125;' on '&#123;fn&#125;' has no default but comes after a defaulted parameter. Put defaulted parameters last, so an omitted argument is always a trailing one. |
 
 ## Static init, config, and imports
 

--- a/packages/agency-lang/docs/site/diagnostics/tools.md
+++ b/packages/agency-lang/docs/site/diagnostics/tools.md
@@ -396,3 +396,13 @@ A finalize body runs in the same variable scope as the function or block it belo
 The `as` clause on a finalize binds what the abort yields to the block, and the abort yields exactly one thing: the scope's saved draft (or null when nothing was saved). There is no second value to bind, so a parameter list has no meaning here. The shared block-argument grammar is why the parser accepts the list at all.
 
 **How to fix:** keep one binder: `finalize as draft { ... }`. Everything else the finalize needs is already in scope as ordinary locals.
+
+<a id="ag6039"></a>
+
+## AG6039 — Parameter '&#123;name&#125;' on '&#123;fn&#125;' has no default but comes after a defaulted parameter. Put defaulted parameters last, so an omitted argument is always a trailing one.
+
+*Default severity: error.*
+
+Arguments bind to parameters left to right, so a call can only ever leave off the LAST arguments. If a parameter without a default comes after one with a default, an omitted argument would fill the defaulted parameter and silently leave the required one empty — for example `node t(a: string = "x", b: string)` called as `goto t("only")` would set `a` and leave `b` undefined.
+
+**How to fix:** move parameters with defaults to the end of the parameter list.

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -3049,7 +3049,13 @@ export class TypeScriptBuilder {
     if (targetNode && targetNode.parameters.length > 0) {
       const entries: Record<string, TsNode> = {};
       targetNode.parameters.forEach((p, i) => {
-        entries[p.name] = argNodes[i];
+        // A goto may omit trailing arguments (legal when the parameter
+        // has a default): leave the key out of data so the node body
+        // sees undefined and applies its default. Emitting argNodes[i]
+        // blindly put undefined into the IR and crashed the printer.
+        if (argNodes[i] !== undefined) {
+          entries[p.name] = argNodes[i];
+        }
       });
       dataNode = ts.obj(entries);
     } else if (argNodes.length > 0) {
@@ -3148,14 +3154,23 @@ export class TypeScriptBuilder {
       ...hoistedAliases,
     ];
 
-    // Param assignments (only when not resuming)
+    // Param assignments (only when not resuming). A parameter default
+    // applies whenever the incoming data slot is undefined — this is the
+    // ONE site every invocation path funnels through (the exported
+    // wrapper, direct runs, and graph transitions all deliver arguments
+    // via __state.data), so defaults work identically for all of them.
     if (parameters.length > 0) {
-      const paramStmts = parameters.map((p) =>
-        ts.assign(
-          $(ts.stack("args")).index(ts.str(p.name)).done(),
-          $(ts.runtime.state).prop("data").prop(p.name).done(),
-        ),
-      );
+      const paramStmts = parameters.map((p) => {
+        const incoming = $(ts.runtime.state).prop("data").prop(p.name).done();
+        const value = p.defaultValue
+          ? ts.ternary(
+              ts.binOp(incoming, "===", ts.id("undefined")),
+              this.processNode(p.defaultValue),
+              incoming,
+            )
+          : incoming;
+        return ts.assign($(ts.stack("args")).index(ts.str(p.name)).done(), value);
+      });
       stmts.push(ts.if(ts.raw("!__state.isResume"), ts.statements(paramStmts)));
     }
 
@@ -4602,6 +4617,25 @@ export class TypeScriptBuilder {
     return nodes;
   }
 
+  /** The exported node wrapper's parameter list: the node's own
+   *  parameters (with their defaults, so TS callers can omit them) plus
+   *  the trailing options object. */
+  private nodeWrapperParams(
+    args: FunctionParameter[],
+  ): { name: string; typeAnnotation?: string; defaultValue?: TsNode }[] {
+    const params = args.map((arg) => ({
+      name: arg.name,
+      typeAnnotation: arg.typeHint ? formatTypeHintTs(arg.typeHint) : "any",
+      defaultValue: arg.defaultValue ? this.processNode(arg.defaultValue) : undefined,
+    }));
+    params.push({
+      name: "{ messages, callbacks }",
+      typeAnnotation: "{ messages?: any; callbacks?: any }",
+      defaultValue: ts.obj({}),
+    });
+    return params;
+  }
+
   private postprocess(): TsNode[] {
     const result: TsNode[] = [];
 
@@ -4635,24 +4669,7 @@ export class TypeScriptBuilder {
 
     for (const node of this.compilationUnit.graphNodes) {
       const args = node.parameters;
-      const fnParams: {
-        name: string;
-        typeAnnotation?: string;
-        defaultValue?: TsNode;
-      }[] = [];
-      if (args.length > 0) {
-        for (const arg of args) {
-          const typeHint = arg.typeHint
-            ? formatTypeHintTs(arg.typeHint)
-            : "any";
-          fnParams.push({ name: arg.name, typeAnnotation: typeHint });
-        }
-      }
-      fnParams.push({
-        name: "{ messages, callbacks }",
-        typeAnnotation: "{ messages?: any; callbacks?: any }",
-        defaultValue: ts.obj({}),
-      });
+      const fnParams = this.nodeWrapperParams(args);
       const dataObj: Record<string, TsNode> = {};
       for (const arg of args) {
         dataObj[arg.name] = ts.id(arg.name);

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -145,6 +145,7 @@ import type {
 import type { CompilationUnit } from "../compilationUnit.js";
 import { SourceMapBuilder } from "./sourceMap.js";
 import { directRunExtraArgsCheck } from "./typescriptBuilder/directRunArgsCheck.js";
+import { nodeWrapperParams } from "./typescriptBuilder/nodeWrapperParams.js";
 import { ScopeManager } from "./typescriptBuilder/scopeManager.js";
 import { StepPathTracker } from "./typescriptBuilder/stepPathTracker.js";
 import { NameClassifier } from "./typescriptBuilder/nameClassifier.js";
@@ -3049,10 +3050,12 @@ export class TypeScriptBuilder {
     if (targetNode && targetNode.parameters.length > 0) {
       const entries: Record<string, TsNode> = {};
       targetNode.parameters.forEach((p, i) => {
-        // A goto may omit trailing arguments (legal when the parameter
-        // has a default): leave the key out of data so the node body
-        // sees undefined and applies its default. Emitting argNodes[i]
-        // blindly put undefined into the IR and crashed the printer.
+        // A goto may omit trailing arguments: leave the key out of data
+        // so the node body sees undefined and applies its default.
+        // (Emitting argNodes[i] blindly put undefined into the IR and
+        // crashed the printer.) Only TRAILING omissions can reach here —
+        // AG6039 rejects a required parameter after a defaulted one, so
+        // a missing slot always belongs to a defaulted parameter.
         if (argNodes[i] !== undefined) {
           entries[p.name] = argNodes[i];
         }
@@ -3159,6 +3162,16 @@ export class TypeScriptBuilder {
     // ONE site every invocation path funnels through (the exported
     // wrapper, direct runs, and graph transitions all deliver arguments
     // via __state.data), so defaults work identically for all of them.
+    // (On the wrapper path the wrapper's own TS default fills data first,
+    // so this ternary is a no-op there; it is what makes goto work.)
+    //
+    // Deliberately `undefined`, NOT the __UNSET sentinel def functions
+    // use: node arguments cross a serialization boundary (checkpoints,
+    // resume) where a module-level sentinel would not survive, and a
+    // missing object key reads as undefined naturally. Edge-semantic
+    // consequence, matching JS default parameters: explicitly passing
+    // undefined/omitting both take the default, whereas a def's __UNSET
+    // preserves an explicit undefined. null does NOT take the default.
     if (parameters.length > 0) {
       const paramStmts = parameters.map((p) => {
         const incoming = $(ts.runtime.state).prop("data").prop(p.name).done();
@@ -4617,25 +4630,6 @@ export class TypeScriptBuilder {
     return nodes;
   }
 
-  /** The exported node wrapper's parameter list: the node's own
-   *  parameters (with their defaults, so TS callers can omit them) plus
-   *  the trailing options object. */
-  private nodeWrapperParams(
-    args: FunctionParameter[],
-  ): { name: string; typeAnnotation?: string; defaultValue?: TsNode }[] {
-    const params = args.map((arg) => ({
-      name: arg.name,
-      typeAnnotation: arg.typeHint ? formatTypeHintTs(arg.typeHint) : "any",
-      defaultValue: arg.defaultValue ? this.processNode(arg.defaultValue) : undefined,
-    }));
-    params.push({
-      name: "{ messages, callbacks }",
-      typeAnnotation: "{ messages?: any; callbacks?: any }",
-      defaultValue: ts.obj({}),
-    });
-    return params;
-  }
-
   private postprocess(): TsNode[] {
     const result: TsNode[] = [];
 
@@ -4669,7 +4663,7 @@ export class TypeScriptBuilder {
 
     for (const node of this.compilationUnit.graphNodes) {
       const args = node.parameters;
-      const fnParams = this.nodeWrapperParams(args);
+      const fnParams = nodeWrapperParams(args, (n) => this.processNode(n));
       const dataObj: Record<string, TsNode> = {};
       for (const arg of args) {
         dataObj[arg.name] = ts.id(arg.name);

--- a/packages/agency-lang/lib/backends/typescriptBuilder/nodeWrapperParams.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder/nodeWrapperParams.ts
@@ -1,0 +1,40 @@
+import { formatTypeHintTs } from "@/utils/formatType.js";
+import { ts } from "../../ir/builders.js";
+import type { TsNode } from "../../ir/tsIR.js";
+import type { FunctionParameter } from "../../types.js";
+
+/**
+ * The exported node wrapper's parameter list — what
+ * `async function main(name = \`fallback\`, { messages, callbacks } = {})`
+ * is built from: the node's own parameters, with their defaults so TS
+ * callers can omit them, plus the trailing options object.
+ *
+ * Emitting the parsed default straight into a parameter list is safe
+ * only because parameter defaults are LITERAL-ONLY — the AST type pins
+ * it (`defaultValue?: Literal | AgencyArray | AgencyObject`,
+ * lib/types/function.ts), and the parser rejects calls and identifiers.
+ * If defaults were ever relaxed to allow expressions, the processed
+ * default could reference runtime scope (or become an await) and this
+ * would have to switch to optional parameters resolved in the body.
+ *
+ * Note the interplay with the body-site default: on this wrapper path JS
+ * fills the parameter before `data` is built, so the body's
+ * undefined-check never fires here — it exists for goto transitions and
+ * anything else that feeds `__state.data` directly.
+ */
+export function nodeWrapperParams(
+  args: FunctionParameter[],
+  processNode: (node: NonNullable<FunctionParameter["defaultValue"]>) => TsNode,
+): { name: string; typeAnnotation?: string; defaultValue?: TsNode }[] {
+  const params = args.map((arg) => ({
+    name: arg.name,
+    typeAnnotation: arg.typeHint ? formatTypeHintTs(arg.typeHint) : "any",
+    defaultValue: arg.defaultValue ? processNode(arg.defaultValue) : undefined,
+  }));
+  params.push({
+    name: "{ messages, callbacks }",
+    typeAnnotation: "{ messages?: any; callbacks?: any }",
+    defaultValue: ts.obj({}),
+  });
+  return params;
+}

--- a/packages/agency-lang/lib/typeChecker/diagnosticExplanations.ts
+++ b/packages/agency-lang/lib/typeChecker/diagnosticExplanations.ts
@@ -455,6 +455,10 @@ def f(): string {
 
 **How to fix:** keep one binder: \`finalize as draft { ... }\`. Everything else the finalize needs is already in scope as ordinary locals.`,
 
+  requiredParamAfterDefault: `Arguments bind to parameters left to right, so a call can only ever leave off the LAST arguments. If a parameter without a default comes after one with a default, an omitted argument would fill the defaulted parameter and silently leave the required one empty — for example \`node t(a: string = "x", b: string)\` called as \`goto t("only")\` would set \`a\` and leave \`b\` undefined.
+
+**How to fix:** move parameters with defaults to the end of the parameter list.`,
+
   // ---- AG7: static init, config, and imports ----
   exportRequiresStaticConst: `Only \`static const\` declarations can be exported from a module. A plain \`const\`, \`let\`, or other declaration is per-run state and is not part of a module's public surface.
 

--- a/packages/agency-lang/lib/typeChecker/diagnostics.ts
+++ b/packages/agency-lang/lib/typeChecker/diagnostics.ts
@@ -566,6 +566,12 @@ export const DIAGNOSTICS = {
     message:
       "finalize yields a single value — the scope's saved draft. Use one binder: finalize as {name} {{ ... }}.",
   },
+  requiredParamAfterDefault: {
+    code: "AG6039",
+    severity: "error",
+    message:
+      "Parameter '{name}' on '{fn}' has no default but comes after a defaulted parameter. Put defaulted parameters last, so an omitted argument is always a trailing one.",
+  },
   staticReassignedAtTopLevel: {
     code: "AG7004",
     severity: "error",

--- a/packages/agency-lang/lib/typeChecker/index.ts
+++ b/packages/agency-lang/lib/typeChecker/index.ts
@@ -46,6 +46,7 @@ import { checkMatchExhaustiveness } from "./matchExhaustiveness.js";
 import { computeMatchExprTypes } from "./matchExprTypes.js";
 import { checkDefiniteReturns } from "./definiteReturns.js";
 import { checkConflictingMarkers } from "./conflictingMarkers.js";
+import { checkParamDefaultOrder } from "./paramDefaultOrder.js";
 import { checkTemplateHoles } from "./templateHoles.js";
 import { checkTopLevelStatements } from "./topLevelStatements.js";
 import { refineInlineHandlerParams } from "./handlerParamTyping.js";
@@ -364,6 +365,10 @@ export class TypeChecker {
 
     // A function cannot be both destructive and idempotent.
     checkConflictingMarkers(ctx);
+
+    // Defaulted parameters must come last (positional binding makes a
+    // required-after-defaulted parameter silently unfillable).
+    checkParamDefaultOrder(ctx);
 
     // Template holes: an expression hole in a position that supplies no
     // type must carry an inline annotation (AG8002).

--- a/packages/agency-lang/lib/typeChecker/paramDefaultOrder.test.ts
+++ b/packages/agency-lang/lib/typeChecker/paramDefaultOrder.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { typeCheckSource } from "../compiler/typecheck.js";
+
+const orderError = (source: string) =>
+  typeCheckSource(source).errors.find(
+    (e) => (e as { code?: string }).code === "AG6039",
+  );
+
+describe("required parameter after a defaulted one (AG6039)", () => {
+  it("errors on a node", () => {
+    const err = orderError('node t(a: string = "x", b: string) { return b }');
+    expect(err).toBeDefined();
+    expect(err?.message).toContain("'b'");
+  });
+
+  it("a def with the same shape is already rejected by the GRAMMAR", () => {
+    // Node parameters accept any order at parse time (hence AG6039);
+    // def parameters do not — the parser stops at the required-after-
+    // defaulted parameter. The pass still covers defs in case the
+    // grammar ever loosens.
+    expect(() => typeCheckSource('def f(a: string = "x", b: string) { return b }'))
+      .toThrow(/expected/);
+  });
+
+  it("allows defaults last", () => {
+    expect(orderError('node t(a: string, b: string = "x") { return a }')).toBeUndefined();
+  });
+
+  it("allows every parameter defaulted", () => {
+    expect(orderError('def f(a: string = "x", b: string = "y") { return a }')).toBeUndefined();
+  });
+
+  it("allows no defaults at all", () => {
+    expect(orderError('node t(a: string, b: string) { return a }')).toBeUndefined();
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/paramDefaultOrder.ts
+++ b/packages/agency-lang/lib/typeChecker/paramDefaultOrder.ts
@@ -1,0 +1,36 @@
+import { declaredName } from "../types/hole.js";
+import { diagnostic } from "./diagnostics.js";
+import type { TypeCheckerContext } from "./types.js";
+
+/**
+ * A parameter without a default may not follow one with a default — on
+ * defs and nodes alike. Arguments bind positionally, so a call that
+ * omits arguments can only ever omit TRAILING ones: `node t(a = "x",
+ * b: string)` called as `t("only")` would fill `a` and silently leave
+ * required `b` undefined (the arity check counts non-defaulted
+ * parameters, which is the right minimum only when defaults are last).
+ * Rejecting the shape here is what makes omitted-argument handling in
+ * the emitter provably safe.
+ */
+export function checkParamDefaultOrder(ctx: TypeCheckerContext): void {
+  for (const node of ctx.programNodes) {
+    if (node.type !== "function" && node.type !== "graphNode") continue;
+    const fn = node.type === "function"
+      ? declaredName(node.functionName)
+      : declaredName(node.nodeName);
+    let sawDefault = false;
+    for (const param of node.parameters ?? []) {
+      if (param.defaultValue) {
+        sawDefault = true;
+      } else if (sawDefault && !param.variadic) {
+        ctx.errors.push(
+          diagnostic(
+            "requiredParamAfterDefault",
+            { name: param.name, fn },
+            node.loc ?? null,
+          ),
+        );
+      }
+    }
+  }
+}

--- a/packages/agency-lang/tests/agency/node-param-defaults.agency
+++ b/packages/agency-lang/tests/agency/node-param-defaults.agency
@@ -1,0 +1,16 @@
+// Node parameter defaults: the default applies when the argument is
+// omitted — whether the node is invoked directly with no input or
+// reached through a goto that leaves the argument off — and an explicit
+// value always wins. (Defaults used to parse but vanish at compile time.)
+
+node withDefault(name: string = "fallback"): string {
+  return "hi " + name
+}
+
+node viaGoto() {
+  goto withDefault()
+}
+
+node viaGotoWithArg() {
+  goto withDefault("explicit")
+}

--- a/packages/agency-lang/tests/agency/node-param-defaults.agency
+++ b/packages/agency-lang/tests/agency/node-param-defaults.agency
@@ -1,7 +1,11 @@
 // Node parameter defaults: the default applies when the argument is
-// omitted — whether the node is invoked directly with no input or
-// reached through a goto that leaves the argument off — and an explicit
-// value always wins. (Defaults used to parse but vanish at compile time.)
+// omitted, and an explicit value always wins. (Defaults used to parse
+// and then vanish at compile time.) Two mechanisms cooperate, and the
+// tests below name which one they pin:
+// - the exported wrapper carries the default in its TS signature, so a
+//   direct invocation with no argument is filled by JS itself;
+// - the node BODY defaults an undefined __state.data slot, which is what
+//   a goto that omits the argument exercises.
 
 node withDefault(name: string = "fallback"): string {
   return "hi " + name
@@ -13,4 +17,21 @@ node viaGoto() {
 
 node viaGotoWithArg() {
   goto withDefault("explicit")
+}
+
+// null is a VALUE, not an omission: it must not trigger the default.
+// (Differs from def functions, whose __UNSET sentinel preserves the
+// omitted-vs-explicit distinction — see the builder comment.)
+node viaGotoWithNull(): string {
+  goto withDefault(null)
+}
+
+// The only non-scalar default shapes the parser accepts.
+node listDefault(items: string[] = ["a", "b"]): number {
+  return items.length
+}
+
+// Several parameters, only the trailing one defaulted.
+node partial(greeting: string, name: string = "world"): string {
+  return greeting + " " + name
 }

--- a/packages/agency-lang/tests/agency/node-param-defaults.test.json
+++ b/packages/agency-lang/tests/agency/node-param-defaults.test.json
@@ -2,31 +2,80 @@
   "tests": [
     {
       "nodeName": "withDefault",
-      "description": "an omitted argument takes the default",
+      "description": "omitted argument takes the default (wrapper-signature path)",
       "input": "",
       "expectedOutput": "\"hi fallback\"",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     },
     {
       "nodeName": "withDefault",
       "description": "an explicit argument wins over the default",
       "input": "\"Ada\"",
       "expectedOutput": "\"hi Ada\"",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     },
     {
       "nodeName": "viaGoto",
-      "description": "a goto that omits the argument also gets the default",
+      "description": "goto omitting the argument takes the default (body/__state.data path)",
       "input": "",
       "expectedOutput": "\"hi fallback\"",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     },
     {
       "nodeName": "viaGotoWithArg",
-      "description": "a goto with an explicit argument passes it through",
+      "description": "goto with an explicit argument passes it through",
       "input": "",
       "expectedOutput": "\"hi explicit\"",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "viaGotoWithNull",
+      "description": "null is a value, not an omission - the default must NOT fire",
+      "input": "",
+      "expectedOutput": "\"hi null\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "listDefault",
+      "description": "array-literal default (the non-scalar shape the parser accepts)",
+      "input": "",
+      "expectedOutput": "2",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "partial",
+      "description": "mixed parameters: required filled, trailing default applies",
+      "input": "\"hello\"",
+      "expectedOutput": "\"hello world\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/node-param-defaults.test.json
+++ b/packages/agency-lang/tests/agency/node-param-defaults.test.json
@@ -1,0 +1,32 @@
+{
+  "tests": [
+    {
+      "nodeName": "withDefault",
+      "description": "an omitted argument takes the default",
+      "input": "",
+      "expectedOutput": "\"hi fallback\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "withDefault",
+      "description": "an explicit argument wins over the default",
+      "input": "\"Ada\"",
+      "expectedOutput": "\"hi Ada\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "viaGoto",
+      "description": "a goto that omits the argument also gets the default",
+      "input": "",
+      "expectedOutput": "\"hi fallback\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "viaGotoWithArg",
+      "description": "a goto with an explicit argument passes it through",
+      "input": "",
+      "expectedOutput": "\"hi explicit\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/integration/cli/test.mjs
+++ b/packages/agency-lang/tests/integration/cli/test.mjs
@@ -208,6 +208,19 @@ node main(task: string): string {
   assertIncludes(withoutArg, "got: undefined");
   console.log("Test 8 passed");
 
+  // --- Test 8b: a node parameter default applies on the direct-run path ---
+  console.log("--- Test 8b: direct-run argv with a parameter default ---");
+  writeFile(dir, "argdefault.agency", `node main(name: string = "fallback"): string {
+  print("got: " + name)
+  return name
+}
+`);
+  const defaulted = run(dir, "npx agency run argdefault.agency");
+  assertIncludes(defaulted, "got: fallback");
+  const explicit = run(dir, "npx agency run argdefault.agency Ada");
+  assertIncludes(explicit, "got: Ada");
+  console.log("Test 8b passed");
+
   console.log("=== All CLI tests passed ===");
   cleanup(dir);
 } catch (err) {


### PR DESCRIPTION
A node parameter default parsed but vanished at compile time: `node main(name: string = "fallback")` compiled to `async function main(name, …)` with the default nowhere in the output, so an omitted argument arrived as `undefined`. Found while building eval-run argument passthrough.

Three changes:
- **The node body applies the default** when the incoming `__state.data` slot is `undefined` — the one site every invocation path funnels through (exported wrapper, direct-run argv, `goto` transitions), so defaults behave identically everywhere.
- **The exported wrapper carries the default in its TypeScript signature** (`async function main(name = `fallback`, …)`), so TS callers can omit the argument.
- **A `goto` that omits a defaulted argument no longer crashes the compiler.** It previously emitted `undefined` into the IR and the printer threw; nobody hit it because defaults never worked. The emitted data object now omits missing keys so the body default fires.

New agency execution test (`tests/agency/node-param-defaults`) pins all four paths: omitted arg → default, explicit arg wins, `goto` without the arg → default, `goto` with the arg passes through. Fixtures regenerated with zero churn (no existing fixture uses node defaults); builder tests, tsc, and `lint:structure` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)