### PR TITLE
feat(serve): expose function parameters in the /list manifest

### DIFF
--- a/packages/agency-lang/lib/serve/createServeHandler.test.ts
+++ b/packages/agency-lang/lib/serve/createServeHandler.test.ts
@@ -21,6 +21,7 @@ export const __toolRegistry = {
     name: "add",
     module: "agent",
     exported: true,
+    params: [{ name: "a" }, { name: "b" }],
     toolDefinition: { name: "add", description: "Add two numbers", schema: null },
   },
 };

--- a/packages/agency-lang/lib/serve/discovery.test.ts
+++ b/packages/agency-lang/lib/serve/discovery.test.ts
@@ -50,6 +50,30 @@ describe("discoverExports", () => {
     ]);
   });
 
+  it("excludes bound params from a function's parameters", () => {
+    const registry: Record<string, AgencyFunction> = {};
+    AgencyFunction.create(
+      {
+        name: "boundFn",
+        module: "test",
+        fn: async () => {},
+        params: [{ name: "visible" }, { name: "hidden", isBound: true }],
+        toolDefinition: { name: "boundFn", description: "", schema: null },
+        exported: true,
+      },
+      registry,
+    );
+
+    const exports = discoverExports({
+      toolRegistry: registry,
+      moduleExports: {},
+      moduleId: "test",
+    });
+    const fn = exports.find((e) => e.name === "boundFn");
+    // Only the unbound param is caller-facing.
+    expect(fn && fn.kind === "function" && fn.parameters).toEqual([{ name: "visible" }]);
+  });
+
   it("filters by moduleId", () => {
     const registry: Record<string, AgencyFunction> = {};
     AgencyFunction.create(

--- a/packages/agency-lang/lib/serve/discovery.test.ts
+++ b/packages/agency-lang/lib/serve/discovery.test.ts
@@ -10,7 +10,7 @@ describe("discoverExports", () => {
         name: "publicFn",
         module: "test",
         fn: async () => {},
-        params: [],
+        params: [{ name: "x" }, { name: "y" }],
         toolDefinition: {
           name: "publicFn",
           description: "A public fn",
@@ -44,6 +44,10 @@ describe("discoverExports", () => {
     const functions = exports.filter((e) => e.kind === "function");
     expect(functions).toHaveLength(1);
     expect(functions[0].name).toBe("publicFn");
+    expect(functions[0].kind === "function" && functions[0].parameters).toEqual([
+      { name: "x" },
+      { name: "y" },
+    ]);
   });
 
   it("filters by moduleId", () => {

--- a/packages/agency-lang/lib/serve/discovery.ts
+++ b/packages/agency-lang/lib/serve/discovery.ts
@@ -58,7 +58,11 @@ function toExportedFunction(
     kind: "function",
     name: fn.name,
     description: fn.toolDefinition!.description,
-    parameters: fn.params.map((param) => ({ name: param.name })),
+    // Only unbound params are caller-facing — bound params are filled at
+    // definition time and rejected if sent. Matches `logRoutes` in adapter.ts.
+    parameters: fn.params
+      .filter((param) => !param.isBound)
+      .map((param) => ({ name: param.name })),
     agencyFunction: fn,
     interruptEffects,
     invoke: makeInvoker(fn, moduleInvoke),

--- a/packages/agency-lang/lib/serve/discovery.ts
+++ b/packages/agency-lang/lib/serve/discovery.ts
@@ -58,6 +58,7 @@ function toExportedFunction(
     kind: "function",
     name: fn.name,
     description: fn.toolDefinition!.description,
+    parameters: fn.params.map((param) => ({ name: param.name })),
     agencyFunction: fn,
     interruptEffects,
     invoke: makeInvoker(fn, moduleInvoke),

--- a/packages/agency-lang/lib/serve/http/adapter.test.ts
+++ b/packages/agency-lang/lib/serve/http/adapter.test.ts
@@ -35,6 +35,7 @@ function makeExports(): {
       kind: "function",
       name: "add",
       description: "Add two numbers",
+      parameters: [{ name: "a" }, { name: "b" }],
       agencyFunction: addFn,
       interruptEffects: [],
       invoke: (namedArgs) => addFn.invoke({ type: "named", positionalArgs: [], namedArgs }),
@@ -115,6 +116,7 @@ describe("HTTP adapter", () => {
     const body = result.body as any;
     expect(body.functions).toHaveLength(1);
     expect(body.functions[0].name).toBe("add");
+    expect(body.functions[0].parameters).toEqual(["a", "b"]);
     expect(body.functions[0].interruptEffects).toEqual([]);
     expect(body.nodes).toHaveLength(1);
     expect(body.nodes[0].name).toBe("main");
@@ -154,6 +156,7 @@ describe("HTTP adapter", () => {
       kind: "function",
       name,
       description: name,
+      parameters: [],
       agencyFunction: mk(name, markers),
       interruptEffects: [],
       invoke: (namedArgs: Record<string, unknown>) =>
@@ -240,6 +243,7 @@ describe("HTTP adapter", () => {
           kind: "function",
           name: "deploy",
           description: "Deploy",
+          parameters: [],
           agencyFunction: deployFn,
           interruptEffects: [{ effect: "myapp::deploy" }],
           invoke: (namedArgs) => deployFn.invoke({ type: "named", positionalArgs: [], namedArgs }),
@@ -359,6 +363,7 @@ describe("startHttpServer auth and host validation", () => {
         kind: "function",
         name: "fail",
         description: "",
+        parameters: [],
         agencyFunction: failFn,
         interruptEffects: [],
         invoke: (namedArgs) => failFn.invoke({ type: "named", positionalArgs: [], namedArgs }),

--- a/packages/agency-lang/lib/serve/http/adapter.ts
+++ b/packages/agency-lang/lib/serve/http/adapter.ts
@@ -153,6 +153,7 @@ export function createHttpHandler(config: HandlerConfig): (
           functions: Object.values(functions).map((f) => ({
             name: f.name,
             description: f.description,
+            parameters: f.parameters.map((p) => p.name),
             // Retry-safety markers, mirroring the MCP adapter's
             // destructiveHint/idempotentHint. Only the set marker appears.
             destructive: f.agencyFunction.markers?.destructive ?? false,

--- a/packages/agency-lang/lib/serve/types.ts
+++ b/packages/agency-lang/lib/serve/types.ts
@@ -5,6 +5,9 @@ export type ExportedFunction = {
   kind: "function";
   name: string;
   description: string;
+  /** Names of the function's parameters, in declaration order — mirrors
+   *  `ExportedNode.parameters` so the manifest describes both the same way. */
+  parameters: Array<{ name: string }>;
   agencyFunction: AgencyFunction;
   interruptEffects: InterruptEffect[];
   /**


### PR DESCRIPTION
## What

The HTTP serve `/list` manifest gives **nodes** a `parameters` array but gave **functions** none — so a client (and `agency deploy`'s generated curl examples) couldn't see a function's argument names, only an empty `{}` body.

`ExportedFunction` now carries `parameters` (from the function's `AgencyFunction.params`), and the `/list` function entry lists the names, exactly like nodes already do.

## Change
- `lib/serve/types.ts` — add `parameters: Array<{ name: string }>` to `ExportedFunction`.
- `lib/serve/discovery.ts` — populate it in `toExportedFunction` from `fn.params`.
- `lib/serve/http/adapter.ts` — include `parameters` in the `/list` function entry.

## Tests
- `discovery.test.ts` — a function with params surfaces them.
- `adapter.test.ts` — `/list` reports `functions[0].parameters` (updated fixtures to include the new required field, since real `AgencyFunction`s always have `params`).
- `createServeHandler.test.ts` — fixture registry entry gains `params`.

103/103 serve tests pass; structural lint clean. (The `functionFrame.integration.test.ts` suite errors on `agency-lang/stdlib` module resolution in a local worktree — pre-existing and environmental, reproduced with these changes stashed; its 2 tests are skipped and it passes in CI.)

Unblocks templated function bodies in `agency deploy`'s curl examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
