### PR TITLE
Teach switch and C-style for what Agency uses instead

### DIFF
--- a/packages/agency-lang/docs/site/stdlib/agents/agency/coding.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/agency/coding.md
@@ -46,27 +46,6 @@ Return the Agency writer's tools: the bundled documentation, the source
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/coding.agency#L106))
 
-### syntaxHintFor
-
-```ts
-syntaxHintFor(errors: string): string
-```
-
-Return a specific syntax reminder to inject next to a diagnostic, or ""
-  when no known pattern matches.
-
-  @param errors - The rendered diagnostic text to match against
-
-**Parameters:**
-
-| Name | Type | Default |
-|---|---|---|
-| errors | `string` |  |
-
-**Returns:** `string`
-
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/coding.agency#L124))
-
 ### agencyCodingAgent
 
 ```ts
@@ -115,4 +94,4 @@ Write an Agency program for the task. Iterates until the source parses,
 
 **Throws:** `std::guard`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/coding.agency#L251))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/coding.agency#L230))

--- a/packages/agency-lang/lib/parsers/foreignSyntax.test.ts
+++ b/packages/agency-lang/lib/parsers/foreignSyntax.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { parseAgency } from "@/parser.js";
+
+function failure(src: string) {
+  const parsed = parseAgency(src, {}, false);
+  if (parsed.success) throw new Error(`expected a failed parse for: ${src}`);
+  return parsed.message ?? "";
+}
+
+function parses(src: string) {
+  return parseAgency(src, {}, false).success;
+}
+
+describe("switch statements are refused with a message naming match", () => {
+  it("catches `case` arms", () => {
+    const message = failure(`node main() { switch (x) { case 1: print(1) } }`);
+    expect(message).toMatch(/no `switch` statement/);
+    expect(message).toContain("match (x)");
+  });
+
+  it("catches a `default`-only body", () => {
+    expect(failure(`node main() { switch (x) { default: print(1) } }`))
+      .toMatch(/no `switch` statement/);
+  });
+
+  it("explains the two things match does differently", () => {
+    const message = failure(`node main() { switch (x) { case 1: print(1) } }`);
+    expect(message).toContain("break");
+    expect(message).toContain("_");
+  });
+
+  // `switch` is a legal identifier and the stdlib already has a
+  // `std::git::switch` effect, so the probe must not fire on an ordinary call.
+  it("leaves a call to something named switch alone", () => {
+    expect(parses(`node main() { switch(x) }`)).toBe(true);
+    expect(parses(`def switch(x: number) { print(x) }\nnode main() { switch(1) }`)).toBe(true);
+  });
+
+  it("leaves a match block alone", () => {
+    expect(parses(`node main() { match (x) { 1 => print(1) _ => print(2) } }`)).toBe(true);
+  });
+});
+
+describe("C-style for loops are refused with a message naming the alternatives", () => {
+  it("catches the `let` form", () => {
+    const message = failure(`node main() { for (let i = 0; i < 10; i++) { print(i) } }`);
+    expect(message).toMatch(/no C-style `for` loop/);
+    expect(message).toContain("range(0, 10)");
+  });
+
+  it("catches the form with no declaration keyword", () => {
+    expect(failure(`node main() { for (i = 0; i < 10; i++) { print(i) } }`))
+      .toMatch(/no C-style `for` loop/);
+  });
+
+  it("offers both iteration and while as alternatives", () => {
+    const message = failure(`node main() { for (let i = 0; i < 10; i++) { print(i) } }`);
+    expect(message).toContain("for (item in items)");
+    expect(message).toContain("while (cond)");
+  });
+
+  it.each([
+    ["plain", `node main() { for (x in xs) { print(x) } }`],
+    ["with index", `node main() { for (x, i in xs) { print(x) } }`],
+    ["object destructuring", `node main() { for ({ a, b } in xs) { print(a) } }`],
+    ["array destructuring", `node main() { for ([a, b] in xs) { print(a) } }`],
+    // A probe that scanned for `;` instead of keying on the initializer shape
+    // would misfire here.
+    ["semicolon inside a string", `node main() { for (x in ["a;b"]) { print(x) } }`],
+    ["over a range call", `node main() { for (i in range(0, 10)) { print(i) } }`],
+  ])("leaves an Agency for loop alone: %s", (_name, src) => {
+    expect(parses(src)).toBe(true);
+  });
+
+  it("leaves a while loop alone", () => {
+    expect(parses(`node main() { let i = 0\nwhile (i < 3) { i = i + 1 } }`)).toBe(true);
+  });
+
+  it("does not fire on an equality comparison in a for header", () => {
+    expect(parses(`node main() { for (x in xs) { if (x == 1) { print(x) } } }`)).toBe(true);
+  });
+});

--- a/packages/agency-lang/lib/parsers/foreignSyntax.test.ts
+++ b/packages/agency-lang/lib/parsers/foreignSyntax.test.ts
@@ -36,6 +36,29 @@ describe("switch statements are refused with a message naming match", () => {
     expect(parses(`def switch(x: number) { print(x) }\nnode main() { switch(1) }`)).toBe(true);
   });
 
+  it("catches a computed condition", () => {
+    // A probe that scanned to the first `)` would stop at the one closing
+    // `f(x)` and decline. Switching on a computed value is at least as common
+    // as switching on a name.
+    expect(failure(`node main() { switch (f(x)) { case 1: print(1) } }`))
+      .toMatch(/no `switch` statement/);
+  });
+
+  it("catches a parenthesized case label", () => {
+    expect(failure(`node main() { switch (x) { case (1): print(1) } }`))
+      .toMatch(/no `switch` statement/);
+  });
+
+  // The label's `:` is what disambiguates. A block that merely starts with
+  // something *named* `case` is ordinary Agency.
+  it("leaves a call whose block starts with a call to `case` alone", () => {
+    expect(parses(`def switch(b) { return b() }\nnode main() { switch(1) { case(1) } }`)).toBe(true);
+  });
+
+  it("leaves a block containing a variable named case alone", () => {
+    expect(parses(`node main() { doThing(1) { case } }`)).toBe(true);
+  });
+
   it("leaves a match block alone", () => {
     expect(parses(`node main() { match (x) { 1 => print(1) _ => print(2) } }`)).toBe(true);
   });
@@ -53,9 +76,10 @@ describe("C-style for loops are refused with a message naming the alternatives",
       .toMatch(/no C-style `for` loop/);
   });
 
-  it("offers both iteration and while as alternatives", () => {
+  it("offers iteration, comprehensions and while as alternatives", () => {
     const message = failure(`node main() { for (let i = 0; i < 10; i++) { print(i) } }`);
     expect(message).toContain("for (item in items)");
+    expect(message).toContain("[x * 2 for x in items]");
     expect(message).toContain("while (cond)");
   });
 

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -4726,16 +4726,23 @@ const SWITCH_MESSAGE =
  * reaching for `switch` is reasoning about the wrong thing and should be told,
  * not silently accommodated.
  *
- * The probe requires a `case` or `default` inside the block rather than
+ * The probe requires a labelled `case ...:` or `default:` arm rather than
  * stopping at `switch (`. `switch` is a legal identifier, and the standard
- * library already has a `std::git::switch` effect, so a bare `switch(...)`
- * could be an ordinary call — possibly one taking a block. Requiring the arm
- * keyword makes the shape unmistakable.
+ * library already has a `std::git::switch` effect, so a bare `switch(...)` can
+ * be an ordinary call — possibly one taking a block. The label's `:` is what
+ * makes the shape unmistakable: a block that merely *starts* with something
+ * named `case` (say `case(1)`) is ordinary Agency and must still parse.
+ *
+ * The condition is scanned to the opening `{`, not to the first `)`. Stopping
+ * at `)` declines on `switch (f(x))`, where the first `)` closes the inner
+ * call — and switching on a computed value is at least as common as switching
+ * on a name. The trade is a `)` in the condition for a `{` in the condition
+ * (`switch ({ a: 1 }.a)`), which is the rarer shape.
  *
  * The cost of that precision: `switch (x) { 1 => ... }`, mixing the two
  * syntaxes, is not caught and still gets a generic error.
  *
- * Throws rather than returning `failure(...)` for the same reason
+ * Commits the failure rather than returning a plain one for the same reason
  * `bodyDeclarationParser` does — a plain failure would be shadowed by a
  * sibling alternative in the enclosing `or(...)`.
  */
@@ -4744,13 +4751,15 @@ const switchStatementParser: Parser<never> = (input: string) => {
     str("switch"),
     optionalSpaces,
     char("("),
-    many(noneOf(")")),
-    char(")"),
-    optionalSpacesOrNewline,
+    many(noneOf("{")),
     char("{"),
     optionalSpacesOrNewline,
-    or(str("case"), str("default")),
-    not(varNameChar),
+    or(
+      // `case <expr>:` — the space is required, which is what keeps `case(1)`
+      // (an ordinary call) from matching.
+      seqC(str("case"), spaces, many1(noneOf(":\n{}")), char(":")),
+      seqC(str("default"), optionalSpaces, char(":")),
+    ),
   );
   const probed = probe(input);
   if (!probed.success) return failure("", input);
@@ -4769,6 +4778,10 @@ const C_STYLE_FOR_MESSAGE =
   "  for (item in items) { print(item) }\n" +
   "  for (item, i in items) { print(i, item) }\n" +
   "\n" +
+  "To build a list from another list, use a comprehension:\n" +
+  "\n" +
+  "  const doubled = [x * 2 for x in items]\n" +
+  "\n" +
   "For a condition-driven loop, use `while (cond) { ... }`.";
 
 /**
@@ -4779,6 +4792,9 @@ const C_STYLE_FOR_MESSAGE =
  * The probe keys on the initializer shape (an optional declaration keyword, a
  * name, then `=`) rather than scanning for a `;`. Scanning would misfire on a
  * semicolon inside a string, as in `for (x in ["a;b"])`.
+ *
+ * Commits the failure rather than returning a plain one, so a sibling
+ * alternative in the enclosing `or(...)` cannot shadow the message.
  */
 const cStyleForParser: Parser<never> = (input: string) => {
   const probe = seqC(

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -4708,6 +4708,97 @@ export const modifiedAssignmentParser: Parser<Assignment> = withLoc((input: stri
   return success(out, result.rest);
 });
 
+const SWITCH_MESSAGE =
+  "Agency has no `switch` statement. Use a `match` block instead:\n" +
+  "\n" +
+  "  match (x) {\n" +
+  '    "a" => doThing()\n' +
+  '    "b" => doOtherThing()\n' +
+  "    _   => fallback()\n" +
+  "  }\n" +
+  "\n" +
+  "Arms do not fall through, so no `break` is needed, and `match` checks that " +
+  "you covered every case. `_` is the catch-all.";
+
+/**
+ * `switch` is a construct Agency deliberately does not have — `match` differs
+ * in ways that matter (no fall-through, exhaustiveness checking), so an author
+ * reaching for `switch` is reasoning about the wrong thing and should be told,
+ * not silently accommodated.
+ *
+ * The probe requires a `case` or `default` inside the block rather than
+ * stopping at `switch (`. `switch` is a legal identifier, and the standard
+ * library already has a `std::git::switch` effect, so a bare `switch(...)`
+ * could be an ordinary call — possibly one taking a block. Requiring the arm
+ * keyword makes the shape unmistakable.
+ *
+ * The cost of that precision: `switch (x) { 1 => ... }`, mixing the two
+ * syntaxes, is not caught and still gets a generic error.
+ *
+ * Throws rather than returning `failure(...)` for the same reason
+ * `bodyDeclarationParser` does — a plain failure would be shadowed by a
+ * sibling alternative in the enclosing `or(...)`.
+ */
+const switchStatementParser: Parser<never> = (input: string) => {
+  const probe = seqC(
+    str("switch"),
+    optionalSpaces,
+    char("("),
+    many(noneOf(")")),
+    char(")"),
+    optionalSpacesOrNewline,
+    char("{"),
+    optionalSpacesOrNewline,
+    or(str("case"), str("default")),
+    not(varNameChar),
+  );
+  const probed = probe(input);
+  if (!probed.success) return failure("", input);
+  const declined = committedFailure(SWITCH_MESSAGE, probed.rest);
+  getParseState().committedFailure = declined;
+  return declined as ParserResult<never>;
+};
+
+const C_STYLE_FOR_MESSAGE =
+  "Agency has no C-style `for` loop. To count, iterate a range:\n" +
+  "\n" +
+  "  for (i in range(0, 10)) { print(i) }\n" +
+  "\n" +
+  "To walk a collection, iterate it directly:\n" +
+  "\n" +
+  "  for (item in items) { print(item) }\n" +
+  "  for (item, i in items) { print(i, item) }\n" +
+  "\n" +
+  "For a condition-driven loop, use `while (cond) { ... }`.";
+
+/**
+ * A C-style `for (let i = 0; i < n; i++)`. Without this the author gets
+ * "expected `(` to open for loop condition", which is actively misleading —
+ * there IS a `(`; what the parser could not find is the `in`.
+ *
+ * The probe keys on the initializer shape (an optional declaration keyword, a
+ * name, then `=`) rather than scanning for a `;`. Scanning would misfire on a
+ * semicolon inside a string, as in `for (x in ["a;b"])`.
+ */
+const cStyleForParser: Parser<never> = (input: string) => {
+  const probe = seqC(
+    str("for"),
+    optionalSpaces,
+    char("("),
+    optionalSpaces,
+    optional(seqC(oneOfStr(["let", "const", "var"]), spaces)),
+    many1WithJoin(varNameChar),
+    optionalSpaces,
+    char("="),
+    not(char("=")),
+  );
+  const probed = probe(input);
+  if (!probed.success) return failure("", input);
+  const declined = committedFailure(C_STYLE_FOR_MESSAGE, probed.rest);
+  getParseState().committedFailure = declined;
+  return declined as ParserResult<never>;
+};
+
 const BODY_DECLARATION_MESSAGE =
   "`node`, `def` and `function` declarations are only legal at the top level of a file.";
 
@@ -4913,6 +5004,12 @@ const _bodyNodeParser: Parser<AgencyNode> = memo("bodyNodeParser", or(
   // must sit ahead of assignmentParser / binOpParser / valueAccessParser,
   // which are what would otherwise read `node` as a name.
   bodyDeclarationParser,
+  // Both decline a construct Agency deliberately does not have, replacing an
+  // unhelpful generic failure with a message naming the Agency equivalent.
+  // `cStyleForParser` MUST precede `forLoopParser`, which would otherwise
+  // report a missing `(` that is plainly present.
+  switchStatementParser,
+  cStyleForParser,
   // withModifierParser must be tried before returnStatementParser/
   // assignmentParser so that `return foo() with approve` and
   // `const x = foo() with approve` don't get partially consumed by

--- a/packages/agency-lang/stdlib/agents/agency/coding.agency
+++ b/packages/agency-lang/stdlib/agents/agency/coding.agency
@@ -121,27 +121,6 @@ export def buildTools(): any[] {
   ]
 }
 
-export def syntaxHintFor(errors: string): string {
-  """
-  Return a specific syntax reminder to inject next to a diagnostic, or ""
-  when no known pattern matches.
-
-  @param errors - The rendered diagnostic text to match against
-  """
-  if (errors =~ re/for loop condition/) {
-    return "Reminder: Agency has no C-style for loop. Count with a while loop, or iterate with for (x in items)."
-  }
-  return ""
-}
-
-/** Prepend the point-of-need syntax hint to a diagnostic block, if one
-  applies. The rule lands better delivered alongside the error than buried in
-  the system prompt. */
-def withSyntaxHint(findings: string): string {
-  const hint = syntaxHintFor(findings)
-  return if hint == "" then findings else "${hint}\n\n${findings}"
-}
-
 /** True when the source declares a `node main` entry point. Missing main is
   not a typecheck diagnostic, so the loop checks for it directly. */
 def hasMainNode(source: string): boolean {
@@ -175,14 +154,14 @@ def checkSource(source: string): Critique {
     const findings = renderFeedback(reviewed)
     return {
       accepted: false,
-      feedback: "That code has problems:\n${withSyntaxHint(findings)}\nReturn a corrected complete program.",
+      feedback: "That code has problems:\n${findings}\nReturn a corrected complete program.",
     }
   }
   const compiled = compile(source)
   if (compiled is failure(compileErr)) {
     return {
       accepted: false,
-      feedback: "That code failed to compile:\n${withSyntaxHint("${compileErr}")}\nReturn a corrected complete program.",
+      feedback: "That code failed to compile:\n${compileErr}\nReturn a corrected complete program.",
     }
   }
   if (!hasMainNode(source)) {

--- a/packages/agency-lang/tests/agency/agents/helpers.agency
+++ b/packages/agency-lang/tests/agency/agents/helpers.agency
@@ -1,7 +1,4 @@
 import { withContext } from "std::agents/lib/shared"
-import { renderFeedback } from "std::agents/lib/feedback"
-import { agencyReviewAgent } from "std::agents/agency/review"
-import { syntaxHintFor } from "std::agents/agency/coding"
 
 node contextEmpty(): boolean {
   return withContext("do X", "") == "do X"
@@ -11,15 +8,3 @@ node contextFilled(): boolean {
   return withContext("do X", "c") == "do X\n\n<context>\nc\n</context>"
 }
 
-// Feed a REAL compiler diagnostic (from review, no LLM) through syntaxHintFor
-// and assert the point-of-need hint actually fires on it, not just on a
-// hand-written string that happens to match the regex.
-node hintFiresOnRealForDiagnostic(): boolean {
-  const fb = agencyReviewAgent("node main() { for (let i = 0; i < 3; i = i + 1) { print(i) } }")
-  return syntaxHintFor(renderFeedback(fb)) != ""
-}
-
-node hintEmptyOnValidProgram(): boolean {
-  const fb = agencyReviewAgent("node main(): number { return 5 }")
-  return syntaxHintFor(renderFeedback(fb)) == ""
-}

--- a/packages/agency-lang/tests/agency/agents/helpers.test.json
+++ b/packages/agency-lang/tests/agency/agents/helpers.test.json
@@ -1,9 +1,25 @@
 {
   "sourceFile": "helpers.agency",
   "tests": [
-    { "nodeName": "contextEmpty", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "contextFilled", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "hintFiresOnRealForDiagnostic", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "hintEmptyOnValidProgram", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] }
+    {
+      "nodeName": "contextEmpty",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "contextFilled",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
Two constructs Agency deliberately does not have now get a targeted error naming the Agency equivalent.

This is the opposite call from #750 and #756. Those accepted spellings of constructs Agency *has*. These two differ in semantics — `match` has no fall-through and does exhaustiveness checking; Agency has no C-style loop at all — so an author reaching for them is reasoning about the wrong construct, and accommodating that silently would be worse than refusing it.

## What you get now

```
node main() { switch (x) { case 1: print(1) } }
```

```
Agency has no `switch` statement. Use a `match` block instead:

  match (x) {
    "a" => doThing()
    "b" => doOtherThing()
    _   => fallback()
  }

Arms do not fall through, so no `break` is needed, and `match` checks that you
covered every case. `_` is the catch-all.
```

```
node main() { for (let i = 0; i < 10; i++) { print(i) } }
```

```
Agency has no C-style `for` loop. To count, iterate a range:

  for (i in range(0, 10)) { print(i) }

To walk a collection, iterate it directly:

  for (item in items) { print(item) }
  for (item, i in items) { print(i, item) }

For a condition-driven loop, use `while (cond) { ... }`.
```

## What they gave before

Both failed already, but with messages that pointed nowhere useful:

| Input | Old message |
|---|---|
| `switch (x) { case 1: ... }` | `expected node body` |
| `for (let i = 0; i < 10; i++)` | ``expected `(` to open for loop condition`` |

The second is worse than unhelpful — there *is* a `(`. What the parser could not find was the `in`.

## Two precision decisions

**The switch probe requires a `case` or `default` arm**, rather than committing as soon as it sees `switch (`. `switch` is a legal identifier, and the standard library already has a `std::git::switch` effect, so a bare `switch(...)` can be an ordinary call — possibly one taking a block, which is valid Agency. Requiring the arm keyword makes the shape unmistakable. The cost: `switch (x) { 1 => ... }`, mixing the two syntaxes, is not caught and still gets a generic error. There is a test that a function named `switch` still parses.

**The for probe keys on the initializer shape** — an optional `let`/`const`/`var`, a name, then `=` — rather than scanning for a `;` before the `)`. Scanning would misfire on a semicolon inside a string:

```ts
for (x in ["a;b"]) { print(x) }   // must still parse
```

That case is tested, along with the index, object-destructuring, array-destructuring, and `range()` forms.

## Testing

New `lib/parsers/foreignSyntax.test.ts`, 16 cases: both constructs caught, the message content asserted (not just that it failed), and a block of negative cases covering every legitimate loop form plus a call to something named `switch`.

Full unit suite: **10162 passed, 0 failed**. `pnpm run lint:structure` clean.

Reviewers: the suite needs a built `dist/`. In a fresh worktree without `make` first, ~114 unrelated tests fail with "Failed to resolve entry for package agency-lang".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
