### PR TITLE
test(cli): fix two tsc-tests type errors from the remote refactors

### DIFF
--- a/packages/agency-lang/lib/cli/statelog/uploadClient.test.ts
+++ b/packages/agency-lang/lib/cli/statelog/uploadClient.test.ts
@@ -2,7 +2,10 @@ import { describe, it, expect, afterEach, vi } from "vitest";
 import { uploadBundle, serveBaseUrl } from "./uploadClient.js";
 
 const target = { host: "https://statelog.example", projectId: "proj", apiKey: "k" };
-const bundle = { entrypoint: "greeter.agency", files: [{ name: "greeter.agency", contents: "x" }] };
+const bundle = {
+  entrypoint: "greeter.agency",
+  files: [{ name: "greeter.agency", contents: "x", absPath: "/tmp/greeter.agency" }],
+};
 
 function mockFetch(handler: (url: string, init?: { method?: string }) => unknown): void {
   vi.spyOn(globalThis, "fetch").mockImplementation((async (url: unknown, init?: { method?: string }) => {

--- a/packages/agency-lang/lib/runtime/interrupts.test.ts
+++ b/packages/agency-lang/lib/runtime/interrupts.test.ts
@@ -283,7 +283,7 @@ describe("reportUnhandledInterrupts", () => {
       .spyOn(process, "exit")
       .mockImplementation(() => undefined as never);
 
-    reportUnhandledInterrupts({ messages: {} as any, data: "the answer" });
+    reportUnhandledInterrupts({ data: "the answer" });
 
     expect(err).not.toHaveBeenCalled();
     expect(exit).not.toHaveBeenCalled();
@@ -296,7 +296,6 @@ describe("reportUnhandledInterrupts", () => {
       .mockImplementation(() => undefined as never);
 
     reportUnhandledInterrupts({
-      messages: {} as any,
       data: [
         interrupt({
           effect: "std::edit",
@@ -322,7 +321,6 @@ describe("reportUnhandledInterrupts", () => {
     vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
 
     reportUnhandledInterrupts({
-      messages: {} as any,
       data: [
         interrupt({ effect: "std::read", message: "read", data: {}, origin: "", runId: "r" }),
         interrupt({ effect: "std::edit", message: "edit", data: {}, origin: "", runId: "r" }),


### PR DESCRIPTION
## What

Fix two `tsc -p tsconfig.tests.json` type errors introduced by the `agency remote` refactors:

- **`interrupts.test.ts`** — three `reportUnhandledInterrupts(...)` calls passed `{ messages: {} as any, data }`. PR #778 narrowed that function's parameter to the minimal `{ data }` `InterruptResult`, so `messages` became an excess property (TS2353). Dropped it — the function only reads `.data`.
- **`uploadClient.test.ts`** — the `bundle` literal was missing `BundleFile.absPath`.

Test-only; runtime behavior unchanged.

## Scope note

`tsconfig.tests.json` is not a CI gate (which is why these didn't block #778/#781). This PR fixes only the two errors from the remote work. There are **10 further pre-existing `tsc-tests` errors under `lib/serve/` (`discovery.test.ts`, `mcp/adapter.test.ts`, `mcp/httpTransport.test.ts`)** — `FuncParam`/`ExportedItem` fixture drift, unrelated to this line of work — left out of scope. Happy to tackle those (and consider gating `tsc-tests` in CI) in a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
