### PR TITLE
fmt: keep end-of-line comments attached to complete constructs

### DIFF
--- a/packages/agency-lang/docs/site/guide/basic-syntax.md
+++ b/packages/agency-lang/docs/site/guide/basic-syntax.md
@@ -208,32 +208,12 @@ You can also write a module-level doc comment using the `@module` tag. This docu
 */
 ```
 
-A `//` comment can also sit at the end of a line, after a complete
-declaration, statement, or match arm. `agency fmt` keeps it on that line,
-beside the thing it describes:
+> Note: comments must be on their own line, they cannot be at the end of a line containing code.
+
+Not allowed:
 
 ```ts
-type UserId = string // stable identifier
-
-node main() {
-  const x = 5 // starting count
-
-  match (x) {
-    5 => "five" // the only case we expect
-    _ => "other"
-  }
-}
-```
-
-Two things are not end-of-line comments. A block comment (`/* ... */`) after
-code is not attached, and neither is a `//` comment between the items of a
-multiline list — `agency fmt` still moves that onto its own line:
-
-```ts
-const xs = [
-  1, // fmt moves this comment above the 2
-  2
-]
+const x = 5 // this is a comment
 ```
 
 ## Functions

--- a/packages/agency-lang/docs/site/guide/basic-syntax.md
+++ b/packages/agency-lang/docs/site/guide/basic-syntax.md
@@ -208,12 +208,32 @@ You can also write a module-level doc comment using the `@module` tag. This docu
 */
 ```
 
-> Note: comments must be on their own line, they cannot be at the end of a line containing code.
-
-Not allowed:
+A `//` comment can also sit at the end of a line, after a complete
+declaration, statement, or match arm. `agency fmt` keeps it on that line,
+beside the thing it describes:
 
 ```ts
-const x = 5 // this is a comment
+type UserId = string // stable identifier
+
+node main() {
+  const x = 5 // starting count
+
+  match (x) {
+    5 => "five" // the only case we expect
+    _ => "other"
+  }
+}
+```
+
+Two things are not end-of-line comments. A block comment (`/* ... */`) after
+code is not attached, and neither is a `//` comment between the items of a
+multiline list — `agency fmt` still moves that onto its own line:
+
+```ts
+const xs = [
+  1, // fmt moves this comment above the 2
+  2
+]
 ```
 
 ## Functions

--- a/packages/agency-lang/lib/backends/agencyGenerator.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.ts
@@ -24,6 +24,7 @@ import {
   formatUnitLiteral,
   isExpressionNode,
 } from "../types.js";
+import { LineComment } from "../types/base.js";
 
 import { AccessChainElement, ValueAccess } from "../types/access.js";
 import { declaredName } from "../types/hole.js";
@@ -51,7 +52,7 @@ import {
 } from "../types/importStatement.js";
 import { ExportFromStatement } from "../types/exportFromStatement.js";
 import { EffectDeclaration } from "../types/effectDeclaration.js";
-import { MatchBlock } from "../types/matchBlock.js";
+import { MatchBlock, MatchBlockCase } from "../types/matchBlock.js";
 import { ReturnStatement } from "../types/returnStatement.js";
 import { GotoStatement } from "../types/gotoStatement.js";
 import { ForLoop } from "../types/forLoop.js";
@@ -486,7 +487,8 @@ export class AgencyGenerator {
 
   public processNode(node: AgencyNode): string {
     const result = this.processNodeInner(node);
-    return this.trace(node.type, result);
+    const traced = this.trace(node.type, result);
+    return this.appendTrailingComment(traced, node.trailingComment);
   }
 
   private processNodeInner(node: AgencyNode): string {
@@ -1454,30 +1456,48 @@ export class AgencyGenerator {
         ? ` if (${this.processNode(caseNode.guard).trim()})`
         : "";
 
-      if (this.armPrintsInline(caseNode)) {
-        const stmt = caseNode.body[0];
-        let stmtCode = this.processNode(stmt).trim();
-        // `=> { ... }` is always parsed as a block, never an object literal
-        // (JS-arrow rule — see matchArmBlockParser). An inline arm whose
-        // sole statement is an object literal must therefore stay
-        // parenthesized so it round-trips as an expression, not a block.
-        if (stmt.type === "agencyObject") {
-          stmtCode = `(${stmtCode})`;
-        }
-        result += this.indentStr(`${pattern}${guardCode} => ${stmtCode}\n`);
-      } else {
-        result += this.indentStr(`${pattern}${guardCode} => {\n`);
-        this.increaseIndent();
-        result += this.renderBody(caseNode.body);
-        this.decreaseIndent();
-        result += this.indentStr("}\n");
-      }
+      const arm = this.armPrintsInline(caseNode)
+        ? this.renderInlineMatchArm(caseNode, pattern, guardCode)
+        : this.renderBlockMatchArm(caseNode, pattern, guardCode);
+      result += this.appendTrailingComment(arm, caseNode.trailingComment) + "\n";
     }
 
     this.decreaseIndent();
 
     result += this.indentStr(`}`);
 
+    return result;
+  }
+
+  /** One arm, without its final newline — a complete construct an
+   *  attached comment can follow. */
+  private renderInlineMatchArm(
+    caseNode: MatchBlockCase,
+    pattern: string,
+    guardCode: string,
+  ): string {
+    const stmt = caseNode.body[0];
+    let stmtCode = this.processNode(stmt).trim();
+    // `=> { ... }` is always parsed as a block, never an object literal
+    // (JS-arrow rule — see matchArmBlockParser). An inline arm whose
+    // sole statement is an object literal must therefore stay
+    // parenthesized so it round-trips as an expression, not a block.
+    if (stmt.type === "agencyObject") {
+      stmtCode = `(${stmtCode})`;
+    }
+    return this.indentStr(`${pattern}${guardCode} => ${stmtCode}`);
+  }
+
+  private renderBlockMatchArm(
+    caseNode: MatchBlockCase,
+    pattern: string,
+    guardCode: string,
+  ): string {
+    let result = this.indentStr(`${pattern}${guardCode} => {\n`);
+    this.increaseIndent();
+    result += this.renderBody(caseNode.body);
+    this.decreaseIndent();
+    result += this.indentStr("}");
     return result;
   }
 
@@ -1604,8 +1624,26 @@ export class AgencyGenerator {
 
   // Utility methods
 
+  /** The sole owner of line-comment source text. Do not rebuild
+   *  `//${content}` anywhere else. */
+  protected commentText(comment: LineComment): string {
+    return `//${comment.content}`;
+  }
+
   protected processComment(node: AgencyComment): string {
-    return this.indentStr(`//${node.content}`);
+    return this.indentStr(this.commentText(node));
+  }
+
+  /** Place an attached comment after already-rendered code. Empty code has
+   *  no construct to attach to, so the comment is left to its owner. */
+  protected appendTrailingComment(
+    code: string,
+    comment: LineComment | undefined,
+  ): string {
+    if (!comment || code === "") {
+      return code;
+    }
+    return `${code} ${this.commentText(comment)}`;
   }
 
   protected processMultiLineComment(node: AgencyMultiLineComment): string {
@@ -1734,10 +1772,13 @@ export class AgencyGenerator {
       node: ImportStatement | ImportNodeStatement,
       body: string,
     ): string => {
+      // Sorting renders imports directly, bypassing processNode, so the
+      // attached comment has to be placed here too.
+      const rendered = this.appendTrailingComment(body, node.trailingComment);
       const attached = this.importAttachedComments.get(node) ?? [];
-      if (attached.length === 0) return body;
+      if (attached.length === 0) return rendered;
       const commentLines = attached.map((c) => this.processNode(c));
-      return [...commentLines, body].join("\n");
+      return [...commentLines, rendered].join("\n");
     };
 
     const stdlib: ImportEntry[] = [];

--- a/packages/agency-lang/lib/backends/agencyGenerator.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.ts
@@ -1776,7 +1776,9 @@ export class AgencyGenerator {
       // attached comment has to be placed here too.
       const rendered = this.appendTrailingComment(body, node.trailingComment);
       const attached = this.importAttachedComments.get(node) ?? [];
-      if (attached.length === 0) return rendered;
+      if (attached.length === 0) {
+        return rendered;
+      }
       const commentLines = attached.map((c) => this.processNode(c));
       return [...commentLines, rendered].join("\n");
     };

--- a/packages/agency-lang/lib/formatter.test.ts
+++ b/packages/agency-lang/lib/formatter.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { formatSource } from "./formatter.js";
+import { parseAgency } from "./parser.js";
 import fs from "fs";
 import { fileURLToPath } from "url";
 import path from "path";
@@ -356,4 +357,74 @@ describe("syntax variations are a fixed point after one format", () => {
       expect(formatSource(once as string)).toBe(once);
     });
   }
+});
+
+function expectTrailingCommentFixedPoint(source: string, expected: string): void {
+  const once = formatSource(source);
+  expect(once).not.toBeNull();
+  expect(once).toBe(expected);
+  expect(formatSource(once as string)).toBe(once);
+  expect(parseAgency(once as string, {}, false, false).success).toBe(true);
+}
+
+describe("complete-construct trailing comments", () => {
+  it("preserves top-level and body comments", () => {
+    expectTrailingCommentFixedPoint(
+      `type UserId=string // id\nnode main(){\nconst x=5 // x\n}\n`,
+      `type UserId = string // id\n\nnode main() {\n  const x = 5 // x\n}\n`,
+    );
+  });
+
+  it("keeps comments with imports while sorting", () => {
+    const formatted = formatSource(
+      `import { z } from "./z" // z comment\nimport { a } from "./a" // a comment\n`,
+    );
+    expect(formatted).toContain(
+      `import { a } from "./a" // a comment\nimport { z } from "./z" // z comment`,
+    );
+  });
+
+  it("keeps a comment after a multiline call closing delimiter", () => {
+    const source = `node main() {\n  save(\n    "a very long argument that keeps this call multiline",\n    "another very long argument that keeps this call multiline"\n  ) // whole call\n}\n`;
+    const once = formatSource(source);
+    expect(once).toContain(`\n  ) // whole call\n`);
+    expect(formatSource(once as string)).toBe(once);
+  });
+});
+
+describe("trailing comments in every body owner", () => {
+  it.each([
+    ["node", `node main() {\n  print(1) // c\n}\n`],
+    ["function", `def f() {\n  print(1) // c\n}\n`],
+    ["if", `node main() {\n  if (true) {\n    print(1) // c\n  }\n}\n`],
+    ["else", `node main() {\n  if (true) {\n    print(2)\n  } else {\n    print(1) // c\n  }\n}\n`],
+    ["while", `node main() {\n  while (true) {\n    print(1) // c\n  }\n}\n`],
+    ["for", `node main() {\n  for (x in xs) {\n    print(1) // c\n  }\n}\n`],
+    ["thread", `node main() {\n  thread {\n    print(1) // c\n  }\n}\n`],
+    ["subthread", `node main() {\n  subthread {\n    print(1) // c\n  }\n}\n`],
+    ["guard", `node main() {\n  guard() {\n    print(1) // c\n  }\n}\n`],
+    ["handle", `node main() {\n  handle {\n    print(1) // c\n  } with approve\n}\n`],
+    ["inline handler", `node main() {\n  handle {\n    print(2)\n  } with (answer) {\n    print(1) // c\n  }\n}\n`],
+    ["finalize", `node main() {\n  finalize {\n    print(1) // c\n  }\n}\n`],
+    ["parallel", `node main() {\n  parallel {\n    print(1) // c\n  }\n}\n`],
+    ["seq", `node main() {\n  seq {\n    print(1) // c\n  }\n}\n`],
+    ["destructive", `node main() {\n  destructive {\n    print(1) // c\n  }\n}\n`],
+    ["block match arm", `node main() {\n  match (x) {\n    1 => {\n      print(1) // c\n    }\n  }\n}\n`],
+    ["block argument", `node main() {\n  each(xs) as item {\n    print(1) // c\n  }\n}\n`],
+    ["statement code literal", `def f(): Code {\n  return [| node main(): number {\n    print(1) // c\n    return 1\n  } |]\n}\n`],
+  ])("preserves a trailing comment in a %s body", (_name, source) => {
+    const once = formatSource(source);
+    expect(once).toContain("print(1) // c");
+    expect(parseAgency(once as string, {}, false, false).success).toBe(true);
+    expect(formatSource(once as string)).toBe(once);
+  });
+
+  it("preserves a trailing comment on an inline match arm", () => {
+    const source = `node main() {\n  match (x) {\n    1 => "one" // first\n    2 => "two" // second\n  }\n}\n`;
+    const once = formatSource(source);
+    expect(once).toContain(`1 => "one" // first`);
+    expect(once).toContain(`2 => "two" // second`);
+    expect(parseAgency(once as string, {}, false, false).success).toBe(true);
+    expect(formatSource(once as string)).toBe(once);
+  });
 });

--- a/packages/agency-lang/lib/parser.ts
+++ b/packages/agency-lang/lib/parser.ts
@@ -69,10 +69,11 @@ import {
   AGENCY_TEMPLATE_OFFSET,
   setTemplateOffset,
   registerProgramParserForLiterals,
+  completeConstructEntry,
 } from "./parsers/parsers.js";
 import { AgencyNode, AgencyProgram } from "./types.js";
 
-const nodeParser = or(
+const nodeParserInner = or(
   keywordParser,
   importNodeStatmentParser,
   importStatmentParser,
@@ -115,16 +116,10 @@ const nodeParser = or(
   newLineParser,
 );
 
+const nodeParser = completeConstructEntry(nodeParserInner);
+
 export const agencyNode: Parser<AgencyNode[]> = (input: string) => {
-  const parser = many(
-    trace(
-      "agencyParser",
-      map(
-        seqC(capture(nodeParser, "node"), optionalSpacesOrNewline),
-        (result) => result.node,
-      ),
-    ),
-  );
+  const parser = many(trace("agencyParser", nodeParser));
 
   return parser(input);
 };

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -88,7 +88,7 @@ import {
 } from "tarsec";
 
 // --- Type imports (combined from all parser files) ---
-import { SourceLocation } from "../types/base.js";
+import { LineComment, SourceLocation } from "../types/base.js";
 import {
   AccessChainElement,
   AgencyNode,
@@ -334,16 +334,108 @@ export const blankLineParser: Parser<NewLine> = map(
 // comment.ts
 // =============================================================================
 
+/** A comment starting exactly at `//`, stopping before its line ending.
+ *  Callers that own the following layout (trailing-comment attachment)
+ *  need those two properties; `commentParser` adds the surrounding
+ *  whitespace policy standalone comments have always had. */
+export const lineCommentCore: Parser<AgencyComment> = seqC(
+  set("type", "comment"),
+  str("//"),
+  capture(manyTill(or(newline, blankLineParser)), "content"),
+);
+
 export const commentParser: Parser<AgencyComment> = (input: string) => {
-  const parser = seqC(
-    set("type", "comment"),
-    optionalSpaces,
-    str("//"),
-    capture(manyTill(or(newline, blankLineParser)), "content"),
-    optionalSpacesOrNewline,
+  const parser = map(
+    seqC(
+      optionalSpaces,
+      capture(lineCommentCore, "comment"),
+      optionalSpacesOrNewline,
+    ),
+    (result: { comment: AgencyComment }) => result.comment,
   );
   return parser(input);
 };
+
+// =============================================================================
+// trailingComment.ts
+// =============================================================================
+
+type TrailingCommentOwner = {
+  type: string;
+  trailingComment?: LineComment;
+};
+
+/** Trivia nodes describe the layout around a construct rather than a
+ *  construct of their own, so nothing attaches to them. */
+const NON_TRAILING_OWNER_TYPES = [
+  "comment",
+  "multiLineComment",
+  "newLine",
+];
+
+/** A construct's own parser may or may not swallow the line ending after
+ *  it. If it did, any `//` that follows starts a later line and belongs to
+ *  whatever comes next. Blank lines are sentinels by this point
+ *  (replaceBlankLines), so they count as line endings too. */
+function consumedLineEnding(input: string, rest: string): boolean {
+  const consumed = input.slice(0, input.length - rest.length);
+  const trailingWhitespace =
+    consumed.match(new RegExp(`[ \\t\\r\\n${BLANK_LINE_SENTINEL}]*$`))?.[0] ?? "";
+  return new RegExp(`[\\r\\n${BLANK_LINE_SENTINEL}]`).test(trailingWhitespace);
+}
+
+const sameLineComment: Parser<LineComment> = map(
+  seqC(optionalSpaces, capture(lineCommentCore, "comment")),
+  (result: { comment: LineComment }) => result.comment,
+);
+
+/** Attach a same-line `//` comment to whatever `parser` produced, without
+ *  consuming the line ending after it. Owns the same-line decision. */
+export function withTrailingLineComment<T extends TrailingCommentOwner>(
+  parser: Parser<T>,
+): Parser<T> {
+  return (input: string) => {
+    const parsed = parser(input);
+    if (!parsed.success) {
+      return parsed;
+    }
+
+    if (NON_TRAILING_OWNER_TYPES.includes(parsed.result.type)) {
+      return parsed;
+    }
+
+    if (consumedLineEnding(input, parsed.rest)) {
+      return parsed;
+    }
+
+    const comment = sameLineComment(parsed.rest);
+    if (!comment.success) {
+      return parsed;
+    }
+
+    return success(
+      { ...parsed.result, trailingComment: comment.result },
+      comment.rest,
+    );
+  };
+}
+
+/** One entry in a stream of complete constructs: the construct, its
+ *  trailing comment, and the layout that ends the line. Sole owner of that
+ *  boundary — callers must not consume the line ending separately, or a
+ *  comment-terminated entry would strand the newline `lineCommentCore`
+ *  deliberately leaves behind. */
+export function completeConstructEntry<T extends TrailingCommentOwner>(
+  parser: Parser<T>,
+): Parser<T> {
+  return map(
+    seqC(
+      capture(withTrailingLineComment(parser), "value"),
+      optionalSpacesOrNewline,
+    ),
+    (result: { value: T }) => result.value,
+  );
+}
 
 // =============================================================================
 // multiLineComment.ts
@@ -5202,12 +5294,7 @@ const _bodyNodeParser: Parser<AgencyNode> = memo("bodyNodeParser", or(
 
 const _bodyParserImpl: Parser<AgencyNode[]> = memo(
   "functionBodyParser",
-  many(
-    map(
-      seqC(capture(_bodyNodeParser, "node"), optionalSpacesOrNewline),
-      (result) => result.node,
-    ),
-  ),
+  many(completeConstructEntry(_bodyNodeParser)),
 );
 
 export const bodyParser = (input: string): ParserResult<AgencyNode[]> => {

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -4321,7 +4321,7 @@ const matchArmBlockParser: Parser<AgencyNode[]> = map(
   (result: { body: AgencyNode[] }) => result.body,
 );
 
-export const matchBlockParserCase: Parser<MatchBlockCase> = (
+const matchBlockParserCaseInner: Parser<MatchBlockCase> = (
   input: string,
 ): ParserResult<MatchBlockCase> => {
   const parser = seqC(
@@ -4371,7 +4371,6 @@ export const matchBlockParserCase: Parser<MatchBlockCase> = (
       "bodyForm",
     ),
     optionalSemicolon,
-    optionalSpacesOrNewline,
   );
   const result = parser(input) as ParserResult<
     Omit<MatchBlockCase, "body"> & { bodyForm: { body: AgencyNode[]; block: boolean } }
@@ -4387,6 +4386,10 @@ export const matchBlockParserCase: Parser<MatchBlockCase> = (
     result.rest,
   );
 };
+
+export const matchBlockParserCase = completeConstructEntry(
+  matchBlockParserCaseInner,
+);
 
 const semicolon = seqC(optionalSpaces, char(";"), optionalSpaces);
 

--- a/packages/agency-lang/lib/parsers/trailingComments.test.ts
+++ b/packages/agency-lang/lib/parsers/trailingComments.test.ts
@@ -54,6 +54,25 @@ describe("complete-construct trailing comment attachment", () => {
     expect(body.some((node) => node.type === "comment")).toBe(true);
   });
 
+  it("does not extend the owner location through the comment", () => {
+    const source = `type UserId = string // identifier\n`;
+    const node = parseRaw(source).nodes[0];
+    expect(node.trailingComment?.content).toBe(" identifier");
+    expect(source.slice(node.loc!.start, node.loc!.end)).not.toContain("//");
+  });
+
+  it("attaches to a match arm without swallowing the next arm", () => {
+    const body = mainBody(
+      `node main() {\n  match (x) {\n    1 => "one" // first\n    2 => "two"\n  }\n}\n`,
+    );
+    const cases = body[0].cases.filter(
+      (entry: any) => entry.type === "matchBlockCase",
+    );
+    expect(cases).toHaveLength(2);
+    expect(cases[0].trailingComment?.content).toBe(" first");
+    expect(cases[1].trailingComment).toBeUndefined();
+  });
+
   it("does not attach a block comment", () => {
     const body = mainBody(
       `node main() {\n  const x = 5 /* why */\n  const y = 6\n}\n`,

--- a/packages/agency-lang/lib/parsers/trailingComments.test.ts
+++ b/packages/agency-lang/lib/parsers/trailingComments.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { parseAgency } from "@/parser.js";
+
+function parseRaw(source: string) {
+  const parsed = parseAgency(source, {}, false, false);
+  if (!parsed.success) {
+    throw new Error(`expected parse success: ${parsed.message}`);
+  }
+  return parsed.result;
+}
+
+function mainBody(source: string): any[] {
+  return (parseRaw(source).nodes[0] as any).body;
+}
+
+describe("complete-construct trailing comment attachment", () => {
+  it("attaches to a top-level declaration", () => {
+    const nodes = parseRaw(`type UserId = string // identifier\n`).nodes;
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].trailingComment).toMatchObject({
+      type: "comment",
+      content: " identifier",
+    });
+  });
+
+  it("attaches to a body statement instead of adding a sibling", () => {
+    const body = mainBody(
+      `node main() {\n  const x = 5 // explains x\n  const y = 6\n}\n`,
+    );
+    expect(body).toHaveLength(2);
+    expect(body[0].trailingComment?.content).toBe(" explains x");
+  });
+
+  it.each([
+    ["assignment", `const x = 5`],
+    ["return", `return 5`],
+    ["raise", `raise("stop")`],
+    ["call", `print(1)`],
+    ["block", `if (true) {\n    print(1)\n  }`],
+  ])("does not attach a standalone comment after %s", (_name, statement) => {
+    const body = mainBody(
+      `node main() {\n  ${statement}\n  // standalone\n  print(2)\n}\n`,
+    );
+    expect(body[0].trailingComment).toBeUndefined();
+    expect(body.some((node) => node.type === "comment")).toBe(true);
+  });
+
+  it("does not attach to a blank-line node", () => {
+    const body = mainBody(
+      `node main() {\n  print(1)\n\n  // standalone\n  print(2)\n}\n`,
+    );
+    const blank = body.find((node) => node.type === "newLine");
+    expect(blank?.trailingComment).toBeUndefined();
+    expect(body.some((node) => node.type === "comment")).toBe(true);
+  });
+
+  it("does not attach a block comment", () => {
+    const body = mainBody(
+      `node main() {\n  const x = 5 /* why */\n  const y = 6\n}\n`,
+    );
+    expect(body[0].trailingComment).toBeUndefined();
+  });
+});

--- a/packages/agency-lang/lib/types/base.ts
+++ b/packages/agency-lang/lib/types/base.ts
@@ -10,6 +10,17 @@ export type SourceLocation = {
   origin?: { kind: "template" | "filler" | "splice"; name: string };
 };
 
+/** A `//` comment. Declared here rather than reused from `../types.js`,
+ *  because that aggregate module imports BaseNode. */
+export type LineComment = {
+  type: "comment";
+  content: string;
+  loc?: SourceLocation;
+};
+
 export type BaseNode = {
   loc?: SourceLocation;
+  /** A same-line `//` comment attached for Agency source formatting.
+   *  Never part of the owner's `loc`. */
+  trailingComment?: LineComment;
 };

--- a/packages/agency-lang/lib/types/hole.ts
+++ b/packages/agency-lang/lib/types/hole.ts
@@ -1,4 +1,4 @@
-import { SourceLocation } from "./base.js";
+import { BaseNode, SourceLocation } from "./base.js";
 import { VariableType } from "./typeHints.js";
 
 /** The syntactic category of thing that can fill a hole. Determined by the
@@ -7,7 +7,7 @@ export type HoleSort = "expr" | "statements" | "identifier" | "decl";
 
 /** A gap in a template. A program containing one cannot be compiled or run;
  *  it must be loaded with loadTemplate and filled first. */
-export type Hole = {
+export type Hole = BaseNode & {
   type: "hole";
   name: string;
   sort: HoleSort;

--- a/packages/agency-lang/lib/types/matchBlock.ts
+++ b/packages/agency-lang/lib/types/matchBlock.ts
@@ -1,5 +1,5 @@
 import { AgencyComment, AgencyNode, Expression, NewLine } from "../types.js";
-import { BaseNode } from "./base.js";
+import { BaseNode, LineComment } from "./base.js";
 import { IsExpression, MatchPattern } from "./pattern.js";
 
 export type DefaultCase = "_";
@@ -14,6 +14,8 @@ export type MatchBlockCase = {
    *  blocks to inline arms. Absent for inline arms and for cases built
    *  programmatically. */
   blockBody?: true;
+  /** A same-line `//` comment after the whole arm. */
+  trailingComment?: LineComment;
 };
 
 export type MatchBlock = BaseNode & {


### PR DESCRIPTION
Tasks 1 and 2 of the trailing-comments plan. This is the first of three PRs; it covers **complete constructs** only. Multiline list items (arrays, call arguments, import lists, and so on) are unchanged and come in the follow-ups.

## The problem

Write a comment at the end of a line and `agency fmt` moves it onto its own line, above the next statement. That silently changes what the comment appears to describe:

```
const x = 5 // explains x        →      const x = 5
const y = 6                             // explains x
                                        const y = 6
```

The guide told people not to do it at all.

## What now works

A `//` comment stays attached to a complete declaration, statement, or match arm:

```
type UserId = string // stable identifier

node main() {
  const x = 5 // starting count

  match (x) {
    5 => "five" // the only case we expect
    _ => "other"
  }
}
```

It works in every body owner: node, def, if, else, while, for, thread, subthread, guard, handle, inline handlers, finalize, parallel, seq, destructive, block arguments, statement code literals, and both inline and block match arms. Comments also survive import sorting, which renders imports on a path that bypasses `processNode`.

## How

**Parsing.** One combinator, `completeConstructEntry`, wraps three existing streams: top level, bodies, and match arms. It parses the construct, and attaches a following `//` only if the construct's own parser did not already consume the line ending — that check is what keeps a standalone comment on the *next* line from being pulled up. Blank lines are sentinel characters by that point, so they count as line endings too.

`completeConstructEntry` is also the single owner of the layout that ends the line. The three call sites each used to consume that whitespace themselves; they no longer do, because `lineCommentCore` deliberately stops before the newline and something has to consume it exactly once.

The comment lands on `BaseNode.trailingComment`. No wrapper node, no change to `loc` — the owner's span still ends where it did, which the LSP and linter position tests confirm.

**Printing.** `commentText` is the only thing that builds `//${content}`; `appendTrailingComment` is the only thing that places one after code. `processNode` calls it once for every node type. Match-arm rendering is split into `renderInlineMatchArm` / `renderBlockMatchArm` so the comment attaches to a finished arm instead of being threaded through both branches.

**One type fix:** `Hole` declared its own `loc` rather than extending `BaseNode`, so a top-level hole could receive a trailing comment the type did not record. It now extends `BaseNode` with `loc` still required.

## Verification

- Full unit suite: **10,440 passed, 0 failed** (674 files).
- `make`: clean, so the whole stdlib and examples recompile through the changed parser with no working-tree changes.
- `pnpm run typecheck`: byte-identical to the `origin/main` baseline. That baseline is red — 15 pre-existing errors in `lib/serve/*` unrelated to this change.
- `pnpm run lint:structure`: clean.
- `pnpm run test:perf`: 16 tests passed; parse/fmt/doc scaling still linear (parse 25.4s, fmt 13.7s, doc 19.9s).

New tests: `lib/parsers/trailingComments.test.ts` (attachment, the newline boundary, and that `loc` excludes the comment), plus an 18-case body-owner matrix and fixed-point assertions in `lib/formatter.test.ts`. Every formatter case asserts the output reparses and that formatting twice is identical.

## Deliberate non-goals

Block comments never attach. Trivia nodes (comments, blank lines) never own a trailing comment. Multiline list items still relocate — the guide now says so explicitly rather than claiming end-of-line comments are disallowed.

## Deviation from the plan

The plan passed a `canAttach` policy only at the body stream. I made the trivia-node exclusion unconditional inside `withTrailingLineComment` instead, so top level and match arms get it too. Without that, `/* x */ // y` at top level would attach a line comment to a block-comment node, since `multiLineCommentParser` does not consume its line ending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
