### PR TITLE
docs: keep the trailing-comment spec, plan, and review notes

### DIFF
--- a/packages/agency-lang/docs/superpowers/plans/2026-08-01-trailing-comments-review.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-08-01-trailing-comments-review.md
@@ -1,0 +1,249 @@
+# Review: Language-Wide Trailing Comments Plan
+
+## Recommendation
+
+**The revised plan is safe to execute as a sequence of reviewable milestones.**
+
+The original plan was not safe. It exposed parser implementation boundaries as
+language rules, could attach standalone comments to the preceding statement,
+and duplicated parser and generator mechanics. The revised design instead
+defines one user-facing boundary:
+
+> Preserve a same-line `//` comment on a complete declaration, statement, or
+> match arm, and on an item in every list grammar that already supports
+> multiline layout.
+
+Inline-only grammars remain inline-only. This is a principled grammar boundary,
+not an exception users must memorize based on whether a construct appears at
+top level or in a body.
+
+The work is intentionally divided into milestones. The universal guide text
+must not ship until every included surface is implemented and verified.
+
+## Scope conclusion
+
+The earlier statement that there was “only one confirmed consumer” was true
+only of the narrow body-parser proposal. It was not true of the desired
+language feature. The revised inventory includes:
+
+- top-level construct streams;
+- every body stream;
+- inline and block match arms;
+- arrays, objects, and object types;
+- calls, call-chain calls, `interrupt`, `raise`, and `guard` arguments;
+- function and node parameters;
+- imports and exports;
+- binding and match patterns;
+- thread/subthread and parallel named arguments;
+- statement-kind code-literal bodies where they reuse `bodyParser`.
+
+The plan excludes only grammars that do not currently permit multiline layout,
+such as tags, generics, effect sets, block parameters, and `new` arguments.
+Supporting comments there would first require a separate syntax decision to
+make those lists multiline.
+
+## Original correctness findings and resolution
+
+### Consumed newlines could attach standalone comments
+
+Many statement parsers consume their terminating whitespace. Looking only at
+`parsed.rest` therefore cannot distinguish:
+
+```agency
+const x = 1 // trailing
+```
+
+from:
+
+```agency
+const x = 1
+// standalone
+```
+
+**Resolved:** `consumedLineEnding(input, rest)` is the single boundary check.
+`withTrailingLineComment` inspects the consumed source and refuses attachment
+when the wrapped parser crossed a line. Negative tests cover assignment,
+return/raise, call, block, and blank-line paths.
+
+### Attached comments could strand their terminating newline
+
+`lineCommentCore` correctly stops before the newline, but a match-arm or list
+stream must then advance past that layout before parsing its next entry.
+
+**Resolved:** `completeConstructEntry` owns post-construct layout for top-level,
+body, and match streams. `trailingLineCommentEntry` owns post-comment layout in
+lists. Tests require a commented non-final match arm, a commented non-final
+list item, and trailing trivia followed by standalone trivia.
+
+### Top-level behavior contradicted the old body-only scope
+
+A generator hook could not emit top-level metadata that only `bodyParser`
+attached.
+
+**Resolved:** top-level `nodeParser`, body streams, and match-arm streams use the
+same complete-entry abstraction. Top-level behavior is now part of the feature,
+not an unsupported “later phase.”
+
+### Body and multiline-expression coverage was incomplete
+
+The original matrix omitted several body owners and substituted a block case
+for the required multiline-call case.
+
+**Resolved:** the plan includes node/function, `if`/`else`, loops, thread and
+subthread, guard, handle and inline handlers, finalize, parallel, seq,
+destructive, match-arm, block-argument, and code-literal bodies. It separately
+tests a comment after the closing `)` of a call that remains multiline.
+
+### Owner source locations could accidentally include comments
+
+Extending `loc.end` would change linter replacements and diagnostics by making
+the comment part of the syntactic statement range.
+
+**Resolved:** attached comments retain their own location and never modify the
+owner's range. The plan includes raw source-slice assertions and existing
+location-sensitive parser, linter, LSP, and formatter suites.
+
+### The proposed base type was not executable
+
+Importing aggregate `AgencyComment` into foundational `base.ts` would create an
+inverted dependency, while using it without an import would not compile.
+
+**Resolved:** a leaf `LineComment` type lives beside `BaseNode` and remains
+structurally compatible with `AgencyComment` without a runtime import cycle.
+
+### Verification commands were incomplete or invalid
+
+The old plan referenced a nonexistent location test, did not reliably typecheck
+tests, and bypassed the repository-owned performance command.
+
+**Resolved:** the revised plan names existing focused files, uses
+`pnpm run typecheck`, runs `make` before broad tests, uses
+`pnpm run test:perf`, saves expensive output once, and runs location-sensitive
+parser/linter/LSP suites.
+
+## Additional findings from the language-wide review
+
+### Shared argument parsing had more consumers than `FunctionCall`
+
+Call-chain calls, `interrupt`, `raise`, and `guard` reshape the output of
+`argumentListParser`; changing the parser alone would lose or fail to render
+their trivia.
+
+**Resolved:** each owning AST type receives explicit `argumentTrivia`, each
+parser propagates it, and each generator path uses the shared argument renderer.
+
+### Inline blocks could disappear on the trivia-aware render path
+
+The parser extracts an inline block from `arguments`, but the initial renderer
+proposal passed only `node.arguments` to the list renderer.
+
+**Resolved:** parsing records source indexes; remapping validates a complete
+permutation; rendering uses a virtual canonical list containing ordinary
+arguments followed by the extracted block. Tests assert the block itself and
+both block/ordinary comment adjacency.
+
+### A universal comma delimiter would broaden existing syntax
+
+Some lists allow trailing commas and some reject them; some are empty-capable
+and others require at least one item.
+
+**Resolved:** `CommaListPolicy` makes `cardinality` and `trailingComma` explicit.
+Named policy choices preserve each current grammar, and negative tests pin every
+rejecting family. Object-type members retain a separate newline-or-punctuation
+policy with an optional final delimiter.
+
+### Object-property tags did not fit a string-only item renderer
+
+Passing pre-indented multiline strings through a generic renderer would leak
+indentation mechanics and risk dropping `@validate`/`@jsonSchema` tags.
+
+**Resolved:** item renderers return `{ leadingLines?, code }`; the shared list
+renderer owns indentation, separators, and comment placement.
+
+### Trivia remapping could silently produce an undefined anchor
+
+`Record<number, number>` falsely represented a partial source-to-canonical
+lookup as total.
+
+**Resolved:** remapping validates that canonical indexes are a permutation,
+uses an explicitly optional lookup, preserves the closer anchor, and fails at
+the remapping boundary if an item anchor is invalid.
+
+## Anti-pattern audit
+
+### Duplicating existing code — present originally, now addressed
+
+The original generator reconstructed `//${content}` in separate standalone and
+trailing paths. The revised plan makes `commentText` the sole line-comment text
+renderer. Existing argument, tag, pattern, alias, and marker renderers remain the
+source of item text.
+
+### Imperative code everywhere — not the final design
+
+Parser cursor management and formatter indentation are inherently imperative.
+The important question is whether every caller repeats those mechanics. In the
+revised plan, they do not:
+
+```ts
+const nodeParser = completeConstructEntry(nodeParserInner);
+
+const arguments = commaDelimitedList(argumentParser, CALL_ARGUMENT_POLICY);
+
+return this.renderListWithTrivia({
+  items,
+  trivia,
+  renderItem,
+  separator,
+  // delimiters omitted here
+});
+```
+
+The imperative mechanics live behind these interfaces:
+
+- `consumedLineEnding` owns consumed-source inspection;
+- `completeConstructEntry` owns complete-stream cursor progress;
+- the list entry engine owns delimiter/comment parsing;
+- `partitionTrivia` owns classification and anchoring;
+- `remapListTrivia` owns canonical reordering;
+- `renderListWithTrivia` owns indentation and placement.
+
+Grammar call sites declaratively select the item parser, attachment predicate,
+cardinality, trailing-comma rule, delimiters, and item renderer. This is the
+intended “declarative interface around imperative implementation” pattern.
+
+### Leaky abstractions — present originally, now addressed
+
+Callers previously needed to know whether a child parser and `commentParser`
+consumed whitespace. Exact line-comment parsing, consumed-line detection, and
+post-comment layout now have named owners. Structured rendered items prevent
+indentation policy from leaking into object-type callers.
+
+### Useless special cases — present originally, now addressed
+
+The old plan branched on `.success` for `many(...)` and `optionalSpaces`, which
+always succeed, and proposed redundant whitespace passes as harmless. The
+revised combinator structure removes those branches. Cardinality is expressed
+by parser shape rather than a fabricated post-`many` failure.
+
+### Inconsistent patterns — present originally, now addressed
+
+Complete constructs share one stream entry, multiline lists share one trivia
+model and rendering contract, and separator differences are explicit policies
+rather than unrelated implementations.
+
+### One-line `if` statements and nested ternaries — present originally, removed
+
+All new snippets use braced conditionals. No nested ternary is proposed.
+
+### Not found
+
+The plan does not introduce order-dependent mutable state outside normal parser
+sequencing, dynamic imports, `Map`, `Set`, unsafe deletion, swallowed exceptions,
+catastrophic tests, wrapper AST nodes, or changes to handler registration.
+
+## Execution guidance
+
+Treat this as one language feature but implement it in the plan's milestones.
+At each milestone, preserve existing no-trivia output and run the focused tests
+before broadening to the next owner family. Do not document the universal rule
+until the final compatibility gate confirms every promised multiline surface.

--- a/packages/agency-lang/docs/superpowers/plans/2026-08-01-trailing-comments.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-08-01-trailing-comments.md
@@ -1,0 +1,1648 @@
+# Language-Wide Trailing Comments Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve an end-of-line `//` comment beside the complete declaration, statement, match arm, or multiline-list item it describes everywhere Agency already permits multiline layout.
+
+**Architecture:** A reusable `completeConstructEntry` parser handles attachment and post-comment layout at top level, in bodies, and in match arms. A compatibility-preserving `ListTrivia` model handles comments after separators in multiline lists, with one list engine configured by explicit cardinality/trailing-comma policies and a separate object-member policy. Comment and list-item rendering use structured, declarative results; cursor movement and indentation stay inside the shared helpers.
+
+**Tech Stack:** TypeScript, tarsec parser combinators, Vitest, `AgencyGenerator`.
+
+Spec: `docs/superpowers/specs/2026-07-31-trailing-comments-design.md`
+
+## Global Constraints
+
+- One user rule: a same-line `//` comment after a complete construct stays attached when formatted.
+- Support top-level declarations/statements, all body statements, match arms, and every list grammar that already permits line breaks.
+- For comma lists, the comma precedes the comment: `item, // comment`.
+- Do not make inline-only grammars multiline. Tags, generics, value-parameterized types, effect/raises lists, block-type parameters, block/lambda parameters, and `new` arguments stay out of scope.
+- Do not attach trailing `/* ... */` comments. Existing block-comment trivia must not regress.
+- Do not introduce a wrapper AST node. Handler registration and invocation must remain unchanged.
+- Do not extend the owner's `loc.end` through the attached comment.
+- Existing ASTs without trailing comments must not gain fields.
+- Existing before-trivia records must not gain a `placement` field.
+- Preserve the exported `Trivia` and `ObjectTypeTrivia` names as aliases.
+- Preserve required-comma behavior in arrays, objects, and every comma list.
+- Trivia forces multiline output. Trivia-free input keeps existing compact/wrapping behavior.
+- Use `parseAgency(src, {}, false, false)` for raw parser assertions and `formatSource(src)` for formatter assertions.
+- Run tests with `pnpm test:run`, save output once, and inspect the saved file rather than rerunning expensive suites.
+- Use `pnpm run typecheck` so test files are type-checked through `tsconfig.tests.json`.
+- Use `pnpm run test:perf` for parser performance.
+- Run `make` before the full test suite in a fresh worktree.
+- Never use dynamic imports, `Map`, `Set`, one-line `if` statements, nested ternaries, or duplicated comment rendering.
+- Never amend or force-push. Put commit messages containing punctuation or apostrophes in a file and use `git commit -F`.
+
+---
+
+## File Structure
+
+| File | Responsibility | Tasks |
+|---|---|---|
+| `lib/types/base.ts` | `LineComment` and complete-node metadata | 1 |
+| `lib/types/dataStructures.ts` | Shared `ListTrivia` model and literal owner fields | 3 |
+| `lib/types/typeHints.ts` | Compatibility alias for object-type trivia | 3 |
+| `lib/types/function.ts` | Argument and function-parameter trivia owners | 4 |
+| `lib/types/graphNode.ts` | Node-parameter trivia owner | 4 |
+| `lib/types/access.ts` | Call-chain argument trivia owner | 4 |
+| `lib/types/interruptStatement.ts` | Interrupt/raise argument trivia owner | 4 |
+| `lib/types/guardBlock.ts` | Guard argument trivia owner | 4 |
+| `lib/types/matchBlock.ts` | Match-arm trailing metadata | 2 |
+| `lib/types/importStatement.ts` | Import-list trivia owners | 5 |
+| `lib/types/exportFromStatement.ts` | Export-list trivia owner | 5 |
+| `lib/types/pattern.ts` | Pattern-list trivia owners | 5 |
+| `lib/types/messageThread.ts` | Thread-argument trivia owner | 5 |
+| `lib/types/parallelBlock.ts` | Parallel-argument trivia owner | 5 |
+| `lib/parsers/parsers.ts` | Exact comment parser, decorator, list parsing, and all parser integrations | 1–5 |
+| `lib/parser.ts` | Top-level decorator integration | 1 |
+| `lib/backends/agencyGenerator.ts` | Shared comment/list rendering and all formatter integrations | 2–5 |
+| `lib/parsers/trailingComments.test.ts` | Complete-construct attachment and location tests | 1–2 |
+| `lib/parsers/listTrailingComments.test.ts` | Shared list AST and parser tests | 3–5 |
+| `lib/formatter.test.ts` | Canonical output and fixed-point tests | 2–5 |
+| Existing focused parser/generator tests | Compatibility and grammar regressions | 3–5 |
+| `docs/site/guide/basic-syntax.md` | Universal user-facing rule | 6 |
+
+Tasks are ordered by interface dependency. Each task ends in a usable,
+independently reviewable milestone.
+
+---
+
+### Task 1: Complete-construct parser infrastructure
+
+**Files:**
+- Modify: `lib/types/base.ts`
+- Modify: `lib/parsers/parsers.ts`
+- Modify: `lib/parser.ts`
+- Create: `lib/parsers/trailingComments.test.ts`
+
+**Interfaces:**
+- Produces: `LineComment`, `BaseNode.trailingComment?: LineComment`,
+  `lineCommentCore`, `withTrailingLineComment<T>()`, and
+  `completeConstructEntry<T>()`.
+- Produces: decorated top-level and body node streams.
+- Consumed by: Tasks 2–5.
+
+- [ ] **Step 1: Write failing attachment and newline-boundary tests**
+
+Create `lib/parsers/trailingComments.test.ts` with raw-AST helpers and these cases:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { parseAgency } from "@/parser.js";
+
+function parseRaw(source: string) {
+  const parsed = parseAgency(source, {}, false, false);
+  if (!parsed.success) {
+    throw new Error(`expected parse success: ${parsed.message}`);
+  }
+  return parsed.result;
+}
+
+function mainBody(source: string): any[] {
+  return (parseRaw(source).nodes[0] as any).body;
+}
+
+describe("complete-construct trailing comment attachment", () => {
+  it("attaches to a top-level declaration", () => {
+    const nodes = parseRaw(`type UserId = string // identifier\n`).nodes;
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].trailingComment).toMatchObject({
+      type: "comment",
+      content: " identifier",
+    });
+  });
+
+  it("attaches to a body statement instead of adding a sibling", () => {
+    const body = mainBody(
+      `node main() {\n  const x = 5 // explains x\n  const y = 6\n}\n`,
+    );
+    expect(body).toHaveLength(2);
+    expect(body[0].trailingComment?.content).toBe(" explains x");
+  });
+
+  it.each([
+    ["assignment", `const x = 5`],
+    ["return", `return 5`],
+    ["raise", `raise("stop")`],
+    ["call", `print(1)`],
+    ["block", `if (true) {\n    print(1)\n  }`],
+  ])("does not attach a standalone comment after %s", (_name, statement) => {
+    const body = mainBody(
+      `node main() {\n  ${statement}\n  // standalone\n  print(2)\n}\n`,
+    );
+    expect(body[0].trailingComment).toBeUndefined();
+    expect(body.some((node) => node.type === "comment")).toBe(true);
+  });
+
+  it("does not attach to a blank-line node", () => {
+    const body = mainBody(
+      `node main() {\n  print(1)\n\n  // standalone\n  print(2)\n}\n`,
+    );
+    const blank = body.find((node) => node.type === "newLine");
+    expect(blank?.trailingComment).toBeUndefined();
+    expect(body.some((node) => node.type === "comment")).toBe(true);
+  });
+
+  it("does not attach a block comment", () => {
+    const body = mainBody(
+      `node main() {\n  const x = 5 /* why */\n  const y = 6\n}\n`,
+    );
+    expect(body[0].trailingComment).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and save the expected failure**
+
+```bash
+pnpm test:run lib/parsers/trailingComments.test.ts > /tmp/trailing-task1-red.txt 2>&1; echo $?
+```
+
+Expected: exit 1. The positive attachment assertions fail; the negative cases
+describe current behavior.
+
+- [ ] **Step 3: Add the leaf type without an aggregate import cycle**
+
+Replace the end of `lib/types/base.ts` with:
+
+```ts
+export type LineComment = {
+  type: "comment";
+  content: string;
+  loc?: SourceLocation;
+};
+
+export type BaseNode = {
+  loc?: SourceLocation;
+  /** A same-line `//` comment attached for Agency source formatting. */
+  trailingComment?: LineComment;
+};
+```
+
+Do not import `AgencyComment` from `../types.js`; that aggregate module imports
+`BaseNode` and would invert the foundational type dependency.
+
+- [ ] **Step 4: Split exact comment text from standalone whitespace policy**
+
+Replace `commentParser` in `lib/parsers/parsers.ts` with:
+
+```ts
+export const lineCommentCore: Parser<AgencyComment> = seqC(
+  set("type", "comment"),
+  str("//"),
+  capture(manyTill(or(newline, blankLineParser)), "content"),
+);
+
+export const commentParser: Parser<AgencyComment> = map(
+  seqC(
+    optionalSpaces,
+    capture(lineCommentCore, "comment"),
+    optionalSpacesOrNewline,
+  ),
+  (result) => result.comment,
+);
+```
+
+This preserves standalone comment behavior while giving the decorator a parser
+that starts exactly at `//` and does not consume the line ending.
+
+- [ ] **Step 5: Add the reusable decorator**
+
+Import `LineComment` from `../types/base.js` in the parser type-import section,
+then add beside the body parser utilities:
+
+```ts
+type TrailingCommentOwner = {
+  type: string;
+  trailingComment?: LineComment;
+};
+
+const NON_TRAILING_OWNER_TYPES = [
+  "comment",
+  "multiLineComment",
+  "newLine",
+];
+
+type TrailingCommentOptions<T> = {
+  canAttach?: (value: T) => boolean;
+};
+
+function consumedLineEnding(input: string, rest: string): boolean {
+  const consumedLength = input.length - rest.length;
+  const consumed = input.slice(0, consumedLength);
+  const trailingWhitespace = consumed.match(/[ \t\r\n]*$/)?.[0] ?? "";
+  return /[\r\n]/.test(trailingWhitespace);
+}
+
+export function withTrailingLineComment<T extends TrailingCommentOwner>(
+  parser: Parser<T>,
+  options: TrailingCommentOptions<T> = {},
+): Parser<T> {
+  return (input: string) => {
+    const parsed = parser(input);
+    if (!parsed.success) {
+      return parsed;
+    }
+
+    if (options.canAttach && !options.canAttach(parsed.result)) {
+      return parsed;
+    }
+
+    if (consumedLineEnding(input, parsed.rest)) {
+      return parsed;
+    }
+
+    const comment = seqR(optionalSpaces, lineCommentCore)(parsed.rest);
+    if (!comment.success) {
+      return parsed;
+    }
+
+    return success(
+      { ...parsed.result, trailingComment: comment.result },
+      comment.rest,
+    );
+  };
+}
+
+export function completeConstructEntry<T extends TrailingCommentOwner>(
+  parser: Parser<T>,
+  options?: TrailingCommentOptions<T>,
+): Parser<T> {
+  return map(
+    seqC(
+      capture(withTrailingLineComment(parser, options), "value"),
+      optionalSpacesOrNewline,
+    ),
+    (result) => result.value,
+  );
+}
+```
+
+`withTrailingLineComment` owns the same-line decision. `completeConstructEntry`
+owns the terminating layout whether or not a comment attached, so match arms
+cannot strand the newline left by `lineCommentCore`. The functions are
+imperative internally because they coordinate parser state, but grammar call
+sites only select a parser and, when needed, a declarative attachment policy.
+
+- [ ] **Step 6: Decorate body and top-level streams**
+
+In `lib/parsers/parsers.ts`, replace `_bodyParserImpl` with:
+
+```ts
+const _bodyParserImpl: Parser<AgencyNode[]> = memo(
+  "functionBodyParser",
+  many(
+    completeConstructEntry(_bodyNodeParser, {
+      canAttach: (node) => !NON_TRAILING_OWNER_TYPES.includes(node.type),
+    }),
+  ),
+);
+```
+
+In `lib/parser.ts`, import `completeConstructEntry`, rename the current
+`nodeParser` to `nodeParserInner`, and declare:
+
+```ts
+const nodeParser = completeConstructEntry(nodeParserInner);
+```
+
+Remove any now-duplicated post-node whitespace consumption from `agencyNode`;
+`completeConstructEntry` is the single owner of that boundary.
+
+- [ ] **Step 7: Run focused parser and location tests**
+
+```bash
+pnpm test:run lib/parsers/trailingComments.test.ts lib/parser.test.ts lib/parsers/body.test.ts lib/parsers/comment.test.ts lib/parsers/blankLine.test.ts lib/parsers/matchBlock.test.ts > /tmp/trailing-task1-green.txt 2>&1; echo $?
+```
+
+Expected: exit 0.
+
+- [ ] **Step 8: Type-check production and tests**
+
+```bash
+pnpm run typecheck > /tmp/trailing-task1-types.txt 2>&1; echo $?
+```
+
+Expected: exit 0.
+
+- [ ] **Step 9: Commit**
+
+Write this message to `/tmp/trailing-task1-commit.txt`:
+
+```text
+parser: attach trailing comments to complete nodes
+
+Keep same-line comments with top-level and body constructs without crossing a
+consumed newline or changing the owner's source location.
+```
+
+Then run:
+
+```bash
+git add lib/types/base.ts lib/parsers/parsers.ts lib/parser.ts lib/parsers/trailingComments.test.ts
+git commit -F /tmp/trailing-task1-commit.txt
+```
+
+---
+
+### Task 2: Render complete constructs and match arms
+
+**Files:**
+- Modify: `lib/types/matchBlock.ts`
+- Modify: `lib/parsers/parsers.ts`
+- Modify: `lib/backends/agencyGenerator.ts`
+- Modify: `lib/parsers/trailingComments.test.ts`
+- Modify: `lib/formatter.test.ts`
+
+**Interfaces:**
+- Consumes: `LineComment`, `withTrailingLineComment`.
+- Produces: `commentText`, `appendTrailingComment`, match-arm metadata, and
+  canonical complete-construct output.
+- Consumed by: Tasks 3–5.
+
+- [ ] **Step 1: Add failing formatter, match-arm, import-sorting, and location tests**
+
+Add a formatter helper and cases to `lib/formatter.test.ts`:
+
+```ts
+function expectTrailingCommentFixedPoint(source: string, expected: string): void {
+  const once = formatSource(source);
+  expect(once).not.toBeNull();
+  expect(once).toBe(expected);
+  expect(formatSource(once as string)).toBe(once);
+  expect(parseAgency(once as string, {}, false, false).success).toBe(true);
+}
+
+describe("complete-construct trailing comments", () => {
+  it("preserves top-level and body comments", () => {
+    expectTrailingCommentFixedPoint(
+      `type UserId=string // id\nnode main(){\nconst x=5 // x\n}\n`,
+      `type UserId = string // id\n\nnode main() {\n  const x = 5 // x\n}\n`,
+    );
+  });
+
+  it("keeps comments with imports while sorting", () => {
+    const formatted = formatSource(
+      `import { z } from "./z" // z comment\nimport { a } from "./a" // a comment\n`,
+    );
+    expect(formatted).toContain(
+      `import { a } from "./a" // a comment\nimport { z } from "./z" // z comment`,
+    );
+  });
+
+  it("keeps a comment after a multiline call closing delimiter", () => {
+    const source = `node main() {\n  save(\n    "a very long argument that keeps this call multiline",\n    "another very long argument that keeps this call multiline"\n  ) // whole call\n}\n`;
+    const once = formatSource(source);
+    expect(once).toContain(`\n  ) // whole call\n`);
+    expect(formatSource(once as string)).toBe(once);
+  });
+});
+```
+
+In `lib/parsers/trailingComments.test.ts`, add a focused location assertion that
+uses the source offsets rather than assuming a nonexistent location suite:
+
+```ts
+it("does not extend the owner location through the comment", () => {
+  const source = `type UserId = string // identifier\n`;
+  const node = parseRaw(source).nodes[0];
+  expect(node.trailingComment?.content).toBe(" identifier");
+  expect(source.slice(node.loc!.start, node.loc!.end)).not.toContain("//");
+});
+```
+
+- [ ] **Step 2: Run the focused tests and confirm failure**
+
+```bash
+pnpm test:run lib/parsers/trailingComments.test.ts lib/formatter.test.ts > /tmp/trailing-task2-red.txt 2>&1; echo $?
+```
+
+Expected: exit 1 because the generator does not emit attached metadata.
+
+- [ ] **Step 3: Separate comment text from placement**
+
+Import `LineComment` into `lib/backends/agencyGenerator.ts`, then replace
+`processComment` and add one placement helper:
+
+```ts
+protected commentText(comment: LineComment): string {
+  return `//${comment.content}`;
+}
+
+protected processComment(comment: AgencyComment): string {
+  return this.indentStr(this.commentText(comment));
+}
+
+protected appendTrailingComment(
+  code: string,
+  comment: LineComment | undefined,
+): string {
+  if (!comment || code === "") {
+    return code;
+  }
+  return `${code} ${this.commentText(comment)}`;
+}
+```
+
+This is the single owner of line-comment source text. Do not reconstruct
+`//${comment.content}` anywhere else.
+
+- [ ] **Step 4: Emit complete-node metadata once**
+
+Replace `processNode` with:
+
+```ts
+public processNode(node: AgencyNode): string {
+  const result = this.processNodeInner(node);
+  const traced = this.trace(node.type, result);
+  return this.appendTrailingComment(traced, node.trailingComment);
+}
+```
+
+In `sortAndRenderImports`, update `renderWithAttached` so the sorted path—which
+bypasses `processNode`—also moves a trailing comment with its import:
+
+```ts
+const renderWithAttached = (
+  node: ImportStatement | ImportNodeStatement,
+  body: string,
+): string => {
+  const rendered = this.appendTrailingComment(body, node.trailingComment);
+  const attached = this.importAttachedComments.get(node) ?? [];
+  if (attached.length === 0) {
+    return rendered;
+  }
+  const commentLines = attached.map((comment) => this.processNode(comment));
+  return [...commentLines, rendered].join("\n");
+};
+```
+
+- [ ] **Step 5: Decorate and render match arms**
+
+In `lib/types/matchBlock.ts`, import `LineComment` from `./base.js` and add:
+
+```ts
+trailingComment?: LineComment;
+```
+
+to `MatchBlockCase`.
+
+In `lib/parsers/parsers.ts`, rename the existing implementation to
+`matchBlockParserCaseInner`, then export the complete stream entry:
+
+```ts
+export const matchBlockParserCase = completeConstructEntry(
+  matchBlockParserCaseInner,
+);
+```
+
+Remove the match loop's now-duplicated post-case whitespace handling. Add a raw
+parser case with two arms where the first has a trailing comment; assert both
+arms parse and remain separate. This pins the progress invariant that the
+entry consumes the line ending after `lineCommentCore` stops.
+
+In `processMatchBlock`, build the complete arm first, then append metadata:
+
+```ts
+const arm = this.armPrintsInline(caseNode)
+  ? this.renderInlineMatchArm(caseNode, pattern, guardCode)
+  : this.renderBlockMatchArm(caseNode, pattern, guardCode);
+result += this.appendTrailingComment(arm, caseNode.trailingComment) + "\n";
+```
+
+Extract `renderInlineMatchArm` and `renderBlockMatchArm` from the existing two
+branches without changing their internal formatting. The extracted methods
+return one arm without its final newline; this gives `appendTrailingComment` a
+complete construct and avoids duplicating comment emission.
+
+- [ ] **Step 6: Add the complete body-owner matrix**
+
+Add to `lib/formatter.test.ts`:
+
+```ts
+it.each([
+  ["node", `node main() {\n  print(1) // c\n}\n`],
+  ["function", `def f() {\n  print(1) // c\n}\n`],
+  ["if", `node main() {\n  if (true) {\n    print(1) // c\n  }\n}\n`],
+  ["else", `node main() {\n  if (true) {\n    print(1)\n  } else {\n    print(2) // c\n  }\n}\n`],
+  ["while", `node main() {\n  while (true) {\n    print(1) // c\n  }\n}\n`],
+  ["for", `node main() {\n  for (x in xs) {\n    print(x) // c\n  }\n}\n`],
+  ["thread", `node main() {\n  thread {\n    print(1) // c\n  }\n}\n`],
+  ["subthread", `node main() {\n  subthread {\n    print(1) // c\n  }\n}\n`],
+  ["guard", `node main() {\n  guard() {\n    print(1) // c\n  }\n}\n`],
+  ["handle", `node main() {\n  handle {\n    print(1) // c\n  } with approve\n}\n`],
+  ["inline handler", `node main() {\n  handle {\n    print(1)\n  } with (answer) {\n    print(answer) // c\n  }\n}\n`],
+  ["finalize", `node main() {\n  finalize {\n    print(1) // c\n  }\n}\n`],
+  ["parallel", `node main() {\n  parallel {\n    print(1) // c\n  }\n}\n`],
+  ["seq", `node main() {\n  seq {\n    print(1) // c\n  }\n}\n`],
+  ["destructive", `node main() {\n  destructive {\n    print(1) // c\n  }\n}\n`],
+  ["block match arm", `node main() {\n  match (x) {\n    1 => {\n      print(1) // c\n    }\n  }\n}\n`],
+])("preserves a trailing comment in a %s body", (_name, source) => {
+  const once = formatSource(source);
+  expect(once).toContain("print(1) // c");
+  expect(parseAgency(once as string, {}, false, false).success).toBe(true);
+  expect(formatSource(once as string)).toBe(once);
+});
+```
+
+Add focused existing-syntax cases for a braced block argument and a
+statement-kind code literal using canonical examples from their existing test
+files; assert the same parse/fixed-point contract.
+
+- [ ] **Step 7: Run complete-construct suites**
+
+```bash
+pnpm test:run lib/parsers/trailingComments.test.ts lib/formatter.test.ts lib/backends/agencyGenerator.test.ts lib/parsers/matchBlock.test.ts lib/parsers/arrowBlocks.test.ts lib/parsers/codeLiteral.test.ts > /tmp/trailing-task2-green.txt 2>&1; echo $?
+```
+
+Expected: exit 0.
+
+- [ ] **Step 8: Commit**
+
+Write `/tmp/trailing-task2-commit.txt`:
+
+```text
+fmt: preserve trailing comments on complete constructs
+
+Render attached comments for top-level nodes, every body owner, sorted imports,
+and match arms through shared comment-text and placement helpers.
+```
+
+Then run:
+
+```bash
+git add lib/types/matchBlock.ts lib/parsers/parsers.ts lib/backends/agencyGenerator.ts lib/parsers/trailingComments.test.ts lib/formatter.test.ts
+git commit -F /tmp/trailing-task2-commit.txt
+```
+
+---
+
+### Task 3: Shared list trivia and existing trivia-aware lists
+
+**Files:**
+- Modify: `lib/types/dataStructures.ts`
+- Modify: `lib/types/typeHints.ts`
+- Modify: `lib/parsers/parsers.ts`
+- Modify: `lib/backends/agencyGenerator.ts`
+- Create: `lib/parsers/listTrailingComments.test.ts`
+- Modify: `lib/parsers/dataStructures.test.ts`
+- Modify: `lib/parsers/objectTypeTrivia.test.ts`
+- Modify: `lib/parsers/literalDelimiter.test.ts`
+- Modify: `lib/backends/agencyGenerator.test.ts`
+
+**Interfaces:**
+- Produces: `ListTrivia`, compatibility aliases, `ParsedList<T>`, shared
+  partition/remap helpers, and trivia-aware list rendering.
+- Consumed by: Tasks 4–5.
+
+- [ ] **Step 1: Write failing compatibility and placement tests**
+
+Create `lib/parsers/listTrailingComments.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { formatSource } from "@/formatter.js";
+import {
+  agencyArrayParser,
+  agencyObjectParser,
+  objectTypeParser,
+} from "./parsers.js";
+
+describe("list trailing trivia", () => {
+  it("distinguishes a trailing comment from a comment before the next item", () => {
+    const parsed = agencyArrayParser(`[
+      first, // explains first
+      // prepares second
+      second
+    ]`);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) {
+      return;
+    }
+    expect(parsed.result.trivia).toEqual([
+      {
+        anchorIndex: 0,
+        placement: "trailing",
+        comments: [{ type: "comment", content: " explains first" }],
+      },
+      {
+        anchorIndex: 1,
+        comments: [{ type: "comment", content: " prepares second" }],
+      },
+    ]);
+  });
+
+  it.each([
+    ["array", `const value = [\n  1, // one\n  2 // two\n]\n`],
+    ["object", `const value = {\n  one: 1, // one\n  two: 2 // two\n}\n`],
+    ["object type", `type Value = {\n  one: number // one\n  two: number // two\n}\n`],
+  ])("formats trailing comments in a %s", (_name, source) => {
+    const once = formatSource(source);
+    expect(once).toContain("// one");
+    expect(once).toContain("// two");
+    expect(formatSource(once as string)).toBe(once);
+  });
+});
+```
+
+Retain the existing exact AST assertions in `dataStructures.test.ts` and
+`objectTypeTrivia.test.ts`; they are the compatibility tests proving ordinary
+trivia still omits `placement`.
+
+- [ ] **Step 2: Run the new and existing tests to verify the red state**
+
+```bash
+pnpm test:run lib/parsers/listTrailingComments.test.ts lib/parsers/dataStructures.test.ts lib/parsers/objectTypeTrivia.test.ts lib/parsers/literalDelimiter.test.ts lib/backends/agencyGenerator.test.ts > /tmp/trailing-task3-red.txt 2>&1; echo $?
+```
+
+Expected: exit 1 only in the new trailing-placement cases.
+
+- [ ] **Step 3: Introduce compatibility-preserving shared trivia types**
+
+In `lib/types/dataStructures.ts`, import `LineComment` from `./base.js` and
+replace `Trivia` with:
+
+```ts
+export type BeforeListTrivia = {
+  /** Index of the item this trivia precedes; item count means the closer. */
+  anchorIndex: number;
+  comments: TriviaNode[];
+  /** Omitted by parsers to preserve existing serialized ASTs. */
+  placement?: "before";
+};
+
+export type TrailingListTrivia = {
+  /** Index of the item this line comment follows. */
+  anchorIndex: number;
+  placement: "trailing";
+  comments: [LineComment];
+};
+
+export type ListTrivia = BeforeListTrivia | TrailingListTrivia;
+export type Trivia = ListTrivia;
+
+export type ParsedList<T> = {
+  items: T[];
+  trivia?: ListTrivia[];
+};
+```
+
+In `lib/types/typeHints.ts`, import `ListTrivia` and replace the parallel object
+type declaration with:
+
+```ts
+export type ObjectTypeTrivia = ListTrivia;
+```
+
+Do not add `placement: "before"` when parsing existing trivia.
+
+- [ ] **Step 4: Extend parse-time entries and partitioning**
+
+In `lib/parsers/parsers.ts`, use these entry shapes:
+
+```ts
+type ItemEntry<T> = {
+  kind: "item";
+  item: T;
+  trailingComment?: LineComment;
+};
+
+type TriviaEntry = {
+  kind: "trivia";
+  node: TriviaNode;
+};
+
+type InterleavedEntry<T> = ItemEntry<T> | TriviaEntry;
+```
+
+Replace `partitionTrivia` with:
+
+```ts
+function partitionTrivia<T>(entries: InterleavedEntry<T>[]): ParsedList<T> {
+  const items: T[] = [];
+  const trivia: ListTrivia[] = [];
+  let pending: TriviaNode[] = [];
+
+  for (const entry of entries) {
+    if (entry.kind === "trivia") {
+      pending.push(entry.node);
+      continue;
+    }
+
+    if (pending.length > 0) {
+      trivia.push({ anchorIndex: items.length, comments: pending });
+      pending = [];
+    }
+
+    items.push(entry.item);
+    if (entry.trailingComment) {
+      trivia.push({
+        anchorIndex: items.length - 1,
+        placement: "trailing",
+        comments: [entry.trailingComment],
+      });
+    }
+  }
+
+  if (pending.length > 0) {
+    trivia.push({ anchorIndex: items.length, comments: pending });
+  }
+
+  return trivia.length > 0 ? { items, trivia } : { items };
+}
+```
+
+- [ ] **Step 5: Encapsulate separator-specific item parsing**
+
+Keep `literalDelimiter`'s missing-comma lookahead intact. Replace `itemEntry`
+with a decorator that inspects the complete item-plus-delimiter span and parses
+a comment only when that span did not cross a line. First define one entry
+parser that consumes both exact comment text and its terminating layout:
+
+```ts
+const trailingLineCommentEntry: Parser<LineComment> = map(
+  seqC(
+    capture(lineCommentCore, "comment"),
+    optionalSpacesOrNewline,
+  ),
+  (result) => result.comment,
+);
+```
+
+Then add:
+
+```ts
+function itemEntryAfterDelimiter<T>(
+  itemParser: Parser<T>,
+  delimiter: Parser<unknown>,
+): Parser<ItemEntry<T>> {
+  return (input: string) => {
+    const item = itemParser(input);
+    if (!item.success) {
+      return item as ParserResult<ItemEntry<T>>;
+    }
+
+    const separated = delimiter(item.rest);
+    if (!separated.success) {
+      return separated as ParserResult<ItemEntry<T>>;
+    }
+
+    if (consumedLineEnding(input, separated.rest)) {
+      return success({ kind: "item", item: item.result }, separated.rest);
+    }
+
+    const comment = seqR(
+      optionalSpaces,
+      trailingLineCommentEntry,
+    )(separated.rest);
+    if (!comment.success) {
+      return success({ kind: "item", item: item.result }, separated.rest);
+    }
+
+    return success(
+      {
+        kind: "item",
+        item: item.result,
+        trailingComment: comment.result,
+      },
+      comment.rest,
+    );
+  };
+}
+```
+
+For object-type properties, newline itself is a legal delimiter. The parser must
+accept both `property // comment` before a newline delimiter and
+`property, // comment` after a punctuation delimiter. Add the separate policy:
+
+```ts
+function objectMemberEntry<T>(
+  itemParser: Parser<T>,
+  delimiter: Parser<unknown>,
+): Parser<ItemEntry<T>> {
+  return (input: string) => {
+    const item = itemParser(input);
+    if (!item.success) {
+      return item as ParserResult<ItemEntry<T>>;
+    }
+
+    const beforeDelimiterComment = seqR(
+      optionalSpaces,
+      trailingLineCommentEntry,
+    )(item.rest);
+    if (beforeDelimiterComment.success) {
+      const separated = delimiter(beforeDelimiterComment.rest);
+      if (!separated.success) {
+        return separated as ParserResult<ItemEntry<T>>;
+      }
+      return success(
+        {
+          kind: "item",
+          item: item.result,
+          trailingComment: beforeDelimiterComment.result,
+        },
+        separated.rest,
+      );
+    }
+
+    const separated = delimiter(item.rest);
+    if (!separated.success) {
+      return separated as ParserResult<ItemEntry<T>>;
+    }
+
+    if (consumedLineEnding(input, separated.rest)) {
+      return success({ kind: "item", item: item.result }, separated.rest);
+    }
+
+    const afterDelimiterComment = seqR(
+      optionalSpaces,
+      trailingLineCommentEntry,
+    )(separated.rest);
+    if (!afterDelimiterComment.success) {
+      return success({ kind: "item", item: item.result }, separated.rest);
+    }
+
+    return success(
+      {
+        kind: "item",
+        item: item.result,
+        trailingComment: afterDelimiterComment.result,
+      },
+      afterDelimiterComment.rest,
+    );
+  };
+}
+```
+
+Use `itemEntryAfterDelimiter` for arrays and object literals. Use
+`objectMemberEntry` for object-type properties, passing the existing optional
+object-property delimiter so an undelimited final member remains valid. Do not
+replace the two delimiter parsers with a universal separator policy.
+
+Add raw parser tests for a non-final trailing-comment item, a trailing comment
+followed by standalone trivia, and a standalone comment after an item parser
+that consumes its own newline. Assert item count, trivia placement, and the
+following item—not only comment text—so parser progress and boundary detection
+cannot regress unnoticed.
+
+- [ ] **Step 6: Add shared trivia rendering**
+
+Replace `emitTriviaAt` with helpers that process all records at an anchor:
+
+```ts
+protected renderTriviaNode(node: TriviaNode): string {
+  if (node.type === "newLine") {
+    return "";
+  }
+  if (node.type === "comment") {
+    return this.processComment(node);
+  }
+  return this.processMultiLineComment(node);
+}
+
+protected beforeTriviaAt(
+  trivia: ListTrivia[] | undefined,
+  anchorIndex: number,
+): TriviaNode[] {
+  return (trivia ?? [])
+    .filter(
+      (entry) =>
+        entry.anchorIndex === anchorIndex && entry.placement !== "trailing",
+    )
+    .flatMap((entry) => entry.comments);
+}
+
+protected trailingTriviaAt(
+  trivia: ListTrivia[] | undefined,
+  anchorIndex: number,
+): LineComment[] {
+  return (trivia ?? [])
+    .filter(
+      (entry) =>
+        entry.anchorIndex === anchorIndex && entry.placement === "trailing",
+    )
+    .flatMap((entry) => entry.comments);
+}
+```
+
+Add the multiline list renderer. Item-owned decorations are structured data,
+not pre-indented multiline strings:
+
+```ts
+type RenderedListItem = {
+  leadingLines?: string[];
+  code: string;
+};
+
+type RenderListWithTriviaOptions<T> = {
+  items: T[];
+  trivia: ListTrivia[];
+  prefix: string;
+  open: string;
+  close: string;
+  suffix?: string;
+  renderItem: (item: T, index: number) => RenderedListItem;
+  separator: (index: number, itemCount: number) => string;
+};
+
+private renderListWithTrivia<T>(
+  args: RenderListWithTriviaOptions<T>,
+): string {
+  this.increaseIndent();
+  const lines: string[] = [];
+
+  for (let index = 0; index < args.items.length; index++) {
+    for (const triviaNode of this.beforeTriviaAt(args.trivia, index)) {
+      lines.push(this.renderTriviaNode(triviaNode));
+    }
+
+    const item = args.renderItem(args.items[index], index);
+    for (const leadingLine of item.leadingLines ?? []) {
+      lines.push(this.indentStr(leadingLine));
+    }
+    const separator = args.separator(index, args.items.length);
+    let line = this.indentStr(`${item.code}${separator}`);
+    for (const comment of this.trailingTriviaAt(args.trivia, index)) {
+      line = this.appendTrailingComment(line, comment);
+    }
+    lines.push(line);
+  }
+
+  for (const triviaNode of this.beforeTriviaAt(
+    args.trivia,
+    args.items.length,
+  )) {
+    lines.push(this.renderTriviaNode(triviaNode));
+  }
+
+  this.decreaseIndent();
+  return `${args.prefix}${args.open}\n${lines.join("\n")}\n${this.indent()}${args.close}${args.suffix ?? ""}`;
+}
+```
+
+Arrays, objects, and object types call this helper only when trivia exists.
+Their no-trivia branches retain current behavior. Array/object separators are
+commas except on the final item; object-type separators retain the current
+canonical semicolon policy. Object-type `renderItem` returns formatted
+`@validate`/`@jsonSchema` tags as `leadingLines` and the property as `code`, so
+the shared renderer—not the caller—owns indentation. Add a tagged object-type
+property with a trailing comment to the fixed-point matrix.
+
+- [ ] **Step 7: Run compatibility, parser, and generator tests**
+
+```bash
+pnpm test:run lib/parsers/listTrailingComments.test.ts lib/parsers/dataStructures.test.ts lib/parsers/objectTypeTrivia.test.ts lib/parsers/literalDelimiter.test.ts lib/backends/agencyGenerator.test.ts lib/formatter.test.ts > /tmp/trailing-task3-green.txt 2>&1; echo $?
+```
+
+Expected: exit 0. In particular, existing trivia AST assertions remain
+byte-for-byte unchanged and missing commas still fail.
+
+- [ ] **Step 8: Commit**
+
+Write `/tmp/trailing-task3-commit.txt`:
+
+```text
+parser: distinguish trailing list trivia
+
+Unify list trivia placement while preserving existing AST shapes and separator
+rules for arrays, objects, and object types.
+```
+
+Then run:
+
+```bash
+git add lib/types/dataStructures.ts lib/types/typeHints.ts lib/parsers/parsers.ts lib/backends/agencyGenerator.ts lib/parsers/listTrailingComments.test.ts lib/parsers/dataStructures.test.ts lib/parsers/objectTypeTrivia.test.ts lib/parsers/literalDelimiter.test.ts lib/backends/agencyGenerator.test.ts
+git commit -F /tmp/trailing-task3-commit.txt
+```
+
+---
+
+### Task 4: Function-call arguments and declaration parameters
+
+**Files:**
+- Modify: `lib/types/function.ts`
+- Modify: `lib/types/graphNode.ts`
+- Modify: `lib/types/access.ts`
+- Modify: `lib/types/interruptStatement.ts`
+- Modify: `lib/types/guardBlock.ts`
+- Modify: `lib/parsers/parsers.ts`
+- Modify: `lib/backends/agencyGenerator.ts`
+- Modify: `lib/parsers/listTrailingComments.test.ts`
+- Modify: `lib/parsers/function.test.ts`
+- Modify: `lib/formatter.test.ts`
+
+**Interfaces:**
+- Consumes: `ListTrivia`, list parsing/partitioning, and list rendering from Task 3.
+- Produces: `argumentTrivia` and `parameterTrivia` on their AST owners.
+- Consumed by: Task 5's named-argument integrations.
+
+- [ ] **Step 1: Write failing argument and parameter matrices**
+
+Add to `lib/parsers/listTrailingComments.test.ts`:
+
+```ts
+describe("call and declaration list comments", () => {
+  it.each([
+    ["positional", `save(\n  first, // first\n  second // second\n)`],
+    ["named", `save(\n  value: first, // value\n  retries: 3 // retries\n)`],
+    ["splat", `save(\n  ...values, // values\n  final // final\n)`],
+    ["method", `client.save(\n  first, // first\n  second // second\n)`],
+    ["call chain", `handlers[0](\n  first, // first\n  second // second\n)`],
+    ["interrupt", `interrupt io::read(\n  first, // first\n  second // second\n)`],
+    ["raise", `raise io::failure(\n  first, // first\n  second // second\n)`],
+  ])("preserves %s argument comments", (_name, call) => {
+    const source = `node main() {\n  ${call}\n}\n`;
+    const once = formatSource(source);
+    expect(once).toContain("// first");
+    expect(once).toContain("// second");
+    expect(parseAgency(once as string, {}, false, false).success).toBe(true);
+    expect(formatSource(once as string)).toBe(once);
+  });
+
+  it.each([
+    ["function", `def save(\n  value: string, // value\n  ...rest: string[] // rest\n) {\n}\n`],
+    ["node", `node save(\n  value: string!, // value\n  retries: number = 3 // retries\n) {\n}\n`],
+  ])("preserves %s parameter comments", (_name, source) => {
+    const once = formatSource(source);
+    expect(once).toContain("// value");
+    expect(parseAgency(once as string, {}, false, false).success).toBe(true);
+    expect(formatSource(once as string)).toBe(once);
+  });
+});
+```
+
+Add a separate `guard(...) { ... }` case because its argument list is reshaped
+into `GuardBlock` rather than `FunctionCall`. These cases pin every current
+consumer of `argumentListParser`; do not assume changing that parser alone
+preserves metadata through each consumer's AST construction and rendering.
+
+- [ ] **Step 2: Run and save the red state**
+
+```bash
+pnpm test:run lib/parsers/listTrailingComments.test.ts lib/parsers/function.test.ts lib/formatter.test.ts > /tmp/trailing-task4-red.txt 2>&1; echo $?
+```
+
+Expected: exit 1 because these lists currently reject comments.
+
+- [ ] **Step 3: Add explicit AST ownership fields**
+
+Import `ListTrivia` into the relevant type files and add:
+
+```ts
+// FunctionCall
+argumentTrivia?: ListTrivia[];
+
+// FunctionDefinition
+parameterTrivia?: ListTrivia[];
+
+// GraphNodeDefinition
+parameterTrivia?: ListTrivia[];
+
+// InterruptStatement and GuardBlock
+argumentTrivia?: ListTrivia[];
+
+// AccessChainElement's `kind: "call"` variant
+Pick<FunctionCall, "arguments" | "block" | "argumentTrivia">
+```
+
+Named fields avoid ambiguity on nodes that own more than one list.
+
+- [ ] **Step 4: Add the policy-driven comma-list parser**
+
+Extract the array/object `many(or(triviaEntry,
+itemEntryAfterDelimiter(...)))` pattern without broadening any caller's
+grammar:
+
+```ts
+type CommaListPolicy = {
+  closer: string;
+  cardinality: "zero-or-more" | "one-or-more";
+  trailingComma: "allow" | "reject";
+};
+
+function commaDelimitedList<T>(
+  itemParser: Parser<T>,
+  policy: CommaListPolicy,
+): Parser<ParsedList<T>> {
+  const item = itemEntryAfterDelimiter(
+    itemParser,
+    commaListDelimiter(policy),
+  );
+  const entry = or(triviaEntry, item);
+  const entries =
+    policy.cardinality === "zero-or-more"
+      ? many(entry)
+      : map(
+          seqC(
+            capture(many(triviaEntry), "leading"),
+            capture(item, "first"),
+            capture(many(entry), "rest"),
+          ),
+          (result) => [
+            ...result.leading,
+            result.first,
+            ...result.rest,
+          ],
+        );
+  return map(
+    entries,
+    partitionTrivia,
+  );
+}
+```
+
+`commaListDelimiter` centralizes cursor mechanics but takes policy as data. Its
+`allow` mode preserves `literalDelimiter`'s existing final-comma behavior. Its
+`reject` mode still requires commas between items but fails when a comma is
+followed only by trivia and the closer. Add named policy constants at call
+sites instead of booleans whose meaning must be remembered.
+
+Use it inside `argumentListParser`, `_baseFunctionParser`, and
+`graphNodeParser`. Map `items` to the existing `arguments`/`parameters` fields
+and set the named trivia field only when `parsedList.trivia` exists.
+
+All three use `{ cardinality: "zero-or-more", trailingComma: "allow" }` with
+the appropriate `)` closer, matching their current `sepBy` plus
+`optional(comma)` grammar. The explicit policy is documentation and an
+executable compatibility constraint, not new configurability for its own sake.
+
+Inventory each migrated parser's current cardinality and trailing-comma rule
+before selecting its policy. In particular, node imports and binding/match
+patterns currently reject trailing commas, while literal lists allow them.
+Add a negative compatibility test for every `reject` family. Object-type
+members do not use this helper: their explicit policy allows punctuation or a
+newline delimiter and permits the final member without a delimiter.
+
+- [ ] **Step 5: Re-anchor trivia when extracting an inline block**
+
+Add the pure helper:
+
+```ts
+function remapListTrivia(
+  trivia: ListTrivia[] | undefined,
+  canonicalSourceIndexes: number[],
+): ListTrivia[] | undefined {
+  if (!trivia) {
+    return undefined;
+  }
+
+  const sourceItemCount = canonicalSourceIndexes.length;
+  const sortedIndexes = [...canonicalSourceIndexes].sort((left, right) =>
+    left - right,
+  );
+  const isPermutation = sortedIndexes.every(
+    (sourceIndex, expectedIndex) => sourceIndex === expectedIndex,
+  );
+  if (!isPermutation) {
+    throw new Error("canonical list order must contain every source item once");
+  }
+
+  const sourceToCanonical: (number | undefined)[] = [];
+  canonicalSourceIndexes.forEach((sourceIndex, canonicalIndex) => {
+    sourceToCanonical[sourceIndex] = canonicalIndex;
+  });
+
+  return trivia.map((entry) => {
+    if (
+      entry.placement !== "trailing" &&
+      entry.anchorIndex === sourceItemCount
+    ) {
+      return { ...entry, anchorIndex: canonicalSourceIndexes.length };
+    }
+    const anchorIndex = sourceToCanonical[entry.anchorIndex];
+    if (anchorIndex === undefined) {
+      throw new Error(`list trivia has invalid source anchor ${entry.anchorIndex}`);
+    }
+    return {
+      ...entry,
+      anchorIndex,
+    };
+  });
+}
+```
+
+Change inline-block extraction to retain each source index. After validation,
+canonical order is every ordinary argument's source index followed by the
+inline block's source index. Store remapped trivia on `FunctionCall`. A before
+comment remains anchored to the source item it preceded; a trailing comment
+moves with the source item. Preserve the existing one-inline-block and
+block-conflict errors.
+
+- [ ] **Step 6: Render call arguments and parameters through one list interface**
+
+When no trivia exists, keep `wrapList` exactly as today. When trivia exists,
+build the same virtual canonical list used by remapping, including the extracted
+inline block:
+
+```ts
+type RenderArgumentItem =
+  | FunctionCall["arguments"][number]
+  | BlockArgument;
+
+const items: RenderArgumentItem[] = inlineBlock
+  ? [...node.arguments, inlineBlock]
+  : node.arguments;
+
+{
+  items,
+  trivia: node.argumentTrivia,
+  prefix: `${asyncPrefix}${declaredName(node.functionName)}`,
+  open: "(",
+  close: ")",
+  renderItem: (argument) => ({
+    code: this.renderArgument(argument),
+  }),
+  separator: (index, count) => (index < count - 1 ? "," : ""),
+}
+```
+
+Extract the existing named/splat/expression branch into `renderArgument` and
+reuse it from `renderArgs`; include the current inline-lambda rendering in that
+same helper. Do not duplicate argument or block rendering. The focused tests
+must assert that the block itself remains present, is canonicalized last, and
+each comment remains adjacent to its intended ordinary or block argument.
+
+Pass `parameterTrivia` into `buildSignature`. With trivia, render parameters
+through `renderListWithTrivia`; without trivia, keep the current `wrapList` call.
+Both `processFunctionDefinition` and `processGraphNode` already use
+`buildSignature`, so one integration covers both.
+
+Propagate `argumentTrivia` through `_interruptExprParser`, every `raise` form,
+`guardBlockParser`, and `callChainParser`. Route `processInterruptStatement`,
+`processGuardBlock`, and the access-chain `kind: "call"` branch through the same
+trivia-aware argument renderer. Method calls already contain a full
+`FunctionCall`; direct call-chain elements need the widened `Pick` above.
+
+- [ ] **Step 7: Add inline-block source-position cases**
+
+Use canonical inline-block syntax from `lib/parsers/blockArgument.test.ts` to
+test a block in first, middle, and last source position. Each case must include:
+
+```ts
+expect(once).toContain("// block");
+expect(once).toContain("// ordinary");
+expect(parseAgency(once as string, {}, false, false).success).toBe(true);
+expect(formatSource(once as string)).toBe(once);
+```
+
+The canonical formatter may move the inline block last, but both comments must
+move with the construct they described.
+
+- [ ] **Step 8: Run call, signature, and formatter suites**
+
+```bash
+pnpm test:run lib/parsers/listTrailingComments.test.ts lib/parsers/function.test.ts lib/parsers/blockArgument.test.ts lib/parsers/access.test.ts lib/parsers/interruptStatement.test.ts lib/parsers/raiseStatement.test.ts lib/parsers/guardBlock.test.ts lib/formatter.test.ts lib/backends/agencyGenerator.test.ts > /tmp/trailing-task4-green.txt 2>&1; echo $?
+```
+
+Expected: exit 0.
+
+- [ ] **Step 9: Commit**
+
+Write `/tmp/trailing-task4-commit.txt`:
+
+```text
+fmt: preserve comments in calls and signatures
+
+Carry trailing list trivia through calls, inline-block canonicalization, and
+function and node parameter rendering.
+```
+
+Then run:
+
+```bash
+git add lib/types/function.ts lib/types/graphNode.ts lib/types/access.ts lib/types/interruptStatement.ts lib/types/guardBlock.ts lib/parsers/parsers.ts lib/backends/agencyGenerator.ts lib/parsers/listTrailingComments.test.ts lib/parsers/function.test.ts lib/formatter.test.ts
+git commit -F /tmp/trailing-task4-commit.txt
+```
+
+---
+
+### Task 5: Remaining multiline surfaces
+
+**Files:**
+- Modify: `lib/types/importStatement.ts`
+- Modify: `lib/types/exportFromStatement.ts`
+- Modify: `lib/types/pattern.ts`
+- Modify: `lib/types/messageThread.ts`
+- Modify: `lib/types/parallelBlock.ts`
+- Modify: `lib/parsers/parsers.ts`
+- Modify: `lib/backends/agencyGenerator.ts`
+- Modify: `lib/parsers/listTrailingComments.test.ts`
+- Modify: focused import/export/pattern/thread/parallel tests
+
+**Interfaces:**
+- Consumes: `ListTrivia`, `commaDelimitedList`, `remapListTrivia`, and
+  `renderListWithTrivia`.
+- Produces: complete support for every currently multiline list surface.
+
+- [ ] **Step 1: Write the remaining syntax matrix before production changes**
+
+Add canonical parse/format/fixed-point cases for:
+
+```agency
+import {
+  alpha, // alpha
+  beta // beta
+} from "./tools"
+
+import node {
+  first, // first
+  second // second
+} from "./nodes.agency"
+
+export {
+  alpha, // alpha
+  beta // beta
+} from "./tools"
+
+node main() {
+  const [
+    first, // first
+    second // second
+  ] = values
+
+  const {
+    name, // name
+    age // age
+  } = user
+
+  match (value) {
+    [
+      "ok", // tag
+      result // payload
+    ] => result
+  }
+
+  thread(
+    label: "work", // label
+    hidden: true // visibility
+  ) {
+  }
+
+  parallel(
+    shared: true // state mode
+  ) {
+  }
+}
+```
+
+Each test must assert the comment remains on the intended item line, the output
+reparses, and the second format is identical. Add a sorted-import case proving
+both outer import comments and inner name comments move with the correct import.
+
+- [ ] **Step 2: Run and save the red state**
+
+```bash
+pnpm test:run lib/parsers/listTrailingComments.test.ts lib/parsers/importStatement.test.ts lib/parsers/exportFromStatement.test.ts lib/parsers/pattern.test.ts lib/parsers/messageThread.test.ts lib/parsers/parallelBlock.test.ts lib/formatter.test.ts > /tmp/trailing-task5-red.txt 2>&1; echo $?
+```
+
+Expected: exit 1 in the new comment cases only. All named focused test files
+exist in the current tree; keep this command concrete rather than substituting
+an ad hoc suite during implementation.
+
+- [ ] **Step 3: Add named trivia ownership fields**
+
+Import `ListTrivia` and add:
+
+```ts
+// NamedImport
+nameTrivia?: ListTrivia[];
+
+// ImportNodeStatement
+nodeTrivia?: ListTrivia[];
+
+// NamedExportBody
+nameTrivia?: ListTrivia[];
+
+// ArrayPattern
+elementTrivia?: ListTrivia[];
+
+// ObjectPattern
+propertyTrivia?: ListTrivia[];
+
+// MessageThread
+argumentTrivia?: ListTrivia[];
+
+// ParallelBlock
+argumentTrivia?: ListTrivia[];
+```
+
+Do not put a generic `trivia` field on owners that may acquire another list;
+the field name must identify the list.
+
+- [ ] **Step 4: Replace multiline `sepBy` sites with `commaDelimitedList`**
+
+Integrate the shared parser in:
+
+- `namedImportParser` and `importNodeStatmentParser`;
+- `namedExportBodyParser`;
+- array/object binding patterns;
+- array/object match patterns;
+- `_threadNamedArgsParser`;
+- `_parallelNamedArgsParser`.
+
+For each parser, map `items` to the existing semantic field and set its named
+trivia field only when trivia exists. Preserve marker/alias extraction,
+rest-pattern validation, thread allowlists, duplicate checking, and
+continue/session mutual exclusion exactly as they are today.
+
+Use `one-or-more` for named imports, node imports, and named exports; use
+`zero-or-more` for patterns and named argument lists that currently admit an
+empty list. Select `allow` or `reject` only after reading each existing
+`optional(comma)`/`sepBy` site, and pin every `reject` choice with a negative
+trailing-comma test. This table-driven inventory prevents reuse from becoming
+an accidental syntax expansion.
+
+- [ ] **Step 5: Re-anchor thread arguments into canonical order**
+
+Thread rendering uses the fixed order:
+
+```ts
+const THREAD_ARGUMENT_ORDER = [
+  "label",
+  "summarize",
+  "continue",
+  "session",
+  "hidden",
+];
+```
+
+After parsing and validation, compute each present canonical argument's source
+index, call `remapListTrivia`, and store the result as `argumentTrivia` while
+continuing to store semantic values in their existing fields. `parallel` has
+only `shared`, so no reorder is necessary.
+
+- [ ] **Step 6: Render all remaining lists through the shared helper**
+
+Use `renderListWithTrivia` only when the named trivia field exists; retain every
+current no-trivia path. Specifically:
+
+- named imports/exports and node imports render comma-separated names;
+- pattern formatters render their current item text and delimiters;
+- thread rendering builds canonical named-argument strings in
+  `THREAD_ARGUMENT_ORDER` and passes the remapped trivia;
+- parallel rendering passes its single `shared` argument and trivia.
+
+Use existing item-formatting helpers (`prefixMarkedName`, `formatPattern`, and
+argument expression rendering). Do not duplicate marker, alias, or pattern
+formatting inside the trivia renderer.
+
+- [ ] **Step 7: Run all focused suites**
+
+```bash
+pnpm test:run lib/parsers/listTrailingComments.test.ts lib/parsers lib/backends/agencyGenerator.test.ts lib/formatter.test.ts > /tmp/trailing-task5-green.txt 2>&1; echo $?
+```
+
+Expected: exit 0.
+
+- [ ] **Step 8: Commit**
+
+Write `/tmp/trailing-task5-commit.txt`:
+
+```text
+fmt: support trailing comments in multiline lists
+
+Apply shared list trivia to imports, exports, patterns, thread arguments, and
+parallel arguments so every currently multiline surface follows one rule.
+```
+
+Then run:
+
+```bash
+git add lib/types/importStatement.ts lib/types/exportFromStatement.ts lib/types/pattern.ts lib/types/messageThread.ts lib/types/parallelBlock.ts lib/parsers/parsers.ts lib/backends/agencyGenerator.ts lib/parsers/listTrailingComments.test.ts lib/parsers lib/formatter.test.ts
+git commit -F /tmp/trailing-task5-commit.txt
+```
+
+---
+
+### Task 6: Documentation and compatibility gate
+
+**Files:**
+- Modify: `docs/site/guide/basic-syntax.md`
+- Modify: any focused tests needed by failures found below
+
+**Interfaces:**
+- Consumes: all production behavior from Tasks 1–5.
+- Produces: documented user rule and release-ready verification evidence.
+
+- [ ] **Step 1: Replace the obsolete guide prohibition**
+
+Replace the passage that says comments must be on their own line with:
+
+````markdown
+> A `//` comment can follow a complete declaration, statement, match arm, or
+> item in a multiline list. `agency fmt` keeps it attached to that construct.
+> In comma-separated lists, put the comma before the comment:
+
+```agency
+type UserId = string // stable identifier
+
+node main() {
+  save(
+    userId, // user to save
+    retries: 3 // retry budget
+  )
+}
+```
+
+Block comments and comments inside an unfinished expression are not trailing
+comments. Lists whose Agency syntax is inline-only, such as tag arguments and
+generic parameters, still do not accept line comments between items.
+````
+
+- [ ] **Step 2: Run the complete typecheck and structural lint**
+
+```bash
+pnpm run typecheck > /tmp/trailing-typecheck.txt 2>&1; echo "typecheck: $?"
+pnpm run lint:structure > /tmp/trailing-lint.txt 2>&1; echo "lint: $?"
+```
+
+Expected: both exit 0.
+
+- [ ] **Step 3: Build before broad tests**
+
+```bash
+make > /tmp/trailing-build.txt 2>&1; echo "build: $?"
+```
+
+Expected: exit 0. This also compiles the standard library and examples through
+the changed parser.
+
+- [ ] **Step 4: Run the full unit suite once**
+
+```bash
+pnpm test:run > /tmp/trailing-full.txt 2>&1; echo "unit: $?"
+grep -E 'Tests |Test Files' /tmp/trailing-full.txt | tail -2
+```
+
+Expected: exit 0 with no failed test files.
+
+- [ ] **Step 5: Run the formatter and location-sensitive suites**
+
+```bash
+pnpm test:run lib/formatter.test.ts lib/parser.test.ts lib/parsers/matchBlock.test.ts lib/linter/rules lib/lsp/foldingRange.test.ts lib/lsp/diagnostics.test.ts lib/lsp/formatting.test.ts > /tmp/trailing-locations.txt 2>&1; echo $?
+```
+
+Expected: exit 0. Do not create or invoke the nonexistent
+`lib/parsers/locations.test.ts`. If a location-sensitive test fails, preserve
+the owner's existing range and fix the consumer/attachment boundary; do not
+extend `loc.end` through the comment.
+
+- [ ] **Step 6: Run parser performance through the package script**
+
+```bash
+pnpm run test:perf > /tmp/trailing-perf.txt 2>&1; echo $?
+```
+
+Expected: exit 0. Record the test count and timing in the PR description.
+
+- [ ] **Step 7: Audit anti-patterns explicitly**
+
+Read `docs/dev/anti-patterns.md` and confirm from the diff:
+
+- `completeConstructEntry` is used by top-level, body, and match-arm streams;
+- `consumedLineEnding` is the single owner of consumed-source boundary checks;
+- list parsing exposes `ParsedList<T>` rather than duplicating imperative loops;
+- separator policies remain separate and named;
+- `commentText` is the only line-comment text renderer;
+- no branch checks `.success` for `many(...)`/`optionalSpaces`, which always
+  succeed;
+- no “harmless” duplicate whitespace consumption remains;
+- no one-line `if` statements or nested ternaries were introduced;
+- no wrapper node, inline duplicated comment type, `Map`, or `Set` was added.
+
+- [ ] **Step 8: Commit docs and verification follow-ups**
+
+Write `/tmp/trailing-task6-commit.txt`:
+
+```text
+docs: explain language-wide trailing comments
+
+Document the complete-construct and multiline-list rule and record the final
+compatibility, location, lint, unit, and performance checks.
+```
+
+Then run:
+
+```bash
+git add docs/site/guide/basic-syntax.md lib
+git commit -F /tmp/trailing-task6-commit.txt
+```
+
+---
+
+## Final review checklist
+
+- [ ] Every supported position in the design spec has a positive canonical
+  output test and fixed-point assertion.
+- [ ] Every principled exclusion remains either inline-only or explicitly
+  rejected; no arbitrary body-versus-top-level rule remains.
+- [ ] Standalone comments never attach across a consumed newline.
+- [ ] Sorted imports retain both outer and inner comments.
+- [ ] Inline blocks retain comments through canonical reordering.
+- [ ] Existing before-trivia AST snapshots are unchanged.
+- [ ] Required commas remain required.
+- [ ] Owner locations exclude attached comments.
+- [ ] The TypeScript generator and handler infrastructure are unchanged except
+  for accepting ignored optional formatter metadata.
+- [ ] Full typecheck, build, unit, formatter, LSP/linter location, structural
+  lint, and performance commands have fresh successful output saved under
+  `/tmp`.

--- a/packages/agency-lang/docs/superpowers/plans/2026-08-01-type-printer-trivia-review.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-08-01-type-printer-trivia-review.md
@@ -1,0 +1,405 @@
+# Review: Type Printer Trivia Implementation Plan
+
+## Recommendation: revise before implementation
+
+The plan correctly identifies the data-loss bug and the formatter as the right
+owner of multiline layout. It also has good round-trip and idempotence goals.
+However, the proposed implementation is not yet a small or safe follow-up. Its
+central design creates a second, incomplete type printer inside
+`AgencyGenerator`. That duplicates syntax and precedence logic already owned by
+`variableTypeToString`, and the proposed printer already has reachable cases
+that change or delete valid source.
+
+The smallest robust design is to keep one recursive type printer and give it an
+optional object-type rendering hook. The Agency source formatter can provide a
+trivia-aware hook; TypeScript generation and display-only consumers can omit
+it and retain their exact current output.
+
+## Explicit audit against `docs/dev/anti-patterns.md`
+
+### Does the plan neatly encapsulate imperative code behind declarative interfaces?
+
+**Not yet.** It makes a partial attempt, but the boundary is misleading.
+
+At the call site, this looks declarative:
+
+```ts
+this.renderTypeSource(type)
+```
+
+The caller says what it wants—Agency source for a type—without managing the
+tree walk or indentation. That part is good. However, `renderTypeSource` then
+implements a second copy of the type grammar using a large imperative switch:
+
+```ts
+switch (type.type) {
+  case "arrayType":
+    // Reimplement array syntax and precedence.
+  case "unionType":
+    // Reimplement union syntax.
+  case "genericType":
+    // Reimplement generic syntax.
+  // ...and so on.
+}
+```
+
+This does not neatly separate the "what" from the "how." It hides the new
+implementation from its immediate callers, but it does not encapsulate the
+underlying complexity in its existing owner. Ordinary type syntax now has two
+implementations, and changing the grammar requires knowing that both must be
+updated.
+
+The plan's Task 4 tests make this leak especially visible. Tests must know that
+there are two printers, know which precedence rules were copied, strip trivia
+and whitespace, and compare selected outputs. In other words, the duplicated
+implementation becomes part of the maintenance interface.
+
+A genuinely declarative boundary is:
+
+```ts
+variableTypeToString(type, aliases, true, {
+  objectType: (object, printChild) =>
+    object.trivia?.length
+      ? this.renderObjectTypeSource(object, printChild)
+      : undefined,
+});
+```
+
+This says: "use the canonical type printer, but give trivia-bearing object
+types formatter-owned layout." The shared printer still encapsulates the
+imperative tree traversal, grammar, precedence, and shorthand rules.
+`AgencyGenerator` encapsulates only indentation and comment placement. Each
+kind of complexity has one owner.
+
+The example above uses a ternary only to illustrate the policy compactly. The
+implementation should use an ordinary `if` block to follow this repository's
+readability rules:
+
+```ts
+objectType: (object, printChild) => {
+  if (!object.trivia?.length) {
+    return undefined;
+  }
+  return this.renderObjectTypeSource(object, printChild);
+},
+```
+
+### Anti-patterns the plan does contain
+
+| Anti-pattern | Verdict | Where it appears |
+|---|---|---|
+| **Duplicating existing code** | **Yes, severe** | Task 2 copies most of `variableTypeToString`, including precedence, wrappers, generic rendering, results, unions, and block types. |
+| **Imperative code everywhere** | **Yes, structurally** | The second switch owns another full tree walk instead of declaring only the object-type formatting policy. `typeHasTrivia` adds a third traversal. |
+| **Order-dependent mutable state** | **Yes, moderate** | Task 5 calls a rendering callback, changes `indentLevel`, calls it again, then restores the state. Correctness depends on call order and balanced mutation. |
+| **Leaky abstractions** | **Yes, severe** | Task 4's tests know about two printers and their duplicated precedence rules. Task 3 also assumes call location determines source-versus-display policy, but `signatureOf` crosses that boundary. |
+| **Useless special cases** | **Yes** | The separate `typeHasTrivia` gate and deliberately simplified `genericType`/`resultType` arms exist only because of the duplicated printer. The simplified arms are also incorrectly claimed to be unreachable. |
+| **Inconsistent patterns** | **Yes, severe** | Ordinary types use the shared printer, while trivia-bearing types use a different printer with different union wrapping, result shorthand, and generic behavior. |
+| **Single-character variable names** | **Minor** | Task 4 introduces `normalize = (s: string) => ...`. Use `source` or `formatted` instead. |
+
+### Catalog entries the proposed code does not appear to add
+
+The plan does **not** appear to introduce nested ternaries, one-line `if`
+statements, dynamic imports/requires, `Map`, `Set`, unlogged `catch` blocks,
+unsafe file deletion, deeply nested object type definitions, or catastrophic
+tests. The existing `80`-column threshold is reused rather than introducing a
+new unexplained magic number.
+
+Those clean details are worth preserving, but they do not offset the central
+duplication and abstraction problems.
+
+## Blocking findings
+
+### 1. The second type printer is duplicated code, and it already loses syntax
+
+Task 2 reimplements arrays, unions, intersections, `keyof`, indexed access,
+generics, results, and block types. This is the "duplicating existing code"
+anti-pattern in `docs/dev/anti-patterns.md`. The proposed agreement tests do
+not make the duplication safe; they only compare four examples and still
+leave two sources of truth.
+
+There are already concrete regressions in the proposed implementation.
+
+#### Generic value arguments are dropped
+
+The proposed `genericType` arm prints only the name and type arguments:
+
+```ts
+return `${type.name}<${args}>`;
+```
+
+But generic types can also carry `valueArgs`, which the existing printer
+preserves. This path is reachable:
+
+```agency
+type T = Container<{
+  x: number // keep
+}>(3)
+```
+
+Because the generic contains object trivia, it takes the new path and formats
+without `(3)`.
+
+#### `Result` shorthand changes on a reachable path
+
+The plan says the simplified `resultType` arm is unreachable, but it is
+reachable whenever either result argument contains a commented object type:
+
+```agency
+type Loaded = Result<{
+  value: string // keep
+}>
+```
+
+The existing printer emits the one-argument `Result<T>` form when the failure
+type is `string`. The proposed printer always emits `Result<T, string>`. That
+violates the plan's byte-for-byte compatibility constraint.
+
+The proposed "simplified arms stay unreachable" tests do not exercise a
+trivia-bearing generic or result. They only prove that trivia-free values take
+the old path, so they cannot catch either bug.
+
+#### Other rules would have two owners
+
+The plan also duplicates:
+
+- array, `keyof`, indexed-access, and intersection parentheses;
+- effect-set handling in unions;
+- long-union wrapping;
+- block-type syntax and `raises` handling;
+- generic and result canonicalization.
+
+A test suite can sample these rules, but it cannot remove the maintenance cost
+or guarantee that future printer changes are copied to both implementations.
+
+### 2. Use a declarative rendering hook instead
+
+The shared printer should continue to own recursion and all ordinary type
+syntax. Give it an optional formatter hook for the one syntax node that needs
+special layout:
+
+```ts
+type TypePrintHooks = {
+  objectType?: (
+    type: ObjectType,
+    printChild: (child: VariableType) => string,
+  ) => string | undefined;
+};
+```
+
+Conceptually, the existing object-type branch becomes:
+
+```ts
+if (variableType.type === "objectType") {
+  const rendered = hooks?.objectType?.(
+    variableType,
+    (child) => variableTypeToString(child, typeAliases, forFormatting, hooks),
+  );
+  if (rendered !== undefined) {
+    return rendered;
+  }
+
+  // Existing inline object rendering remains unchanged.
+}
+```
+
+Every existing recursive call forwards the same hooks. `AgencyGenerator`
+provides a hook that renders an object type multiline only when that object has
+trivia. This gives consumers a declarative interface—"render object types this
+way when appropriate"—while leaving the imperative indentation logic
+encapsulated in `AgencyGenerator`.
+
+This design eliminates:
+
+- `typeHasTrivia`;
+- the second recursive printer;
+- all three duplicated precedence helpers;
+- Task 4's printer-agreement tests;
+- the double traversal of every formatted type.
+
+It also naturally finds trivia at any printed depth without maintaining a
+second list of recursive `VariableType` edges.
+
+### 3. `typeHasTrivia` duplicates an existing traversal and is incomplete
+
+If the gate is retained, it should use the existing declarative `visitTypes`
+abstraction rather than implement another type-tree traversal:
+
+```ts
+return visitTypes(type, (nested) =>
+  nested.type === "objectType" && (nested.trivia?.length ?? 0) > 0
+);
+```
+
+More importantly, the plan incorrectly calls `schemaType` and
+`functionRefType` leaves. They contain nested types:
+
+```ts
+type SchemaType = {
+  type: "schemaType";
+  inner: VariableType;
+};
+
+type FunctionRefType = {
+  params: FunctionParameter[];
+  returnType: VariableType | null;
+  raises?: VariableType;
+};
+```
+
+The proposed traversal also ignores `blockType.raises`. The existing
+`visitTypes` is itself missing the `raises` edges, so reusing it would first
+require deciding and testing its child-edge contract. The rendering-hook
+design avoids this unrelated walker work because it follows exactly the nodes
+the printer actually prints.
+
+### 4. Routing every `AgencyGenerator` call also changes user-facing docs
+
+Task 3 says display-only consumers are protected because direct calls outside
+`agencyGenerator.ts` remain unchanged. That is not true.
+
+Both `agency doc` and `std::agency` create an `AgencyGenerator` and call
+`signatureOf`. `signatureOf` delegates to the methods Task 3 changes:
+
+```diagram
+agency doc / std::agency
+          │
+          ▼
+     signatureOf
+          │
+          ├──▶ buildSignature ──▶ renderParams / return type
+          │
+          └──▶ aliasedTypeToString
+```
+
+Therefore, a comment inside a parameter, return type, or nested alias can make
+a user-facing signature multiline and expose formatter trivia. Running the
+current doc tests does not prove otherwise because the plan adds no commented
+signature cases.
+
+Make the rendering policy explicit:
+
+- source formatting uses the trivia-aware hook;
+- `signatureOf` uses the existing plain rendering policy;
+- add exact regression tests for `agency doc` and `std::agency` describe with
+  comments in alias, parameter, and return types.
+
+Do not rely on an allowlist of direct calls outside one file to define this
+boundary.
+
+## Important findings
+
+### 5. Task 5 is too broad and renders stateful content twice
+
+Changing `wrapList` and every caller to callbacks broadens this fix into calls,
+arrays, imports, and every parenthesized list. The callback is invoked once to
+measure and again after mutating `indentLevel` to render. Even if current
+parameter rendering is safe to repeat, "render this arbitrary content twice"
+is a fragile contract for a stateful generator.
+
+Prefer a local layout operation: when `wrapList` chooses multiline output,
+indent every continuation line in an already rendered item by one additional
+indent level. For example:
+
+```ts
+private indentContinuationLines(item: string): string {
+  const continuationIndent = this.indent(1);
+  return item
+    .split("\n")
+    .map((line, index) => (index === 0 || line === "" ? line : continuationIndent + line))
+    .join("\n");
+}
+```
+
+Then use that only in `wrapList`'s wrapped branch. One-line items remain
+unchanged, multiline parameter types gain the missing indentation, and no
+content is rendered twice. If a lazy callback is still preferred, scope it to
+signature parameters rather than converting every list caller.
+
+### 6. Coverage does not support the plan's completeness claim
+
+The wrapper tests should include exact-output cases for at least:
+
+```agency
+type Generic = Container<{
+  x: number // keep
+}>(3)
+
+type Loaded = Result<{
+  x: number // keep
+}>
+
+type Callback = (arg: {
+  x: number // keep
+}) -> {
+  y: string // keep
+}
+
+type Optional = {
+  nested: {
+    x: number // keep
+  } | null
+}
+```
+
+Also test each formatter-facing source position that the plan routes: schema
+expressions, holes, type patterns, generic defaults, value-parameter types,
+handler parameters, and finalize parameters. `toContain` alone is insufficient
+for wrapper semantics; assert exact canonical output where suffixes,
+parentheses, shorthand, or value arguments could be lost.
+
+### 7. The plan's absolute paths point at the wrong checkout
+
+The plan is in:
+
+```text
+/Users/adityabhargava/agency-lang/worktree-type-trivia/packages/agency-lang
+```
+
+but many instructions edit or `cd` to:
+
+```text
+/Users/adityabhargava/agency-lang/packages/agency-lang
+```
+
+Following those commands would modify and test the main checkout instead of
+this worktree. Remove the absolute paths. State once that commands run from
+`packages/agency-lang` in the current worktree, then use relative paths.
+
+### 8. Several verification steps do not verify what they claim
+
+- The Task 6 typecheck baseline is captured after Tasks 1–5 are committed.
+  `git stash` does not remove those commits, so the "baseline" already includes
+  nearly the complete implementation. Capture the baseline before Task 1 or
+  compare with the base commit in another worktree.
+- `make` rebuilds much more than source formatting and can regenerate tracked
+  files, including content under `docs/site/`, contrary to this work's stated
+  constraint. Use targeted formatter round-trip tests instead unless a
+  standard-library source file changes.
+- The final full test and performance suites contradict the earlier instruction
+  to run only tests covering the change. Focus first on missing exact wrapper,
+  source-position, and display-consumer tests.
+
+## Parser finding from the preceding review
+
+The separate parser bug reported on PR #768 is already fixed in this branch.
+`objectMemberEntry` now checks `consumedLineEnding(input, item.rest)` both before
+trying a pre-delimiter trailing comment and before trying a post-delimiter one.
+This prevents a standalone comment after a multiline nested object type from
+attaching to the previous property. This follow-up does not need another parser
+change for that issue.
+
+## Suggested revised scope
+
+1. Add an optional object-type rendering hook to the existing recursive type
+   printer, with no-hook behavior pinned as unchanged.
+2. Add a formatter-owned `renderTypeSource` that installs the hook.
+3. Let `renderObjectTypeSource` and `stringifyProp` use the hook's recursive
+   `printChild` callback.
+4. Route source-formatting positions through that policy while keeping
+   `signatureOf` explicitly on its display policy.
+5. Fix multiline continuation indentation locally in `wrapList`.
+6. Add exact wrapper, source-position, idempotence, reparse, and display-policy
+   tests.
+
+This is still a moderate follow-up, but it is substantially smaller and less
+risky than maintaining a second type grammar inside `AgencyGenerator`.

--- a/packages/agency-lang/docs/superpowers/specs/2026-07-31-trailing-comments-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-07-31-trailing-comments-design.md
@@ -1,304 +1,505 @@
 # Trailing comments
 
-## Background
+## Goal
 
-Write this in an Agency file:
+Agency preserves a same-line `//` comment beside the complete construct it
+describes when `agency fmt` reformats the file.
 
-```ts
+Users learn one rule:
+
+> A `//` comment written at the end of a complete declaration, statement,
+> match arm, or item in a multiline list stays attached to that construct.
+> In a comma-separated list, write the comma before the comment.
+
+```agency
+type UserId = string // top-level declaration
+
+node main() {
+  const ids = [
+    1, // first item
+    2, // second item
+  ]
+
+  save(
+    ids, // values to save
+    retries: 3, // retry budget
+  ) // complete call statement
+}
+```
+
+The rule follows Agency's existing layout grammar rather than parser
+implementation boundaries. It applies to complete constructs and to item lists
+that already permit line breaks. It does not make an inline-only grammar
+multiline merely to admit comments.
+
+## Problem
+
+Today Agency usually parses a trailing comment but loses its placement. For
+example:
+
+```agency
 const x = 5 // explains x
 const y = 6
 ```
 
-Run `agency fmt` and you get this:
+formats as:
 
-```ts
+```agency
 const x = 5
 // explains x
 const y = 6
 ```
 
-The comment parses, and its text is never lost. But it moves. And where it
-moves to is directly above `const y = 6`, so a comment written to explain `x`
-now reads as explaining `y`. Formatting a file silently changed what a comment
-appears to say.
+The text survives, but the formatter makes it appear to describe `y`. Similar
+relocation occurs at top level, in match arms, and in trivia-aware lists such as
+arrays, objects, and object types. Other multiline lists, including calls and
+function parameters, reject comments because they have no trivia model.
 
-The same thing happens for object type members, array items, object literal
-fields, and match arms. In every position, a comment following code on the same
-line is re-rendered on its own line above whatever comes next.
+The language should not expose those internal differences to users.
 
-This matters because agents write trailing comments constantly. It is one of
-the most ingrained habits in every language they have learned from, and Agency
-neither rejects it nor honors it — it accepts the input and quietly rearranges
-the meaning. Of all the ways Agency can surprise someone writing it, this is the
-only one I know of where being permissive produces a *wrong result* rather than
-an inconvenient one.
+## Supported positions
 
-### Why it happens
+The complete feature includes every complete-construct stream and every list
+grammar that already accepts line breaks.
 
-This is not a formatter bug. Trailing comments have nowhere to live in the AST.
+### Complete constructs
 
-Comments inside a function body are parsed as ordinary body nodes. In
-`_bodyParserImpl` (`lib/parsers/parsers.ts:4804`) the body is
-`many(seqC(capture(_bodyNodeParser, "node"), optionalSpacesOrNewline))`, and
-`commentParser` (`lib/parsers/parsers.ts:4781`) is one of the alternatives
-`_bodyNodeParser` (`:4744`) tries. So
-`const x = 5 // explains x` parses as two sibling nodes in the body array: an
-assignment, then a comment. Nothing records that they were on the same line.
-The generator walks the body and emits one line per node, which is exactly what
-you see.
+- Top-level declarations and expression statements.
+- Statements in every body, including function, node, `if`/`else`, `while`,
+  `for`, `thread`, `subthread`, `guard`, `handle`, inline handler, `finalize`,
+  `parallel`, `seq`, destructive, block-argument, and block match-arm bodies.
+- Inline and block match arms.
+- Statement-kind code-literal bodies, which parse through `bodyParser`.
 
-Inside literals and type bodies there is a richer mechanism — *trivia* — but it
-cannot express trailing either. Trivia anchors a comment to a position
-*between* items. `lib/types/typeHints.ts:255-258` documents the scheme:
+### Multiline lists
 
+- Array items.
+- Object-literal entries.
+- Object-type properties and schema/effect payload properties.
+- Function-call arguments, including named and splat arguments, method/access
+  chain calls, and inline block arguments.
+- Interrupt, `raise`, and `guard` argument lists, which consume the same
+  multiline argument grammar.
+- `def` and `node` parameters.
+- Named imports, node imports, and named exports.
+- Array and object binding patterns.
+- Array and object match patterns.
+- Thread/subthread named arguments.
+- Parallel named arguments.
+
+### Principled exclusions
+
+These positions are out of scope because their current grammar is inline-only:
+
+- tag arguments;
+- generic type arguments and generic declaration parameters;
+- value-parameterized type arguments and declarations;
+- effect sets, `raises` lists, and block-type parameters;
+- block/lambda parameter lists;
+- `new` arguments;
+- any other list whose separators accept horizontal spaces but not newlines.
+
+If a future change makes one of those lists multiline, trailing-comment support
+becomes part of that syntax change's definition of done.
+
+Also out of scope:
+
+- trailing `/* ... */` metadata—block comments remain ordinary trivia;
+- comments inside unfinished expressions, such as between an operator and its
+  right operand;
+- placing a comma after a `//` comment—the comment owns the rest of the line, so
+  comma lists use `item, // comment`;
+- comment reflow or width-based relocation;
+- preserving exact original whitespace or delimiter spelling;
+- emitting source comments into generated TypeScript.
+
+## Architecture
+
+Two parser shapes need different metadata, but they implement one language
+rule.
+
+```diagram
+                          ┌──────────────────────────────┐
+                          │ Preserve trailing // comment │
+                          └──────────────┬───────────────┘
+                                         │
+                     ┌───────────────────┴───────────────────┐
+                     │                                       │
+                     ▼                                       ▼
+┌──────────────────────────────────┐      ┌──────────────────────────────────┐
+│ Complete construct streams       │      │ Multiline delimited lists       │
+│                                  │      │                                  │
+│ completeConstructEntry(parser)   │      │ owner.trivia: ListTrivia[]       │
+│                                  │      │                                  │
+│ BaseNode.trailingComment         │      │ placement: before | trailing     │
+└──────────────────────────────────┘      └──────────────────────────────────┘
 ```
-anchorIndex: 0                    — appears before the first property
-anchorIndex: N                    — appears between
-anchorIndex: properties.length    — appears after the last property
-```
 
-It answers "which gap is this comment in", not "which line is it at the end
-of". And `emitTriviaAt` (`lib/backends/agencyGenerator.ts:774`) can only push
-whole lines into the output. Object types, array literals, and object literals
-all share that one helper, which is why all three behave identically.
+### A leaf `LineComment` type
 
-So the fix has to add a place for the information to live.
-
-## Why not a wrapper node
-
-The obvious model is a node that wraps another node and adds a comment to it:
+`BaseNode` must not import the aggregate `lib/types.ts` module that imports it.
+Define the leaf shape beside `BaseNode`:
 
 ```ts
-type TrailingComment = { type: "trailingComment", node: AgencyNode, comment: AgencyComment }
-```
+export type LineComment = {
+  type: "comment";
+  content: string;
+  loc?: SourceLocation;
+};
 
-This is the wrong shape for this codebase, and the reason is a documented safety
-property rather than a style preference.
-
-A wrapper changes the shape of the tree. Every consumer that matches on node
-types — the walkers, the typechecker, the preprocessors, both lowering passes,
-both generators — would need to know to unwrap it. And
-`docs/dev/template-agency.md:75` records what happens when one of them doesn't:
-
-> That makes **`walkNodes`' descent completeness load-bearing for safety**: a
-> node kind whose expression children the walker misses under-reports free
-> names, no test fails, and a filler silently captures a template binder — the
-> exact bug hygiene exists to prevent, failing open.
-
-That is the failure mode. Not a crash, not a red test — a Template Agency filler
-silently capturing a binder it should not have. The corpus invariants in
-`lib/utils/expressionSlots.test.ts` exist specifically because this class of bug
-is invisible. Introducing a wrapper node that can appear in any position is
-volunteering for it.
-
-An optional **field** avoids all of it:
-
-```ts
 export type BaseNode = {
   loc?: SourceLocation;
-  /** A `//` comment that followed this node on the same source line. */
-  trailingComment?: AgencyComment;
+  trailingComment?: LineComment;
 };
 ```
 
-The tree shape is unchanged, so no walker needs to know the field exists. A
-consumer that ignores it behaves exactly as it does today. This is how every
-comparable piece of formatter-only or optional metadata is already modeled here:
-`trivia` on arrays and object types, `raises` and `markers` on function
-definitions, `loc` on everything. None of them is a wrapper node.
+`AgencyComment` remains structurally compatible. This avoids both an aggregate
+import cycle and a duplicated inline type.
 
-## The model
+An optional field is safer than a wrapper node. A wrapper changes tree shape and
+would require every walker, lowerer, checker, and generator to unwrap it.
+`docs/dev/template-agency.md` explains why walker completeness is load-bearing
+for Template Agency hygiene: a missed child can silently capture a binder.
 
-**A comment trails the node whose source range ends on that line.**
+### Exact line-comment parsing
 
-That single rule handles the case that seems hardest — a multi-line construct:
+Split the current comment parser into two layers:
 
 ```ts
-const x = someCall(
-  a,
-  b
-) // trailing on the whole statement
+export const lineCommentCore: Parser<AgencyComment> = seqC(
+  set("type", "comment"),
+  str("//"),
+  capture(manyTill(or(newline, blankLineParser)), "content"),
+);
+
+export const commentParser: Parser<AgencyComment> = map(
+  seqC(
+    optionalSpaces,
+    capture(lineCommentCore, "comment"),
+    optionalSpacesOrNewline,
+  ),
+  (result) => result.comment,
+);
 ```
 
-The comment attaches to the statement, because the statement is what ends on
-that line. The generator emits it after the closing `)`. This also survives
-reflow: the comment stays at the end of its node even if the formatter moves the
-node to a different physical line.
+`lineCommentCore` begins exactly at `//` and does not own surrounding
+whitespace. The standalone `commentParser` preserves today's behavior. Other
+parsers no longer need undocumented knowledge of `commentParser`'s whitespace
+policy.
 
-Every node carries `loc` with `start` and `end` character offsets
-(`lib/types/base.ts`), so "which node ends here" is computable. Note that
-`loc.line` is the node's *start* line only — the end line has to be derived from
-the `end` offset.
+### Complete constructs: a reusable decorator
 
-**Only `//` comments.** A `//` comment necessarily runs to the end of its line,
-so "the code before it on this line" is unambiguous. A `/* ... */` comment can
-have code after it on the same line, which makes "trailing" undefined —
-`const x = 5 /* why */ + 1` is not a trailing comment at all. Block comments
-keep today's behavior.
-
-## Phase 1 — statements in a body
-
-This is the common case and the one agents hit. It is also the simplest, because
-a statement's trailing comment is already parsed as its immediate next sibling.
-
-### Parser
-
-One site: `_bodyParserImpl` (`lib/parsers/parsers.ts:4804`). Today each
-iteration parses a node then consumes `optionalSpacesOrNewline`. Change it so
-that after parsing a node, the parser looks ahead past spaces **but not past a
-newline** for a comment. If it finds one, it attaches it as `trailingComment` on
-the node just parsed and consumes it, instead of letting the next loop iteration
-pick it up as a sibling.
-
-The distinction is entirely "did we cross a newline first". A comment on its own
-line is still a sibling body node and keeps today's behavior, which is correct —
-that is what a standalone comment is.
-
-### Generator
-
-`AgencyGenerator` renders a body one node per line. Where a body statement's
-line is produced, append `" " + this.processComment(node.trailingComment)` when
-the field is set. `processComment` already exists at
-`lib/backends/agencyGenerator.ts:1607`.
-
-### What Phase 1 covers
-
-Any statement in any body: node bodies, function bodies, `if` and `while` and
-`for` bodies, `handle` blocks, `guard` blocks, `thread` blocks. All of them go
-through `bodyParser`, so one parser change covers them all.
-
-## Phase 2 — items in literals and type bodies
+Top-level and body child parsers consume inconsistent amounts of trailing
+whitespace. The decorator must inspect the trailing whitespace in the source
+the wrapped parser consumed; checking only `rest` is incorrect because a child
+may already have consumed the newline before a standalone comment.
 
 ```ts
-const arr = [
-  1, // one
-  2, // two
+type TrailingCommentOwner = {
+  type: string;
+  trailingComment?: LineComment;
+};
+
+type TrailingCommentOptions<T> = {
+  canAttach?: (value: T) => boolean;
+};
+
+function consumedLineEnding(input: string, rest: string): boolean {
+  const consumedLength = input.length - rest.length;
+  const consumed = input.slice(0, consumedLength);
+  const trailingWhitespace = consumed.match(/[ \t\r\n]*$/)?.[0] ?? "";
+  return /[\r\n]/.test(trailingWhitespace);
+}
+
+export function withTrailingLineComment<T extends TrailingCommentOwner>(
+  parser: Parser<T>,
+  options: TrailingCommentOptions<T> = {},
+): Parser<T> {
+  return (input: string) => {
+    const parsed = parser(input);
+    if (!parsed.success) {
+      return parsed;
+    }
+
+    if (options.canAttach && !options.canAttach(parsed.result)) {
+      return parsed;
+    }
+
+    if (consumedLineEnding(input, parsed.rest)) {
+      return parsed;
+    }
+
+    const comment = seqR(optionalSpaces, lineCommentCore)(parsed.rest);
+    if (!comment.success) {
+      return parsed;
+    }
+
+    return success(
+      { ...parsed.result, trailingComment: comment.result },
+      comment.rest,
+    );
+  };
+}
+
+export function completeConstructEntry<T extends TrailingCommentOwner>(
+  parser: Parser<T>,
+  options?: TrailingCommentOptions<T>,
+): Parser<T> {
+  return map(
+    seqC(
+      capture(withTrailingLineComment(parser, options), "value"),
+      optionalSpacesOrNewline,
+    ),
+    (result) => result.value,
+  );
+}
+```
+
+`withTrailingLineComment` owns the same-line decision and leaves the line ending
+in `rest`. A second shared `completeConstructEntry` composes it with
+`optionalSpacesOrNewline`. Top-level, body, and match-arm streams consume that
+complete entry, so every stream advances past an attached comment without
+duplicating cursor logic. Body/top-level call sites supply a declarative
+`canAttach` policy where trivia alternatives share the same parser union.
+
+The owner's `loc.end` does **not** extend through the comment. Existing source
+replacement and diagnostic code treats the construct's location as its
+syntactic range; the comment remains separate formatter metadata.
+
+### Lists: compatibility-preserving placement metadata
+
+Lists own their trivia because the separator belongs before a trailing comment:
+
+```agency
+first, // comment
+```
+
+Attaching the comment to the expression would make generic expression rendering
+produce the invalid order `first // comment,`.
+
+Unify the existing `Trivia` and `ObjectTypeTrivia` shapes without changing
+serialized ASTs for existing standalone comments:
+
+```ts
+export type BeforeListTrivia = {
+  anchorIndex: number;
+  comments: TriviaNode[];
+  placement?: "before";
+};
+
+export type TrailingListTrivia = {
+  anchorIndex: number;
+  placement: "trailing";
+  comments: [LineComment];
+};
+
+export type ListTrivia = BeforeListTrivia | TrailingListTrivia;
+
+export type Trivia = ListTrivia;
+export type ObjectTypeTrivia = ListTrivia;
+```
+
+For `before`, `anchorIndex` is the item the trivia precedes; `items.length`
+means before the closer. Existing parser output omits `placement`, preserving
+current AST snapshots. For `trailing`, `anchorIndex` is the item the line
+comment follows.
+
+Multiple entries may share an anchor. For example:
+
+```agency
+[
+  first, // explains first
+  // prepares second
+  second,
 ]
 ```
 
-Arrays, object literals, and object types already anchor comments by index. What
-is missing is one bit per trivia entry distinguishing the two placements:
+produces a trailing record for item 0 and a before record for item 1. The
+generator must process all matching entries, not use `.find(...)`.
+
+### Shared list parsing without erasing separator rules
+
+Share trivia classification, partitioning, and result shape. Do not force all
+lists through one separator policy. Agency has at least:
+
+1. comma lists, where another item requires a comma;
+2. object-type lists, where comma, semicolon, or newline separates properties;
+3. match-arm streams, which contain complete constructs and use the decorator.
+
+The common list result is:
 
 ```ts
-export type Trivia = {
-  anchorIndex: number;
-  comments: TriviaNode[];
-  /** True when these comments trailed item `anchorIndex - 1` on its own line,
-   *  rather than sitting on their own line before item `anchorIndex`. */
-  trailing?: boolean;
+export type ParsedList<T> = {
+  items: T[];
+  trivia?: ListTrivia[];
 };
 ```
 
-`ObjectTypeTrivia` gets the same field. The generator change is confined to
-`emitTriviaAt` (`lib/backends/agencyGenerator.ts:774`) plus its three callers,
-since a trailing entry must be appended to the previous line rather than pushed
-as a new one — which means `emitTriviaAt` needs to return the trailing text
-instead of only pushing lines.
-
-Splitting a single trivia entry that holds both kinds is the fiddly part: a
-trailing comment and then a standalone comment before the next item are both
-anchored at the same index and must not be merged. The cleanest handling is to
-let the parser emit two entries at the same `anchorIndex`, one flagged trailing
-and one not, and have the generator emit the trailing one first.
-
-## Phase 3 — argument and parameter lists — deferred
+A comma-list parser accepts the item parser plus explicit policy data:
 
 ```ts
-foo(
-  a, // first
-  b
-)
+type CommaListPolicy = {
+  closer: string;
+  cardinality: "zero-or-more" | "one-or-more";
+  trailingComma: "allow" | "reject";
+};
 ```
 
-Function calls and parameter lists have no trivia at all today, so this needs
-the anchoring infrastructure built from scratch for them, not just extended.
-Deferred, and possibly indefinitely — this is a much rarer shape in agent-written
-code than the first two.
+This retains each grammar's load-bearing missing-comma checks without silently
+broadening trailing-comma or empty-list behavior. Arrays, objects, calls, and
+parameters keep their existing policies. Node imports and binding/match
+patterns continue to reject trailing commas. Object-type members keep their
+separate punctuation-or-newline policy and permit an undelimited final member.
+The comma-list source order is:
 
-## The reflow rule
+1. item;
+2. horizontal whitespace;
+3. comma when another item follows;
+4. horizontal whitespace;
+5. optional same-line `//` trailing trivia;
+6. line ending and standalone trivia;
+7. next item or closer.
 
-The genuine hazard is not modeling, it is collapsing. If the formatter takes a
-multi-line construct holding two trailing comments and prints it on one line,
-both comments end up on the same output line and the result is nonsense — or,
-worse, unparseable.
+The final item may use `item // comment` before a closer on the next line. A
+non-final item must use `item, // comment`.
 
-**A construct containing trailing comments never collapses to one line.**
+### AST ownership
 
-There is direct precedent. `armPrintsInline`
-(`lib/backends/agencyGenerator.ts:1484`) already governs when a one-statement
-match arm may print inline, and its rule is "the author's form wins: an arm
-written as a block prints as a block." PR #712 tightened it further so that an
-arm only collapses when the single-statement grammar can re-parse the result,
-with the reasoning that degrading to block form is "more verbose, never
-unparseable — the right failure direction for a formatter." The same reasoning
-applies unchanged here.
+Named fields make the list being described explicit when a node can own more
+than one list:
+
+```ts
+FunctionCall.argumentTrivia?: ListTrivia[];
+FunctionDefinition.parameterTrivia?: ListTrivia[];
+GraphNodeDefinition.parameterTrivia?: ListTrivia[];
+InterruptStatement.argumentTrivia?: ListTrivia[];
+GuardBlock.argumentTrivia?: ListTrivia[];
+type CallChainElement = {
+  kind: "call";
+  optional?: boolean;
+} & Pick<FunctionCall, "arguments" | "block" | "argumentTrivia">;
+NamedImport.nameTrivia?: ListTrivia[];
+ImportNodeStatement.nodeTrivia?: ListTrivia[];
+NamedExportBody.nameTrivia?: ListTrivia[];
+ArrayPattern.elementTrivia?: ListTrivia[];
+ObjectPattern.propertyTrivia?: ListTrivia[];
+MessageThread.argumentTrivia?: ListTrivia[];
+ParallelBlock.argumentTrivia?: ListTrivia[];
+MatchBlockCase.trailingComment?: LineComment;
+```
+
+Arrays, objects, and object types retain their existing `trivia` field names.
+
+Function-call inline blocks need explicit re-anchoring. The parser currently
+extracts an inline block from `arguments`, and the formatter canonicalizes it to
+the last argument. Trivia must move with its source item into that canonical
+order. A standalone comment before the following source argument remains with
+that following argument. Remapping validates that canonical source indexes are
+a permutation and rejects an unmapped anchor instead of producing
+`anchorIndex: undefined`. Rendering uses a virtual item list containing ordinary
+arguments followed by the extracted inline block, so the block cannot disappear
+on the trivia-aware path.
+
+### Generator interfaces
+
+Separate comment text from standalone placement:
+
+```ts
+protected commentText(comment: LineComment): string {
+  return `//${comment.content}`;
+}
+
+protected processComment(comment: AgencyComment): string {
+  return this.indentStr(this.commentText(comment));
+}
+
+protected appendTrailingComment(
+  code: string,
+  comment: LineComment | undefined,
+): string {
+  return comment ? `${code} ${this.commentText(comment)}` : code;
+}
+```
+
+`processNode` uses `appendTrailingComment` for ordinary complete constructs.
+Sorted imports bypass ordinary `processNode`, so their sorting render path must
+append the comment after moving the import. Match arms use the same helper.
+
+Delimited lists use a shared multiline renderer. An item renderer returns
+structured `{ leadingLines?, code }` data, allowing object-property tags and
+similar item-owned lines without passing pre-indented multiline strings through
+the abstraction. With no trivia, callers retain the existing `wrapList` output.
+With trivia, rendering must:
+
+1. force multiline form;
+2. emit every before record for the item;
+3. render the item and its canonical separator;
+4. append every trailing record for that item;
+5. emit before records anchored at the closer.
+
+A construct containing trailing comments never collapses to one line.
 
 ## Testing
 
-Round-trip tests are the core of this. For each supported position: parse source
-with a trailing comment, format, and assert the output is byte-identical to the
-input. That single assertion covers both the parser attaching correctly and the
-generator emitting in the right place.
+Formatter tests assert canonical expected output, successful reparsing, and a
+second-format fixed point. Byte identity is not required because imports,
+spacing, delimiters, and inline-block position already canonicalize.
 
-Specific cases to pin:
+Required coverage includes:
 
-- **Every body kind.** A trailing comment on a statement inside a node body,
-  function body, `if`, `while`, `for`, `handle`, `guard`, and `thread` block.
-- **The relocation regression.** The exact case from the Background —
-  `const x = 5 // explains x` followed by `const y = 6` — must round-trip with
-  the comment still on the first line. This is the bug the whole spec exists for.
-- **Multi-line node.** A comment after the closing `)` of a call spanning several
-  lines attaches to the statement and stays after the `)`.
-- **Standalone comments are unaffected.** A comment on its own line stays a
-  sibling body node and renders on its own line. This is the negative case that
-  proves the newline check works.
-- **Last statement in a body.** A trailing comment on the final statement, with
-  the closing `}` on the next line.
-- **Block comments keep old behavior.** `const x = 5 /* why */` does not attach.
-- **No collapse.** A construct holding trailing comments stays expanded even when
-  it would otherwise print inline.
-- **Idempotence.** Formatting twice changes nothing on the second pass.
+- top-level declarations and sorted imports whose comments move with them;
+- standalone-comment negatives after assignment, return, call, block, and blank
+  line paths that consume whitespace differently;
+- every body owner listed above;
+- inline and block match arms;
+- a comment after the closing `)` of a multiline call statement;
+- unchanged owner `loc.end`;
+- existing array/object/object-type trivia AST snapshots with no new
+  `placement` field;
+- missing-comma regressions for arrays and objects;
+- trailing plus standalone comments at the same logical list boundary;
+- parser progress after a trailing comment on a non-final match arm and list
+  item;
+- a standalone comment after a nested item parser that consumes its newline;
+- non-final and final items in each supported list family;
+- calls with positional, named, splat, access-chain, and inline-block arguments;
+- interrupt, `raise`, and `guard` arguments;
+- function and node parameters, including variadic, defaulted, and validated
+  parameters;
+- imports, exports, binding patterns, match patterns, thread args, and parallel
+  args;
+- tagged object-type properties with trailing comments;
+- unchanged cardinality and trailing-comma acceptance for every migrated list
+  family;
+- block comments remaining ordinary before-trivia;
+- test TypeScript compilation, structural lint, unit tests, formatter corpus,
+  build, and parser performance.
 
-Phase 2 adds the same battery for array items, object literal fields, and object
-type members, plus the mixed case where one item has a trailing comment and the
-next is preceded by a standalone one.
+Comments have no runtime semantics, so no Agency execution tests or LLM calls
+are needed.
 
-No Agency execution tests are needed. Comments have no runtime meaning; this is
-entirely a parse-and-print change.
+## Compatibility and safety
 
-## Risks and open questions
+- No wrapper node is introduced, preserving walker completeness.
+- Existing ASTs without trailing comments do not gain fields.
+- Existing before-trivia records do not gain `placement`.
+- Existing `Trivia` and `ObjectTypeTrivia` exported names remain aliases.
+- `loc` continues to describe the syntactic owner, not attached formatter
+  metadata.
+- Literal comma requirements remain unchanged.
+- Handlers remain ordinary body consumers; the shared body decorator must never
+  skip or unregister them.
+- The TypeScript generator ignores formatter-only trivia exactly as it does
+  today.
 
-**`BaseNode` is universal.** Adding `trailingComment` to `BaseNode` puts the
-field on every node type in the language, including ones that can never carry a
-trailing comment because they are not statements. That is harmless — it is
-optional and nothing reads it unless set — and it matches how `loc` is already
-handled. The alternative, declaring it on each statement type individually,
-means a long list that will drift as node types are added. `BaseNode` is the
-right call, but it is worth naming the trade-off rather than pretending there
-isn't one.
+## Delivery
 
-**Exact-match AST tests.** Some parser tests assert on whole AST objects. Adding
-an optional field does not change any existing tree, since the field is only
-present when a trailing comment was actually found, so those should be
-unaffected. Worth confirming early rather than discovering late.
+This is one language feature delivered in reviewable milestones:
 
-**The TypeScript generator.** This spec covers `AgencyGenerator` only, since the
-motivating problem is `agency fmt` rearranging a user's file. Carrying trailing
-comments into generated TypeScript would make compiled output more readable, but
-nothing depends on it and it is a separate change.
+1. complete-construct metadata, parsing, and rendering;
+2. shared list metadata and migration of existing trivia-aware lists;
+3. call arguments and declaration parameters;
+4. remaining already-multiline surfaces;
+5. documentation and compatibility verification.
 
-**Interaction with `loc` offsets.** Attaching a comment to the preceding node
-does not change that node's `loc.end`, so a node's recorded range will no longer
-cover everything the parser consumed for it. Nothing currently depends on that
-being exact for statements, but source-map generation and the LSP both read
-`loc`, so this deserves a check before implementation rather than an assumption.
-
-## Out of scope
-
-- **Making trailing comments idiomatic.** This spec makes them survive; it does
-  not make them recommended. The guide should keep advising against them until
-  Phase 1 lands, then say plainly which positions honor them.
-- **Comment reflow or rewrapping.** A long trailing comment stays long. The
-  formatter does not move it to its own line to fit a width budget.
-- **Attaching comments to expressions inside a line.** `foo(a /* x */, b)`
-  stays as-is. Only end-of-line comments are in scope.
+The guide should publish the universal rule only after all milestones land.


### PR DESCRIPTION
Four documents that existed only inside working trees during the trailing-comment work (#767, #768, #770, #772, #774). They would have been lost when those trees were removed, so I copied them out before cleanup and this puts them somewhere durable.

- `specs/2026-07-31-trailing-comments-design.md` — **updated.** The version on `main` predates its revisions; this is the revised one (+661 lines of changes).
- `plans/2026-08-01-trailing-comments.md` — **new.** The implementation plan, as revised.
- `plans/2026-08-01-trailing-comments-review.md` — **new.** Review notes on that plan.
- `plans/2026-08-01-type-printer-trivia-review.md` — **new.** Review notes on the type-printer plan.

These are work artifacts. The durable reference for how the feature actually behaves is `docs/dev/trailing-comments.md`, which landed with #774.

Note the type-printer *plan* itself is deliberately not here — it was dropped from #774 on review, on the grounds that the dev doc supersedes it. Only its review notes are restored, since those were never committed anywhere. Happy to restore the plan too if you would rather the pair stayed together.

Docs only; no code changes.
