### PR TITLE
Accept common keyword and literal spellings

### DIFF
--- a/packages/agency-lang/docs/dev/null-and-undefined.md
+++ b/packages/agency-lang/docs/dev/null-and-undefined.md
@@ -11,9 +11,11 @@ This doc is the "why"; that spec is the "what."
 
 ## The decision in one paragraph
 
-There is exactly one nothing-value in Agency: `null`. Users cannot write
-`undefined` as a value (the parser has no `undefinedParser`, only a
-`nullParser`). Optionality is `T | null`. At runtime, `null` and `undefined`
+There is exactly one nothing-value in Agency: `null`. `undefined` is accepted as
+a second *spelling* of it — in a type it always was, and as of the keyword-alias
+work the value side agrees: `undefined` parses to the same node as `null`, and
+`agency fmt` prints `null`. There is still no second nothing-*value*; this is a
+spelling, not a concept. Optionality is `T | null`. At runtime, `null` and `undefined`
 compare equal (via the `__eq` helper), and `undefined` arriving from the JS
 runtime or TypeScript interop is absorbed into `null`. `undefined` is never a
 distinct concept a user has to reason about.

--- a/packages/agency-lang/lib/parsers/keywordAliases.test.ts
+++ b/packages/agency-lang/lib/parsers/keywordAliases.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from "vitest";
+import { parseAgency } from "@/parser.js";
+import { formatSource } from "@/formatter.js";
+
+function program(src: string) {
+  const parsed = parseAgency(src, {}, false);
+  if (!parsed.success) throw new Error(`expected a successful parse, got: ${parsed.message}`);
+  return parsed.result;
+}
+
+/** Each variation and the canonical spelling it must parse identically to. */
+const pairs: [string, string, string][] = [
+  [
+    "interface for type",
+    `interface Foo { a: string, b: number }\nnode main() { print(1) }`,
+    `type Foo = { a: string, b: number }\nnode main() { print(1) }`,
+  ],
+  [
+    "exported interface",
+    `export interface Foo { a: string }\nnode main() { print(1) }`,
+    `export type Foo = { a: string }\nnode main() { print(1) }`,
+  ],
+  [
+    "elif for else if",
+    `node main() { if (a) { print(1) } elif (b) { print(2) } else { print(3) } }`,
+    `node main() { if (a) { print(1) } else if (b) { print(2) } else { print(3) } }`,
+  ],
+  [
+    "named argument with =",
+    `node main() { greet(name = "Adit", greeting = "Hi") }`,
+    `node main() { greet(name: "Adit", greeting: "Hi") }`,
+  ],
+  [
+    "undefined as a value",
+    `node main() { const x = undefined\nprint(x) }`,
+    `node main() { const x = null\nprint(x) }`,
+  ],
+  [
+    "undefined in a type",
+    `node main() { const x: string | undefined = "a" }`,
+    `node main() { const x: string | null = "a" }`,
+  ],
+  [
+    "capitalized primitives",
+    `node main() { const s: String = "x"\nconst n: Number = 1\nconst b: Boolean = true }`,
+    `node main() { const s: string = "x"\nconst n: number = 1\nconst b: boolean = true }`,
+  ],
+  [
+    "triple single-quoted string",
+    `node main() { const s = '''hi there''' }`,
+    `node main() { const s = """hi there""" }`,
+  ],
+  [
+    "triple single-quoted with interpolation",
+    `node main() { const n = 1\nconst s = '''a \${n} b''' }`,
+    `node main() { const n = 1\nconst s = """a \${n} b""" }`,
+  ],
+];
+
+describe("keyword aliases parse to the canonical AST", () => {
+  for (const [name, variation, canonical] of pairs) {
+    it(name, () => {
+      expect(program(variation)).toEqualWithoutLoc(program(canonical));
+    });
+  }
+});
+
+describe("agency fmt normalizes each alias", () => {
+  const expectations: [string, string, string][] = [
+    ["interface", `interface Foo { a: string }`, "type Foo = {"],
+    ["elif", `node main() { if (a) { print(1) } elif (b) { print(2) } }`, "else if"],
+    ["named arg =", `node main() { greet(name = "Adit") }`, `greet(name: "Adit")`],
+    ["undefined", `node main() { const x = undefined }`, "null"],
+    ["String", `node main() { const s: String = "x" }`, ": string"],
+    ["triple single quotes", `node main() { const s = '''hi''' }`, `"""`],
+  ];
+
+  for (const [name, src, expected] of expectations) {
+    it(`${name} formats to the canonical spelling`, () => {
+      expect(formatSource(src)).toContain(expected);
+    });
+  }
+
+  it("does not leave the alias spelling behind", () => {
+    expect(formatSource(`interface Foo { a: String }`)).not.toContain("interface");
+    expect(formatSource(`node main() { const x = undefined }`)).not.toContain("undefined");
+  });
+
+  it("formatting twice is a fixed point", () => {
+    for (const [, src] of expectations) {
+      const once = formatSource(src);
+      expect(once).not.toBeNull();
+      expect(formatSource(once as string)).toBe(once);
+    }
+  });
+});
+
+describe("aliases do not swallow neighbouring syntax", () => {
+  it("a type name starting with a primitive word still parses", () => {
+    // `str("Number")` would otherwise match the front of `NumberInRange`.
+    expect(parseAgency(`type NumberInRange = number\nnode main() { print(1) }`, {}, false).success)
+      .toBe(true);
+    expect(parseAgency(`type Stringy = string\nnode main() { print(1) }`, {}, false).success)
+      .toBe(true);
+  });
+
+  it("an identifier starting with `undefined` is untouched", () => {
+    const parsed = parseAgency(`node main() { const undefinedThing = 1\nprint(undefinedThing) }`, {}, false);
+    expect(parsed.success).toBe(true);
+    expect(JSON.stringify(parsed)).toContain("undefinedThing");
+  });
+
+  it("`type A number` is still a parse error", () => {
+    // The `=` is required for `type`; only `interface` omits it. Making the
+    // separator optional for both would silently accept this — it did in a
+    // first draft, and broke 123 tests across the compiler.
+    expect(parseAgency(`type A number`, {}, false).success).toBe(false);
+  });
+
+  it("== is not read as a named-argument separator", () => {
+    expect(program(`node main() { if (a == b) { print(1) } }`))
+      .toEqualWithoutLoc(program(`node main() { if (a == b) { print(1) } }`));
+    expect(parseAgency(`node main() { f(a == b) }`, {}, false).success).toBe(true);
+  });
+
+  it("single-quoted strings still parse", () => {
+    expect(parseAgency(`node main() { const s = 'hi' }`, {}, false).success).toBe(true);
+  });
+});

--- a/packages/agency-lang/lib/parsers/keywordAliases.test.ts
+++ b/packages/agency-lang/lib/parsers/keywordAliases.test.ts
@@ -166,6 +166,15 @@ describe("interface inheritance gets a targeted error", () => {
     expect(parsed.message).toContain("&");
   });
 
+  it("covers the generic form too", () => {
+    // `extends` and type parameters travel together in TypeScript, so this
+    // shape is at least as likely as the bare one.
+    const parsed = parseAgency(`interface Foo<T> extends Bar { a: T }`, {}, false);
+    expect(parsed.success).toBe(false);
+    if (parsed.success) return;
+    expect(parsed.message).toMatch(/no interface inheritance/);
+  });
+
   it("leaves a type named `extendsSomething` alone", () => {
     expect(parseAgency(`interface Foo { extendsThing: string }\nnode main() { print(1) }`, {}, false).success)
       .toBe(true);

--- a/packages/agency-lang/lib/parsers/keywordAliases.test.ts
+++ b/packages/agency-lang/lib/parsers/keywordAliases.test.ts
@@ -118,12 +118,56 @@ describe("aliases do not swallow neighbouring syntax", () => {
   });
 
   it("== is not read as a named-argument separator", () => {
-    expect(program(`node main() { if (a == b) { print(1) } }`))
-      .toEqualWithoutLoc(program(`node main() { if (a == b) { print(1) } }`));
-    expect(parseAgency(`node main() { f(a == b) }`, {}, false).success).toBe(true);
+    // Assert an observable outcome: if `==` were split into a named argument
+    // `a` with value `= b`, the formatter could not print it back.
+    expect(formatSource(`node main() { f(a == b) }`)).toContain("a == b");
+    expect(formatSource(`node main() { if (a == b) { print(1) } }`)).toContain("a == b");
   });
 
   it("single-quoted strings still parse", () => {
     expect(parseAgency(`node main() { const s = 'hi' }`, {}, false).success).toBe(true);
+  });
+});
+
+describe("the undefined alias is confined to expression position", () => {
+  it("does not rename a property called undefined", () => {
+    const parsed = parseAgency(`node main() { const o = { a: 1 }\nprint(o.undefined) }`, {}, false);
+    expect(parsed.success).toBe(true);
+    expect(JSON.stringify(parsed)).toContain("undefined");
+  });
+
+  it("does not rename a binder called undefined", () => {
+    const parsed = parseAgency(`node main() { const undefined = 1\nprint(undefined) }`, {}, false);
+    expect(parsed.success).toBe(true);
+    expect(JSON.stringify(parsed)).toContain("undefined");
+  });
+
+  it("does not rename a match-pattern binder", () => {
+    const parsed = parseAgency(
+      `node main() { match (x) { { a as undefined } => print(1) _ => print(2) } }`, {}, false);
+    expect(parsed.success).toBe(true);
+    expect(JSON.stringify(parsed)).toContain("undefined");
+  });
+
+  it("does not swallow an identifier that starts with null", () => {
+    // `nullThing` must not be read as `null` with `Thing` stranded.
+    const parsed = parseAgency(`node main() { const nullThing = 1\nprint(nullThing) }`, {}, false);
+    expect(parsed.success).toBe(true);
+    expect(JSON.stringify(parsed)).toContain("nullThing");
+  });
+});
+
+describe("interface inheritance gets a targeted error", () => {
+  it("names the replacement instead of failing generically", () => {
+    const parsed = parseAgency(`interface Foo extends Bar { a: string }`, {}, false);
+    expect(parsed.success).toBe(false);
+    if (parsed.success) return;
+    expect(parsed.message).toMatch(/no interface inheritance/);
+    expect(parsed.message).toContain("&");
+  });
+
+  it("leaves a type named `extendsSomething` alone", () => {
+    expect(parseAgency(`interface Foo { extendsThing: string }\nnode main() { print(1) }`, {}, false).success)
+      .toBe(true);
   });
 });

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -214,7 +214,7 @@ export const LEGAL_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/;
  *  modifiers, literal words); extend it when a new keyword lands. */
 export const RESERVED_WORDS: readonly string[] = [
   "def", "function", "node", "return", "goto", "raise", "interrupt", "import", "export",
-  "type", "effect", "effectSet", "if", "else", "for", "while", "in",
+  "type", "interface", "effect", "effectSet", "if", "else", "elif", "for", "while", "in",
   "match", "thread", "subthread", "handle", "finalize", "guard", "debugger",
   "skills", "skill", "static", "const", "let", "async", "sync", "await",
   "fork", "race", "try", "catch", "is", "as", "from", "with",
@@ -932,6 +932,14 @@ export const multiLineStringParser: Parser<MultiLineStringLiteral> = or(
   multiLineStringParserFor("'''"),
 );
 
+/** `undefined` written as a value, rewritten to `null`. See `nullParser` for
+ *  why they are one value with two spellings. Used only from the expression
+ *  atom, so binders and property names keep their own name. */
+const undefinedAliasParser: Parser<VariableNameLiteral> = map(
+  seqC(str("undefined"), not(varNameChar)),
+  () => ({ type: "variableName" as const, value: "null" }),
+);
+
 export const variableNameParser: Parser<VariableNameLiteral> = label("an identifier", memo("variableNameParser", (
   input: string,
 ) => {
@@ -942,16 +950,9 @@ export const variableNameParser: Parser<VariableNameLiteral> = label("an identif
       capture(manyWithJoin(varNameChar), "value"),
     ],
     (_, captures) => {
-      const name = `${captures.init}${captures.value}`;
       return {
         type: "variableName" as const,
-        // `undefined` is a second spelling of `null`, not a second value —
-        // Agency has exactly one nothing-value (docs/dev/null-and-undefined.md),
-        // and the *type* `undefined` has always normalized to `null`. In
-        // expression position both spellings arrive here rather than at
-        // `nullParser`, so converging them here is what makes the value side
-        // agree with the type side. `agency fmt` prints `null`.
-        value: name === "undefined" ? "null" : name,
+        value: `${captures.init}${captures.value}`,
       };
     },
   );
@@ -1141,9 +1142,17 @@ export const booleanParser: Parser<BooleanLiteral> = label("a boolean", (input: 
 // exactly one nothing-value (docs/dev/null-and-undefined.md); the *type*
 // `undefined` has always normalized to `null` here, and accepting the literal
 // makes the value side agree. `agency fmt` prints `null`.
+// `undefined` is a second spelling of `null`, not a second value. Agency has
+// exactly one nothing-value (docs/dev/null-and-undefined.md); the *type*
+// `undefined` has always normalized to `null`, and accepting the literal makes
+// the value side agree. `agency fmt` prints `null`.
+//
+// Both spellings need the word boundary: without it `nullThing` is consumed as
+// `null` with `Thing` stranded, the same hazard the primitive types have.
 export const nullParser: Parser<NullLiteral> = label("null", seqC(
   set("type", "null"),
-  or(str("null"), seqR(str("undefined"), not(varNameChar))),
+  or(str("null"), str("undefined")),
+  not(varNameChar),
 ));
 
 export const literalParser: Parser<Literal> = memo("literalParser", or(
@@ -1216,10 +1225,12 @@ export const primitiveTypeParser: Parser<PrimitiveType> = memo(
       // routinely start with these words.
       not(varNameChar),
     ),
-    // Nullish unification: the `undefined` type keyword is accepted (e.g. from
-    // imported TS type annotations) but normalized to `null` at parse time, so
-    // the stored AST never contains an `undefined` primitive. The *value*
-    // `undefined` remains unparseable. See docs/dev/null-and-undefined.md.
+    // Nullish unification: `undefined` is accepted (e.g. from imported TS type
+    // annotations) but normalized to `null` at parse time, so the stored AST
+    // never contains an `undefined` primitive. The *value* `undefined` is
+    // likewise a spelling of `null` — see `nullParser`. The capitalized
+    // TypeScript spellings normalize the same way.
+    // See docs/dev/null-and-undefined.md.
     (r: PrimitiveType) => {
       const normalized: Record<string, string> = {
         undefined: "null",
@@ -2120,7 +2131,38 @@ const baseTypeAliasParserFor = (keyword: string, separator: Parser<unknown>) => 
   ),
 ));
 
+const INTERFACE_EXTENDS_MESSAGE =
+  "Agency has no interface inheritance. Write `type Foo = Bar & { ... }` instead.";
+
+/**
+ * `interface Foo extends Bar { ... }` is a shape models write constantly.
+ * Without this it reaches `variableTypeParser` as `extends Bar { ... }` and
+ * fails with a generic type error that names nothing useful. Commit to a
+ * message that names the replacement instead.
+ *
+ * Throws rather than returning `failure(...)` for the same reason
+ * `bodyDeclarationParser` does — a plain failure would be shadowed by a sibling
+ * alternative in the enclosing `or(...)`.
+ */
+const interfaceExtendsParser: Parser<never> = (input: string) => {
+  const probe = seqC(
+    optional(seqC(str("export"), spaces)),
+    str("interface"),
+    spaces,
+    many1WithJoin(varNameChar),
+    spaces,
+    str("extends"),
+    not(varNameChar),
+  );
+  const probed = probe(input);
+  if (!probed.success) return failure("", input);
+  const declined = committedFailure(INTERFACE_EXTENDS_MESSAGE, probed.rest);
+  getParseState().committedFailure = declined;
+  return declined as ParserResult<never>;
+};
+
 const baseTypeAliasParser: Parser<TypeAlias> = or(
+  interfaceExtendsParser,
   baseTypeAliasParserFor("type", str("=")),
   baseTypeAliasParserFor("interface", succeed(undefined)),
 );
@@ -2563,8 +2605,11 @@ const namedArgumentParser: Parser<NamedArgument> = memo(
     set("type", "namedArgument"),
     capture(many1WithJoin(varNameChar), "name"),
     optionalSpaces,
-    // `=` is the Python spelling. Agency has no assignment expression, so
-    // nothing else can appear here; `agency fmt` prints `:`.
+    // `=` is the Python spelling; `agency fmt` prints `:`. The `not(char("="))`
+    // guard is what keeps this off `==`. Compound assignment operators (`+=`,
+    // `-=`, `*=`, `/=` — all real binops in the table below) are already
+    // excluded because their leading character matches neither `varNameChar`
+    // nor `char("=")`.
     or(char(":"), seqR(char("="), not(char("=")))),
     optionalSpaces,
     capture(or(lazy(() => inlineBlockParser), lazy(() => exprParser)), "value"),
@@ -3411,6 +3456,16 @@ const baseAtom: Parser<Expression> = or(
   lazy(() => agencyObjectParser),
   lazy(() => booleanParser),
   lazy(() => regexLiteralParser),
+  // MUST precede valueAccessParser, which would otherwise take `undefined` as
+  // an ordinary name. Placed here rather than in `variableNameParser` because
+  // that parser also supplies property names, pattern binders and template hole
+  // names — rewriting there renames `obj.undefined` and `{ a as undefined }`.
+  //
+  // Emits the same node `null` produces along this path (a `variableName`, not
+  // a `null` literal), so the two spellings stay indistinguishable downstream.
+  // That `null` has two node shapes depending on whether `literalParser` or
+  // this path reached it is pre-existing; unifying it is a separate change.
+  lazy(() => undefinedAliasParser),
   lazy(() => valueAccessParser),
   lazy(() => literalParser),
 );
@@ -5255,12 +5310,11 @@ export const withModifierParser: Parser<WithModifier> = withLoc((input: string) 
 });
 
 const elseClauseParser: Parser<AgencyNode[]> = (input: string) => {
-  // `elif` is the Python spelling of `else if`, and is rewritten to one here:
-  // the remaining input keeps the `if`, so the "else if" branch below handles
-  // it unchanged. `agency fmt` prints `else if`.
-  const elif = seqC(optionalSpaces, str("elif"), peek(not(varNameChar)))(input);
-  if (elif.success) {
-    const asElseIf = ifParser("if" + elif.rest);
+  // `elif` stands in for `else if`, so it is an else clause whose sole
+  // statement is an if. See `elifParser`.
+  const elifPrefix = seqC(optionalSpaces)(input);
+  if (elifPrefix.success) {
+    const asElseIf = elifParser(elifPrefix.rest);
     if (asElseIf.success) {
       return success([asElseIf.result], asElseIf.rest);
     }
@@ -5290,12 +5344,12 @@ const elseClauseParser: Parser<AgencyNode[]> = (input: string) => {
   return success(blockResult.result.body, blockResult.rest);
 };
 
-const _ifParserInner: Parser<IfElse> = (input: string) => {
+const _ifParserInnerFor = (keyword: string): Parser<IfElse> => (input: string) => {
   const parser = trace(
     "ifParser",
     seqC(
       set("type", "ifElse"),
-      str("if"),
+      str(keyword),
       optionalSpaces,
       char("("),
       optionalSpaces,
@@ -5330,7 +5384,19 @@ const _ifParserInner: Parser<IfElse> = (input: string) => {
 
   return result;
 };
+const _ifParserInner = _ifParserInnerFor("if");
+
 export const ifParser: Parser<IfElse> = label("an if statement", withLoc(_ifParserInner));
+
+/** `elif` is the Python spelling of `else if`. Parsed in place by swapping the
+ *  opening keyword, NOT by rewriting the source and re-parsing: tarsec measures
+ *  spans against the input it is handed, so a synthetic string would put every
+ *  `loc` inside the branch at the wrong offset, and nested `elif` would compound
+ *  the error. `agency fmt` prints `else if`. */
+const elifParser: Parser<IfElse> = label(
+  "an elif statement",
+  withLoc(_ifParserInnerFor("elif")),
+);
 
 // `if <condition> then <thenExpr> else <elseExpr>` — a conditional EXPRESSION.
 // Produces the SAME `IfElse` node a statement `if` uses (single-expression

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -1140,10 +1140,6 @@ export const booleanParser: Parser<BooleanLiteral> = label("a boolean", (input: 
 
 // `undefined` is a second spelling of `null`, not a second value. Agency has
 // exactly one nothing-value (docs/dev/null-and-undefined.md); the *type*
-// `undefined` has always normalized to `null` here, and accepting the literal
-// makes the value side agree. `agency fmt` prints `null`.
-// `undefined` is a second spelling of `null`, not a second value. Agency has
-// exactly one nothing-value (docs/dev/null-and-undefined.md); the *type*
 // `undefined` has always normalized to `null`, and accepting the literal makes
 // the value side agree. `agency fmt` prints `null`.
 //
@@ -2150,6 +2146,12 @@ const interfaceExtendsParser: Parser<never> = (input: string) => {
     str("interface"),
     spaces,
     many1WithJoin(varNameChar),
+    // The type-parameter list is optional but must be skipped when present:
+    // `extends` and type parameters travel together in TypeScript, so
+    // `interface Foo<T> extends Bar` is at least as likely as the bare form.
+    // Without this the probe declines on `<` and the author gets back the
+    // generic error this parser exists to replace.
+    optional(seqC(optionalSpaces, char("<"), manyTill(char(">")), char(">"))),
     spaces,
     str("extends"),
     not(varNameChar),
@@ -5312,12 +5314,10 @@ export const withModifierParser: Parser<WithModifier> = withLoc((input: string) 
 const elseClauseParser: Parser<AgencyNode[]> = (input: string) => {
   // `elif` stands in for `else if`, so it is an else clause whose sole
   // statement is an if. See `elifParser`.
-  const elifPrefix = seqC(optionalSpaces)(input);
-  if (elifPrefix.success) {
-    const asElseIf = elifParser(elifPrefix.rest);
-    if (asElseIf.success) {
-      return success([asElseIf.result], asElseIf.rest);
-    }
+  const afterSpaces = optionalSpaces(input);
+  const asElseIf = elifParser(afterSpaces.rest);
+  if (asElseIf.success) {
+    return success([asElseIf.result], asElseIf.rest);
   }
 
   const parser = seqC(optionalSpaces, str("else"), optionalSpaces);

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -511,10 +511,13 @@ const stringTextSegmentParserFor = (delim: '"' | "'" | "`"): Parser<TextSegment>
 // One character of raw multi-line text: any char that does not begin the close
 // delimiter (`"""`) or an interpolation (`${`). `not(...)` is a zero-width
 // negative lookahead; `capture(anyChar)` then consumes the single char.
-const multiLineRawChar: Parser<string> = map(
-  seqC(not(or(str('"""'), str("${"))), capture(anyChar, "c")),
-  (r) => r.c,
-);
+const multiLineRawCharFor = (delim: string): Parser<string> =>
+  map(
+    seqC(not(or(str(delim), str("${"))), capture(anyChar, "c")),
+    (r: { c: string }) => r.c,
+  );
+
+const multiLineRawChar: Parser<string> = multiLineRawCharFor('"""');
 
 // Text segment inside a triple-quoted string. Raw by design — backslash escapes
 // like `\n` are NOT interpreted (a literal backslash then `n`) — with ONE
@@ -523,10 +526,16 @@ const multiLineRawChar: Parser<string> = map(
 // source) without opening an interpolation. `\${` is tried first so its `${` is
 // consumed as an escape rather than starting one; a lone backslash and every
 // other `\x` stays verbatim. Ends at the closing `"""` or an unescaped `${`.
-export const multiLineStringTextSegmentParser: Parser<TextSegment> = map(
-  many1WithJoin(or(dollarBraceEscape, multiLineRawChar)),
-  (value) => ({ type: "text", value }),
-);
+export const multiLineStringTextSegmentParserFor = (
+  delim: string,
+): Parser<TextSegment> =>
+  map(
+    many1WithJoin(or(dollarBraceEscape, multiLineRawCharFor(delim))),
+    (value: string) => ({ type: "text" as const, value }),
+  );
+
+export const multiLineStringTextSegmentParser: Parser<TextSegment> =
+  multiLineStringTextSegmentParserFor('"""');
 
 export const interpolationSegmentParser: Parser<InterpolationSegment> = withLoc((
   input: string,
@@ -890,24 +899,38 @@ export const stringParser: Parser<StringLiteral> = label("a string", (input: str
   );
 });
 
-export const multiLineStringParser: Parser<MultiLineStringLiteral> = (input: string) => {
-  const parser = seqC(
-    set("type", "multiLineString"),
-    str('"""'),
-    capture(
-      many(or(multiLineStringTextSegmentParser, interpolationSegmentParser)),
-      "segments",
-    ),
-    str('"""'),
-  );
-  const result = parser(input);
-  if (result.success) {
-    for (const seg of result.result.segments) {
-      if (seg.type === "text") seg.value = stripSentinels(seg.value);
+const multiLineStringParserFor =
+  (delim: string): Parser<MultiLineStringLiteral> =>
+  (input: string) => {
+    const parser = seqC(
+      set("type", "multiLineString"),
+      str(delim),
+      capture(
+        many(
+          or(multiLineStringTextSegmentParserFor(delim), interpolationSegmentParser),
+        ),
+        "segments",
+      ),
+      str(delim),
+    );
+    const result = parser(input);
+    if (result.success) {
+      for (const seg of result.result.segments) {
+        if (seg.type === "text") seg.value = stripSentinels(seg.value);
+      }
     }
-  }
-  return result;
-};
+    return result;
+  };
+
+// Triple single-quotes are a second spelling of `"""`. Both build the same
+// `multiLineString` node — the delimiter is not recorded — so `agency fmt`
+// prints the canonical `"""`. Without this, a triple-single-quoted string
+// parsed as an empty single-quoted string followed by stray statements, losing
+// its contents silently.
+export const multiLineStringParser: Parser<MultiLineStringLiteral> = or(
+  multiLineStringParserFor('"""'),
+  multiLineStringParserFor("'''"),
+);
 
 export const variableNameParser: Parser<VariableNameLiteral> = label("an identifier", memo("variableNameParser", (
   input: string,
@@ -919,9 +942,16 @@ export const variableNameParser: Parser<VariableNameLiteral> = label("an identif
       capture(manyWithJoin(varNameChar), "value"),
     ],
     (_, captures) => {
+      const name = `${captures.init}${captures.value}`;
       return {
         type: "variableName" as const,
-        value: `${captures.init}${captures.value}`,
+        // `undefined` is a second spelling of `null`, not a second value —
+        // Agency has exactly one nothing-value (docs/dev/null-and-undefined.md),
+        // and the *type* `undefined` has always normalized to `null`. In
+        // expression position both spellings arrive here rather than at
+        // `nullParser`, so converging them here is what makes the value side
+        // agree with the type side. `agency fmt` prints `null`.
+        value: name === "undefined" ? "null" : name,
       };
     },
   );
@@ -1107,9 +1137,13 @@ export const booleanParser: Parser<BooleanLiteral> = label("a boolean", (input: 
   return parser(input);
 });
 
+// `undefined` is a second spelling of `null`, not a second value. Agency has
+// exactly one nothing-value (docs/dev/null-and-undefined.md); the *type*
+// `undefined` has always normalized to `null` here, and accepting the literal
+// makes the value side agree. `agency fmt` prints `null`.
 export const nullParser: Parser<NullLiteral> = label("null", seqC(
   set("type", "null"),
-  str("null"),
+  or(str("null"), seqR(str("undefined"), not(varNameChar))),
 ));
 
 export const literalParser: Parser<Literal> = memo("literalParser", or(
@@ -1157,6 +1191,12 @@ export const primitiveTypeParser: Parser<PrimitiveType> = memo(
           str("number"),
           str("string"),
           str("boolean"),
+          // TypeScript's boxed-object spellings. Accepted because models reach
+          // for them; normalized below so the AST only ever holds the
+          // lowercase primitive.
+          str("Number"),
+          str("String"),
+          str("Boolean"),
           str("undefined"),
           str("void"),
           str("null"),
@@ -1169,12 +1209,27 @@ export const primitiveTypeParser: Parser<PrimitiveType> = memo(
         ),
         "value",
       ),
+      // A primitive name must be a whole word. Without this, `str("Number")`
+      // matches the front of a type reference like `NumberInRange` and strands
+      // the rest. The lowercase names have the same hazard (`stringify`); the
+      // capitalized ones just make it far likelier, since PascalCase type names
+      // routinely start with these words.
+      not(varNameChar),
     ),
     // Nullish unification: the `undefined` type keyword is accepted (e.g. from
     // imported TS type annotations) but normalized to `null` at parse time, so
     // the stored AST never contains an `undefined` primitive. The *value*
     // `undefined` remains unparseable. See docs/dev/null-and-undefined.md.
-    (r: PrimitiveType) => (r.value === "undefined" ? { ...r, value: "null" } : r),
+    (r: PrimitiveType) => {
+      const normalized: Record<string, string> = {
+        undefined: "null",
+        Number: "number",
+        String: "string",
+        Boolean: "boolean",
+      };
+      const value = normalized[r.value];
+      return value ? { ...r, value } : r;
+    },
   ),
 );
 
@@ -1996,11 +2051,20 @@ export const valueParamParser: Parser<ValueParam> = memo(
   ),
 );
 
-const baseTypeAliasParser: Parser<TypeAlias> = withLoc(memo(
-  "typeAliasParser",
+/**
+ * `type Foo = X` and `interface Foo X` are the same declaration with two
+ * spellings. They differ only in the separator: `type` requires `=`, and
+ * `interface` has none.
+ *
+ * The separator is a PARAMETER rather than an `optional(str("="))` shared by
+ * both. Making it optional would also accept `type A number`, which is
+ * currently a targeted parse error and is relied on well beyond this parser.
+ */
+const baseTypeAliasParserFor = (keyword: string, separator: Parser<unknown>) => withLoc(memo(
+  `typeAliasParser:${keyword}`,
   seqC(
     set("type", "typeAlias"),
-    str("type"),
+    str(keyword),
     spaces,
     captureCaptures(
       parseError(
@@ -2046,7 +2110,7 @@ const baseTypeAliasParser: Parser<TypeAlias> = withLoc(memo(
           ),
         ),
         optionalSpaces,
-        str("="),
+        separator,
         optionalSpaces,
         capture(variableTypeParser, "aliasedType"),
         optionalSemicolon,
@@ -2055,6 +2119,11 @@ const baseTypeAliasParser: Parser<TypeAlias> = withLoc(memo(
     ),
   ),
 ));
+
+const baseTypeAliasParser: Parser<TypeAlias> = or(
+  baseTypeAliasParserFor("type", str("=")),
+  baseTypeAliasParserFor("interface", succeed(undefined)),
+);
 
 export const typeAliasParser: Parser<TypeAlias> = label("a type alias",
   (input: string) => {
@@ -2494,7 +2563,9 @@ const namedArgumentParser: Parser<NamedArgument> = memo(
     set("type", "namedArgument"),
     capture(many1WithJoin(varNameChar), "name"),
     optionalSpaces,
-    char(":"),
+    // `=` is the Python spelling. Agency has no assignment expression, so
+    // nothing else can appear here; `agency fmt` prints `:`.
+    or(char(":"), seqR(char("="), not(char("=")))),
     optionalSpaces,
     capture(or(lazy(() => inlineBlockParser), lazy(() => exprParser)), "value"),
   ),
@@ -5184,6 +5255,17 @@ export const withModifierParser: Parser<WithModifier> = withLoc((input: string) 
 });
 
 const elseClauseParser: Parser<AgencyNode[]> = (input: string) => {
+  // `elif` is the Python spelling of `else if`, and is rewritten to one here:
+  // the remaining input keeps the `if`, so the "else if" branch below handles
+  // it unchanged. `agency fmt` prints `else if`.
+  const elif = seqC(optionalSpaces, str("elif"), peek(not(varNameChar)))(input);
+  if (elif.success) {
+    const asElseIf = ifParser("if" + elif.rest);
+    if (asElseIf.success) {
+      return success([asElseIf.result], asElseIf.rest);
+    }
+  }
+
   const parser = seqC(optionalSpaces, str("else"), optionalSpaces);
   const prefixResult = parser(input);
   if (!prefixResult.success) return prefixResult;

--- a/packages/agency-lang/lib/runtime/template/fill.test.ts
+++ b/packages/agency-lang/lib/runtime/template/fill.test.ts
@@ -343,6 +343,13 @@ describe("fillHoles: identifier holes", () => {
     expect(() => fillHoles(load(template), { tool: "function" })).toThrow(/reserved word/);
   });
 
+  it.each(["interface", "elif"])(
+    "rejects `%s`, a keyword the grammar now consumes",
+    (kw) => {
+      expect(() => fillHoles(load(template), { tool: kw })).toThrow(/reserved word/);
+    },
+  );
+
   it("rejects the hygiene prefix", () => {
     expect(() => fillHoles(load(template), { tool: "__hyg1_x" })).toThrow(/reserved/);
   });

--- a/packages/agency-lang/lib/typeChecker/narrowing.test.ts
+++ b/packages/agency-lang/lib/typeChecker/narrowing.test.ts
@@ -243,9 +243,17 @@ describe("analyzeCondition", () => {
     "r.kind == s.kind", // both member access (RHS not a literal)
     "x == 1", // no member access
     "r.kind == r.text", // same var both sides, no literal
-    "r.kind == undefined", // undefined is a variableName, not a literal
   ])("produces no candidates for %s", (src) => {
     expect(analyzeCondition(firstIfCondition(src))).toEqual({ then: [], else: [] });
+  });
+
+  // `undefined` used to reach here as a plain variable name, so it narrowed
+  // nothing. It is now a second spelling of `null` (parsed to the same node),
+  // so it gets null-presence narrowing like `== null` does.
+  it("narrows r.kind == undefined exactly like r.kind == null", () => {
+    expect(analyzeCondition(firstIfCondition("r.kind == undefined"))).toEqual(
+      analyzeCondition(firstIfCondition("r.kind == null")),
+    );
   });
 
   it('r.a.kind == "x": one-hop receiver r.a now narrows (M1; was out-of-scope)', () => {


### PR DESCRIPTION
Six more spellings models reach for, following the same rule as #750: a variation belongs here only if the AST can forget which spelling was used. None is recorded, so `AgencyGenerator` needed no changes and `agency fmt` normalizes for free.

| Also accepted | Canonical |
|---|---|
| `interface Foo { a: string }` | `type Foo = { a: string }` |
| `elif (b) { }` | `else if (b) { }` |
| `greet(name = "Adit")` | `greet(name: "Adit")` |
| `const x = undefined` | `const x = null` |
| `const s: String` | `const s: string` |
| `'''hi'''` | `"""hi"""` |

## Two of these were silent misparses, not missing features

Worth calling out because they were worse than "doesn't work":

**`'''hi'''` lost its contents.** It parsed as an empty single-quoted string followed by two stray statements — no error, and the text silently gone.

**`const s: String = "x"` accepted anything.** `String` parsed as an unresolved type alias, which types as `any` through the known checker hole. So the annotation was decorative.

## A latent hazard the capitalized primitives exposed

Primitive type names were matched with no word boundary, so adding `String`/`Number`/`Boolean` made `str("Number")` match the front of `NumberInRange` and strand the rest. The lowercase names had the same hazard (`stringify`) — the capitalized ones just make it far likelier, since PascalCase type names routinely start with these words. The alternation now requires a whole word, which fixes both.

## `undefined`

`docs/dev/null-and-undefined.md` records a deliberate decision that Agency has exactly one nothing-value. This does not change that: `undefined` becomes a second *spelling* of `null`, not a second value. The *type* `undefined` has normalized to `null` since that work landed; this makes the value side agree. The doc's rejected alternative was "keep both, distinct", which is not what this does.

Two consequences worth knowing:

- In expression position both `null` and `undefined` arrive at `variableNameParser`, not `nullParser` — so that is where they converge.
- `undefined` now narrows like `null`. A narrowing test that asserted `r.kind == undefined` produced no candidates ("undefined is a variableName, not a literal") is updated to assert it matches `== null`. That premise is obsolete, and the new behaviour is strictly better.

The one dev-doc sentence stating users cannot write `undefined` as a value is updated, since it is now false. No guide pages touched.

## One thing I got wrong and caught

The first draft made the `=` in a type alias `optional(...)` so one parser could serve both keywords. That also accepts `type A number`, which is a targeted error relied on well beyond this parser — 123 tests failed. The separator is now a parameter: `type` requires `=`, `interface` has none. There is a test pinning it.

## Testing

New `lib/parsers/keywordAliases.test.ts`: an AST-equality pair per variation, a formatter assertion per variation, idempotence, and a "does not swallow neighbouring syntax" block covering `NumberInRange`, `undefinedThing`, `a == b` vs the named-argument `=`, single-quoted strings, and `type A number`.

Full unit suite: **10137 passed, 0 failed**. `pnpm run lint:structure` clean. `make` builds the stdlib and examples through the changed parser.

Note for reviewers: most of the suite needs a built `dist/`. Running it in a fresh worktree without `make` first shows ~115 unrelated failures ("Failed to resolve entry for package agency-lang").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
