### PR TITLE
Refuse ternaries; add worked examples to three parser messages

### DIFF
--- a/packages/agency-lang/lib/parsers/errorExamples.test.ts
+++ b/packages/agency-lang/lib/parsers/errorExamples.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import { parseAgency } from "@/parser.js";
+
+function failure(src: string) {
+  const parsed = parseAgency(src, {}, false);
+  if (parsed.success) throw new Error(`expected a failed parse for: ${src}`);
+  return parsed.message ?? "";
+}
+
+function parses(src: string) {
+  return parseAgency(src, {}, false).success;
+}
+
+describe("ternaries are refused with the if-then-else form", () => {
+  it.each([
+    ["a const value", `node main() { const y = x ? 1 : 2 }`],
+    ["a return value", `def f(x: boolean): number { return x ? 1 : 2 }`],
+    ["a call argument", `node main() { print(x ? 1 : 2) }`],
+    ["an object field", `node main() { const o = { a: x ? 1 : 2 } }`],
+  ])("catches a ternary as %s", (_name, src) => {
+    const message = failure(src);
+    expect(message).toMatch(/no ternary/);
+    expect(message).toContain("if isProd then");
+  });
+
+  it("reports a real position rather than the body catch-all", () => {
+    const message = failure(`node main() { const y = x ? 1 : 2 }`);
+    expect(message).toMatch(/^Line \d+, col \d+:/);
+    expect(message).not.toContain("expected node body");
+  });
+
+  // `?.` and `??` are real Agency operators; only a bare `?` is a ternary.
+  it.each([
+    ["optional chaining", `node main() { const o = { a: 1 }\nprint(o?.a) }`],
+    ["nullish coalescing", `node main() { const y = a ?? 1 }`],
+    ["an optional parameter", `def f(a?: number) { print(a) }\nnode main() { f(1) }`],
+    ["an optional property", `type T = { a?: string }\nnode main() { print(1) }`],
+    ["a question mark in a string", `node main() { const s = "a ? b : c" }`],
+    ["an object literal", `node main() { const o = { a: 1, b: 2 } }`],
+    ["match arms", `node main() { match (x) { 1 => print(1) _ => print(2) } }`],
+  ])("leaves %s alone", (_name, src) => {
+    expect(parses(src)).toBe(true);
+  });
+});
+
+describe("messages carry a worked example", () => {
+  it("match arms show patterns, a guard, a block arm and the catch-all", () => {
+    const message = failure(`node main() { match (x) { 1: print(1) } }`);
+    expect(message).toContain("match (shape)");
+    expect(message).toContain("if (side > 0) =>");
+    expect(message).toContain("_ =>");
+  });
+
+  it("if-then-else names itself as the ternary replacement", () => {
+    const message = failure(`node main() { const y = if x then 1 }`);
+    expect(message).toContain("if isProd then");
+    expect(message).toContain("ternary");
+  });
+
+  it("the handler body shows the `with` form and the verbs", () => {
+    const message = failure(`node main() { handle { read("a") } with (i) }`);
+    expect(message).toContain("} with (intr) {");
+    expect(message).toContain("approve()");
+    expect(message).toContain("with approve");
+  });
+});
+
+/**
+ * Every code example embedded in a parser error message must itself be valid
+ * Agency. An example that does not parse is worse than no example: it teaches
+ * the wrong thing to exactly the reader who is already stuck.
+ *
+ * Each entry is the example as it appears in its message, wrapped in the least
+ * scaffolding needed to stand alone.
+ */
+describe("every example in a parser message is valid Agency", () => {
+  it.each([
+    ["match arms", `type Shape = { kind: "circle", r: number } | { kind: "square", side: number }
+node main(shape: Shape) {
+  const area = match (shape) {
+    { kind: "circle", r } => 3.14 * r * r
+    { kind: "square", side } if (side > 0) => side * side
+    _ => {
+      print("unknown")
+      return 0
+    }
+  }
+  print(area)
+}`],
+    ["if-then-else, also quoted by the ternary message", `node main(isProd: boolean) {
+  const label = if isProd then "Production" else "Local"
+  print(label)
+}`],
+    ["handler", `node main() {
+  handle {
+    read("./notes.md")
+  } with (intr) {
+    if (intr.effect == "std::read") { return approve() }
+    return reject()
+  }
+}`],
+    ["the C-style-for alternatives", `node main(items: string[]) {
+  for (i in range(0, 10)) { print(i) }
+  for (item in items) { print(item) }
+  for (item, i in items) { print(i, item) }
+  const doubled = [x * 2 for x in items]
+  print(doubled)
+}`],
+    ["the switch replacement", `node main(x: string) {
+  match (x) {
+    "a" => doThing()
+    "b" => doOtherThing()
+    _   => fallback()
+  }
+}`],
+  ])("%s", (_name, example) => {
+    expect(parses(example)).toBe(true);
+  });
+});

--- a/packages/agency-lang/lib/parsers/errorExamples.test.ts
+++ b/packages/agency-lang/lib/parsers/errorExamples.test.ts
@@ -1,5 +1,24 @@
 import { describe, it, expect } from "vitest";
 import { parseAgency } from "@/parser.js";
+import {
+  C_STYLE_FOR_MESSAGE,
+  HANDLER_BODY_MESSAGE,
+  IF_EXPRESSION_MESSAGE,
+  MATCH_CASES_MESSAGE,
+  SWITCH_MESSAGE,
+  TERNARY_MESSAGE,
+} from "./messages.js";
+
+/** Pull the code example out of a message. `messages.ts` requires every example
+ *  to be indented by exactly two spaces, which is what makes this possible;
+ *  prose lines are flush left. */
+function exampleFrom(message: string): string {
+  return message
+    .split("\n")
+    .filter((line) => line.startsWith("  "))
+    .map((line) => line.slice(2))
+    .join("\n");
+}
 
 function failure(src: string) {
   const parsed = parseAgency(src, {}, false);
@@ -21,6 +40,37 @@ describe("ternaries are refused with the if-then-else form", () => {
     const message = failure(src);
     expect(message).toMatch(/no ternary/);
     expect(message).toContain("if isProd then");
+  });
+
+  // Prettier wraps any ternary past the line limit onto three lines, so this
+  // is the shape a model has seen most. Skipping only spaces missed it
+  // entirely and fell through to the catch-all.
+  it.each([
+    ["wrapped across three lines", `node main() {\n  const y = cond\n    ? a\n    : b\n}`],
+    ["a newline after the question mark", `node main() { const y = cond ?\n a : b }`],
+    ["a newline before the colon", `node main() { const y = cond ? a\n : b }`],
+  ])("catches a ternary %s", (_name, src) => {
+    expect(failure(src)).toMatch(/no ternary/);
+  });
+
+  // The inner refusal fires first and anchors the message at the inner `?`.
+  // Recorded because the behaviour is a consequence of the wrapper running on
+  // every expression, not something designed.
+  it("reports a nested ternary at the inner question mark", () => {
+    const message = failure(`node main() { const y = a ? b ? c : d : e }`);
+    expect(message).toMatch(/no ternary/);
+    expect(message).toMatch(/^Line 1, col 3[0-9]:/);
+  });
+
+  // Unlike the statement-level probes, this one runs inside speculative
+  // branches. A ternary refusal recorded in a branch that is later discarded
+  // must not outrank the real failure.
+  it("does not hijack an unrelated later failure", () => {
+    const message = failure(
+      `node main() {\n  match (x) {\n    1 => print(1)\n    _ => print(2)\n  }\n  switch (y) { case 1: print(1) }\n}`,
+    );
+    expect(message).toMatch(/no `switch` statement/);
+    expect(message).not.toMatch(/no ternary/);
   });
 
   it("reports a real position rather than the body catch-all", () => {
@@ -70,50 +120,44 @@ describe("messages carry a worked example", () => {
  * Agency. An example that does not parse is worse than no example: it teaches
  * the wrong thing to exactly the reader who is already stuck.
  *
- * Each entry is the example as it appears in its message, wrapped in the least
- * scaffolding needed to stand alone.
+ * The example is EXTRACTED from the real message string rather than
+ * transcribed here, so editing a message cannot leave this passing on a stale
+ * copy. Extraction keys on the two-space indent that `messages.ts` requires of
+ * every example.
+ *
+ * The scaffolding around each example (the types and node it needs to stand
+ * alone) still has to be written by hand; `%s` in it marks where the extracted
+ * block goes.
  */
 describe("every example in a parser message is valid Agency", () => {
-  it.each([
-    ["match arms", `type Shape = { kind: "circle", r: number } | { kind: "square", side: number }
+  const cases: [string, string, string][] = [
+    [
+      "match arms",
+      MATCH_CASES_MESSAGE,
+      `type Shape = { kind: "circle", r: number } | { kind: "square", side: number }
 node main(shape: Shape) {
-  const area = match (shape) {
-    { kind: "circle", r } => 3.14 * r * r
-    { kind: "square", side } if (side > 0) => side * side
-    _ => {
-      print("unknown")
-      return 0
-    }
-  }
+  const area = %s
   print(area)
-}`],
-    ["if-then-else, also quoted by the ternary message", `node main(isProd: boolean) {
-  const label = if isProd then "Production" else "Local"
-  print(label)
-}`],
-    ["handler", `node main() {
-  handle {
-    read("./notes.md")
-  } with (intr) {
-    if (intr.effect == "std::read") { return approve() }
-    return reject()
-  }
-}`],
-    ["the C-style-for alternatives", `node main(items: string[]) {
-  for (i in range(0, 10)) { print(i) }
-  for (item in items) { print(item) }
-  for (item, i in items) { print(i, item) }
-  const doubled = [x * 2 for x in items]
-  print(doubled)
-}`],
-    ["the switch replacement", `node main(x: string) {
-  match (x) {
-    "a" => doThing()
-    "b" => doOtherThing()
-    _   => fallback()
-  }
-}`],
-  ])("%s", (_name, example) => {
-    expect(parses(example)).toBe(true);
+}`,
+    ],
+    ["if-then-else", IF_EXPRESSION_MESSAGE, `node main(isProd: boolean) {\n  %s\n}`],
+    ["ternary replacement", TERNARY_MESSAGE, `node main(isProd: boolean) {\n  %s\n}`],
+    ["handler", HANDLER_BODY_MESSAGE, `node main() {\n  %s\n}`],
+    ["switch replacement", SWITCH_MESSAGE, `node main(x: string) {\n  %s\n}`],
+    [
+      "C-style-for alternatives",
+      C_STYLE_FOR_MESSAGE,
+      `node main(items: string[]) {\n  %s\n  print(1)\n}`,
+    ],
+  ];
+
+  it.each(cases)("%s", (_name, message, scaffold) => {
+    const example = exampleFrom(message);
+    expect(example).not.toBe("");
+    const source = scaffold.replace("%s", example.split("\n").join("\n  "));
+    if (!parses(source)) {
+      throw new Error(`example does not parse:\n${source}`);
+    }
   });
+
 });

--- a/packages/agency-lang/lib/parsers/messages.ts
+++ b/packages/agency-lang/lib/parsers/messages.ts
@@ -1,0 +1,105 @@
+/**
+ * Parse-error messages that name an Agency replacement for something the
+ * author wrote.
+ *
+ * These live apart from the grammar because they are prose, not parsing: they
+ * are the longest strings in the parser and they change for editorial reasons
+ * rather than syntactic ones.
+ *
+ * **Indent every code example by exactly two spaces.** `errorExamples.test.ts`
+ * extracts examples from these strings by that indentation and asserts each one
+ * is valid Agency. An example that does not parse teaches the wrong thing to
+ * precisely the reader who is already stuck, so the test reads the real string
+ * rather than a transcription of it.
+ */
+
+export const BODY_DECLARATION_MESSAGE =
+  "`node`, `def` and `function` declarations are only legal at the top level of a file.";
+
+export const BODY_RESERVED_MODIFIER_MESSAGE =
+  "`static` and `export` declarations are only supported at module top level. " +
+  "Inside function and node bodies, use `optimize const ...` for optimizable local declarations or ordinary `const`/`let` declarations.";
+
+export const STATIC_LET_MESSAGE =
+  "`static let` is not allowed. Use `static const <name> = ...` for a " +
+  "once-per-process binding, or `static <expr>` (e.g. `static foo()`) " +
+  "for a once-per-process side effect.";
+
+export const STATIC_ASSIGN_MESSAGE =
+  "`static <name> = ...` is not allowed. Use `static const <name> = ...` " +
+  "for a once-per-process binding, or `static <expr>` (e.g. `static foo()`) " +
+  "for a once-per-process side effect.";
+
+export const STATIC_INNER_MESSAGE =
+  "`static` at top level must be followed by `const <name> = ...` " +
+  "or an expression statement (e.g., `static foo()` or " +
+  "`static logger.flush()`).";
+
+export const RESERVED_CLASS_MESSAGE =
+  "`class` definitions are no longer supported in Agency. " +
+  "Use functions and plain objects instead, or instantiate an imported " +
+  "JS class with `new Foo(...)`.";
+
+export const INTERFACE_EXTENDS_MESSAGE =
+  "Agency has no interface inheritance. Write `type Foo = Bar & { ... }` instead.";
+
+export const SWITCH_MESSAGE = `Agency has no \`switch\` statement. Use a \`match\` block instead:
+
+  match (x) {
+    "a" => doThing()
+    "b" => doOtherThing()
+    _   => fallback()
+  }
+
+Arms do not fall through, so no \`break\` is needed, and \`match\` checks that you covered every case. \`_\` is the catch-all.`;
+
+export const C_STYLE_FOR_MESSAGE = `Agency has no C-style \`for\` loop. To count, iterate a range:
+
+  for (i in range(0, 10)) { print(i) }
+
+To walk a collection, iterate it directly:
+
+  for (item in items) { print(item) }
+  for (item, i in items) { print(i, item) }
+
+To build a list from another list, use a comprehension:
+
+  const doubled = [x * 2 for x in items]
+
+For a condition-driven loop, use \`while (cond) { ... }\`.`;
+
+export const TERNARY_MESSAGE = `Agency has no ternary (\`? :\`). Use an \`if ... then ... else\` expression:
+
+  const label = if isProd then "Production" else "Local"
+
+The \`else\` is required. The expression is only allowed as a \`const\`/\`let\` value or a \`return\` — for anything more involved, use \`match\`.`;
+
+export const IF_EXPRESSION_MESSAGE = `an \`if ... then ... else\` expression requires an \`else\` branch:
+
+  const label = if isProd then "Production" else "Local"
+
+This is Agency's replacement for the ternary, so it always produces a value and the \`else\` is not optional. It is allowed only as a \`const\`/\`let\` value or a \`return\`, and does not nest — use \`match\` for more than two cases.`;
+
+export const MATCH_CASES_MESSAGE = `expected match cases of the form \`value => expression\`, separated by \`;\` or newlines, followed by \`}\`:
+
+  match (shape) {
+    { kind: "circle", r } => 3.14 * r * r
+    { kind: "square", side } if (side > 0) => side * side
+    _ => {
+      print("unknown")
+      return 0
+    }
+  }
+
+An arm is \`pattern => expression\`, with an optional \`if (...)\` guard before the arrow. Use a block when an arm needs several statements. \`_\` is the catch-all, and an open type such as \`string\` requires one.`;
+
+export const HANDLER_BODY_MESSAGE = `expected \`{\` to open handler body:
+
+  handle {
+    read("./notes.md")
+  } with (intr) {
+    if (intr.effect == "std::read") { return approve() }
+    return reject()
+  }
+
+The handler takes the interrupt and returns \`approve()\`, \`reject()\`, \`propagate()\` or \`pass()\`. \`with approve\` is shorthand for a handler that approves everything.`;

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -7,6 +7,21 @@
 // --- tarsec imports (combined from all parser files) ---
 import { TarsecError } from "tarsec";
 import {
+  BODY_DECLARATION_MESSAGE,
+  BODY_RESERVED_MODIFIER_MESSAGE,
+  C_STYLE_FOR_MESSAGE,
+  HANDLER_BODY_MESSAGE,
+  IF_EXPRESSION_MESSAGE,
+  INTERFACE_EXTENDS_MESSAGE,
+  MATCH_CASES_MESSAGE,
+  RESERVED_CLASS_MESSAGE,
+  STATIC_ASSIGN_MESSAGE,
+  STATIC_INNER_MESSAGE,
+  STATIC_LET_MESSAGE,
+  SWITCH_MESSAGE,
+  TERNARY_MESSAGE,
+} from "./messages.js";
+import {
   anyChar,
   between,
   buildExpressionParser,
@@ -2128,8 +2143,6 @@ const baseTypeAliasParserFor = (keyword: string, separator: Parser<unknown>) => 
   ),
 ));
 
-const INTERFACE_EXTENDS_MESSAGE =
-  "Agency has no interface inheritance. Write `type Foo = Bar & { ... }` instead.";
 
 /**
  * `interface Foo extends Bar { ... }` is a shape models write constantly.
@@ -3589,13 +3602,6 @@ const atomWithIs: Parser<Expression> = (input: string) => {
 // Operator table: highest precedence first.
 // Multi-char operators must come before their single-char prefixes
 // (e.g., *= before *, <= before <).
-const TERNARY_MESSAGE =
-  "Agency has no ternary (`? :`). Use an `if ... then ... else` expression:\n" +
-  "\n" +
-  "  const label = if isProd then \"Production\" else \"Local\"\n" +
-  "\n" +
-  "The `else` is required. The expression is only allowed as a `const`/`let` " +
-  "value or a `return` — for anything more involved, use `match`.";
 
 const _exprParserBase: Parser<Expression> = label("an expression", memo("exprParser", buildExpressionParser<Expression>(
   atomWithIs,
@@ -3664,28 +3670,27 @@ const _exprParserBase: Parser<Expression> = label("an expression", memo("exprPar
 /**
  * `exprParser` plus one refusal: a JavaScript ternary.
  *
- * The check lives here rather than in the statement list because a ternary
- * never appears in statement position — it is the value of an assignment, the
- * operand of a return, an argument, an object field. Wrapping the expression
- * parser is what reaches all of those at once.
- *
- * Without it the author gets the enclosing `parseError`'s catch-all, `expected
- * node body`, with no position and no hint.
- *
- * Cost is a single character peek on every successful expression parse; the
- * expensive branch only runs once a bare `?` is actually sitting there.
+ * Wraps the expression parser rather than joining the statement-level probes
+ * because a ternary is always a value — of an assignment, a return, an
+ * argument, an object field — and never a statement.
  */
+/** `?` not followed by `.` or `?`. Optional chaining and nullish coalescing are
+ *  both real Agency operators, so a bare `?` is the only ternary candidate.
+ *  Built once: this runs on every successful expression parse. */
+const ternaryMarker = seqC(char("?"), not(oneOf(".?")));
+
 const ternaryRefusal = (rest: string): ParserFailure | null => {
-  const afterExpr = optionalSpaces(rest);
-  if (!afterExpr.success) return null;
-  // `?.` (optional chaining) and `??` (nullish coalescing) are both real
-  // Agency operators, so a bare `?` is the only ternary candidate.
-  const marker = seqC(char("?"), not(oneOf(".?")))(afterExpr.rest);
+  // Newlines are crossed on purpose. Prettier wraps any ternary past the line
+  // limit onto three lines, so `cond\n  ? a\n  : b` is the shape a model has
+  // seen most, and skipping only spaces would miss it. A statement cannot begin
+  // with `?`, so a `?` on the next line is unambiguously a continuation.
+  const afterExpr = optionalSpacesOrNewline(rest);
+  const marker = ternaryMarker(afterExpr.success ? afterExpr.rest : rest);
   if (!marker.success) return null;
   const tail = seqC(
-    optionalSpaces,
+    optionalSpacesOrNewline,
     lazy(() => exprParser),
-    optionalSpaces,
+    optionalSpacesOrNewline,
     char(":"),
   )(marker.rest);
   if (!tail.success) return null;
@@ -4235,21 +4240,7 @@ export const matchBlockExprParser = label("a match expression", withLoc(seqC(
   char("{"),
   captureCaptures(
     parseError(
-      "expected match cases of the form `value => expression`, separated by " +
-        "`;` or newlines, followed by `}`:\n" +
-        "\n" +
-        "  match (shape) {\n" +
-        '    { kind: "circle", r } => 3.14 * r * r\n' +
-        '    { kind: "square", side } if (side > 0) => side * side\n' +
-        "    _ => {\n" +
-        "      print(\"unknown\")\n" +
-        "      return 0\n" +
-        "    }\n" +
-        "  }\n" +
-        "\n" +
-        "An arm is `pattern => expression`, with an optional `if (...)` guard " +
-        "before the arrow. Use a block when an arm needs several statements. " +
-        "`_` is the catch-all, and an open type such as `string` requires one.",
+      MATCH_CASES_MESSAGE,
       optionalSpacesOrNewline,
       capture(many(or(blankLineParser, commentParser, matchBlockParserCase)), "cases"),
       optionalSpaces,
@@ -4773,17 +4764,6 @@ export const modifiedAssignmentParser: Parser<Assignment> = withLoc((input: stri
   return success(out, result.rest);
 });
 
-const SWITCH_MESSAGE =
-  "Agency has no `switch` statement. Use a `match` block instead:\n" +
-  "\n" +
-  "  match (x) {\n" +
-  '    "a" => doThing()\n' +
-  '    "b" => doOtherThing()\n' +
-  "    _   => fallback()\n" +
-  "  }\n" +
-  "\n" +
-  "Arms do not fall through, so no `break` is needed, and `match` checks that " +
-  "you covered every case. `_` is the catch-all.";
 
 /**
  * `switch` is a construct Agency deliberately does not have — `match` differs
@@ -4833,21 +4813,6 @@ const switchStatementParser: Parser<never> = (input: string) => {
   return declined as ParserResult<never>;
 };
 
-const C_STYLE_FOR_MESSAGE =
-  "Agency has no C-style `for` loop. To count, iterate a range:\n" +
-  "\n" +
-  "  for (i in range(0, 10)) { print(i) }\n" +
-  "\n" +
-  "To walk a collection, iterate it directly:\n" +
-  "\n" +
-  "  for (item in items) { print(item) }\n" +
-  "  for (item, i in items) { print(i, item) }\n" +
-  "\n" +
-  "To build a list from another list, use a comprehension:\n" +
-  "\n" +
-  "  const doubled = [x * 2 for x in items]\n" +
-  "\n" +
-  "For a condition-driven loop, use `while (cond) { ... }`.";
 
 /**
  * A C-style `for (let i = 0; i < n; i++)`. Without this the author gets
@@ -4880,8 +4845,6 @@ const cStyleForParser: Parser<never> = (input: string) => {
   return declined as ParserResult<never>;
 };
 
-const BODY_DECLARATION_MESSAGE =
-  "`node`, `def` and `function` declarations are only legal at the top level of a file.";
 
 /**
  * Decline a statement that starts like a `node` or `def` declaration.
@@ -4944,9 +4907,6 @@ const bodyOptimizeAssignmentParser: Parser<Assignment> = (input: string) => {
   return failure("expected optimize assignment", input);
 };
 
-const BODY_RESERVED_MODIFIER_MESSAGE =
-  "`static` and `export` declarations are only supported at module top level. " +
-  "Inside function and node bodies, use `optimize const ...` for optimizable local declarations or ordinary `const`/`let` declarations.";
 
 const bodyReservedModifierParser: Parser<never> = (input: string) => {
   const probe = seqC(
@@ -4995,20 +4955,8 @@ const bodyReservedModifierParser: Parser<never> = (input: string) => {
  * the wrapper never appears again — downstream codegen sees only the
  * inner statement.
  */
-const STATIC_LET_MESSAGE =
-  "`static let` is not allowed. Use `static const <name> = ...` for a " +
-  "once-per-process binding, or `static <expr>` (e.g. `static foo()`) " +
-  "for a once-per-process side effect.";
 
-const STATIC_ASSIGN_MESSAGE =
-  "`static <name> = ...` is not allowed. Use `static const <name> = ...` " +
-  "for a once-per-process binding, or `static <expr>` (e.g. `static foo()`) " +
-  "for a once-per-process side effect.";
 
-const STATIC_INNER_MESSAGE =
-  "`static` at top level must be followed by `const <name> = ...` " +
-  "or an expression statement (e.g., `static foo()` or " +
-  "`static logger.flush()`).";
 
 export const staticStatementParser: Parser<StaticStatement> = withLoc(
   (input: string) => {
@@ -5311,18 +5259,7 @@ const inlineHandlerParser: Parser<HandleBlock["handler"]> = (input) => {
     optionalSpaces,
     captureCaptures(
       parseError(
-        "expected `{` to open handler body:\n" +
-          "\n" +
-          "  handle {\n" +
-          '    read("./notes.md")\n' +
-          "  } with (intr) {\n" +
-          '    if (intr.effect == "std::read") { return approve() }\n' +
-          "    return reject()\n" +
-          "  }\n" +
-          "\n" +
-          "The handler takes the interrupt and returns `approve()`, `reject()`, " +
-          "`propagate()` or `pass()`. `with approve` is shorthand for a handler " +
-          "that approves everything.",
+        HANDLER_BODY_MESSAGE,
         char("{"),
         optionalSpacesOrNewline,
         capture(bodyParser, "body"),
@@ -5629,14 +5566,7 @@ export const ifExpressionParser: Parser<IfElse> = label(
     optionalSpacesOrNewline,
     captureCaptures(
       parseError(
-        "an `if ... then ... else` expression requires an `else` branch:\n" +
-          "\n" +
-          '  const label = if isProd then "Production" else "Local"\n' +
-          "\n" +
-          "This is Agency's replacement for the ternary, so it always produces " +
-          "a value and the `else` is not optional. It is allowed only as a " +
-          "`const`/`let` value or a `return`, and does not nest — use `match` " +
-          "for more than two cases.",
+        IF_EXPRESSION_MESSAGE,
         str("else"),
         not(varNameChar),
         optionalSpacesOrNewline,
@@ -6340,10 +6270,6 @@ export const graphNodeParser: Parser<GraphNodeDefinition> = label("a node defini
 //   over an always-failing inner parser to throw a `TarsecError` that
 //   bypasses `or()` backtracking entirely. `parseAgency` already catches
 //   `TarsecError` and surfaces it as a normal parse diagnostic.
-const RESERVED_CLASS_MESSAGE =
-  "`class` definitions are no longer supported in Agency. " +
-  "Use functions and plain objects instead, or instantiate an imported " +
-  "JS class with `new Foo(...)`.";
 
 export const reservedClassParser: Parser<never> = (input: string) => {
   // Probe: `class` followed by one-or-more space/tab and an identifier.

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -40,6 +40,7 @@ import {
   peek,
   Parser,
   ParserResult,
+  ParserFailure,
   quotedString,
   regexParser,
   sepBy,
@@ -3588,7 +3589,15 @@ const atomWithIs: Parser<Expression> = (input: string) => {
 // Operator table: highest precedence first.
 // Multi-char operators must come before their single-char prefixes
 // (e.g., *= before *, <= before <).
-export const exprParser: Parser<Expression> = label("an expression", memo("exprParser", buildExpressionParser<Expression>(
+const TERNARY_MESSAGE =
+  "Agency has no ternary (`? :`). Use an `if ... then ... else` expression:\n" +
+  "\n" +
+  "  const label = if isProd then \"Production\" else \"Local\"\n" +
+  "\n" +
+  "The `else` is required. The expression is only allowed as a `const`/`let` " +
+  "value or a `return` — for anything more involved, use `match`.";
+
+const _exprParserBase: Parser<Expression> = label("an expression", memo("exprParser", buildExpressionParser<Expression>(
   atomWithIs,
   [
     // Precedence 7: exponentiation
@@ -3651,6 +3660,48 @@ export const exprParser: Parser<Expression> = label("an expression", memo("exprP
   ],
   parenParser,
 )));
+
+/**
+ * `exprParser` plus one refusal: a JavaScript ternary.
+ *
+ * The check lives here rather than in the statement list because a ternary
+ * never appears in statement position — it is the value of an assignment, the
+ * operand of a return, an argument, an object field. Wrapping the expression
+ * parser is what reaches all of those at once.
+ *
+ * Without it the author gets the enclosing `parseError`'s catch-all, `expected
+ * node body`, with no position and no hint.
+ *
+ * Cost is a single character peek on every successful expression parse; the
+ * expensive branch only runs once a bare `?` is actually sitting there.
+ */
+const ternaryRefusal = (rest: string): ParserFailure | null => {
+  const afterExpr = optionalSpaces(rest);
+  if (!afterExpr.success) return null;
+  // `?.` (optional chaining) and `??` (nullish coalescing) are both real
+  // Agency operators, so a bare `?` is the only ternary candidate.
+  const marker = seqC(char("?"), not(oneOf(".?")))(afterExpr.rest);
+  if (!marker.success) return null;
+  const tail = seqC(
+    optionalSpaces,
+    lazy(() => exprParser),
+    optionalSpaces,
+    char(":"),
+  )(marker.rest);
+  if (!tail.success) return null;
+  return committedFailure(TERNARY_MESSAGE, tail.rest);
+};
+
+export const exprParser: Parser<Expression> = (input: string) => {
+  const result = _exprParserBase(input);
+  if (!result.success) return result;
+  const refused = ternaryRefusal(result.rest);
+  if (!refused) return result;
+  // The enclosing node body is wrapped in a `parseError` that would otherwise
+  // win the reporting contest, so record the commit in the parse state too.
+  getParseState().committedFailure = refused;
+  return refused as ParserResult<Expression>;
+};
 
 // Wire up the circular reference for parenParser
 _exprParser = exprParser;
@@ -4184,7 +4235,21 @@ export const matchBlockExprParser = label("a match expression", withLoc(seqC(
   char("{"),
   captureCaptures(
     parseError(
-      "expected match cases of the form `value => expression` separated by `;` or newlines, followed by `}`",
+      "expected match cases of the form `value => expression`, separated by " +
+        "`;` or newlines, followed by `}`:\n" +
+        "\n" +
+        "  match (shape) {\n" +
+        '    { kind: "circle", r } => 3.14 * r * r\n' +
+        '    { kind: "square", side } if (side > 0) => side * side\n' +
+        "    _ => {\n" +
+        "      print(\"unknown\")\n" +
+        "      return 0\n" +
+        "    }\n" +
+        "  }\n" +
+        "\n" +
+        "An arm is `pattern => expression`, with an optional `if (...)` guard " +
+        "before the arrow. Use a block when an arm needs several statements. " +
+        "`_` is the catch-all, and an open type such as `string` requires one.",
       optionalSpacesOrNewline,
       capture(many(or(blankLineParser, commentParser, matchBlockParserCase)), "cases"),
       optionalSpaces,
@@ -5246,7 +5311,18 @@ const inlineHandlerParser: Parser<HandleBlock["handler"]> = (input) => {
     optionalSpaces,
     captureCaptures(
       parseError(
-        "expected `{` to open handler body",
+        "expected `{` to open handler body:\n" +
+          "\n" +
+          "  handle {\n" +
+          '    read("./notes.md")\n' +
+          "  } with (intr) {\n" +
+          '    if (intr.effect == "std::read") { return approve() }\n' +
+          "    return reject()\n" +
+          "  }\n" +
+          "\n" +
+          "The handler takes the interrupt and returns `approve()`, `reject()`, " +
+          "`propagate()` or `pass()`. `with approve` is shorthand for a handler " +
+          "that approves everything.",
         char("{"),
         optionalSpacesOrNewline,
         capture(bodyParser, "body"),
@@ -5553,7 +5629,14 @@ export const ifExpressionParser: Parser<IfElse> = label(
     optionalSpacesOrNewline,
     captureCaptures(
       parseError(
-        "an `if ... then ... else` expression requires an `else` branch",
+        "an `if ... then ... else` expression requires an `else` branch:\n" +
+          "\n" +
+          '  const label = if isProd then "Production" else "Local"\n' +
+          "\n" +
+          "This is Agency's replacement for the ternary, so it always produces " +
+          "a value and the `else` is not optional. It is allowed only as a " +
+          "`const`/`let` value or a `return`, and does not nest — use `match` " +
+          "for more than two cases.",
         str("else"),
         not(varNameChar),
         optionalSpacesOrNewline,


### PR DESCRIPTION
Follows #757. One new refusal, three messages that gain a worked example, and a test that keeps every example honest.

## Ternaries

```ts
const y = x ? 1 : 2
```

Before, that produced the body parser's catch-all — `expected node body`, with no line or column:

```
Agency has no ternary (`? :`). Use an `if ... then ... else` expression:

  const label = if isProd then "Production" else "Local"

The `else` is required. The expression is only allowed as a `const`/`let` value
or a `return` — for anything more involved, use `match`.
```

**The check wraps `exprParser`, not the statement list.** A ternary never appears in statement position — it is the value of an assignment, the operand of a `return`, a call argument, an object field. My first attempt registered it alongside `switchStatementParser` and it never fired once, because the body-node parser never sees it. Wrapping the expression parser reaches all four positions at once, and there are tests for each.

`?.` and `??` are both real Agency operators, so the probe requires a bare `?` — `not(oneOf(".?"))` — followed by a complete `? expr :`. Optional parameters (`def f(a?: number)`) and optional properties (`{ a?: string }`) cannot reach it: neither is in expression position, and in both the `?` is followed immediately by `:` with no expression between.

## Three messages gain an example

Chosen where the *shape* is what the reader is missing, rather than a token at a known place.

**`match` arms** — Agency's most distinctive construct, and the one agents arrive at from `switch`. Now shows patterns, a guard, a block arm and the catch-all, and states the arm grammar.

**`if ... then ... else`** — names itself as the ternary replacement, since the reader is often someone who just learned there is no `? :`, and gives the else-required and no-nesting rules.

**Handler body** — shows the `handle { } with (intr) { }` shape, the four verbs, and the `with approve` shorthand, none of which were guessable from "expected `{` to open handler body".

## Left alone deliberately

The positional messages — "expected `,` between parameters", "expected `{` to open while loop body", "unterminated destructive block". They name the exact missing token at a known place; an example would be noise. Same for the list-comprehension family, whose syntax matches Python's and whose messages already name the missing piece.

The `static` family, `class`, `interface extends` and the import messages already carry inline examples. They were the model for these.

## A test that keeps the examples honest

`errorExamples.test.ts` asserts that **every code example embedded in a parser error message is itself valid Agency**, including the two shipped in #757. An example that does not parse is worse than no example — it teaches the wrong thing to exactly the reader who is already stuck.

## Verification

- Full unit suite: **10186 passed, 0 failed**.
- `make` builds the whole stdlib and every example through the wrapped expression parser.
- All 16 perf tests pass, including `parse.perf` still scaling linearly — relevant because the wrapper adds a peek to every successful expression parse. The expensive branch only runs once a bare `?` is actually present.
- Swept every `.agency` file in `tests/`, `examples/` and `stdlib/` for a bare `?`: 234 files match, and every one is inside a string literal or a comment. No false-positive surface.

Reviewers: the suite needs a built `dist/`. In a fresh worktree without `make` first, ~114 unrelated tests fail with "Failed to resolve entry for package agency-lang".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
