### PR TITLE
Accept arrow functions as block arguments

### DIFF
--- a/packages/agency-lang/lib/parsers/arrowBlocks.test.ts
+++ b/packages/agency-lang/lib/parsers/arrowBlocks.test.ts
@@ -53,6 +53,81 @@ describe("arrow functions parse to the canonical block AST", () => {
   ])("%s", (_name, arrow, canonical) => {
     expect(program(arrow)).toEqualWithoutLoc(program(canonical));
   });
+
+  it.each([
+    [
+      "typed parameters",
+      `node main() { const y = map(xs, (n: number) => n * 2) }`,
+      `node main() { const y = map(xs, \\(n: number) -> n * 2) }`,
+    ],
+    [
+      "multiple parameters with a braced body",
+      `node main() { const y = mapWithIndex(xs, (n, i) => { return n * i }) }`,
+      `node main() { const y = mapWithIndex(xs) as (n, i) { return n * i } }`,
+    ],
+    // Prettier wraps an arrow whose body passes the line limit, so this is a
+    // shape models produce. The canonical `\\n ->` form still does not accept
+    // it; this deliberately goes further, since meeting that habit is the point.
+    [
+      "a body on the next line",
+      `node main() { const r = map(items, (item) =>\n  item * 2\n) }`,
+      `node main() { const r = map(items, \\item -> item * 2) }`,
+    ],
+    // `async` is accepted and discarded, like `await` and `sync`.
+    [
+      "an async arrow",
+      `node main() { const y = map(xs, async (n) => n * 2) }`,
+      `node main() { const y = map(xs, \\n -> n * 2) }`,
+    ],
+  ])("%s", (_name, arrow, canonical) => {
+    expect(program(arrow)).toEqualWithoutLoc(program(canonical));
+  });
+
+  // JavaScript famously reads these braces as a block. Here `braced` tries
+  // first, `bodyParser` declines, and it falls through to `exprParser`, which
+  // reads an object literal. Pinned because it depends on that ordering.
+  it("reads a braced object literal body as an object, not a block", () => {
+    expect(program(`node main() { const y = f((n) => { a: 1 }) }`))
+      .toEqualWithoutLoc(program(`node main() { const y = f(\\n -> { a: 1 }) }`));
+  });
+
+  it("requires `()` for a zero-parameter arrow", () => {
+    // `blockParamsParser` returns an empty list without consuming, so a bare
+    // `=>` would otherwise read as a zero-parameter block.
+    expect(parses(`node main() { f(=> 1) }`)).toBe(false);
+    expect(parses(`node main() { f(() => 1) }`)).toBe(true);
+    // The canonical zero-parameter form is unaffected.
+    expect(parses(`node main() { f(\\ -> 1) }`)).toBe(true);
+  });
+
+  // A block is not a value, so it cannot be a block's body either. The
+  // canonical form behaves identically; pinned so a reorder cannot change it
+  // silently.
+  it("does not support currying", () => {
+    expect(parses(`node main() { const y = map(xs, (a) => (b) => a + b) }`)).toBe(false);
+    expect(parses(`node main() { const y = map(xs, \\a -> \\b -> a + b) }`)).toBe(false);
+  });
+});
+
+describe("a block assigned to a variable gets a message, not the catch-all", () => {
+  it.each([
+    ["the arrow spelling", `node main() { const double = (n) => n * 2 }`],
+    ["the canonical spelling", `node main() { const double = \\n -> n * 2 }`],
+    ["let rather than const", `node main() { let double = (n) => n * 2 }`],
+    ["an async arrow", `node main() { const double = async (n) => n * 2 }`],
+  ])("catches %s", (_name, src) => {
+    const parsed = parseAgency(src, {}, false);
+    expect(parsed.success).toBe(false);
+    if (parsed.success) return;
+    expect(parsed.message).toMatch(/blocks are arguments, not values/);
+    expect(parsed.message).toContain("def double");
+  });
+
+  it("leaves an ordinary assignment alone", () => {
+    expect(parses(`node main() { const double = 2 }`)).toBe(true);
+    expect(parses(`node main() { const f = someFn }`)).toBe(true);
+    expect(parses(`node main() { const eq = a == b }`)).toBe(true);
+  });
 });
 
 describe("agency fmt normalizes arrow functions", () => {

--- a/packages/agency-lang/lib/parsers/arrowBlocks.test.ts
+++ b/packages/agency-lang/lib/parsers/arrowBlocks.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { parseAgency } from "@/parser.js";
+import { formatSource } from "@/formatter.js";
+
+function program(src: string) {
+  const parsed = parseAgency(src, {}, false);
+  if (!parsed.success) throw new Error(`expected a successful parse, got: ${parsed.message}`);
+  return parsed.result;
+}
+
+function parses(src: string) {
+  return parseAgency(src, {}, false).success;
+}
+
+describe("arrow functions parse to the canonical block AST", () => {
+  it.each([
+    [
+      "one parenthesized parameter",
+      `node main() { const y = map(xs, (n) => n * 2) }`,
+      `node main() { const y = map(xs, \\n -> n * 2) }`,
+    ],
+    [
+      "one bare parameter",
+      `node main() { const y = map(xs, n => n * 2) }`,
+      `node main() { const y = map(xs, \\n -> n * 2) }`,
+    ],
+    [
+      "two parameters",
+      `node main() { const y = mapWithIndex(xs, (n, i) => n * i) }`,
+      `node main() { const y = mapWithIndex(xs, \\(n, i) -> n * i) }`,
+    ],
+    [
+      "no parameters",
+      `node main() { const y = twice(() => 5) }`,
+      `node main() { const y = twice(\\ -> 5) }`,
+    ],
+    [
+      "as a named argument",
+      `node main() { const y = map(xs, func = (n) => n * 2) }`,
+      `node main() { const y = map(xs, func: \\n -> n * 2) }`,
+    ],
+    // A braced body is the `as` form, not the inline one.
+    [
+      "a braced body",
+      `node main() { const y = map(xs, (n) => { return n * 2 }) }`,
+      `node main() { const y = map(xs) as n { return n * 2 } }`,
+    ],
+    [
+      "a braced body with several statements",
+      `node main() { const y = map(xs, (n) => { print(n)\nreturn n * 2 }) }`,
+      `node main() { const y = map(xs) as n { print(n)\nreturn n * 2 } }`,
+    ],
+  ])("%s", (_name, arrow, canonical) => {
+    expect(program(arrow)).toEqualWithoutLoc(program(canonical));
+  });
+});
+
+describe("agency fmt normalizes arrow functions", () => {
+  it("prints an expression body as an inline block", () => {
+    const formatted = formatSource(`node main() { const y = map(xs, (n) => n * 2) }`);
+    expect(formatted).toContain("\\n -> n * 2");
+    expect(formatted).not.toContain("=>");
+  });
+
+  it("prints a braced body as an `as` block", () => {
+    const formatted = formatSource(`node main() { const y = map(xs, (n) => { return n * 2 }) }`);
+    expect(formatted).toContain("as n {");
+    expect(formatted).not.toContain("=>");
+  });
+
+  it("formatting twice is a fixed point", () => {
+    for (const src of [
+      `node main() { const y = map(xs, (n) => n * 2) }`,
+      `node main() { const y = map(xs, (n) => { return n * 2 }) }`,
+    ]) {
+      const once = formatSource(src);
+      expect(once).not.toBeNull();
+      expect(formatSource(once as string)).toBe(once);
+    }
+  });
+});
+
+describe("things that look like arrows but are not", () => {
+  it.each([
+    ["a parenthesized argument", `node main() { print((a + b)) }`],
+    ["plain arguments", `node main() { f(a, b, c) }`],
+    ["nested calls", `node main() { f(g(x), h(y)) }`],
+    ["named arguments", `node main() { greet(name: "A", greeting: "B") }`],
+    ["a comparison", `node main() { f(a >= b) }`],
+    ["an object literal", `node main() { f({ a: 1 }) }`],
+    ["a function type in a signature", `def f(cb: (string) -> string) { print(1) }\nnode main() { f(g) }`],
+    ["the backslash block form", `node main() { const y = map(xs, \\n -> n * 2) }`],
+    ["the as block form", `node main() { const y = map(xs) as n { return n * 2 } }`],
+    ["an arrow nested in another call", `node main() { const y = [1, 2]\nprint(map(y, (n) => n + 1)) }`],
+  ])("leaves %s alone", (_name, src) => {
+    expect(parses(src)).toBe(true);
+  });
+
+  // Match arms use `=>` too. The arrow parser only runs in argument position,
+  // so the two cannot meet.
+  it("leaves match arms alone", () => {
+    expect(parses(`node main() { match (x) { 1 => print(1) _ => print(2) } }`)).toBe(true);
+  });
+});

--- a/packages/agency-lang/lib/parsers/messages.ts
+++ b/packages/agency-lang/lib/parsers/messages.ts
@@ -103,3 +103,14 @@ export const HANDLER_BODY_MESSAGE = `expected \`{\` to open handler body:
   }
 
 The handler takes the interrupt and returns \`approve()\`, \`reject()\`, \`propagate()\` or \`pass()\`. \`with approve\` is shorthand for a handler that approves everything.`;
+
+export const BLOCK_AS_VALUE_MESSAGE = `Agency blocks are arguments, not values, so a block cannot be assigned to a variable:
+
+  const double = (n) => n * 2      // not allowed
+  const doubled = map(xs, (n) => n * 2)
+
+Pass the block directly to the function that takes it. If you want a reusable
+function, declare one with \`def\`:
+
+  def double(n: number): number { return n * 2 }
+  const doubled = map(xs, double)`;

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -7,6 +7,7 @@
 // --- tarsec imports (combined from all parser files) ---
 import { TarsecError } from "tarsec";
 import {
+  BLOCK_AS_VALUE_MESSAGE,
   BODY_DECLARATION_MESSAGE,
   BODY_RESERVED_MODIFIER_MESSAGE,
   C_STYLE_FOR_MESSAGE,
@@ -4024,34 +4025,31 @@ export const inlineBlockParser: Parser<BlockArgument> = memo(
 
 /**
  * A JavaScript arrow function in argument position, accepted as a second
- * spelling of a block argument:
+ * spelling of a block argument. An expression body builds the node
+ * `inlineBlockParser` builds; a braced body builds the node the `as` form
+ * builds, so neither records the spelling and `agency fmt` prints canonical.
  *
- *   map(xs, (n) => n * 2)     is  map(xs, \n -> n * 2)
- *   map(xs, n => n * 2)       is  map(xs, \n -> n * 2)
- *   map(xs, () => 5)          is  map(xs, \ -> 5)
- *   map(xs, (n) => { ... })   is  map(xs) as n { ... }
- *
- * Both bodies are supported because both are what models write. An expression
- * body produces the same node `inlineBlockParser` does, wrapping the expression
- * in a synthetic return; a braced body produces the same node the `as` form
- * does. Nothing records which spelling was used, so `agency fmt` prints the
- * canonical one.
- *
- * MUST be tried before `exprParser` in argument position, since `(n)` and `n`
- * both parse as ordinary expressions. It only commits once the `=>` is there,
- * so anything else backtracks cleanly.
+ * MUST precede `exprParser` in argument position: `(n)` and `n` are both
+ * ordinary expressions, so the arrow form needs first refusal on them. It
+ * commits only once `=>` is present.
  */
 const arrowBlockParser: Parser<BlockArgument> = memo(
   "arrowBlockParser",
   (input: string): ParserResult<BlockArgument> => {
-    const head = seqC(
-      capture(blockParamsParser, "params"),
-      optionalSpaces,
-      str("=>"),
-      optionalSpaces,
-    )(input);
-    if (!head.success) return head as ParserResult<BlockArgument>;
-    const params = head.result.params as FunctionParameter[];
+    // `async` is accepted and discarded, the same treatment `await` and `sync`
+    // already get: models write it from JS habit and Agency awaits everything.
+    const afterAsync = optional(seqC(str("async"), spaces))(input);
+    const rest = afterAsync.success ? afterAsync.rest : input;
+
+    // `blockParamsParser` returns an empty list without consuming when it
+    // matches nothing, so a bare `=>` would otherwise read as a zero-parameter
+    // block. JavaScript requires `()` there and so do we.
+    const params = blockParamsParser(rest);
+    if (!params.success) return params as ParserResult<BlockArgument>;
+    if (params.rest === rest) return failure("expected arrow function parameters", input);
+
+    const arrow = seqC(optionalSpaces, str("=>"), optionalSpacesOrNewline)(params.rest);
+    if (!arrow.success) return arrow as ParserResult<BlockArgument>;
 
     const braced = seqC(
       char("{"),
@@ -4059,26 +4057,26 @@ const arrowBlockParser: Parser<BlockArgument> = memo(
       capture(lazy(() => bodyParser), "body"),
       optionalSpacesOrNewline,
       char("}"),
-    )(head.rest);
+    )(arrow.rest);
     if (braced.success) {
       return success(
         {
           type: "blockArgument" as const,
           inline: false,
-          params,
+          params: params.result,
           body: braced.result.body as AgencyNode[],
         },
         braced.rest,
       );
     }
 
-    const expr = lazy(() => exprParser)(head.rest);
+    const expr = lazy(() => exprParser)(arrow.rest);
     if (!expr.success) return expr as ParserResult<BlockArgument>;
     return success(
       {
         type: "blockArgument" as const,
         inline: true,
-        params,
+        params: params.result,
         body: [{ type: "returnStatement", value: expr.result } as ReturnStatement],
       },
       expr.rest,
@@ -4921,6 +4919,46 @@ const cStyleForParser: Parser<never> = (input: string) => {
 
 
 /**
+ * `const double = (n) => n * 2`. Blocks in Agency are arguments, not values,
+ * so this is not a gap in `arrowBlockParser` — the canonical `\\n -> n * 2`
+ * fails in the same position for the same reason. What was missing is the
+ * message: it landed on the body parser's catch-all with no position.
+ *
+ * Detects both spellings, since the canonical one deserves the message too.
+ */
+const blockAsValueParser: Parser<never> = (input: string) => {
+  const head = seqC(
+    oneOfStr(["const", "let"]),
+    spaces,
+    many1WithJoin(varNameChar),
+    optionalSpaces,
+    char("="),
+    not(char("=")),
+    optionalSpaces,
+  )(input);
+  if (!head.success) return failure("", input);
+
+  const arrow = seqC(
+    optional(seqC(str("async"), spaces)),
+    blockParamsParser,
+    optionalSpaces,
+    str("=>"),
+  )(head.rest);
+  const backslash = seqC(
+    char("\\"),
+    optionalSpaces,
+    blockParamsParser,
+    optionalSpaces,
+    str("->"),
+  )(head.rest);
+  if (!arrow.success && !backslash.success) return failure("", input);
+
+  const declined = committedFailure(BLOCK_AS_VALUE_MESSAGE, head.rest);
+  getParseState().committedFailure = declined;
+  return declined as ParserResult<never>;
+};
+
+/**
  * Decline a statement that starts like a `node` or `def` declaration.
  *
  * A call may take a trailing block and keywords are not reserved in
@@ -5113,6 +5151,7 @@ const _bodyNodeParser: Parser<AgencyNode> = memo("bodyNodeParser", or(
   // report a missing `(` that is plainly present.
   switchStatementParser,
   cStyleForParser,
+  blockAsValueParser,
   // withModifierParser must be tried before returnStatementParser/
   // assignmentParser so that `return foo() with approve` and
   // `const x = foo() with approve` don't get partially consumed by

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -2628,7 +2628,14 @@ const namedArgumentParser: Parser<NamedArgument> = memo(
     // nor `char("=")`.
     or(char(":"), seqR(char("="), not(char("=")))),
     optionalSpaces,
-    capture(or(lazy(() => inlineBlockParser), lazy(() => exprParser)), "value"),
+    capture(
+      or(
+        lazy(() => inlineBlockParser),
+        lazy(() => arrowBlockParser),
+        lazy(() => exprParser),
+      ),
+      "value",
+    ),
   ),
 );
 
@@ -2647,6 +2654,9 @@ const argumentListParser = memo("argumentListParser", seqC(
         // `f(#...args)` needs its own alternative here.
         lazy(() => spliceHoleParser),
         lazy(() => inlineBlockParser),
+        // Before exprParser: `(n)` and `n` both parse as expressions, so the
+        // arrow form has to get first refusal on them.
+        lazy(() => arrowBlockParser),
         lazy(() => exprParser),
       ),
     ),
@@ -4010,6 +4020,70 @@ export const inlineBlockParser: Parser<BlockArgument> = memo(
       body: [{ type: "returnStatement", value: result.expr } as ReturnStatement],
     }),
   ),
+);
+
+/**
+ * A JavaScript arrow function in argument position, accepted as a second
+ * spelling of a block argument:
+ *
+ *   map(xs, (n) => n * 2)     is  map(xs, \n -> n * 2)
+ *   map(xs, n => n * 2)       is  map(xs, \n -> n * 2)
+ *   map(xs, () => 5)          is  map(xs, \ -> 5)
+ *   map(xs, (n) => { ... })   is  map(xs) as n { ... }
+ *
+ * Both bodies are supported because both are what models write. An expression
+ * body produces the same node `inlineBlockParser` does, wrapping the expression
+ * in a synthetic return; a braced body produces the same node the `as` form
+ * does. Nothing records which spelling was used, so `agency fmt` prints the
+ * canonical one.
+ *
+ * MUST be tried before `exprParser` in argument position, since `(n)` and `n`
+ * both parse as ordinary expressions. It only commits once the `=>` is there,
+ * so anything else backtracks cleanly.
+ */
+const arrowBlockParser: Parser<BlockArgument> = memo(
+  "arrowBlockParser",
+  (input: string): ParserResult<BlockArgument> => {
+    const head = seqC(
+      capture(blockParamsParser, "params"),
+      optionalSpaces,
+      str("=>"),
+      optionalSpaces,
+    )(input);
+    if (!head.success) return head as ParserResult<BlockArgument>;
+    const params = head.result.params as FunctionParameter[];
+
+    const braced = seqC(
+      char("{"),
+      optionalSpacesOrNewline,
+      capture(lazy(() => bodyParser), "body"),
+      optionalSpacesOrNewline,
+      char("}"),
+    )(head.rest);
+    if (braced.success) {
+      return success(
+        {
+          type: "blockArgument" as const,
+          inline: false,
+          params,
+          body: braced.result.body as AgencyNode[],
+        },
+        braced.rest,
+      );
+    }
+
+    const expr = lazy(() => exprParser)(head.rest);
+    if (!expr.success) return expr as ParserResult<BlockArgument>;
+    return success(
+      {
+        type: "blockArgument" as const,
+        inline: true,
+        params,
+        body: [{ type: "returnStatement", value: expr.result } as ReturnStatement],
+      },
+      expr.rest,
+    );
+  },
 );
 
 // =============================================================================


### PR DESCRIPTION
The last item from the syntax-variation audit. Arrow functions in argument position are now a second spelling of a block argument.

| Written | Canonical |
|---|---|
| `map(xs, (n) => n * 2)` | `map(xs, \n -> n * 2)` |
| `map(xs, n => n * 2)` | `map(xs, \n -> n * 2)` |
| `mapWithIndex(xs, (n, i) => n * i)` | `mapWithIndex(xs, \(n, i) -> n * i)` |
| `twice(() => 5)` | `twice(\ -> 5)` |
| `map(xs, (n) => { ... })` | `map(xs) as n { ... }` |

This is the acceptance route rather than the refusal route used for `switch`, C-style `for` and ternaries — those name constructs Agency deliberately does not have, whereas this is Agency's own block argument written in a different hand. `\n -> n * 2` is the least guessable syntax in the language, so it is the one most worth meeting halfway.

## Both bodies

An expression body produces the node `inlineBlockParser` builds, wrapping the expression in a synthetic return. A braced body produces the node the `as` form builds. Models write both, and the two map cleanly onto constructs that already exist, so there was no reason to accept only one.

Nothing records which spelling was used, so `agency fmt` prints the canonical form and `AgencyGenerator` needed no changes — the same rule as #750 and #756. Parameter parsing reuses `blockParamsParser`, which already handled `(a, b)` and a bare identifier.

## Ordering, and why it backtracks cleanly

The arrow parser has to be tried before `exprParser` in argument position, because `(n)` and `n` are both perfectly ordinary expressions. It commits only once the `=>` is actually there, so everything else falls through. Tested to be unaffected: parenthesized arguments, plain arguments, nested calls, named arguments, comparisons, object literals, function types in signatures, and both existing block forms.

Match arms use `=>` as well, but the arrow parser only runs in argument position, so the two never meet. There is a test.

## One thing I checked rather than assumed

`f(match (x) { 1 => 2 _ => 3 })` fails to parse. I stashed the change and confirmed it fails **identically** without it — this is the documented rule that a `match` expression is allowed only as a `const`/`let` value or a `return`, not nested inside another value. Not a regression, and out of scope here.

## Verification

- Full unit suite: **10213 passed, 0 failed**.
- `make` builds the whole stdlib and every example through the changed argument parser.
- All 16 perf tests pass — relevant because this adds an alternative to the argument list, which is a hot path.
- `pnpm run lint:structure` clean.

Reviewers: the suite needs a built `dist/`. In a fresh worktree without `make` first, ~114 unrelated tests fail with "Failed to resolve entry for package agency-lang".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
