### PR TITLE
fmt: keep end-of-line comments attached in multiline lists, calls, and signatures

### DIFF
--- a/packages/agency-lang/lib/backends/agencyGenerator.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.ts
@@ -25,6 +25,28 @@ import {
   isExpressionNode,
 } from "../types.js";
 import { LineComment } from "../types/base.js";
+import {
+  ListTrivia,
+  TriviaNode,
+  isTrailingListTrivia,
+} from "../types/dataStructures.js";
+
+/** One rendered list item. `leadingLines` are whole lines that print above
+ *  it (an object-type property's `@validate` tags); the shared renderer
+ *  indents them, so callers hand back plain text. */
+type RenderedListItem = {
+  leadingLines?: string[];
+  code: string;
+};
+
+type RenderListWithTriviaOptions<T> = {
+  items: T[];
+  trivia: ListTrivia[] | undefined;
+  open: string;
+  close: string;
+  renderItem: (item: T, index: number) => RenderedListItem;
+  separator: (index: number, itemCount: number) => string;
+};
 
 import { AccessChainElement, ValueAccess } from "../types/access.js";
 import { declaredName } from "../types/hole.js";
@@ -773,38 +795,99 @@ export class AgencyGenerator {
   // one rendered line per comment. Shared by object types and array/object
   // literals so all three preserve trivia identically. Accepts either
   // `ObjectTypeTrivia[]` or `Trivia[]` (structurally identical).
+  protected renderTriviaNode(node: TriviaNode): string {
+    if (node.type === "newLine") {
+      return "";
+    }
+    if (node.type === "comment") {
+      return this.processComment(node);
+    }
+    return this.processMultiLineComment(node);
+  }
+
+  /** Comments that print on their own line ABOVE item `anchorIndex`. */
+  protected beforeTriviaAt(
+    trivia: ListTrivia[] | undefined,
+    anchorIndex: number,
+  ): TriviaNode[] {
+    return (trivia ?? [])
+      .filter(
+        (entry) =>
+          entry.anchorIndex === anchorIndex && entry.placement !== "trailing",
+      )
+      .flatMap((entry) => entry.comments);
+  }
+
+  /** Comments that print at the END of item `anchorIndex`'s line. */
+  protected trailingTriviaAt(
+    trivia: ListTrivia[] | undefined,
+    anchorIndex: number,
+  ): LineComment[] {
+    return (trivia ?? [])
+      .filter(isTrailingListTrivia)
+      .filter((entry) => entry.anchorIndex === anchorIndex)
+      .flatMap((entry) => entry.comments);
+  }
+
   protected emitTriviaAt(
     trivia: (ObjectTypeTrivia | Trivia)[] | undefined,
     anchorIndex: number,
     lines: string[],
   ): void {
-    const match = (trivia ?? []).find((t) => t.anchorIndex === anchorIndex);
-    for (const n of match?.comments ?? []) {
-      if (n.type === "newLine") lines.push("");
-      else if (n.type === "comment") lines.push(this.processComment(n));
-      else lines.push(this.processMultiLineComment(n));
+    for (const node of this.beforeTriviaAt(trivia, anchorIndex)) {
+      lines.push(this.renderTriviaNode(node));
     }
+  }
+
+  /** Render one multiline list, owning indentation and both comment
+   *  placements. Callers supply how to render an item and where separators
+   *  go; they must not place comments themselves. */
+  protected renderListWithTrivia<T>(
+    args: RenderListWithTriviaOptions<T>,
+  ): string {
+    this.increaseIndent();
+    const lines: string[] = [];
+
+    for (let index = 0; index < args.items.length; index++) {
+      for (const node of this.beforeTriviaAt(args.trivia, index)) {
+        lines.push(this.renderTriviaNode(node));
+      }
+
+      const item = args.renderItem(args.items[index], index);
+      for (const leadingLine of item.leadingLines ?? []) {
+        lines.push(this.indentStr(leadingLine));
+      }
+      const separator = args.separator(index, args.items.length);
+      let line = this.indentStr(`${item.code}${separator}`);
+      for (const comment of this.trailingTriviaAt(args.trivia, index)) {
+        line = this.appendTrailingComment(line, comment);
+      }
+      lines.push(line);
+    }
+
+    for (const node of this.beforeTriviaAt(args.trivia, args.items.length)) {
+      lines.push(this.renderTriviaNode(node));
+    }
+
+    this.decreaseIndent();
+    return `${args.open}\n${lines.join("\n")}\n${this.indentStr(args.close)}`;
   }
 
   protected aliasedTypeToString(aliasedType: VariableType): string {
     if (aliasedType.type === "objectType") {
-      this.increaseIndent();
-      const lines: string[] = [];
-      const props = aliasedType.properties;
-      for (let i = 0; i < props.length; i++) {
-        this.emitTriviaAt(aliasedType.trivia, i, lines);
+      return this.renderListWithTrivia({
+        items: aliasedType.properties,
+        trivia: aliasedType.trivia,
+        open: "{",
+        close: "}",
         // `@validate(...)` / `@jsonSchema(...)` annotations render on their
-        // own lines above the property, matching source layout. `formatTag`
-        // already applies the current (property-level) indentation.
-        for (const tag of props[i].tags ?? []) {
-          lines.push(this.formatTag(tag));
-        }
-        const sep = i === props.length - 1 ? "" : ";";
-        lines.push(this.indentStr(this.stringifyProp(props[i])) + sep);
-      }
-      this.emitTriviaAt(aliasedType.trivia, props.length, lines);
-      this.decreaseIndent();
-      return "{\n" + lines.join("\n") + "\n" + this.indentStr("}");
+        // own lines above the property, matching source layout.
+        renderItem: (prop) => ({
+          leadingLines: (prop.tags ?? []).map((tag) => this.formatTag(tag).trim()),
+          code: this.stringifyProp(prop),
+        }),
+        separator: (index, count) => (index === count - 1 ? "" : ";"),
+      });
     }
     return variableTypeToString(aliasedType, this.typeAliases, true);
   }
@@ -1301,57 +1384,50 @@ export class AgencyGenerator {
     // (which may render on a single line). Trivia forces the multi-line form
     // so each comment gets its own line.
     if (!node.trivia?.length) {
-      const items = node.items.map((item) => {
-        if (item.type === "splat") {
-          return `...${this.processNode(item.value).trim()}`;
-        }
-        return this.processNode(item).trim();
-      });
+      const items = node.items.map((item) => this.renderArrayItem(item));
       return this.wrapList(items, "", "[", "]");
     }
 
-    this.increaseIndent();
-    const lines: string[] = [];
-    for (let i = 0; i < node.items.length; i++) {
-      this.emitTriviaAt(node.trivia, i, lines);
-      const item = node.items[i];
-      const itemStr =
-        item.type === "splat"
-          ? `...${this.processNode(item.value).trim()}`
-          : this.processNode(item).trim();
-      const sep = i === node.items.length - 1 ? "" : ",";
-      lines.push(this.indentStr(itemStr) + sep);
+    return this.renderListWithTrivia({
+      items: node.items,
+      trivia: node.trivia,
+      open: "[",
+      close: "]",
+      renderItem: (item) => ({ code: this.renderArrayItem(item) }),
+      separator: (index, count) => (index === count - 1 ? "" : ","),
+    });
+  }
+
+  private renderArrayItem(item: AgencyArray["items"][number]): string {
+    if (item.type === "splat") {
+      return `...${this.processNode(item.value).trim()}`;
     }
-    this.emitTriviaAt(node.trivia, node.items.length, lines);
-    this.decreaseIndent();
-    return "[\n" + lines.join("\n") + "\n" + this.indentStr("]");
+    return this.processNode(item).trim();
   }
 
   protected processAgencyObject(node: AgencyObject): string {
     if (node.entries.length === 0 && !node.trivia?.length) {
       return `{}`;
     }
-    this.increaseIndent();
-    const lines: string[] = [];
-    for (let i = 0; i < node.entries.length; i++) {
-      this.emitTriviaAt(node.trivia, i, lines);
-      const entry = node.entries[i];
-      let entryStr: string;
-      if ("type" in entry && entry.type === "splat") {
-        entryStr = `...${this.processNode(entry.value).trim()}`;
-      } else {
-        const kv = entry as AgencyObjectKV;
-        const valueCode = this.processNode(kv.value).trim();
-        entryStr = kv.computedKey
-          ? `[${this.processNode(kv.computedKey).trim()}]: ${valueCode}`
-          : `${this.addQuotesToKey(kv.key)}: ${valueCode}`;
-      }
-      const sep = i === node.entries.length - 1 ? "" : ",";
-      lines.push(this.indentStr(entryStr) + sep);
+    return this.renderListWithTrivia({
+      items: node.entries,
+      trivia: node.trivia,
+      open: "{",
+      close: "}",
+      renderItem: (entry) => ({ code: this.renderObjectEntry(entry) }),
+      separator: (index, count) => (index === count - 1 ? "" : ","),
+    });
+  }
+
+  private renderObjectEntry(entry: AgencyObject["entries"][number]): string {
+    if ("type" in entry && entry.type === "splat") {
+      return `...${this.processNode(entry.value).trim()}`;
     }
-    this.emitTriviaAt(node.trivia, node.entries.length, lines);
-    this.decreaseIndent();
-    return "{\n" + lines.join("\n") + "\n" + this.indentStr("}");
+    const kv = entry as AgencyObjectKV;
+    const valueCode = this.processNode(kv.value).trim();
+    return kv.computedKey
+      ? `[${this.processNode(kv.computedKey).trim()}]: ${valueCode}`
+      : `${this.addQuotesToKey(kv.key)}: ${valueCode}`;
   }
 
   private addQuotesToKey(key: string): string {

--- a/packages/agency-lang/lib/backends/agencyGenerator.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.ts
@@ -13,7 +13,6 @@ import {
   MultiLineStringLiteral,
   NewLine,
   ObjectProperty,
-  ObjectTypeTrivia,
   ParallelBlock,
   Scope,
   ScopeType,
@@ -58,7 +57,6 @@ import {
   AgencyArray,
   AgencyObject,
   AgencyObjectKV,
-  Trivia,
 } from "../types/dataStructures.js";
 import {
   FunctionCall,
@@ -652,7 +650,11 @@ export class AgencyGenerator {
   }
 
   protected processInterruptStatement(node: InterruptStatement): string {
-    const args = this.renderArgList(node.arguments);
+    const args = this.renderArgList(
+      node.arguments,
+      undefined,
+      node.argumentTrivia,
+    );
     // `raise` lowers to an interruptStatement; viaRaise drives the keyword.
     const keyword = node.viaRaise ? "raise" : "interrupt";
     if (node.effect === "unknown") {
@@ -791,10 +793,7 @@ export class AgencyGenerator {
     return str;
   }
 
-  // Append the comment/blank-line trivia anchored at `anchorIndex` to `lines`,
-  // one rendered line per comment. Shared by object types and array/object
-  // literals so all three preserve trivia identically. Accepts either
-  // `ObjectTypeTrivia[]` or `Trivia[]` (structurally identical).
+  /** One trivia node as its own source line. */
   protected renderTriviaNode(node: TriviaNode): string {
     if (node.type === "newLine") {
       return "";
@@ -827,16 +826,6 @@ export class AgencyGenerator {
       .filter(isTrailingListTrivia)
       .filter((entry) => entry.anchorIndex === anchorIndex)
       .flatMap((entry) => entry.comments);
-  }
-
-  protected emitTriviaAt(
-    trivia: (ObjectTypeTrivia | Trivia)[] | undefined,
-    anchorIndex: number,
-    lines: string[],
-  ): void {
-    for (const node of this.beforeTriviaAt(trivia, anchorIndex)) {
-      lines.push(this.renderTriviaNode(node));
-    }
   }
 
   /** Render one multiline list, owning indentation and both comment
@@ -1217,11 +1206,10 @@ export class AgencyGenerator {
         returnTypeBang
       : "";
     const raisesStr = this.formatRaisesClause(node.raises);
-    return this.wrapList(
+    return this.renderParenList(
       this.renderParams(node.parameters),
+      node.parameterTrivia,
       prefix,
-      "(",
-      ")",
       `${returnTypeStr}${raisesStr}${opener}`,
     );
   }
@@ -1326,12 +1314,45 @@ export class AgencyGenerator {
     return rendered;
   }
 
+  /** The one way a parenthesized `( ... )` list is printed. Without trivia
+   *  it keeps `wrapList`'s compact/wrapping behavior exactly; with trivia it
+   *  goes multiline so every comment gets a line to sit at the end of.
+   *  `rendered` must already be in canonical print order — for a call that
+   *  means `renderArgs` has appended any inline block last, matching how
+   *  `extractInlineBlock` remapped the anchors. */
+  protected renderParenList(
+    rendered: string[],
+    trivia: ListTrivia[] | undefined,
+    prefix: string,
+    suffix: string,
+  ): string {
+    if (!trivia?.length) {
+      return this.wrapList(rendered, prefix, "(", ")", suffix);
+    }
+    const body = this.renderListWithTrivia({
+      items: rendered,
+      trivia,
+      open: "(",
+      close: ")",
+      renderItem: (code) => ({ code }),
+      separator: (index, count) => (index === count - 1 ? "" : ","),
+    });
+    return `${prefix}${body}${suffix}`;
+  }
+
   // Format args as inline parenthesized list (no wrapping — used by access chain callers)
+  /** A parenthesized argument list that normally stays on one line
+   *  (access chains, `interrupt`, `guard`). Trivia forces the multiline
+   *  form, since a `//` comment cannot share a line with what follows it. */
   protected renderArgList(
     args: FunctionCall["arguments"],
     block?: BlockArgument,
+    trivia?: ListTrivia[],
   ): string {
     const rendered = this.renderArgs(args, block);
+    if (trivia?.length) {
+      return this.renderParenList(rendered, trivia, "", "");
+    }
     return `(${rendered.join(", ")})`;
   }
 
@@ -1349,11 +1370,10 @@ export class AgencyGenerator {
     const block = node.block;
     const inlineBlock = block?.inline ? block : undefined;
     const rendered = this.renderArgs(node.arguments, inlineBlock);
-    let result = this.wrapList(
+    let result = this.renderParenList(
       rendered,
+      node.argumentTrivia,
       `${asyncPrefix}${declaredName(node.functionName)}`,
-      "(",
-      ")",
       "",
     );
 
@@ -2062,6 +2082,8 @@ export class AgencyGenerator {
     this.decreaseIndent();
     const argsStr = this.renderArgList(
       node.arguments as FunctionCall["arguments"],
+      undefined,
+      node.argumentTrivia,
     );
     return this.indentStr(
       `guard${argsStr} {\n${bodyCodeStr}${this.indentStr("}")}`,
@@ -2155,7 +2177,7 @@ export class AgencyGenerator {
       case "methodCall":
         return `${dot}${this.generateFunctionCallExpression(node.functionCall, "valueAccess")}`;
       case "call":
-        return `${node.optional ? "?." : ""}${this.renderArgList(node.arguments, node.block)}`;
+        return `${node.optional ? "?." : ""}${this.renderArgList(node.arguments, node.block, node.argumentTrivia)}`;
       default:
         throw new Error(
           `Unknown access chain element kind: ${(node as any).kind}`,

--- a/packages/agency-lang/lib/parsers/listTrailingComments.test.ts
+++ b/packages/agency-lang/lib/parsers/listTrailingComments.test.ts
@@ -176,3 +176,36 @@ describe("inline block canonicalization keeps comments with their argument", () 
     expect(formatSource(once as string)).toBe(once);
   });
 });
+
+// A nested list parser consumes the layout after its own closer, so the next
+// line's standalone comment is already sitting where a trailing comment would
+// be. These pin the boundary from both sides.
+describe("line boundaries around nested members", () => {
+  it("leaves a comment on the line AFTER a nested object type standalone", () => {
+    const source = `type Value = {\n  nested: {\n    x: number\n  }\n  // describes next\n  next: string\n}\n`;
+    const once = formatSource(source);
+    expect(once).toContain("nested: { x: number };\n  // describes next");
+    expect(formatSource(once as string)).toBe(once);
+  });
+
+  it("still attaches a comment ON the nested closing brace's line", () => {
+    const source = `type Value = {\n  nested: {\n    x: number\n  } // about nested\n  next: string\n}\n`;
+    const once = formatSource(source);
+    expect(once).toContain("nested: { x: number }; // about nested");
+    expect(formatSource(once as string)).toBe(once);
+  });
+
+  it("does not attach across a leading-comma line break", () => {
+    const source = `node main() {\n  const xs = [\n    first\n    , // comment\n    second\n  ]\n}\n`;
+    const once = formatSource(source);
+    expect(once).toContain("first,\n    // comment");
+    expect(formatSource(once as string)).toBe(once);
+  });
+
+  it("attaches after a multiline item, whose own newlines do not count", () => {
+    const source = `node main() {\n  const xs = [\n    [\n      1,\n      2\n    ], // outer\n    third\n  ]\n}\n`;
+    const once = formatSource(source);
+    expect(once).toContain("], // outer");
+    expect(formatSource(once as string)).toBe(once);
+  });
+});

--- a/packages/agency-lang/lib/parsers/listTrailingComments.test.ts
+++ b/packages/agency-lang/lib/parsers/listTrailingComments.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import { formatSource } from "@/formatter.js";
+import { agencyArrayParser } from "./parsers.js";
+
+describe("list trailing trivia", () => {
+  it("distinguishes a trailing comment from a comment before the next item", () => {
+    const parsed = agencyArrayParser(`[
+      first, // explains first
+      // prepares second
+      second
+    ]`);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) {
+      return;
+    }
+    expect(parsed.result.trivia).toEqual([
+      {
+        anchorIndex: 0,
+        placement: "trailing",
+        comments: [{ type: "comment", content: " explains first" }],
+      },
+      {
+        anchorIndex: 1,
+        comments: [{ type: "comment", content: " prepares second" }],
+      },
+    ]);
+  });
+
+  // Assert the FOLLOWING item too, not just comment text: these pin parser
+  // progress and boundary detection, which a text-only assertion misses.
+  it("keeps parsing after a non-final trailing comment", () => {
+    const parsed = agencyArrayParser(`[\n  first, // one\n  second,\n  third\n]`);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) {
+      return;
+    }
+    expect(parsed.result.items).toHaveLength(3);
+    expect(parsed.result.trivia).toEqual([
+      {
+        anchorIndex: 0,
+        placement: "trailing",
+        comments: [{ type: "comment", content: " one" }],
+      },
+    ]);
+  });
+
+  it("keeps a trailing comment and following standalone trivia apart", () => {
+    const parsed = agencyArrayParser(
+      `[\n  first, // one\n\n  // about second\n  second\n]`,
+    );
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) {
+      return;
+    }
+    expect(parsed.result.items).toHaveLength(2);
+    const trailing = (parsed.result.trivia ?? []).filter(
+      (entry: any) => entry.placement === "trailing",
+    );
+    expect(trailing).toHaveLength(1);
+    expect(trailing[0].anchorIndex).toBe(0);
+    const before = (parsed.result.trivia ?? []).filter(
+      (entry: any) => entry.placement !== "trailing",
+    );
+    expect(before.every((entry: any) => entry.anchorIndex === 1)).toBe(true);
+  });
+
+  it("does not attach a comment on the line after the item", () => {
+    const parsed = agencyArrayParser(`[\n  first,\n  // about second\n  second\n]`);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) {
+      return;
+    }
+    expect(parsed.result.items).toHaveLength(2);
+    expect(parsed.result.trivia).toEqual([
+      {
+        anchorIndex: 1,
+        comments: [{ type: "comment", content: " about second" }],
+      },
+    ]);
+  });
+
+  // `toContain("// one")` alone would pass even if the comment were moved
+  // onto its own line, which is the bug. Assert the whole line.
+  it.each([
+    ["array", `const value = [\n  1, // one\n  2 // two\n]\n`, ["1, // one", "2 // two"]],
+    [
+      "object",
+      `const value = {\n  one: 1, // one\n  two: 2 // two\n}\n`,
+      ["one: 1, // one", "two: 2 // two"],
+    ],
+    [
+      "object type",
+      `type Value = {\n  one: number // one\n  two: number // two\n}\n`,
+      ["one: number; // one", "two: number // two"],
+    ],
+  ])("formats trailing comments in a %s", (_name, source, expectedLines) => {
+    const once = formatSource(source);
+    for (const line of expectedLines) {
+      expect(once).toContain(line);
+    }
+    expect(formatSource(once as string)).toBe(once);
+  });
+});
+
+describe("object type members with tags", () => {
+  it("keeps a trailing comment on a tagged property", () => {
+    const source = `type Value = {\n  @validate(min.partial(n: 0))\n  count: number // how many\n  name: string // who\n}\n`;
+    const once = formatSource(source);
+    expect(once).toContain("@validate(min.partial(n: 0))");
+    expect(once).toContain("count: number; // how many");
+    expect(once).toContain("name: string // who");
+    expect(formatSource(once as string)).toBe(once);
+  });
+});

--- a/packages/agency-lang/lib/parsers/listTrailingComments.test.ts
+++ b/packages/agency-lang/lib/parsers/listTrailingComments.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { formatSource } from "@/formatter.js";
+import { parseAgency } from "@/parser.js";
 import { agencyArrayParser } from "./parsers.js";
 
 describe("list trailing trivia", () => {
@@ -109,6 +110,69 @@ describe("object type members with tags", () => {
     expect(once).toContain("@validate(min.partial(n: 0))");
     expect(once).toContain("count: number; // how many");
     expect(once).toContain("name: string // who");
+    expect(formatSource(once as string)).toBe(once);
+  });
+});
+
+describe("call and declaration list comments", () => {
+  it.each([
+    ["positional", `save(\n  first, // first\n  second // second\n)`],
+    ["named", `save(\n  value: first, // first\n  retries: 3 // second\n)`],
+    ["splat", `save(\n  ...values, // first\n  final // second\n)`],
+    ["method", `client.save(\n  first, // first\n  second // second\n)`],
+    ["call chain", `handlers[0](\n  first, // first\n  second // second\n)`],
+    ["interrupt", `interrupt io::read(\n  first, // first\n  second // second\n)`],
+    ["raise", `raise io::failure(\n  first, // first\n  second // second\n)`],
+    ["guard", `guard(\n  cost: $1, // first\n  time: 5m // second\n) {\n    print(1)\n  }`],
+  ])("preserves %s argument comments", (_name, call) => {
+    const source = `node main() {\n  ${call}\n}\n`;
+    const once = formatSource(source);
+    expect(once).not.toBeNull();
+    expect(once).toContain("// first");
+    expect(once).toContain("// second");
+    expect(parseAgency(once as string, {}, false, false).success).toBe(true);
+    expect(formatSource(once as string)).toBe(once);
+  });
+
+  it.each([
+    [
+      "function",
+      `def save(\n  value: string, // value\n  ...rest: string[] // rest\n) {\n}\n`,
+      ["value: string, // value", "...rest: string[] // rest"],
+    ],
+    [
+      "node",
+      `node save(\n  value: string!, // value\n  retries: number = 3 // retries\n) {\n}\n`,
+      ["value: string!, // value", "retries: number = 3 // retries"],
+    ],
+  ])("preserves %s parameter comments", (_name, source, expectedLines) => {
+    const once = formatSource(source);
+    expect(once).not.toBeNull();
+    for (const line of expectedLines) {
+      expect(once).toContain(line);
+    }
+    expect(parseAgency(once as string, {}, false, false).success).toBe(true);
+    expect(formatSource(once as string)).toBe(once);
+  });
+});
+
+describe("inline block canonicalization keeps comments with their argument", () => {
+  it.each([
+    ["first", `map(\n  \\n -> n * n, // block\n  items // ordinary\n)`],
+    ["last", `map(\n  items, // ordinary\n  \\n -> n * n // block\n)`],
+    [
+      "middle",
+      `reduce(\n  items, // ordinary\n  \\n -> n * n, // block\n  0 // seed\n)`,
+    ],
+  ])("keeps both comments when the block starts %s", (_name, call) => {
+    const source = `node main() {\n  const r = ${call}\n}\n`;
+    const once = formatSource(source);
+    expect(once).not.toBeNull();
+    expect(once).toContain("// block");
+    expect(once).toContain("// ordinary");
+    // The block itself must survive canonicalization, not just its comment.
+    expect(once).toContain("\\n -> n * n");
+    expect(parseAgency(once as string, {}, false, false).success).toBe(true);
     expect(formatSource(once as string)).toBe(once);
   });
 });

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -375,15 +375,27 @@ const NON_TRAILING_OWNER_TYPES = [
   "newLine",
 ];
 
+const LINE_ENDING_PATTERN = new RegExp(`[\\r\\n${BLANK_LINE_SENTINEL}]`);
+
+/** Whether ANY line ending was crossed going from `from` to `to`. Use this
+ *  for a span that should sit entirely on one line, such as the delimiter
+ *  between two list items. Do not use it across an item, whose own text may
+ *  legitimately span lines. */
+function spanCrossesLine(from: string, to: string): boolean {
+  return LINE_ENDING_PATTERN.test(from.slice(0, from.length - to.length));
+}
+
 /** A construct's own parser may or may not swallow the line ending after
  *  it. If it did, any `//` that follows starts a later line and belongs to
- *  whatever comes next. Blank lines are sentinels by this point
- *  (replaceBlankLines), so they count as line endings too. */
+ *  whatever comes next. Only the TRAILING whitespace is examined, so an item
+ *  that spans lines internally still counts as ending on its last line.
+ *  Blank lines are sentinels by this point (replaceBlankLines), so they
+ *  count as line endings too. */
 function consumedLineEnding(input: string, rest: string): boolean {
   const consumed = input.slice(0, input.length - rest.length);
   const trailingWhitespace =
     consumed.match(new RegExp(`[ \\t\\r\\n${BLANK_LINE_SENTINEL}]*$`))?.[0] ?? "";
-  return new RegExp(`[\\r\\n${BLANK_LINE_SENTINEL}]`).test(trailingWhitespace);
+  return LINE_ENDING_PATTERN.test(trailingWhitespace);
 }
 
 const sameLineComment: Parser<LineComment> = map(
@@ -1731,7 +1743,7 @@ const itemEntryAfterDelimiter = <T>(
       return separated as ParserResult<ItemEntry<T>>;
     }
 
-    if (consumedLineEnding(input, separated.rest)) {
+    if (spanCrossesLine(item.rest, separated.rest)) {
       return success({ kind: "item", item: item.result }, separated.rest);
     }
 
@@ -1760,7 +1772,9 @@ const objectMemberEntry = <T>(
       return item as ParserResult<ItemEntry<T>>;
     }
 
-    const beforeDelimiter = trailingLineCommentEntry(item.rest);
+    const beforeDelimiter = consumedLineEnding(input, item.rest)
+      ? failure("item ended on a later line", item.rest)
+      : trailingLineCommentEntry(item.rest);
     if (beforeDelimiter.success) {
       const separated = delimiter(beforeDelimiter.rest);
       if (!separated.success) {
@@ -1781,7 +1795,10 @@ const objectMemberEntry = <T>(
       return separated as ParserResult<ItemEntry<T>>;
     }
 
-    if (consumedLineEnding(input, separated.rest)) {
+    if (
+      consumedLineEnding(input, item.rest) ||
+      spanCrossesLine(item.rest, separated.rest)
+    ) {
       return success({ kind: "item", item: item.result }, separated.rest);
     }
 

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -170,6 +170,7 @@ import {
   ListTrivia,
   ParsedList,
   TriviaNode,
+  isTrailingListTrivia,
 } from "../types/dataStructures.js";
 import {
   DefaultImport,
@@ -1836,6 +1837,91 @@ function partitionTrivia<T>(entries: InterleavedEntry<T>[]): ParsedList<T> {
   return trivia.length > 0 ? { items, trivia } : { items };
 }
 
+/** A comma-separated list that may span lines, with trivia between items.
+ *  `closer` is only looked at, never consumed: it lets the last item go
+ *  without a comma while still requiring commas between items (#602). */
+function commaDelimitedList<T>(
+  itemParser: Parser<T>,
+  closer: string,
+): Parser<ParsedList<T>> {
+  return map(
+    many(
+      or(
+        triviaEntry,
+        itemEntryAfterDelimiter(itemParser, literalDelimiter(closer)),
+      ),
+    ),
+    (entries: InterleavedEntry<T>[]) => partitionTrivia(entries),
+  );
+}
+
+/** `commaDelimitedList` shaped for `captureCaptures`: lifts the items and
+ *  their trivia into the parent under the two given field names. */
+function commaDelimitedListCaptures<
+  T,
+  ItemsKey extends string,
+  TriviaKey extends string,
+>(
+  itemParser: Parser<T>,
+  closer: string,
+  itemsKey: ItemsKey,
+  triviaKey: TriviaKey,
+): Parser<{ [K in ItemsKey]: T[] } & { [K in TriviaKey]?: ListTrivia[] }> {
+  return map(
+    commaDelimitedList(itemParser, closer),
+    (parsed: ParsedList<T>) =>
+      ({
+        [itemsKey]: parsed.items,
+        ...(parsed.trivia && { [triviaKey]: parsed.trivia }),
+      }) as { [K in ItemsKey]: T[] } & { [K in TriviaKey]?: ListTrivia[] },
+  );
+}
+
+/** Move trivia anchors from source order to the order a list will print in.
+ *  `canonicalSourceIndexes[c]` is the source index of the item that ends up
+ *  at canonical position `c`. A before-comment stays with the item it
+ *  preceded and a trailing comment stays with the item it followed, so both
+ *  travel when the formatter reorders (an inline block moving last, thread
+ *  arguments taking canonical order). */
+export function remapListTrivia(
+  trivia: ListTrivia[] | undefined,
+  canonicalSourceIndexes: number[],
+): ListTrivia[] | undefined {
+  if (!trivia) {
+    return undefined;
+  }
+
+  const sourceItemCount = canonicalSourceIndexes.length;
+  const sortedIndexes = [...canonicalSourceIndexes].sort(
+    (left, right) => left - right,
+  );
+  const isPermutation = sortedIndexes.every(
+    (sourceIndex, expectedIndex) => sourceIndex === expectedIndex,
+  );
+  if (!isPermutation) {
+    throw new Error("canonical list order must contain every source item once");
+  }
+
+  const sourceToCanonical: (number | undefined)[] = [];
+  canonicalSourceIndexes.forEach((sourceIndex, canonicalIndex) => {
+    sourceToCanonical[sourceIndex] = canonicalIndex;
+  });
+
+  return trivia.map((entry) => {
+    // The after-the-last-item anchor is not an item, so it does not move.
+    if (!isTrailingListTrivia(entry) && entry.anchorIndex === sourceItemCount) {
+      return entry;
+    }
+    const anchorIndex = sourceToCanonical[entry.anchorIndex];
+    if (anchorIndex === undefined) {
+      throw new Error(
+        `list trivia has invalid source anchor ${entry.anchorIndex}`,
+      );
+    }
+    return { ...entry, anchorIndex };
+  });
+}
+
 const objectMember = objectMemberEntry(
   or(
     taggedObjectPropertyParser,
@@ -1863,7 +1949,9 @@ export const objectTypeParser: Parser<ObjectType> = memo(
         r.entries as InterleavedEntry<ObjectProperty>[],
       );
       const objectType: ObjectType = { type: "objectType", properties: items };
-      if (trivia) objectType.trivia = trivia;
+      if (trivia) {
+        objectType.trivia = trivia;
+      }
       return objectType;
     },
   ),
@@ -2733,7 +2821,9 @@ export const agencyArrayParser: Parser<AgencyArray> = memo(
         r.entries as InterleavedEntry<Expression | SplatExpression>[],
       );
       const node: AgencyArray = { type: "agencyArray", items };
-      if (trivia) node.trivia = trivia;
+      if (trivia) {
+        node.trivia = trivia;
+      }
       return node;
     },
   ),
@@ -2803,7 +2893,9 @@ export const agencyObjectParser: Parser<AgencyObject> = map(
       r.entries as InterleavedEntry<AgencyObjectKV | SplatExpression>[],
     );
     const node: AgencyObject = { type: "agencyObject", entries: items };
-    if (trivia) node.trivia = trivia;
+    if (trivia) {
+      node.trivia = trivia;
+    }
     return node;
   },
 );
@@ -2836,33 +2928,40 @@ const namedArgumentParser: Parser<NamedArgument> = memo(
   ),
 );
 
+const argumentItemParser = or(
+  namedArgumentParser,
+  splatParser,
+  // Before exprParser: the expression path rejects splices, so
+  // `f(#...args)` needs its own alternative here.
+  lazy(() => spliceHoleParser),
+  lazy(() => inlineBlockParser),
+  // Before exprParser: `(n)` and `n` both parse as expressions, so the
+  // arrow form has to get first refusal on them.
+  lazy(() => arrowBlockParser),
+  lazy(() => exprParser),
+);
+
 // Shared argument list parser: (arg1, arg2, \x -> expr, ...)
-// Used by both _functionCallParser and callChainParser.
-const argumentListParser = memo("argumentListParser", seqC(
-  char("("),
-  optionalSpacesOrNewline,
-  capture(
-    sepBy(
-      commaWithNewline,
-      or(
-        namedArgumentParser,
-        splatParser,
-        // Before exprParser: the expression path rejects splices, so
-        // `f(#...args)` needs its own alternative here.
-        lazy(() => spliceHoleParser),
-        lazy(() => inlineBlockParser),
-        // Before exprParser: `(n)` and `n` both parse as expressions, so the
-        // arrow form has to get first refusal on them.
-        lazy(() => arrowBlockParser),
-        lazy(() => exprParser),
+// Used by _functionCallParser, callChainParser, interrupt/raise, and guard.
+// Captures `arguments` plus `argumentTrivia`, so the consumers that lift it
+// with `captureCaptures` carry comments through without extra wiring.
+const argumentListParser = memo(
+  "argumentListParser",
+  seqC(
+    char("("),
+    optionalSpacesOrNewline,
+    captureCaptures(
+      commaDelimitedListCaptures(
+        argumentItemParser,
+        ")",
+        "arguments",
+        "argumentTrivia",
       ),
     ),
-    "arguments",
+    optionalSpacesOrNewline,
+    char(")"),
   ),
-  optional(comma),
-  optionalSpacesOrNewline,
-  char(")"),
-));
+);
 
 // Extract inline block from parsed arguments into a separate block field.
 // Returns { arguments, block } or a failure if there are multiple inline blocks,
@@ -2871,7 +2970,8 @@ function extractInlineBlock(
   args: ArgWithBlock[],
   existingBlock: BlockArgument | undefined,
   input: string,
-): { success: true; arguments: FunctionCall["arguments"]; block?: BlockArgument } | { success: false; error: ParserResult<any> } {
+  trivia?: ListTrivia[],
+): { success: true; arguments: FunctionCall["arguments"]; block?: BlockArgument; trivia?: ListTrivia[] } | { success: false; error: ParserResult<any> } {
   const inlineBlocks = args.filter((a): a is BlockArgument => a.type === "blockArgument");
   if (inlineBlocks.length > 1) {
     return { success: false, error: failure("A function call cannot have more than one block argument", input) };
@@ -2880,13 +2980,21 @@ function extractInlineBlock(
     if (existingBlock) {
       return { success: false, error: failure("A function call cannot have both an inline block and a trailing 'as' block", input) };
     }
+    // The block prints last regardless of where it was written, so canonical
+    // order is every other argument followed by the block. Trivia anchors
+    // move with it.
+    const blockIndex = args.findIndex((a) => a.type === "blockArgument");
+    const ordinaryIndexes = args
+      .map((_, index) => index)
+      .filter((index) => index !== blockIndex);
     return {
       success: true,
       arguments: args.filter((a): a is Exclude<ArgWithBlock, BlockArgument> => a.type !== "blockArgument"),
       block: inlineBlocks[0],
+      trivia: remapListTrivia(trivia, [...ordinaryIndexes, blockIndex]),
     };
   }
-  return { success: true, arguments: args as FunctionCall["arguments"], block: existingBlock };
+  return { success: true, arguments: args as FunctionCall["arguments"], block: existingBlock, trivia };
 }
 
 type ArgWithBlock = Expression | SplatExpression | NamedArgument | BlockArgument;
@@ -2915,10 +3023,16 @@ export const _functionCallParser: Parser<FunctionCall> = memo("_functionCallPars
   if (!result.success) return result;
 
   const funcCall = result.result;
-  const extracted = extractInlineBlock(funcCall.arguments, funcCall.block, input);
+  const extracted = extractInlineBlock(
+    funcCall.arguments,
+    funcCall.block,
+    input,
+    funcCall.argumentTrivia,
+  );
   if (!extracted.success) return extracted.error;
   funcCall.arguments = extracted.arguments;
   funcCall.block = extracted.block;
+  funcCall.argumentTrivia = extracted.trivia;
 
   return result as ParserResult<FunctionCall>;
 });
@@ -3070,11 +3184,16 @@ const callChainParser: Parser<AccessChainElement> = (input: string) => {
   const result = argumentListParser(isOptional ? optResult.rest : input);
   if (!result.success) return failure("expected call arguments", input);
 
-  const extracted = extractInlineBlock(result.result.arguments, undefined, input);
+  const extracted = extractInlineBlock(
+    result.result.arguments,
+    undefined,
+    input,
+    result.result.argumentTrivia,
+  );
   if (!extracted.success) return extracted.error;
 
   return success(
-    { kind: "call" as const, arguments: extracted.arguments, ...(extracted.block && { block: extracted.block }), ...(isOptional && { optional: true }) },
+    { kind: "call" as const, arguments: extracted.arguments, ...(extracted.block && { block: extracted.block }), ...(extracted.trivia && { argumentTrivia: extracted.trivia }), ...(isOptional && { optional: true }) },
     result.rest,
   );
 };
@@ -5636,6 +5755,9 @@ export const guardBlockParser: Parser<GuardBlock> = label(
         {
           type: "guardBlock",
           arguments: (pre.result as any).arguments,
+          ...((pre.result as any).argumentTrivia && {
+            argumentTrivia: (pre.result as any).argumentTrivia,
+          }),
           body: (bodyR.result as any).body,
         } as GuardBlock,
         bodyR.rest,
@@ -6345,14 +6467,14 @@ const _baseFunctionParser: Parser<any> = memo(
     capture(declNameParser, "functionName"),
     char("("),
     optionalSpacesOrNewline,
-    capture(
-      sepBy(
-        seqC(commaWithNewline, optionalSpaces),
+    captureCaptures(
+      commaDelimitedListCaptures(
         or(variadicParameterParser, functionParameterParser),
+        ")",
+        "parameters",
+        "parameterTrivia",
       ),
-      "parameters",
     ),
-    optional(comma),
     optionalSpacesOrNewline,
     // Once we've consumed `def NAME (` plus parameters, we're committed
     // to a function definition. Anything other than `,` (another param)
@@ -6514,14 +6636,14 @@ export const graphNodeParser: Parser<GraphNodeDefinition> = label("a node defini
       capture(declNameParser, "nodeName"),
       char("("),
       optionalSpacesOrNewline,
-      capture(
-        sepBy(
-          seqC(commaWithNewline, optionalSpaces),
+      captureCaptures(
+        commaDelimitedListCaptures(
           functionParameterParser,
+          ")",
+          "parameters",
+          "parameterTrivia",
         ),
-        "parameters",
       ),
-      optional(comma),
       optionalSpacesOrNewline,
       parseError(
         "expected `,` between parameters or `)` to close the parameter list",

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -167,7 +167,8 @@ import {
   AgencyObject,
   AgencyObjectKV,
   SplatExpression,
-  Trivia,
+  ListTrivia,
+  ParsedList,
   TriviaNode,
 } from "../types/dataStructures.js";
 import {
@@ -1674,7 +1675,11 @@ export const taggedObjectPropertyParser: Parser<ObjectProperty> = memo(
 // anchor-indexed trivia. These are parse-time tagging types, not AST nodes.
 // -----------------------------------------------------------------------------
 
-type ItemEntry<T> = { kind: "item"; item: T };
+type ItemEntry<T> = {
+  kind: "item";
+  item: T;
+  trailingComment?: LineComment;
+};
 type TriviaEntry = { kind: "trivia"; node: TriviaNode };
 type InterleavedEntry<T> = ItemEntry<T> | TriviaEntry;
 
@@ -1694,45 +1699,144 @@ const triviaEntry: Parser<TriviaEntry> = seqC(
   optionalSpacesOrNewline,
 ) as Parser<TriviaEntry>;
 
+/** A `//` comment plus the layout that ends its line, for the list item it
+ *  follows. Unlike the complete-construct case, the list's own `many(...)`
+ *  loop does not consume that layout, so the entry must. */
+const trailingLineCommentEntry: Parser<LineComment> = map(
+  seqC(
+    optionalSpaces,
+    capture(lineCommentCore, "comment"),
+    optionalSpacesOrNewline,
+  ),
+  (result: { comment: LineComment }) => result.comment,
+);
+
 // Wrap an item parser as a tagged `{ kind: "item", item }` entry, consuming
-// the trailing delimiter (`delimiter`) after it.
-const itemEntry = <T>(
+// the trailing delimiter (`delimiter`) after it. A `//` comment is attached
+// only when the item AND its delimiter stayed on one line, so
+// `first, \n // about second` still belongs to `second`.
+const itemEntryAfterDelimiter = <T>(
   itemParser: Parser<T>,
   delimiter: Parser<unknown>,
 ): Parser<ItemEntry<T>> =>
-  seqC(
-    set("kind", "item"),
-    capture(itemParser, "item"),
-    delimiter,
-  ) as Parser<ItemEntry<T>>;
+  (input: string): ParserResult<ItemEntry<T>> => {
+    const item = itemParser(input);
+    if (!item.success) {
+      return item as ParserResult<ItemEntry<T>>;
+    }
+
+    const separated = delimiter(item.rest);
+    if (!separated.success) {
+      return separated as ParserResult<ItemEntry<T>>;
+    }
+
+    if (consumedLineEnding(input, separated.rest)) {
+      return success({ kind: "item", item: item.result }, separated.rest);
+    }
+
+    const comment = trailingLineCommentEntry(separated.rest);
+    if (!comment.success) {
+      return success({ kind: "item", item: item.result }, separated.rest);
+    }
+
+    return success(
+      { kind: "item", item: item.result, trailingComment: comment.result },
+      comment.rest,
+    );
+  };
+
+/** Object-TYPE members, where a newline is itself a legal delimiter. Both
+ *  `property // comment` (comment before the newline delimiter) and
+ *  `property, // comment` (comment after a punctuation delimiter) are
+ *  legal, so this policy tries the comment on both sides. */
+const objectMemberEntry = <T>(
+  itemParser: Parser<T>,
+  delimiter: Parser<unknown>,
+): Parser<ItemEntry<T>> =>
+  (input: string): ParserResult<ItemEntry<T>> => {
+    const item = itemParser(input);
+    if (!item.success) {
+      return item as ParserResult<ItemEntry<T>>;
+    }
+
+    const beforeDelimiter = trailingLineCommentEntry(item.rest);
+    if (beforeDelimiter.success) {
+      const separated = delimiter(beforeDelimiter.rest);
+      if (!separated.success) {
+        return separated as ParserResult<ItemEntry<T>>;
+      }
+      return success(
+        {
+          kind: "item",
+          item: item.result,
+          trailingComment: beforeDelimiter.result,
+        },
+        separated.rest,
+      );
+    }
+
+    const separated = delimiter(item.rest);
+    if (!separated.success) {
+      return separated as ParserResult<ItemEntry<T>>;
+    }
+
+    if (consumedLineEnding(input, separated.rest)) {
+      return success({ kind: "item", item: item.result }, separated.rest);
+    }
+
+    const afterDelimiter = trailingLineCommentEntry(separated.rest);
+    if (!afterDelimiter.success) {
+      return success({ kind: "item", item: item.result }, separated.rest);
+    }
+
+    return success(
+      {
+        kind: "item",
+        item: item.result,
+        trailingComment: afterDelimiter.result,
+      },
+      afterDelimiter.rest,
+    );
+  };
 
 // Fold an interleaved item/trivia list into the item array plus anchor-indexed
-// trivia. Trivia is anchored to the index of the item it precedes; trailing
-// trivia is anchored at `items.length`. The one place this rule lives.
-function partitionTrivia<T>(
-  entries: InterleavedEntry<T>[],
-): { items: T[]; trivia: Trivia[] } {
+// trivia. Before-trivia is anchored to the index of the item it precedes, and
+// trivia after the last item is anchored at `items.length`; a trailing comment
+// is anchored to the item it follows. The one place these rules live.
+function partitionTrivia<T>(entries: InterleavedEntry<T>[]): ParsedList<T> {
   const items: T[] = [];
-  const trivia: Trivia[] = [];
+  const trivia: ListTrivia[] = [];
   let pending: TriviaNode[] = [];
+
   for (const entry of entries) {
     if (entry.kind === "trivia") {
       pending.push(entry.node);
-    } else {
-      if (pending.length > 0) {
-        trivia.push({ anchorIndex: items.length, comments: pending });
-        pending = [];
-      }
-      items.push(entry.item);
+      continue;
+    }
+
+    if (pending.length > 0) {
+      trivia.push({ anchorIndex: items.length, comments: pending });
+      pending = [];
+    }
+
+    items.push(entry.item);
+    if (entry.trailingComment) {
+      trivia.push({
+        anchorIndex: items.length - 1,
+        placement: "trailing",
+        comments: [entry.trailingComment],
+      });
     }
   }
+
   if (pending.length > 0) {
     trivia.push({ anchorIndex: items.length, comments: pending });
   }
-  return { items, trivia };
+
+  return trivia.length > 0 ? { items, trivia } : { items };
 }
 
-const objectMember = itemEntry(
+const objectMember = objectMemberEntry(
   or(
     taggedObjectPropertyParser,
     objectPropertyParser,
@@ -1759,7 +1863,7 @@ export const objectTypeParser: Parser<ObjectType> = memo(
         r.entries as InterleavedEntry<ObjectProperty>[],
       );
       const objectType: ObjectType = { type: "objectType", properties: items };
-      if (trivia.length > 0) objectType.trivia = trivia;
+      if (trivia) objectType.trivia = trivia;
       return objectType;
     },
   ),
@@ -2616,7 +2720,7 @@ export const agencyArrayParser: Parser<AgencyArray> = memo(
         many(
           or(
             triviaEntry,
-            itemEntry(or(splatParser, lazy(() => exprParser)), literalDelimiter("]")),
+            itemEntryAfterDelimiter(or(splatParser, lazy(() => exprParser)), literalDelimiter("]")),
           ),
         ),
         "entries",
@@ -2629,7 +2733,7 @@ export const agencyArrayParser: Parser<AgencyArray> = memo(
         r.entries as InterleavedEntry<Expression | SplatExpression>[],
       );
       const node: AgencyArray = { type: "agencyArray", items };
-      if (trivia.length > 0) node.trivia = trivia;
+      if (trivia) node.trivia = trivia;
       return node;
     },
   ),
@@ -2686,7 +2790,7 @@ export const agencyObjectParser: Parser<AgencyObject> = map(
       many(
         or(
           triviaEntry,
-          itemEntry(or(splatParser, agencyObjectKVParser), literalDelimiter("}")),
+          itemEntryAfterDelimiter(or(splatParser, agencyObjectKVParser), literalDelimiter("}")),
         ),
       ),
       "entries",
@@ -2699,7 +2803,7 @@ export const agencyObjectParser: Parser<AgencyObject> = map(
       r.entries as InterleavedEntry<AgencyObjectKV | SplatExpression>[],
     );
     const node: AgencyObject = { type: "agencyObject", entries: items };
-    if (trivia.length > 0) node.trivia = trivia;
+    if (trivia) node.trivia = trivia;
     return node;
   },
 );

--- a/packages/agency-lang/lib/types/access.ts
+++ b/packages/agency-lang/lib/types/access.ts
@@ -6,7 +6,10 @@ export type AccessChainElement =
   | { kind: "index"; index: Expression; optional?: boolean }
   | { kind: "slice"; start?: Expression; end?: Expression; optional?: boolean }
   | { kind: "methodCall"; functionCall: FunctionCall; optional?: boolean }
-  | { kind: "call"; optional?: boolean } & Pick<FunctionCall, "arguments" | "block">;
+  | { kind: "call"; optional?: boolean } & Pick<
+      FunctionCall,
+      "arguments" | "block" | "argumentTrivia"
+    >;
 
 export type ValueAccess = BaseNode & {
   type: "valueAccess";

--- a/packages/agency-lang/lib/types/dataStructures.ts
+++ b/packages/agency-lang/lib/types/dataStructures.ts
@@ -4,21 +4,50 @@ import {
   AgencyMultiLineComment,
   NewLine,
 } from "../types.js";
-import { BaseNode } from "./base.js";
+import { BaseNode, LineComment } from "./base.js";
 
 /** A single comment or blank-line node preserved as trivia. */
 export type TriviaNode = AgencyComment | AgencyMultiLineComment | NewLine;
 
 /**
- * Comment / blank-line trivia preserved inside array and object literals so
- * `agency fmt` round-trips losslessly. `anchorIndex` is the index of the
- * item/entry that the trivia immediately precedes; trailing trivia (after the
- * last item) is anchored at the item count. Same shape as
- * `ObjectTypeTrivia`, which does the equivalent for object *type* bodies.
+ * Comment / blank-line trivia sitting BEFORE an item. `anchorIndex` is the
+ * index of the item/entry the trivia immediately precedes; trivia after the
+ * last item is anchored at the item count.
  */
-export type Trivia = {
+export type BeforeListTrivia = {
   anchorIndex: number;
   comments: TriviaNode[];
+  /** Omitted by parsers, so existing ASTs keep their exact shape. */
+  placement?: "before";
+};
+
+/** A `//` comment on the same line as the item it follows. */
+export type TrailingListTrivia = {
+  anchorIndex: number;
+  placement: "trailing";
+  comments: [LineComment];
+};
+
+/**
+ * Trivia preserved inside a multiline list so `agency fmt` round-trips
+ * losslessly. Shared by array literals, object literals, and object *type*
+ * bodies (which alias this as `ObjectTypeTrivia`).
+ */
+export type ListTrivia = BeforeListTrivia | TrailingListTrivia;
+
+/** Long-standing name for the same thing. */
+export type Trivia = ListTrivia;
+
+export function isTrailingListTrivia(
+  entry: ListTrivia,
+): entry is TrailingListTrivia {
+  return entry.placement === "trailing";
+}
+
+/** What a list parser produces: items, plus trivia when any was found. */
+export type ParsedList<T> = {
+  items: T[];
+  trivia?: ListTrivia[];
 };
 
 export type SplatExpression = {

--- a/packages/agency-lang/lib/types/function.ts
+++ b/packages/agency-lang/lib/types/function.ts
@@ -1,3 +1,4 @@
+import type { ListTrivia } from "./dataStructures.js";
 import {
   AgencyMultiLineComment,
   AgencyNode,
@@ -63,6 +64,8 @@ export type FunctionDefinition = BaseNode & {
    *  a compilable program. */
   functionName: string | Hole;
   parameters: FunctionParameter[];
+  /** Comments between parameters in the signature. */
+  parameterTrivia?: ListTrivia[];
   body: AgencyNode[];
   returnType?: VariableType | null;
   returnTypeValidated?: boolean;
@@ -85,6 +88,8 @@ export type FunctionCall = BaseNode & {
    *  lexical chain the owning block is. 0 (or absent) = the current block. */
   blockDepth?: number;
   arguments: (Expression | SplatExpression | NamedArgument)[];
+  /** Comments between arguments, in the order the call PRINTS. */
+  argumentTrivia?: ListTrivia[];
   block?: BlockArgument;
   async?: boolean;
   tags?: Tag[];

--- a/packages/agency-lang/lib/types/graphNode.ts
+++ b/packages/agency-lang/lib/types/graphNode.ts
@@ -1,3 +1,4 @@
+import type { ListTrivia } from "./dataStructures.js";
 import { AgencyMultiLineComment, AgencyNode, FunctionCall, VariableType } from "../types.js";
 import { ValueAccess } from "./access.js";
 import { BaseNode } from "./base.js";
@@ -12,6 +13,8 @@ export type GraphNodeDefinition = BaseNode & {
    *  a compilable program. */
   nodeName: string | Hole;
   parameters: FunctionParameter[];
+  /** Comments between parameters in the signature. */
+  parameterTrivia?: ListTrivia[];
   body: AgencyNode[];
   returnType?: VariableType | null;
   returnTypeValidated?: boolean;

--- a/packages/agency-lang/lib/types/guardBlock.ts
+++ b/packages/agency-lang/lib/types/guardBlock.ts
@@ -1,3 +1,4 @@
+import type { ListTrivia } from "./dataStructures.js";
 import type { AgencyNode, BaseNode, Expression } from "../types.js";
 import type { NamedArgument, SplatExpression } from "./dataStructures.js";
 
@@ -22,5 +23,7 @@ import type { NamedArgument, SplatExpression } from "./dataStructures.js";
 export type GuardBlock = BaseNode & {
   type: "guardBlock";
   arguments: (Expression | SplatExpression | NamedArgument)[];
+  /** Comments between arguments. */
+  argumentTrivia?: ListTrivia[];
   body: AgencyNode[];
 };

--- a/packages/agency-lang/lib/types/interruptStatement.ts
+++ b/packages/agency-lang/lib/types/interruptStatement.ts
@@ -1,3 +1,4 @@
+import type { ListTrivia } from "./dataStructures.js";
 import { BaseNode } from "./base.js";
 import { Expression } from "../types.js";
 import { SplatExpression, NamedArgument } from "./dataStructures.js";
@@ -6,6 +7,8 @@ export type InterruptStatement = BaseNode & {
   type: "interruptStatement";
   effect: string; // e.g. "std::read", "myapp::deploy"
   arguments: (Expression | SplatExpression | NamedArgument)[];
+  /** Comments between arguments. */
+  argumentTrivia?: ListTrivia[];
   /** True when written as a `raise` statement (vs `interrupt(...)`).
    *  Codegen is identical; this only drives formatter output. */
   viaRaise?: boolean;

--- a/packages/agency-lang/lib/types/typeHints.ts
+++ b/packages/agency-lang/lib/types/typeHints.ts
@@ -2,6 +2,7 @@ import { AgencyComment, AgencyMultiLineComment, NewLine } from "../types.js";
 import type { FunctionParameter } from "./function.js";
 import { BaseNode } from "./base.js";
 import type { Tag } from "./tag.js";
+import type { ListTrivia } from "./dataStructures.js";
 import type { Expression } from "../types.js";
 
 /**
@@ -265,10 +266,7 @@ export type ObjectProperty = {
  * Trivia is *not* semantic — no consumer outside the agency formatter
  * should read it.
  */
-export type ObjectTypeTrivia = {
-  anchorIndex: number;
-  comments: (AgencyComment | AgencyMultiLineComment | NewLine)[];
-};
+export type ObjectTypeTrivia = ListTrivia;
 
 export type ObjectType = {
   type: "objectType";


### PR DESCRIPTION
Tasks 3 and 4 of the trailing-comments plan, targeting the integration branch. PR 1 (#767) covered complete constructs; this covers **multiline lists**: array and object literals, object types, call arguments, and `def` / `node` parameters. Imports, patterns, and thread/parallel arguments are the last PR.

Code and tests only — no doc changes.

## The problem

Inside a multiline list, a comment was anchored only to the item it came *before*. There was nowhere to record "this comment sits at the end of item N's line", so `fmt` pushed it onto its own line:

```
const xs = [        →      const xs = [
  1, // one                   1,
  2 // two                    // one
]                             2
                              // two
                            ]
```

## What now works

```
const xs = [
  1, // one
  2 // two
]

save(
  userId, // who to save
  retries: 3 // how hard to try
)

def save(
  value: string, // the payload
  ...rest: string[] // everything else
) { }
```

Covered: array literals, object literals, object types (including tagged properties), positional/named/splat call arguments, method calls, call chains, `interrupt`, every `raise` form, `guard`, and both `def` and `node` parameter lists.

## How

**One bit on trivia, not a new list.** `ListTrivia` became a union: `BeforeListTrivia` (what already existed) and `TrailingListTrivia` (`placement: "trailing"`). Parsers never write `placement: "before"`, so **every existing trivia AST is byte-for-byte unchanged** — the existing assertions in `dataStructures.test.ts` and `objectTypeTrivia.test.ts` are the compatibility proof and were not touched. `Trivia` and `ObjectTypeTrivia` survive as aliases.

**Two delimiter policies, deliberately not one.** `itemEntryAfterDelimiter` attaches a comment only when the item *and* its delimiter stayed on one line, so `first,\n// about second` still belongs to `second`. Object *types* need a separate policy (`objectMemberEntry`) because a newline is itself a legal delimiter there, so a comment can appear on either side of it. Merging these into one "universal separator" would have widened the grammar.

**One shared list renderer.** `renderListWithTrivia` owns indentation and both comment placements; callers pass their existing item renderer and a separator policy. `renderParenList` is the single entry point for `( ... )` lists — without trivia it is exactly the old `wrapList` call, with trivia it goes multiline. Nothing outside `commentText` builds `//...`, and no node renderer places a comment itself.

**Reordering.** The formatter moves an inline block argument last. `remapListTrivia` translates source anchors to print anchors so a before-comment stays with the item it preceded and a trailing comment with the item it followed. It throws if the permutation is malformed rather than silently dropping a comment. Tested with the block in first, middle, and last source position, asserting the block itself survives too — not just its comment.

## The one that would have slipped through

`guardBlockParser` hand-builds its node and copied only `arguments`, so trivia reached the parser and vanished before the AST. Widening the shared argument parser was not enough. Every current consumer of `argumentListParser` now has a test pinning it — that is why the matrix includes method calls, call chains, `interrupt`, `raise`, and `guard` separately rather than testing plain calls and assuming the rest follow.

Also worth flagging: the first version of these tests asserted `toContain("// one")`, which **passes even when the comment is relocated** — the exact bug. The assertions now pin whole lines (`"1, // one"`).

## Verification

- Full unit suite: **10,461 passed, 0 failed** (675 files), re-run after the final cleanup commit rather than relying on the earlier run.
- `make`: clean, so the whole stdlib and examples recompile through the new argument grammar with no working-tree changes.
- `tsc --noEmit`: no new errors (the 15 pre-existing `lib/serve/*` errors on the base branch are unchanged).
- `lint:structure`: clean.
- `test:perf`: 16 passed, parse/fmt/doc scaling still linear.

## Deviation from the plan

The plan specified a `CommaListPolicy` object with `cardinality` and `trailingComma` fields. All three call sites in this PR are identical (zero-or-more, trailing comma allowed), so the policy would carry no information yet. `commaDelimitedList(itemParser, closer)` is the shared engine now; PR 3 adds the policy fields when it has sites that actually differ — imports and patterns reject trailing commas where literals allow them. Adding unused configurability ahead of that is the kind of speculative generality the plan itself warns about.

Removed `emitTriviaAt`, which became dead once the three literal renderers moved to the shared helper. Nothing outside a stale `dist/` artifact referenced it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
