### PR TITLE
feat(compiler): compileSource sourcePath — resolve relative imports

### DIFF
--- a/packages/agency-lang/lib/compiler/compile.test.ts
+++ b/packages/agency-lang/lib/compiler/compile.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
 import { compileSource, typeCheckSource } from "./compile.js";
 
 describe("compileSource", () => {
@@ -10,6 +13,33 @@ describe("compileSource", () => {
       expect(result.code).toContain("function");
       expect(result.moduleId).toBeTruthy();
     }
+  });
+
+  describe("sourcePath — resolving relative imports", () => {
+    const HELPERS = `export def helper(x: string): string {\n  """h"""\n  return x\n}\n`;
+    const MAIN = `import { helper } from "./helpers.agency"\n\nexport node main(x: string) {\n  return helper(x)\n}\n`;
+
+    it("resolves a relative .agency import when sourcePath is given", () => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), "compile-sourcepath-"));
+      try {
+        fs.writeFileSync(path.join(dir, "helpers.agency"), HELPERS);
+        const mainPath = path.join(dir, "main.agency");
+        fs.writeFileSync(mainPath, MAIN);
+
+        const result = compileSource(MAIN, { sourcePath: mainPath });
+        expect(result.success).toBe(true);
+        if (result.success) {
+          expect(result.code).toContain('from "./helpers.js"');
+        }
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("cannot resolve the relative import without sourcePath (single-file compile)", () => {
+      const result = compileSource(MAIN, {});
+      expect(result.success).toBe(false);
+    });
   });
 
   it("returns errors for invalid syntax", () => {

--- a/packages/agency-lang/lib/compiler/compile.test.ts
+++ b/packages/agency-lang/lib/compiler/compile.test.ts
@@ -40,6 +40,26 @@ describe("compileSource", () => {
       const result = compileSource(MAIN, {});
       expect(result.success).toBe(false);
     });
+
+    it("treats the on-disk file as authoritative when source and disk disagree", () => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), "compile-sourcepath-"));
+      try {
+        const onDisk = `export node main(): string {\n  return "from-disk"\n}\n`;
+        const mainPath = path.join(dir, "main.agency");
+        fs.writeFileSync(mainPath, onDisk);
+
+        // Pass a DIFFERENT source string; the file at sourcePath must win.
+        const stale = `export node main(): string {\n  return "from-arg"\n}\n`;
+        const result = compileSource(stale, { sourcePath: mainPath });
+        expect(result.success).toBe(true);
+        if (result.success) {
+          expect(result.code).toContain("from-disk");
+          expect(result.code).not.toContain("from-arg");
+        }
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
   });
 
   it("returns errors for invalid syntax", () => {

--- a/packages/agency-lang/lib/compiler/compile.ts
+++ b/packages/agency-lang/lib/compiler/compile.ts
@@ -58,12 +58,16 @@ export type CompileSourceOptions = AgencyConfig & {
    */
   imports?: ImportPolicy;
   /**
-   * Real on-disk path of `source`, when it already exists on disk. Given it,
-   * `compileSource` compiles at that path — where sibling `.agency` files live —
-   * so relative imports resolve. Without it, `source` is written to an isolated
-   * temp file, so relative imports cannot resolve (single-file compile). A host
-   * that stores multi-file agents on disk passes this to compile each file
-   * against its real neighbors.
+   * Real on-disk path of the file to compile. Given it, `compileSource` compiles
+   * at that path — where sibling `.agency` files live — so relative imports
+   * resolve. Without it, `source` is written to an isolated temp file, so
+   * relative imports cannot resolve (single-file compile). A host that stores
+   * multi-file agents on disk passes this to compile each file against its real
+   * neighbors.
+   *
+   * When set, the file at this path is authoritative: it is parsed AND used for
+   * symbol/import resolution, so the two can't diverge. The `source` argument is
+   * ignored (pass the file's contents for clarity, but the disk file wins).
    */
   sourcePath?: string;
 };
@@ -124,9 +128,18 @@ export function compileSource(
     fs.writeFileSync(syntheticPath, source, "utf-8");
   }
 
+  // The file at `syntheticPath` is the single source of truth: SymbolTable.build
+  // and buildCompiledClosure read the entrypoint and its imports from there, so
+  // parse the SAME bytes rather than the passed `source`. In the temp-file case
+  // that file IS `source` (just written); with a caller `sourcePath` this reads
+  // the on-disk file, so the AST and symbol/import resolution can't diverge.
+  const compiledSource = config.sourcePath
+    ? fs.readFileSync(syntheticPath, "utf-8")
+    : source;
+
   try {
     // 1. Parse
-    const parseResult = parseAgency(source, config, true);
+    const parseResult = parseAgency(compiledSource, config, true);
     if (!parseResult.success) {
       return {
         success: false,
@@ -183,7 +196,7 @@ export function compileSource(
       liftedProgram,
       symbolTable,
       syntheticPath,
-      source,
+      compiledSource,
     );
 
     // 5. Type check

--- a/packages/agency-lang/lib/compiler/compile.ts
+++ b/packages/agency-lang/lib/compiler/compile.ts
@@ -57,6 +57,15 @@ export type CompileSourceOptions = AgencyConfig & {
    * See `lib/importPaths.ts` for the ImportPolicy shape.
    */
   imports?: ImportPolicy;
+  /**
+   * Real on-disk path of `source`, when it already exists on disk. Given it,
+   * `compileSource` compiles at that path — where sibling `.agency` files live —
+   * so relative imports resolve. Without it, `source` is written to an isolated
+   * temp file, so relative imports cannot resolve (single-file compile). A host
+   * that stores multi-file agents on disk passes this to compile each file
+   * against its real neighbors.
+   */
+  sourcePath?: string;
 };
 
 // Walk every import in the program and reject anything that fails the
@@ -100,11 +109,20 @@ export function compileSource(
   config: CompileSourceOptions,
 ): CompileResult {
   const moduleId = `agency_${nanoid()}`;
-  // Write source to a temp file so SymbolTable.build() can read it.
-  // The symbol table walks the file system to resolve imports and find builtins.
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-compile-"));
-  const syntheticPath = path.join(tempDir, `${moduleId}.agency`);
-  fs.writeFileSync(syntheticPath, source, "utf-8");
+  // SymbolTable.build() walks the file system from the source's path to resolve
+  // imports. With a caller-supplied sourcePath (the file is already on disk
+  // beside its siblings), compile at that path so relative `.agency` imports
+  // resolve. Otherwise write to an isolated temp file — relative imports cannot
+  // resolve there, by design (single-file compile).
+  let tempDir: string | undefined;
+  let syntheticPath: string;
+  if (config.sourcePath) {
+    syntheticPath = config.sourcePath;
+  } else {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-compile-"));
+    syntheticPath = path.join(tempDir, `${moduleId}.agency`);
+    fs.writeFileSync(syntheticPath, source, "utf-8");
+  }
 
   try {
     // 1. Parse
@@ -240,8 +258,9 @@ export function compileSource(
       errors: [error instanceof Error ? error.message : String(error)],
     };
   } finally {
-    // Clean up temp source file (best-effort — OS cleans tmpdir eventually)
-    if (tempDir.startsWith(os.tmpdir())) {
+    // Clean up temp source file (best-effort — OS cleans tmpdir eventually).
+    // Skipped when compiling at a caller-owned sourcePath (no temp dir created).
+    if (tempDir && tempDir.startsWith(os.tmpdir())) {
       try {
         fs.rmSync(tempDir, { recursive: true });
       } catch (_) {


### PR DESCRIPTION
## What

`compileSource(source, config)` takes source as a **string**, so it can't know where that source lives on disk. To resolve an import like `import { helper } from "./helpers.agency"`, the compiler walks the filesystem — so `compileSource` wrote the source to an isolated temp dir and compiled there. The sibling `helpers.agency` isn't in that temp dir, so the import fails ("Symbol 'helper' is not defined in './helpers.agency'"). This is the root cause of statelog#9 — hosted multi-file agents can't be compiled or served.

This adds an optional `sourcePath` to `CompileSourceOptions`. When given (the file is already on disk beside its siblings), `compileSource` compiles **at that real path**, so relative `.agency` imports resolve. Without it, behavior is unchanged: the source goes to a temp file (single-file compile), exactly as before.

## Why this shape

A host that serves multi-file agents (statelog) already stores every uploaded file on disk. So it always has real paths, at upload and serve time — passing `sourcePath` is all it needs. No new public function; one optional field on the existing one.

## Test

`compile.test.ts` — a two-file agent (`main.agency` imports `./helpers.agency`): with `sourcePath` the import resolves (compiled output imports `./helpers.js`); without it, compilation fails (today's single-file behavior). 20/20 compile tests pass; build + structural lint clean.

Design was prototyped first on `proto/multifile-compile`. Follow-ups (separate PRs): statelog switches upload + serveHost to path-based compile; then `agency deploy`'s single-file refusal is relaxed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
