### PR TITLE
refactor(cli): sealed statelog wire under lib/cli/statelog

### DIFF
--- a/packages/agency-lang/lib/cli/deploy/curlExamples.test.ts
+++ b/packages/agency-lang/lib/cli/deploy/curlExamples.test.ts
@@ -4,10 +4,10 @@ import { curlExamples } from "./curlExamples.js";
 const BASE = "https://statelog.example/serve/u/proj/greeter";
 
 describe("curlExamples", () => {
-  it("emits a GET for the manifest, a templated POST per node, and a POST per function", () => {
+  it("emits a GET for the manifest, a templated POST per node, and a templated POST per function", () => {
     const examples = curlExamples(BASE, {
-      nodes: [{ name: "main", parameters: ["message"] }],
-      functions: [{ name: "add" }],
+      nodes: [{ name: "main", parameters: ["message"], interruptEffects: [] }],
+      functions: [{ name: "add", parameters: ["a", "b"], interruptEffects: [] }],
     });
 
     expect(examples.map((example) => example.label)).toEqual([
@@ -19,14 +19,16 @@ describe("curlExamples", () => {
     expect(examples[1].command).toContain(`-X POST "${BASE}/node/main"`);
     expect(examples[1].command).toContain(`-d '{"message":"…"}'`);
     expect(examples[2].command).toContain(`-X POST "${BASE}/function/add"`);
-    expect(examples[2].command).toContain(`-d '{}'`);
+    // Function bodies template from their parameters, just like nodes.
+    expect(examples[2].command).toContain(`-d '{"a":"…","b":"…"}'`);
   });
 
-  it("uses an empty body for a node with no parameters", () => {
+  it("uses an empty body for a node or function with no parameters", () => {
     const examples = curlExamples(BASE, {
-      nodes: [{ name: "run", parameters: [] }],
-      functions: [],
+      nodes: [{ name: "run", parameters: [], interruptEffects: [] }],
+      functions: [{ name: "ping", parameters: [], interruptEffects: [] }],
     });
     expect(examples[1].command).toContain(`-d '{}'`);
+    expect(examples[2].command).toContain(`-d '{}'`);
   });
 });

--- a/packages/agency-lang/lib/cli/deploy/curlExamples.ts
+++ b/packages/agency-lang/lib/cli/deploy/curlExamples.ts
@@ -1,7 +1,7 @@
 // Ready-to-run curl commands for a deployed agent. Pure: manifest in, command
 // strings out. Uses a `$KEY` placeholder — never the real API key.
 
-import type { Manifest } from "../statelog/uploadClient.js";
+import type { ServeManifest } from "../statelog/serveClient.js";
 
 export type CurlExample = { label: string; command: string };
 
@@ -13,7 +13,7 @@ const JSON_HEADER = `-H "Content-Type: application/json"`;
  * templated from its parameters), and each function (POST). Functions get an
  * empty `{}` body because the manifest does not yet expose their parameters.
  */
-export function curlExamples(serveBase: string, manifest: Manifest): CurlExample[] {
+export function curlExamples(serveBase: string, manifest: ServeManifest): CurlExample[] {
   const manifestExample: CurlExample = {
     label: "manifest",
     command: `curl -s ${AUTH} "${serveBase}/list"`,

--- a/packages/agency-lang/lib/cli/deploy/curlExamples.ts
+++ b/packages/agency-lang/lib/cli/deploy/curlExamples.ts
@@ -9,9 +9,8 @@ const AUTH = `-H "Authorization: Bearer $KEY"`;
 const JSON_HEADER = `-H "Content-Type: application/json"`;
 
 /**
- * One curl per endpoint: the manifest (GET), each node (POST with a body
- * templated from its parameters), and each function (POST). Functions get an
- * empty `{}` body because the manifest does not yet expose their parameters.
+ * One curl per endpoint: the manifest (GET), each node (POST), and each function
+ * (POST) — every call body templated from that endpoint's parameters.
  */
 export function curlExamples(serveBase: string, manifest: ServeManifest): CurlExample[] {
   const manifestExample: CurlExample = {
@@ -26,7 +25,7 @@ export function curlExamples(serveBase: string, manifest: ServeManifest): CurlEx
 
   const functionExamples = manifest.functions.map((fn) => ({
     label: `function ${fn.name}`,
-    command: post(`${serveBase}/function/${fn.name}`, "{}"),
+    command: post(`${serveBase}/function/${fn.name}`, bodyTemplate(fn.parameters)),
   }));
 
   return [manifestExample, ...nodeExamples, ...functionExamples];

--- a/packages/agency-lang/lib/cli/deploy/curlExamples.ts
+++ b/packages/agency-lang/lib/cli/deploy/curlExamples.ts
@@ -1,7 +1,7 @@
 // Ready-to-run curl commands for a deployed agent. Pure: manifest in, command
 // strings out. Uses a `$KEY` placeholder — never the real API key.
 
-import type { Manifest } from "./uploadClient.js";
+import type { Manifest } from "../statelog/uploadClient.js";
 
 export type CurlExample = { label: string; command: string };
 

--- a/packages/agency-lang/lib/cli/deploy/deploy.ts
+++ b/packages/agency-lang/lib/cli/deploy/deploy.ts
@@ -7,8 +7,8 @@ import { resolveDeployTarget } from "./target.js";
 import type { DeployTarget, TargetProvenance } from "./target.js";
 import { collectAgencyBundle, validateBundleCompiles } from "./bundle.js";
 import type { AgencyBundle } from "./bundle.js";
-import { uploadBundle } from "./uploadClient.js";
-import type { Manifest } from "./uploadClient.js";
+import { uploadBundle } from "../statelog/uploadClient.js";
+import type { Manifest } from "../statelog/uploadClient.js";
 
 export type DeployOptions = {
   host?: string;

--- a/packages/agency-lang/lib/cli/deploy/deploy.ts
+++ b/packages/agency-lang/lib/cli/deploy/deploy.ts
@@ -8,7 +8,7 @@ import type { DeployTarget, TargetProvenance } from "./target.js";
 import { collectAgencyBundle, validateBundleCompiles } from "./bundle.js";
 import type { AgencyBundle } from "./bundle.js";
 import { uploadBundle } from "../statelog/uploadClient.js";
-import type { Manifest } from "../statelog/uploadClient.js";
+import type { ServeManifest } from "../statelog/serveClient.js";
 
 export type DeployOptions = {
   host?: string;
@@ -27,7 +27,7 @@ export type DeployPlan = {
 export type DeployOutcome =
   | { kind: "error"; error: string }
   | { kind: "preview"; plan: DeployPlan }
-  | { kind: "deployed"; plan: DeployPlan; endpointUrls: string[]; manifest?: Manifest };
+  | { kind: "deployed"; plan: DeployPlan; endpointUrls: string[]; manifest?: ServeManifest };
 
 export async function deploy(
   entrypointPath: string,

--- a/packages/agency-lang/lib/cli/deploy/render.ts
+++ b/packages/agency-lang/lib/cli/deploy/render.ts
@@ -8,7 +8,7 @@ import { color } from "@/utils/termcolors.js";
 import renderDeployReport from "@/templates/cli/deployReport.js";
 import type { DeployOutcome, DeployPlan } from "./deploy.js";
 import { serveBaseUrl } from "../statelog/uploadClient.js";
-import type { Manifest } from "../statelog/uploadClient.js";
+import type { ServeManifest } from "../statelog/serveClient.js";
 import { curlExamples } from "./curlExamples.js";
 
 export function renderOutcome(outcome: DeployOutcome): void {
@@ -55,7 +55,7 @@ function filesBlock(plan: DeployPlan): string {
 }
 
 /** Banner + serve endpoints + (when a manifest was fetched) curl examples. */
-function deployedBody(endpointUrls: string[], manifest: Manifest | undefined): string {
+function deployedBody(endpointUrls: string[], manifest: ServeManifest | undefined): string {
   const endpoints = section(color.bold("Serve endpoints"), endpointRows(endpointUrls));
   const banner = `\n\n${color.green("✓ deployed")}`;
   return banner + endpoints + curlSection(endpointUrls, manifest);
@@ -78,7 +78,7 @@ function endpointLabel(url: string): string {
   return "endpoint";
 }
 
-function curlSection(endpointUrls: string[], manifest: Manifest | undefined): string {
+function curlSection(endpointUrls: string[], manifest: ServeManifest | undefined): string {
   const base = serveBaseUrl(endpointUrls);
   if (!base || !manifest) {
     return "";

--- a/packages/agency-lang/lib/cli/deploy/render.ts
+++ b/packages/agency-lang/lib/cli/deploy/render.ts
@@ -7,8 +7,8 @@
 import { color } from "@/utils/termcolors.js";
 import renderDeployReport from "@/templates/cli/deployReport.js";
 import type { DeployOutcome, DeployPlan } from "./deploy.js";
-import { serveBaseUrl } from "./uploadClient.js";
-import type { Manifest } from "./uploadClient.js";
+import { serveBaseUrl } from "../statelog/uploadClient.js";
+import type { Manifest } from "../statelog/uploadClient.js";
 import { curlExamples } from "./curlExamples.js";
 
 export function renderOutcome(outcome: DeployOutcome): void {

--- a/packages/agency-lang/lib/cli/statelog/serveClient.test.ts
+++ b/packages/agency-lang/lib/cli/statelog/serveClient.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { createServeClient, ServeRequestError } from "./serveClient.js";
+import { parseServeBaseUrl } from "./serveUrl.js";
+import { interrupt } from "@/runtime/interrupts.js";
+
+const address = parseServeBaseUrl("https://statelog.example/serve/u/p/agent.agency")!;
+
+// Stub fetch: `handler(url)` returns { status?, json } or throws for a network
+// error. Records every requested URL.
+function mockFetch(handler: (url: string) => { status?: number; json: unknown }): {
+  urls: string[];
+} {
+  const urls: string[] = [];
+  vi.spyOn(globalThis, "fetch").mockImplementation((async (url: unknown) => {
+    urls.push(String(url));
+    const { status = 200, json } = handler(String(url));
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => json,
+    } as unknown as globalThis.Response;
+  }) as unknown as typeof fetch);
+  return { urls };
+}
+
+function client() {
+  return createServeClient(address, "key");
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("createServeClient", () => {
+  it("invokeNode returns a final value as { data: value }", async () => {
+    mockFetch(() => ({ json: { success: true, value: { answer: 42 } } }));
+    expect(await client().invokeNode("main", {})).toEqual({ data: { answer: 42 } });
+  });
+
+  it("invokeNode returns a pause (state string + real interrupts) as { data: interrupts }", async () => {
+    const paused = [interrupt({ effect: "app::confirm", message: "ok?", data: null, origin: "o", runId: "r", interruptId: "i1" })];
+    mockFetch(() => ({ json: { success: true, value: { interrupts: paused, state: "serialized" } } }));
+    expect(await client().invokeNode("main", {})).toEqual({ data: paused });
+  });
+
+  it("treats an object without a string state (or without real interrupts) as final", async () => {
+    mockFetch(() => ({ json: { success: true, value: { interrupts: [], completed: 12 } } }));
+    expect(await client().invokeNode("main", {})).toEqual({ data: { interrupts: [], completed: 12 } });
+
+    mockFetch(() => ({ json: { success: true, value: { interrupts: ["not-an-interrupt"], state: "s" } } }));
+    expect(await client().invokeNode("main", {})).toEqual({
+      data: { interrupts: ["not-an-interrupt"], state: "s" },
+    });
+  });
+
+  it("throws ServeRequestError on a success:false envelope", async () => {
+    mockFetch(() => ({ json: { success: false, error: "Tool execution failed" } }));
+    await expect(client().invokeNode("main", {})).rejects.toThrow(/Tool execution failed/);
+  });
+
+  it("throws ServeRequestError on an HTTP/JSON failure", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation((async () => ({
+      ok: false,
+      status: 500,
+      json: async () => {
+        throw new Error("not json");
+      },
+    })) as unknown as typeof fetch);
+    await expect(client().invokeNode("main", {})).rejects.toBeInstanceOf(ServeRequestError);
+  });
+
+  it("encodes a node name needing escaping exactly once", async () => {
+    const { urls } = mockFetch(() => ({ json: { success: true, value: null } }));
+    await client().invokeNode("a b", {});
+    expect(urls[0]).toBe("https://statelog.example/serve/u/p/agent.agency/node/a%20b");
+  });
+
+  it("invokeFunction returns the raw value", async () => {
+    mockFetch(() => ({ json: { success: true, value: 5 } }));
+    expect(await client().invokeFunction("add", { a: 2, b: 3 })).toBe(5);
+  });
+
+  it("resume returns an InterruptResult and can fail on a later leg", async () => {
+    mockFetch(() => ({ json: { success: true, value: "resumed" } }));
+    expect(await client().resume([], [])).toEqual({ data: "resumed" });
+
+    mockFetch(() => ({ json: { success: false, error: "resume boom" } }));
+    await expect(client().resume([], [])).rejects.toThrow(/resume boom/);
+  });
+
+  it("fetchManifest validates and returns a typed manifest", async () => {
+    mockFetch(() => ({
+      json: {
+        nodes: [{ name: "main", parameters: ["message"], interruptEffects: ["app::confirm"] }],
+        functions: [
+          { name: "add", parameters: ["a", "b"], interruptEffects: [], description: "adds", destructive: false },
+        ],
+      },
+    }));
+    const manifest = await client().fetchManifest();
+    expect(manifest.nodes[0]).toEqual({
+      name: "main",
+      parameters: ["message"],
+      interruptEffects: ["app::confirm"],
+    });
+    expect(manifest.functions[0].description).toBe("adds");
+    expect(manifest.functions[0].destructive).toBe(false);
+  });
+
+  it("fetchManifest throws on a malformed manifest item rather than reaching render code", async () => {
+    mockFetch(() => ({
+      json: { nodes: [{ name: "main", parameters: [42], interruptEffects: [] }], functions: [] },
+    }));
+    await expect(client().fetchManifest()).rejects.toBeInstanceOf(ServeRequestError);
+
+    mockFetch(() => ({ json: { nodes: "nope", functions: [] } }));
+    await expect(client().fetchManifest()).rejects.toBeInstanceOf(ServeRequestError);
+  });
+});

--- a/packages/agency-lang/lib/cli/statelog/serveClient.test.ts
+++ b/packages/agency-lang/lib/cli/statelog/serveClient.test.ts
@@ -56,6 +56,15 @@ describe("createServeClient", () => {
     await expect(client().invokeNode("main", {})).rejects.toThrow(/Tool execution failed/);
   });
 
+  it("throws ServeRequestError on a non-2xx response with a valid JSON body", async () => {
+    // A 404 whose body carries an error message — surfaced, not accepted.
+    mockFetch(() => ({ status: 404, json: { error: "no such node" } }));
+    await expect(client().invokeNode("main", {})).rejects.toThrow(/no such node/);
+    // A 500 whose body happens to be manifest-shaped must not be returned.
+    mockFetch(() => ({ status: 500, json: { nodes: [], functions: [] } }));
+    await expect(client().fetchManifest()).rejects.toBeInstanceOf(ServeRequestError);
+  });
+
   it("throws ServeRequestError on an HTTP/JSON failure", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation((async () => ({
       ok: false,

--- a/packages/agency-lang/lib/cli/statelog/serveClient.ts
+++ b/packages/agency-lang/lib/cli/statelog/serveClient.ts
@@ -65,11 +65,33 @@ export function createServeClient(address: ServeAddress, apiKey: string): ServeC
     } catch (error) {
       throw new ServeRequestError(`could not reach ${url} (${message(error)})`);
     }
+
+    let json: unknown;
+    let parsed = true;
     try {
-      return await response.json();
+      json = await response.json();
     } catch {
+      parsed = false;
+    }
+
+    // A non-2xx is a failure even with a valid JSON body — surface it as a
+    // ServeRequestError (with the server's message when it gave one) rather than
+    // letting a 404/500 body flow on as a bogus value or manifest.
+    if (!response.ok) {
+      const envelopeError =
+        parsed && json !== null && typeof json === "object"
+          ? (json as { error?: unknown }).error
+          : undefined;
+      throw new ServeRequestError(
+        typeof envelopeError === "string"
+          ? envelopeError
+          : `statelog request failed (HTTP ${response.status})`,
+      );
+    }
+    if (!parsed) {
       throw new ServeRequestError(`statelog returned a non-JSON response (HTTP ${response.status})`);
     }
+    return json;
   }
 
   // node/function/resume speak the { success, value } envelope; /list does not.

--- a/packages/agency-lang/lib/cli/statelog/serveClient.ts
+++ b/packages/agency-lang/lib/cli/statelog/serveClient.ts
@@ -1,0 +1,193 @@
+// The statelog *serve* wire, sealed here. This is the only file that knows the
+// serve routes, the `{ success, value }` envelope, and how a node pause is
+// encoded. Callers ask for a manifest, a function value, or an interrupt-driver
+// result and never see the transport shape. Every failure — network, HTTP,
+// JSON, schema, or a `success:false` body — surfaces as a ServeRequestError.
+
+import { hasInterrupts } from "@/runtime/interrupts.js";
+import type { Interrupt } from "@/runtime/interrupts.js";
+import type { InterruptResult, ResumeFn } from "@/runtime/interruptResolution.js";
+import { serveRouteUrl } from "./serveUrl.js";
+import type { ServeAddress } from "./serveUrl.js";
+
+export type ServeFunctionManifest = {
+  name: string;
+  description?: string;
+  parameters: string[];
+  destructive?: boolean;
+  idempotent?: boolean;
+  interruptEffects: string[];
+};
+
+export type ServeNodeManifest = {
+  name: string;
+  parameters: string[];
+  interruptEffects: string[];
+};
+
+export type ServeManifest = {
+  functions: ServeFunctionManifest[];
+  nodes: ServeNodeManifest[];
+};
+
+/** Any serve request that did not produce a usable result. */
+export class ServeRequestError extends Error {}
+
+export type ServeClient = {
+  /** GET /list, validated. */
+  fetchManifest(): Promise<ServeManifest>;
+  /** POST /node/:name — a final value or a pause, as an InterruptResult. */
+  invokeNode(name: string, args: Record<string, unknown>): Promise<InterruptResult>;
+  /** POST /function/:name — one-shot, never pauses. */
+  invokeFunction(name: string, args: Record<string, unknown>): Promise<unknown>;
+  /** POST /resume — the shape the shared interrupt driver expects. */
+  resume: ResumeFn<InterruptResult>;
+};
+
+export function createServeClient(address: ServeAddress, apiKey: string): ServeClient {
+  const authHeaders: Record<string, string> = {
+    Authorization: `Bearer ${apiKey}`,
+    "Content-Type": "application/json",
+  };
+
+  async function requestJson(
+    url: string,
+    method: "GET" | "POST",
+    body?: unknown,
+  ): Promise<unknown> {
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method,
+        headers: authHeaders,
+        body: method === "POST" ? JSON.stringify(body ?? {}) : undefined,
+      });
+    } catch (error) {
+      throw new ServeRequestError(`could not reach ${url} (${message(error)})`);
+    }
+    try {
+      return await response.json();
+    } catch {
+      throw new ServeRequestError(`statelog returned a non-JSON response (HTTP ${response.status})`);
+    }
+  }
+
+  // node/function/resume speak the { success, value } envelope; /list does not.
+  async function requestValue(url: string, body: unknown): Promise<unknown> {
+    const json = await requestJson(url, "POST", body);
+    if (json === null || typeof json !== "object" || typeof (json as { success?: unknown }).success !== "boolean") {
+      throw new ServeRequestError("unexpected serve response shape");
+    }
+    const envelope = json as { success: boolean; value?: unknown; error?: unknown };
+    if (!envelope.success) {
+      throw new ServeRequestError(
+        typeof envelope.error === "string" ? envelope.error : "serve request failed",
+      );
+    }
+    return envelope.value;
+  }
+
+  async function fetchManifest(): Promise<ServeManifest> {
+    const json = await requestJson(serveRouteUrl(address.serveUrl, ["list"]), "GET");
+    return validateManifest(json);
+  }
+
+  async function invokeNode(name: string, args: Record<string, unknown>): Promise<InterruptResult> {
+    const value = await requestValue(serveRouteUrl(address.serveUrl, ["node", name]), args);
+    return toInterruptResult(value);
+  }
+
+  async function invokeFunction(name: string, args: Record<string, unknown>): Promise<unknown> {
+    return requestValue(serveRouteUrl(address.serveUrl, ["function", name]), args);
+  }
+
+  const resume: ResumeFn<InterruptResult> = async (interrupts, responses) => {
+    const value = await requestValue(serveRouteUrl(address.serveUrl, ["resume"]), {
+      interrupts,
+      responses,
+    });
+    return toInterruptResult(value);
+  };
+
+  return { fetchManifest, invokeNode, invokeFunction, resume };
+}
+
+/**
+ * A node/resume success value is a *pause* only when it carries a serialized
+ * `state` string AND a non-empty runtime `Interrupt[]`. Anything else — a plain
+ * value, or a final result that happens to have an `interrupts` field — is the
+ * final value. Pauses become `{ data: interrupts }` so the shared driver's
+ * `hasInterrupts(data)` loops; final values become `{ data: value }`.
+ */
+function toInterruptResult(value: unknown): InterruptResult {
+  if (value !== null && typeof value === "object") {
+    const wrapped = value as { state?: unknown; interrupts?: unknown };
+    if (typeof wrapped.state === "string" && hasInterrupts(wrapped.interrupts)) {
+      return { data: wrapped.interrupts as Interrupt[] };
+    }
+  }
+  return { data: value };
+}
+
+function validateManifest(json: unknown): ServeManifest {
+  if (json === null || typeof json !== "object") {
+    throw new ServeRequestError("manifest is not an object");
+  }
+  const body = json as { nodes?: unknown; functions?: unknown };
+  if (!Array.isArray(body.nodes) || !Array.isArray(body.functions)) {
+    throw new ServeRequestError("manifest is missing nodes/functions arrays");
+  }
+  return {
+    nodes: body.nodes.map(validateNode),
+    functions: body.functions.map(validateFunction),
+  };
+}
+
+function validateNode(item: unknown): ServeNodeManifest {
+  const fields = asManifestObject(item, "node");
+  const name = requireString(fields.name, "node name");
+  return {
+    name,
+    parameters: requireStringArray(fields.parameters, `node ${name} parameters`),
+    interruptEffects: requireStringArray(fields.interruptEffects, `node ${name} interruptEffects`),
+  };
+}
+
+function validateFunction(item: unknown): ServeFunctionManifest {
+  const fields = asManifestObject(item, "function");
+  const name = requireString(fields.name, "function name");
+  const manifest: ServeFunctionManifest = {
+    name,
+    parameters: requireStringArray(fields.parameters, `function ${name} parameters`),
+    interruptEffects: requireStringArray(fields.interruptEffects, `function ${name} interruptEffects`),
+  };
+  if (typeof fields.description === "string") manifest.description = fields.description;
+  if (typeof fields.destructive === "boolean") manifest.destructive = fields.destructive;
+  if (typeof fields.idempotent === "boolean") manifest.idempotent = fields.idempotent;
+  return manifest;
+}
+
+function asManifestObject(item: unknown, kind: string): Record<string, unknown> {
+  if (item === null || typeof item !== "object" || Array.isArray(item)) {
+    throw new ServeRequestError(`each ${kind} entry must be an object`);
+  }
+  return item as Record<string, unknown>;
+}
+
+function requireString(value: unknown, label: string): string {
+  if (typeof value !== "string") {
+    throw new ServeRequestError(`${label} must be a string`);
+  }
+  return value;
+}
+
+function requireStringArray(value: unknown, label: string): string[] {
+  if (!Array.isArray(value) || !value.every((entry) => typeof entry === "string")) {
+    throw new ServeRequestError(`${label} must be an array of strings`);
+  }
+  return value as string[];
+}
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/agency-lang/lib/cli/statelog/serveUrl.test.ts
+++ b/packages/agency-lang/lib/cli/statelog/serveUrl.test.ts
@@ -68,6 +68,10 @@ describe("parseServeBaseUrl", () => {
     expect(parseServeBaseUrl(`${HOST}/serve/u/p`)).toBeNull();
   });
 
+  it("returns null on a malformed percent-encoded identifier (does not throw)", () => {
+    expect(parseServeBaseUrl(`${HOST}/serve/u/p/%E0%A4%A`)).toBeNull();
+  });
+
   it("rejects query, hash, credentials, and unsupported protocols", () => {
     expect(parseServeBaseUrl(`${HOST}/serve/u/p/a?x=1`)).toBeNull();
     expect(parseServeBaseUrl(`${HOST}/serve/u/p/a#frag`)).toBeNull();

--- a/packages/agency-lang/lib/cli/statelog/serveUrl.test.ts
+++ b/packages/agency-lang/lib/cli/statelog/serveUrl.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolveTrustedEndpointUrl,
+  parseServeBaseUrl,
+  serveRouteUrl,
+  projectPageUrl,
+} from "./serveUrl.js";
+
+const HOST = "https://statelog.example.com";
+
+describe("resolveTrustedEndpointUrl", () => {
+  it("resolves a relative endpoint against the trusted host", () => {
+    expect(resolveTrustedEndpointUrl("/serve/u/p/a/list", HOST)).toBe(
+      "https://statelog.example.com/serve/u/p/a/list",
+    );
+  });
+
+  it("keeps a same-origin absolute endpoint", () => {
+    expect(resolveTrustedEndpointUrl(`${HOST}/serve/u/p/a`, HOST)).toBe(
+      "https://statelog.example.com/serve/u/p/a",
+    );
+  });
+
+  it("rejects a cross-origin endpoint", () => {
+    expect(() => resolveTrustedEndpointUrl("https://evil.com/x", HOST)).toThrow();
+  });
+
+  it("rejects embedded credentials", () => {
+    expect(() =>
+      resolveTrustedEndpointUrl("https://user:pw@statelog.example.com/x", HOST),
+    ).toThrow();
+  });
+
+  it("rejects a non-HTTP(S) protocol", () => {
+    expect(() => resolveTrustedEndpointUrl("ftp://statelog.example.com/x", HOST)).toThrow();
+  });
+
+  it("rejects a non-string", () => {
+    expect(() => resolveTrustedEndpointUrl(42 as unknown as string, HOST)).toThrow();
+  });
+});
+
+describe("parseServeBaseUrl", () => {
+  it("parses the exact serve base and decodes identifiers", () => {
+    expect(parseServeBaseUrl(`${HOST}/serve/u/p/agent.agency`)).toMatchObject({
+      origin: HOST,
+      userId: "u",
+      projectId: "p",
+      filename: "agent.agency",
+      serveUrl: `${HOST}/serve/u/p/agent.agency`,
+    });
+  });
+
+  it("decodes percent-encoded identifiers and re-encodes the canonical serveUrl once", () => {
+    const address = parseServeBaseUrl(`${HOST}/serve/u%20x/p/a`);
+    expect(address?.userId).toBe("u x");
+    expect(address?.serveUrl).toBe(`${HOST}/serve/u%20x/p/a`);
+  });
+
+  it("canonicalizes a trailing slash", () => {
+    expect(parseServeBaseUrl(`${HOST}/serve/u/p/a/`)?.serveUrl).toBe(`${HOST}/serve/u/p/a`);
+  });
+
+  it("rejects a command route, extra/prefix segments, and empty identifiers", () => {
+    expect(parseServeBaseUrl(`${HOST}/serve/u/p/a/node/main`)).toBeNull();
+    expect(parseServeBaseUrl(`${HOST}/x/serve/u/p/a`)).toBeNull();
+    expect(parseServeBaseUrl(`${HOST}/serve//p/a`)).toBeNull();
+    expect(parseServeBaseUrl(`${HOST}/serve/u/p`)).toBeNull();
+  });
+
+  it("rejects query, hash, credentials, and unsupported protocols", () => {
+    expect(parseServeBaseUrl(`${HOST}/serve/u/p/a?x=1`)).toBeNull();
+    expect(parseServeBaseUrl(`${HOST}/serve/u/p/a#frag`)).toBeNull();
+    expect(parseServeBaseUrl(`https://user:pw@statelog.example.com/serve/u/p/a`)).toBeNull();
+    expect(parseServeBaseUrl(`ftp://statelog.example.com/serve/u/p/a`)).toBeNull();
+    expect(parseServeBaseUrl("not a url")).toBeNull();
+  });
+});
+
+describe("serveRouteUrl", () => {
+  const base = `${HOST}/serve/u/p/a`;
+
+  it("appends encoded path segments exactly once", () => {
+    expect(serveRouteUrl(base, ["list"])).toBe(`${base}/list`);
+    expect(serveRouteUrl(base, ["node", "main"])).toBe(`${base}/node/main`);
+    expect(serveRouteUrl(base, ["node", "a b"])).toBe(`${base}/node/a%20b`);
+  });
+
+  it("returns the base itself for no segments", () => {
+    expect(serveRouteUrl(base, [])).toBe(base);
+  });
+
+  it("throws when the base is not a serve URL", () => {
+    expect(() => serveRouteUrl(`${HOST}/not/serve`, ["list"])).toThrow();
+  });
+});
+
+describe("projectPageUrl", () => {
+  it("builds the project page URL, encoding the decoded project id", () => {
+    const address = parseServeBaseUrl(`${HOST}/serve/u/p%20q/a`)!;
+    expect(projectPageUrl(address)).toBe(`${HOST}/projects/show?id=p+q`);
+  });
+});

--- a/packages/agency-lang/lib/cli/statelog/serveUrl.ts
+++ b/packages/agency-lang/lib/cli/statelog/serveUrl.ts
@@ -65,9 +65,18 @@ export function parseServeBaseUrl(rawUrl: string): ServeAddress | null {
   const segments = parsed.pathname.split("/").filter((segment) => segment.length > 0);
   if (segments.length !== 4 || segments[0] !== "serve") return null;
 
-  const userId = decodeURIComponent(segments[1]);
-  const projectId = decodeURIComponent(segments[2]);
-  const filename = decodeURIComponent(segments[3]);
+  // decodeURIComponent throws on malformed escapes (e.g. `%E0%A4%A`); the
+  // contract is to reject such input with null, not crash the caller.
+  let userId: string;
+  let projectId: string;
+  let filename: string;
+  try {
+    userId = decodeURIComponent(segments[1]);
+    projectId = decodeURIComponent(segments[2]);
+    filename = decodeURIComponent(segments[3]);
+  } catch {
+    return null;
+  }
   const serveUrl = `${parsed.origin}/serve/${encodeURIComponent(userId)}/${encodeURIComponent(
     projectId,
   )}/${encodeURIComponent(filename)}`;

--- a/packages/agency-lang/lib/cli/statelog/serveUrl.ts
+++ b/packages/agency-lang/lib/cli/statelog/serveUrl.ts
@@ -1,0 +1,96 @@
+// The one place that knows statelog serve-URL shape and trust rules. A hosted
+// agent's serve base is exactly `…/serve/:userId/:projectId/:filename`; every
+// request URL is built from it, and every URL the server hands back is checked
+// against the deploy target's origin before the API key follows it.
+
+/**
+ * Resolve a response-supplied endpoint URL against the trusted host, then
+ * reject it if it left that origin, embedded credentials, or used a non-HTTP(S)
+ * scheme. Resolve first, validate second — a relative `/serve/...` (which
+ * statelog returns) is legitimate and must survive. Throws on any violation.
+ */
+export function resolveTrustedEndpointUrl(rawUrl: string, targetHost: string): string {
+  if (typeof rawUrl !== "string") {
+    throw new Error(`endpoint URL must be a string, got ${typeof rawUrl}`);
+  }
+  const target = new URL(targetHost);
+  let endpoint: URL;
+  try {
+    endpoint = new URL(rawUrl, target);
+  } catch {
+    throw new Error(`invalid endpoint URL: ${rawUrl}`);
+  }
+  if (endpoint.protocol !== "http:" && endpoint.protocol !== "https:") {
+    throw new Error(`endpoint URL must use HTTP(S): ${rawUrl}`);
+  }
+  if (endpoint.username || endpoint.password) {
+    throw new Error(`endpoint URL must not embed credentials: ${rawUrl}`);
+  }
+  if (endpoint.origin !== target.origin) {
+    throw new Error(
+      `endpoint origin ${endpoint.origin} does not match target ${target.origin}`,
+    );
+  }
+  return endpoint.toString();
+}
+
+/** A parsed, canonicalized serve base. Identifiers are decoded for use;
+ *  `serveUrl` re-encodes each exactly once. */
+export type ServeAddress = {
+  serveUrl: string;
+  origin: string;
+  userId: string;
+  projectId: string;
+  filename: string;
+};
+
+/**
+ * Parse a serve base URL, accepting *only* the exact
+ * `…/serve/:userId/:projectId/:filename` shape. A trailing slash is
+ * canonicalized away; anything else — query, hash, credentials, a non-HTTP(S)
+ * scheme, empty identifiers, or extra/command segments (`…/node/main`) — is
+ * rejected with `null`.
+ */
+export function parseServeBaseUrl(rawUrl: string): ServeAddress | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
+  if (parsed.username || parsed.password) return null;
+  if (parsed.search || parsed.hash) return null;
+
+  const segments = parsed.pathname.split("/").filter((segment) => segment.length > 0);
+  if (segments.length !== 4 || segments[0] !== "serve") return null;
+
+  const userId = decodeURIComponent(segments[1]);
+  const projectId = decodeURIComponent(segments[2]);
+  const filename = decodeURIComponent(segments[3]);
+  const serveUrl = `${parsed.origin}/serve/${encodeURIComponent(userId)}/${encodeURIComponent(
+    projectId,
+  )}/${encodeURIComponent(filename)}`;
+  return { serveUrl, origin: parsed.origin, userId, projectId, filename };
+}
+
+/** Build a request URL under a serve base, encoding each dynamic segment once.
+ *  Validates the base through `parseServeBaseUrl` first. */
+export function serveRouteUrl(serveUrl: string, segments: string[]): string {
+  const address = parseServeBaseUrl(serveUrl);
+  if (!address) {
+    throw new Error(`not a serve base URL: ${serveUrl}`);
+  }
+  if (segments.length === 0) {
+    return address.serveUrl;
+  }
+  const suffix = segments.map((segment) => encodeURIComponent(segment)).join("/");
+  return `${address.serveUrl}/${suffix}`;
+}
+
+/** The statelog web-app page for an agent's project. */
+export function projectPageUrl(address: ServeAddress): string {
+  const url = new URL("/projects/show", address.origin);
+  url.searchParams.set("id", address.projectId);
+  return url.toString();
+}

--- a/packages/agency-lang/lib/cli/statelog/uploadClient.test.ts
+++ b/packages/agency-lang/lib/cli/statelog/uploadClient.test.ts
@@ -66,6 +66,31 @@ describe("uploadBundle", () => {
     expect(result.manifest).toBeUndefined();
   });
 
+  it("rejects a cross-origin endpoint URL and never fetches the manifest", async () => {
+    let listFetched = false;
+    mockFetch((url) => {
+      if (url.endsWith("/upload")) {
+        return { success: true, value: { endpointUrls: ["https://evil.example/serve/u/p/g/list"] } };
+      }
+      listFetched = true;
+      return {};
+    });
+    const result = await uploadBundle(target, bundle);
+    expect(result.ok).toBe(false);
+    expect(listFetched).toBe(false);
+  });
+
+  it("rejects a non-string endpoint URL entry", async () => {
+    mockFetch((url) => {
+      if (url.endsWith("/upload")) {
+        return { success: true, value: { endpointUrls: [42] } };
+      }
+      return {};
+    });
+    const result = await uploadBundle(target, bundle);
+    expect(result.ok).toBe(false);
+  });
+
   it("reports a friendly error when the host is unreachable", async () => {
     vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("ECONNREFUSED"));
     const result = await uploadBundle(target, bundle);

--- a/packages/agency-lang/lib/cli/statelog/uploadClient.test.ts
+++ b/packages/agency-lang/lib/cli/statelog/uploadClient.test.ts
@@ -15,7 +15,10 @@ afterEach(() => vi.restoreAllMocks());
 
 describe("uploadBundle", () => {
   it("returns absolute endpoint URLs and the fetched manifest", async () => {
-    const manifest = { nodes: [{ name: "main", parameters: ["message"] }], functions: [{ name: "add" }] };
+    const manifest = {
+      nodes: [{ name: "main", parameters: ["message"], interruptEffects: [] }],
+      functions: [{ name: "add", parameters: ["a", "b"], interruptEffects: [] }],
+    };
     mockFetch((url) => {
       if (url.endsWith("/upload")) {
         return { success: true, value: { endpointUrls: ["/serve/u/proj/greeter/list", "/serve/u/proj/greeter/node/main"] } };

--- a/packages/agency-lang/lib/cli/statelog/uploadClient.ts
+++ b/packages/agency-lang/lib/cli/statelog/uploadClient.ts
@@ -4,8 +4,9 @@
 // as untrusted: a bad body reports an error or drops the extra (the manifest)
 // rather than crashing a deploy that already landed.
 
-import type { DeployTarget } from "./target.js";
-import type { AgencyBundle } from "./bundle.js";
+import type { DeployTarget } from "../deploy/target.js";
+import type { AgencyBundle } from "../deploy/bundle.js";
+import { resolveTrustedEndpointUrl } from "./serveUrl.js";
 
 /** The `/list` manifest, narrowed to what the curl examples need. Functions
  *  currently carry no `parameters` — a known serve-side gap. */
@@ -64,7 +65,17 @@ export async function uploadBundle(
     return { ok: false, error: rejectionMessage(envelope, response.status) };
   }
 
-  const absoluteUrls = endpointUrls.map((relative) => new URL(relative, target.host).toString());
+  // Resolve and origin-check every response URL BEFORE the Bearer token follows
+  // it to fetch /list or the caller persists it — a compromised response must
+  // not redirect the API key to another origin.
+  let absoluteUrls: string[];
+  try {
+    absoluteUrls = endpointUrls.map((relative) =>
+      resolveTrustedEndpointUrl(relative, target.host),
+    );
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+  }
   const manifest = await fetchManifest(absoluteUrls, target.apiKey);
   return { ok: true, endpointUrls: absoluteUrls, manifest };
 }

--- a/packages/agency-lang/lib/cli/statelog/uploadClient.ts
+++ b/packages/agency-lang/lib/cli/statelog/uploadClient.ts
@@ -6,17 +6,12 @@
 
 import type { DeployTarget } from "../deploy/target.js";
 import type { AgencyBundle } from "../deploy/bundle.js";
-import { resolveTrustedEndpointUrl } from "./serveUrl.js";
-
-/** The `/list` manifest, narrowed to what the curl examples need. Functions
- *  currently carry no `parameters` — a known serve-side gap. */
-export type Manifest = {
-  nodes: { name: string; parameters: string[] }[];
-  functions: { name: string }[];
-};
+import { resolveTrustedEndpointUrl, parseServeBaseUrl } from "./serveUrl.js";
+import { createServeClient, ServeRequestError } from "./serveClient.js";
+import type { ServeManifest } from "./serveClient.js";
 
 export type UploadResult =
-  | { ok: true; endpointUrls: string[]; manifest?: Manifest }
+  | { ok: true; endpointUrls: string[]; manifest?: ServeManifest }
   | { ok: false; error: string };
 
 /**
@@ -76,7 +71,7 @@ export async function uploadBundle(
   } catch (error) {
     return { ok: false, error: error instanceof Error ? error.message : String(error) };
   }
-  const manifest = await fetchManifest(absoluteUrls, target.apiKey);
+  const manifest = await enrichManifest(absoluteUrls, target.apiKey);
   return { ok: true, endpointUrls: absoluteUrls, manifest };
 }
 
@@ -102,34 +97,26 @@ function rejectionMessage(envelope: unknown, status: number): string {
   return typeof error === "string" ? error : `Upload rejected (HTTP ${status}).`;
 }
 
-/** Fetch the agent's `/list` manifest. Best-effort — returns undefined on any
- *  failure or unexpected shape, since the deploy already succeeded and this only
- *  enriches the output. */
-async function fetchManifest(
+/** Best-effort `/list` fetch to enrich the deploy output with curl examples.
+ *  The manifest model and reader now live in serveClient; a fetch failure just
+ *  omits the manifest, since the deploy already succeeded. */
+async function enrichManifest(
   endpointUrls: string[],
   apiKey: string,
-): Promise<Manifest | undefined> {
-  const listUrl = manifestUrl(endpointUrls);
-  if (!listUrl) {
+): Promise<ServeManifest | undefined> {
+  const base = serveBaseUrl(endpointUrls);
+  const address = base ? parseServeBaseUrl(base) : null;
+  if (!address) {
     return undefined;
   }
   try {
-    const response = await fetch(listUrl, { headers: { Authorization: `Bearer ${apiKey}` } });
-    if (!response.ok) {
-      return undefined;
-    }
-    const body = (await response.json()) as { nodes?: unknown; functions?: unknown };
-    if (!Array.isArray(body.nodes) || !Array.isArray(body.functions)) {
-      return undefined;
-    }
-    return body as Manifest;
+    return await createServeClient(address, apiKey).fetchManifest();
   } catch (error) {
-    console.error(
-      `deploy: could not fetch manifest for curl examples: ${
-        error instanceof Error ? error.message : String(error)
-      }`,
-    );
-    return undefined;
+    if (error instanceof ServeRequestError) {
+      console.error(`deploy: could not fetch manifest for curl examples: ${error.message}`);
+      return undefined;
+    }
+    throw error;
   }
 }
 


### PR DESCRIPTION
## What

Consolidate everything that speaks statelog's HTTP wire under a new `lib/cli/statelog/` boundary, and add the sealed serve client the `remote` commands (PR 4) will use. PR 3 of the `agency remote` work — CLI-only, no runtime or statelog-server changes. Branches off merged PR 2 (it uses `InterruptResult`/`ResumeFn`).

## The pieces

- **`serveUrl.ts`** — the single owner of serve-URL trust and shape:
  - `resolveTrustedEndpointUrl(rawUrl, targetHost)` — resolve a relative endpoint against the target host, then reject cross-origin, embedded credentials, or non-HTTP(S) **before the API key follows it**. Resolve-then-validate, so statelog's relative `/serve/...` URLs survive.
  - `parseServeBaseUrl` — the canonical parser accepting only the exact `…/serve/:user/:project/:file` (rejects query, hash, credentials, extra/command segments, empty ids; canonicalizes a trailing slash; decodes ids and re-encodes once).
  - `serveRouteUrl` / `projectPageUrl`.
- **`uploadClient.ts`** — **moved** here from `lib/cli/deploy/`, now origin-checking every response URL through `resolveTrustedEndpointUrl` before fetching `/list`.
- **`serveClient.ts`** — `createServeClient(address, apiKey)` exposing `fetchManifest` / `invokeNode` / `invokeFunction` / `resume`. It hides the `{ success, value }` envelope and the node-pause encoding: node/resume return the shared **`InterruptResult`** (pause → `{ data: interrupts }`, done → `{ data: value }`), and `resume` matches **`ResumeFn`**, so PR 2's interrupt driver consumes it directly. A pause is recognized only when a string `state` accompanies a real `Interrupt[]`; every failure throws `ServeRequestError`; manifest items are validated at the boundary. It is now the sole manifest model/reader — `uploadClient` drops its private `Manifest`/`fetchManifest` and enriches via a client (catching `ServeRequestError` to keep best-effort behavior). Deploy render/curl-examples consume `ServeManifest`.

## Testing

`serveUrl.test.ts` (trust + canonical-parse cases: cross-origin, credentials, query/hash, trailing slash, encoding, command/extra segments), `serveClient.test.ts` (envelope, pause-vs-final classification incl. `{interrupts:[], completed}` staying final, encoding, manifest validation, resume failure), `uploadClient.test.ts` (moved + cross-origin/non-string rejection). `lint:structure` clean (no cycle). `lib/cli/statelog` + `lib/cli/deploy` green (51 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
