### PR TITLE
fix(fmt): render unwrapped nested calls once

### DIFF
--- a/packages/agency-lang/lib/backends/agencyGenerator.test.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.test.ts
@@ -3,7 +3,18 @@ import { AgencyGenerator, generateAgency } from "./agencyGenerator.js";
 import { parseAgency } from "../parser.js";
 import { formatSource } from "../formatter.js";
 import { deepFreeze } from "../runtime/utils.js";
-import { FunctionDefinition } from "../types.js";
+import { AgencyNode, FunctionDefinition } from "../types.js";
+
+class ProcessCountingGenerator extends AgencyGenerator {
+  functionCallsProcessed = 0;
+
+  override processNode(node: AgencyNode): string {
+    if (node.type === "functionCall") {
+      this.functionCallsProcessed++;
+    }
+    return super.processNode(node);
+  }
+}
 
 describe("AgencyGenerator - Function Parameter Type Hints", () => {
   describe("processFunctionDefinition", () => {
@@ -1477,5 +1488,20 @@ describe("AgencyGenerator - does not modify its input", () => {
     expect(printed.indexOf('import { read } from "std::fs"')).toBeLessThan(
       printed.indexOf("node main(): string {"),
     );
+  });
+});
+
+describe("AgencyGenerator - nested call rendering", () => {
+  it("renders each unwrapped nested call once", () => {
+    const depth = 12;
+    const expression = "f(".repeat(depth) + "x" + ")".repeat(depth);
+    const parsed = parseAgency(`node main() {\n  return ${expression}\n}\n`);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+
+    const generator = new ProcessCountingGenerator();
+    generator.generate(parsed.result);
+
+    expect(generator.functionCallsProcessed).toBe(depth);
   });
 });

--- a/packages/agency-lang/lib/backends/agencyGenerator.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.ts
@@ -1449,10 +1449,10 @@ export class AgencyGenerator {
     prefix: string,
     suffix: string,
   ): string {
-    const body = this.renderListIfTrivia(renderItems(), trivia, "(", ")");
-    if (body === undefined) {
+    if (!trivia?.length) {
       return this.wrapList(renderItems, prefix, "(", ")", suffix);
     }
+    const body = this.renderListIfTrivia(renderItems(), trivia, "(", ")");
     return `${prefix}${body}${suffix}`;
   }
 


### PR DESCRIPTION
## What changed

Avoid rendering parenthesized-list items before checking whether the list has trivia. On the normal no-trivia path, `wrapList` now owns the first render.

This fixes the recursive duplication introduced by #783: each unwrapped function call rendered its arguments once in `renderParenList` and again in `wrapList`, so nested calls recursively doubled the work at every level.

## Regression test

The new test uses a counting generator over a 12-deep unwrapped call expression. It asserts that the 12 function-call nodes are each processed once.

- Before the fix: 4,095 function-call processings
- After the fix: 12 function-call processings

This is deterministic and avoids timing-based assertions.

## Verification

- Focused formatter, generator, round-trip, comment-conservation, and trailing-comment suites: 290 passed
- `pnpm run lint:structure`
- `pnpm exec tsc --noEmit`
