### PR TITLE
fmt: keep end-of-line comments attached in imports, patterns, and block arguments

### DIFF
--- a/packages/agency-lang/lib/backends/agencyGenerator.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.ts
@@ -1167,12 +1167,18 @@ export class AgencyGenerator {
       // `{ name: _: string }`.
       return `${prop.key}: ${this.formatIsRhs(prop.value)}`;
     });
-    return `{ ${parts.join(", ")} }`;
+    return (
+      this.renderListIfTrivia(parts, node.propertyTrivia, "{", "}") ??
+      `{ ${parts.join(", ")} }`
+    );
   }
 
   private formatArrayPattern(node: ArrayPattern): string {
     const parts = node.elements.map((el) => this.formatPattern(el));
-    return `[${parts.join(", ")}]`;
+    return (
+      this.renderListIfTrivia(parts, node.elementTrivia, "[", "]") ??
+      `[${parts.join(", ")}]`
+    );
   }
 
   protected generateLiteral(literal: Literal): string {
@@ -1406,23 +1412,40 @@ export class AgencyGenerator {
    *  `rendered` must already be in canonical print order — for a call that
    *  means `renderArgs` has appended any inline block last, matching how
    *  `extractInlineBlock` remapped the anchors. */
+  /** A list of already-rendered items laid out across lines with its
+   *  comments, or `undefined` when there are none. Callers keep their own
+   *  inline or wrapping behavior for the no-comment case, so trivia-free
+   *  output is untouched; a comment cannot share a line with what follows
+   *  it, so its presence forces the multiline form. */
+  protected renderListIfTrivia(
+    rendered: string[],
+    trivia: ListTrivia[] | undefined,
+    open: string,
+    close: string,
+  ): string | undefined {
+    if (!trivia?.length) {
+      return undefined;
+    }
+    return this.renderListWithTrivia({
+      items: rendered,
+      trivia,
+      open,
+      close,
+      renderItem: (code) => ({ code }),
+      separator: (index, count) => (index === count - 1 ? "" : ","),
+    });
+  }
+
   protected renderParenList(
     rendered: string[],
     trivia: ListTrivia[] | undefined,
     prefix: string,
     suffix: string,
   ): string {
-    if (!trivia?.length) {
+    const body = this.renderListIfTrivia(rendered, trivia, "(", ")");
+    if (body === undefined) {
       return this.wrapList(rendered, prefix, "(", ")", suffix);
     }
-    const body = this.renderListWithTrivia({
-      items: rendered,
-      trivia,
-      open: "(",
-      close: ")",
-      renderItem: (code) => ({ code }),
-      separator: (index, count) => (index === count - 1 ? "" : ","),
-    });
     return `${prefix}${body}${suffix}`;
   }
 
@@ -1871,6 +1894,15 @@ export class AgencyGenerator {
           namedImport.idempotentNames,
         );
       });
+      const withTrivia = this.renderListIfTrivia(
+        names,
+        namedImport.nameTrivia,
+        "{",
+        "}",
+      );
+      if (withTrivia !== undefined) {
+        return this.indentStr(`${importKeyword}${withTrivia}${suffix}`);
+      }
       return this.indentStr(
         this.wrapList(names, importKeyword, "{ ", " }", suffix),
       );
@@ -1924,7 +1956,17 @@ export class AgencyGenerator {
   }
 
   protected processImportNodeStatement(node: ImportNodeStatement): string {
-    return `import node { ${node.importedNodes.join(", ")} } from "${node.agencyFile}"`;
+    const suffix = ` from "${node.agencyFile}"`;
+    const withTrivia = this.renderListIfTrivia(
+      node.importedNodes,
+      node.nodeTrivia,
+      "{",
+      "}",
+    );
+    if (withTrivia !== undefined) {
+      return `import node ${withTrivia}${suffix}`;
+    }
+    return `import node { ${node.importedNodes.join(", ")} }${suffix}`;
   }
 
   protected processExportFromStatement(node: ExportFromStatement): string {
@@ -1942,9 +1984,17 @@ export class AgencyGenerator {
         body.idempotentNames,
       );
     });
-    return this.indentStr(
-      `export { ${items.join(", ")} } from "${node.modulePath}"`,
+    const suffix = ` from "${node.modulePath}"`;
+    const withTrivia = this.renderListIfTrivia(
+      items,
+      body.nameTrivia,
+      "{",
+      "}",
     );
+    if (withTrivia !== undefined) {
+      return this.indentStr(`export ${withTrivia}${suffix}`);
+    }
+    return this.indentStr(`export { ${items.join(", ")} }${suffix}`);
   }
 
   private sortAndRenderImports(): string {
@@ -2087,7 +2137,16 @@ export class AgencyGenerator {
       }
     }
 
-    const paramsStr = params.length > 0 ? `(${params.join(", ")})` : "";
+    // `params` is built in THREAD_ARGUMENT_ORDER, the same canonical order
+    // the parser remapped the trivia anchors into.
+    const withTrivia = this.renderListIfTrivia(
+      params,
+      node.argumentTrivia,
+      "(",
+      ")",
+    );
+    const paramsStr =
+      withTrivia ?? (params.length > 0 ? `(${params.join(", ")})` : "");
 
     return this.indentStr(
       `${threadType}${paramsStr} {\n${bodyCodeStr}${this.indentStr("}")}`,
@@ -2098,9 +2157,12 @@ export class AgencyGenerator {
     this.increaseIndent();
     const bodyCodeStr = this.renderBody(node.body);
     this.decreaseIndent();
-    const sharedSuffix = node.shared
-      ? `(shared: ${this.processNode(node.shared).trim()})`
-      : "";
+    const sharedArgs = node.shared
+      ? [`shared: ${this.processNode(node.shared).trim()}`]
+      : [];
+    const sharedSuffix =
+      this.renderListIfTrivia(sharedArgs, node.argumentTrivia, "(", ")") ??
+      (node.shared ? `(${sharedArgs[0]})` : "");
     return this.indentStr(
       `parallel${sharedSuffix} {\n${bodyCodeStr}${this.indentStr("}")}`,
     );

--- a/packages/agency-lang/lib/backends/agencyGenerator.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.ts
@@ -68,6 +68,7 @@ import { GraphNodeDefinition } from "../types/graphNode.js";
 import { IfElse } from "../types/ifElse.js";
 import {
   ImportNameType,
+  NamedImport,
   ImportNodeStatement,
   ImportStatement,
 } from "../types/importStatement.js";
@@ -1449,7 +1450,6 @@ export class AgencyGenerator {
     return `${prefix}${body}${suffix}`;
   }
 
-  // Format args as inline parenthesized list (no wrapping — used by access chain callers)
   /** A parenthesized argument list that normally stays on one line
    *  (access chains, `interrupt`, `guard`). Trivia forces the multiline
    *  form, since a `//` comment cannot share a line with what follows it. */
@@ -1883,17 +1883,7 @@ export class AgencyGenerator {
       node.importedNames[0].type === "namedImport"
     ) {
       const namedImport = node.importedNames[0];
-      const names = namedImport.importedNames.map((entry) => {
-        const name = declaredName(entry);
-        const alias = namedImport.aliases[name];
-        const base = alias ? `${name} as ${alias}` : name;
-        return this.prefixMarkedName(
-          name,
-          base,
-          namedImport.destructiveNames,
-          namedImport.idempotentNames,
-        );
-      });
+      const names = this.renderImportNames(namedImport);
       const withTrivia = this.renderListIfTrivia(
         names,
         namedImport.nameTrivia,
@@ -1915,21 +1905,33 @@ export class AgencyGenerator {
     return this.indentStr(`${importKeyword}${importedNames.join(", ")}${suffix}`);
   }
 
+  /** The names inside an import's `{ ... }`, with their aliases and
+   *  retry-safety markers. Shared by the sole-named and mixed paths. */
+  private renderImportNames(namedImport: NamedImport): string[] {
+    return namedImport.importedNames.map((entry) => {
+      const name = declaredName(entry);
+      const alias = namedImport.aliases[name];
+      const base = alias ? `${name} as ${alias}` : name;
+      return this.prefixMarkedName(
+        name,
+        base,
+        namedImport.destructiveNames,
+        namedImport.idempotentNames,
+      );
+    });
+  }
+
   protected processImportNameType(node: ImportNameType): string {
     switch (node.type) {
       case "namedImport": {
-        const names = node.importedNames.map((entry) => {
-          const name = declaredName(entry);
-          const alias = node.aliases[name];
-          const base = alias ? `${name} as ${alias}` : name;
-          return this.prefixMarkedName(
-            name,
-            base,
-            node.destructiveNames,
-            node.idempotentNames,
-          );
-        });
-        return `{ ${names.join(", ")} }`;
+        const names = this.renderImportNames(node);
+        // A mixed import (`import tools, { a } from ...`) reaches this path
+        // too, so it has to honor trivia the same way a sole named import
+        // does — otherwise the comment is dropped on the first format.
+        return (
+          this.renderListIfTrivia(names, node.nameTrivia, "{", "}") ??
+          `{ ${names.join(", ")} }`
+        );
       }
       case "namespaceImport":
         return `* as ${node.importedNames}`;

--- a/packages/agency-lang/lib/parsers/listTrailingComments.test.ts
+++ b/packages/agency-lang/lib/parsers/listTrailingComments.test.ts
@@ -273,14 +273,36 @@ describe("remaining multiline surfaces", () => {
     expect(formatSource(once as string)).toBe(once);
   });
 
+  // A mixed import renders through a different path than a sole named
+  // import, so it needs its own coverage — it silently dropped the comment
+  // until the second path learned about trivia.
+  it.each([
+    [
+      "default plus named",
+      `import tools, {\n  alpha // keep\n} from "./tools"\n`,
+      `import tools, {\n  alpha // keep\n} from "./tools"\n`,
+    ],
+    [
+      "namespace plus named",
+      `import * as t, {\n  alpha // keep\n} from "./tools"\n`,
+      `import * as t, {\n  alpha // keep\n} from "./tools"\n`,
+    ],
+  ])("keeps a comment in a %s import", (_name, source, expected) => {
+    const once = formatSource(source);
+    expect(once).toBe(expected);
+    expect(parseAgency(once as string, {}, false, false).success).toBe(true);
+    expect(formatSource(once as string)).toBe(once);
+  });
+
   it("keeps inner and trailing import comments with the right import when sorting", () => {
     // Written zeta-first; the formatter sorts alpha first. Both the name
     // comment inside each list and the comment after each `from` clause must
     // travel with their own import.
     const source =
       `import {\n  zeta // the zeta name\n} from "./zeta" // trailing zeta\nimport {\n  alpha // the alpha name\n} from "./alpha" // trailing alpha\n`;
-    const once = formatSource(source) as string;
-    expect(once).not.toBeNull();
+    const formatted = formatSource(source);
+    expect(formatted).not.toBeNull();
+    const once = formatted as string;
     expect(once.indexOf("alpha // the alpha name")).toBeLessThan(
       once.indexOf("zeta // the zeta name"),
     );

--- a/packages/agency-lang/lib/parsers/listTrailingComments.test.ts
+++ b/packages/agency-lang/lib/parsers/listTrailingComments.test.ts
@@ -209,3 +209,105 @@ describe("line boundaries around nested members", () => {
     expect(formatSource(once as string)).toBe(once);
   });
 });
+
+describe("remaining multiline surfaces", () => {
+  it.each([
+    [
+      "named import",
+      `import {\n  alpha, // alpha\n  beta // beta\n} from "./tools"\n`,
+      ["alpha, // alpha", "beta // beta"],
+    ],
+    [
+      "node import",
+      `import node {\n  first, // first\n  second // second\n} from "./nodes.agency"\n`,
+      ["first, // first", "second // second"],
+    ],
+    [
+      "named export",
+      `export {\n  alpha, // alpha\n  beta // beta\n} from "./tools"\n`,
+      ["alpha, // alpha", "beta // beta"],
+    ],
+    [
+      "array binding pattern",
+      `node main() {\n  const [\n    first, // first\n    second // second\n  ] = values\n}\n`,
+      ["first, // first", "second // second"],
+    ],
+    [
+      "object binding pattern",
+      `node main() {\n  const {\n    name, // name\n    age // age\n  } = user\n}\n`,
+      ["name, // name", "age // age"],
+    ],
+    [
+      "match array pattern",
+      `node main() {\n  match (value) {\n    [\n      "ok", // tag\n      result // payload\n    ] => result\n  }\n}\n`,
+      [`"ok", // tag`, "result // payload"],
+    ],
+    [
+      "thread arguments",
+      `node main() {\n  thread(\n    label: "work", // label\n    hidden: true // visibility\n  ) {\n    print(1)\n  }\n}\n`,
+      [`label: "work", // label`, "hidden: true // visibility"],
+    ],
+    [
+      "parallel arguments",
+      `node main() {\n  parallel(\n    shared: true // state mode\n  ) {\n    print(1)\n  }\n}\n`,
+      ["shared: true // state mode"],
+    ],
+  ])("preserves %s comments", (_name, source, expectedLines) => {
+    const once = formatSource(source);
+    expect(once).not.toBeNull();
+    for (const line of expectedLines) {
+      expect(once).toContain(line);
+    }
+    expect(parseAgency(once as string, {}, false, false).success).toBe(true);
+    expect(formatSource(once as string)).toBe(once);
+  });
+
+  it("moves a thread comment with its argument when the order is canonicalized", () => {
+    // Written hidden-first; the formatter prints label first. Each comment
+    // must travel with the argument it described, not stay at its index.
+    const source = `node main() {\n  thread(\n    hidden: true, // about hidden\n    label: "work" // about label\n  ) {\n    print(1)\n  }\n}\n`;
+    const once = formatSource(source);
+    expect(once).toContain(`label: "work", // about label`);
+    expect(once).toContain("hidden: true // about hidden");
+    expect(parseAgency(once as string, {}, false, false).success).toBe(true);
+    expect(formatSource(once as string)).toBe(once);
+  });
+
+  it("keeps inner and trailing import comments with the right import when sorting", () => {
+    // Written zeta-first; the formatter sorts alpha first. Both the name
+    // comment inside each list and the comment after each `from` clause must
+    // travel with their own import.
+    const source =
+      `import {\n  zeta // the zeta name\n} from "./zeta" // trailing zeta\nimport {\n  alpha // the alpha name\n} from "./alpha" // trailing alpha\n`;
+    const once = formatSource(source) as string;
+    expect(once).not.toBeNull();
+    expect(once.indexOf("alpha // the alpha name")).toBeLessThan(
+      once.indexOf("zeta // the zeta name"),
+    );
+    expect(once).toContain("alpha // the alpha name");
+    expect(once).toContain(`from "./alpha" // trailing alpha`);
+    expect(once).toContain("zeta // the zeta name");
+    expect(once).toContain(`from "./zeta" // trailing zeta`);
+    expect(formatSource(once)).toBe(once);
+  });
+});
+
+// Each `reject` policy needs its own negative test, or migrating a site to the
+// shared parser could silently start accepting a trailing comma.
+describe("trailing commas stay rejected where they always were", () => {
+  it.each([
+    ["node import", `import node { first, second, } from "./nodes.agency"\n`],
+    ["array binding pattern", `node main() {\n  const [first, second, ] = values\n}\n`],
+    ["object binding pattern", `node main() {\n  const { name, age, } = user\n}\n`],
+  ])("rejects a trailing comma in a %s", (_name, source) => {
+    expect(parseAgency(source, {}, false, false).success).toBe(false);
+  });
+
+  it.each([
+    ["named import", `import { alpha, beta, } from "./tools"\n`],
+    ["named export", `export { alpha, beta, } from "./tools"\n`],
+    ["call arguments", `node main() {\n  save(first, second, )\n}\n`],
+  ])("still accepts a trailing comma in a %s", (_name, source) => {
+    expect(parseAgency(source, {}, false, false).success).toBe(true);
+  });
+});

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -1857,20 +1857,100 @@ function partitionTrivia<T>(entries: InterleavedEntry<T>[]): ParsedList<T> {
 /** A comma-separated list that may span lines, with trivia between items.
  *  `closer` is only looked at, never consumed: it lets the last item go
  *  without a comma while still requiring commas between items (#602). */
+/** What a particular comma list allows. Stated per call site rather than
+ *  inferred, because these differ across the grammar and getting one wrong
+ *  silently widens what the language accepts: `import { a, b }` permits a
+ *  trailing comma while `import node { a, b }` and every destructuring
+ *  pattern reject one. */
+type CommaListPolicy = {
+  closer: string;
+  cardinality: "zero-or-more" | "one-or-more";
+  trailingComma: "allow" | "reject";
+};
+
+/** Look ahead past trivia to the closer, without consuming anything. */
+const closerAhead = (closer: string) =>
+  peek(seqR(many(seqR(literalTrivia, optionalSpacesOrNewline)), char(closer)));
+
+/** The separator between two items. In `reject` mode a comma must be
+ *  followed by another item, so `[a, b,]` fails rather than quietly
+ *  dropping the empty slot. */
+function commaListDelimiter(policy: CommaListPolicy): Parser<unknown> {
+  const ahead = closerAhead(policy.closer);
+  const comma =
+    policy.trailingComma === "allow" ? char(",") : seqR(char(","), not(ahead));
+  return seqR(optionalSpacesOrNewline, or(comma, ahead), optionalSpacesOrNewline);
+}
+
 function commaDelimitedList<T>(
   itemParser: Parser<T>,
-  closer: string,
+  policy: CommaListPolicy,
 ): Parser<ParsedList<T>> {
-  return map(
-    many(
-      or(
-        triviaEntry,
-        itemEntryAfterDelimiter(itemParser, literalDelimiter(closer)),
-      ),
+  const entries = many(
+    or(
+      triviaEntry,
+      itemEntryAfterDelimiter(itemParser, commaListDelimiter(policy)),
     ),
-    (entries: InterleavedEntry<T>[]) => partitionTrivia(entries),
   );
+  return (input: string) => {
+    const parsed = entries(input);
+    if (!parsed.success) {
+      return parsed as ParserResult<ParsedList<T>>;
+    }
+    const list = partitionTrivia(parsed.result as InterleavedEntry<T>[]);
+    if (policy.cardinality === "one-or-more" && list.items.length === 0) {
+      return failure("expected at least one item", input);
+    }
+    return success(list, parsed.rest);
+  };
 }
+
+/** Every comma list's policy, named so a call site reads as a rule rather
+ *  than as three anonymous arguments. Each one mirrors the grammar that
+ *  site accepted before it moved onto the shared parser. */
+const CALL_ARGUMENT_LIST: CommaListPolicy = {
+  closer: ")",
+  cardinality: "zero-or-more",
+  trailingComma: "allow",
+};
+
+const NAMED_ARGUMENT_LIST: CommaListPolicy = {
+  closer: ")",
+  cardinality: "zero-or-more",
+  trailingComma: "allow",
+};
+
+const IMPORT_NAME_LIST: CommaListPolicy = {
+  closer: "}",
+  cardinality: "one-or-more",
+  trailingComma: "allow",
+};
+
+/** `import node { a, b }` never accepted a trailing comma, unlike the
+ *  value-import list above. */
+const IMPORT_NODE_LIST: CommaListPolicy = {
+  closer: "}",
+  cardinality: "one-or-more",
+  trailingComma: "reject",
+};
+
+const EXPORT_NAME_LIST: CommaListPolicy = {
+  closer: "}",
+  cardinality: "one-or-more",
+  trailingComma: "allow",
+};
+
+const ARRAY_PATTERN_LIST: CommaListPolicy = {
+  closer: "]",
+  cardinality: "zero-or-more",
+  trailingComma: "reject",
+};
+
+const OBJECT_PATTERN_LIST: CommaListPolicy = {
+  closer: "}",
+  cardinality: "zero-or-more",
+  trailingComma: "reject",
+};
 
 /** `commaDelimitedList` shaped for `captureCaptures`: lifts the items and
  *  their trivia into the parent under the two given field names. */
@@ -1880,12 +1960,12 @@ function commaDelimitedListCaptures<
   TriviaKey extends string,
 >(
   itemParser: Parser<T>,
-  closer: string,
+  policy: CommaListPolicy,
   itemsKey: ItemsKey,
   triviaKey: TriviaKey,
 ): Parser<{ [K in ItemsKey]: T[] } & { [K in TriviaKey]?: ListTrivia[] }> {
   return map(
-    commaDelimitedList(itemParser, closer),
+    commaDelimitedList(itemParser, policy),
     (parsed: ParsedList<T>) =>
       ({
         [itemsKey]: parsed.items,
@@ -2970,7 +3050,7 @@ const argumentListParser = memo(
     captureCaptures(
       commaDelimitedListCaptures(
         argumentItemParser,
-        ")",
+        CALL_ARGUMENT_LIST,
         "arguments",
         "argumentTrivia",
       ),
@@ -4704,7 +4784,14 @@ export const importNodeStatmentParser: Parser<ImportNodeStatement> = withLoc(mem
         spaces,
         char("{"),
         optionalSpacesOrNewline,
-        capture(sepBy1(commaWithNewline, many1WithJoin(varNameChar)), "importedNodes"),
+        captureCaptures(
+          commaDelimitedListCaptures(
+            many1WithJoin(varNameChar),
+            IMPORT_NODE_LIST,
+            "importedNodes",
+            "nodeTrivia",
+          ),
+        ),
         optionalSpacesOrNewline,
         char("}"),
         spaces,
@@ -4775,8 +4862,14 @@ const namedImportParser: Parser<NamedImport> = memo(
     seqC(
       char("{"),
       optionalSpacesOrNewline,
-      capture(sepBy1(commaWithNewline, markedNameItem), "items"),
-      optional(commaWithNewline),
+      captureCaptures(
+        commaDelimitedListCaptures(
+          markedNameItem,
+          IMPORT_NAME_LIST,
+          "items",
+          "nameTrivia",
+        ),
+      ),
       optionalSpacesOrNewline,
       char("}"),
     ),
@@ -4897,8 +4990,14 @@ const namedExportBodyParser = map(
   seqC(
     char("{"),
     optionalSpacesOrNewline,
-    capture(sepBy1(commaWithNewline, markedNameItem), "items"),
-    optional(commaWithNewline),
+    captureCaptures(
+      commaDelimitedListCaptures(
+        markedNameItem,
+        EXPORT_NAME_LIST,
+        "items",
+        "nameTrivia",
+      ),
+    ),
     optionalSpacesOrNewline,
     char("}"),
   ),
@@ -5554,7 +5653,19 @@ type ThreadNamedArgs = {
   continueExpr: Expression | null;
   sessionExpr: Expression | null;
   hidden: Expression | null;
+  argumentTrivia?: ListTrivia[];
 };
+
+/** The order the formatter prints thread arguments in, regardless of the
+ *  order they were written. Trivia anchors are remapped into it so a
+ *  comment travels with the argument it described. */
+const THREAD_ARGUMENT_ORDER = [
+  "label",
+  "summarize",
+  "continue",
+  "session",
+  "hidden",
+];
 
 const _threadNamedArgsParser: Parser<ThreadNamedArgs> = (
   input: string,
@@ -5564,18 +5675,21 @@ const _threadNamedArgsParser: Parser<ThreadNamedArgs> = (
   const inner: Parser<any> = seqC(
     char("("),
     optionalSpacesOrNewline,
-    capture(
-      sepBy(commaWithNewline, namedArgumentParser),
-      "arguments",
+    captureCaptures(
+      commaDelimitedListCaptures(
+        namedArgumentParser,
+        NAMED_ARGUMENT_LIST,
+        "arguments",
+        "argumentTrivia",
+      ),
     ),
-    optional(comma),
     optionalSpacesOrNewline,
     char(")"),
   );
   const r = inner(input);
   if (!r.success) return r as ParserResult<ThreadNamedArgs>;
   const args: NamedArgument[] = r.result.arguments;
-  const allowed = ["label", "summarize", "continue", "session", "hidden"];
+  const allowed = THREAD_ARGUMENT_ORDER;
   const seen: Record<string, Expression> = {};
   for (const arg of args) {
     if (!allowed.includes(arg.name)) {
@@ -5595,6 +5709,15 @@ const _threadNamedArgsParser: Parser<ThreadNamedArgs> = (
       input,
     );
   }
+  // Printing reorders the arguments, so the anchors have to move with them.
+  const canonicalSourceIndexes = THREAD_ARGUMENT_ORDER.flatMap((name) => {
+    const index = args.findIndex((arg) => arg.name === name);
+    return index === -1 ? [] : [index];
+  });
+  const argumentTrivia = remapListTrivia(
+    r.result.argumentTrivia,
+    canonicalSourceIndexes,
+  );
   return success(
     {
       label: seen.label ?? null,
@@ -5602,6 +5725,7 @@ const _threadNamedArgsParser: Parser<ThreadNamedArgs> = (
       continueExpr: seen.continue ?? null,
       sessionExpr: seen.session ?? null,
       hidden: seen.hidden ?? null,
+      ...(argumentTrivia && { argumentTrivia }),
     },
     r.rest,
   );
@@ -5659,16 +5783,7 @@ export const _submessageThreadParser: Parser<MessageThread> = memo(
 /** Lift `_args` (the optional named-args object) to top-level fields on
  *  the MessageThread node. */
 const liftThreadArgs = (parsed: any): MessageThread => {
-  const args = parsed._args as
-    | {
-      label: Expression | null;
-      summarize: Expression | null;
-      continueExpr: Expression | null;
-      sessionExpr: Expression | null;
-      hidden: Expression | null;
-    }
-    | null
-    | undefined;
+  const args = parsed._args as ThreadNamedArgs | null | undefined;
   const out: any = { ...parsed };
   delete out._args;
   if (args) {
@@ -5677,6 +5792,9 @@ const liftThreadArgs = (parsed: any): MessageThread => {
     out.continueExpr = args.continueExpr;
     out.sessionExpr = args.sessionExpr;
     out.hidden = args.hidden;
+    if (args.argumentTrivia) {
+      out.argumentTrivia = args.argumentTrivia;
+    }
   } else {
     out.label = null;
     out.summarize = null;
@@ -6051,22 +6169,30 @@ export const whileLoopParser: Parser<WhileLoop> = label("a while loop", withLoc(
 /** Parser for the optional `(shared: <expr>)` named-args list after
  *  `parallel`. Modelled on `_threadNamedArgsParser` but with a smaller
  *  allowlist. Returns `{ shared: Expression | null }` on success. */
-const _parallelNamedArgsParser: Parser<{ shared: Expression | null }> = (
+type ParallelNamedArgs = {
+  shared: Expression | null;
+  argumentTrivia?: ListTrivia[];
+};
+
+const _parallelNamedArgsParser: Parser<ParallelNamedArgs> = (
   input: string,
-): ParserResult<{ shared: Expression | null }> => {
+): ParserResult<ParallelNamedArgs> => {
   const inner: Parser<any> = seqC(
     char("("),
     optionalSpacesOrNewline,
-    capture(
-      sepBy(commaWithNewline, namedArgumentParser),
-      "arguments",
+    captureCaptures(
+      commaDelimitedListCaptures(
+        namedArgumentParser,
+        NAMED_ARGUMENT_LIST,
+        "arguments",
+        "argumentTrivia",
+      ),
     ),
-    optional(comma),
     optionalSpacesOrNewline,
     char(")"),
   );
   const r = inner(input);
-  if (!r.success) return r as ParserResult<{ shared: Expression | null }>;
+  if (!r.success) return r as ParserResult<ParallelNamedArgs>;
   const args: NamedArgument[] = r.result.arguments;
   const seen: Record<string, Expression> = {};
   for (const arg of args) {
@@ -6081,7 +6207,13 @@ const _parallelNamedArgsParser: Parser<{ shared: Expression | null }> = (
     }
     seen[arg.name] = arg.value as Expression;
   }
-  return success({ shared: seen.shared ?? null }, r.rest);
+  return success(
+    {
+      shared: seen.shared ?? null,
+      ...(r.result.argumentTrivia && { argumentTrivia: r.result.argumentTrivia }),
+    },
+    r.rest,
+  );
 };
 
 export const parallelBlockParser: Parser<ParallelBlock> = label("a parallel block", withLoc(map(memo(
@@ -6103,11 +6235,14 @@ export const parallelBlockParser: Parser<ParallelBlock> = label("a parallel bloc
     ),
   ),
 ), (parsed: any): ParallelBlock => {
-  const args = parsed._args as { shared: Expression | null } | null | undefined;
+  const args = parsed._args as ParallelNamedArgs | null | undefined;
   const out: any = { ...parsed };
   delete out._args;
   if (args && args.shared !== null) {
     out.shared = args.shared;
+  }
+  if (args?.argumentTrivia) {
+    out.argumentTrivia = args.argumentTrivia;
   }
   return out as ParallelBlock;
 })));
@@ -6487,7 +6622,7 @@ const _baseFunctionParser: Parser<any> = memo(
     captureCaptures(
       commaDelimitedListCaptures(
         or(variadicParameterParser, functionParameterParser),
-        ")",
+        CALL_ARGUMENT_LIST,
         "parameters",
         "parameterTrivia",
       ),
@@ -6656,7 +6791,7 @@ export const graphNodeParser: Parser<GraphNodeDefinition> = label("a node defini
       captureCaptures(
         commaDelimitedListCaptures(
           functionParameterParser,
-          ")",
+          CALL_ARGUMENT_LIST,
           "parameters",
           "parameterTrivia",
         ),
@@ -6822,12 +6957,13 @@ export const arrayBindingPatternParser: Parser<ArrayPattern> = label(
         set("type", "arrayPattern"),
         char("["),
         optionalSpacesOrNewline,
-        capture(
-          or(
-            sepBy(commaWithNewline, lazy(() => bindingPatternParser)),
-            succeed([]),
+        captureCaptures(
+          commaDelimitedListCaptures(
+            lazy(() => bindingPatternParser),
+            ARRAY_PATTERN_LIST,
+            "elements",
+            "elementTrivia",
           ),
-          "elements",
         ),
         optionalSpacesOrNewline,
         char("]"),
@@ -6920,12 +7056,13 @@ export const objectBindingPatternParser: Parser<ObjectPattern> = label(
       set("type", "objectPattern"),
       char("{"),
       optionalSpacesOrNewline,
-      capture(
-        or(
-          sepBy(commaWithNewline, _bindingObjectPropertyParser),
-          succeed([]),
+      captureCaptures(
+        commaDelimitedListCaptures(
+          _bindingObjectPropertyParser,
+          OBJECT_PATTERN_LIST,
+          "properties",
+          "propertyTrivia",
         ),
-        "properties",
       ),
       optionalSpacesOrNewline,
       char("}"),
@@ -7112,15 +7249,13 @@ export const arrayMatchPatternParser: Parser<ArrayPattern> = label(
         set("type", "arrayPattern"),
         char("["),
         optionalSpacesOrNewline,
-        capture(
-          or(
-            sepBy(
-              commaWithNewline,
-              lazy(() => matchPatternParser) as Parser<ArrayPattern["elements"][number]>,
-            ),
-            succeed([]),
+        captureCaptures(
+          commaDelimitedListCaptures(
+            lazy(() => matchPatternParser) as Parser<ArrayPattern["elements"][number]>,
+            ARRAY_PATTERN_LIST,
+            "elements",
+            "elementTrivia",
           ),
-          "elements",
         ),
         optionalSpacesOrNewline,
         char("]"),
@@ -7146,12 +7281,13 @@ export const objectMatchPatternParser: Parser<ObjectPattern> = label(
       set("type", "objectPattern"),
       char("{"),
       optionalSpacesOrNewline,
-      capture(
-        or(
-          sepBy(commaWithNewline, _matchObjectPropertyParser),
-          succeed([]),
+      captureCaptures(
+        commaDelimitedListCaptures(
+          _matchObjectPropertyParser,
+          OBJECT_PATTERN_LIST,
+          "properties",
+          "propertyTrivia",
         ),
-        "properties",
       ),
       optionalSpacesOrNewline,
       char("}"),

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -1854,9 +1854,6 @@ function partitionTrivia<T>(entries: InterleavedEntry<T>[]): ParsedList<T> {
   return trivia.length > 0 ? { items, trivia } : { items };
 }
 
-/** A comma-separated list that may span lines, with trivia between items.
- *  `closer` is only looked at, never consumed: it lets the last item go
- *  without a comma while still requiring commas between items (#602). */
 /** What a particular comma list allows. Stated per call site rather than
  *  inferred, because these differ across the grammar and getting one wrong
  *  silently widens what the language accepts: `import { a, b }` permits a
@@ -1888,6 +1885,10 @@ function commaListDelimiter(policy: CommaListPolicy): Parser<unknown> {
   return seqR(optionalSpacesOrNewline, or(comma, ahead), optionalSpacesOrNewline);
 }
 
+/** A comma-separated list that may span lines, with trivia between items.
+ *  `policy.closer` is only looked at, never consumed: that is what lets the
+ *  last item go without a comma while still requiring commas between items
+ *  (#602). */
 function commaDelimitedList<T>(
   itemParser: Parser<T>,
   policy: CommaListPolicy,

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -1870,7 +1870,13 @@ type CommaListPolicy = {
 
 /** Look ahead past trivia to the closer, without consuming anything. */
 const closerAhead = (closer: string) =>
-  peek(seqR(many(seqR(literalTrivia, optionalSpacesOrNewline)), char(closer)));
+  peek(
+    seqR(
+      optionalSpacesOrNewline,
+      many(seqR(literalTrivia, optionalSpacesOrNewline)),
+      char(closer),
+    ),
+  );
 
 /** The separator between two items. In `reject` mode a comma must be
  *  followed by another item, so `[a, b,]` fails rather than quietly
@@ -4898,6 +4904,9 @@ const namedImportParser: Parser<NamedImport> = memo(
         importedNames,
         aliases,
       };
+      if (result.nameTrivia) {
+        node.nameTrivia = result.nameTrivia;
+      }
       if (destructiveNames.length > 0) {
         node.destructiveNames = destructiveNames;
       }
@@ -5020,6 +5029,9 @@ const namedExportBodyParser = map(
       names,
       aliases,
     };
+    if (result.nameTrivia) {
+      body.nameTrivia = result.nameTrivia;
+    }
     if (destructiveNames.length > 0) {
       body.destructiveNames = destructiveNames;
     }
@@ -6192,7 +6204,9 @@ const _parallelNamedArgsParser: Parser<ParallelNamedArgs> = (
     char(")"),
   );
   const r = inner(input);
-  if (!r.success) return r as ParserResult<ParallelNamedArgs>;
+  if (!r.success) {
+    return r as ParserResult<ParallelNamedArgs>;
+  }
   const args: NamedArgument[] = r.result.arguments;
   const seen: Record<string, Expression> = {};
   for (const arg of args) {

--- a/packages/agency-lang/lib/types/exportFromStatement.ts
+++ b/packages/agency-lang/lib/types/exportFromStatement.ts
@@ -1,3 +1,4 @@
+import type { ListTrivia } from "./dataStructures.js";
 import { BaseNode } from "./base.js";
 
 export type ExportFromStatement = BaseNode & {
@@ -11,6 +12,8 @@ export type NamedExportBody = {
   kind: "namedExport";
   /** Source-side names being re-exported. */
   names: string[];
+  /** Comments between items in this list. */
+  nameTrivia?: ListTrivia[];
   /** Map of sourceName → localName for entries written as `name as alias`. */
   aliases: Record<string, string>;
   /** Source-side names marked `destructive` / `idempotent`. Present only

--- a/packages/agency-lang/lib/types/importStatement.ts
+++ b/packages/agency-lang/lib/types/importStatement.ts
@@ -1,3 +1,4 @@
+import type { ListTrivia } from "./dataStructures.js";
 import { BaseNode } from "./base.js";
 import { Hole } from "./hole.js";
 
@@ -19,6 +20,8 @@ export type NamedImport = {
   /** An entry is a Hole only inside a template (`import { #tool } from ...`);
    *  always strings in a compilable program. */
   importedNames: (string | Hole)[];
+  /** Comments between items in this list. */
+  nameTrivia?: ListTrivia[];
   /** Source-side names marked `destructive` / `idempotent`. Each present
    *  only when non-empty (matching `testOnly` above) so exact-match AST
    *  comparisons stay clean. */
@@ -61,6 +64,8 @@ export function getImportedNames(importNameType: ImportNameType): string[] {
 export type ImportNodeStatement = BaseNode & {
   type: "importNodeStatement";
   importedNodes: string[];
+  /** Comments between items in this list. */
+  nodeTrivia?: ListTrivia[];
   agencyFile: string;
   /**
    * When true, the typescript builder also emits a JS-level re-export of each

--- a/packages/agency-lang/lib/types/messageThread.ts
+++ b/packages/agency-lang/lib/types/messageThread.ts
@@ -1,3 +1,4 @@
+import type { ListTrivia } from "./dataStructures.js";
 import { AgencyNode, Expression } from "@/types.js";
 import { BaseNode } from "./base.js";
 
@@ -7,6 +8,8 @@ export type MessageThread = BaseNode & {
   type: "messageThread";
   threadType: ThreadType;
   body: AgencyNode[];
+  /** Comments between the named arguments, in the order they PRINT. */
+  argumentTrivia?: ListTrivia[];
   /** Optional template-level label from `thread(label: "...") { }`. */
   label?: Expression | null;
   /** Optional eager-summarize flag from `thread(summarize: true) { }`. */

--- a/packages/agency-lang/lib/types/parallelBlock.ts
+++ b/packages/agency-lang/lib/types/parallelBlock.ts
@@ -1,3 +1,4 @@
+import type { ListTrivia } from "./dataStructures.js";
 import { AgencyNode, Expression } from "../types.js";
 import { BaseNode } from "./base.js";
 
@@ -8,6 +9,8 @@ export type ParallelBlock = BaseNode & {
    *  Forwarded by `parallelDesugar` onto the synthesized `fork(arms,
    *  shared: <expr>)` call. Absent means isolated (the default). */
   shared?: Expression;
+  /** Comments between the named arguments. */
+  argumentTrivia?: ListTrivia[];
 };
 
 export type SeqBlock = BaseNode & {

--- a/packages/agency-lang/lib/types/pattern.ts
+++ b/packages/agency-lang/lib/types/pattern.ts
@@ -1,3 +1,4 @@
+import type { ListTrivia } from "./dataStructures.js";
 import { BaseNode } from "./base.js";
 import { Literal, VariableNameLiteral } from "./literals.js";
 import type { Expression, VariableType } from "../types.js";
@@ -18,6 +19,8 @@ export type ObjectPatternShorthand = {
 export type ObjectPattern = BaseNode & {
   type: "objectPattern";
   properties: (ObjectPatternProperty | ObjectPatternShorthand | RestPattern)[];
+  /** Comments between properties. */
+  propertyTrivia?: ListTrivia[];
 };
 
 export type ArrayPattern = BaseNode & {
@@ -32,6 +35,8 @@ export type ArrayPattern = BaseNode & {
     | ResultPattern
     | TypePattern
   )[];
+  /** Comments between elements. */
+  elementTrivia?: ListTrivia[];
 };
 
 export type RestPattern = BaseNode & {


### PR DESCRIPTION
Tasks 5 and 6 of the trailing-comments plan — the last of the three. #767 covered complete constructs, #768 covered literals, calls and signatures, and this covers everything that was left.

Code and tests only.

## What now works

```agency
import {
  alpha, // the fast path
  beta // the fallback
} from "./tools"

node main() {
  const [
    first, // the header row
    second // everything else
  ] = values

  thread(
    label: "work", // shown in the log
    hidden: true // keep it out of the transcript
  ) {
    print(1)
  }
}
```

Covered: named imports, `import node { … }`, named exports, array and object binding patterns, array and object match patterns, and `thread` / `parallel` arguments.

## The policy fields finally earn their place

In #768 I deliberately shipped `commaDelimitedList(itemParser, closer)` without the `cardinality` / `trailingComma` fields the plan called for, because all three call sites there were identical and the policy would have carried no information. These nine sites are not identical — all four combinations are present:

| Site | Cardinality | Trailing comma |
|---|---|---|
| `import node { … }` | one-or-more | **reject** |
| `import { … }` | one-or-more | allow |
| `export { … } from` | one-or-more | allow |
| thread / parallel arguments | zero-or-more | allow |
| binding + match patterns (4 sites) | zero-or-more | **reject** |

Each site names its policy (`IMPORT_NODE_LIST`, `ARRAY_PATTERN_LIST`, …) so it reads as a rule rather than three anonymous arguments, and every `reject` has a negative test asserting the trailing comma still fails. That is the guard against this refactor quietly widening the grammar.

Thread arguments print in a fixed order regardless of how they were written, so their anchors go through `remapListTrivia` — the same machinery the inline-block case used in #768. There is a test that writes `hidden` first and checks both comments land on the right argument after reordering.

## Three bugs found while writing the tests

**Two parsers dropped the trivia on the floor.** `namedImportParser` and `namedExportBodyParser` both hand-build their node and copied only the fields they knew about, so widening the shared list parser was not enough. This is exactly the `guardBlockParser` failure from #768, twice more. Any parser that constructs its node literally needs its own test.

**The `reject` lookahead did not skip whitespace.** `import node { a, b, }` was still accepted, because the "is the closer next?" check ran immediately after the comma, before the delimiter consumed the space in front of `}`. Every `reject` site was silently still permissive until this was fixed — which is why the negative tests matter more than the positive ones here.

## Two pre-existing bugs I hit, and did not fix

Both were verified against the base branch, so neither is from this change.

**An empty `thread` or `parallel` body does not round-trip.** `thread(label: "w") { }` formats to a body containing a blank line, and that output then fails to re-parse. My first draft of the thread tests used empty bodies and failed on this; they now use a non-empty body. Worth its own issue.

**A standalone comment above an import does not travel with it when imports are sorted.** Comments written above two imports both float to the top of the sorted block. The test asserts what this change actually owns — the name comments inside each list, and the comment after each `from` clause, both of which do move correctly.

Also worth noting: `[a, b, ]` in a match arm is accepted on the base branch too. The arm's left-hand side reaches the literal grammar rather than the pattern list, so the pattern policy does not govern it. End-to-end behavior is unchanged; I dropped that case from the negative tests rather than asserting something that was never true.

## Verification

- Full unit suite: **10,519 passed, 0 failed** (675 files).
- `make`: clean, no generated file shifted.
- `tsc --noEmit`: no new errors beyond the 15 pre-existing `lib/serve/` ones.
- `lint:structure`: clean.
- `test:perf`: 16 passed, parse/fmt/doc scaling still linear.

After this lands, `adit/trailing-comments-integration` has the complete feature and is ready for the final PR into `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
