### PR TITLE
A template can only use names it declares itself (AG8015)

### DIFF
--- a/packages/agency-lang/docs/site/diagnostics/index.md
+++ b/packages/agency-lang/docs/site/diagnostics/index.md
@@ -161,6 +161,7 @@ or suppress a type-checker one on the next line with `// @tc-ignore AG####`.
 | [AG8012](templates.md#ag8012) | The generator `&#123;name&#125;` declares `&#123;declared&#125;`, which this file already declares. Generated declarations may not replace existing ones. |
 | [AG8013](templates.md#ag8013) | The generator `&#123;name&#125;` produced an exported declaration (`&#123;declared&#125;`). Generated declarations cannot be exported yet, because other files resolve imports without running generators. Remove the `export`. |
 | [AG8014](templates.md#ag8014) | The generator `&#123;name&#125;` returned &#123;kind&#125;, which cannot sit at the top level of a file. Top-level code runs at initialization, which cannot branch, loop, or wait. |
+| [AG8015](templates.md#ag8015) | `&#123;name&#125;` is not defined in this template. A template can only use names it declares or imports itself, because a hole hides whatever fills it. Move the code that defines `&#123;name&#125;` into this template, or move the code that uses it into the fragment that defines it. |
 
 ## Lint
 

--- a/packages/agency-lang/docs/site/diagnostics/templates.md
+++ b/packages/agency-lang/docs/site/diagnostics/templates.md
@@ -182,3 +182,15 @@ Lifting this restriction is tracked as issue #687.
 A splice at the top level of a file adds the generator's output to the file, so that output is held to the same rule as anything you write there yourself: top-level code runs at initialization and cannot branch, loop, or wait.
 
 **How to fix:** have the generator return declarations (`node`, `def`, `type`), bindings, or plain calls. If it needs to branch, put the branching inside a `def` it declares, or splice it inside a node body instead.
+
+<a id="ag8015"></a>
+
+## AG8015 — `&#123;name&#125;` is not defined in this template. A template can only use names it declares or imports itself, because a hole hides whatever fills it. Move the code that defines `&#123;name&#125;` into this template, or move the code that uses it into the fragment that defines it.
+
+*Default severity: error.*
+
+A template is checked before anything fills it, so a hole is opaque: the checker cannot see what will arrive there, and neither can the code around it.
+
+This also covers names from the file the template is written in. A template becomes its own program — `toSource` prints it and `runCode` compiles the print — and the surrounding file is not there when that happens.
+
+**How to fix:** keep each fragment self-contained. Move the code that defines the name into the template, or move the code that uses it into the fragment that defines it. A template may always use the prelude, language builtins, and anything it declares or imports itself.

--- a/packages/agency-lang/docs/site/guide/template-agency.md
+++ b/packages/agency-lang/docs/site/guide/template-agency.md
@@ -215,6 +215,40 @@ The filler must be a plain string that is a legal identifier. Anything else is r
 
 A declaration hole is a bare `#name` at the top level of a file. They accept more than a statement — you can give whole declarations like functions, nodes, types, and imports.
 
+## What names a template can use
+
+A template can use the prelude and the built-in functions, plus whatever it declares or imports itself. It cannot use a name from the file around it, and it cannot use a name that arrives through a hole. A hole is opaque while the template is checked, so the compiler has no way to know what will fill it, and the file the template turns into does not contain the surrounding program at all.
+
+So this is rejected, because `helper` lives in the host file and will not exist in the generated program:
+
+```ts
+def helper(): string {
+  return "hi"
+}
+
+static const template = [|
+  node main(): string {
+    return helper()   // AG8015: `helper` is not defined in this template
+  }
+|]
+```
+
+Move the definition into the template, and it works:
+
+```ts
+static const template = [|
+  def helper(): string {
+    return "hi"
+  }
+
+  node main(): string {
+    return helper()
+  }
+|]
+```
+
+The same rule applies when you compose. A fragment that fills a hole cannot supply a function that another fragment calls: keep the definition and its callers together in one fragment, and use holes for the parts that vary.
+
 ## Composing templates
 
 Here's a template for a main node where the body is empty:

--- a/packages/agency-lang/lib/typeChecker/codeLiteral.test.ts
+++ b/packages/agency-lang/lib/typeChecker/codeLiteral.test.ts
@@ -77,9 +77,14 @@ describe("code literals: typechecking", () => {
     expect(codesOf(source)).toEqual([]);
   });
 
-  it("names inside a body produce no host diagnostics (quoted-leaf proof)", () => {
+  it("names inside a body are not checked against the HOST scope (quoted-leaf proof)", () => {
+    // The leaf property still holds: the host checker does not resolve a
+    // quoted name against host declarations. What changed is that the
+    // template pass now resolves it against the TEMPLATE's own scope, so
+    // an undefined name there is AG8015 rather than silence.
+    //
     // Non-vacuous by construction: the SAME undefined name at host level
-    // is the sanity anchor below.
+    // is the sanity anchor below, and it reports a different code.
     const quoted = [
       "node main(): number {",
       "  const t = [| definitelyNotAHostName() |]",
@@ -87,7 +92,8 @@ describe("code literals: typechecking", () => {
       "}",
       "",
     ].join("\n");
-    expect(messagesOf(quoted).filter((m) => m.includes("definitelyNotAHostName"))).toEqual([]);
+    expect(codesOf(quoted)).not.toContain("AG4004");
+    expect(codesOf(quoted)).toContain("AG8015");
   });
 
   it("sanity anchor: the same undefined name AT HOST LEVEL does diagnose", () => {

--- a/packages/agency-lang/lib/typeChecker/diagnosticExplanations.ts
+++ b/packages/agency-lang/lib/typeChecker/diagnosticExplanations.ts
@@ -497,6 +497,12 @@ def f(): string {
 
 **How to fix:** move the \`handle\` block inside the node or function whose work it should guard.`,
 
+  templateNameNotDefined: `A template is checked before anything fills it, so a hole is opaque: the checker cannot see what will arrive there, and neither can the code around it.
+
+This also covers names from the file the template is written in. A template becomes its own program — \`toSource\` prints it and \`runCode\` compiles the print — and the surrounding file is not there when that happens.
+
+**How to fix:** keep each fragment self-contained. Move the code that defines the name into the template, or move the code that uses it into the fragment that defines it. A template may always use the prelude, language builtins, and anything it declares or imports itself.`,
+
   unfilledHoles: `This file contains template holes (\`#name\`), which mark gaps for code or values to be filled in later. A file with unfilled holes is a template, not a program, so it cannot be compiled or run directly.
 
 **How to fix:** load the file with \`loadTemplate\`, fill every hole with \`fill\`, and run the completed program (for example with \`runCode(toSource(filled))\`). Use \`holesOf\` to list what still needs filling.`,

--- a/packages/agency-lang/lib/typeChecker/diagnostics.ts
+++ b/packages/agency-lang/lib/typeChecker/diagnostics.ts
@@ -626,6 +626,12 @@ export const DIAGNOSTICS = {
     message:
       "The generator `{name}` reaches non-Agency code through `{importPath}`. Compile-time generators may import only `std::` modules and relative `.agency` files, because JavaScript raises no interrupts and cannot be checked. Set `allowNonAgencyGenerators` in your config to permit it.",
   },
+  templateNameNotDefined: {
+    code: "AG8015",
+    severity: "error",
+    message:
+      "`{name}` is not defined in this template. A template can only use names it declares or imports itself, because a hole hides whatever fills it. Move the code that defines `{name}` into this template, or move the code that uses it into the fragment that defines it.",
+  },
   spliceTopLevelStatement: {
     code: "AG8014",
     severity: "error",

--- a/packages/agency-lang/lib/typeChecker/index.ts
+++ b/packages/agency-lang/lib/typeChecker/index.ts
@@ -48,6 +48,7 @@ import { checkDefiniteReturns } from "./definiteReturns.js";
 import { checkConflictingMarkers } from "./conflictingMarkers.js";
 import { checkParamDefaultOrder } from "./paramDefaultOrder.js";
 import { checkTemplateHoles } from "./templateHoles.js";
+import { checkTemplateNames } from "./templateNames.js";
 import { checkTopLevelStatements } from "./topLevelStatements.js";
 import { refineInlineHandlerParams } from "./handlerParamTyping.js";
 import { declareFinalizeBinders } from "./finalizeBinder.js";
@@ -373,6 +374,9 @@ export class TypeChecker {
     // Template holes: an expression hole in a position that supplies no
     // type must carry an inline annotation (AG8002).
     checkTemplateHoles(ctx);
+
+    // A template can only use names it declares or imports itself (AG8015).
+    checkTemplateNames(ctx);
 
     // Top-level code is initialization: it may establish something but not
     // control anything (AG3017, AG3018).

--- a/packages/agency-lang/lib/typeChecker/nameReferences.ts
+++ b/packages/agency-lang/lib/typeChecker/nameReferences.ts
@@ -1,0 +1,87 @@
+import type { AgencyNode, FunctionCall, VariableNameLiteral } from "../types.js";
+import type { WalkAncestor } from "../utils/node.js";
+
+/**
+ * Which AST positions hold a lexical name that has to resolve.
+ *
+ * Shared by the ordinary undefined-name diagnostics and the template one,
+ * so all three make the same call. Not every `variableName` is a lookup
+ * and not every `functionCall` is a bare call, and a pass that gets those
+ * rules half right reports correct code.
+ */
+
+/** Is this node inside a `def` or `node` body?
+ *
+ *  Those bodies have their own scope, so the top-level walk skips them or
+ *  every name in them fires twice. */
+export function hasFunctionOrNodeAncestor(
+  ancestors: readonly unknown[],
+): boolean {
+  for (const ancestor of ancestors) {
+    const type = (ancestor as AgencyNode | undefined)?.type;
+    if (type === "function" || type === "graphNode") {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Is this `variableName` a real read that has to resolve?
+ *
+ * Three positions look like reads and are not. A property name in
+ * `obj.x` is not a lookup. A `for` binder is a declaration. A block-call
+ * parameter, as in `xs.map(\(item) -> item)`, is a binding the
+ * typechecker's `Scope` does not track at all, so resolving it would
+ * always fail.
+ */
+export function isResolvableVariableReference(
+  ref: VariableNameLiteral,
+  ancestors: readonly WalkAncestor[],
+): boolean {
+  const parent = ancestors[ancestors.length - 1] as AgencyNode | undefined;
+  if (!parent) {
+    return false;
+  }
+  // The base of `obj.x` is a real reference. The property is not, and
+  // walkNodes does not yield it as a standalone name anyway.
+  if (parent.type === "valueAccess" && parent.base !== ref) {
+    return false;
+  }
+  for (const ancestor of ancestors) {
+    const node = ancestor as AgencyNode;
+    if (node.type === "forLoop") {
+      if (ref.value === node.itemVar || ref.value === node.indexVar) {
+        return false;
+      }
+    }
+    if ((ancestor as { type: string }).type === "blockArgument") {
+      const block = ancestor as {
+        type: "blockArgument";
+        params: { name: string }[];
+      };
+      if (block.params.some((param) => param.name === ref.value)) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+/**
+ * Is this `functionCall` a bare call whose name has to resolve?
+ *
+ * A synthetic call has no declaration to find, and the builder compiles
+ * it away. A call under a `valueAccess` is `obj.foo()`, where `foo` is a
+ * method rather than a lexical name; the access chain checks it instead.
+ */
+export function isResolvableBareCall(
+  call: FunctionCall,
+  ancestors: readonly WalkAncestor[],
+): boolean {
+  if (call.synthetic) {
+    return false;
+  }
+  const parent = ancestors[ancestors.length - 1] as AgencyNode | undefined;
+  return parent?.type !== "valueAccess";
+}

--- a/packages/agency-lang/lib/typeChecker/nameReferences.ts
+++ b/packages/agency-lang/lib/typeChecker/nameReferences.ts
@@ -29,11 +29,15 @@ export function hasFunctionOrNodeAncestor(
 /**
  * Is this `variableName` a real read that has to resolve?
  *
- * Three positions look like reads and are not. A property name in
- * `obj.x` is not a lookup. A `for` binder is a declaration. A block-call
- * parameter, as in `xs.map(\(item) -> item)`, is a binding the
- * typechecker's `Scope` does not track at all, so resolving it would
- * always fail.
+ * Two positions look like reads and are not. A `for` binder is a
+ * declaration. A block-call parameter, as in `xs.map(\(item) -> item)`,
+ * is a binding the typechecker's `Scope` does not track at all, so
+ * resolving it would always fail.
+ *
+ * Names under a `valueAccess` are all real reads. A property name is not
+ * a lookup, but `walkNodes` never yields one as a standalone name; what
+ * it does yield with the access as parent is the base and the index and
+ * slice expressions, as in `obj[i]` and `obj[lo:hi]`.
  */
 export function isResolvableVariableReference(
   ref: VariableNameLiteral,
@@ -41,11 +45,6 @@ export function isResolvableVariableReference(
 ): boolean {
   const parent = ancestors[ancestors.length - 1] as AgencyNode | undefined;
   if (!parent) {
-    return false;
-  }
-  // The base of `obj.x` is a real reference. The property is not, and
-  // walkNodes does not yield it as a standalone name anyway.
-  if (parent.type === "valueAccess" && parent.base !== ref) {
     return false;
   }
   for (const ancestor of ancestors) {

--- a/packages/agency-lang/lib/typeChecker/templateNames.test.ts
+++ b/packages/agency-lang/lib/typeChecker/templateNames.test.ts
@@ -357,4 +357,85 @@ describe("AG8015: template files", () => {
     expect(codesOf(source)).toContain("AG4004");
     expect(codesOf(source)).not.toContain("AG8015");
   });
+
+  it("still checks a literal inside a file that has its own hole", () => {
+    // The whole-file walk treats a literal's nodes as opaque, so the
+    // literal loop has to keep running after the file-level report.
+    const source = [
+      "#helpers",
+      "",
+      "node main(): string {",
+      "  const template = [|",
+      "    node inner(): string {",
+      "      return missingInLiteral()",
+      "    }",
+      "  |]",
+      '  return "x"',
+      "}",
+      "",
+    ].join("\n");
+    expect(messageFor(source, "AG8015")).toBeDefined();
+    const names = diagnosticsOf(source)
+      .filter((found) => found.code === "AG8015")
+      .map((found) => found.message);
+    expect(names.some((message) => message.includes("missingInLiteral"))).toBe(
+      true,
+    );
+  });
+
+  it("keeps checking JS namespace members in a template file", () => {
+    // AG8015 sees `nosuch` as a method, not a lexical name, so the
+    // ordinary pass has to keep covering this position.
+    const source = [
+      "#helpers",
+      "",
+      "node main(): number {",
+      "  return Math.nosuch(1)",
+      "}",
+      "",
+    ].join("\n");
+    expect(codesOf(source)).toContain("AG4004");
+  });
+});
+
+describe("AG8015: names reached through an access", () => {
+  it("reports an index expression the template does not define", () => {
+    const source = withLiteral([
+      "    const items = [1, 2]",
+      "    print(items[missingIndex])",
+    ]);
+    expect(codesOf(source)).toContain("AG8015");
+    expect(messageFor(source, "AG8015")).toMatch(/missingIndex/);
+  });
+
+  it("says nothing about an index the template declares", () => {
+    const source = withLiteral([
+      "    const items = [1, 2]",
+      "    const i = 0",
+      "    print(items[i])",
+    ]);
+    expect(codesOf(source)).not.toContain("AG8015");
+  });
+});
+
+describe("AG8015: a template's own imported node", () => {
+  it("says nothing about a direct call to it", () => {
+    const source = withLiteral([
+      '    import node { helper } from "./helper.agency"',
+      "",
+      "    node main(): string {",
+      "      return helper()",
+      "    }",
+    ]);
+    expect(codesOf(source)).not.toContain("AG8015");
+  });
+
+  it("says nothing about a first-class reference to it", () => {
+    const source = withLiteral([
+      '    import node { helper } from "./helper.agency"',
+      "",
+      "    const tool = helper",
+    ]);
+    expect(codesOf(source)).not.toContain("AG8015");
+  });
 });

--- a/packages/agency-lang/lib/typeChecker/templateNames.test.ts
+++ b/packages/agency-lang/lib/typeChecker/templateNames.test.ts
@@ -1,0 +1,285 @@
+import { describe, expect, it } from "vitest";
+import { typeCheckSource } from "../compiler/typecheck.js";
+
+function diagnosticsOf(source: string) {
+  const report = typeCheckSource(source);
+  return [...report.errors, ...report.warnings];
+}
+
+function codesOf(source: string): string[] {
+  return diagnosticsOf(source).map((diagnostic) => diagnostic.code);
+}
+
+function messageFor(source: string, code: string): string | undefined {
+  return diagnosticsOf(source).find((diagnostic) => diagnostic.code === code)
+    ?.message;
+}
+
+/** A host file with `body` inside a code literal. */
+function withLiteral(body: string[]): string {
+  return [
+    "node host() {",
+    "  const template = [|",
+    ...body,
+    "  |]",
+    '  print("host")',
+    "}",
+    "",
+  ].join("\n");
+}
+
+describe("AG8015: names a template does not define", () => {
+  it("reports a variable a statement hole would supply", () => {
+    const source = withLiteral([
+      "    node main() {",
+      "    #body",
+      "      print(res)",
+      "    }",
+    ]);
+    expect(codesOf(source)).toContain("AG8015");
+  });
+
+  it("reports a call a declaration hole would supply", () => {
+    // A FunctionCall's name is a plain string, not a variableName node, so
+    // a variable-only walk would miss this entirely.
+    const source = withLiteral([
+      "    #helpers",
+      "",
+      "    export node main(): string {",
+      "      return guarded()",
+      "    }",
+    ]);
+    expect(codesOf(source)).toContain("AG8015");
+    expect(messageFor(source, "AG8015")).toMatch(/guarded/);
+  });
+
+  it("reports a call to a helper that exists only in the host file", () => {
+    const source = [
+      "def helper(): string {",
+      '  return "hi"',
+      "}",
+      "",
+      "node host() {",
+      "  const template = [|",
+      "    node main(): string {",
+      "      return helper()",
+      "    }",
+      "  |]",
+      '  print("host")',
+      "}",
+      "",
+    ].join("\n");
+    expect(codesOf(source)).toContain("AG8015");
+    expect(messageFor(source, "AG8015")).toMatch(/helper/);
+  });
+
+  it("reports a first-class reference to a host helper", () => {
+    const source = [
+      "def helper(): string {",
+      '  return "hi"',
+      "}",
+      "",
+      "node host() {",
+      "  const template = [|",
+      "    const tool = helper",
+      "  |]",
+      '  print("host")',
+      "}",
+      "",
+    ].join("\n");
+    expect(codesOf(source)).toContain("AG8015");
+  });
+
+  it("reports a local read from a sibling definition", () => {
+    // One flat scope would let this resolve. Each definition has its own.
+    const source = withLiteral([
+      "    def first(): number {",
+      "      const secret = 1",
+      "      return secret",
+      "    }",
+      "",
+      "    def second(): number {",
+      "      return secret",
+      "    }",
+    ]);
+    expect(codesOf(source)).toContain("AG8015");
+  });
+
+  it("reports a misspelled direct call", () => {
+    const source = withLiteral([
+      "    def greet(): string {",
+      '      return "hi"',
+      "    }",
+      "",
+      "    def main(): string {",
+      "      return greeet()",
+      "    }",
+    ]);
+    expect(codesOf(source)).toContain("AG8015");
+    expect(messageFor(source, "AG8015")).toMatch(/greeet/);
+  });
+});
+
+describe("AG8015: names a template does define", () => {
+  // Over-rejection guards. Each covers a pattern real templates use, and
+  // a flat scope model fails most of them.
+
+  it("a parameter of a nested def", () => {
+    const source = withLiteral([
+      "    def greet(name: string): string {",
+      "      return name",
+      "    }",
+    ]);
+    expect(codesOf(source)).not.toContain("AG8015");
+  });
+
+  it("a parameter of a nested node", () => {
+    const source = withLiteral([
+      "    node main(topic: string): string {",
+      "      return topic",
+      "    }",
+    ]);
+    expect(codesOf(source)).not.toContain("AG8015");
+  });
+
+  it("a local declared inside one nested definition", () => {
+    const source = withLiteral([
+      "    def f(): number {",
+      "      const x = 1",
+      "      return x",
+      "    }",
+    ]);
+    expect(codesOf(source)).not.toContain("AG8015");
+  });
+
+  it("a for binder used inside the loop", () => {
+    const source = withLiteral([
+      "    def f(): number {",
+      "      for (item in [1, 2]) {",
+      "        print(item)",
+      "      }",
+      "      return 1",
+      "    }",
+    ]);
+    expect(codesOf(source)).not.toContain("AG8015");
+  });
+
+  it("a block parameter", () => {
+    // Block params are not tracked in the typechecker's Scope at all, so
+    // resolving one would always fail. The shared classifier skips them.
+    const source = withLiteral([
+      "    def f(): number[] {",
+      "      return map([1, 2], \\(item) -> item + 1)",
+      "    }",
+    ]);
+    expect(codesOf(source)).not.toContain("AG8015");
+  });
+
+  it("a top-level binding in the literal, used later", () => {
+    const source = withLiteral(["    const res = 1", "    print(res)"]);
+    expect(codesOf(source)).not.toContain("AG8015");
+  });
+
+  it("a direct call to a def the literal declares", () => {
+    const source = withLiteral([
+      "    def greet(): string {",
+      '      return "hi"',
+      "    }",
+      "",
+      "    def main(): string {",
+      "      return greet()",
+      "    }",
+    ]);
+    expect(codesOf(source)).not.toContain("AG8015");
+  });
+
+  it("a first-class reference to a def the literal declares", () => {
+    const source = withLiteral([
+      "    def greet(): string {",
+      '      return "hi"',
+      "    }",
+      "",
+      "    const tool = greet",
+    ]);
+    expect(codesOf(source)).not.toContain("AG8015");
+  });
+
+  it("a non-prelude import, called and referenced", () => {
+    // `edit`, not `read`: `read` is in PRELUDE_NAMES, which would make
+    // this test vacuous.
+    const source = withLiteral([
+      '    import { edit } from "std::fs"',
+      "",
+      "    def g(): string {",
+      '      return edit("x", "y", "z")',
+      "    }",
+      "",
+      "    const tool = edit",
+    ]);
+    expect(codesOf(source)).not.toContain("AG8015");
+  });
+
+  it("a prelude call", () => {
+    const source = withLiteral(['    print("hi")']);
+    expect(codesOf(source)).not.toContain("AG8015");
+  });
+
+  it("a builtin call", () => {
+    const source = withLiteral(['    const answer = llm("hi")']);
+    expect(codesOf(source)).not.toContain("AG8015");
+  });
+
+  it("a method call on a binding the literal declares", () => {
+    // `method` in `obj.method()` is not a lexical name.
+    const source = withLiteral([
+      '    const greeting = "hi"',
+      "    const loud = greeting.toUpperCase()",
+    ]);
+    expect(codesOf(source)).not.toContain("AG8015");
+  });
+});
+
+describe("AG8015: the analysis is isolated", () => {
+  it("does not leak diagnostics from its own synthetic pass", () => {
+    // Building scopes for the literal can produce incidental diagnostics.
+    // This pass reports undefined names and nothing else.
+    const source = withLiteral(['    const value: string = 1']);
+    expect(codesOf(source)).not.toContain("AG2001");
+  });
+
+  it("lets two literals declare the same name", () => {
+    // Scope keys derive from definition names, so per-call state has to
+    // be isolated or these two collide.
+    const source = [
+      "node host() {",
+      "  const first = [|",
+      "    def greet(): string {",
+      '      return "one"',
+      "    }",
+      "  |]",
+      "  const second = [|",
+      "    def greet(): string {",
+      '      return "two"',
+      "    }",
+      "  |]",
+      '  print("host")',
+      "}",
+      "",
+    ].join("\n");
+    expect(codesOf(source)).not.toContain("AG8015");
+  });
+});
+
+describe("AG8015: the message", () => {
+  it("names the name and says what to do", () => {
+    const source = withLiteral([
+      "    node main() {",
+      "    #body",
+      "      print(res)",
+      "    }",
+    ]);
+    const message = messageFor(source, "AG8015");
+    expect(message).toMatch(/res/);
+    expect(message).toMatch(/declares or imports/);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/templateNames.test.ts
+++ b/packages/agency-lang/lib/typeChecker/templateNames.test.ts
@@ -283,3 +283,78 @@ describe("AG8015: the message", () => {
     expect(message).toMatch(/declares or imports/);
   });
 });
+
+describe("AG8015: template files", () => {
+  // A .agency file with holes is itself a template, so the always-on pass
+  // owns every undefined name in it.
+
+  const missingVariable = [
+    "node main(): string {",
+    "#body",
+    "  print(res)",
+    "  return res",
+    "}",
+    "",
+  ].join("\n");
+
+  const missingCall = [
+    "#helpers",
+    "",
+    "node main(): string {",
+    "  return guarded()",
+    "}",
+    "",
+  ].join("\n");
+
+  it("reports a missing variable as AG8015, not AG4007", () => {
+    expect(codesOf(missingVariable)).toContain("AG8015");
+    expect(codesOf(missingVariable)).not.toContain("AG4007");
+  });
+
+  it("reports a missing call as AG8015, not AG4004", () => {
+    expect(codesOf(missingCall)).toContain("AG8015");
+    expect(codesOf(missingCall)).not.toContain("AG4004");
+  });
+
+  it("still reports an ordinary variable typo away from the hole", () => {
+    // AG4007 stands down for the whole file, so this pass has to cover
+    // what it stopped covering.
+    const source = [
+      "node main(): string {",
+      "#body",
+      "  const greeting = 1",
+      "  print(greetign)",
+      '  return "x"',
+      "}",
+      "",
+    ].join("\n");
+    expect(codesOf(source)).toContain("AG8015");
+  });
+
+  it("still reports an ordinary call typo away from the hole", () => {
+    const source = [
+      "#helpers",
+      "",
+      "def greet(): string {",
+      '  return "hi"',
+      "}",
+      "",
+      "node main(): string {",
+      "  return greeet()",
+      "}",
+      "",
+    ].join("\n");
+    expect(codesOf(source)).toContain("AG8015");
+  });
+
+  it("leaves a hole-free file's missing variable to the ordinary pass", () => {
+    const source = 'node main(): string {\n  print(res)\n  return "x"\n}\n';
+    expect(codesOf(source)).not.toContain("AG8015");
+  });
+
+  it("leaves a hole-free file's missing call to AG4004", () => {
+    const source = 'node main(): string {\n  return missingHelper()\n}\n';
+    expect(codesOf(source)).toContain("AG4004");
+    expect(codesOf(source)).not.toContain("AG8015");
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/templateNames.ts
+++ b/packages/agency-lang/lib/typeChecker/templateNames.ts
@@ -12,6 +12,7 @@ import {
 import { resolveCall } from "./resolveCall.js";
 import { resolveVariable } from "./resolveVariable.js";
 import { buildScopes } from "./scopes.js";
+import { collectProgramShadowing } from "./shadowing.js";
 import { ANY_T } from "./primitives.js";
 import type { AgencyConfig } from "../config.js";
 import type { AgencyNode, AgencyProgram, CodeLiteral } from "../types.js";
@@ -95,8 +96,9 @@ export function checkTemplateNames(ctx: TypeCheckerContext): void {
   if (holeNames(ctx.programNodes).length > 0) {
     const findings = findUndefinedTemplateNames(ctx.programNodes, ctx.config);
     reportTemplateNameFindings(findings, ctx);
-    return;
   }
+  // The literal loop still runs: the walker treats a literal's nodes as
+  // opaque, so the whole-file pass above never looked inside them.
   for (const visit of walkNodesArray(ctx.programNodes)) {
     if (visit.node.type !== "codeLiteral") {
       continue;
@@ -134,6 +136,10 @@ function templateNameScopes(
 ): TemplateNameScope[] {
   const program: AgencyProgram = { type: "agencyProgram", nodes };
   const context = isolatedContext(program, config);
+  // `walkScopeBody` has no `importNodeStatement` case, so an `import node`
+  // the template makes itself has no lexical-scope fallback. Collect those
+  // names here or a template-local imported node looks undefined.
+  const { importedNodeNames } = collectProgramShadowing(nodes);
   return buildScopes(context).map((info) => ({
     body: info.body,
     kind: info.name === "top-level" ? "topLevel" : "definition",
@@ -143,7 +149,7 @@ function templateNameScopes(
         functionDefs: context.functionDefs,
         nodeDefs: context.nodeDefs,
         importedFunctions: context.importedFunctions,
-        importedNodeNames: [],
+        importedNodeNames,
         jsImportedNames: context.jsImportedNames,
         scopeHas: (candidate: string) => info.scope.has(candidate),
       }).kind !== "unresolved",
@@ -153,7 +159,7 @@ function templateNameScopes(
         functionDefs: context.functionDefs,
         nodeDefs: context.nodeDefs,
         importedFunctions: context.importedFunctions,
-        importedNodeNames: [],
+        importedNodeNames,
         jsImportedNames: context.jsImportedNames,
         scopeHas: (candidate: string) => info.scope.has(candidate),
       }).kind !== "unresolved",

--- a/packages/agency-lang/lib/typeChecker/templateNames.ts
+++ b/packages/agency-lang/lib/typeChecker/templateNames.ts
@@ -1,0 +1,203 @@
+import { buildCompilationUnit, GLOBAL_SCOPE_KEY } from "../compilationUnit.js";
+import { PRELUDE_NAMES } from "../prelude.js";
+import { declaredName } from "../types/hole.js";
+import { walkNodes, walkNodesArray } from "../utils/node.js";
+import { diagnostic } from "./diagnostics.js";
+import {
+  hasFunctionOrNodeAncestor,
+  isResolvableBareCall,
+  isResolvableVariableReference,
+} from "./nameReferences.js";
+import { resolveCall } from "./resolveCall.js";
+import { resolveVariable } from "./resolveVariable.js";
+import { buildScopes } from "./scopes.js";
+import { ANY_T } from "./primitives.js";
+import type { AgencyConfig } from "../config.js";
+import type { AgencyNode, AgencyProgram, CodeLiteral } from "../types.js";
+import type { SourceLocation } from "../types/base.js";
+import type { TypeCheckerContext } from "./types.js";
+
+const PRELUDE = new Set(PRELUDE_NAMES);
+
+/** A name a template uses but does not define. */
+export type UndefinedTemplateName = {
+  name: string;
+  loc: SourceLocation | null;
+};
+
+/** One body to check, with its own view of what resolves. */
+type TemplateNameScope = {
+  body: AgencyNode[];
+  kind: "topLevel" | "definition";
+  resolvesVariable(name: string): boolean;
+  resolvesCall(name: string): boolean;
+};
+
+/**
+ * Names a template uses that it does not define.
+ *
+ * A template body is analysed as if it were its own file, because that is
+ * what it becomes. `toSource` prints it, `runCode` compiles the print, and
+ * the surrounding file is not there. So this takes `config` and nothing
+ * else from the caller: there is no host context to leak from.
+ *
+ * A template may use language builtins and JS globals, the prelude, and
+ * whatever it declares or imports itself.
+ */
+export function findUndefinedTemplateNames(
+  nodes: AgencyNode[],
+  config: AgencyConfig,
+): UndefinedTemplateName[] {
+  const found: UndefinedTemplateName[] = [];
+  for (const scope of templateNameScopes(nodes, config)) {
+    const isTopLevel = scope.kind === "topLevel";
+    for (const { node, ancestors } of walkNodes(scope.body)) {
+      // A definition's body has its own scope below, so skip it here or
+      // every name inside fires twice.
+      if (isTopLevel && hasFunctionOrNodeAncestor(ancestors)) {
+        continue;
+      }
+      if (node.type === "variableName") {
+        if (!isResolvableVariableReference(node, ancestors)) {
+          continue;
+        }
+        if (scope.resolvesVariable(node.value)) {
+          continue;
+        }
+        found.push({ name: node.value, loc: node.loc ?? null });
+      }
+      if (node.type === "functionCall") {
+        if (!isResolvableBareCall(node, ancestors)) {
+          continue;
+        }
+        if (scope.resolvesCall(node.functionName)) {
+          continue;
+        }
+        found.push({ name: node.functionName, loc: node.loc ?? null });
+      }
+    }
+  }
+  return found;
+}
+
+/**
+ * AG8015 — report every name a template uses but does not define.
+ *
+ * Always on, unlike the ordinary undefined-name checks. A template is
+ * printed, compiled and run elsewhere, so nothing downstream catches this
+ * before run time.
+ */
+export function checkTemplateNames(ctx: TypeCheckerContext): void {
+  for (const visit of walkNodesArray(ctx.programNodes)) {
+    if (visit.node.type !== "codeLiteral") {
+      continue;
+    }
+    report((visit.node as CodeLiteral).nodes, ctx);
+  }
+}
+
+function report(nodes: AgencyNode[], ctx: TypeCheckerContext): void {
+  for (const undefinedName of findUndefinedTemplateNames(nodes, ctx.config)) {
+    ctx.errors.push(
+      diagnostic(
+        "templateNameNotDefined",
+        { name: undefinedName.name },
+        undefinedName.loc,
+      ),
+    );
+  }
+}
+
+/**
+ * One scope per body: the template's top level, plus one per nested
+ * definition with its parameters seeded.
+ *
+ * `buildScopes` produces that shape already. A single flat scope would
+ * reject `def greet(name: string) { return name }`, because a parameter
+ * lives in its definition's own scope.
+ */
+function templateNameScopes(
+  nodes: AgencyNode[],
+  config: AgencyConfig,
+): TemplateNameScope[] {
+  const program: AgencyProgram = { type: "agencyProgram", nodes };
+  const context = isolatedContext(program, config);
+  return buildScopes(context).map((info) => ({
+    body: info.body,
+    kind: info.name === "top-level" ? "topLevel" : "definition",
+    resolvesVariable: (name: string) =>
+      PRELUDE.has(name) ||
+      resolveVariable(name, {
+        functionDefs: context.functionDefs,
+        nodeDefs: context.nodeDefs,
+        importedFunctions: context.importedFunctions,
+        importedNodeNames: [],
+        jsImportedNames: context.jsImportedNames,
+        scopeHas: (candidate: string) => info.scope.has(candidate),
+      }).kind !== "unresolved",
+    resolvesCall: (name: string) =>
+      PRELUDE.has(name) ||
+      resolveCall(name, {
+        functionDefs: context.functionDefs,
+        nodeDefs: context.nodeDefs,
+        importedFunctions: context.importedFunctions,
+        importedNodeNames: [],
+        jsImportedNames: context.jsImportedNames,
+        scopeHas: (candidate: string) => info.scope.has(candidate),
+      }).kind !== "unresolved",
+  }));
+}
+
+/**
+ * A context for the template body alone.
+ *
+ * Built from the body and the config, never from the host's. Host
+ * declarations, imports, aliases, flow state and errors are all absent by
+ * construction rather than by discipline.
+ *
+ * `buildCompilationUnit` leaves `importedFunctions` empty without a symbol
+ * table, which is fine here. `walkScopeBody` declares every syntactic
+ * import in the lexical scope, so an imported name still resolves through
+ * `scope.has`. Do not copy the host's imports to compensate.
+ */
+function isolatedContext(
+  program: AgencyProgram,
+  config: AgencyConfig,
+): TypeCheckerContext {
+  const unit = buildCompilationUnit(program);
+  const nodeDefs = Object.fromEntries(
+    unit.graphNodes.map((node) => [declaredName(node.nodeName), node]),
+  );
+  let currentScopeKey = GLOBAL_SCOPE_KEY;
+
+  const context: TypeCheckerContext = {
+    programNodes: program.nodes,
+    scopedTypeAliases: unit.typeAliases,
+    get currentScopeKey() {
+      return currentScopeKey;
+    },
+    functionDefs: unit.functionDefinitions,
+    nodeDefs,
+    importedFunctions: unit.importedFunctions,
+    jsImportedNames: unit.jsImportedNames,
+    interruptEffectsByFunction: {},
+    errors: [],
+    inferredReturnTypes: {},
+    inferringReturnType: new Set<string>(),
+    matchExprTypes: {},
+    matchExprYieldTypes: {},
+    config,
+    getTypeAliases: () => unit.typeAliases.visibleIn(currentScopeKey),
+    withScope<T>(key: string, fn: () => T): T {
+      const previous = currentScopeKey;
+      currentScopeKey = key;
+      try {
+        return fn();
+      } finally {
+        currentScopeKey = previous;
+      }
+    },
+    inferReturnTypeFor: () => ANY_T,
+  };
+  return context;
+}

--- a/packages/agency-lang/lib/typeChecker/templateNames.ts
+++ b/packages/agency-lang/lib/typeChecker/templateNames.ts
@@ -1,6 +1,7 @@
 import { buildCompilationUnit, GLOBAL_SCOPE_KEY } from "../compilationUnit.js";
 import { PRELUDE_NAMES } from "../prelude.js";
 import { declaredName } from "../types/hole.js";
+import { holeNames } from "../utils/holes.js";
 import { walkNodes, walkNodesArray } from "../utils/node.js";
 import { diagnostic } from "./diagnostics.js";
 import {
@@ -88,22 +89,33 @@ export function findUndefinedTemplateNames(
  * before run time.
  */
 export function checkTemplateNames(ctx: TypeCheckerContext): void {
+  // A file with holes is itself a template, so this pass owns every name
+  // in it, not just the ones inside literals. The ordinary undefined-name
+  // passes stand down for such a file.
+  if (holeNames(ctx.programNodes).length > 0) {
+    const findings = findUndefinedTemplateNames(ctx.programNodes, ctx.config);
+    reportTemplateNameFindings(findings, ctx);
+    return;
+  }
   for (const visit of walkNodesArray(ctx.programNodes)) {
     if (visit.node.type !== "codeLiteral") {
       continue;
     }
-    report((visit.node as CodeLiteral).nodes, ctx);
+    const literal = visit.node as CodeLiteral;
+    reportTemplateNameFindings(
+      findUndefinedTemplateNames(literal.nodes, ctx.config),
+      ctx,
+    );
   }
 }
 
-function report(nodes: AgencyNode[], ctx: TypeCheckerContext): void {
-  for (const undefinedName of findUndefinedTemplateNames(nodes, ctx.config)) {
+function reportTemplateNameFindings(
+  findings: UndefinedTemplateName[],
+  ctx: TypeCheckerContext,
+): void {
+  for (const finding of findings) {
     ctx.errors.push(
-      diagnostic(
-        "templateNameNotDefined",
-        { name: undefinedName.name },
-        undefinedName.loc,
-      ),
+      diagnostic("templateNameNotDefined", { name: finding.name }, finding.loc),
     );
   }
 }

--- a/packages/agency-lang/lib/typeChecker/undefinedFunctionDiagnostic.ts
+++ b/packages/agency-lang/lib/typeChecker/undefinedFunctionDiagnostic.ts
@@ -5,6 +5,10 @@ import type { AgencyNode, FunctionCall } from "../types.js";
 import type { ValueAccess, AccessChainElement } from "../types/access.js";
 import { walkNodes } from "../utils/node.js";
 import {
+  hasFunctionOrNodeAncestor,
+  isResolvableBareCall,
+} from "./nameReferences.js";
+import {
   resolveCall,
   lookupJsMember,
   isJsGlobalBase,
@@ -48,12 +52,7 @@ export function checkUndefinedFunctions(
         if (isTopLevel && hasFunctionOrNodeAncestor(ancestors)) continue;
 
         if (node.type === "functionCall") {
-          // `walkNodes` descends into a `valueAccess`'s methodCall.functionCall.
-          // That method-call is already covered by checkAccessChain on its
-          // parent valueAccess; reporting it again here would double-fire and
-          // also incorrectly treat `obj.foo()` as a bare call to `foo`.
-          const parent = ancestors[ancestors.length - 1];
-          if (parent && (parent as AgencyNode).type === "valueAccess") continue;
+          if (!isResolvableBareCall(node, ancestors)) continue;
           checkBareCall(node, info.scope, ctx, mode, shadowing.importedNodeNames);
         } else if (node.type === "valueAccess") {
           checkAccessChain(node, info.scope, ctx, mode, shadowing);
@@ -63,13 +62,6 @@ export function checkUndefinedFunctions(
   }
 }
 
-function hasFunctionOrNodeAncestor(ancestors: readonly unknown[]): boolean {
-  for (const a of ancestors) {
-    const t = (a as AgencyNode | undefined)?.type;
-    if (t === "function" || t === "graphNode") return true;
-  }
-  return false;
-}
 
 // --- Internal helpers ---
 
@@ -93,9 +85,6 @@ function checkBareCall(
   mode: "warn" | "error",
   importedNodeNames: readonly string[],
 ): void {
-  // A call the lowerer synthesized, not one the user wrote. It has no
-  // declaration to find, and the builder compiles it away before runtime.
-  if (call.synthetic) return;
   const resolution = resolveCall(call.functionName, {
     functionDefs: ctx.functionDefs,
     nodeDefs: ctx.nodeDefs,

--- a/packages/agency-lang/lib/typeChecker/undefinedFunctionDiagnostic.ts
+++ b/packages/agency-lang/lib/typeChecker/undefinedFunctionDiagnostic.ts
@@ -40,10 +40,11 @@ export function checkUndefinedFunctions(
   const mode = ctx.config.typechecker?.undefinedFunctions ?? "warn";
   if (mode === "silent") return;
 
-  // A file with holes is a template. AG8015 owns every call name in it, so
-  // reporting here too would double up. The JS-namespace chain check below
-  // goes quiet in such a file as well.
-  if (holeNames(ctx.programNodes).length > 0) return;
+  // A file with holes is a template. AG8015 owns bare call names in it, so
+  // reporting them here too would double up. It does not look at JS
+  // namespace members — `nosuch` in `Math.nosuch()` is a method to it, not
+  // a lexical name — so the chain check below keeps running.
+  const isTemplateFile = holeNames(ctx.programNodes).length > 0;
 
   const shadowing = collectProgramShadowing(ctx.programNodes);
 
@@ -58,6 +59,7 @@ export function checkUndefinedFunctions(
         if (isTopLevel && hasFunctionOrNodeAncestor(ancestors)) continue;
 
         if (node.type === "functionCall") {
+          if (isTemplateFile) continue;
           if (!isResolvableBareCall(node, ancestors)) continue;
           checkBareCall(node, info.scope, ctx, mode, shadowing.importedNodeNames);
         } else if (node.type === "valueAccess") {

--- a/packages/agency-lang/lib/typeChecker/undefinedFunctionDiagnostic.ts
+++ b/packages/agency-lang/lib/typeChecker/undefinedFunctionDiagnostic.ts
@@ -4,6 +4,7 @@ import type { Scope } from "./scope.js";
 import type { AgencyNode, FunctionCall } from "../types.js";
 import type { ValueAccess, AccessChainElement } from "../types/access.js";
 import { walkNodes } from "../utils/node.js";
+import { holeNames } from "../utils/holes.js";
 import {
   hasFunctionOrNodeAncestor,
   isResolvableBareCall,
@@ -38,6 +39,11 @@ export function checkUndefinedFunctions(
   // `{ typechecker: { undefinedFunctions: "silent" } }` in agency.json.
   const mode = ctx.config.typechecker?.undefinedFunctions ?? "warn";
   if (mode === "silent") return;
+
+  // A file with holes is a template. AG8015 owns every call name in it, so
+  // reporting here too would double up. The JS-namespace chain check below
+  // goes quiet in such a file as well.
+  if (holeNames(ctx.programNodes).length > 0) return;
 
   const shadowing = collectProgramShadowing(ctx.programNodes);
 

--- a/packages/agency-lang/lib/typeChecker/undefinedVariableDiagnostic.ts
+++ b/packages/agency-lang/lib/typeChecker/undefinedVariableDiagnostic.ts
@@ -4,6 +4,7 @@ import type { Scope } from "./scope.js";
 import type { AgencyNode, VariableNameLiteral } from "../types.js";
 import type { WalkAncestor } from "../utils/node.js";
 import { walkNodes } from "../utils/node.js";
+import { holeNames } from "../utils/holes.js";
 import { resolveVariable } from "./resolveVariable.js";
 import {
   hasFunctionOrNodeAncestor,
@@ -44,6 +45,10 @@ export function checkUndefinedVariables(
 ): void {
   const mode = ctx.config.typechecker?.undefinedVariables ?? "silent";
   if (mode === "silent") return;
+
+  // A file with holes is a template. AG8015 owns every name in it, and
+  // reports what this pass would, so reporting here too would double up.
+  if (holeNames(ctx.programNodes).length > 0) return;
 
   const { importedNodeNames } = collectProgramShadowing(
     ctx.programNodes,

--- a/packages/agency-lang/lib/typeChecker/undefinedVariableDiagnostic.ts
+++ b/packages/agency-lang/lib/typeChecker/undefinedVariableDiagnostic.ts
@@ -5,6 +5,10 @@ import type { AgencyNode, VariableNameLiteral } from "../types.js";
 import type { WalkAncestor } from "../utils/node.js";
 import { walkNodes } from "../utils/node.js";
 import { resolveVariable } from "./resolveVariable.js";
+import {
+  hasFunctionOrNodeAncestor,
+  isResolvableVariableReference,
+} from "./nameReferences.js";
 import { collectProgramShadowing } from "./shadowing.js";
 
 /**
@@ -54,7 +58,7 @@ export function checkUndefinedVariables(
         // function/graphNode bodies during the top-level pass.
         if (isTopLevel && hasFunctionOrNodeAncestor(ancestors)) continue;
         if (node.type !== "variableName") continue;
-        if (isReferencePosition(node, ancestors)) {
+        if (isResolvableVariableReference(node, ancestors)) {
           checkVariableRef(node, ancestors, info.scope, ctx, mode, importedNodeNames);
         }
       }
@@ -62,48 +66,7 @@ export function checkUndefinedVariables(
   }
 }
 
-function hasFunctionOrNodeAncestor(ancestors: readonly unknown[]): boolean {
-  for (const a of ancestors) {
-    const t = (a as AgencyNode | undefined)?.type;
-    if (t === "function" || t === "graphNode") return true;
-  }
-  return false;
-}
 
-/**
- * A bare `variableName` node can show up in many positions where it's
- * NOT a real variable reference (e.g. import statements, type alias
- * names, parameter names). Only fire the diagnostic when the position
- * actually represents a value being read.
- *
- * Rather than enumerate every "skip" position, we accept positions where
- * walkNodes recurses into a value — those are the ones where a missing
- * binding would actually be a runtime error.
- */
-function isReferencePosition(
-  node: VariableNameLiteral,
-  ancestors: readonly WalkAncestor[],
-): boolean {
-  const parent = ancestors[ancestors.length - 1];
-  if (!parent) return false;
-  const p = parent as AgencyNode;
-
-  // The base of a valueAccess (`obj.x`, `obj[i]`, `obj.foo()`). The base
-  // IS a value reference and must resolve. Property/method names are NOT
-  // variable refs and are filtered by walkNodes already (it doesn't yield
-  // them as standalone variableNames).
-  if (p.type === "valueAccess") return p.base === node;
-
-  // LHS of assignment (`x = 5`, no decl) is a write, not a read; the
-  // const-reassignment pass handles unknown writes.
-  if (p.type === "assignment") {
-    // walkNodes only yields `node.value` (and accessChain elements), not
-    // `variableName`. So if we reach here, it's nested deeper. Treat as
-    // a real reference.
-    return true;
-  }
-  return true;
-}
 
 function checkVariableRef(
   ref: VariableNameLiteral,
@@ -113,23 +76,6 @@ function checkVariableRef(
   mode: "warn" | "error",
   importedNodeNames: readonly string[],
 ): void {
-  // Don't check the LHS of `for (item in items)` — itemVar/indexVar are
-  // declarations, not references. (walkNodes shouldn't yield them, but
-  // belt-and-suspenders.)
-  for (const a of ancestors) {
-    if ((a as AgencyNode).type === "forLoop") {
-      const fl = a as AgencyNode & { type: "forLoop" };
-      if (ref.value === fl.itemVar || ref.value === fl.indexVar) return;
-    }
-    // Block params on method calls (`xs.map(\(x) -> x + 1)`) and any
-    // other call-with-block aren't currently tracked in the typechecker's
-    // Scope, so look them up directly from any enclosing blockArgument.
-    if ((a as { type: string }).type === "blockArgument") {
-      const block = a as { type: "blockArgument"; params: { name: string }[] };
-      if (block.params.some((p) => p.name === ref.value)) return;
-    }
-  }
-
   const resolution = resolveVariable(ref.value, {
     functionDefs: ctx.functionDefs,
     nodeDefs: ctx.nodeDefs,

--- a/packages/agency-lang/tests/agency/templates/composeGuardedGuard.agency
+++ b/packages/agency-lang/tests/agency/templates/composeGuardedGuard.agency
@@ -7,3 +7,7 @@ def guarded(): string {
   }
   return result.value
 }
+
+export node main(): string {
+  return guarded()
+}

--- a/packages/agency-lang/tests/agency/templates/composeGuardedMain.agency
+++ b/packages/agency-lang/tests/agency/templates/composeGuardedMain.agency
@@ -1,5 +1,8 @@
 #helpers
 
-export node main(): string {
-  return guarded()
+// This wrapper declares something of its own so `#helpers` sits at a
+// declaration position. It cannot call what fills the hole: a template may
+// only use names it declares or imports itself.
+def wrapperTag(): string {
+  return "wrapper"
 }

--- a/packages/agency-lang/tests/agency/templates/literalComposeSelfContained.agency
+++ b/packages/agency-lang/tests/agency/templates/literalComposeSelfContained.agency
@@ -1,30 +1,38 @@
 import { fill, holesOf, toSource, runCode } from "std::agency"
 
-// The flagship inline workflow: three literals (expr body via the
-// relaxation, program-kind templates), partial fill, composition with a
-// hole still open, origin on the grafted hole, and the generated program
-// actually running. No template files, no loadTemplate interrupts.
+// The flagship inline workflow: partial fill, composition with a hole
+// still open, origin on the grafted hole, and the generated program
+// actually running. Every fragment declares the names it uses, because a
+// template may not depend on a declaration arriving through a hole.
 node main(): string {
-  const guardTpl = [|
+  const programTemplate = [|
     def guarded(): string {
       const ms: number = #minutes
       #body
       return "lit-ok"
     }
-  |]
-  const mainTpl = [|
-    #helpers
 
     export node main(): string {
       return guarded()
     }
   |]
   const body = [| print("step") |]
-  const partial = fill(guardTpl, { body: body })
+  // The wrapper declares something of its own, so `#helpers` sits at a
+  // declaration position. A body that is only a hole would be an
+  // expression, which a program fragment cannot fill.
+  const wrapper = [|
+    #helpers
+
+    def wrapperTag(): string {
+      return "wrapper"
+    }
+  |]
+
+  const partial = fill(programTemplate, { body: body })
   if (isFailure(partial)) {
-    return "guard fill failed: ${partial.error}"
+    return "program fill failed: ${partial.error}"
   }
-  const program = fill(mainTpl, { helpers: partial.value })
+  const program = fill(wrapper, { helpers: partial.value })
   if (isFailure(program)) {
     return "compose failed: ${program.error}"
   }
@@ -45,8 +53,8 @@ node main(): string {
       return "run failed: ${result.error}"
     }
     return result.value
-  } with (e) {
-    if (e.effect == "std::run") {
+  } with (effect) {
+    if (effect.effect == "std::run") {
       return approve()
     }
   }

--- a/packages/agency-lang/tests/agency/templates/literalComposeSelfContained.test.json
+++ b/packages/agency-lang/tests/agency/templates/literalComposeSelfContained.test.json
@@ -5,7 +5,7 @@
       "input": "",
       "expectedOutput": "\"lit-ok\"",
       "evaluationCriteria": [{ "type": "exact" }],
-      "description": "Inline literals compose with a hole still open; the grafted hole carries origin and the completed program runs"
+      "description": "Self-contained inline literals compose with a hole still open; the grafted hole carries origin and the completed program runs"
     }
   ]
 }


### PR DESCRIPTION
## What this does

A template can now only use names it declares or imports itself, plus the prelude and the language builtins. Using a name that comes from the host file, or one that arrives through a hole, is a new error: **AG8015**.

Today a code literal body is never name-checked at all, so this compiles and fails at run time:

```ts
def helper(): string {
  return "hi"
}

static const template = [|
  node main(): string {
    return helper()   // helper will not exist in the generated program
  }
|]
```

`toSource` prints that template into its own file and `runCode` compiles the print. The host file is not there, so `helper` is gone. The same holds for a name a hole supplies: the hole is opaque while the template is checked, so the compiler cannot know what fills it.

## Behavior changes

**This rejects templates that compile today.** Any template that leans on a host declaration or on a filler-supplied declaration now fails to compile. That is the intended breaking change.

**A file with holes no longer emits AG4004 or AG4007 for a plain name.** A `.agency` file with holes is itself a template, so the always-on AG8015 pass owns every undefined variable and bare call in it, and the two ordinary passes stand down for those positions. One missing name produces one diagnostic instead of two. The JS-namespace chain check in the undefined-function pass (`Math.nosuch()`) keeps running, because AG8015 treats `nosuch` as a method rather than a lexical name.

## How it works

- `lib/typeChecker/nameReferences.ts` — the rules for which AST positions actually hold a lexical name, moved out of the two existing diagnostics so all three passes agree. It carries the easy-to-miss skips: `for` binders, block-call parameters (which the typechecker's `Scope` does not track at all), property names, and synthetic calls.
- `lib/typeChecker/templateNames.ts` — the analysis. It builds a `TypeCheckerContext` from the template body and the config alone, so host declarations, imports, aliases and errors are absent by construction rather than by discipline. It mirrors `buildScopes`, one scope per body, so a nested `def`'s parameters resolve.
- The pass is always on, unlike the ordinary undefined-name checks, which are silent by default. Nothing downstream catches this before run time.

## Fixtures and docs

- Deleted `tests/agency/templates/literalCompose.agency` and its `.test.json`. It was built on exactly the pattern this rejects: one literal called `guarded()`, which the `#helpers` hole supplied.
- Added `tests/agency/templates/literalComposeSelfContained.agency`, which keeps all the same coverage — expression-literal filling, partial fill, grafting into a wrapper, hole origin, a second fill, `toSource`, `runCode`, interrupt approval, the `"lit-ok"` result — with every fragment declaring the names it uses.
- `composeGuardedGuard.agency` and `composeGuardedMain.agency` change for the same reason: `main` moves next to the `guarded()` it calls, and the wrapper keeps a declaration of its own so `#helpers` still sits at a declaration position.
- `docs/site/guide/template-agency.md` gets a short section on what names a template can use, with the rejected form and the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
