### PR TITLE
fix(serve): validate /resume input before running (safety)

### DIFF
--- a/packages/agency-lang/lib/runtime/interrupts.test.ts
+++ b/packages/agency-lang/lib/runtime/interrupts.test.ts
@@ -424,6 +424,17 @@ describe("validateResumeBatch", () => {
     ).not.toBeNull();
   });
 
+  it("treats an interruptId of __proto__ as an ordinary key", () => {
+    // A plain-object seen-set would report the first "__proto__" as a duplicate
+    // (it inherits truthy from the prototype); a single one must be accepted,
+    // and two of them must still be rejected as duplicates.
+    const proto = { ...validInterrupt, interruptId: "__proto__" };
+    expect(validateResumeBatch([proto], [approveResponse])).toBeNull();
+    expect(
+      validateResumeBatch([proto, { ...proto }], [approveResponse, approveResponse]),
+    ).not.toBeNull();
+  });
+
   it("rejects a non approve/reject response discriminant", () => {
     // Deliberately invalid discriminant — the type is cast so the test can send it.
     const badResponses = [{ type: "propagate" }] as unknown as InterruptResponse[];

--- a/packages/agency-lang/lib/runtime/interrupts.test.ts
+++ b/packages/agency-lang/lib/runtime/interrupts.test.ts
@@ -456,8 +456,10 @@ describe("respondToInterrupts input validation (defense in depth)", () => {
     // buildResponseMap runs before ctx is touched, so this stub is never read.
     const stubCtx = {} as unknown as Parameters<typeof respondToInterrupts>[0]["ctx"];
     const badResponses = [{ type: "propagate" }] as unknown as InterruptResponse[];
+    // The validator rejects with a `respondToInterrupts:`-prefixed error before
+    // the context is touched (a later checkpoint error has no such prefix).
     await expect(
       respondToInterrupts({ ctx: stubCtx, interrupts: [validInterrupt], responses: badResponses }),
-    ).rejects.toThrow(/approve or reject/);
+    ).rejects.toThrow(/^respondToInterrupts:/);
   });
 });

--- a/packages/agency-lang/lib/runtime/interrupts.test.ts
+++ b/packages/agency-lang/lib/runtime/interrupts.test.ts
@@ -7,7 +7,10 @@ import {
   interruptWithHandlers,
   gatherChainOutcome,
   pass,
+  validateResumeBatch,
+  respondToInterrupts,
 } from "./interrupts.js";
+import type { InterruptResponse } from "./interrupts.js";
 import { RuntimeContext } from "./state/context.js";
 import { StateStack } from "./state/stateStack.js";
 
@@ -379,5 +382,71 @@ describe("pass()", () => {
     const verdict = await interruptWithHandlers("std::bash", "m", {}, "o", ctx, new StateStack());
     expect(Array.isArray(verdict)).toBe(true);
     expect((verdict as any)[0].effect).toBe("std::bash");
+  });
+});
+
+describe("validateResumeBatch", () => {
+  const validInterrupt = interrupt({
+    effect: "delete",
+    message: "?",
+    data: null,
+    origin: "o",
+    runId: "run-1",
+    interruptId: "id-1",
+  });
+  const approveResponse = { type: "approve" as const };
+
+  it("accepts a well-formed approve/reject batch", () => {
+    expect(validateResumeBatch([validInterrupt], [approveResponse])).toBeNull();
+  });
+
+  it("rejects non-arrays, empty, and length mismatch", () => {
+    expect(validateResumeBatch("x", [])).not.toBeNull();
+    expect(validateResumeBatch([], [])).not.toBeNull();
+    expect(validateResumeBatch([validInterrupt], [])).not.toBeNull();
+  });
+
+  it("rejects malformed interrupt items without throwing on null/primitives", () => {
+    expect(validateResumeBatch([null], [approveResponse])).not.toBeNull();
+    expect(validateResumeBatch([42], [approveResponse])).not.toBeNull();
+    expect(
+      validateResumeBatch([{ ...validInterrupt, type: "notInterrupt" }], [approveResponse]),
+    ).not.toBeNull();
+    expect(
+      validateResumeBatch([{ ...validInterrupt, interruptId: "" }], [approveResponse]),
+    ).not.toBeNull();
+  });
+
+  it("rejects duplicate interrupt IDs", () => {
+    const duplicate = { ...validInterrupt };
+    expect(
+      validateResumeBatch([validInterrupt, duplicate], [approveResponse, approveResponse]),
+    ).not.toBeNull();
+  });
+
+  it("rejects a non approve/reject response discriminant", () => {
+    // Deliberately invalid discriminant — the type is cast so the test can send it.
+    const badResponses = [{ type: "propagate" }] as unknown as InterruptResponse[];
+    expect(validateResumeBatch([validInterrupt], badResponses)).not.toBeNull();
+    expect(validateResumeBatch([validInterrupt], [null])).not.toBeNull();
+  });
+});
+
+describe("respondToInterrupts input validation (defense in depth)", () => {
+  it("rejects an invalid response before the runtime context is used", async () => {
+    const validInterrupt = interrupt({
+      effect: "delete",
+      message: "?",
+      data: null,
+      origin: "o",
+      runId: "run-1",
+      interruptId: "id-1",
+    });
+    // buildResponseMap runs before ctx is touched, so this stub is never read.
+    const stubCtx = {} as unknown as Parameters<typeof respondToInterrupts>[0]["ctx"];
+    const badResponses = [{ type: "propagate" }] as unknown as InterruptResponse[];
+    await expect(
+      respondToInterrupts({ ctx: stubCtx, interrupts: [validInterrupt], responses: badResponses }),
+    ).rejects.toThrow(/approve or reject/);
   });
 });

--- a/packages/agency-lang/lib/runtime/interrupts.ts
+++ b/packages/agency-lang/lib/runtime/interrupts.ts
@@ -606,6 +606,62 @@ export async function interruptWithHandlers<T = any>(
   return renderVerdict(outcome, ctx, interruptId, interruptObj, parentDecided ? "ipc" : "handler");
 }
 
+/**
+ * Validate a resume batch before it can reach interrupt-resume execution.
+ *
+ * This is the single gate protecting a safety-critical path: the generated
+ * resume code acts only on `"approve"` and `"reject"`, so a malformed response
+ * would otherwise fall through and continue execution *past* the interrupt. It
+ * proves each item is a real object before reading any field, so a `null` or a
+ * primitive returns an error string rather than throwing. Returns the first
+ * problem found, or `null` when the batch is well-formed.
+ *
+ * Owns: non-empty arrays, equal lengths, interrupt identity, unique interrupt
+ * IDs (the response map is ID-keyed, so duplicates would silently overwrite),
+ * and approve/reject response discriminants.
+ */
+export function validateResumeBatch(
+  interrupts: unknown,
+  responses: unknown,
+): string | null {
+  if (!Array.isArray(interrupts) || !Array.isArray(responses)) {
+    return "interrupts and responses must be arrays";
+  }
+  if (interrupts.length === 0) {
+    return "interrupts must be non-empty";
+  }
+  if (interrupts.length !== responses.length) {
+    return "interrupts and responses length mismatch";
+  }
+  const seenInterruptIds: string[] = [];
+  for (const item of interrupts) {
+    if (typeof item !== "object" || item === null || Array.isArray(item)) {
+      return "each interrupt must be an object";
+    }
+    const fields = item as Record<string, unknown>;
+    if (fields.type !== "interrupt") {
+      return "each interrupt type must be interrupt";
+    }
+    if (typeof fields.interruptId !== "string" || fields.interruptId.length === 0) {
+      return "each interrupt must carry a non-empty string interruptId";
+    }
+    if (seenInterruptIds.includes(fields.interruptId)) {
+      return "interrupt IDs must be unique";
+    }
+    seenInterruptIds.push(fields.interruptId);
+  }
+  for (const item of responses) {
+    if (typeof item !== "object" || item === null || Array.isArray(item)) {
+      return "each response must be an object";
+    }
+    const responseType = (item as { type?: unknown }).type;
+    if (responseType !== "approve" && responseType !== "reject") {
+      return "each response type must be approve or reject";
+    }
+  }
+  return null;
+}
+
 /** Build the ID-keyed response map for `respondToInterrupts`. Extracted
  * to keep the main function under the structural lint limit. */
 function buildResponseMap(

--- a/packages/agency-lang/lib/runtime/interrupts.ts
+++ b/packages/agency-lang/lib/runtime/interrupts.ts
@@ -622,7 +622,12 @@ const ResumeBatchSchema = z
     responses: z.array(z.object({ type: z.enum(["approve", "reject"]) })),
   })
   .refine((batch) => batch.interrupts.length === batch.responses.length, {
-    message: "interrupts and responses length mismatch",
+    // Name the counts — this is the actionable message TS callers of
+    // respondToInterrupts see, and a test pins that it mentions them.
+    error: (issue) => {
+      const batch = issue.input as { interrupts: unknown[]; responses: unknown[] };
+      return `expected ${batch.interrupts.length} responses but got ${batch.responses.length}`;
+    },
   })
   .refine(
     (batch) =>

--- a/packages/agency-lang/lib/runtime/interrupts.ts
+++ b/packages/agency-lang/lib/runtime/interrupts.ts
@@ -633,7 +633,10 @@ export function validateResumeBatch(
   if (interrupts.length !== responses.length) {
     return "interrupts and responses length mismatch";
   }
-  const seenInterruptIds: string[] = [];
+  // Null-prototype set: O(1) membership on untrusted, possibly large input, and
+  // an id like "__proto__" is an ordinary key rather than a prototype hit that a
+  // plain object would report as already-seen.
+  const seenInterruptIds: Record<string, true> = Object.create(null);
   for (const item of interrupts) {
     if (typeof item !== "object" || item === null || Array.isArray(item)) {
       return "each interrupt must be an object";
@@ -645,10 +648,10 @@ export function validateResumeBatch(
     if (typeof fields.interruptId !== "string" || fields.interruptId.length === 0) {
       return "each interrupt must carry a non-empty string interruptId";
     }
-    if (seenInterruptIds.includes(fields.interruptId)) {
+    if (seenInterruptIds[fields.interruptId]) {
       return "interrupt IDs must be unique";
     }
-    seenInterruptIds.push(fields.interruptId);
+    seenInterruptIds[fields.interruptId] = true;
   }
   for (const item of responses) {
     if (typeof item !== "object" || item === null || Array.isArray(item)) {
@@ -674,7 +677,9 @@ function buildResponseMap(
   if (validationError) {
     throw new Error(`respondToInterrupts: ${validationError}`);
   }
-  const responseMap: Record<string, { response: InterruptResponse }> = {};
+  // Null-prototype: interruptId comes from the (client-echoed) request, so an id
+  // like "__proto__" must be a plain key, not a write to the map's prototype.
+  const responseMap: Record<string, { response: InterruptResponse }> = Object.create(null);
   for (let i = 0; i < interrupts.length; i++) {
     responseMap[interrupts[i].interruptId] = {
       response: deepClone(responses[i]),

--- a/packages/agency-lang/lib/runtime/interrupts.ts
+++ b/packages/agency-lang/lib/runtime/interrupts.ts
@@ -668,10 +668,11 @@ function buildResponseMap(
   interrupts: Interrupt[],
   responses: InterruptResponse[],
 ): Record<string, { response: InterruptResponse }> {
-  if (responses.length !== interrupts.length) {
-    throw new Error(
-      `respondToInterrupts: expected ${interrupts.length} responses but got ${responses.length}`,
-    );
+  // Defense in depth: non-HTTP callers (MCP, direct embedders) reach here
+  // without the adapter's check, so the same validator gates this path too.
+  const validationError = validateResumeBatch(interrupts, responses);
+  if (validationError) {
+    throw new Error(`respondToInterrupts: ${validationError}`);
   }
   const responseMap: Record<string, { response: InterruptResponse }> = {};
   for (let i = 0; i < interrupts.length; i++) {

--- a/packages/agency-lang/lib/runtime/interrupts.ts
+++ b/packages/agency-lang/lib/runtime/interrupts.ts
@@ -1,6 +1,7 @@
 import * as smoltalk from "smoltalk";
 import { AsyncLocalStorage } from "node:async_hooks";
 import { nanoid } from "nanoid";
+import { z } from "zod";
 import { runInBootstrapFrame } from "./asyncContext.js";
 import { __initAllRegisteredCallbacks } from "./crossModuleInitRegistry.js";
 import {
@@ -606,63 +607,41 @@ export async function interruptWithHandlers<T = any>(
   return renderVerdict(outcome, ctx, interruptId, interruptObj, parentDecided ? "ipc" : "handler");
 }
 
+// A resume batch, validated before it can reach interrupt-resume execution.
+// The generated resume code acts only on `"approve"` and `"reject"`, so a
+// malformed response would otherwise fall through and continue execution *past*
+// the interrupt. The schema also enforces equal lengths and unique interrupt
+// IDs — the response map is ID-keyed, so duplicates would silently overwrite.
+// Each item schema keeps only the identity fields it gates on; interrupts and
+// responses carry more fields, which parse harmlessly.
+const ResumeBatchSchema = z
+  .object({
+    interrupts: z
+      .array(z.object({ type: z.literal("interrupt"), interruptId: z.string().min(1) }))
+      .min(1),
+    responses: z.array(z.object({ type: z.enum(["approve", "reject"]) })),
+  })
+  .refine((batch) => batch.interrupts.length === batch.responses.length, {
+    message: "interrupts and responses length mismatch",
+  })
+  .refine(
+    (batch) =>
+      new Set(batch.interrupts.map((interrupt) => interrupt.interruptId)).size ===
+      batch.interrupts.length,
+    { message: "interrupt IDs must be unique" },
+  );
+
 /**
- * Validate a resume batch before it can reach interrupt-resume execution.
- *
- * This is the single gate protecting a safety-critical path: the generated
- * resume code acts only on `"approve"` and `"reject"`, so a malformed response
- * would otherwise fall through and continue execution *past* the interrupt. It
- * proves each item is a real object before reading any field, so a `null` or a
- * primitive returns an error string rather than throwing. Returns the first
- * problem found, or `null` when the batch is well-formed.
- *
- * Owns: non-empty arrays, equal lengths, interrupt identity, unique interrupt
- * IDs (the response map is ID-keyed, so duplicates would silently overwrite),
- * and approve/reject response discriminants.
+ * Validate a resume batch. Returns the first problem as a message, or `null`
+ * when the batch is well-formed. `safeParse` never throws — a `null` or
+ * primitive item is a validation error, not a crash.
  */
 export function validateResumeBatch(
   interrupts: unknown,
   responses: unknown,
 ): string | null {
-  if (!Array.isArray(interrupts) || !Array.isArray(responses)) {
-    return "interrupts and responses must be arrays";
-  }
-  if (interrupts.length === 0) {
-    return "interrupts must be non-empty";
-  }
-  if (interrupts.length !== responses.length) {
-    return "interrupts and responses length mismatch";
-  }
-  // Null-prototype set: O(1) membership on untrusted, possibly large input, and
-  // an id like "__proto__" is an ordinary key rather than a prototype hit that a
-  // plain object would report as already-seen.
-  const seenInterruptIds: Record<string, true> = Object.create(null);
-  for (const item of interrupts) {
-    if (typeof item !== "object" || item === null || Array.isArray(item)) {
-      return "each interrupt must be an object";
-    }
-    const fields = item as Record<string, unknown>;
-    if (fields.type !== "interrupt") {
-      return "each interrupt type must be interrupt";
-    }
-    if (typeof fields.interruptId !== "string" || fields.interruptId.length === 0) {
-      return "each interrupt must carry a non-empty string interruptId";
-    }
-    if (seenInterruptIds[fields.interruptId]) {
-      return "interrupt IDs must be unique";
-    }
-    seenInterruptIds[fields.interruptId] = true;
-  }
-  for (const item of responses) {
-    if (typeof item !== "object" || item === null || Array.isArray(item)) {
-      return "each response must be an object";
-    }
-    const responseType = (item as { type?: unknown }).type;
-    if (responseType !== "approve" && responseType !== "reject") {
-      return "each response type must be approve or reject";
-    }
-  }
-  return null;
+  const result = ResumeBatchSchema.safeParse({ interrupts, responses });
+  return result.success ? null : result.error.issues[0].message;
 }
 
 /** Build the ID-keyed response map for `respondToInterrupts`. Extracted

--- a/packages/agency-lang/lib/serve/createServeHandler.test.ts
+++ b/packages/agency-lang/lib/serve/createServeHandler.test.ts
@@ -37,10 +37,10 @@ export async function main(message) {
   return { data: { echo: message, version: ${JSON.stringify(version)} } };
 }
 export async function needsApproval() {
-  return { data: { __interrupts: [{ type: "interrupt", effect: "std::read", message: "ok?" }] } };
+  return { data: [{ type: "interrupt", effect: "std::read", message: "ok?", origin: "agent", interruptId: "fixture-int-1", runId: "fixture-run-1", data: null }] };
 }
 export function hasInterrupts(data) {
-  return !!(data && data.__interrupts);
+  return Array.isArray(data) && data.length > 0 && data.every((item) => item && item.type === "interrupt");
 }
 export async function respondToInterrupts(interrupts, responses) {
   return { data: { resumed: true, responses } };
@@ -109,11 +109,12 @@ describe("createServeHandler", () => {
   it("returns the interrupts payload, then resumes to the final value", async () => {
     const handler = await createServeHandler(modulePath, baseOptions());
     const paused = await handler("POST", "/node/needsApproval", {});
-    const pausedBody = paused.body as { success: boolean; value: { interrupts: unknown } };
-    expect(pausedBody.value.interrupts).toBeTruthy();
+    const pausedBody = paused.body as { success: boolean; value: { interrupts: unknown[] } };
+    expect(Array.isArray(pausedBody.value.interrupts)).toBe(true);
 
+    // Echo the exact interrupt array from the pause, as a real client would.
     const resumed = await handler("POST", "/resume", {
-      interrupts: [{ type: "interrupt", effect: "std::read", message: "ok?" }],
+      interrupts: pausedBody.value.interrupts,
       responses: [{ type: "approve" }],
     });
     const resumedBody = resumed.body as { success: boolean; value: { resumed: boolean } };

--- a/packages/agency-lang/lib/serve/http/adapter.test.ts
+++ b/packages/agency-lang/lib/serve/http/adapter.test.ts
@@ -1,11 +1,44 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import http from "http";
 import { AddressInfo } from "net";
 import { createHttpHandler, startHttpServer } from "./adapter.js";
 import { AgencyFunction } from "../../runtime/agencyFunction.js";
+import { interrupt } from "../../runtime/interrupts.js";
+import type { Interrupt } from "../../runtime/interrupts.js";
 import type { ExportedItem } from "../types.js";
 import { createLogger } from "../../logger.js";
 import type { Logger } from "../../logger.js";
+
+// A fully-formed interrupt, as the runtime produces one — every identity field
+// present. Resume validation now requires these, so tests build real interrupts
+// instead of `{ id: "1" }` shaped partials.
+function makeInterrupt(interruptId: string): Interrupt {
+  return interrupt({
+    effect: "delete",
+    message: "delete emails?",
+    data: null,
+    origin: "test",
+    runId: "run-1",
+    interruptId,
+  });
+}
+
+// A handler whose respondToInterrupts is a spy, so a malformed /resume can be
+// proven to never reach the runtime.
+function makeSpyHandler(): {
+  handler: ReturnType<typeof createHttpHandler>;
+  respondSpy: ReturnType<typeof vi.fn>;
+} {
+  const { exports } = makeExports();
+  const respondSpy = vi.fn(async () => ({ data: "resumed" }));
+  const handler = createHttpHandler({
+    exports,
+    logger: createLogger("error"),
+    hasInterrupts: () => false,
+    respondToInterrupts: respondSpy,
+  });
+  return { handler, respondSpy };
+}
 
 function makeExports(): {
   exports: ExportedItem[];
@@ -203,12 +236,13 @@ describe("HTTP adapter", () => {
 
   it("POST /resume calls respondToInterrupts", async () => {
     const result = await handler("POST", "/resume", {
-      interrupts: [{ id: "1" }],
+      interrupts: [makeInterrupt("id-1")],
       responses: [{ type: "approve" }],
     });
     expect(result.status).toBe(200);
     const body = result.body as any;
     expect(body.success).toBe(true);
+    expect(body.value).toBe("resumed");
   });
 
   it("POST /resume rejects non-array inputs", async () => {
@@ -217,6 +251,77 @@ describe("HTTP adapter", () => {
       responses: "not-array",
     });
     expect(result.status).toBe(400);
+  });
+
+  it("POST /resume rejects an unknown response type without running", async () => {
+    // The core safety case: an unrecognized response type would otherwise fall
+    // through the generated resume branch and continue PAST the interrupt.
+    const { handler: spyHandler, respondSpy } = makeSpyHandler();
+    const result = await spyHandler("POST", "/resume", {
+      interrupts: [makeInterrupt("id-1")],
+      responses: [{ type: "propagate" }],
+    });
+    expect(result.status).toBe(400);
+    expect(respondSpy).not.toHaveBeenCalled();
+  });
+
+  it("POST /resume rejects length mismatch, empty, and duplicate-id batches", async () => {
+    const { handler: spyHandler, respondSpy } = makeSpyHandler();
+    const first = makeInterrupt("id-1");
+    const second = makeInterrupt("id-2");
+    const approveResponse = { type: "approve" };
+    const rejectResponse = { type: "reject" };
+
+    const mismatched = await spyHandler("POST", "/resume", {
+      interrupts: [first, second],
+      responses: [approveResponse],
+    });
+    expect(mismatched.status).toBe(400);
+
+    const empty = await spyHandler("POST", "/resume", { interrupts: [], responses: [] });
+    expect(empty.status).toBe(400);
+
+    // buildResponseMap is keyed by interruptId, so duplicate ids would overwrite
+    // one response and leave an interrupt unanswered.
+    const duplicate = await spyHandler("POST", "/resume", {
+      interrupts: [first, { ...second, interruptId: first.interruptId }],
+      responses: [approveResponse, rejectResponse],
+    });
+    expect(duplicate.status).toBe(400);
+
+    expect(respondSpy).not.toHaveBeenCalled();
+  });
+
+  it("POST /resume rejects malformed interrupt and response items via a table", async () => {
+    const { handler: spyHandler, respondSpy } = makeSpyHandler();
+    const valid = makeInterrupt("id-1");
+    const approveResponse = { type: "approve" };
+
+    const badInterrupts: unknown[] = [
+      null,
+      42,
+      ["array"],
+      { ...valid, type: "notInterrupt" },
+      { ...valid, interruptId: "" },
+    ];
+    for (const badInterrupt of badInterrupts) {
+      const result = await spyHandler("POST", "/resume", {
+        interrupts: [badInterrupt],
+        responses: [approveResponse],
+      });
+      expect(result.status).toBe(400);
+    }
+
+    const badResponses: unknown[] = [null, 42, ["array"], {}, { type: "propagate" }];
+    for (const badResponse of badResponses) {
+      const result = await spyHandler("POST", "/resume", {
+        interrupts: [valid],
+        responses: [badResponse],
+      });
+      expect(result.status).toBe(400);
+    }
+
+    expect(respondSpy).not.toHaveBeenCalled();
   });
 
   it("returns 404 for unknown routes", async () => {

--- a/packages/agency-lang/lib/serve/http/adapter.ts
+++ b/packages/agency-lang/lib/serve/http/adapter.ts
@@ -1,6 +1,7 @@
 import http from "http";
 import type { ExportedItem, ExportedFunction, ExportedNode } from "../types.js";
 import { errorMessage, toArgs, parseJsonBody } from "../util.js";
+import { validateResumeBatch } from "../../runtime/interrupts.js";
 import type { Logger } from "../../logger.js";
 import {
   DEFAULT_HOST,
@@ -105,8 +106,11 @@ async function resumeInterrupts(
     interrupts: unknown[];
     responses: unknown[];
   };
-  if (!Array.isArray(interrupts) || !Array.isArray(responses)) {
-    return { status: 400, body: { error: "interrupts and responses must be arrays" } };
+  const validationError = validateResumeBatch(interrupts, responses);
+  if (validationError) {
+    // Reject before any runtime code runs: a malformed response must never
+    // reach the resume path, where an unknown type continues past the interrupt.
+    return { status: 400, body: { error: validationError } };
   }
   try {
     const result = (await respondToInterrupts(interrupts, responses)) as { data: unknown };


### PR DESCRIPTION
## What

Harden the `/resume` serve route (and the `respondToInterrupts` runtime boundary) against malformed input. This is PR 1 of the `agency remote` work — pure safety, self-contained, no dependency on the rest.

## Why

The generated resume path acts only on `"approve"` and `"reject"`. An unknown response `type` matches neither branch and **execution continues past the interrupt** — silently skipping a safety gate. The two gatekeepers didn't catch it:

- the HTTP adapter only checked that `interrupts`/`responses` were arrays;
- `buildResponseMap` only checked that the two arrays were the same length.

So a malformed `/resume` body (e.g. `responses: [{ "type": "propagate" }]`) returned HTTP 200 and ran the code the interrupt was meant to gate.

## Change

- **`validateResumeBatch(interrupts, responses)`** (`lib/runtime/interrupts.ts`) — the single owner of resume-batch validity: non-empty arrays, equal lengths, per-item interrupt identity (`type: "interrupt"` + non-empty `interruptId`), **unique** interrupt IDs (the response map is ID-keyed, so duplicates would overwrite an answer), and `approve`/`reject` response discriminants. It proves each item is a real object before reading any field, so a `null`/primitive returns an error string instead of throwing.
- **Adapter** (`lib/serve/http/adapter.ts`) calls it and returns **HTTP 400 before `respondToInterrupts`** on any error.
- **Runtime defense in depth** — `buildResponseMap` reuses the same validator, so non-HTTP callers (MCP, direct embedders) reject the same malformed batches. Replaces the length-only check the validator subsumes.

## Testing

- New adapter tests: unknown response type, length mismatch, empty batch, duplicate ids, and a table of malformed interrupt/response items all return 400 with `respondToInterrupts` never called; a well-formed pair still resumes.
- New runtime tests: `validateResumeBatch` directly, plus `respondToInterrupts` rejecting an invalid response before its context is used.
- `createServeHandler` pause/resume fixture updated to carry a real interrupt and echo it on resume.
- Guard: `lib/serve` + `lib/runtime/interrupts.test.ts` — 144 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
