### PR TITLE
docs(dev): hosted agent execution (agency deploy + statelog serve)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,7 @@ Pipeline and architecture:
 - `docs/dev/splices.md` — Compile-time splices `$( ... )`: where expansion sits in the pipeline, the five paths that must run it, why the cache is mandatory, the import restriction that carries the safety argument, and the cycle guard
 - `docs/dev/effect-propagation.md` — How a function's interrupt effects are computed: the shared walk in lib/analysis/effects.ts, the fixpoint at the end of SymbolTable.build, following re-exports, the `.invoke()` shape, why `_guard` is seeded rather than walked, and the four things the walk cannot see
 - `docs/dev/template-agency.md` — Template Agency internals: the Hole node and per-position parsing, `Code` fragment kinds, the never-parse lifting rule and its two escaping conventions, scope-keyed hygiene with `__hyg` seeding, AG8001/AG8002 refusals, and the walker-completeness tripwire
+- `docs/dev/hosted-agent-execution.md` — Hosting agents on statelog (`agency deploy` + the `./serve` API): the serve wire contract and moduleId gotcha, per-agent observability via `withRuntimeConfigOverrides`, `compileSource(sourcePath)` for multi-file, the deploy CLI's module layout, the statelog host pieces, and the known limitations
 
 Other references:
 - `docs/misc/TESTING.md` — Full testing guide (unit tests, fixtures, execution tests, agency-js tests)

--- a/packages/agency-lang/docs/dev/hosted-agent-execution.md
+++ b/packages/agency-lang/docs/dev/hosted-agent-execution.md
@@ -1,0 +1,248 @@
+# Hosted agent execution (`agency deploy` + statelog serve)
+
+This doc explains how an Agency agent is uploaded to a hosted [statelog](https://github.com/egonSchiele/statelog) instance and run over HTTP — the hosted equivalent of `agency serve http`. It spans two repositories, so both are covered here: **agency-lang** (the language, the CLI, and the serve API a host embeds) and **statelog** (the host app that stores agents, runs them, and collects their traces).
+
+Read this before working on `agency deploy`, the `./serve` API, per-agent observability, or multi-file hosting.
+
+## What "hosted execution" means
+
+Normally you run an agent locally: `agency run agent.agency`, or expose it over HTTP with `agency serve http agent.agency`, which starts a server in your own process. **Hosted execution** moves that server into statelog: you upload the agent once, and statelog runs it on demand and records every run's trace automatically.
+
+The end-to-end flow:
+
+1. **Deploy** — `agency deploy agent.agency` reads the agent's source, uploads it to statelog, and prints the URLs where it can be run.
+2. **Serve** — statelog compiles the uploaded source, and each request to a `/serve/...` URL runs the agent and returns its result (or an interrupt to respond to).
+3. **Observe** — every hosted run auto-traces into the same statelog instance, attributed to the agent's own project.
+
+## The map: which piece lives where
+
+| Piece | Repo | Path |
+|---|---|---|
+| `./serve` API (the dispatcher a host embeds) | agency-lang | `lib/serve/` |
+| `agency deploy` CLI | agency-lang | `lib/cli/deploy/` |
+| `compileSource` (with `sourcePath`) | agency-lang | `lib/compiler/compile.ts` |
+| Per-agent observability seam | agency-lang | `lib/runtime/configOverrides.ts` |
+| The serve host (runs agents per request) | statelog | `src/backend/lib/serveHost.ts` |
+| Upload endpoint | statelog | `src/backend/routes/api/projects/[id]/upload.ts` |
+| Compile + write helpers | statelog | `src/backend/lib/agencyCompiler.ts` |
+| Observability config | statelog | `src/backend/lib/config.ts` |
+| Route registration | statelog | `src/backend/server.ts` |
+
+---
+
+## 1. The serve API (agency-lang `lib/serve/`)
+
+A host embeds a small dispatcher that turns HTTP requests into agent runs. The public surface is `agency-lang/serve` (barrel: `lib/serve/public.ts`):
+
+- **`createServeHandler(compiledPath, options) => Promise<ServeHandler>`** — imports a compiled Agency module and returns a `ServeHandler`, which is a function `(method, path, body) => Promise<RouteResult>`. It handles four routes: `/list`, `/function/:name`, `/node/:name`, `/resume`.
+- **`collectServeMetadata({ filePath, config }) => { moduleId, exportedNodeNames, interruptEffectsByName, errors }`** — builds a symbol table and type-checks, producing the metadata `createServeHandler` needs.
+- **`ServeHandler`, `CreateServeHandlerOptions`, `RouteResult`** — the types.
+
+Internally (`lib/serve/discovery.ts`), `discoverExports` walks the compiled module and builds one `ExportedFunction` or `ExportedNode` per exported item. `ExportedNode` carries a `parameters` array; **`ExportedFunction` also carries `parameters`** (added so `/list` describes function arguments — before, only nodes did; see "PR history"). Bound params (from partial application) are filtered out — only caller-facing params are listed.
+
+### moduleId consistency — the load-bearing gotcha
+
+`createServeHandler` filters *exported functions* by `moduleId`: it only serves functions whose compiled `fn.module` equals the `moduleId` you pass in `options`. `compileSource` stamps a **fresh random** `moduleId` (`agency_<nanoid>`) into the code each time it compiles, and that id is **not recoverable** from a stored `.js` file.
+
+So a host must **recompile at serve time** and pass `compiled.moduleId` (the id of the code it just wrote), not reuse a previously stored artifact with an unknown id. If the ids disagree, `/list` shows an empty `functions` array and function calls 404. Nodes are discovered by name and are moduleId-independent, which is why a mismatch silently breaks only functions.
+
+### The wire contract
+
+All routes return `RouteResult = { status, body }`. Bodies use a `{ success, ... }` envelope:
+
+- **`GET /list`** → `{ functions: [{ name, description, parameters, destructive, idempotent, interruptEffects }], nodes: [{ name, parameters, interruptEffects }] }`. `parameters` is a list of names.
+- **`POST /function/:name`** (body = named args, e.g. `{ "a": 2, "b": 3 }`) → `{ success: true, value }` on success, or `{ success: false, error }` on a tool failure. **Note: failures come back with HTTP 200** — the adapter maps tool errors into the body, not the status, and sanitizes the message (the full error is logged server-side, never sent to the client).
+- **`POST /node/:name`** (body = named args) → same as function, **except** if the run raises an interrupt it returns `{ success: true, value: { interrupts: [...], state } }`. Each interrupt item is `{ type: "interrupt", effect, message }` (`effect` like `app::confirm`, `message` a human string).
+- **`POST /resume`** (body = `{ interrupts, responses }`) → resumes a paused run. `interrupts` is the array echoed from the previous response's `value.interrupts`; `responses` is one response per interrupt, each `{ type: "approve" | "reject", value? }`. The result is again either a final value or another interrupt, so a client loops until there are no more interrupts. **The run is stateless across requests** — the interrupt payload carries the run state, so `/resume` needs no server-side session.
+
+The interrupt/resume loop is exactly the ceremony a future `agency call` command would hide (see "Follow-ups").
+
+---
+
+## 2. Per-agent observability (`withRuntimeConfigOverrides`)
+
+**Goal:** every hosted run auto-traces into statelog, attributed to *its own* project. A statelog instance hosts many agents from different projects, so run A's trace must go to project A and run B's to project B.
+
+### Why config can't be baked at compile time
+
+The obvious approach — compile each agent with its statelog config (host, project, apiKey) baked in — is wrong for a multi-agent host, and was rejected during review:
+
+- The statelog **API key would sit in the compiled `.js` on disk** (plaintext at rest).
+- One compiled artifact can't carry per-project routing; caching artifacts keyed by observability config fights the one-artifact-per-agent cache and causes write races.
+- It violates the principle that config belongs to the *run*, not the *build*.
+
+### How config actually reaches a run
+
+`compileSource` bakes a `statelogConfig` object into the compiled module. At runtime, when the module's `RuntimeContext` is constructed, it applies runtime overrides on top of the baked config (`lib/runtime/state/context.ts`). Two override transports feed the same merge (`lib/runtime/configOverrides.ts`, `applyRuntimeConfigOverridesToContextArgs`):
+
+- `AGENCY_CONFIG_OVERRIDES` — an environment variable (read by `readConfigOverrides`).
+- `setRuntimeConfigOverrides(overrides)` — a process-global (used by subprocess IPC).
+
+**The crucial fact:** that `RuntimeContext` is built **once, at module-import time** — the moment `createServeHandler` calls `await import(...)`. The per-invocation path (`createExecutionContext`) just copies the frozen config. So observability is decided when the module loads, and both override transports are process-global.
+
+### The seam: `withRuntimeConfigOverrides`
+
+`lib/runtime/configOverrides.ts` exports (via `agency-lang/serve`):
+
+```ts
+withRuntimeConfigOverrides(overrides, fn)  // set overrides, run fn, restore previous
+```
+
+A host wraps the **module import** in it, so the module's `RuntimeContext` reads that agent's config as it constructs:
+
+```ts
+await withImportLock(() =>
+  withRuntimeConfigOverrides(
+    { observability: true, log: { host, projectId, apiKey } },
+    () => createServeHandler(compiledPath, { ... }),
+  ),
+);
+```
+
+Two things make this correct:
+
+- **Routing is per-agent, not per-request.** An agent belongs to one project; that never changes. Each agent is a separately-cached module import. So config only needs to bind once, at that agent's import.
+- **Imports are serialized (`withImportLock`).** The override is a process-global and `import` has an `await` inside it, so two overlapping imports could read each other's config. A mutex around the import prevents that. Invocations don't need the lock — they never touch the global.
+
+### The invariant, and its guard
+
+This design rests on one invariant: **a `RuntimeContext` is only constructed at module import, never per-invocation.** If a future agency-lang change made that read lazy (deferred to first run), the override would already be cleared and observability would silently go dark. The statelog test `serveHost.test.ts > "per-agent observability routing"` is the guard — it builds two agents with different configs and asserts each traces only to its own project; it fails if the import-time capture stops happening.
+
+There is a filed follow-up to replace this ambient-global coupling with a first-class `createServeHandler({ observability })` binding API (see "Follow-ups").
+
+---
+
+## 3. Multi-file compile: `compileSource(sourcePath)`
+
+An agent can import sibling `.agency` files (`import { helper } from "./helpers.agency"`). Hosting these was originally impossible, for a subtle reason.
+
+### The bug
+
+`compileSource(source, config)` takes source as a **string**, with no location. To resolve a relative import, the compiler's symbol table has to find the sibling file on disk. So `compileSource` wrote the source to a **throwaway temp directory** and compiled it there — where the sibling doesn't exist. Result: `Symbol 'helper' is not defined in './helpers.agency'`. Statelog used `compileSource` on both upload and serve, so multi-file agents couldn't even be uploaded.
+
+### The fix
+
+`CompileSourceOptions` gained an optional **`sourcePath`**. When set, `compileSource` compiles at that real on-disk path (where the siblings live) instead of a temp dir, so relative imports resolve. Without it, behavior is unchanged (single-file, temp dir).
+
+**The on-disk file is authoritative when `sourcePath` is set:** `compileSource` reads and parses the bytes at `sourcePath` (ignoring the passed `source` string), because the symbol table and closure builder also read from disk. Parsing the string while resolving from disk could silently diverge; reading both from disk removes that risk. Pass the file's contents as `source` for clarity, but the disk file wins.
+
+### The flat-directory constraint
+
+Statelog stores an agent's files **flat** (one directory, keyed by basename), and its upload filename schema forbids slashes. So multi-file hosting only supports **same-directory siblings**. An import that resolves outside the entrypoint's directory (`./sub/x.agency`, `../x.agency`) cannot be represented and is refused (by `agency deploy`, and should be contained server-side — see statelog#11 under "Follow-ups").
+
+---
+
+## 4. `agency deploy` (agency-lang `lib/cli/deploy/`)
+
+`agency deploy agent.agency` uploads an agent to statelog. The command is currently **registered hidden** in `scripts/agency.ts` (works, but not shown in `--help`) while the hosted feature matures.
+
+### Architecture — "what" split from "how"
+
+The orchestrator reads like a recipe; each stage is one single-concept module hiding its mechanics behind a typed result:
+
+```
+deploy.ts        the "what": resolveDeployTarget → collectAgencyBundle
+                 → validateBundleCompiles → uploadBundle
+target.ts        resolve { host, projectId, apiKey } + provenance
+bundle.ts        collect the .agency file set + local compile pre-flight
+uploadClient.ts  the ONLY file that knows statelog's upload API
+curlExamples.ts  pure: manifest → ready-to-run curl commands
+render.ts        terminal output (via a typestache template)
+```
+
+`render.ts` builds coloured blocks (using `lib/utils/termcolors.ts`) and hands them to `lib/templates/cli/deployReport.mustache`, which owns the layout. (The template is deliberately compact — one line with placeholders and two sections — because typestache does not strip standalone section-tag lines and nested inline sections don't render; the block builders own all the spacing.)
+
+### Configuration
+
+Deploy reuses the **`log` section of `agency.json`** (`log.host`, `log.projectId`) for the target — the same config observability uses. The **API key is read only from an environment variable** (`--api-key-env <NAME>`, default `STATELOG_API_KEY`), never from a flag or `agency.json`, so it can't be committed or leak into process listings. The host is required and URL-validated.
+
+### Multi-file bundling
+
+`collectAgencyBundle` walks the entrypoint's transitive local `.agency` imports (reusing the compiler's own `resolveAgencyImportPath` and `agencyImportTargets`, so the deploy walk resolves imports exactly as the compiler will). It refuses imports resolving outside the entrypoint's directory (the flat constraint) and local TypeScript/JavaScript interop imports (statelog only compiles `.agency` source). `validateBundleCompiles` compiles each file at its `sourcePath`, so the local pre-flight resolves imports the same way statelog does.
+
+Nothing local leaks to the server: `uploadClient` sends only `{ entrypoint, files: [{ name, contents }] }`; the on-disk absolute paths stay client-side.
+
+### The statelog coupling is sealed
+
+`uploadClient.ts` is the single file that knows statelog's HTTP contract: it POSTs to `/api/projects/:project/upload` with body `{ entrypoint, files }`, reads the `Result<{ endpointUrls }>` envelope, and best-effort fetches `/list` for the manifest (to print curl examples). Server responses are treated as untrusted — a bad shape reports an error or drops the extra rather than crashing a deploy that already landed. If statelog's API changes, only this file changes.
+
+---
+
+## 5. The statelog host (statelog repo)
+
+The host is a React + Express + Postgres app. The relevant backend pieces:
+
+### `serveHost.ts` — runs an agent per request
+
+`buildServeHandler({ sourcePath, compiledPath, observability })`:
+
+1. Reads the agent source, `compileSource(source, { sourcePath })` (real-path compile, so multi-file imports resolve), writes the `.js` to `compiledPath`.
+2. `collectServeMetadata` for the moduleId/nodes/effects.
+3. Wraps `createServeHandler` in `withImportLock(() => withRuntimeConfigOverrides(observability, () => ...))` so the run binds this agent's trace destination at import (section 2).
+
+It **recompiles the entrypoint** rather than reusing the stored `.js`, because it must pass `compiled.moduleId` (the moduleId gotcha in section 1). For a multi-file agent it recompiles only the entrypoint; the siblings' `.js` were written at upload time and sit next to `compiledPath`, so the generated `import "./helper.js"` resolves at runtime.
+
+Built handlers are cached, keyed by `compiled_path:mtime` (of the entrypoint). **Authorization is off the API key's identity (`res.locals`), not the URL** — the key is bound to one project, so URL ids that disagree are rejected (this closed an IDOR where trusting `req.params` ids let one tenant act on another's agent).
+
+### `upload.ts` — the upload endpoint
+
+`POST /api/projects/:projectId/upload`, body `{ entrypoint, files: [{ name, contents }] }`. It **writes every source file to disk *before* compiling any of them**, so a multi-file agent's `./sibling.agency` is present when each file compiles. Then it compiles each file at its stored `sourcePath`, writes the `.js`, and upserts a DB row. The response's `endpointUrls` advertise the `/serve/...` URLs (a client that follows them hits the serve routes; earlier they pointed at the older `/run/...` path).
+
+`agencyCompiler.ts` provides `compileAgencySource(source, config, publicNodesOnly, sourcePath?)` and the path helpers `sourcePathFor` / `compiledPathFor` (single source of truth for the `UPLOADS_DIR/userId/projectId/` layout, so sources and their compiled `.js` always colocate).
+
+### `config.ts` — observability config
+
+`getServeObservabilityConfig({ projectId, apiKey }) => { observability: true, log: { host: INGEST_HOST, projectId, apiKey } }`. `INGEST_HOST` is where a run POSTs its traces (the statelog client sends them to `${host}/api/logs`); it defaults to this server's own origin (derived from `STATELOG_PORT`) so a run auto-traces back into this instance, overridable via `STATELOG_INGEST_HOST`.
+
+### The serve routes (`server.ts`)
+
+```
+GET  /serve/:userId/:projectId/:filename/list
+POST /serve/:userId/:projectId/:filename/function/:name
+POST /serve/:userId/:projectId/:filename/node/:name
+POST /serve/:userId/:projectId/:filename/resume
+```
+
+`filename` is the base name (no `.agency`; `serveHost` re-appends it). All are behind the API-key auth middleware.
+
+---
+
+## Running a deployed agent (curl)
+
+```bash
+export KEY='<project-api-key>'
+export BASE='https://<host>/serve/<userId>/<project>/<agent>'   # from the deploy output
+
+curl -s -H "Authorization: Bearer $KEY" "$BASE/list" | jq
+curl -s -X POST "$BASE/node/main" -H "Authorization: Bearer $KEY" \
+  -H "Content-Type: application/json" -d '{"message":"hi"}' | jq
+```
+
+Check the `success` field, not the HTTP code (failures are 200). If a node returns `value.interrupts`, respond by POSTing `{ interrupts, responses }` to `$BASE/resume`.
+
+---
+
+## Known limitations (trusted single-tenant v1)
+
+These are accepted for the current trusted, single-tenant posture and tracked in **statelog#11**:
+
+- **No sandboxing.** Hosted code runs in the statelog process. A hung agent can stall the server.
+- **Compile-time containment gap.** Compiling at a real path means a traversing import (`../../other/agent.agency`) reads the live filesystem at compile time. The upload filename is sanitized, but import specifiers inside a file's source are not. Compile-only and low-leak, but a new cross-project read surface.
+- **Sibling cache staleness.** `serveHost` cache-busts the entrypoint's module URL by content hash, but its relative `import "./sibling.js"` is not version-busted, so Node's ESM cache serves an old sibling even after a re-upload — a multi-file sibling edit needs a process restart. Same root cause as the general "ESM registry accretes modules" caveat; the planned child-process execution model fixes it.
+- **Upload atomicity.** Upload pre-writes all sources then compiles/upserts per file; a mid-batch failure can leave partial on-disk/DB state. Re-uploading recovers.
+- **Per-agent (not per-request) observability.** Trace routing is fixed per agent at import time; a single agent can't route different runs to different projects.
+
+---
+
+## Follow-ups
+
+- **`agency call`** — a CLI command to invoke a hosted node/function and drive the interrupt/resume loop, hiding the "check `success`, detect interrupts, thread through `/resume`" ceremony. Design was scoped (the open fork was the interrupt UX: interactive prompt vs non-interactive policy) but the work is **punted**.
+- **First-class observability binding** — replace the ambient `withRuntimeConfigOverrides` + import-mutex with a supported `createServeHandler({ observability })` option that agency-lang applies internally. Filed as an agency-lang issue.
+- **statelog#11** — the containment, sibling-cache, and atomicity items above.
+- **Minimal statelog UI** — an upload/list/invoke browser flow with a jump to a run's trace. Deferred in favor of the CLI (`agency deploy`) path.
+
+---
+
+## PR history (the arc, for context)
+
+The feature landed as a sequence of small PRs. In agency-lang: the `./serve` public API; per-agent observability (`withRuntimeConfigOverrides`, released in 0.11.0); `/list` function parameters; `compileSource(sourcePath)` (released in 0.12.0); `agency deploy` (single-file, then multi-file). In statelog: migration to the newer agency-lang, the `/list` + `/function` + `/node` + `/resume` serve host, per-agent auto-observability, the `endpointUrls`-point-at-`/serve` fix, and multi-file serve support. The dependency direction is one-way: statelog consumes published agency-lang versions, so an agency-lang change ships first (merge + publish), then statelog bumps the dependency.


### PR DESCRIPTION
## What

A consolidated developer doc for the hosted-agent-execution work — uploading an agent to statelog and running it over HTTP (`agency deploy` + the `./serve` API). It spans both repos, so the doc covers agency-lang and statelog together, enough to pick the work back up cold.

`docs/dev/hosted-agent-execution.md` covers:
- **The map** — which piece lives in which repo/file.
- **The `./serve` API** — `createServeHandler`/`collectServeMetadata`, the full `/list` `/function` `/node` `/resume` wire contract (incl. failures-return-200 and the interrupt/resume loop), and the **moduleId consistency gotcha** (recompile at serve time, pass `compiled.moduleId`).
- **Per-agent observability** — why config can't be baked, how `withRuntimeConfigOverrides` binds a run's trace destination at import time, the import mutex, and the invariant + guard test.
- **`compileSource(sourcePath)`** — the multi-file root cause/fix and the flat-directory constraint.
- **`agency deploy`** — the what/how module layout, config (log section + env-only key), multi-file bundling, and the sealed statelog coupling.
- **The statelog host** — `serveHost`, `upload`, `agencyCompiler`, `config`, and the serve routes.
- **Curl reference, known limitations (statelog#11), and follow-ups** (`agency call`, first-class observability binding, the UI).

Linked from `CLAUDE.md`'s docs list. Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
