### PR TITLE
feat(config): budget field for per-run spend/time limits, honored when served

### DIFF
--- a/packages/agency-lang/lib/backends/budget.codegen.test.ts
+++ b/packages/agency-lang/lib/backends/budget.codegen.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { parseAgency } from "../parser.js";
+import { TypeScriptBuilder } from "./typescriptBuilder.js";
+import { TypescriptPreprocessor } from "@/preprocessors/typescriptPreprocessor.js";
+import { buildCompilationUnit } from "@/compilationUnit.js";
+import { printTs } from "../ir/prettyPrint.js";
+import type { AgencyConfig } from "@/config.js";
+
+// Codegen wiring: agency.json `budget` must be baked into the generated
+// `new RuntimeContext({...})` args, with maxTime resolved to milliseconds at
+// compile time. installRootBudget reads it at runtime when no --max-cost /
+// --max-time flag is set. (Served agents get the budget via runtime-config
+// overrides instead — statelog compiles the uploaded source without this config.)
+function generate(source: string, config?: Partial<AgencyConfig>): string {
+  const parseResult = parseAgency(source, {}, false);
+  if (!parseResult.success) {
+    throw new Error(`Failed to parse: ${parseResult.message}`);
+  }
+  const info = buildCompilationUnit(parseResult.result);
+  const preprocessor = new TypescriptPreprocessor(parseResult.result, {}, info);
+  const pre = preprocessor.preprocess();
+  const builder = new TypeScriptBuilder(config as AgencyConfig, info, "test.agency");
+  return printTs(builder.build(pre));
+}
+
+const PROGRAM = "node main() {\n  const x = 1\n}\n";
+
+describe("budget codegen", () => {
+  it("bakes budget.maxCost and resolves maxTime to milliseconds", () => {
+    const out = generate(PROGRAM, { budget: { maxCost: 0.5, maxTime: "10m" } });
+    expect(out).toContain("maxCost: 0.5");
+    expect(out).toContain("maxTimeMs: 600000");
+  });
+
+  it("bakes maxCost alone (0 is a real limit) without maxTimeMs", () => {
+    const out = generate(PROGRAM, { budget: { maxCost: 0 } });
+    expect(out).toContain("maxCost: 0");
+    expect(out).not.toContain("maxTimeMs");
+  });
+
+  it("omits budget entirely when not configured", () => {
+    const out = generate(PROGRAM);
+    expect(out).not.toContain("maxTimeMs");
+    expect(out).not.toContain("budget:");
+  });
+});

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -50,6 +50,7 @@ import * as renderResultCheckpointSetup from "../templates/backends/typescriptGe
 import * as renderFunctionCatchFailure from "../templates/backends/typescriptGenerator/functionCatchFailure.js";
 
 import { AgencyConfig } from "@/config.js";
+import { parseDurationMs } from "@/duration.js";
 import {
   BinOpArgument,
   BinOpExpression,
@@ -4499,6 +4500,23 @@ export class TypeScriptBuilder {
       runtimeCtxArgs.failurePropagation = ts.str(
         this.agencyConfig.failurePropagation,
       );
+    }
+    // Bake the config `budget` into the RuntimeContext, resolving maxTime to ms
+    // at compile time. installRootBudget reads this when no --max-cost/--max-time
+    // flag is set. (Served agents get the budget via runtime-config overrides
+    // instead, since statelog compiles the uploaded source without this config.)
+    if (this.agencyConfig.budget !== undefined) {
+      const b = this.agencyConfig.budget;
+      const budgetFields: Record<string, TsNode> = {};
+      if (b.maxCost !== undefined) {
+        budgetFields.maxCost = ts.raw(String(b.maxCost));
+      }
+      if (b.maxTime !== undefined) {
+        budgetFields.maxTimeMs = ts.raw(
+          String(parseDurationMs(b.maxTime, "budget.maxTime")),
+        );
+      }
+      runtimeCtxArgs.budget = ts.obj(budgetFields);
     }
     if (cfg.client?.maxToolResultChars !== undefined) {
       runtimeCtxArgs.maxToolResultChars = ts.raw(

--- a/packages/agency-lang/lib/cli/budget.ts
+++ b/packages/agency-lang/lib/cli/budget.ts
@@ -1,32 +1,9 @@
-const UNIT_MS: Record<string, number> = {
-  ms: 1,
-  s: 1_000,
-  m: 60_000,
-  h: 3_600_000,
-  d: 86_400_000,
-  w: 604_800_000,
-};
+import { parseDurationMs } from "@/duration.js";
 
-/** Parse a duration string (`500ms`, `30s`, `5m`, `1h`, `2d`, `1w`, or a
- *  leading-minus disable value like `-1s`) to milliseconds. A bare unitless
- *  number throws: the CLI requires an explicit unit so a value's meaning is
- *  never guessed. The computed milliseconds must be finite — an absurdly
- *  long digit string would otherwise overflow to Infinity, stringify into
- *  the env, and silently install no guard (fail-open on a cost-control
- *  feature). */
-export function parseDurationMs(s: string): number {
-  const m = /^(-?\d+(?:\.\d+)?)(ms|s|m|h|d|w)$/.exec(s.trim());
-  if (!m) {
-    throw new Error(
-      `--max-time: expected a duration like 500ms, 30s, 5m, 1h, 2d, or 1w (got "${s}")`,
-    );
-  }
-  const ms = parseFloat(m[1]) * UNIT_MS[m[2]];
-  if (!Number.isFinite(ms)) {
-    throw new Error(`--max-time: duration is too large (got "${s}")`);
-  }
-  return ms;
-}
+// Re-export so existing `@/cli/budget.js` importers are unaffected by the move
+// to the neutral lib/duration.ts (the runtime and builder need the parser too,
+// and must not import from lib/cli).
+export { parseDurationMs };
 
 /** Resolve --max-cost / --max-time flag strings into the env-var string
  *  values the child reads. Cost stays as dollars; time becomes milliseconds.
@@ -47,7 +24,7 @@ export function resolveBudget(opts: {
     out.maxCost = String(n);
   }
   if (opts.maxTime !== undefined) {
-    out.maxTime = String(parseDurationMs(opts.maxTime));
+    out.maxTime = String(parseDurationMs(opts.maxTime, "--max-time"));
   }
   return out;
 }

--- a/packages/agency-lang/lib/config.test.ts
+++ b/packages/agency-lang/lib/config.test.ts
@@ -27,6 +27,18 @@ describe("AgencyConfigSchema", () => {
     expect(result.success).toBe(true);
   });
 
+  it("accepts a budget with a finite maxCost and a duration maxTime", () => {
+    const result = AgencyConfigSchema.safeParse({
+      budget: { maxCost: 0.5, maxTime: "30m" },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a non-finite budget.maxCost (a 1e309 Infinity must not uncap spend)", () => {
+    const result = AgencyConfigSchema.safeParse({ budget: { maxCost: 1e309 } });
+    expect(result.success).toBe(false);
+  });
+
   it("accepts eval runsDir config", () => {
     const result = AgencyConfigSchema.safeParse({
       eval: { runsDir: "custom-runs" },

--- a/packages/agency-lang/lib/config.ts
+++ b/packages/agency-lang/lib/config.ts
@@ -274,6 +274,16 @@ export interface AgencyConfig {
    * "off": no checks. */
   failurePropagation?: "off" | "warn" | "on";
 
+  /** Root spend/time budget for each run — the same ceiling as `agency run
+   * --max-cost` / `--max-time`, but declarative and honored when the agent is
+   * served remotely (a CLI flag, when given, wins). `maxCost` is dollars of LLM
+   * spend; `< 0` disables, `0` is a real limit (no paid spend). `maxTime` is a
+   * duration string like `30s`, `5m`, `1h`; `<= 0` disables. */
+  budget?: {
+    maxCost?: number;
+    maxTime?: string;
+  };
+
   /** Enable execution tracing — writes checkpoints to a .trace file */
   trace?: boolean;
 
@@ -507,6 +517,10 @@ export const AgencyConfigSchema = z
     // throw — reject it at config-load rather than bricking the program.
     maxCallDepth: z.number().int().positive(),
     failurePropagation: z.enum(["off", "warn", "on"]),
+    // maxCost is dollars: negatives (disable) and 0 (no paid spend) are both
+    // meaningful, so it is a plain number, not positive-only. maxTime is a
+    // duration string validated when parsed (parseDurationMs), fail-closed.
+    budget: z.object({ maxCost: z.number(), maxTime: z.string() }).partial(),
     trace: z.boolean(),
     traceFile: z.string(),
     traceDir: z.string(),

--- a/packages/agency-lang/lib/config.ts
+++ b/packages/agency-lang/lib/config.ts
@@ -518,9 +518,18 @@ export const AgencyConfigSchema = z
     maxCallDepth: z.number().int().positive(),
     failurePropagation: z.enum(["off", "warn", "on"]),
     // maxCost is dollars: negatives (disable) and 0 (no paid spend) are both
-    // meaningful, so it is a plain number, not positive-only. maxTime is a
-    // duration string validated when parsed (parseDurationMs), fail-closed.
-    budget: z.object({ maxCost: z.number(), maxTime: z.string() }).partial(),
+    // meaningful, so it is a plain number, not positive-only — but it MUST be
+    // finite. A non-finite cap (e.g. a JSON `1e309` parsing to Infinity) would
+    // silently uncap spend, the wrong failure for a budget; reject it at load.
+    // maxTime is a duration string validated when parsed (parseDurationMs).
+    budget: z
+      .object({
+        maxCost: z
+          .number()
+          .refine((n) => Number.isFinite(n), "budget.maxCost must be a finite number"),
+        maxTime: z.string(),
+      })
+      .partial(),
     trace: z.boolean(),
     traceFile: z.string(),
     traceDir: z.string(),

--- a/packages/agency-lang/lib/duration.test.ts
+++ b/packages/agency-lang/lib/duration.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { parseDurationMs } from "@/duration.js";
+
+describe("parseDurationMs", () => {
+  it("parses each unit to milliseconds", () => {
+    expect(parseDurationMs("500ms")).toBe(500);
+    expect(parseDurationMs("30s")).toBe(30_000);
+    expect(parseDurationMs("5m")).toBe(300_000);
+    expect(parseDurationMs("1h")).toBe(3_600_000);
+    expect(parseDurationMs("2d")).toBe(172_800_000);
+    expect(parseDurationMs("1w")).toBe(604_800_000);
+  });
+
+  it("accepts a leading-minus disable value", () => {
+    expect(parseDurationMs("-1s")).toBe(-1_000);
+  });
+
+  it("throws on a unitless number, with the default label", () => {
+    expect(() => parseDurationMs("300")).toThrow(/duration: expected/);
+  });
+
+  it("uses the supplied label in the error message", () => {
+    expect(() => parseDurationMs("nope", "budget.maxTime")).toThrow(
+      /budget\.maxTime: expected/,
+    );
+  });
+
+  it("rejects an absurdly long value as too large (fail closed)", () => {
+    expect(() => parseDurationMs("9".repeat(320) + "s")).toThrow(/too large/);
+  });
+});

--- a/packages/agency-lang/lib/duration.ts
+++ b/packages/agency-lang/lib/duration.ts
@@ -1,0 +1,33 @@
+// Parsing human duration strings (`500ms`, `30s`, `5m`, `1h`, `2d`, `1w`) to
+// milliseconds. Shared by the `--max-time` flag (lib/cli/budget.ts), the
+// `budget.maxTime` config field, and the runtime that installs the time guard —
+// so a duration means the same thing everywhere.
+
+const UNIT_MS: Record<string, number> = {
+  ms: 1,
+  s: 1_000,
+  m: 60_000,
+  h: 3_600_000,
+  d: 86_400_000,
+  w: 604_800_000,
+};
+
+/** Parse a duration string to milliseconds. Accepts a leading-minus disable
+ *  value like `-1s`. A bare unitless number throws: the unit must be explicit so
+ *  a value's meaning is never guessed. The result must be finite — an absurdly
+ *  long digit string would otherwise overflow to Infinity and silently install
+ *  no guard (fail-open on a cost-control feature). `label` names the source in
+ *  error messages (e.g. `--max-time` or `budget.maxTime`). */
+export function parseDurationMs(s: string, label = "duration"): number {
+  const m = /^(-?\d+(?:\.\d+)?)(ms|s|m|h|d|w)$/.exec(s.trim());
+  if (!m) {
+    throw new Error(
+      `${label}: expected a duration like 500ms, 30s, 5m, 1h, 2d, or 1w (got "${s}")`,
+    );
+  }
+  const ms = parseFloat(m[1]) * UNIT_MS[m[2]];
+  if (!Number.isFinite(ms)) {
+    throw new Error(`${label}: duration is too large (got "${s}")`);
+  }
+  return ms;
+}

--- a/packages/agency-lang/lib/runtime/configOverrides.test.ts
+++ b/packages/agency-lang/lib/runtime/configOverrides.test.ts
@@ -268,3 +268,36 @@ describe("failurePropagation override", () => {
     expect(merged.failurePropagation).toBeUndefined();
   });
 });
+
+describe("budget override (how statelog sets a served agent's spend limit)", () => {
+  const base = () => ({
+    statelogConfig: { host: "", apiKey: "", projectId: "", debugMode: false, observability: false },
+    smoltalkDefaults: {},
+    dirname: "/p",
+  });
+
+  it("resolves the config shape (maxTime string) into { maxCost, maxTimeMs }", () => {
+    const merged = applyRuntimeConfigOverridesToContextArgs(base(), {
+      budget: { maxCost: 1.5, maxTime: "10m" },
+    });
+    expect(merged.budget).toEqual({ maxCost: 1.5, maxTimeMs: 600_000 });
+  });
+
+  it("carries maxCost alone (no maxTimeMs) when maxTime is omitted", () => {
+    const merged = applyRuntimeConfigOverridesToContextArgs(base(), {
+      budget: { maxCost: 0 },
+    });
+    expect(merged.budget).toEqual({ maxCost: 0 });
+  });
+
+  it("fails closed on a malformed maxTime", () => {
+    expect(() =>
+      applyRuntimeConfigOverridesToContextArgs(base(), { budget: { maxTime: "soon" } }),
+    ).toThrow(/budget\.maxTime/);
+  });
+
+  it("leaves budget unset when the override omits it", () => {
+    const merged = applyRuntimeConfigOverridesToContextArgs(base(), { maxCallDepth: 7 });
+    expect(merged.budget).toBeUndefined();
+  });
+});

--- a/packages/agency-lang/lib/runtime/configOverrides.ts
+++ b/packages/agency-lang/lib/runtime/configOverrides.ts
@@ -1,5 +1,6 @@
 import type { SmolConfig } from "smoltalk";
 
+import { parseDurationMs } from "../duration.js";
 import type { AgencyConfig } from "../config.js";
 import type { StatelogConfig } from "../statelogClient.js";
 import type { LogLevel } from "../logger.js";
@@ -15,6 +16,7 @@ export type RuntimeContextConstructorArgs = {
   maxRestores?: number;
   maxCallDepth?: number;
   failurePropagation?: "off" | "warn" | "on";
+  budget?: { maxCost?: number; maxTimeMs?: number };
   traceConfig?: TraceConfig;
   verbose?: boolean;
   memory?: MemoryConfig;
@@ -82,6 +84,9 @@ export async function withRuntimeConfigOverrides<T>(
  *     the same custom/local providers; de-duped at load time).
  *   • `maxCallDepth` → inherit the parent's runaway-recursion ceiling.
  *   • `failurePropagation` → inherit the parent's failure-propagation mode.
+ *   • `budget` → the root spend/time cap; the config shape (`maxTime` as a
+ *     duration string) is resolved to `{ maxCost, maxTimeMs }` here. This is how
+ *     a host (statelog) sets a served agent's per-agent spend limit.
  */
 export function applyRuntimeConfigOverridesToContextArgs(
   args: RuntimeContextConstructorArgs,
@@ -128,6 +133,20 @@ export function applyRuntimeConfigOverridesToContextArgs(
   // Let a subprocess inherit the parent's failure-propagation mode.
   if (overrides.failurePropagation !== undefined) {
     merged.failurePropagation = overrides.failurePropagation;
+  }
+
+  // Root budget: resolve the config shape (maxTime as a duration string) into
+  // the numeric shape the guard installer uses. A malformed maxTime throws —
+  // fail closed, never silently run a cost-capped agent unbounded.
+  if (overrides.budget !== undefined) {
+    const b = overrides.budget;
+    merged.budget = {
+      ...(merged.budget ?? {}),
+      ...(b.maxCost !== undefined ? { maxCost: b.maxCost } : {}),
+      ...(b.maxTime !== undefined
+        ? { maxTimeMs: parseDurationMs(b.maxTime, "budget.maxTime") }
+        : {}),
+    };
   }
 
   return merged;

--- a/packages/agency-lang/lib/runtime/node.ts
+++ b/packages/agency-lang/lib/runtime/node.ts
@@ -329,7 +329,7 @@ export async function runNode({
   // installer): no-op in IPC subprocesses, whose budgets are owned by the
   // parent's guard. Outermost, before the node body runs, so it cannot be
   // bypassed.
-  installRootBudget(execCtx.stateStack);
+  installRootBudget(execCtx.stateStack, execCtx.budget);
   // Externally-passed callbacks are stored on ctx; hook execution merges them
   // with scoped/top-level callbacks at call time.
   if (callbacks) {

--- a/packages/agency-lang/lib/runtime/rootBudget.test.ts
+++ b/packages/agency-lang/lib/runtime/rootBudget.test.ts
@@ -113,4 +113,18 @@ describe("installRootBudget with a context budget (config, no flag)", () => {
     installRootBudget(stack, { maxCost: 5, maxTimeMs: 5000 });
     expect(stack.guards.length).toBe(0);
   });
+  test("a non-finite context budget FAILS CLOSED (Infinity/NaN never uncaps spend)", () => {
+    // Infinity would install an effectively unbounded guard; NaN (NaN >= 0 is
+    // false) would install none. Both must refuse the run instead. This is the
+    // gate for every non-env ingress: agency.json bake and runtime overrides.
+    expect(() => installRootBudget(new StateStack(), { maxCost: Infinity })).toThrow(
+      /budget\.maxCost is not a finite number/,
+    );
+    expect(() => installRootBudget(new StateStack(), { maxCost: NaN })).toThrow(
+      /budget\.maxCost is not a finite number/,
+    );
+    expect(() => installRootBudget(new StateStack(), { maxTimeMs: Infinity })).toThrow(
+      /budget\.maxTime is not a finite number/,
+    );
+  });
 });

--- a/packages/agency-lang/lib/runtime/rootBudget.test.ts
+++ b/packages/agency-lang/lib/runtime/rootBudget.test.ts
@@ -71,3 +71,46 @@ describe("installRootBudget", () => {
     expect(stack.guards[1]).toBeInstanceOf(TimeGuard);
   });
 });
+
+describe("installRootBudget with a context budget (config, no flag)", () => {
+  test("installs cost and time guards from the context budget when no env is set", () => {
+    const stack = new StateStack();
+    installRootBudget(stack, { maxCost: 2, maxTimeMs: 5000 });
+    expect(stack.guards.some((g) => g instanceof CostGuard)).toBe(true);
+    expect(stack.guards.some((g) => g instanceof TimeGuard)).toBe(true);
+  });
+  test("context cost 0 installs (local-only limit); negative installs nothing", () => {
+    const zero = new StateStack();
+    installRootBudget(zero, { maxCost: 0 });
+    expect(zero.guards.some((g) => g instanceof CostGuard)).toBe(true);
+
+    const neg = new StateStack();
+    installRootBudget(neg, { maxCost: -1 });
+    expect(neg.guards.length).toBe(0);
+  });
+  test("context time <= 0 installs nothing", () => {
+    const stack = new StateStack();
+    installRootBudget(stack, { maxTimeMs: 0 });
+    expect(stack.guards.length).toBe(0);
+  });
+  test("the env flag wins over the context budget, per dimension", () => {
+    // Env disables cost; a context cost would have installed one — env wins.
+    process.env[AGENCY_MAX_COST] = "-1";
+    const disabled = new StateStack();
+    installRootBudget(disabled, { maxCost: 5 });
+    expect(disabled.guards.some((g) => g instanceof CostGuard)).toBe(false);
+    delete process.env[AGENCY_MAX_COST];
+
+    // Env sets cost; a disabling context is ignored — env wins.
+    process.env[AGENCY_MAX_COST] = "0.5";
+    const enabled = new StateStack();
+    installRootBudget(enabled, { maxCost: -1 });
+    expect(enabled.guards.some((g) => g instanceof CostGuard)).toBe(true);
+  });
+  test("no-op in IPC mode even with a context budget", () => {
+    process.env.AGENCY_IPC = "1";
+    const stack = new StateStack();
+    installRootBudget(stack, { maxCost: 5, maxTimeMs: 5000 });
+    expect(stack.guards.length).toBe(0);
+  });
+});

--- a/packages/agency-lang/lib/runtime/rootBudget.ts
+++ b/packages/agency-lang/lib/runtime/rootBudget.ts
@@ -3,7 +3,13 @@ import { CostGuard, TimeGuard } from "./guard.js";
 import { isIpcMode } from "./subprocessRunInfo.js";
 import type { StateStack } from "./state/stateStack.js";
 
-/** Install a root cost/time guard from AGENCY_MAX_COST / AGENCY_MAX_TIME.
+/** Install a root cost/time guard from the CLI flags (AGENCY_MAX_COST /
+ *  AGENCY_MAX_TIME env vars) or, when a flag is absent for that dimension, the
+ *  resolved config `budget` (passed as `contextBudget`). The flag wins per
+ *  dimension, so `agency run --max-cost` still overrides an `agency.json`
+ *  budget; a served agent, which has no flag, is governed by the budget its
+ *  host bound via runtime-config overrides.
+ *
  *  Applies the disable rule: cost < 0 installs nothing; time <= 0 installs
  *  nothing (cost 0 IS a real limit — no paid spend, local-models-only).
  *  Called once at the root, next to installRunPolicyHandler, before the
@@ -14,27 +20,34 @@ import type { StateStack } from "./state/stateStack.js";
  *  pushGuard() installs immediately, so a time budget's clock starts at
  *  run start — the intended whole-run semantics. Interrupt halts and
  *  input() waits still pause it like any other time guard. */
-export function installRootBudget(stack: StateStack): void {
+export function installRootBudget(
+  stack: StateStack,
+  contextBudget?: { maxCost?: number; maxTimeMs?: number },
+): void {
   if (isIpcMode()) return;
+
   const rawCost = process.env[AGENCY_MAX_COST];
-  if (rawCost !== undefined) {
-    const cost = parseBudgetValue(rawCost, AGENCY_MAX_COST);
-    if (cost >= 0) {
-      const g = new CostGuard(cost);
-      // The operator's ceiling: never raises an interrupt, never
-      // extendable by user code. Serialized with the guard.
-      g.isRootBudget = true;
-      stack.pushGuard(g);
-    }
+  const cost =
+    rawCost !== undefined
+      ? parseBudgetValue(rawCost, AGENCY_MAX_COST)
+      : contextBudget?.maxCost;
+  if (cost !== undefined && cost >= 0) {
+    const g = new CostGuard(cost);
+    // The operator's ceiling: never raises an interrupt, never
+    // extendable by user code. Serialized with the guard.
+    g.isRootBudget = true;
+    stack.pushGuard(g);
   }
+
   const rawTime = process.env[AGENCY_MAX_TIME];
-  if (rawTime !== undefined) {
-    const ms = parseBudgetValue(rawTime, AGENCY_MAX_TIME);
-    if (ms > 0) {
-      const g = new TimeGuard(ms);
-      g.isRootBudget = true;
-      stack.pushGuard(g);
-    }
+  const ms =
+    rawTime !== undefined
+      ? parseBudgetValue(rawTime, AGENCY_MAX_TIME)
+      : contextBudget?.maxTimeMs;
+  if (ms !== undefined && ms > 0) {
+    const g = new TimeGuard(ms);
+    g.isRootBudget = true;
+    stack.pushGuard(g);
   }
 }
 

--- a/packages/agency-lang/lib/runtime/rootBudget.ts
+++ b/packages/agency-lang/lib/runtime/rootBudget.ts
@@ -30,7 +30,9 @@ export function installRootBudget(
   const cost =
     rawCost !== undefined
       ? parseBudgetValue(rawCost, AGENCY_MAX_COST)
-      : contextBudget?.maxCost;
+      : contextBudget?.maxCost !== undefined
+        ? finiteContextBudget(contextBudget.maxCost, "budget.maxCost")
+        : undefined;
   if (cost !== undefined && cost >= 0) {
     const g = new CostGuard(cost);
     // The operator's ceiling: never raises an interrupt, never
@@ -43,7 +45,9 @@ export function installRootBudget(
   const ms =
     rawTime !== undefined
       ? parseBudgetValue(rawTime, AGENCY_MAX_TIME)
-      : contextBudget?.maxTimeMs;
+      : contextBudget?.maxTimeMs !== undefined
+        ? finiteContextBudget(contextBudget.maxTimeMs, "budget.maxTime")
+        : undefined;
   if (ms !== undefined && ms > 0) {
     const g = new TimeGuard(ms);
     g.isRootBudget = true;
@@ -57,6 +61,23 @@ export function installRootBudget(
  *  feature, silently running UNBOUNDED is the wrong failure direction.
  *  Refuse the run instead. (Negative values are not malformed: they are
  *  the documented disable range and fall through the install checks.) */
+/** FAIL CLOSED on a non-finite config/override budget number. Env values go
+ *  through parseBudgetValue; this guards the RuntimeContext path (an agency.json
+ *  bake or a programmatic `withRuntimeConfigOverrides` value), where
+ *  TypeScript's `number` still admits NaN/Infinity. A non-finite cap is the
+ *  wrong direction for a budget — Infinity installs an effectively unbounded
+ *  guard, and NaN (NaN >= 0 is false) installs none at all — so refuse the run.
+ *  Negatives are fine: they are the documented disable range. */
+function finiteContextBudget(value: number, name: string): number {
+  if (!Number.isFinite(value)) {
+    throw new Error(
+      `${name} is not a finite number (got ${value}). Refusing to run without ` +
+        `the requested budget — fix the config or the runtime override.`,
+    );
+  }
+  return value;
+}
+
 function parseBudgetValue(raw: string, name: string): number {
   const n = Number(raw);
   if (raw.trim() === "" || !Number.isFinite(n)) {

--- a/packages/agency-lang/lib/runtime/state/context.ts
+++ b/packages/agency-lang/lib/runtime/state/context.ts
@@ -214,6 +214,12 @@ export class RuntimeContext<T> {
    *  recursion guard trips. See lib/runtime/callDepth.ts. */
   maxCallDepth: number;
   failurePropagation: "off" | "warn" | "on";
+  /** Resolved root budget (dollars of LLM spend / wall-clock ms) sourced from
+   *  the `budget` config field — baked for local runs, override-supplied for
+   *  served agents. Read by installRootBudget, where a CLI flag (env var) wins.
+   *  Undefined means "no config budget"; the guard installer then relies on the
+   *  env vars alone. */
+  budget?: { maxCost?: number; maxTimeMs?: number };
 
   // Memory layer (resolved decisions in
   // docs/superpowers/plans/2026-05-12-memory-layer.md and
@@ -244,6 +250,7 @@ export class RuntimeContext<T> {
     maxRestores?: number;
     maxCallDepth?: number;
     failurePropagation?: "off" | "warn" | "on";
+    budget?: { maxCost?: number; maxTimeMs?: number };
     traceConfig?: TraceConfig;
     verbose?: boolean;
     memory?: MemoryConfig;
@@ -283,6 +290,7 @@ export class RuntimeContext<T> {
     // fallback in failurePropagation.ts is a SEPARATE default serving unit
     // tests — this literal is the one that governs compiled programs.
     this.failurePropagation = args.failurePropagation ?? "on";
+    this.budget = args.budget;
     this.statelogClient = new StatelogClient(statelogConfig);
     this.stateStack = new StateStack();
     this.globals = GlobalStore.withTokenStats();


### PR DESCRIPTION
## What

Adds a top-level `budget` to `agency.json` for a per-run spend/time limit:

```jsonc
{
  "budget": {
    "maxCost": 0.50,   // dollars of LLM spend; matches --max-cost
    "maxTime": "30m"   // duration string; matches --max-time
  }
}
```

Same root ceiling as `agency run --max-cost` / `--max-time`, but declarative and — the point of this PR — **honored when the agent is served remotely**.

## Why config, not just the flag

The budget is a `CostGuard`/`TimeGuard` installed at the root of every run by `installRootBudget` (already fires on the serve path). Today it's fed **only** by the `AGENCY_MAX_COST` / `AGENCY_MAX_TIME` env vars that the flags set. For a hosted agent that doesn't work:

- **`agency.json` never reaches the host** — the deploy bundle uploads source only; statelog compiles it itself.
- **The serve process is shared** across agents, so a process-global env var can't give agent A a $1 cap and agent B a $5 cap.

So the limit has to be a typed `AgencyConfig` field that flows through the per-agent runtime-config override statelog already uses for observability.

## How it's wired (mirrors `maxCallDepth`)

- **`installRootBudget`** reads a resolved budget off the `RuntimeContext`, falling back to it **per dimension** only when the flag/env is absent — so the flag still wins, and a served agent (no flag) is governed by the config budget.
- **The TypeScript builder** bakes `budget` into the generated `RuntimeContext` for local `agency run`.
- **`applyRuntimeConfigOverridesToContextArgs`** honors `budget`, so statelog sets a served agent's limit via `withRuntimeConfigOverrides({ budget: { maxCost: 1, maxTime: "10m" } })` — the same mechanism it already uses for per-agent logging.
- **`parseDurationMs`** moves to a neutral `lib/duration.ts` (re-exported from `lib/cli/budget.ts`) so the runtime and builder can resolve `maxTime` without importing from `lib/cli`.

Disable rules (`cost < 0`, `time <= 0`, `cost 0` = no paid spend) and fail-closed duration parsing are preserved. Precedence: **CLI flag/env > config**.

## Scope

This is the **agency-lang half**. Statelog then stores a per-agent limit and passes it through the override. Not included, by design:

- **Per-invocation caps.** The override is frozen at import, so every run of a given served agent shares one cap — right for one-agent-per-project. A caller-supplied cap would need a budget threaded through the serve invoke path, a larger change.
- **No change to `eval.limits.maxCostUsd`** (a separate, eval-harness-only surface).

## Verification

- `pnpm run typecheck` → clean (source + tests + evals).
- New/affected unit tests pass (52): `duration`, `budget` (re-export path), `rootBudget` (env-vs-config precedence, disable rules, IPC no-op), `configOverrides` (budget resolved + fail-closed), and a codegen test that the builder bakes `budget` with `maxTime` resolved to ms. `config` tests still green (33).

Design spec (gitignored, on disk): `docs/superpowers/specs/2026-08-03-agent-spend-limit-config.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
