### PR TITLE
ci: gate the test/eval typecheck and fix its outstanding errors

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,31 @@
+# Security: all actions pinned to SHA. Do not use pull_request_target.
+name: Typecheck
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: typecheck-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+        with:
+          version: 9
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      # Type-checks the source, the tests (tsconfig.tests.json), and the evals
+      # (tsconfig.evals.json). No build needed — tsc only type-checks.
+      - run: pnpm run typecheck
+        working-directory: packages/agency-lang

--- a/packages/agency-lang/lib/cli/remote/exportedEndpoints.test.ts
+++ b/packages/agency-lang/lib/cli/remote/exportedEndpoints.test.ts
@@ -18,7 +18,7 @@ function writeFixture(name: string, source: string): string {
 afterAll(() => {
   const result = safeDeleteDirectory(fixturesRoot, false);
   if (!result.success) {
-    console.error(`exportedEndpoints fixture cleanup failed: ${result.error}`);
+    console.error(`exportedEndpoints fixture cleanup failed: ${result.message}`);
   }
 });
 

--- a/packages/agency-lang/lib/serve/discovery.test.ts
+++ b/packages/agency-lang/lib/serve/discovery.test.ts
@@ -10,7 +10,10 @@ describe("discoverExports", () => {
         name: "publicFn",
         module: "test",
         fn: async () => {},
-        params: [{ name: "x" }, { name: "y" }],
+        params: [
+          { name: "x", hasDefault: false, defaultValue: undefined, variadic: false },
+          { name: "y", hasDefault: false, defaultValue: undefined, variadic: false },
+        ],
         toolDefinition: {
           name: "publicFn",
           description: "A public fn",
@@ -57,7 +60,10 @@ describe("discoverExports", () => {
         name: "boundFn",
         module: "test",
         fn: async () => {},
-        params: [{ name: "visible" }, { name: "hidden", isBound: true }],
+        params: [
+          { name: "visible", hasDefault: false, defaultValue: undefined, variadic: false },
+          { name: "hidden", hasDefault: false, defaultValue: undefined, variadic: false, isBound: true },
+        ],
         toolDefinition: { name: "boundFn", description: "", schema: null },
         exported: true,
       },

--- a/packages/agency-lang/lib/serve/mcp/adapter.test.ts
+++ b/packages/agency-lang/lib/serve/mcp/adapter.test.ts
@@ -35,6 +35,7 @@ function makeTestExports(): ExportedItem[] {
       kind: "function",
       name: "add",
       description: "Add two numbers",
+      parameters: [{ name: "a" }, { name: "b" }],
       agencyFunction: addFn,
       interruptEffects: [],
       invoke: (namedArgs) => addFn.invoke({ type: "named", positionalArgs: [], namedArgs }),
@@ -173,6 +174,7 @@ describe("MCP adapter", () => {
           kind: "function",
           name: "deploy",
           description: "Deploy app",
+          parameters: [],
           agencyFunction: deployFn,
           interruptEffects: [{ effect: "myapp::deploy" }, { effect: "myapp::approve" }],
           invoke: (namedArgs) => deployFn.invoke({ type: "named", positionalArgs: [], namedArgs }),
@@ -219,6 +221,7 @@ describe("MCP adapter", () => {
         kind: "function" as const,
         name,
         description: name,
+        parameters: [],
         agencyFunction: fn,
         interruptEffects: [],
         invoke: (namedArgs: Record<string, unknown>) =>
@@ -406,7 +409,7 @@ describe("MCP adapter — policy tools", () => {
       serverName: "test",
       serverVersion: "1.0.0",
       exports: [
-        { kind: "function", name: "greet", description: "Greet someone", agencyFunction: greetFn, interruptEffects: [{ effect: "test::greet" }], invoke: (namedArgs) => greetFn.invoke({ type: "named", positionalArgs: [], namedArgs }) },
+        { kind: "function", name: "greet", description: "Greet someone", parameters: [{ name: "name" }], agencyFunction: greetFn, interruptEffects: [{ effect: "test::greet" }], invoke: (namedArgs) => greetFn.invoke({ type: "named", positionalArgs: [], namedArgs }) },
       ],
       policyConfig: {
         policyStore: new PolicyStore("test", tmpDir),
@@ -456,7 +459,7 @@ describe("MCP adapter — policy tools", () => {
       serverName: "test",
       serverVersion: "1.0.0",
       exports: [
-        { kind: "function", name: "sendEmail", description: "Send an email", agencyFunction: sendFn, interruptEffects: [{ effect: "email::send" }], invoke: (namedArgs) => sendFn.invoke({ type: "named", positionalArgs: [], namedArgs }) },
+        { kind: "function", name: "sendEmail", description: "Send an email", parameters: [], agencyFunction: sendFn, interruptEffects: [{ effect: "email::send" }], invoke: (namedArgs) => sendFn.invoke({ type: "named", positionalArgs: [], namedArgs }) },
       ],
       policyConfig: {
         policyStore: store,

--- a/packages/agency-lang/lib/serve/mcp/httpTransport.test.ts
+++ b/packages/agency-lang/lib/serve/mcp/httpTransport.test.ts
@@ -28,6 +28,7 @@ function makeHandler() {
       kind: "function",
       name: "add",
       description: "Add two numbers",
+      parameters: [{ name: "a" }, { name: "b" }],
       agencyFunction: addFn,
       interruptEffects: [],
       invoke: (namedArgs) => addFn.invoke({ type: "named", positionalArgs: [], namedArgs }),

--- a/packages/agency-lang/tsconfig.tests.json
+++ b/packages/agency-lang/tsconfig.tests.json
@@ -6,7 +6,10 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "noEmit": true,
-    "incremental": false
+    // Own buildinfo file so this check never clobbers the main build's, which
+    // the base tsconfig points at ./.agency-build/tsc.tsbuildinfo. Both live in
+    // .agency-build/ (gitignored, wiped by `make clean`).
+    "tsBuildInfoFile": "./.agency-build/tsc-tests.tsbuildinfo"
   },
   "include": ["lib", "scripts"],
   "exclude": [


### PR DESCRIPTION
## What

`pnpm run typecheck` type-checks three things — the source (`tsc --noEmit`), the tests (`tsconfig.tests.json`), and the evals (`tsconfig.evals.json`) — but nothing in CI ever ran it. So type errors in test files could pile up without any PR going red. This PR fixes the errors that had already accumulated and adds a CI gate so they can't come back silently.

## The two problems

1. **The tests typecheck was broken outright.** `tsconfig.tests.json` set `incremental: false` while inheriting `tsBuildInfoFile` from the base config. TypeScript rejects that combination (TS5069), so the check aborted before type-checking a single file. It now points at its own buildinfo file under `.agency-build/` (gitignored, like the base config's), which resolves the conflict without clobbering the main build's buildinfo.

2. **10 stale-fixture errors in `lib/serve/` tests.** Once the check actually ran, test fixtures had drifted from the real types:
   - `FuncParam` requires `hasDefault` / `defaultValue` / `variadic` — `discovery.test.ts` built params with just `{ name }`.
   - `ExportedFunction` requires `parameters` — the `mcp/adapter.test.ts` and `mcp/httpTransport.test.ts` fixtures omitted it.

   Updated the fixtures to match the current types (the added `parameters` mirror each function's real params).

## The gate

New `.github/workflows/typecheck.yml` runs `pnpm run typecheck` on every PR to `main`. No build step needed — `tsc` only type-checks.

## Verification

- `pnpm run typecheck` → exit 0 (all three configs clean).
- `vitest run lib/serve/discovery.test.ts lib/serve/mcp/adapter.test.ts lib/serve/mcp/httpTransport.test.ts` → 44 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
