### PR TITLE
refactor(eval): rebuild the labeling TUI on the existing terminal library

### DIFF
--- a/packages/agency-lang/lib/cli/eval/label.test.ts
+++ b/packages/agency-lang/lib/cli/eval/label.test.ts
@@ -11,6 +11,7 @@ import {
   evalLabel,
   resolveAnnotator,
   resolveLabelStore,
+  terminalDimension,
   type EvalLabelDependencies,
 } from "./label.js";
 
@@ -44,8 +45,8 @@ function dependencies(over: Partial<EvalLabelDependencies> = {}): EvalLabelDepen
   return {
     openSession: vi.fn(async () => fakeController()) as never,
     runTui: vi.fn(async () => {}) as never,
-    input: { isTTY: true } as NodeJS.ReadStream,
-    output: { isTTY: true } as NodeJS.WriteStream,
+    makeScreen: () => ({ destroy: () => {} }) as never,
+    isInteractive: () => true,
     environment: { USER: "adit" },
     osUserName: () => "os-account",
     ...over,
@@ -124,6 +125,28 @@ describe("evalLabel", () => {
       .rejects.toThrow(/Source run directory not found/);
   });
 
+  it("refuses a non-interactive terminal before opening a session", async () => {
+    const openSession = vi.fn(async () => fakeController());
+    const deps = dependencies({ isInteractive: () => false, openSession: openSession as never });
+    await expect(evalLabel({ source: sourceDir, checklist: checklistFile }, deps))
+      .rejects.toThrow(/interactive terminal/i);
+    expect(openSession).not.toHaveBeenCalled();
+  });
+
+  it("destroys the screen even when the terminal loop throws", async () => {
+    const destroyed = vi.fn();
+    const controller = fakeController();
+    const deps = dependencies({
+      openSession: (async () => controller) as never,
+      makeScreen: () => ({ destroy: destroyed }) as never,
+      runTui: (async () => { throw new Error("tui exploded"); }) as never,
+    });
+    await expect(evalLabel({ source: sourceDir, checklist: checklistFile }, deps))
+      .rejects.toThrow(/tui exploded/);
+    expect(destroyed).toHaveBeenCalled();
+    expect(controller.closed()).toBe(1);
+  });
+
   it("opens a session with resolved paths and annotator", async () => {
     const openSession = vi.fn(async () => fakeController());
     await evalLabel(
@@ -162,5 +185,21 @@ describe("evalLabel", () => {
     });
     await expect(evalLabel({ source: sourceDir, checklist: checklistFile }, deps))
       .rejects.toThrow(/store is locked/);
+  });
+});
+
+describe("terminalDimension", () => {
+  it("uses a real dimension when the terminal reports one", () => {
+    expect(terminalDimension(120, 100)).toBe(120);
+  });
+
+  it("falls back when a PTY reports 0, which `??` would let through", () => {
+    expect(terminalDimension(0, 100)).toBe(100);
+  });
+
+  it("falls back for undefined, negative and non-finite values", () => {
+    expect(terminalDimension(undefined, 100)).toBe(100);
+    expect(terminalDimension(-5, 100)).toBe(100);
+    expect(terminalDimension(Number.NaN, 100)).toBe(100);
   });
 });

--- a/packages/agency-lang/lib/cli/eval/label.ts
+++ b/packages/agency-lang/lib/cli/eval/label.ts
@@ -86,7 +86,7 @@ const defaultDependencies: EvalLabelDependencies = {
   openSession: openLabelingSession,
   runTui: runLabelTui,
   makeScreen: () => new Screen({
-    input: new TerminalInput(),
+    input: new TerminalInput({ suppressSigint: true }),
     output: new TerminalOutput(),
     width: terminalDimension(process.stdout.columns, DEFAULT_COLUMNS),
     height: terminalDimension(process.stdout.rows, DEFAULT_ROWS),
@@ -142,7 +142,15 @@ export async function evalLabel(
   // the terminal loop.
   const screen = dependencies.makeScreen();
   try {
-    await dependencies.runTui({ controller, screen, storeLabel: path.basename(storeDir) });
+    await dependencies.runTui({
+      controller,
+      screen,
+      storeLabel: path.basename(storeDir),
+      currentSize: () => ({
+        width: terminalDimension(process.stdout.columns, DEFAULT_COLUMNS),
+        height: terminalDimension(process.stdout.rows, DEFAULT_ROWS),
+      }),
+    });
   } finally {
     try {
       screen.destroy();

--- a/packages/agency-lang/lib/cli/eval/label.ts
+++ b/packages/agency-lang/lib/cli/eval/label.ts
@@ -5,6 +5,9 @@ import * as path from "path";
 import type { AgencyConfig } from "@/config.js";
 import { openLabelingSession, type LabelingSessionController } from "@/eval/label/controller.js";
 import { runLabelTui } from "@/eval/label/labelTui.js";
+import { TerminalInput } from "@/tui/input/terminal.js";
+import { TerminalOutput } from "@/tui/output/terminal.js";
+import { Screen } from "@/tui/screen.js";
 import type { Annotator } from "@/eval/label/types.js";
 
 const DEFAULT_STORE_DIRECTORY = "labels";
@@ -23,8 +26,10 @@ export type EvalLabelOptions = {
 export type EvalLabelDependencies = {
   openSession: typeof openLabelingSession;
   runTui: typeof runLabelTui;
-  input: NodeJS.ReadStream;
-  output: NodeJS.WriteStream;
+  /** Built here rather than inside the TUI so the terminal lifecycle has one
+   *  owner, alongside the session it must be torn down with. */
+  makeScreen(): Screen;
+  isInteractive(): boolean;
   environment: NodeJS.ProcessEnv;
   osUserName(): string | undefined;
 };
@@ -62,11 +67,31 @@ export function resolveAnnotator(
   return { kind: "human", id: FALLBACK_ANNOTATOR_ID };
 }
 
+const DEFAULT_COLUMNS = 100;
+const DEFAULT_ROWS = 30;
+
+/**
+ * A usable terminal dimension.
+ *
+ * `??` is not enough: a PTY with no attached window reports **0**, not
+ * undefined, and a zero-width screen lays every element out to nothing and
+ * renders a blank frame. Anything that is not a positive finite number falls
+ * back.
+ */
+export function terminalDimension(value: number | undefined, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
 const defaultDependencies: EvalLabelDependencies = {
   openSession: openLabelingSession,
   runTui: runLabelTui,
-  input: process.stdin,
-  output: process.stdout,
+  makeScreen: () => new Screen({
+    input: new TerminalInput(),
+    output: new TerminalOutput(),
+    width: terminalDimension(process.stdout.columns, DEFAULT_COLUMNS),
+    height: terminalDimension(process.stdout.rows, DEFAULT_ROWS),
+  }),
+  isInteractive: () => process.stdin.isTTY === true && process.stdout.isTTY === true,
   environment: process.env,
   osUserName: () => {
     try {
@@ -95,25 +120,34 @@ export async function evalLabel(
   if (!fs.existsSync(options.source)) {
     throw new Error(`Source run directory not found: ${options.source}`);
   }
+  if (!dependencies.isInteractive()) {
+    throw new Error(
+      "agency eval label needs an interactive terminal: it shows outputs and reads " +
+      "keystrokes. Run it directly rather than through a pipe.",
+    );
+  }
 
   const config = options.config ?? {};
+  const storeDir = resolveLabelStore(options, config);
   const controller: LabelingSessionController = await dependencies.openSession({
     sourceDir: path.resolve(options.source),
-    storeDir: resolveLabelStore(options, config),
+    storeDir,
     checklistFile: path.resolve(options.checklist),
     annotator: resolveAnnotator(options, dependencies),
     reportWarning: (message) => console.warn(message),
   });
 
-  // The session owns a lock and a draft; closing it is not optional, which is
-  // why the CLI holds the finally rather than the terminal loop.
+  // The session owns a lock and a draft, and the screen owns raw mode; closing
+  // both is not optional, which is why the CLI holds the finallys rather than
+  // the terminal loop.
+  const screen = dependencies.makeScreen();
   try {
-    await dependencies.runTui({
-      controller,
-      input: dependencies.input,
-      output: dependencies.output,
-    });
+    await dependencies.runTui({ controller, screen, storeLabel: path.basename(storeDir) });
   } finally {
-    await controller.close();
+    try {
+      screen.destroy();
+    } finally {
+      await controller.close();
+    }
   }
 }

--- a/packages/agency-lang/lib/eval/label/labelTui.test.ts
+++ b/packages/agency-lang/lib/eval/label/labelTui.test.ts
@@ -339,6 +339,26 @@ describe("runLabelTui", () => {
   });
 });
 
+describe("resizing", () => {
+  it("adopts a new terminal size on the next draw", async () => {
+    const { screen } = scriptedScreen(["q"]);
+    const { controller } = fakeController();
+    await runLabelTui({
+      controller,
+      screen,
+      currentSize: () => ({ width: 60, height: 18 }),
+    });
+    expect(screen.size()).toEqual({ width: 60, height: 18 });
+  });
+
+  it("leaves the size alone when no provider is given", async () => {
+    const { screen } = scriptedScreen(["q"]);
+    const { controller } = fakeController();
+    await runLabelTui({ controller, screen });
+    expect(screen.size()).toEqual({ width: 100, height: 30 });
+  });
+});
+
 describe("layout arithmetic", () => {
   it("leaves room for the chrome above and below the panes", () => {
     expect(paneHeightFor(30)).toBeLessThan(30);

--- a/packages/agency-lang/lib/eval/label/labelTui.test.ts
+++ b/packages/agency-lang/lib/eval/label/labelTui.test.ts
@@ -12,6 +12,7 @@ import {
   labelScreen,
   paneHeightFor,
   renderChecklist,
+  pastedText,
   renderMarkdownSafely,
   runLabelTui,
   sanitizeUntrusted,
@@ -205,6 +206,33 @@ describe("actionForKey", () => {
   });
 });
 
+describe("paste in the editor", () => {
+  it("appends the whole clipboard in one action", () => {
+    expect(actionForKey(key({ key: "paste", text: "some pasted text" }), true))
+      .toEqual({ kind: "appendEditorText", text: "some pasted text" });
+  });
+
+  it("is ignored outside the editor, where keys are commands", () => {
+    expect(actionForKey(key({ key: "paste", text: "x" }), false)).toBeNull();
+  });
+
+  it("ignores an empty paste rather than dispatching a no-op", () => {
+    expect(actionForKey(key({ key: "paste", text: "" }), true)).toBeNull();
+  });
+
+  it("collapses newlines and tabs, because the draft renders on one row", () => {
+    expect(pastedText("first\nsecond\tthird")).toBe("first second third");
+  });
+
+  it("drops other control characters from pasted text", () => {
+    expect(pastedText("safe\x1b[2Jhidden")).toBe("safe[2Jhidden");
+  });
+
+  it("leaves ordinary pasted text alone", () => {
+    expect(pastedText("Is the information accurate?")).toBe("Is the information accurate?");
+  });
+});
+
 describe("scrollDelta and isQuitKey", () => {
   it("pages with ctrl-f and ctrl-b", () => {
     expect(scrollDelta(key({ key: "f", ctrl: true }), 20)).toBeGreaterThan(0);
@@ -218,6 +246,16 @@ describe("scrollDelta and isQuitKey", () => {
 
   it("ignores the same letters without ctrl, which are commands", () => {
     expect(scrollDelta(key({ key: "d" }), 20)).toBe(0);
+  });
+
+  it("pages with the dedicated pageup and pagedown keys", () => {
+    expect(scrollDelta(key({ key: "pagedown" }), 20)).toBeGreaterThan(0);
+    expect(scrollDelta(key({ key: "pageup" }), 20)).toBeLessThan(0);
+  });
+
+  it("pages the same distance whether by page key or ctrl chord", () => {
+    expect(scrollDelta(key({ key: "pagedown" }), 20))
+      .toBe(scrollDelta(key({ key: "f", ctrl: true }), 20));
   });
 
   it("treats q and ctrl-c as quit", () => {
@@ -262,6 +300,13 @@ describe("runLabelTui", () => {
     const { controller, dispatched } = fakeController();
     await runLabelTui({ controller, screen });
     expect(dispatched).toContainEqual({ kind: "toggleAnswer" });
+  });
+
+  it("does not dispatch for a page key either", async () => {
+    const { screen } = scriptedScreen([key({ key: "pagedown" }), "q"]);
+    const { controller, dispatched } = fakeController();
+    await runLabelTui({ controller, screen });
+    expect(dispatched).toEqual([]);
   });
 
   it("does not dispatch for a scroll chord", async () => {

--- a/packages/agency-lang/lib/eval/label/labelTui.test.ts
+++ b/packages/agency-lang/lib/eval/label/labelTui.test.ts
@@ -1,27 +1,29 @@
-import { EventEmitter } from "events";
-
 import { describe, expect, it, vi } from "vitest";
+
+import { ScriptedInput } from "@/tui/input/scripted.js";
+import type { KeyEvent } from "@/tui/input/types.js";
+import { FrameRecorder } from "@/tui/output/recorder.js";
+import { Screen } from "@/tui/screen.js";
 
 import type { LabelingSessionController } from "./controller.js";
 import {
   actionForKey,
   isQuitKey,
-  parseKeys,
-  renderLabelScreen,
+  labelScreen,
+  paneHeightFor,
+  renderChecklist,
   renderMarkdownSafely,
   runLabelTui,
+  sanitizeUntrusted,
   scrollDelta,
   stripAnsi,
-  visibleLength,
-  wrapAnsi,
 } from "./labelTui.js";
 import type { SessionAction, SessionSnapshot } from "./session.js";
 
-const BOLD = "\x1b[1m";
-const RESET = "\x1b[0m";
+const OUTPUT_ID = `out_${"a".repeat(64)}`;
 
 function snapshot(over: Partial<SessionSnapshot> = {}): SessionSnapshot {
-  const item = { outputId: `out_${"a".repeat(64)}`, task: "a task", text: "some output" };
+  const item = { outputId: OUTPUT_ID, task: "a task", text: "some output" };
   return {
     items: [item],
     itemIndex: 0,
@@ -35,8 +37,8 @@ function snapshot(over: Partial<SessionSnapshot> = {}): SessionSnapshot {
     answers: { q_a: true },
     note: "",
     editor: { kind: "none" },
-    statuses: { [item.outputId]: "untouched" },
-    scores: { [item.outputId]: null },
+    statuses: { [OUTPUT_ID]: "untouched" },
+    scores: { [OUTPUT_ID]: null },
     progress: { reviewed: 0, total: 1, stale: 0 },
     canSignOff: true,
     hasStagedQuestions: false,
@@ -44,45 +46,124 @@ function snapshot(over: Partial<SessionSnapshot> = {}): SessionSnapshot {
   };
 }
 
-describe("visibleLength", () => {
-  it("ignores colour codes", () => {
-    expect(visibleLength(`${BOLD}abc${RESET}`)).toBe(3);
+const key = (event: Partial<KeyEvent> & { key: string }): KeyEvent => event as KeyEvent;
+
+/** Lay the element tree out through the real engine and read it as plain
+ *  text — what the terminal would actually show, rather than a string this
+ *  module assembled and this test re-parsed. */
+function frameText(over: Partial<SessionSnapshot> = {}, size = { width: 100, height: 30 }): string {
+  const recorder = new FrameRecorder();
+  const screen = new Screen({
+    input: new ScriptedInput(),
+    output: recorder,
+    width: size.width,
+    height: size.height,
+  });
+  screen.render(labelScreen({
+    snapshot: snapshot(over),
+    storeLabel: "labels",
+    width: size.width,
+    height: size.height,
+    scroll: 0,
+    body: ["output line one", "output line two"],
+  }));
+  return recorder.lastText();
+}
+
+describe("frame content", () => {
+  it("shows the header with reviewed progress", () => {
+    const text = frameText();
+    expect(text).toContain("eval label");
+    expect(text).toContain("0/1 reviewed");
   });
 
-  it("ignores OSC-8 hyperlinks, which carry a URL in zero columns", () => {
-    const link = "\x1b]8;;https://example.com/very/long/path\x07label\x1b]8;;\x07";
-    expect(visibleLength(link)).toBe(5);
+  it("shows a ticked box for an answered question", () => {
+    expect(frameText()).toContain("[✓] Accurate?");
+  });
+
+  it("shows a deleted question with a dot box rather than hiding it", () => {
+    const text = frameText();
+    expect(text).toContain("[·]");
+    expect(text).toContain("Today?");
+  });
+
+  it("shows a dash rather than a number for an unscored item", () => {
+    expect(frameText()).toMatch(/untouched\s+—/);
+  });
+
+  it("reports stale items in the header", () => {
+    expect(frameText({ progress: { reviewed: 1, total: 3, stale: 2 } })).toContain("2 stale");
+  });
+
+  it("switches the footer to the question editor", () => {
+    expect(frameText({ editor: { kind: "question", draft: "Sourced?" } }))
+      .toContain("new question Sourced?");
+  });
+
+  it("labels d as undelete when the focused question is deleted", () => {
+    expect(frameText({ currentQuestion: { id: "q_b", text: "Today?", weight: 1, deleted: true } }))
+      .toContain("d undelete");
+  });
+
+  it("handles an empty corpus without throwing", () => {
+    expect(frameText({ currentItem: null, items: [] })).toContain("nothing to label");
+  });
+
+  it("shows the output body in the left pane", () => {
+    expect(frameText()).toContain("output line one");
+  });
+
+  it("keeps every rendered row within the terminal width", () => {
+    for (const row of frameText().split("\n")) {
+      expect(row.length).toBeLessThanOrEqual(100);
+    }
   });
 });
 
-describe("wrapAnsi", () => {
-  it("keeps every wrapped line within the width", () => {
-    for (const line of wrapAnsi("the quick brown fox jumps over the lazy dog", 12)) {
-      expect(visibleLength(line)).toBeLessThanOrEqual(12);
-    }
+describe("renderChecklist", () => {
+  it("reports the line the focused question starts on", () => {
+    expect(renderChecklist(snapshot({ questionIndex: 1 }), 40).focusLine).toBe(1);
   });
 
-  it("hard-breaks a token longer than the column", () => {
-    const lines = wrapAnsi("x".repeat(50), 10);
-    expect(lines.length).toBeGreaterThan(1);
-    for (const line of lines) {
-      expect(visibleLength(line)).toBeLessThanOrEqual(10);
-    }
+  it("accounts for wrapped questions when reporting the focus line", () => {
+    const questions = [
+      {
+        id: "q_a",
+        text: "A question long enough that it certainly wraps across several lines",
+        weight: 1,
+        deleted: false,
+      },
+      { id: "q_b", text: "Second", weight: 1, deleted: false },
+    ];
+    expect(renderChecklist(snapshot({ questions, questionIndex: 1 }), 24).focusLine)
+      .toBeGreaterThan(1);
+  });
+});
+
+describe("checklist viewport", () => {
+  function manyQuestions(count: number, focusIndex: number): Partial<SessionSnapshot> {
+    const questions = Array.from({ length: count }, (_, index) => ({
+      id: `q_${index}`, text: `Question number ${index}`, weight: 1, deleted: false,
+    }));
+    return { questions, questionIndex: focusIndex, currentQuestion: questions[focusIndex] };
+  }
+
+  it("keeps a question near the end of a long checklist visible", () => {
+    // Without followCursor the pane always starts at question 0, so Space and
+    // Enter would act on a checkbox the reader cannot see.
+    expect(frameText(manyQuestions(40, 39), { width: 100, height: 20 }))
+      .toContain("Question number 39");
   });
 
-  it("loses no visible words", () => {
-    const source = "alpha beta gamma delta epsilon zeta";
-    const joined = stripAnsi(wrapAnsi(source, 9).join(" "));
-    for (const word of source.split(" ")) {
-      expect(joined).toContain(word);
-    }
+  it("still shows the first question when focus is at the top", () => {
+    expect(frameText(manyQuestions(40, 0), { width: 100, height: 20 }))
+      .toContain("Question number 0");
   });
 
-  it("does not let a hyperlink swallow the text after it", () => {
-    const source = "(\x1b]8;;https://example.com/a/b/c\x07site\x1b]8;;\x07) and more words here";
-    const joined = wrapAnsi(source, 40).join(" ");
-    expect(joined).toContain("and more words here");
-    expect(joined).toContain("site");
+  it("does not scroll a checklist that already fits", () => {
+    const text = frameText(manyQuestions(3, 2), { width: 100, height: 30 });
+    expect(text).toContain("Question number 0");
+    expect(text).toContain("Question number 2");
   });
 });
 
@@ -94,145 +175,57 @@ describe("renderMarkdownSafely", () => {
       expect(rendered).toContain(word);
     }
   });
-
-  it("returns plain text unchanged when there is nothing to highlight", () => {
-    expect(stripAnsi(renderMarkdownSafely("plain"))).toContain("plain");
-  });
-});
-
-describe("renderLabelScreen", () => {
-  const base = { storeLabel: "labels", columns: 100, rows: 30, scroll: 0, body: ["output line"] };
-
-  it("aligns the divider on every body row", () => {
-    const frame = stripAnsi(renderLabelScreen({ ...base, snapshot: snapshot() }));
-    const columns = frame.split("\n").slice(5, 15).map((line) => line.indexOf("│"));
-    expect(new Set(columns.filter((column) => column >= 0)).size).toBe(1);
-  });
-
-  it("shows a ticked box for an answered question and an empty one otherwise", () => {
-    const frame = stripAnsi(renderLabelScreen({ ...base, snapshot: snapshot() }));
-    expect(frame).toContain("[✓] Accurate?");
-  });
-
-  it("shows a deleted question with a dot box rather than hiding it", () => {
-    const frame = stripAnsi(renderLabelScreen({ ...base, snapshot: snapshot() }));
-    expect(frame).toContain("[·]");
-    expect(frame).toContain("Today?");
-  });
-
-  it("shows a dash rather than a number for an unscored item", () => {
-    const frame = stripAnsi(renderLabelScreen({ ...base, snapshot: snapshot() }));
-    expect(frame).toMatch(/untouched\s+—/);
-  });
-
-  it("reports stale items in the header", () => {
-    const frame = stripAnsi(renderLabelScreen({
-      ...base, snapshot: snapshot({ progress: { reviewed: 1, total: 3, stale: 2 } }),
-    }));
-    expect(frame).toContain("2 stale");
-  });
-
-  it("switches the footer to the question editor", () => {
-    const frame = stripAnsi(renderLabelScreen({
-      ...base, snapshot: snapshot({ editor: { kind: "question", draft: "Sourced?" } }),
-    }));
-    expect(frame).toContain("new question Sourced?");
-  });
-
-  it("labels d as undelete when the focused question is deleted", () => {
-    const frame = stripAnsi(renderLabelScreen({
-      ...base,
-      snapshot: snapshot({ currentQuestion: { id: "q_b", text: "Today?", weight: 1, deleted: true } }),
-    }));
-    expect(frame).toContain("d undelete");
-  });
-
-  it("handles an empty corpus without throwing", () => {
-    const frame = stripAnsi(renderLabelScreen({
-      ...base, snapshot: snapshot({ currentItem: null, items: [] }),
-    }));
-    expect(frame).toContain("nothing to label");
-  });
-});
-
-describe("parseKeys", () => {
-  it("parses arrows from one chunk", () => {
-    expect(parseKeys("\x1b[A\x1b[B\x1b[C\x1b[D").map((key) => key.kind))
-      .toEqual(["up", "down", "right", "left"]);
-  });
-
-  it("parses enter, escape and backspace", () => {
-    expect(parseKeys("\r\x1b\x7f").map((key) => key.kind)).toEqual(["enter", "escape", "backspace"]);
-  });
-
-  it("parses a space as a character", () => {
-    expect(parseKeys(" ")).toEqual([{ kind: "char", value: " " }]);
-  });
 });
 
 describe("actionForKey", () => {
   it("maps navigation and toggling while labelling", () => {
-    expect(actionForKey({ kind: "char", value: " " }, false)).toEqual({ kind: "toggleAnswer" });
-    expect(actionForKey({ kind: "left" }, false)).toEqual({ kind: "previousItem" });
-    expect(actionForKey({ kind: "up" }, false)).toEqual({ kind: "previousQuestion" });
-    expect(actionForKey({ kind: "enter" }, false)).toEqual({ kind: "signOff" });
-    expect(actionForKey({ kind: "char", value: "d" }, false)).toEqual({ kind: "toggleQuestionDeleted" });
+    expect(actionForKey(key({ key: " " }), false)).toEqual({ kind: "toggleAnswer" });
+    expect(actionForKey(key({ key: "left" }), false)).toEqual({ kind: "previousItem" });
+    expect(actionForKey(key({ key: "up" }), false)).toEqual({ kind: "previousQuestion" });
+    expect(actionForKey(key({ key: "enter" }), false)).toEqual({ kind: "signOff" });
+    expect(actionForKey(key({ key: "d" }), false)).toEqual({ kind: "toggleQuestionDeleted" });
   });
 
   it("routes printable keys into the editor while editing", () => {
-    expect(actionForKey({ kind: "char", value: "x" }, true))
-      .toEqual({ kind: "appendEditorText", text: "x" });
-    expect(actionForKey({ kind: "enter" }, true)).toEqual({ kind: "submitEditor" });
-    expect(actionForKey({ kind: "escape" }, true)).toEqual({ kind: "cancelEditor" });
+    expect(actionForKey(key({ key: "x" }), true)).toEqual({ kind: "appendEditorText", text: "x" });
+    expect(actionForKey(key({ key: "enter" }), true)).toEqual({ kind: "submitEditor" });
+    expect(actionForKey(key({ key: "escape" }), true)).toEqual({ kind: "cancelEditor" });
   });
 
-  it("keeps a control key out of the editor text", () => {
-    expect(actionForKey({ kind: "char", value: "\x06" }, true)).toBeNull();
+  it("keeps a ctrl chord out of the editor text", () => {
+    expect(actionForKey(key({ key: "f", ctrl: true }), true)).toBeNull();
   });
 
-  it("does not treat space as a toggle while editing", () => {
-    expect(actionForKey({ kind: "char", value: " " }, true))
-      .toEqual({ kind: "appendEditorText", text: " " });
+  it("does not treat a ctrl chord as a command while labelling", () => {
+    expect(actionForKey(key({ key: "d", ctrl: true }), false)).toBeNull();
+  });
+
+  it("treats space as text while editing, not as a toggle", () => {
+    expect(actionForKey(key({ key: " " }), true)).toEqual({ kind: "appendEditorText", text: " " });
   });
 });
 
 describe("scrollDelta and isQuitKey", () => {
-  it("scrolls by a page with ctrl-f and ctrl-b", () => {
-    expect(scrollDelta({ kind: "char", value: "\x06" }, 30)).toBeGreaterThan(0);
-    expect(scrollDelta({ kind: "char", value: "\x02" }, 30)).toBeLessThan(0);
+  it("pages with ctrl-f and ctrl-b", () => {
+    expect(scrollDelta(key({ key: "f", ctrl: true }), 20)).toBeGreaterThan(0);
+    expect(scrollDelta(key({ key: "b", ctrl: true }), 20)).toBeLessThan(0);
   });
 
-  it("scrolls by half a page with ctrl-d and ctrl-u", () => {
-    expect(scrollDelta({ kind: "char", value: "\x04" }, 30))
-      .toBeLessThan(scrollDelta({ kind: "char", value: "\x06" }, 30));
+  it("half-pages with ctrl-d and ctrl-u", () => {
+    expect(scrollDelta(key({ key: "d", ctrl: true }), 20))
+      .toBeLessThan(scrollDelta(key({ key: "f", ctrl: true }), 20));
+  });
+
+  it("ignores the same letters without ctrl, which are commands", () => {
+    expect(scrollDelta(key({ key: "d" }), 20)).toBe(0);
   });
 
   it("treats q and ctrl-c as quit", () => {
-    expect(isQuitKey({ kind: "char", value: "q" })).toBe(true);
-    expect(isQuitKey({ kind: "char", value: "\x03" })).toBe(true);
-    expect(isQuitKey({ kind: "char", value: "a" })).toBe(false);
+    expect(isQuitKey(key({ key: "q" }))).toBe(true);
+    expect(isQuitKey(key({ key: "c", ctrl: true }))).toBe(true);
+    expect(isQuitKey(key({ key: "c" }))).toBe(false);
   });
 });
-
-/** A terminal pair that records what was written and lets a test push keys. */
-function fakeTerminal(isTTY = true) {
-  const input = new EventEmitter() as unknown as NodeJS.ReadStream & {
-    setRawMode: ReturnType<typeof vi.fn>;
-    isRaw: boolean;
-  };
-  input.isTTY = isTTY;
-  input.isRaw = false;
-  input.setRawMode = vi.fn((raw: boolean) => { input.isRaw = raw; return input; });
-  input.resume = vi.fn(() => input);
-  input.pause = vi.fn(() => input);
-  input.setEncoding = vi.fn(() => input);
-  const written: string[] = [];
-  const output = {
-    isTTY, columns: 100, rows: 30,
-    write: (text: string) => { written.push(text); return true; },
-  } as unknown as NodeJS.WriteStream;
-  return { input, output, written };
-}
 
 function fakeController(over: Partial<SessionSnapshot> = {}) {
   const dispatched: SessionAction[] = [];
@@ -244,58 +237,69 @@ function fakeController(over: Partial<SessionSnapshot> = {}) {
   return { controller, dispatched };
 }
 
-describe("runLabelTui", () => {
-  it("refuses a non-interactive terminal", async () => {
-    const { input, output } = fakeTerminal(false);
-    const { controller } = fakeController();
-    await expect(runLabelTui({ controller, input, output }))
-      .rejects.toThrow(/interactive terminal/i);
+function scriptedScreen(keys: (KeyEvent | string)[]) {
+  const recorder = new FrameRecorder();
+  const screen = new Screen({
+    input: new ScriptedInput(keys),
+    output: recorder,
+    width: 100,
+    height: 30,
   });
+  return { screen, recorder };
+}
 
-  it("draws a frame on start and restores raw mode on quit", async () => {
-    const { input, output, written } = fakeTerminal();
+describe("runLabelTui", () => {
+  it("draws a frame and exits on quit", async () => {
+    const { screen, recorder } = scriptedScreen(["q"]);
     const { controller } = fakeController();
-    const done = runLabelTui({ controller, input, output });
-    expect(written.length).toBeGreaterThan(0);
-    input.emit("data", "q");
-    await done;
-    expect(input.setRawMode).toHaveBeenLastCalledWith(false);
+    await runLabelTui({ controller, screen });
+    expect(recorder.frames.length).toBeGreaterThan(0);
+    expect(recorder.lastText()).toContain("eval label");
   });
 
   it("dispatches the action a key maps to", async () => {
-    const { input, output } = fakeTerminal();
+    const { screen } = scriptedScreen([" ", "q"]);
     const { controller, dispatched } = fakeController();
-    const done = runLabelTui({ controller, input, output });
-    input.emit("data", " ");
-    input.emit("data", "q");
-    await done;
+    await runLabelTui({ controller, screen });
     expect(dispatched).toContainEqual({ kind: "toggleAnswer" });
   });
 
-  it("restores raw mode when the controller throws", async () => {
-    const { input, output } = fakeTerminal();
+  it("does not dispatch for a scroll chord", async () => {
+    const { screen } = scriptedScreen([key({ key: "f", ctrl: true }), "q"]);
+    const { controller, dispatched } = fakeController();
+    await runLabelTui({ controller, screen });
+    expect(dispatched).toEqual([]);
+  });
+
+  it("propagates a controller failure rather than swallowing it", async () => {
+    const { screen } = scriptedScreen([" "]);
     const controller: LabelingSessionController = {
       snapshot: () => snapshot(),
       dispatch: async () => { throw new Error("controller exploded"); },
       close: async () => {},
     };
-    const done = runLabelTui({ controller, input, output });
-    input.emit("data", " ");
-    await expect(done).rejects.toThrow(/exploded/);
-    expect(input.setRawMode).toHaveBeenLastCalledWith(false);
+    await expect(runLabelTui({ controller, screen })).rejects.toThrow(/exploded/);
   });
 
   it("never calls close: the CLI owns the session lifecycle", async () => {
-    const { input, output } = fakeTerminal();
+    const { screen } = scriptedScreen(["q"]);
     const closed = vi.fn(async () => {});
     const controller: LabelingSessionController = {
       snapshot: () => snapshot(),
       dispatch: async () => snapshot(),
       close: closed,
     };
-    const done = runLabelTui({ controller, input, output });
-    input.emit("data", "q");
-    await done;
+    await runLabelTui({ controller, screen });
     expect(closed).not.toHaveBeenCalled();
+  });
+});
+
+describe("layout arithmetic", () => {
+  it("leaves room for the chrome above and below the panes", () => {
+    expect(paneHeightFor(30)).toBeLessThan(30);
+  });
+
+  it("keeps newlines and tabs when sanitizing", () => {
+    expect(sanitizeUntrusted("a\nb\tc")).toBe("a\nb\tc");
   });
 });

--- a/packages/agency-lang/lib/eval/label/labelTui.ts
+++ b/packages/agency-lang/lib/eval/label/labelTui.ts
@@ -1,6 +1,7 @@
 import { stripAnsi, visualWidth, wrapText } from "@/stdlib/layout/ansi.js";
 import { syntaxHighlight } from "@/stdlib/syntax.js";
 import { column, line, lines, row } from "@/tui/builders.js";
+import { escapeStyleTags } from "@/tui/styleParser.js";
 import type { Element, Style } from "@/tui/elements.js";
 import type { KeyEvent } from "@/tui/input/types.js";
 import type { Screen } from "@/tui/screen.js";
@@ -28,6 +29,10 @@ export { stripAnsi, visualWidth };
  * them; everything else in C0, C1 and DEL becomes a visible replacement so the
  * reader can see something was there.
  *
+ * Style tags are escaped too. The TUI parser reads `{black-fg}` as markup, so
+ * plain text alone is enough to restyle or hide the very evidence being
+ * judged — control characters are not the only way into a terminal.
+ *
  * Styling is applied afterwards, so the tool's own colour is unaffected.
  */
 export function sanitizeUntrusted(text: string): string {
@@ -43,7 +48,7 @@ export function sanitizeUntrusted(text: string): string {
     const isC1 = code >= 0x80 && code <= 0x9f;
     out += isC0 || isDelete || isC1 ? "�" : character;
   }
-  return out;
+  return escapeStyleTags(out);
 }
 
 /**
@@ -182,7 +187,7 @@ function headerLine(snapshot: SessionSnapshot, storeLabel: string): string {
   const stale = snapshot.progress.stale > 0
     ? `  ${color.yellow(`⟳ ${snapshot.progress.stale} stale`)}`
     : "";
-  return ` ${color.bgBlue.bold(" eval label ")} ${color.brightBlack(storeLabel)}  ` +
+  return ` ${color.bgBlue.bold(" eval label ")} ${color.brightBlack(sanitizeUntrusted(storeLabel))}  ` +
     `${color.bold.green(String(snapshot.progress.reviewed))}` +
     `${color.dim(`/${snapshot.progress.total} reviewed`)}${stale}`;
 }
@@ -303,8 +308,7 @@ function pane(contentLines: string[], style: Style): Element {
  *
  * Returns null for keys the loop handles itself (scrolling, quitting) or
  * ignores. Events arrive already parsed by the TUI input layer, which owns
- * escape-sequence reassembly across stream chunks — the thing this module used
- * to do by hand, and got wrong.
+ * escape-sequence reassembly and bracketed paste.
  */
 export function actionForKey(event: KeyEvent, editing: boolean): SessionAction | null {
   if (editing) {
@@ -371,6 +375,10 @@ export type RunLabelTuiArgs = {
   controller: LabelingSessionController;
   screen: Screen;
   storeLabel?: string;
+  /** Current terminal size, read before every draw. Screen stores its
+   *  dimensions, so without this a resize leaves stale pane widths, wrapping
+   *  and scroll bounds until restart. */
+  currentSize?: () => { width: number; height: number };
 };
 
 type BodyCache = { outputId: string; width: number; lines: string[] };
@@ -384,15 +392,25 @@ type LoopState = {
 };
 
 export async function runLabelTui(args: RunLabelTuiArgs): Promise<void> {
-  const { width, height } = args.screen.size();
-  const leftWidth = leftPaneWidthFor(width);
-  const paneHeight = paneHeightFor(height);
+  /** Adopt the terminal's current size, so a resize takes effect on the next
+   *  draw rather than at restart. */
+  const syncSize = (): { width: number; height: number } => {
+    const current = args.currentSize?.();
+    if (current !== undefined) {
+      const stored = args.screen.size();
+      if (current.width !== stored.width || current.height !== stored.height) {
+        args.screen.resize(current.width, current.height);
+      }
+    }
+    return args.screen.size();
+  };
 
   const withBody = (state: LoopState): LoopState => {
     const item = args.controller.snapshot().currentItem;
     if (item === null) {
       return state;
     }
+    const leftWidth = leftPaneWidthFor(args.screen.size().width);
     if (state.body?.outputId === item.outputId && state.body.width === leftWidth) {
       return state;
     }
@@ -403,14 +421,17 @@ export async function runLabelTui(args: RunLabelTuiArgs): Promise<void> {
 
   await args.screen.runLoop<LoopState>({
     initialState: withBody({ scroll: 0, done: false, body: null }),
-    render: (state) => labelScreen({
-      snapshot: args.controller.snapshot(),
-      storeLabel: args.storeLabel ?? "",
-      width,
-      height,
-      scroll: state.scroll,
-      body: state.body?.lines ?? [],
-    }),
+    render: (state) => {
+      const size = syncSize();
+      return labelScreen({
+        snapshot: args.controller.snapshot(),
+        storeLabel: args.storeLabel ?? "",
+        width: size.width,
+        height: size.height,
+        scroll: state.scroll,
+        body: state.body?.lines ?? [],
+      });
+    },
     handleKey: async (state, event) => {
       const snapshot = args.controller.snapshot();
       const editing = snapshot.editor.kind !== "none";
@@ -427,6 +448,7 @@ export async function runLabelTui(args: RunLabelTuiArgs): Promise<void> {
         }
       }
       next = withBody(next);
+      const paneHeight = paneHeightFor(args.screen.size().height);
       const maxScroll = Math.max(0, (next.body?.lines.length ?? 0) - paneHeight);
       const scrolled = next.scroll + scrollDelta(event, paneHeight);
       return { ...next, scroll: Math.min(Math.max(0, scrolled), maxScroll) };

--- a/packages/agency-lang/lib/eval/label/labelTui.ts
+++ b/packages/agency-lang/lib/eval/label/labelTui.ts
@@ -46,6 +46,30 @@ export function sanitizeUntrusted(text: string): string {
   return out;
 }
 
+/**
+ * Clipboard text, made safe for a single-line editor.
+ *
+ * Newlines and tabs are collapsed to spaces because the draft renders on one
+ * footer row, and every other control character is dropped rather than
+ * replaced — a paste is the user's own text, so a visible replacement marker
+ * would be noise rather than evidence.
+ */
+export function pastedText(text: string): string {
+  let out = "";
+  for (const character of text) {
+    const code = character.codePointAt(0) ?? 0;
+    if (character === "\n" || character === "\r" || character === "\t") {
+      out += " ";
+      continue;
+    }
+    const isControl = code < 0x20 || code === 0x7f || (code >= 0x80 && code <= 0x9f);
+    if (!isControl) {
+      out += character;
+    }
+  }
+  return out;
+}
+
 function contentWords(text: string): string[] {
   const withoutUrls = text.replace(/https?:\/\/\S+/g, " ");
   return (withoutUrls.match(/[A-Za-z]{5,}/g) ?? []).map((word) => word.toLowerCase());
@@ -287,6 +311,14 @@ export function actionForKey(event: KeyEvent, editing: boolean): SessionAction |
     if (event.key === "enter") return { kind: "submitEditor" };
     if (event.key === "escape") return { kind: "cancelEditor" };
     if (event.key === "backspace") return { kind: "backspaceEditor" };
+    // Bracketed paste arrives as ONE event carrying the whole clipboard, not
+    // as a stream of characters. Dropping it would make paste silently do
+    // nothing, which is worse than the keystroke-at-a-time behaviour it
+    // replaced.
+    if (event.key === "paste") {
+      const pasted = pastedText(event.text ?? "");
+      return pasted.length === 0 ? null : { kind: "appendEditorText", text: pasted };
+    }
     // A stray Ctrl-F while typing must not land in the text.
     if (event.ctrl === true) return null;
     if (event.key.length === 1 && event.key >= " ") {
@@ -314,11 +346,14 @@ export function actionForKey(event: KeyEvent, editing: boolean): SessionAction |
 /** Vim-style paging. Cmd+arrow is not bindable — terminals do not transmit the
  *  Cmd modifier. */
 export function scrollDelta(event: KeyEvent, paneHeight: number): number {
+  const page = Math.max(1, paneHeight - 1);
+  const half = Math.max(1, Math.floor(page / 2));
+  // Dedicated page keys, for keyboards that have them.
+  if (event.key === "pageup") return -page;
+  if (event.key === "pagedown") return page;
   if (event.ctrl !== true) {
     return 0;
   }
-  const page = Math.max(1, paneHeight - 1);
-  const half = Math.max(1, Math.floor(page / 2));
   if (event.key === "f") return page;
   if (event.key === "b") return -page;
   if (event.key === "d") return half;

--- a/packages/agency-lang/lib/eval/label/labelTui.ts
+++ b/packages/agency-lang/lib/eval/label/labelTui.ts
@@ -1,42 +1,34 @@
+import { stripAnsi, visualWidth, wrapText } from "@/stdlib/layout/ansi.js";
 import { syntaxHighlight } from "@/stdlib/syntax.js";
-import { color, RESET } from "@/utils/termcolors.js";
+import { column, line, lines, row } from "@/tui/builders.js";
+import type { Element, Style } from "@/tui/elements.js";
+import type { KeyEvent } from "@/tui/input/types.js";
+import type { Screen } from "@/tui/screen.js";
+import { followCursor } from "@/tui/scroll.js";
+import { color } from "@/utils/termcolors.js";
 
 import type { LabelingSessionController } from "./controller.js";
 import type { SessionAction, SessionSnapshot } from "./session.js";
 
-// Styling goes through lib/utils/termcolors rather than raw escapes, so the
-// palette has one home. RESET is still needed directly: wrapAnsi ends each
-// wrapped line with it to stop colour bleeding into the next row, which is a
-// line-level concern rather than styling a span of text.
-
-/**
- * Two kinds of zero-width escape appear in highlighted markdown: SGR colour
- * codes, and OSC 8 hyperlinks, which carry a whole URL that occupies no
- * columns. Counting either as visible text throws the column arithmetic off
- * badly, and the outputs being labelled are link-dense.
- */
-const ESCAPE_SOURCE = "\\x1b\\[[0-9;]*m|\\x1b\\]8;;[^\\x07\\x1b]*(?:\\x07|\\x1b\\\\)";
-
 /** Highlighting is a nice-to-have; showing the actual output is not. */
 const CONTENT_KEEP_RATIO = 0.9;
-const SCROLL_PAGE_MARGIN = 12;
+const LEFT_PANE_FRACTION = 0.6;
+/** Rows the header, rules and footer occupy, leaving the rest for the panes. */
+const CHROME_ROWS = 7;
 
-export function stripAnsi(text: string): string {
-  return text.replace(new RegExp(ESCAPE_SOURCE, "g"), "");
-}
+export { stripAnsi, visualWidth };
 
 /**
  * Neutralize control characters in text this tool did not author.
  *
- * Agent output, task text, question text and notes are all untrusted here: a
- * model can emit cursor movement, clear-screen, or OSC 52 clipboard writes,
- * and rendering those raw would let the thing being judged hide or forge the
+ * Agent output, task text, question text and notes are all untrusted: a model
+ * can emit cursor movement, clear-screen, or OSC 52 clipboard writes, and
+ * rendering those raw would let the thing being judged hide or forge the
  * evidence on screen. Only newline and tab survive, because the layout uses
  * them; everything else in C0, C1 and DEL becomes a visible replacement so the
- * reader can see that something was there.
+ * reader can see something was there.
  *
- * Styling is applied by this module AFTER sanitizing, so the tool's own colour
- * is unaffected.
+ * Styling is applied afterwards, so the tool's own colour is unaffected.
  */
 export function sanitizeUntrusted(text: string): string {
   let out = "";
@@ -52,63 +44,6 @@ export function sanitizeUntrusted(text: string): string {
     out += isC0 || isDelete || isC1 ? "�" : character;
   }
   return out;
-}
-
-export function visibleLength(text: string): number {
-  return stripAnsi(text).length;
-}
-
-/** Split into units of one escape sequence or one visible character, so
- *  wrapping counts what the eye sees. */
-function units(text: string): string[] {
-  // The (?:...) group is load-bearing: "^a|b" parses as "(^a)|(b)", so without
-  // it the second alternative is unanchored and matches anywhere in the rest
-  // of the string, eating every visible character in between.
-  const anchored = new RegExp(`^(?:${ESCAPE_SOURCE})`);
-  const out: string[] = [];
-  let index = 0;
-  while (index < text.length) {
-    const match = text.slice(index).match(anchored);
-    if (match !== null) {
-      out.push(match[0]);
-      index += match[0].length;
-    } else {
-      out.push(text[index]);
-      index += 1;
-    }
-  }
-  return out;
-}
-
-/** Wrap highlighted text, breaking at spaces where possible and hard-breaking
- *  tokens longer than the column. Styles reset at each break rather than being
- *  carried, which keeps colour from bleeding down the pane. */
-export function wrapAnsi(text: string, width: number): string[] {
-  const lines: string[] = [];
-  for (const paragraph of text.split("\n")) {
-    let current: string[] = [];
-    let visible = 0;
-    let lastBreak = -1;
-    for (const unit of units(paragraph)) {
-      const isEscape = unit.length > 1;
-      if (!isEscape && unit === " ") {
-        lastBreak = current.length;
-      }
-      current.push(unit);
-      if (!isEscape) {
-        visible += 1;
-      }
-      if (visible >= width) {
-        const cut = lastBreak > 0 ? lastBreak : current.length;
-        lines.push(current.slice(0, cut).join("") + RESET);
-        current = current.slice(lastBreak > 0 ? cut + 1 : cut);
-        visible = current.filter((entry) => entry.length === 1).length;
-        lastBreak = -1;
-      }
-    }
-    lines.push(current.join("") + RESET);
-  }
-  return lines;
 }
 
 function contentWords(text: string): string[] {
@@ -139,85 +74,7 @@ export function renderMarkdownSafely(source: string): string {
   return kept / wanted.length >= CONTENT_KEEP_RATIO ? rendered : source;
 }
 
-function pad(text: string, width: number): string {
-  return text + " ".repeat(Math.max(0, width - visibleLength(text)));
-}
-
-export type RenderArgs = {
-  snapshot: SessionSnapshot;
-  storeLabel: string;
-  columns: number;
-  rows: number;
-  scroll: number;
-  body: string[];
-};
-
-/** Build the whole frame as a string. Pure, so the layout is testable without
- *  a terminal. */
-export function renderLabelScreen(args: RenderArgs): string {
-  const { snapshot } = args;
-  const leftWidth = Math.floor(args.columns * 0.6);
-  const rightWidth = args.columns - leftWidth - 3;
-  const bodyHeight = Math.max(8, args.rows - 10);
-
-  const out: string[] = [];
-  const staleNote = snapshot.progress.stale > 0
-    ? `  ${color.yellow(`⟳ ${snapshot.progress.stale} stale`)}`
-    : "";
-  out.push(
-    ` ${color.bgBlue.bold(" eval label ")} ${color.brightBlack(args.storeLabel)}  ` +
-    `${color.bold.green(String(snapshot.progress.reviewed))}` +
-    `${color.dim(`/${snapshot.progress.total} reviewed`)}${staleNote}`,
-  );
-  out.push(color.brightBlack("━".repeat(args.columns)));
-
-  const item = snapshot.currentItem;
-  if (item === null) {
-    out.push(" nothing to label");
-    return out.join("\n");
-  }
-
-  const status = snapshot.statuses[item.outputId] ?? "untouched";
-  const chip = {
-    untouched: color.brightBlack("○ untouched"),
-    reviewed: color.green("● reviewed"),
-    stale: color.yellow("⟳ stale — a question was added since"),
-  }[status];
-  const score = snapshot.scores[item.outputId];
-  const scoreText = score === null || score === undefined
-    ? color.brightBlack("—")
-    : scoreColour(score)(score.toFixed(2));
-  out.push(
-    ` ${color.bold.cyan(item.outputId.slice(0, 12))} ` +
-    `${color.brightBlack(`${snapshot.itemIndex + 1}/${snapshot.items.length}`)}  ${chip}  ${scoreText}`,
-  );
-  out.push(` ${color.dim(sanitizeUntrusted(item.task).split("\n")[0].slice(0, args.columns - 4))}`);
-  out.push("");
-
-  const checklist = renderChecklist(snapshot, rightWidth);
-  const checklistView = checklist.lines.slice(
-    checklistOffset(checklist.focusLine, checklist.lines.length, bodyHeight),
-    checklistOffset(checklist.focusLine, checklist.lines.length, bodyHeight) + bodyHeight,
-  );
-  const visibleBody = args.body.slice(args.scroll, args.scroll + bodyHeight);
-  for (let row = 0; row < bodyHeight; row += 1) {
-    out.push(`${pad(visibleBody[row] ?? "", leftWidth)}${color.brightBlack("│")} ${checklistView[row] ?? ""}`);
-  }
-
-  out.push(color.brightBlack("━".repeat(args.columns)));
-  out.push(renderFooter(snapshot));
-  return out.join("\n");
-}
-
-function scoreColour(score: number) {
-  if (score >= 0.75) {
-    return color.bold.green;
-  }
-  if (score >= 0.4) {
-    return color.bold.yellow;
-  }
-  return color.bold.magenta;
-}
+// --- rendering -----------------------------------------------------------
 
 /** A deleted question keeps its place in the list, struck through, because it
  *  still holds every answer recorded against it. */
@@ -231,8 +88,7 @@ function checkbox(deleted: boolean, checked: boolean): string {
   return color.brightBlack("[ ]");
 }
 
-/** Returns a styler rather than an escape prefix, so callers wrap text instead
- *  of concatenating codes. */
+/** Returns a styler rather than an escape prefix, so callers wrap text. */
 function questionStyle(deleted: boolean, focused: boolean, checked: boolean) {
   if (deleted) {
     return color.strikethrough.brightBlack;
@@ -246,281 +102,300 @@ function questionStyle(deleted: boolean, focused: boolean, checked: boolean) {
   return color.dim;
 }
 
-/** Where the right pane starts, so the focused question is always on screen.
- *  Without this, Space and Enter act on a checkbox the reader cannot see once
- *  the checklist is longer than the pane. */
-function checklistOffset(focusLine: number, total: number, height: number): number {
-  if (total <= height || focusLine < height) {
-    return 0;
+function scoreStyle(score: number) {
+  if (score >= 0.75) {
+    return color.bold.green;
   }
-  return Math.min(focusLine - height + 1, Math.max(0, total - height));
+  if (score >= 0.4) {
+    return color.bold.yellow;
+  }
+  return color.bold.magenta;
 }
 
-function renderChecklist(
-  snapshot: SessionSnapshot,
-  width: number,
-): { lines: string[]; focusLine: number } {
-  const lines: string[] = [];
+export type ChecklistRender = { lines: string[]; focusLine: number };
+
+/** The right pane's lines, plus which line the focused question starts on so
+ *  the viewport can keep it visible. */
+export function renderChecklist(snapshot: SessionSnapshot, width: number): ChecklistRender {
+  const out: string[] = [];
   let focusLine = 0;
   snapshot.questions.forEach((question, index) => {
     const checked = snapshot.answers[question.id] === true;
-    const deleted = question.deleted;
     const focused = index === snapshot.questionIndex;
-    const box = checkbox(deleted, checked);
-    const arrow = focused ? color.bold.cyan("▸") : " ";
-    const style = questionStyle(deleted, focused, checked);
     if (focused) {
-      focusLine = lines.length;
+      focusLine = out.length;
     }
-    const wrapped = wrapAnsi(sanitizeUntrusted(question.text), Math.max(8, width - 7));
-    lines.push(`${arrow} ${box} ${style(wrapped[0] ?? "")}`);
+    const style = questionStyle(question.deleted, focused, checked);
+    const wrapped = wrapText(sanitizeUntrusted(question.text), Math.max(8, width - 7));
+    const arrow = focused ? color.bold.cyan("▸") : " ";
+    out.push(`${arrow} ${checkbox(question.deleted, checked)} ${style(wrapped[0] ?? "")}`);
     for (const continuation of wrapped.slice(1)) {
-      lines.push(`     ${style(continuation)}`);
+      out.push(`     ${style(continuation)}`);
     }
   });
-  lines.push("");
-  lines.push(`${color.bold.blue("note")} ${snapshot.note.length === 0 ? color.brightBlack("—") : ""}`);
+  out.push("");
+  out.push(`${color.bold.blue("note")} ${snapshot.note.length === 0 ? color.brightBlack("—") : ""}`);
   const noteLines = snapshot.note.length === 0
     ? []
-    : wrapAnsi(sanitizeUntrusted(snapshot.note), Math.max(8, width - 2));
-  for (const line of noteLines) {
-    lines.push(` ${line}`);
+    : wrapText(sanitizeUntrusted(snapshot.note), Math.max(8, width - 2));
+  for (const noteLine of noteLines) {
+    out.push(` ${noteLine}`);
   }
-  return { lines, focusLine };
+  return { lines: out, focusLine };
 }
 
-function renderFooter(snapshot: SessionSnapshot): string {
+function statusChip(status: string): string {
+  if (status === "reviewed") {
+    return color.green("● reviewed");
+  }
+  if (status === "stale") {
+    return color.yellow("⟳ stale — a question was added since");
+  }
+  return color.brightBlack("○ untouched");
+}
+
+function headerLine(snapshot: SessionSnapshot, storeLabel: string): string {
+  const stale = snapshot.progress.stale > 0
+    ? `  ${color.yellow(`⟳ ${snapshot.progress.stale} stale`)}`
+    : "";
+  return ` ${color.bgBlue.bold(" eval label ")} ${color.brightBlack(storeLabel)}  ` +
+    `${color.bold.green(String(snapshot.progress.reviewed))}` +
+    `${color.dim(`/${snapshot.progress.total} reviewed`)}${stale}`;
+}
+
+function itemLine(snapshot: SessionSnapshot): string {
+  const item = snapshot.currentItem;
+  if (item === null) {
+    return "";
+  }
+  const score = snapshot.scores[item.outputId];
+  const scoreText = score === null || score === undefined
+    ? color.brightBlack("—")
+    : scoreStyle(score)(score.toFixed(2));
+  return ` ${color.bold.cyan(item.outputId.slice(0, 12))} ` +
+    `${color.brightBlack(`${snapshot.itemIndex + 1}/${snapshot.items.length}`)}  ` +
+    `${statusChip(snapshot.statuses[item.outputId] ?? "untouched")}  ${scoreText}`;
+}
+
+function footerLines(snapshot: SessionSnapshot): string[] {
   if (snapshot.editor.kind === "question") {
-    return ` ${color.bold.yellow("new question")} ${sanitizeUntrusted(snapshot.editor.draft)}${color.cyan("▏")}\n` +
-      ` ${color.dim("enter: add to every item   esc: cancel")}`;
+    return [
+      ` ${color.bold.yellow("new question")} ${sanitizeUntrusted(snapshot.editor.draft)}${color.cyan("▏")}`,
+      ` ${color.dim("enter: add to every item   esc: cancel")}`,
+    ];
   }
   if (snapshot.editor.kind === "note") {
-    return ` ${color.bold.blue("note")} ${sanitizeUntrusted(snapshot.editor.draft)}${color.cyan("▏")}\n` +
-      ` ${color.dim("enter: save   esc: cancel")}`;
+    return [
+      ` ${color.bold.blue("note")} ${sanitizeUntrusted(snapshot.editor.draft)}${color.cyan("▏")}`,
+      ` ${color.dim("enter: save   esc: cancel")}`,
+    ];
   }
-  const deleteLabel = snapshot.currentQuestion?.deleted === true ? "undelete" : "delete";
   const key = (name: string, description: string) =>
     `${color.bold(name)}${color.brightBlack(` ${description}`)}`;
-  return ` ${key("space", "toggle")}  ${key("↑↓", "question")}  ${key("←→", "item")}  ` +
+  const deleteLabel = snapshot.currentQuestion?.deleted === true ? "undelete" : "delete";
+  return [
+    ` ${key("space", "toggle")}  ${key("↑↓", "question")}  ${key("←→", "item")}  ` +
     `${key("enter", "reviewed+next")}  ${key("a", "add")}  ${key("d", deleteLabel)}  ` +
-    `${key("m", "note")}  ${key("^f/^b", "scroll")}  ${key("q", "quit")}`;
+    `${key("m", "note")}  ${key("^f/^b", "scroll")}  ${key("q", "quit")}`,
+  ];
+}
+
+export type RenderArgs = {
+  snapshot: SessionSnapshot;
+  storeLabel: string;
+  width: number;
+  height: number;
+  /** Left-pane scroll position, owned by the loop. */
+  scroll: number;
+  /** The output body, already highlighted and wrapped to the left pane. */
+  body: string[];
+};
+
+export function paneHeightFor(height: number): number {
+  return Math.max(4, height - CHROME_ROWS);
+}
+
+export function leftPaneWidthFor(width: number): number {
+  return Math.max(10, Math.floor(width * LEFT_PANE_FRACTION));
+}
+
+/**
+ * Build the frame as an Element tree.
+ *
+ * Pure, and laid out by the same engine the terminal uses — so a test asserts
+ * on the real frame rather than on a string this module assembled by hand.
+ */
+export function labelScreen(args: RenderArgs): Element {
+  const { snapshot } = args;
+  const leftWidth = leftPaneWidthFor(args.width);
+  const rightWidth = Math.max(10, args.width - leftWidth - 1);
+  const paneHeight = paneHeightFor(args.height);
+
+  if (snapshot.currentItem === null) {
+    return lines([headerLine(snapshot, args.storeLabel), "", " nothing to label"]);
+  }
+
+  const checklist = renderChecklist(snapshot, rightWidth);
+  // followCursor is the library's keep-the-cursor-visible-without-jitter rule,
+  // the same one the logs viewer uses. Without it, Space and Enter would act
+  // on a checkbox scrolled off the bottom of the pane.
+  const checklistScroll = followCursor(0, checklist.focusLine, paneHeight);
+
+  return column(
+    line(headerLine(snapshot, args.storeLabel)),
+    line("", { fill: "━", fg: "gray" }),
+    line(itemLine(snapshot)),
+    line(` ${color.dim(sanitizeUntrusted(snapshot.currentItem.task).split("\n")[0])}`),
+    row(
+      { height: paneHeight },
+      pane(args.body, { width: leftWidth, height: paneHeight, scrollOffset: args.scroll }),
+      pane(
+        Array.from({ length: paneHeight }, () => color.brightBlack("│")),
+        { width: 1, height: paneHeight },
+      ),
+      pane(checklist.lines, { flex: 1, height: paneHeight, scrollOffset: checklistScroll }),
+    ),
+    line("", { fill: "━", fg: "gray" }),
+    ...footerLines(snapshot).map((footer) => line(footer)),
+  );
+}
+
+/**
+ * A scrollable pane.
+ *
+ * The content is ONE text element joined by newlines rather than a column of
+ * `line()` children, because `scrollOffset` slices an element's own content by
+ * newline — a column of one-line children has nothing to slice, and the offset
+ * is silently ignored.
+ */
+function pane(contentLines: string[], style: Style): Element {
+  return { type: "text", content: contentLines.join("\n"), style };
 }
 
 // --- input ---------------------------------------------------------------
 
-export type Key =
-  | { kind: "up" } | { kind: "down" } | { kind: "left" } | { kind: "right" }
-  | { kind: "pageUp" } | { kind: "pageDown" }
-  | { kind: "enter" } | { kind: "escape" } | { kind: "backspace" }
-  | { kind: "char"; value: string };
-
-/** A prefix of a sequence we would recognise if more bytes arrived. */
-function isIncompleteSequence(rest: string): boolean {
-  if (rest === "\x1b") {
-    return true;
-  }
-  if (!rest.startsWith("\x1b[")) {
-    return false;
-  }
-  // "\x1b[" alone, or "\x1b[5" waiting for its "~".
-  return rest === "\x1b[" || /^\x1b\[[0-9]*$/.test(rest);
-}
-
 /**
- * Parse a chunk into keys, returning any trailing partial escape sequence.
+ * Translate a keystroke into a domain action.
  *
- * A stream can split an arrow key as `"\x1b["` then `"A"`. Parsing each chunk
- * independently reads that as Escape, `[`, `A` — which cancels the editor
- * mid-word, and in normal mode turns fragments into character commands. The
- * caller keeps `rest` and prepends it to the next chunk.
+ * Returns null for keys the loop handles itself (scrolling, quitting) or
+ * ignores. Events arrive already parsed by the TUI input layer, which owns
+ * escape-sequence reassembly across stream chunks — the thing this module used
+ * to do by hand, and got wrong.
  */
-export function parseKeysBuffered(chunk: string): { keys: Key[]; rest: string } {
-  const keys: Key[] = [];
-  let index = 0;
-  while (index < chunk.length) {
-    const rest = chunk.slice(index);
-    if (isIncompleteSequence(rest)) {
-      return { keys, rest };
-    }
-    const parsed = parseOneKey(rest);
-    keys.push(parsed.key);
-    index += parsed.length;
-  }
-  return { keys, rest: "" };
-}
-
-function parseOneKey(rest: string): { key: Key; length: number } {
-  if (rest.startsWith("\x1b[5~")) return { key: { kind: "pageUp" }, length: 4 };
-  if (rest.startsWith("\x1b[6~")) return { key: { kind: "pageDown" }, length: 4 };
-  if (rest.startsWith("\x1b[A")) return { key: { kind: "up" }, length: 3 };
-  if (rest.startsWith("\x1b[B")) return { key: { kind: "down" }, length: 3 };
-  if (rest.startsWith("\x1b[C")) return { key: { kind: "right" }, length: 3 };
-  if (rest.startsWith("\x1b[D")) return { key: { kind: "left" }, length: 3 };
-  const character = rest[0];
-  if (character === "\x1b") return { key: { kind: "escape" }, length: 1 };
-  if (character === "\r" || character === "\n") return { key: { kind: "enter" }, length: 1 };
-  if (character === "\x7f") return { key: { kind: "backspace" }, length: 1 };
-  return { key: { kind: "char", value: character }, length: 1 };
-}
-
-/** Parse a complete chunk, treating any trailing partial sequence as literal
- *  keys. Used where no more bytes are coming. */
-export function parseKeys(chunk: string): Key[] {
-  const keys: Key[] = [];
-  let index = 0;
-  while (index < chunk.length) {
-    const parsed = parseOneKey(chunk.slice(index));
-    keys.push(parsed.key);
-    index += parsed.length;
-  }
-  return keys;
-}
-
-/** Translate a keystroke into a domain action. Returns null for keys that are
- *  handled by the loop itself (scrolling, quitting) or ignored. */
-export function actionForKey(key: Key, editing: boolean): SessionAction | null {
+export function actionForKey(event: KeyEvent, editing: boolean): SessionAction | null {
   if (editing) {
-    if (key.kind === "enter") return { kind: "submitEditor" };
-    if (key.kind === "escape") return { kind: "cancelEditor" };
-    if (key.kind === "backspace") return { kind: "backspaceEditor" };
-    if (key.kind === "char" && key.value >= " ") {
-      return { kind: "appendEditorText", text: key.value };
+    if (event.key === "enter") return { kind: "submitEditor" };
+    if (event.key === "escape") return { kind: "cancelEditor" };
+    if (event.key === "backspace") return { kind: "backspaceEditor" };
+    // A stray Ctrl-F while typing must not land in the text.
+    if (event.ctrl === true) return null;
+    if (event.key.length === 1 && event.key >= " ") {
+      return { kind: "appendEditorText", text: event.key };
     }
     return null;
   }
-  switch (key.kind) {
+  if (event.ctrl === true) {
+    return null;
+  }
+  switch (event.key) {
     case "up": return { kind: "previousQuestion" };
     case "down": return { kind: "nextQuestion" };
     case "left": return { kind: "previousItem" };
     case "right": return { kind: "nextItem" };
     case "enter": return { kind: "signOff" };
-    case "char":
-      if (key.value === " ") return { kind: "toggleAnswer" };
-      if (key.value === "a") return { kind: "beginQuestion" };
-      if (key.value === "d") return { kind: "toggleQuestionDeleted" };
-      if (key.value === "m") return { kind: "beginNote" };
-      return null;
-    default:
-      return null;
+    case " ": return { kind: "toggleAnswer" };
+    case "a": return { kind: "beginQuestion" };
+    case "d": return { kind: "toggleQuestionDeleted" };
+    case "m": return { kind: "beginNote" };
+    default: return null;
   }
 }
 
-export function scrollDelta(key: Key, rows: number): number {
-  const page = Math.max(4, rows - SCROLL_PAGE_MARGIN);
-  const half = Math.max(2, Math.floor(page / 2));
-  if (key.kind === "pageDown") return page;
-  if (key.kind === "pageUp") return -page;
-  if (key.kind !== "char") return 0;
-  if (key.value === "\x06") return page;
-  if (key.value === "\x02") return -page;
-  if (key.value === "\x04") return half;
-  if (key.value === "\x15") return -half;
+/** Vim-style paging. Cmd+arrow is not bindable — terminals do not transmit the
+ *  Cmd modifier. */
+export function scrollDelta(event: KeyEvent, paneHeight: number): number {
+  if (event.ctrl !== true) {
+    return 0;
+  }
+  const page = Math.max(1, paneHeight - 1);
+  const half = Math.max(1, Math.floor(page / 2));
+  if (event.key === "f") return page;
+  if (event.key === "b") return -page;
+  if (event.key === "d") return half;
+  if (event.key === "u") return -half;
   return 0;
 }
 
-export function isQuitKey(key: Key): boolean {
-  return key.kind === "char" && (key.value === "q" || key.value === "\x03");
+export function isQuitKey(event: KeyEvent): boolean {
+  return event.key === "q" || (event.key === "c" && event.ctrl === true);
 }
 
 // --- the loop ------------------------------------------------------------
 
 export type RunLabelTuiArgs = {
   controller: LabelingSessionController;
-  input: NodeJS.ReadStream;
-  output: NodeJS.WriteStream;
+  screen: Screen;
+  storeLabel?: string;
+};
+
+type BodyCache = { outputId: string; width: number; lines: string[] };
+
+type LoopState = {
+  scroll: number;
+  done: boolean;
+  /** Highlight and wrap are expensive enough that redoing them per keystroke
+   *  shows, so the result is cached until the item or the width changes. */
+  body: BodyCache | null;
 };
 
 export async function runLabelTui(args: RunLabelTuiArgs): Promise<void> {
-  assertInteractiveTerminal(args.input, args.output);
-  const restore = enterTerminalMode(args.input);
-  try {
-    await runInputLoop(args);
-  } finally {
-    restore();
-  }
-}
+  const { width, height } = args.screen.size();
+  const leftWidth = leftPaneWidthFor(width);
+  const paneHeight = paneHeightFor(height);
 
-function assertInteractiveTerminal(input: NodeJS.ReadStream, output: NodeJS.WriteStream): void {
-  if (input.isTTY !== true || output.isTTY !== true) {
-    throw new Error(
-      "agency eval label needs an interactive terminal: it shows outputs and reads keystrokes. " +
-      "Run it directly rather than through a pipe.",
-    );
-  }
-}
-
-function enterTerminalMode(input: NodeJS.ReadStream): () => void {
-  const wasRaw = input.isRaw === true;
-  input.setRawMode(true);
-  input.resume();
-  input.setEncoding("utf8");
-  return () => {
-    // Restoring must happen even when the loop threw, or the caller's shell is
-    // left in raw mode with no echo.
-    input.setRawMode(wasRaw);
-    input.pause();
-  };
-}
-
-async function runInputLoop(args: RunLabelTuiArgs): Promise<void> {
-  let scroll = 0;
-  let bodyCache: { outputId: string; width: number; lines: string[] } | undefined;
-
-  const draw = (): void => {
-    const snapshot = args.controller.snapshot();
-    const columns = args.output.columns ?? 100;
-    const rows = args.output.rows ?? 30;
-    const leftWidth = Math.floor(columns * 0.6) - 1;
-    const item = snapshot.currentItem;
-    if (item !== null && (bodyCache?.outputId !== item.outputId || bodyCache?.width !== leftWidth)) {
-      // Highlighting parses the whole document, which is far too slow to redo
-      // on every keystroke.
-      bodyCache = {
-        outputId: item.outputId,
-        width: leftWidth,
-        lines: renderMarkdownSafely(sanitizeUntrusted(item.text)).split("\n")
-          .flatMap((line) => wrapAnsi(line, leftWidth)),
-      };
+  const withBody = (state: LoopState): LoopState => {
+    const item = args.controller.snapshot().currentItem;
+    if (item === null) {
+      return state;
     }
-    args.output.write(`\x1b[2J\x1b[H${renderLabelScreen({
-      snapshot, storeLabel: "", columns, rows, scroll, body: bodyCache?.lines ?? [],
-    })}\n`);
+    if (state.body?.outputId === item.outputId && state.body.width === leftWidth) {
+      return state;
+    }
+    const rendered = renderMarkdownSafely(sanitizeUntrusted(item.text));
+    const wrapped = rendered.split("\n").flatMap((source) => wrapText(source, leftWidth));
+    return { ...state, body: { outputId: item.outputId, width: leftWidth, lines: wrapped } };
   };
 
-  draw();
-
-  await new Promise<void>((resolve, reject) => {
-    let pending = "";
-    const onData = (chunk: string): void => {
-      void (async () => {
-        try {
-          const parsed = parseKeysBuffered(pending + chunk);
-          pending = parsed.rest;
-          for (const key of parsed.keys) {
-            const snapshot = args.controller.snapshot();
-            const editing = snapshot.editor.kind !== "none";
-            if (!editing && isQuitKey(key)) {
-              args.input.off("data", onData);
-              resolve();
-              return;
-            }
-            const previousItem = snapshot.currentItem?.outputId;
-            const action = actionForKey(key, editing);
-            if (action !== null) {
-              const next = await args.controller.dispatch(action);
-              if (next.currentItem?.outputId !== previousItem) {
-                scroll = 0;
-              }
-            }
-            scroll = Math.max(0, scroll + scrollDelta(key, args.output.rows ?? 30));
-          }
-          draw();
-        } catch (error) {
-          args.input.off("data", onData);
-          reject(error);
+  await args.screen.runLoop<LoopState>({
+    initialState: withBody({ scroll: 0, done: false, body: null }),
+    render: (state) => labelScreen({
+      snapshot: args.controller.snapshot(),
+      storeLabel: args.storeLabel ?? "",
+      width,
+      height,
+      scroll: state.scroll,
+      body: state.body?.lines ?? [],
+    }),
+    handleKey: async (state, event) => {
+      const snapshot = args.controller.snapshot();
+      const editing = snapshot.editor.kind !== "none";
+      if (!editing && isQuitKey(event)) {
+        return { ...state, done: true };
+      }
+      const previousItem = snapshot.currentItem?.outputId;
+      let next = state;
+      const action = actionForKey(event, editing);
+      if (action !== null) {
+        const after = await args.controller.dispatch(action);
+        if (after.currentItem?.outputId !== previousItem) {
+          next = { ...next, scroll: 0 };
         }
-      })();
-    };
-    args.input.on("data", onData);
+      }
+      next = withBody(next);
+      const maxScroll = Math.max(0, (next.body?.lines.length ?? 0) - paneHeight);
+      const scrolled = next.scroll + scrollDelta(event, paneHeight);
+      return { ...next, scroll: Math.min(Math.max(0, scrolled), maxScroll) };
+    },
+    isDone: (state) => state.done,
   });
 }

--- a/packages/agency-lang/lib/eval/label/labelTui.untrusted.test.ts
+++ b/packages/agency-lang/lib/eval/label/labelTui.untrusted.test.ts
@@ -1,15 +1,15 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  parseKeysBuffered,
-  renderLabelScreen,
-  sanitizeUntrusted,
-  stripAnsi,
-} from "./labelTui.js";
+import { ScriptedInput } from "@/tui/input/scripted.js";
+import { FrameRecorder } from "@/tui/output/recorder.js";
+import { Screen } from "@/tui/screen.js";
+
+import { labelScreen, sanitizeUntrusted } from "./labelTui.js";
 import type { SessionSnapshot } from "./session.js";
 
 const OUTPUT_ID = `out_${"a".repeat(64)}`;
 const ESC = "\x1b";
+const BEL = "\x07";
 
 function snapshot(over: Partial<SessionSnapshot> = {}): SessionSnapshot {
   const item = { outputId: OUTPUT_ID, task: "a task", text: "some output" };
@@ -32,7 +32,31 @@ function snapshot(over: Partial<SessionSnapshot> = {}): SessionSnapshot {
   };
 }
 
-const baseRender = { storeLabel: "labels", columns: 100, rows: 30, scroll: 0, body: [] as string[] };
+/**
+ * Render through the real layout engine and read back what the terminal would
+ * receive, escapes included. Asserting on the frame rather than on a string
+ * this module built is the point: it proves nothing hostile survives all the
+ * way to the output target.
+ */
+function frameCells(over: Partial<SessionSnapshot> = {}, body: string[] = ["output"]): string {
+  const recorder = new FrameRecorder();
+  const screen = new Screen({
+    input: new ScriptedInput(),
+    output: recorder,
+    width: 100,
+    height: 30,
+  });
+  screen.render(labelScreen({
+    snapshot: snapshot(over),
+    storeLabel: "labels",
+    width: 100,
+    height: 30,
+    scroll: 0,
+    body,
+  }));
+  // Every character the frame holds, so a stray escape cannot hide in a cell.
+  return recorder.lastText();
+}
 
 describe("sanitizeUntrusted", () => {
   it("neutralizes cursor movement and clear-screen", () => {
@@ -40,11 +64,11 @@ describe("sanitizeUntrusted", () => {
   });
 
   it("neutralizes an OSC 52 clipboard write", () => {
-    expect(sanitizeUntrusted(`${ESC}]52;c;cGF5bG9hZA==`)).not.toContain(ESC);
+    expect(sanitizeUntrusted(`${ESC}]52;c;cGF5bG9hZA==${BEL}`)).not.toContain(ESC);
   });
 
   it("neutralizes C1 controls, which are a single byte each", () => {
-    expect(sanitizeUntrusted("ac")).not.toContain("");
+    expect(sanitizeUntrusted("ac")).not.toContain("");
   });
 
   it("neutralizes a bare carriage return, which would overwrite the line", () => {
@@ -61,126 +85,35 @@ describe("sanitizeUntrusted", () => {
   });
 });
 
-describe("untrusted content never reaches the terminal raw", () => {
+describe("untrusted content never reaches the frame raw", () => {
   it("sanitizes a hostile task", () => {
     const hostile = { outputId: OUTPUT_ID, task: `safe${ESC}[2Jhidden`, text: "x" };
-    const frame = renderLabelScreen({
-      ...baseRender,
-      snapshot: snapshot({ currentItem: hostile, items: [hostile] }),
-    });
-    expect(frame).not.toContain(`${ESC}[2J`);
+    expect(frameCells({ currentItem: hostile, items: [hostile] })).not.toContain(ESC);
   });
 
   it("sanitizes a hostile question", () => {
-    const frame = renderLabelScreen({
-      ...baseRender,
-      snapshot: snapshot({
-        questions: [{ id: "q_a", text: `ok${ESC}[2Jgone`, weight: 1, deleted: false }],
-      }),
-    });
-    expect(frame).not.toContain(`${ESC}[2J`);
+    const questions = [{ id: "q_a", text: `ok${ESC}[2Jgone`, weight: 1, deleted: false }];
+    expect(frameCells({ questions })).not.toContain(ESC);
   });
 
   it("sanitizes a hostile note", () => {
-    const frame = renderLabelScreen({
-      ...baseRender,
-      snapshot: snapshot({ note: `note${ESC}[2Jgone` }),
-    });
-    expect(frame).not.toContain(`${ESC}[2J`);
+    expect(frameCells({ note: `note${ESC}[2Jgone` })).not.toContain(ESC);
   });
 
   it("sanitizes a hostile editor draft", () => {
-    const frame = renderLabelScreen({
-      ...baseRender,
-      snapshot: snapshot({ editor: { kind: "note", draft: `typed${ESC}[2J` } }),
-    });
-    expect(frame).not.toContain(`${ESC}[2J`);
+    // A draft is untrusted after a round trip: beginNote seeds it from a
+    // stored note, which came from this same input.
+    expect(frameCells({ editor: { kind: "note", draft: `typed${ESC}[2J` } })).not.toContain(ESC);
+  });
+
+  it("sanitizes hostile output body text", () => {
+    expect(frameCells({}, [sanitizeUntrusted(`body${ESC}[2Jgone`)])).not.toContain(ESC);
   });
 
   it("shows only the first line of a multi-line task, so the layout cannot be broken", () => {
     const multiline = { outputId: OUTPUT_ID, task: "first line\nsecond line", text: "x" };
-    const frame = stripAnsi(renderLabelScreen({
-      ...baseRender,
-      snapshot: snapshot({ currentItem: multiline, items: [multiline] }),
-    }));
-    expect(frame).toContain("first line");
-    expect(frame).not.toContain("second line");
-  });
-});
-
-describe("checklist viewport follows the focused question", () => {
-  function manyQuestions(count: number, focusIndex: number): SessionSnapshot {
-    const questions = Array.from({ length: count }, (_, index) => ({
-      id: `q_${index}`, text: `Question number ${index}`, weight: 1, deleted: false,
-    }));
-    return snapshot({
-      questions, questionIndex: focusIndex, currentQuestion: questions[focusIndex],
-    });
-  }
-
-  it("keeps a question near the end of a long checklist visible", () => {
-    // Without a viewport the right pane always starts at question 0, so Space
-    // and Enter would act on a checkbox the reader cannot see.
-    const frame = stripAnsi(renderLabelScreen({
-      ...baseRender, rows: 20, snapshot: manyQuestions(40, 39),
-    }));
-    expect(frame).toContain("Question number 39");
-  });
-
-  it("still shows the first question when focus is at the top", () => {
-    const frame = stripAnsi(renderLabelScreen({
-      ...baseRender, rows: 20, snapshot: manyQuestions(40, 0),
-    }));
-    expect(frame).toContain("Question number 0");
-  });
-
-  it("does not scroll a checklist that already fits", () => {
-    const frame = stripAnsi(renderLabelScreen({
-      ...baseRender, rows: 30, snapshot: manyQuestions(3, 2),
-    }));
-    expect(frame).toContain("Question number 0");
-    expect(frame).toContain("Question number 2");
-  });
-});
-
-describe("parseKeysBuffered", () => {
-  it("holds a split arrow key until the rest arrives", () => {
-    const first = parseKeysBuffered(`${ESC}[`);
-    expect(first.keys).toEqual([]);
-    expect(first.rest).toBe(`${ESC}[`);
-    const second = parseKeysBuffered(first.rest + "A");
-    expect(second.keys).toEqual([{ kind: "up" }]);
-    expect(second.rest).toBe("");
-  });
-
-  it("holds a lone escape, which could begin a sequence", () => {
-    expect(parseKeysBuffered(ESC)).toEqual({ keys: [], rest: ESC });
-  });
-
-  it("holds a partial page-up until its terminator arrives", () => {
-    const first = parseKeysBuffered(`${ESC}[5`);
-    expect(first.rest).toBe(`${ESC}[5`);
-    expect(parseKeysBuffered(first.rest + "~").keys).toEqual([{ kind: "pageUp" }]);
-  });
-
-  it("parses every supported sequence split at each byte boundary", () => {
-    const sequences: [string, string][] = [
-      [`${ESC}[A`, "up"], [`${ESC}[B`, "down"], [`${ESC}[C`, "right"], [`${ESC}[D`, "left"],
-      [`${ESC}[5~`, "pageUp"], [`${ESC}[6~`, "pageDown"],
-    ];
-    for (const [sequence, kind] of sequences) {
-      for (let split = 1; split < sequence.length; split += 1) {
-        const first = parseKeysBuffered(sequence.slice(0, split));
-        const second = parseKeysBuffered(first.rest + sequence.slice(split));
-        expect([...first.keys, ...second.keys]).toEqual([{ kind }]);
-      }
-    }
-  });
-
-  it("emits ordinary characters immediately", () => {
-    expect(parseKeysBuffered("ab")).toEqual({
-      keys: [{ kind: "char", value: "a" }, { kind: "char", value: "b" }],
-      rest: "",
-    });
+    const text = frameCells({ currentItem: multiline, items: [multiline] });
+    expect(text).toContain("first line");
+    expect(text).not.toContain("second line");
   });
 });

--- a/packages/agency-lang/lib/eval/label/labelTui.untrusted.test.ts
+++ b/packages/agency-lang/lib/eval/label/labelTui.untrusted.test.ts
@@ -110,6 +110,22 @@ describe("untrusted content never reaches the frame raw", () => {
     expect(frameCells({}, [sanitizeUntrusted(`body${ESC}[2Jgone`)])).not.toContain(ESC);
   });
 
+  it("escapes style tags in a hostile question, which are markup to the parser", () => {
+    // Control characters are not the only way in: {black-fg} is markup, so
+    // text alone could restyle or hide the evidence being judged.
+    const questions = [{ id: "q_a", text: "{black-fg}invisible?{/black-fg}", weight: 1, deleted: false }];
+    expect(frameCells({ questions })).toContain("{black-fg}invisible?");
+  });
+
+  it("escapes style tags in a hostile note", () => {
+    expect(frameCells({ note: "{bg-red}alarming{/bg-red}" })).toContain("{bg-red}alarming");
+  });
+
+  it("escapes style tags in a hostile task", () => {
+    const hostile = { outputId: OUTPUT_ID, task: "{black-fg}hidden", text: "x" };
+    expect(frameCells({ currentItem: hostile, items: [hostile] })).toContain("{black-fg}hidden");
+  });
+
   it("shows only the first line of a multi-line task, so the layout cannot be broken", () => {
     const multiline = { outputId: OUTPUT_ID, task: "first line\nsecond line", text: "x" };
     const text = frameCells({ currentItem: multiline, items: [multiline] });

--- a/packages/agency-lang/lib/eval/label/labelTui.untrusted.test.ts
+++ b/packages/agency-lang/lib/eval/label/labelTui.untrusted.test.ts
@@ -9,7 +9,7 @@ import {
 import type { SessionSnapshot } from "./session.js";
 
 const OUTPUT_ID = `out_${"a".repeat(64)}`;
-const ESC = "";
+const ESC = "\x1b";
 
 function snapshot(over: Partial<SessionSnapshot> = {}): SessionSnapshot {
   const item = { outputId: OUTPUT_ID, task: "a task", text: "some output" };

--- a/packages/agency-lang/lib/stdlib/layout/ansi.hyperlink.test.ts
+++ b/packages/agency-lang/lib/stdlib/layout/ansi.hyperlink.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import { stripAnsi, visualWidth, wrapText } from "./ansi.js";
+
+const ESC = "\x1b";
+const BEL = "\x07";
+/** An OSC 8 hyperlink: opener carrying the URL, the visible label, then the
+ *  closer. Terminal-rendered Markdown produces these for every link. */
+function link(url: string, label: string): string {
+  return `${ESC}]8;;${url}${BEL}${label}${ESC}]8;;${BEL}`;
+}
+
+const LONG_URL = "https://www.example.com/a/very/long/path/that/goes/on?utm_source=somewhere";
+
+describe("visualWidth", () => {
+  it("counts only the visible label of a hyperlink, not its URL", () => {
+    expect(visualWidth(link(LONG_URL, "site"))).toBe(4);
+  });
+
+  it("still ignores SGR colour codes", () => {
+    expect(visualWidth(`${ESC}[1mbold${ESC}[0m`)).toBe(4);
+  });
+
+  it("handles a link terminated with ST instead of BEL", () => {
+    const withSt = `${ESC}]8;;${LONG_URL}${ESC}\\label${ESC}]8;;${ESC}\\`;
+    expect(visualWidth(withSt)).toBe(5);
+  });
+
+  it("counts plain text unchanged", () => {
+    expect(visualWidth("plain text")).toBe(10);
+  });
+});
+
+describe("stripAnsi", () => {
+  it("removes the hyperlink wrapper and keeps the label", () => {
+    expect(stripAnsi(link(LONG_URL, "site"))).toBe("site");
+  });
+
+  it("keeps text either side of a link", () => {
+    expect(stripAnsi(`see ${link(LONG_URL, "site")} for more`)).toBe("see site for more");
+  });
+});
+
+describe("wrapText with hyperlinks", () => {
+  it("does not treat a link's URL as content that must be wrapped", () => {
+    // Before OSC awareness this wrapped into many lines of URL fragments,
+    // because the URL counted toward the column budget.
+    const lines = wrapText(`see ${link(LONG_URL, "site")} now`, 20);
+    expect(lines).toHaveLength(1);
+    expect(stripAnsi(lines[0])).toBe("see site now");
+  });
+
+  it("keeps every wrapped line within the column budget", () => {
+    const source = `alpha ${link(LONG_URL, "beta")} gamma delta epsilon zeta eta theta`;
+    for (const wrapped of wrapText(source, 12)) {
+      expect(visualWidth(wrapped)).toBeLessThanOrEqual(12);
+    }
+  });
+
+  it("loses no visible words around a link", () => {
+    const source = `alpha ${link(LONG_URL, "beta")} gamma delta epsilon`;
+    const joined = wrapText(source, 10).map(stripAnsi).join(" ");
+    for (const word of ["alpha", "beta", "gamma", "delta", "epsilon"]) {
+      expect(joined).toContain(word);
+    }
+  });
+
+  it("does not let a link swallow the text after it", () => {
+    const source = `(${link(LONG_URL, "site")}) and more words here`;
+    const joined = wrapText(source, 40).map(stripAnsi).join(" ");
+    expect(joined).toContain("and more words here");
+    expect(joined).toContain("site");
+  });
+
+  it("still hard-breaks a genuinely long visible token", () => {
+    const lines = wrapText("x".repeat(50), 10);
+    expect(lines.length).toBeGreaterThan(1);
+    for (const wrapped of lines) {
+      expect(visualWidth(wrapped)).toBeLessThanOrEqual(10);
+    }
+  });
+});

--- a/packages/agency-lang/lib/stdlib/layout/ansi.hyperlink.test.ts
+++ b/packages/agency-lang/lib/stdlib/layout/ansi.hyperlink.test.ts
@@ -80,3 +80,33 @@ describe("wrapText with hyperlinks", () => {
     }
   });
 });
+
+describe("hyperlink state across wrap boundaries", () => {
+  it("closes an open link at the end of a wrapped segment", () => {
+    // A long label forces the link to span more than one line. Leaving the
+    // link open would make the rest of the row, and the next pane, clickable.
+    const label = "a clickable label long enough to wrap across two lines";
+    const wrapped = wrapText(link(LONG_URL, label), 20);
+    expect(wrapped.length).toBeGreaterThan(1);
+    expect(wrapped[0].endsWith(`${ESC}]8;;${BEL}`)).toBe(true);
+  });
+
+  it("reopens the link on the following segment", () => {
+    const label = "a clickable label long enough to wrap across two lines";
+    const wrapped = wrapText(link(LONG_URL, label), 20);
+    expect(wrapped[1].startsWith(`${ESC}]8;;${LONG_URL}${BEL}`)).toBe(true);
+  });
+
+  it("does not reopen a link after its closer", () => {
+    const wrapped = wrapText(`${link(LONG_URL, "site")} then plenty more words here to wrap`, 12);
+    expect(wrapped[wrapped.length - 1]).not.toContain(LONG_URL);
+  });
+
+  it("still loses no visible text", () => {
+    const label = "a clickable label long enough to wrap";
+    const joined = wrapText(link(LONG_URL, label), 15).map(stripAnsi).join(" ");
+    for (const word of label.split(" ")) {
+      expect(joined).toContain(word);
+    }
+  });
+});

--- a/packages/agency-lang/lib/stdlib/layout/ansi.ts
+++ b/packages/agency-lang/lib/stdlib/layout/ansi.ts
@@ -5,15 +5,22 @@
 // `visualWidth`, and only emit escape sequences via `sgr` (or by
 // asking `stripAnsi` to remove them).
 
-const CSI_RE = /\x1b\[[\d;]*[A-Za-z]/g;
-const CSI_TOKEN_RE = /\x1b\[[\d;]*[A-Za-z]/y;
+const CSI_SOURCE = "\\x1b\\[[\\d;]*[A-Za-z]";
+// OSC sequences — `ESC ] … BEL` or `ESC ] … ST`. The one that matters in
+// practice is OSC 8, the hyperlink wrapper, which carries a whole URL that
+// occupies no columns. Counting that URL as visible text throws every width
+// calculation off, and terminal-rendered Markdown is full of links.
+const OSC_SOURCE = "\\x1b\\][^\\x07\\x1b]*(?:\\x07|\\x1b\\\\)";
+
+const ZERO_WIDTH_RE = new RegExp(`${CSI_SOURCE}|${OSC_SOURCE}`, "g");
+const ZERO_WIDTH_TOKEN_RE = new RegExp(`${CSI_SOURCE}|${OSC_SOURCE}`, "y");
 
 export function visualWidth(s: string): number {
-  return s.replace(CSI_RE, "").length;
+  return s.replace(ZERO_WIDTH_RE, "").length;
 }
 
 export function stripAnsi(s: string): string {
-  return s.replace(CSI_RE, "");
+  return s.replace(ZERO_WIDTH_RE, "");
 }
 
 // Matches SGR sequences only (CSI … `m`), not other CSI like cursor/erase.
@@ -98,11 +105,11 @@ function breakLongToken(token: string, width: number): string[] {
   let index = 0;
 
   while (index < token.length) {
-    CSI_TOKEN_RE.lastIndex = index;
-    const escape = CSI_TOKEN_RE.exec(token);
+    ZERO_WIDTH_TOKEN_RE.lastIndex = index;
+    const escape = ZERO_WIDTH_TOKEN_RE.exec(token);
     if (escape && escape.index === index) {
       current += escape[0];
-      index = CSI_TOKEN_RE.lastIndex;
+      index = ZERO_WIDTH_TOKEN_RE.lastIndex;
       continue;
     }
 

--- a/packages/agency-lang/lib/stdlib/layout/ansi.ts
+++ b/packages/agency-lang/lib/stdlib/layout/ansi.ts
@@ -5,6 +5,8 @@
 // `visualWidth`, and only emit escape sequences via `sgr` (or by
 // asking `stripAnsi` to remove them).
 
+const ESC = "\x1b";
+const BEL = "\x07";
 const CSI_SOURCE = "\\x1b\\[[\\d;]*[A-Za-z]";
 // OSC sequences — `ESC ] … BEL` or `ESC ] … ST`. The one that matters in
 // practice is OSC 8, the hyperlink wrapper, which carries a whole URL that
@@ -48,13 +50,33 @@ function updateActiveSgr(active: string, segment: string): string {
 // never dropped mid-span; when no style is active a blank line stays "".
 function reinjectSgr(segments: string[]): string[] {
   let active = "";
+  let link = "";
   return segments.map((segment) => {
     const opened = active;
     const closed = updateActiveSgr(opened, segment);
     active = closed;
-    const suffix = closed === "" ? "" : RESET;
-    return opened + segment + suffix;
+    const openedLink = link;
+    link = updateActiveHyperlink(openedLink, segment);
+    // A hyperlink left open across a wrap makes everything after it — borders,
+    // the next pane, unrelated rows — clickable. Close it at the boundary and
+    // reopen it on the next segment, the same way SGR state is carried.
+    const suffix = (closed === "" ? "" : RESET) + (link === "" ? "" : HYPERLINK_CLOSE);
+    return openedLink + opened + segment + suffix;
   });
+}
+
+// OSC 8 opener carrying a URL, and the closer that ends the link.
+const OSC8_RE = /\x1b\]8;;([^\x07\x1b]*)(?:\x07|\x1b\\)/g;
+const HYPERLINK_CLOSE = `${ESC}]8;;${BEL}`;
+
+/** Track the hyperlink open since the last closer. An opener with an empty URL
+ *  IS the closer, per the OSC 8 spec. */
+function updateActiveHyperlink(active: string, segment: string): string {
+  let result = active;
+  for (const match of segment.matchAll(OSC8_RE)) {
+    result = match[1] === "" ? "" : match[0];
+  }
+  return result;
 }
 
 export function wrapText(content: string, width: number): string[] {

--- a/packages/agency-lang/lib/tui/input/terminal.escape.test.ts
+++ b/packages/agency-lang/lib/tui/input/terminal.escape.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import { TerminalInput } from "./terminal.js";
+import type { KeyEvent } from "./types.js";
+
+const ESC = "\x1b";
+
+/** Drive the private chunk parser the way the stream would. */
+function feed(input: TerminalInput, chunks: string[]): KeyEvent[] {
+  const seen: KeyEvent[] = [];
+  const emit = (input as unknown as { emitKey(key: KeyEvent): void }).emitKey.bind(input);
+  (input as unknown as { emitKey(key: KeyEvent): void }).emitKey = (key) => { seen.push(key); };
+  for (const chunk of chunks) {
+    (input as unknown as { parseAndEmit(text: string): void }).parseAndEmit(chunk);
+  }
+  (input as unknown as { emitKey(key: KeyEvent): void }).emitKey = emit;
+  return seen;
+}
+
+describe("escape sequences split across chunks", () => {
+  it("reassembles an arrow key split after the bracket", () => {
+    expect(feed(new TerminalInput(), [`${ESC}[`, "A"])).toEqual([{ key: "up" }]);
+  });
+
+  it("reassembles a page key split before its terminator", () => {
+    expect(feed(new TerminalInput(), [`${ESC}[5`, "~"])).toEqual([{ key: "pageup" }]);
+  });
+
+  it("reassembles a sequence split anywhere after the introducer", () => {
+    for (const [sequence, key] of [[`${ESC}[C`, "right"], [`${ESC}[6~`, "pagedown"]] as const) {
+      for (let split = 2; split < sequence.length; split += 1) {
+        const keys = feed(new TerminalInput(), [sequence.slice(0, split), sequence.slice(split)]);
+        expect(keys).toEqual([{ key }]);
+      }
+    }
+  });
+
+  it("still emits a bare Escape immediately, since that is the Escape key", () => {
+    expect(feed(new TerminalInput(), [ESC])).toEqual([{ key: "escape" }]);
+  });
+
+  it("KNOWN GAP: a chunk ending on the bare introducer is read as Escape", () => {
+    // Holding a lone ESC would need a timer to tell the Escape key apart from
+    // the first byte of a sequence, so this case is left as-is deliberately.
+    // Terminals emit a sequence in one write, so a split here needs a 1-byte
+    // buffer boundary — rare, and never silent, since the reader sees Escape.
+    expect(feed(new TerminalInput(), [ESC, "[C"])[0]).toEqual({ key: "escape" });
+  });
+
+  it("emits ordinary characters without buffering", () => {
+    expect(feed(new TerminalInput(), ["ab"])).toEqual([
+      { key: "a" }, { key: "b" },
+    ]);
+  });
+});
+
+describe("suppressSigint", () => {
+  it("emits ctrl-c as a key without raising SIGINT when asked", () => {
+    const raised: string[] = [];
+    const original = process.kill;
+    (process as unknown as { kill: typeof process.kill }).kill = ((pid: number, signal?: string) => {
+      raised.push(String(signal));
+      return true;
+    }) as typeof process.kill;
+    try {
+      const keys = feed(new TerminalInput({ suppressSigint: true }), ["\x03"]);
+      expect(keys).toEqual([{ key: "c", ctrl: true }]);
+      expect(raised).toEqual([]);
+    } finally {
+      (process as unknown as { kill: typeof process.kill }).kill = original;
+    }
+  });
+});

--- a/packages/agency-lang/lib/tui/input/terminal.ts
+++ b/packages/agency-lang/lib/tui/input/terminal.ts
@@ -139,6 +139,30 @@ export function readEscapeSequence(
   return null;
 }
 
+/**
+ * True when `str` from `i` begins an escape sequence that has not finished
+ * arriving, so the caller should hold it for the next chunk.
+ *
+ * A lone ESC is excluded, and that is a deliberate limit: telling the Escape
+ * KEY apart from the first byte of a sequence needs a timer, and holding every
+ * ESC would make Escape feel broken. Terminals write a sequence in one call,
+ * so a split at that exact byte needs a one-byte buffer boundary.
+ */
+function isIncompleteEscape(str: string, i: number): boolean {
+  const rest = str.slice(i);
+  if (!rest.startsWith("\x1b[") && !rest.startsWith("\x1bO")) {
+    return false;
+  }
+  // Complete once a final byte arrives (@ through ~ for CSI, a letter for SS3).
+  return !/^\x1b(\[[\d;?]*[\x40-\x7e]|O.)/.test(rest);
+}
+
+export type TerminalInputOptions = {
+  /** Emit Ctrl-C as a key WITHOUT raising SIGINT, so the app can run its own
+   *  teardown. Default false, which keeps the signal. */
+  suppressSigint?: boolean;
+};
+
 export class TerminalInput implements InputSource {
   private keyWaiters: ((key: KeyEvent) => void)[] = [];
   private keyQueue: KeyEvent[] = [];
@@ -152,6 +176,12 @@ export class TerminalInput implements InputSource {
   // events. `null` when no paste is in progress; a string buffer
   // collecting the body once `PASTE_START` has been seen.
   private pasteBuffer: string | null = null;
+  private escapeBuffer = "";
+  private readonly suppressSigint: boolean;
+
+  constructor(options: TerminalInputOptions = {}) {
+    this.suppressSigint = options.suppressSigint === true;
+  }
 
   private ensureInitialized(): void {
     if (this.initialized) return;
@@ -280,7 +310,8 @@ export class TerminalInput implements InputSource {
    *   6. A single character (printable or ctrl+letter)
    */
   private parseAndEmit(input: string): void {
-    let str = input;
+    let str = this.escapeBuffer + input;
+    this.escapeBuffer = "";
 
     // 1. Mid-paste continuation. Treat the carried `pasteBuffer` as
     //    text already inside the markers, and look for the close
@@ -313,6 +344,16 @@ export class TerminalInput implements InputSource {
         continue;
       }
 
+      // 2b. An escape sequence cut in half by the stream boundary. Hold it
+      //     for the next chunk rather than emitting Escape, `[`, `A` — which
+      //     cancels an editor mid-word and turns fragments into commands. Only
+      //     prefixes LONGER than a lone ESC are held: a bare ESC is the Escape
+      //     key and must stay immediate.
+      if (isIncompleteEscape(str, i)) {
+        this.escapeBuffer = str.slice(i);
+        return;
+      }
+
       // 3. Ctrl+Z: surface as SIGTSTP and stop processing — the
       //    rest of this chunk is irrelevant once we're suspended.
       const code = str.charCodeAt(i);
@@ -324,7 +365,12 @@ export class TerminalInput implements InputSource {
       // 4. Ctrl+C: re-raise SIGINT and ALSO emit the key so Agency
       //    handlers can react before the signal actually lands.
       if (code === 0x03) {
-        process.kill(process.pid, "SIGINT");
+        // An app that wants to run its own teardown on Ctrl-C opts out of the
+        // signal: SIGINT would otherwise exit the process before the app's
+        // loop ever sees the key, skipping its cleanup entirely.
+        if (!this.suppressSigint) {
+          process.kill(process.pid, "SIGINT");
+        }
         this.emitKey({ key: "c", ctrl: true });
         i += 1;
         continue;

--- a/packages/agency-lang/lib/tui/screen.ts
+++ b/packages/agency-lang/lib/tui/screen.ts
@@ -37,6 +37,13 @@ export class Screen {
     return { width: this.width, height: this.height };
   }
 
+  /** Adopt a new terminal size. Layout reads these on every render, so an app
+   *  that watches SIGWINCH can keep panes correct without restarting. */
+  resize(width: number, height: number): void {
+    this.width = width;
+    this.height = height;
+  }
+
   async runLoop<S>(opts: {
     initialState: S;
     render: (state: S) => Element | Promise<Element>;

--- a/packages/agency-lang/lib/tui/styleParser.hyperlink.test.ts
+++ b/packages/agency-lang/lib/tui/styleParser.hyperlink.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { parseStyledText } from "./styleParser.js";
+
+const ESC = "\x1b";
+const BEL = "\x07";
+
+/** An OSC 8 hyperlink: opener carrying the URL, the visible label, the closer. */
+function link(url: string, label: string): string {
+  return `${ESC}]8;;${url}${BEL}${label}${ESC}]8;;${BEL}`;
+}
+
+function visibleText(input: string): string {
+  return parseStyledText(input).map((span) => span.text).join("");
+}
+
+describe("OSC sequences in styled text", () => {
+  it("keeps a hyperlink's label and drops its URL", () => {
+    expect(visibleText(link("https://example.com/a/long/path", "site"))).toBe("site");
+  });
+
+  it("keeps the surrounding prose intact", () => {
+    expect(visibleText(`see ${link("https://example.com", "site")} now`)).toBe("see site now");
+  });
+
+  it("handles a link terminated with ST rather than BEL", () => {
+    const withSt = `${ESC}]8;;https://example.com${ESC}\\label${ESC}]8;;${ESC}\\`;
+    expect(visibleText(withSt)).toBe("label");
+  });
+
+  it("drops a non-8 OSC sequence too, such as a clipboard write", () => {
+    expect(visibleText(`before${ESC}]52;c;cGF5bG9hZA==${BEL}after`)).toBe("beforeafter");
+  });
+
+  it("still applies SGR styling around a link", () => {
+    const spans = parseStyledText(`${ESC}[1mbold ${link("https://example.com", "site")}${ESC}[0m`);
+    expect(spans.map((span) => span.text).join("")).toBe("bold site");
+    expect(spans.some((span) => span.bold === true)).toBe(true);
+  });
+
+  it("leaves text with no escapes unchanged", () => {
+    expect(visibleText("just words")).toBe("just words");
+  });
+});

--- a/packages/agency-lang/lib/tui/styleParser.ts
+++ b/packages/agency-lang/lib/tui/styleParser.ts
@@ -15,10 +15,16 @@ type StyleEntry =
   | { type: "fg"; color: string; origin: Origin }
   | { type: "bg"; color: string; origin: Origin };
 
-// Matches either a `{tag}` (not preceded by a backslash) or an ANSI SGR
-// escape sequence `ESC[<params>m`. Tag bodies may not contain `}`, so an
-// escaped `}` inside a tag body is not supported by design.
-const TAG_PATTERN_SOURCE = String.raw`(?<!\\)\{(\/?)([^}]+)\}|\x1b\[([\d;]*)m`;
+// Matches a `{tag}` (not preceded by a backslash), an ANSI SGR escape
+// sequence `ESC[<params>m`, or an OSC sequence `ESC] … BEL/ST`. Tag bodies may
+// not contain `}`, so an escaped `}` inside a tag body is not supported by
+// design.
+//
+// OSC carries no styling and occupies no columns — OSC 8 is the terminal
+// hyperlink wrapper, whose URL is metadata. Without this alternative the whole
+// sequence, URL included, was emitted as literal cells, so a link in rendered
+// Markdown printed its own href across the screen.
+const TAG_PATTERN_SOURCE = String.raw`(?<!\\)\{(\/?)([^}]+)\}|\x1b\[([\d;]*)m|(\x1b\][^\x07\x1b]*(?:\x07|\x1b\\))`;
 const TAG_FLAGS = "g";
 
 // Map standard ANSI color codes (30-37, 40-47, 90-97, 100-107) to our
@@ -200,7 +206,7 @@ export function parseStyledText(input: string): StyledSpan[] {
   const tagRe = new RegExp(TAG_PATTERN_SOURCE, TAG_FLAGS);
   let match;
   while ((match = tagRe.exec(input)) !== null) {
-    const [fullMatch, isClosing, tagName, ansiParams] = match;
+    const [fullMatch, isClosing, tagName, ansiParams, oscSequence] = match;
 
     // Text before this tag
     if (match.index > lastIndex) {
@@ -208,7 +214,9 @@ export function parseStyledText(input: string): StyledSpan[] {
       spans.push(makeSpan(textBefore, currentStyle(stack)));
     }
 
-    if (ansiParams !== undefined) {
+    if (oscSequence !== undefined) {
+      // Consumed and dropped: no text, no style change.
+    } else if (ansiParams !== undefined) {
       // ANSI SGR sequence — apply codes to the style stack.
       const codes = ansiParams === "" ? [] : ansiParams.split(";").map((p) => parseInt(p, 10) || 0);
       applyAnsiCodes(stack, codes);


### PR DESCRIPTION
## Why

The labeling TUI hand-rolled a terminal loop, key parsing, scrolling, layout and text wrapping. `lib/tui` and `std::ui/layout` already provide all of it, and `lib/cli/logsView.ts` — the closest existing feature — already uses them. **Net 383 lines deleted from `labelTui.ts`.**

Gone, replaced by the library: `parseKeys`, `parseKeysBuffered`, `parseOneKey`, `isIncompleteSequence`, `enterTerminalMode`, `runInputLoop`, `wrapAnsi`, `visibleLength`, `checklistOffset`, and `scrollDelta`'s clamping.

| Now used | Replaced |
|---|---|
| `Screen.runLoop` | hand-rolled promise + `data` listener |
| `TerminalInput` | raw mode, key parsing, escape reassembly |
| `followCursor` | `checklistOffset` — same rule, exactly |
| `wrapText` / `visualWidth` | `wrapAnsi` / `visibleLength` |
| `ScriptedInput` + `FrameRecorder` | hand-built fake streams |

`TerminalInput` already handles escape sequences split across stream chunks, which is the P2 a reviewer found in my parser — a bug I introduced by not using the existing input layer. `wrapText` is also better than what it replaces: `reinjectSgr` re-opens the active style at each wrapped segment, where mine reset and lost it.

## Shared fixes, where the bug actually lived

**`std::ui/layout` did not know OSC hyperlinks are zero-width.** `visualWidth`, `stripAnsi` and `breakLongToken` handled CSI only, so a link counted its whole URL toward the column budget. Any caller rendering terminal Markdown had this; it surfaced here because the corpus is link-dense.

**The TUI style parser had the same gap**, one layer up: it matched `{tag}` and SGR only, so OSC sequences became literal cells. A link printed its own href across the pane. It now consumes and drops them. Before/after on the real corpus:

```
before:  featuring Medić—launch on August 2. (8;;https://www.tomsg…
after:   featuring Medić—launch on August 2. (tomsguide.com)
```

## Two defects found while building

**A pane cannot be a column of `line()` children.** `scrollOffset` slices an element's *own* content by newline, so a column of one-line children has nothing to slice and the offset is silently ignored — the checklist rendered from question 0 no matter where focus was. Each pane is now a single text element.

**`process.stdout.columns ?? 100` is not enough.** A PTY with no attached window reports **0**, not undefined, so the screen laid out to nothing and rendered a blank frame. Found by driving the real command through a PTY and noticing the terminal entered the alternate screen and drew *nothing*. `terminalDimension` now falls back for anything that is not a positive finite number.

## Lifecycle

The CLI builds the `Screen` and destroys it, alongside the session it must be torn down with, and rejects a non-interactive terminal *before* opening a session — so a piped invocation no longer creates a store and takes a lock it will never use.

## Verification

- **2841 tests** across `lib/eval`, `lib/tui`, `lib/stdlib`, `lib/cli`, `lib/logsViewer`.
- `pnpm run typecheck` (all three configs), `lint:structure`, and `lib/sourceIsText.test.ts` — the two guards that broke the previous PR, run explicitly this time.
- **End to end through a real PTY**: 8 outputs captured, checklist published, space toggles, enter signs off one annotation covering 4 questions with recorded timing, q quits, no lock left behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
