### PR TITLE
A template must import the types it names

### DIFF
--- a/packages/agency-lang/lib/typeChecker/templateNames.test.ts
+++ b/packages/agency-lang/lib/typeChecker/templateNames.test.ts
@@ -439,3 +439,145 @@ describe("AG8015: a template's own imported node", () => {
     expect(codesOf(source)).not.toContain("AG8015");
   });
 });
+
+describe("AG8015: type names a template does not define", () => {
+  it("reports a borrowed type on an annotated declaration", () => {
+    const source = [
+      "type Person = {",
+      "  name: string",
+      "}",
+      "",
+      "node host() {",
+      "  const template = [|",
+      '    const p: Person = { name: "a" }',
+      "  |]",
+      '  print("host")',
+      "}",
+      "",
+    ].join("\n");
+    expect(codesOf(source)).toContain("AG8015");
+    expect(messageFor(source, "AG8015")).toMatch(/Person/);
+  });
+
+  it("reports a borrowed type on a hole annotation", () => {
+    // The #719 case: the hole's type is one the template does not have,
+    // so fill cannot check it and the generated program will not compile.
+    const source = withLiteral([
+      "    node main(): string {",
+      "      const p: Person = #person",
+      '      return "x"',
+      "    }",
+    ]);
+    expect(codesOf(source)).toContain("AG8015");
+    expect(messageFor(source, "AG8015")).toMatch(/Person/);
+  });
+
+  it("reports a borrowed type on a parameter", () => {
+    const source = withLiteral([
+      "    def greet(who: Person): string {",
+      '      return "hi"',
+      "    }",
+    ]);
+    expect(codesOf(source)).toContain("AG8015");
+    expect(messageFor(source, "AG8015")).toMatch(/Person/);
+  });
+
+  it("reports a borrowed type on a return annotation", () => {
+    const source = withLiteral([
+      "    def make(): Person {",
+      '      return { name: "a" }',
+      "    }",
+    ]);
+    expect(codesOf(source)).toContain("AG8015");
+  });
+
+  it("reports a borrowed type on a node parameter", () => {
+    const source = withLiteral([
+      "    node main(who: Person): string {",
+      '      return "hi"',
+      "    }",
+    ]);
+    expect(codesOf(source)).toContain("AG8015");
+  });
+});
+
+describe("AG8015: type names a template does define", () => {
+  it("a type the template declares", () => {
+    const source = withLiteral([
+      "    type Person = {",
+      "      name: string",
+      "    }",
+      "",
+      '    const p: Person = { name: "a" }',
+    ]);
+    expect(codesOf(source)).not.toContain("AG8015");
+  });
+
+  it("a type the template declares, used in a signature", () => {
+    const source = withLiteral([
+      "    type Person = {",
+      "      name: string",
+      "    }",
+      "",
+      "    def greet(who: Person): Person {",
+      "      return who",
+      "    }",
+    ]);
+    expect(codesOf(source)).not.toContain("AG8015");
+  });
+
+  it("a type the template imports", () => {
+    const source = withLiteral([
+      '    import { Person } from "./types.agency"',
+      "",
+      '    const p: Person = { name: "a" }',
+      "",
+      "    def greet(who: Person): Person {",
+      "      return who",
+      "    }",
+    ]);
+    expect(codesOf(source)).not.toContain("AG8015");
+  });
+
+  it("a builtin generic", () => {
+    const source = withLiteral([
+      '    const r: Result<string> = success("a")',
+      "    const counts: Record<string, number> = {}",
+    ]);
+    expect(codesOf(source)).not.toContain("AG8015");
+  });
+
+  it("primitives and arrays", () => {
+    const source = withLiteral([
+      "    const n: number = 1",
+      '    const names: string[] = ["a"]',
+      "    def add(x: number, y: number): number {",
+      "      return x + y",
+      "    }",
+    ]);
+    expect(codesOf(source)).not.toContain("AG8015");
+  });
+
+  it("a generic parameter in an alias body", () => {
+    // Alias bodies are deliberately unchecked: `T` is bound here, and the
+    // resolver has no notion of bound names.
+    const source = withLiteral([
+      "    type Box<T> = {",
+      "      value: T",
+      "    }",
+      "",
+      "    const b: Box<number> = { value: 1 }",
+    ]);
+    expect(codesOf(source)).not.toContain("AG8015");
+  });
+});
+
+describe("AG8015: type names in a template file", () => {
+  it("leaves an unknown type in a holey file to AG1006", () => {
+    // A file's own annotations resolve against its real imports, so that
+    // pass already covers them. Two codes for one name would be noise.
+    const source = 'node main(): string {\n  const p: Person = #person\n  return "x"\n}\n';
+    expect(codesOf(source)).toContain("AG1006");
+    expect(codesOf(source)).not.toContain("AG8015");
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/templateNames.test.ts
+++ b/packages/agency-lang/lib/typeChecker/templateNames.test.ts
@@ -581,3 +581,24 @@ describe("AG8015: type names in a template file", () => {
     expect(codesOf(source)).not.toContain("AG8015");
   });
 });
+
+describe("AG8015: type names that collide with object methods", () => {
+  it("reports a borrowed type named after a prototype method", () => {
+    // A plain-object alias table would find Object.prototype.toString and
+    // treat the name as resolved.
+    const source = withLiteral(["    const x: toString = 1"]);
+    expect(codesOf(source)).toContain("AG8015");
+    expect(messageFor(source, "AG8015")).toMatch(/toString/);
+  });
+
+  it("says nothing when the template imports that name", () => {
+    // The alias map is a plain object too, so reading it needs the same
+    // care: without it the stub is keyed by a function.
+    const source = withLiteral([
+      '    import { toString } from "./types.agency"',
+      "",
+      "    const x: toString = 1",
+    ]);
+    expect(codesOf(source)).not.toContain("AG8015");
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/templateNames.ts
+++ b/packages/agency-lang/lib/typeChecker/templateNames.ts
@@ -265,7 +265,12 @@ function importedTypeStubs(
       if (entry.type !== "namedImport") continue;
       for (const name of entry.importedNames) {
         if (typeof name !== "string") continue;
-        stubs[entry.aliases[name] ?? name] = { body: ANY_T };
+        // Own-property only: `import { toString }` would otherwise read the
+        // alias map's prototype and key the stub by a function.
+        const local = Object.hasOwn(entry.aliases, name)
+          ? entry.aliases[name]
+          : name;
+        stubs[local] = { body: ANY_T };
       }
     }
   }
@@ -313,10 +318,13 @@ function isolatedContext(
     matchExprYieldTypes: {},
     config,
     // Imported stubs first, so a name the template also declares wins.
-    getTypeAliases: () => ({
-      ...imported,
-      ...unit.typeAliases.visibleIn(currentScopeKey),
-    }),
+    // Null-prototype: a type named `toString` must miss, not find a method.
+    getTypeAliases: () =>
+      Object.assign(
+        Object.create(null) as Record<string, TypeAliasEntry>,
+        imported,
+        unit.typeAliases.visibleIn(currentScopeKey),
+      ),
     withScope<T>(key: string, fn: () => T): T {
       const previous = currentScopeKey;
       currentScopeKey = key;

--- a/packages/agency-lang/lib/typeChecker/templateNames.ts
+++ b/packages/agency-lang/lib/typeChecker/templateNames.ts
@@ -13,11 +13,19 @@ import { resolveCall } from "./resolveCall.js";
 import { resolveVariable } from "./resolveVariable.js";
 import { buildScopes } from "./scopes.js";
 import { collectProgramShadowing } from "./shadowing.js";
+import { validateTypeReferences } from "./validate.js";
 import { ANY_T } from "./primitives.js";
 import type { AgencyConfig } from "../config.js";
-import type { AgencyNode, AgencyProgram, CodeLiteral } from "../types.js";
+import type {
+  AgencyNode,
+  AgencyProgram,
+  CodeLiteral,
+  TypeAliasEntry,
+} from "../types.js";
 import type { SourceLocation } from "../types/base.js";
-import type { TypeCheckerContext } from "./types.js";
+import type { FunctionDefinition } from "../types/function.js";
+import type { GraphNodeDefinition } from "../types/graphNode.js";
+import type { TypeCheckError, TypeCheckerContext } from "./types.js";
 
 const PRELUDE = new Set(PRELUDE_NAMES);
 
@@ -49,9 +57,12 @@ type TemplateNameScope = {
 export function findUndefinedTemplateNames(
   nodes: AgencyNode[],
   config: AgencyConfig,
+  options: { includeTypeNames?: boolean } = {},
 ): UndefinedTemplateName[] {
+  const { includeTypeNames = true } = options;
   const found: UndefinedTemplateName[] = [];
-  for (const scope of templateNameScopes(nodes, config)) {
+  const context = isolatedContext({ type: "agencyProgram", nodes }, config);
+  for (const scope of templateNameScopes(nodes, context)) {
     const isTopLevel = scope.kind === "topLevel";
     for (const { node, ancestors } of walkNodes(scope.body)) {
       // A definition's body has its own scope below, so skip it here or
@@ -79,7 +90,71 @@ export function findUndefinedTemplateNames(
       }
     }
   }
+  if (includeTypeNames) {
+    // Building the scopes above already validated every annotated
+    // declaration, including a hole's, against the template's own aliases.
+    // Those findings are in the isolated context; the rest of what it
+    // collected stays discarded.
+    found.push(...unknownTypesIn(context.errors));
+    found.push(...undefinedSignatureTypes(nodes, context));
+  }
   return found;
+}
+
+/** The unknown-type findings among diagnostics, by their recorded name. */
+function unknownTypesIn(
+  errors: readonly TypeCheckError[],
+): UndefinedTemplateName[] {
+  return errors
+    .filter((error) => error.name === "unknownTypeAlias")
+    .map((error) => ({
+      name: String((error.params as { alias?: unknown }).alias ?? ""),
+      loc: error.loc ?? null,
+    }));
+}
+
+/**
+ * Types named in a `def` or `node` signature.
+ *
+ * `walkScopeBody` validates annotated declarations and nothing else, so a
+ * parameter or return type would otherwise go unchecked.
+ *
+ * Alias bodies stay unchecked on purpose: `type Box<T>` binds `T`, and
+ * `validateTypeReferences` has no notion of a bound name, so checking one
+ * would report every generic alias a template declares.
+ */
+function undefinedSignatureTypes(
+  nodes: AgencyNode[],
+  context: TypeCheckerContext,
+): UndefinedTemplateName[] {
+  const errors: TypeCheckError[] = [];
+  const aliases = context.getTypeAliases();
+  for (const { node } of walkNodes(nodes)) {
+    if (node.type !== "function" && node.type !== "graphNode") {
+      continue;
+    }
+    const signature = node as FunctionDefinition | GraphNodeDefinition;
+    for (const parameter of signature.parameters) {
+      if (!parameter.typeHint) continue;
+      validateTypeReferences(
+        parameter.typeHint,
+        parameter.name,
+        aliases,
+        errors,
+        node.loc,
+      );
+    }
+    if (signature.returnType) {
+      validateTypeReferences(
+        signature.returnType,
+        "return",
+        aliases,
+        errors,
+        node.loc,
+      );
+    }
+  }
+  return unknownTypesIn(errors);
 }
 
 /**
@@ -94,7 +169,12 @@ export function checkTemplateNames(ctx: TypeCheckerContext): void {
   // in it, not just the ones inside literals. The ordinary undefined-name
   // passes stand down for such a file.
   if (holeNames(ctx.programNodes).length > 0) {
-    const findings = findUndefinedTemplateNames(ctx.programNodes, ctx.config);
+    // Type names are left alone here. A file's own annotations are already
+    // validated against its real imports, which resolve; reporting them
+    // again would put AG8015 beside the AG1006 that pass emits.
+    const findings = findUndefinedTemplateNames(ctx.programNodes, ctx.config, {
+      includeTypeNames: false,
+    });
     reportTemplateNameFindings(findings, ctx);
   }
   // The literal loop still runs: the walker treats a literal's nodes as
@@ -132,10 +212,8 @@ function reportTemplateNameFindings(
  */
 function templateNameScopes(
   nodes: AgencyNode[],
-  config: AgencyConfig,
+  context: TypeCheckerContext,
 ): TemplateNameScope[] {
-  const program: AgencyProgram = { type: "agencyProgram", nodes };
-  const context = isolatedContext(program, config);
   // `walkScopeBody` has no `importNodeStatement` case, so an `import node`
   // the template makes itself has no lexical-scope fallback. Collect those
   // names here or a template-local imported node looks undefined.
@@ -167,6 +245,34 @@ function templateNameScopes(
 }
 
 /**
+ * Every name the template's own imports bring in, as a resolvable alias.
+ *
+ * A template that imports `Person` may annotate with it, and no file gets
+ * read to prove that, exactly as an imported function is accepted without
+ * one. The stub body is `any` because nothing here knows the real shape.
+ *
+ * Imports do not say which names are types, so a function's name lands
+ * here too: a template writing `const x: edit = …` goes unreported. That
+ * costs a message the compile of the generated program still gives.
+ */
+function importedTypeStubs(
+  nodes: AgencyNode[],
+): Record<string, TypeAliasEntry> {
+  const stubs: Record<string, TypeAliasEntry> = Object.create(null);
+  for (const node of nodes) {
+    if (node.type !== "importStatement") continue;
+    for (const entry of node.importedNames) {
+      if (entry.type !== "namedImport") continue;
+      for (const name of entry.importedNames) {
+        if (typeof name !== "string") continue;
+        stubs[entry.aliases[name] ?? name] = { body: ANY_T };
+      }
+    }
+  }
+  return stubs;
+}
+
+/**
  * A context for the template body alone.
  *
  * Built from the body and the config, never from the host's. Host
@@ -186,6 +292,7 @@ function isolatedContext(
   const nodeDefs = Object.fromEntries(
     unit.graphNodes.map((node) => [declaredName(node.nodeName), node]),
   );
+  const imported = importedTypeStubs(program.nodes);
   let currentScopeKey = GLOBAL_SCOPE_KEY;
 
   const context: TypeCheckerContext = {
@@ -205,7 +312,11 @@ function isolatedContext(
     matchExprTypes: {},
     matchExprYieldTypes: {},
     config,
-    getTypeAliases: () => unit.typeAliases.visibleIn(currentScopeKey),
+    // Imported stubs first, so a name the template also declares wins.
+    getTypeAliases: () => ({
+      ...imported,
+      ...unit.typeAliases.visibleIn(currentScopeKey),
+    }),
     withScope<T>(key: string, fn: () => T): T {
       const previous = currentScopeKey;
       currentScopeKey = key;


### PR DESCRIPTION
Closes part of #719.

## What this does

AG8015 says a template can only use names it declares or imports itself. Until now it only looked at *value* names — variables and calls. Type names were checked by nothing at all, so this compiled clean:

```ts
type Person = {
  name: string
}

static const template = [|
  const p: Person = { name: "a" }   // Person is the host file's, not the template's
|]
```

That template does not compile once `toSource` prints it and `runCode` runs it, because `Person` is not there. It is also the shape behind #719: a hole annotated with a borrowed type can never be checked at fill, since `fill` has no way to know what `Person` is either.

Type names now follow the same rule as everything else.

## Where the check came from

Mostly from work already being done and thrown away. `templateNames.ts` builds a context from the template body alone, and building its scopes validates every annotated declaration against the template's own aliases (`lib/typeChecker/scopes.ts:141`). Those diagnostics landed in the isolated context's error array, which the pass discarded wholesale. Instrumenting it showed exactly what was being lost:

```
CASE annotatedConst   ["AG1006 Type alias 'Person' is not defined (referenced in 'p')."]
CASE holeAnnotation   ["AG1006 Type alias 'Person' is not defined (referenced in 'p')."]
CASE defParam         []
CASE defReturn        []
```

So the change is three small things:

- Keep the unknown-type findings instead of discarding them, and report them as AG8015 so the message teaches the template rule.
- Add a short walk over `def` and `node` signatures, since building scopes covers annotated declarations and nothing else. `FunctionDefinition` has no type parameters, so there are no bound names to mistake for unknown ones.
- Treat a name the template imports itself as known. No file is read to prove it, exactly as an imported function is accepted without one.

## What it deliberately does not check

**Alias bodies.** `type Box<T> = { value: T }` binds `T`, and `validateTypeReferences` has no notion of a bound name, so checking bodies would report every generic alias a template declares. A test pins that this stays quiet.

**Template files.** A `.agency` file with holes keeps reporting AG1006 for an unknown type. Its imports resolve for real, so that pass is already correct there; reporting again just put two codes on one name. Measured before deciding — the holey file produced `["AG1006","AG8015"]`.

**Whether the imported type actually exists.** An import makes the name known, not correct. Resolving it means reading other modules at compile time and carrying the result into the compiled program so `fill` can use it. That is the rest of #719, and we decided the carrying cost is not worth it for now: a `Code` value would have to hold checking metadata that merges correctly every time fragments graft together, and the error it buys is one `runCode` already reports, just later.

## Checks

- 45 tests in `templateNames.test.ts`, 5 of them red before the change. The guards are the point: a declared type, an imported type, `Result<string>`, `Record<string, number>`, primitives, arrays, and a generic alias body.
- `lib/typeChecker`, `lib/typescriptGenerator`, `lib/runtime/template`: 1978 passed.
- `agency tc` over `tests/agency`, `examples`, `lib` and `stdlib`: no new AG8015. Nothing in the repo relied on borrowing a type.
- `make` exit 0, `lint:structure` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
