### PR TITLE
feat(deploy): support multi-file agents (flat same-dir siblings)

### DIFF
--- a/packages/agency-lang/docs/site/cli/deploy.md
+++ b/packages/agency-lang/docs/site/cli/deploy.md
@@ -44,9 +44,9 @@ The global `-c, --config <path>` option selects which `agency.json` to read.
 
 ## What gets uploaded
 
-`agency deploy` compiles the agent locally first, so obvious errors surface before any upload. It then sends the source; statelog compiles it again server-side.
+`agency deploy` uploads the entrypoint and every local `.agency` file it imports (transitively), compiling them locally first so obvious errors surface before any upload. statelog compiles them again server-side.
 
-**Deploy is single-file for now.** An agent that imports another local `.agency` file, or local TypeScript/JavaScript interop, is refused with a clear message — statelog compiles each uploaded file in isolation, so multi-file hosting isn't supported yet (tracked in statelog#9).
+**All the files must sit in one directory.** statelog stores an agent's files flat, so a local import that resolves outside the entrypoint's directory (e.g. `./sub/helper.agency` or `../helper.agency`) is refused. Local TypeScript/JavaScript interop imports are also refused — statelog only compiles `.agency` source.
 
 ## Running a deployed agent
 

--- a/packages/agency-lang/lib/cli/deploy/bundle.test.ts
+++ b/packages/agency-lang/lib/cli/deploy/bundle.test.ts
@@ -4,12 +4,15 @@ import path from "path";
 import { collectAgencyBundle, validateBundleCompiles } from "./bundle.js";
 
 const SINGLE = `export node main(message: string) {\n  return message\n}\n`;
+const HELPERS = `export def helper(x: string): string {\n  """h"""\n  return x\n}\n`;
+const IMPORTS_HELPER = `import { helper } from "./helpers.agency"\n\nexport node main(x: string) {\n  return helper(x)\n}\n`;
 const WITH_TS_INTEROP = `import { helper } from "./helpers.js"\n\nexport node main(x: string) {\n  return x\n}\n`;
-const WITH_AGENCY_IMPORT = `import { helper } from "./helpers.agency"\n\nexport node main(x: string) {\n  return x\n}\n`;
+const IMPORTS_NESTED = `import { deep } from "./sub/deep.agency"\n\nexport node main(x: string) {\n  return x\n}\n`;
 
 let dir: string;
 const write = (name: string, contents: string): string => {
   const filePath = path.join(dir, name);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
   fs.writeFileSync(filePath, contents, "utf-8");
   return filePath;
 };
@@ -23,13 +26,31 @@ afterAll(() => {
 
 describe("collectAgencyBundle", () => {
   it("bundles a single self-contained file", () => {
-    const result = collectAgencyBundle(write("solo.agency", SINGLE), {});
+    const soloPath = write("solo.agency", SINGLE);
+    const result = collectAgencyBundle(soloPath, {});
     expect(result.ok).toBe(true);
     if (!result.ok) {
       return;
     }
     expect(result.bundle.entrypoint).toBe("solo.agency");
-    expect(result.bundle.files).toEqual([{ name: "solo.agency", contents: SINGLE }]);
+    expect(result.bundle.files).toEqual([
+      { name: "solo.agency", contents: SINGLE, absPath: soloPath },
+    ]);
+  });
+
+  it("bundles the entrypoint and its sibling .agency imports", () => {
+    write("helpers.agency", HELPERS);
+    const mainPath = write("main.agency", IMPORTS_HELPER);
+    const result = collectAgencyBundle(mainPath, {});
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.bundle.entrypoint).toBe("main.agency");
+    expect(result.bundle.files.map((f) => f.name).sort()).toEqual([
+      "helpers.agency",
+      "main.agency",
+    ]);
   });
 
   it("refuses local TypeScript/JavaScript interop imports", () => {
@@ -42,14 +63,14 @@ describe("collectAgencyBundle", () => {
     expect(result.error).toContain("can't be deployed");
   });
 
-  it("refuses local .agency imports (multi-file not supported yet)", () => {
-    const result = collectAgencyBundle(write("multi.agency", WITH_AGENCY_IMPORT), {});
+  it("refuses an import that resolves outside the entrypoint's directory", () => {
+    write("sub/deep.agency", HELPERS);
+    const result = collectAgencyBundle(write("nested.agency", IMPORTS_NESTED), {});
     expect(result.ok).toBe(false);
     if (result.ok) {
       return;
     }
-    expect(result.error).toContain("single-file");
-    expect(result.error).toContain("statelog#9");
+    expect(result.error).toContain("outside the entrypoint's directory");
   });
 
   it("errors when the entrypoint does not exist", () => {
@@ -58,18 +79,40 @@ describe("collectAgencyBundle", () => {
     if (result.ok) {
       return;
     }
-    expect(result.error).toContain("File not found");
+    expect(result.error).toContain("not found");
   });
 });
 
 describe("validateBundleCompiles", () => {
-  it("passes for a file that compiles", () => {
-    const bundle = { entrypoint: "solo.agency", files: [{ name: "solo.agency", contents: SINGLE }] };
+  it("passes for a self-contained file", () => {
+    const soloPath = write("v-solo.agency", SINGLE);
+    const bundle = {
+      entrypoint: "v-solo.agency",
+      files: [{ name: "v-solo.agency", contents: SINGLE, absPath: soloPath }],
+    };
+    expect(validateBundleCompiles(bundle, {})).toEqual({ ok: true });
+  });
+
+  it("passes for a multi-file agent (imports resolve via sourcePath)", () => {
+    write("v-helpers.agency", HELPERS);
+    const mainPath = write("v-main.agency", IMPORTS_HELPER.replace("helpers", "v-helpers"));
+    const helpersPath = path.join(dir, "v-helpers.agency");
+    const bundle = {
+      entrypoint: "v-main.agency",
+      files: [
+        { name: "v-helpers.agency", contents: HELPERS, absPath: helpersPath },
+        { name: "v-main.agency", contents: IMPORTS_HELPER.replace("helpers", "v-helpers"), absPath: mainPath },
+      ],
+    };
     expect(validateBundleCompiles(bundle, {})).toEqual({ ok: true });
   });
 
   it("reports the file and error when compilation fails", () => {
-    const broken = { entrypoint: "bad.agency", files: [{ name: "bad.agency", contents: "node main( {" }] };
+    const badPath = write("bad.agency", "node main( {");
+    const broken = {
+      entrypoint: "bad.agency",
+      files: [{ name: "bad.agency", contents: "node main( {", absPath: badPath }],
+    };
     const result = validateBundleCompiles(broken, {});
     expect(result.ok).toBe(false);
     if (result.ok) {

--- a/packages/agency-lang/lib/cli/deploy/bundle.test.ts
+++ b/packages/agency-lang/lib/cli/deploy/bundle.test.ts
@@ -73,13 +73,13 @@ describe("collectAgencyBundle", () => {
     expect(result.error).toContain("outside the entrypoint's directory");
   });
 
-  it("errors when the entrypoint does not exist", () => {
+  it("errors clearly when the entrypoint does not exist", () => {
     const result = collectAgencyBundle(path.join(dir, "missing.agency"), {});
     expect(result.ok).toBe(false);
     if (result.ok) {
       return;
     }
-    expect(result.error).toContain("not found");
+    expect(result.error).toContain("Entrypoint not found");
   });
 });
 

--- a/packages/agency-lang/lib/cli/deploy/bundle.ts
+++ b/packages/agency-lang/lib/cli/deploy/bundle.ts
@@ -1,9 +1,8 @@
-// Turning an entrypoint into the `.agency` source to upload, and checking it
-// compiles. Deploy is single-file for now: statelog compiles each uploaded file
-// in isolation (agencyCompiler/serveHost both use `compileSource`, which loses
-// the file's location and so can't resolve relative imports), so an agent that
-// imports another local `.agency` file cannot be hosted yet. This module refuses
-// what statelog can't serve. Multi-file is tracked in statelog#9.
+// Turning an entrypoint into the set of `.agency` source files to upload, and
+// checking they compile. Statelog stores uploaded files flat (one directory,
+// keyed by basename) and its filenames can't contain slashes, so a hosted
+// agent's local imports must all be same-directory `.agency` siblings — this
+// module gathers exactly that set and refuses anything statelog can't host.
 
 import fs from "fs";
 import path from "path";
@@ -13,12 +12,16 @@ import { compileSource } from "@/compiler/compile.js";
 import {
   agencyImportTargets,
   nonAgencyLocalImportTargets,
+  resolveAgencyImportPath,
 } from "@/importPaths.js";
 
 export type BundleFile = {
   /** Upload key — the basename, which is all statelog's flat store keeps. */
   name: string;
   contents: string;
+  /** Real on-disk path — passed as `sourcePath` so the pre-flight compile
+   *  resolves this file's relative imports against its siblings. */
+  absPath: string;
 };
 
 export type AgencyBundle = {
@@ -32,65 +35,88 @@ export type CollectBundleResult =
   | { ok: false; error: string };
 
 /**
- * Collect the single-file bundle for an entrypoint. Refuses agents statelog
- * cannot host: local TypeScript/JavaScript interop imports (the server only
- * compiles `.agency` source), and — for now — any local `.agency` import
- * (multi-file hosting is blocked on statelog#9).
+ * Collect the entrypoint and every local `.agency` file it imports
+ * (transitively) into one flat bundle. Refuses agents statelog cannot host:
+ * imports that resolve outside the entrypoint's directory (the flat store can't
+ * represent subpaths), and local TypeScript/JavaScript interop imports (the
+ * server only compiles `.agency` source).
  */
 export function collectAgencyBundle(
   entrypointPath: string,
   config: AgencyConfig,
 ): CollectBundleResult {
   const entrypointAbs = path.resolve(entrypointPath);
-  if (!fs.existsSync(entrypointAbs)) {
-    return { ok: false, error: `File not found: ${entrypointAbs}` };
-  }
-  const name = path.basename(entrypointAbs);
-  const contents = fs.readFileSync(entrypointAbs, "utf-8");
+  const rootDir = path.dirname(entrypointAbs);
 
-  const parsed = parseAgency(contents, config);
-  if (!parsed.success) {
-    return { ok: false, error: `Parse error in ${name}: ${parsed.message ?? "invalid Agency source"}` };
+  const collected: Record<string, BundleFile> = {};
+  const queue: string[] = [entrypointAbs];
+
+  while (queue.length > 0) {
+    const fileAbs = queue.pop()!;
+    if (collected[fileAbs]) {
+      continue;
+    }
+    if (!fs.existsSync(fileAbs)) {
+      return { ok: false, error: `Imported file not found: ${fileAbs}` };
+    }
+
+    const name = path.basename(fileAbs);
+    const contents = fs.readFileSync(fileAbs, "utf-8");
+    const parsed = parseAgency(contents, config);
+    if (!parsed.success) {
+      return { ok: false, error: `Parse error in ${name}: ${parsed.message ?? "invalid Agency source"}` };
+    }
+    collected[fileAbs] = { name, contents, absPath: fileAbs };
+
+    const interop = nonAgencyLocalImportTargets(parsed.result);
+    if (interop.length > 0) {
+      return {
+        ok: false,
+        error:
+          `${name} imports local code ${interop.map((target) => `"${target}"`).join(", ")}. ` +
+          `Hosted agents can only use .agency files (statelog compiles the source it hosts); ` +
+          `local TypeScript/JavaScript interop can't be deployed.`,
+      };
+    }
+
+    for (const importPath of agencyImportTargets(parsed.result, { localOnly: true })) {
+      const importAbs = resolveAgencyImportPath(importPath, fileAbs);
+      if (path.dirname(importAbs) !== rootDir) {
+        return {
+          ok: false,
+          error:
+            `${name} imports "${importPath}", which resolves outside the entrypoint's directory. ` +
+            `Hosted agents must keep all .agency files in one directory (statelog stores them flat).`,
+        };
+      }
+      queue.push(importAbs);
+    }
   }
 
-  const interop = nonAgencyLocalImportTargets(parsed.result);
-  if (interop.length > 0) {
-    return {
-      ok: false,
-      error:
-        `${name} imports local code ${interop.map((target) => `"${target}"`).join(", ")}. ` +
-        `Hosted agents can only use .agency files (statelog compiles the source it hosts); ` +
-        `local TypeScript/JavaScript interop can't be deployed.`,
-    };
-  }
-
-  const localAgencyImports = agencyImportTargets(parsed.result, { localOnly: true });
-  if (localAgencyImports.length > 0) {
-    return {
-      ok: false,
-      error:
-        `${name} imports ${localAgencyImports.map((target) => `"${target}"`).join(", ")}. ` +
-        `Deploy is single-file for now — hosted multi-file agents aren't supported yet ` +
-        `(statelog compiles each file in isolation). Tracking: statelog#9.`,
-    };
-  }
-
-  return { ok: true, bundle: { entrypoint: name, files: [{ name, contents }] } };
+  return {
+    ok: true,
+    bundle: { entrypoint: path.basename(entrypointAbs), files: Object.values(collected) },
+  };
 }
 
 export type ValidateResult = { ok: true } | { ok: false; error: string };
 
 /**
- * Compile each bundle file locally for fast feedback before the upload, mirroring
- * statelog's per-file server compile. A pass here is a pre-flight, not a
- * guarantee the server — which may run a different agency-lang — accepts it.
+ * Compile each bundle file locally for fast feedback before the upload. Each is
+ * compiled at its real path (`sourcePath`), so a file's relative `.agency`
+ * imports resolve against its siblings — the same way statelog compiles them.
+ * A pass here is a pre-flight, not a guarantee the server (which may run a
+ * different agency-lang) accepts it.
  */
 export function validateBundleCompiles(
   bundle: AgencyBundle,
   config: AgencyConfig,
 ): ValidateResult {
   const failures = bundle.files
-    .map((file) => ({ file, result: compileSource(file.contents, config) }))
+    .map((file) => ({
+      file,
+      result: compileSource(file.contents, { ...config, sourcePath: file.absPath }),
+    }))
     .filter(
       (entry): entry is { file: BundleFile; result: { success: false; errors: string[] } } =>
         !entry.result.success,

--- a/packages/agency-lang/lib/cli/deploy/bundle.ts
+++ b/packages/agency-lang/lib/cli/deploy/bundle.ts
@@ -46,6 +46,9 @@ export function collectAgencyBundle(
   config: AgencyConfig,
 ): CollectBundleResult {
   const entrypointAbs = path.resolve(entrypointPath);
+  if (!fs.existsSync(entrypointAbs)) {
+    return { ok: false, error: `Entrypoint not found: ${entrypointAbs}` };
+  }
   const rootDir = path.dirname(entrypointAbs);
 
   const collected: Record<string, BundleFile> = {};


### PR DESCRIPTION
## What

Relaxes `agency deploy`'s single-file restriction now that hosted serve can compile multi-file agents (statelog#10, on `agency-lang@0.12.0`'s `compileSource(sourcePath)`).

`agency deploy` now uploads the **entrypoint plus every local `.agency` file it imports** (transitively):
- `collectAgencyBundle` walks the local import graph and gathers the file set.
- `validateBundleCompiles` compiles each file **at its real path** (`sourcePath`), so the local pre-flight resolves relative imports the same way statelog does.
- `BundleFile` gains `absPath` (used as that `sourcePath`).

## Still refused (statelog can't host these)

- **Imports resolving outside the entrypoint's directory** (`./sub/x.agency`, `../x.agency`) — statelog stores an agent's files flat and its filenames can't contain slashes, so everything must sit in one directory.
- **Local TypeScript/JavaScript interop** — statelog only compiles `.agency` source.

## Tests

`bundle.test.ts` — bundles a sibling `.agency` import; refuses an outside-dir import; `validateBundleCompiles` passes a multi-file agent (imports resolve via `sourcePath`). 24/24 deploy tests pass; build + structural lint clean. Smoke-tested end-to-end: a two-file agent bundles both; a nested import is refused.

Docs updated (`docs/site/cli/deploy.md`). This completes the multi-file arc: agency-lang#763 → statelog#10 → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
