### PR TITLE
fmt: let thread read back its own empty body

### DIFF
--- a/packages/agency-lang/lib/formatter.test.ts
+++ b/packages/agency-lang/lib/formatter.test.ts
@@ -527,3 +527,25 @@ describe("a multi-line item inside a wrapped list", () => {
     expect(formatSource(once as string)).toBe(once);
   });
 });
+
+describe("blocks with an empty body", () => {
+  // The formatter puts a blank line in an empty body. That blank line is a
+  // sentinel character by the time the next parse runs, and `thread` was the
+  // one block that required real whitespace after its `{`, so it could not
+  // read back what the formatter had just written.
+  it.each([
+    ["thread", `node main() {\n  thread {\n  }\n}\n`],
+    ["thread with arguments", `node main() {\n  thread(label: "w") {\n  }\n}\n`],
+    ["subthread", `node main() {\n  subthread {\n  }\n}\n`],
+    ["parallel", `node main() {\n  parallel {\n  }\n}\n`],
+    ["seq", `node main() {\n  seq {\n  }\n}\n`],
+    ["if", `node main() {\n  if (x) {\n  }\n}\n`],
+    ["guard", `node main() {\n  guard() {\n  }\n}\n`],
+    ["node", `node main() {\n}\n`],
+    ["def", `def f() {\n}\n`],
+  ])("formats an empty %s body to something it can read back", (_name, source) => {
+    const once = formatSource(source);
+    expect(once).not.toBeNull();
+    expect(formatSource(once as string)).toBe(once);
+  });
+});

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -5766,10 +5766,9 @@ export const _messageThreadParser: Parser<MessageThread> = memo(
     captureCaptures(
       parseError(
         "expected block body followed by `}`",
-        // Not `spaces`: an empty body prints as a blank line, which is a
-        // sentinel character rather than whitespace by the time this runs.
-        // Every other block parser uses this, and `thread` was the one that
-        // could not read back what the formatter wrote.
+        // Not `spaces`: an empty body prints as a blank line, which becomes a
+        // BLANK_LINE_SENTINEL by the time this runs. `spaces` would fail before
+        // bodyParser can consume it, breaking fmt idempotence for thread/subthread.
         optionalSpacesOrNewline,
         capture(bodyParser, "body"),
         optionalSpacesOrNewline,

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -5766,7 +5766,11 @@ export const _messageThreadParser: Parser<MessageThread> = memo(
     captureCaptures(
       parseError(
         "expected block body followed by `}`",
-        spaces,
+        // Not `spaces`: an empty body prints as a blank line, which is a
+        // sentinel character rather than whitespace by the time this runs.
+        // Every other block parser uses this, and `thread` was the one that
+        // could not read back what the formatter wrote.
+        optionalSpacesOrNewline,
         capture(bodyParser, "body"),
         optionalSpacesOrNewline,
         char("}"),
@@ -5790,7 +5794,11 @@ export const _submessageThreadParser: Parser<MessageThread> = memo(
     captureCaptures(
       parseError(
         "expected block body followed by `}`",
-        spaces,
+        // Not `spaces`: an empty body prints as a blank line, which is a
+        // sentinel character rather than whitespace by the time this runs.
+        // Every other block parser uses this, and `thread` was the one that
+        // could not read back what the formatter wrote.
+        optionalSpacesOrNewline,
         capture(bodyParser, "body"),
         optionalSpacesOrNewline,
         char("}"),


### PR DESCRIPTION
Fixes #776.

## The bug

`agency fmt` prints an empty block body as a blank line:

```agency
thread(label: "w") {

}
```

Formatting that again returned `null` — the formatter could not read back what it had just written, so `agency fmt` was not idempotent on any file containing an empty thread body.

## The cause

Blank lines become sentinel characters before parsing (`replaceBlankLines`), and statement boundaries depend on that. The `thread` and `subthread` parsers required `spaces` — real whitespace — immediately after `{`. A sentinel is not whitespace, so the committing `parseError` fired.

Every other block parser already uses `optionalSpacesOrNewline` there. `thread` and `subthread` were the only two that did not, which is why this affected nothing else.

## The fix

Two words, in the two thread parsers. The blank line is then consumed by `bodyParser`'s existing blank-line handling, exactly as it is in every other block.

## Correction to the issue

I wrote #776 as "an empty thread **or parallel** body". That was wrong — I inferred it rather than checking. `parallel` handles this correctly, as do `seq`, `if`, `guard`, `node`, and `def`. Only `thread` and `subthread` were affected. The test table covers all of them so the distinction stays pinned.

## Verification

- New table test formatting an empty body twice for all nine block kinds. It failed on exactly the three thread forms before the fix.
- `messageThread`, `parsers`, `parser`, `agencyGenerator`, `agencyGenerator.roundtrip`, and `commentConservation` suites: 226 passed.
- `make` succeeds and leaves the tree clean, so no generated output shifts.
- `tsc` and `lint:structure` clean.

Per speedy mode I left the full suite to CI. This is a parser change, so the agency execution tests are the ones worth watching there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
