### PR TITLE
feat(remote): whoami, projects, and keys management commands

### DIFF
--- a/packages/agency-lang/docs/dev/hosted-agent-execution.md
+++ b/packages/agency-lang/docs/dev/hosted-agent-execution.md
@@ -209,13 +209,28 @@ POST /serve/:userId/:projectId/:filename/resume
 
 ## 6. `agency remote` (agency-lang `lib/cli/remote/`)
 
-`agency remote` is the CLI surface for a hosted agent — the ceremony a client would otherwise hand-write against the serve routes. Five subcommands:
+`agency remote` is the CLI surface for a hosted agent — the ceremony a client would otherwise hand-write against the serve routes.
+
+Agent commands:
 
 - **`remote link`** — show, or set with `--url`, the linked agent (stored as `remote.serveUrl` in `agency.json`).
 - **`remote deploy <file>`** — upload + link (reuses the `deploy()` engine). Warns, and on a TTY confirms, if the agent exports no nodes/functions.
 - **`remote ls`** — the callable nodes/functions (`GET /list`).
 - **`remote call <name>`** — invoke a node (or `--function`) and drive the interrupt cycle.
 - **`remote open`** — the project page in a browser.
+
+Account-management commands (consume statelog's account API, `GET/POST /api/{whoami,projects,api_keys}`):
+
+- **`remote whoami`** — the authenticated user.
+- **`remote projects`** (list) and **`remote projects create <project_id> --name …`** — list and create projects.
+- **`remote keys`** (list) and **`remote keys create <name> --project <slug>`** — list and create API keys.
+
+Rules the CLI enforces around these:
+
+- **`whoami` accepts an account- or project-scoped key**; **projects and keys require an account-scoped key** (a project-scoped key is refused with 403 and the CLI names the env var to fix).
+- **`keys create` mints project-scoped keys only** — minting an account key is session/web-only on the server.
+- **CLI project arguments and output are public `project_id` slugs.** The sealed account client (`lib/cli/statelog/accountClient.ts`) translates statelog's internal database ids in both directions and never exposes them.
+- **A newly created key's plaintext is shown once** and must be copied immediately; the list view never returns it.
 
 **One interrupt mechanism, shared with `agency run`.** `remote call` reuses the runtime's `resolveInterrupts` + `buildDecider` (`lib/runtime/interruptResolution.ts`); it differs from a local run only in the resume transport (HTTP `/resume` vs in-process). It borrows run's flags — `--interactive`, `--policy`, `--approve`, `--reject` — through `resolveRunPolicy`. With no such flag a surfaced interrupt is reported unhandled and exits, exactly like `run`. **The remote policy acts on *surfaced* interrupts only** (the server's own handlers ran first), unlike run's in-chain policy.
 
@@ -225,7 +240,7 @@ POST /serve/:userId/:projectId/:filename/resume
 
 Top-level `agency deploy` has been **removed** (a breaking change) in favor of `agency remote deploy`; the `deploy()` engine in `lib/cli/deploy/` stays and is what `remote deploy` calls.
 
-**Deferred (need statelog changes):** `remote inspect` (files/last-upload), `remote pull` (source zip), and `remote logs` (traces in the CLI viewer) — all read routes that are browser-session-only today. A statelog "whoami" route would let the binding drop its cached `userId`.
+**Deferred (need statelog changes):** `remote inspect` (files/last-upload), `remote pull` (source zip), and `remote logs` (traces in the CLI viewer) — all read routes that are browser-session-only today. The statelog `whoami` route now exists and `remote whoami` uses it; a `remote link --project <slug>` that builds the serve URL from `host + whoami.userId + project + file` (dropping the pasted URL) is the remaining follow-up.
 
 ---
 

--- a/packages/agency-lang/lib/cli/remote/commands/keys.test.ts
+++ b/packages/agency-lang/lib/cli/remote/commands/keys.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import type { RemoteCommandContext } from "./util.js";
+
+const hoisted = vi.hoisted(() => {
+  class AccountRequestError extends Error {}
+  class AccountScopeError extends AccountRequestError {}
+  const client = { listKeys: vi.fn(), createProjectKey: vi.fn() };
+  return { AccountRequestError, AccountScopeError, client, createAccountClient: vi.fn(() => client) };
+});
+
+vi.mock("../../statelog/accountClient.js", () => ({
+  createAccountClient: hoisted.createAccountClient,
+  AccountRequestError: hoisted.AccountRequestError,
+  AccountScopeError: hoisted.AccountScopeError,
+}));
+
+import { runKeysList, runKeysCreate } from "./keys.js";
+
+class ProcessExit extends Error {
+  constructor(readonly code: number) {
+    super(`exit ${code}`);
+  }
+}
+
+let dir: string;
+let configPath: string;
+let logs: string[];
+let errors: string[];
+
+function context(): RemoteCommandContext {
+  return { config: { log: { host: "https://host.example" } }, configPath };
+}
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "remote-keys-"));
+  configPath = path.join(dir, "agency.json");
+  process.env.STATELOG_API_KEY = "secret";
+  logs = [];
+  errors = [];
+  vi.spyOn(console, "log").mockImplementation((...a: unknown[]) => {
+    logs.push(a.join(" "));
+  });
+  vi.spyOn(console, "error").mockImplementation((...a: unknown[]) => {
+    errors.push(a.join(" "));
+  });
+  vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+    throw new ProcessExit(code ?? 0);
+  }) as never);
+  hoisted.createAccountClient.mockClear();
+  hoisted.client.listKeys.mockReset();
+  hoisted.client.createProjectKey.mockReset();
+});
+
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+  delete process.env.STATELOG_API_KEY;
+  vi.restoreAllMocks();
+});
+
+describe("runKeysList", () => {
+  it("prints keys", async () => {
+    hoisted.client.listKeys.mockResolvedValue([
+      { id: "k1", name: "CI", scope: "project", projectId: "my-proj", createdAt: "2026-08-03" },
+    ]);
+    await runKeysList({}, context());
+    expect(logs.join("\n")).toContain("my-proj");
+  });
+
+  it("renders the empty state", async () => {
+    hoisted.client.listKeys.mockResolvedValue([]);
+    await runKeysList({}, context());
+    expect(logs.join("\n")).toContain("No API keys yet.");
+  });
+});
+
+describe("runKeysCreate", () => {
+  it("forwards the public slug and prints the one-time key with a warning", async () => {
+    hoisted.client.createProjectKey.mockResolvedValue({
+      id: "k1",
+      name: "CI",
+      scope: "project",
+      projectId: "my-proj",
+      createdAt: "2026-08-03",
+      plainKey: "plain-once",
+    });
+    await runKeysCreate("CI", { project: "my-proj" }, context());
+    expect(hoisted.client.createProjectKey).toHaveBeenCalledWith({ name: "CI", projectId: "my-proj" });
+    const out = logs.join("\n");
+    expect(out).toContain("plain-once");
+    expect(out).toContain("will not be shown again");
+  });
+
+  it("names the resolved env var on a scope error", async () => {
+    process.env.MYKEY = "secret2";
+    hoisted.client.createProjectKey.mockRejectedValue(new hoisted.AccountScopeError("scope"));
+    await expect(
+      runKeysCreate("CI", { project: "my-proj", apiKeyEnv: "MYKEY" }, context()),
+    ).rejects.toBeInstanceOf(ProcessExit);
+    expect(errors.join("\n")).toContain("$MYKEY");
+    delete process.env.MYKEY;
+  });
+});

--- a/packages/agency-lang/lib/cli/remote/commands/keys.ts
+++ b/packages/agency-lang/lib/cli/remote/commands/keys.ts
@@ -1,0 +1,42 @@
+import { createAccountClient } from "../../statelog/accountClient.js";
+import { renderKeys, renderCreatedKey } from "../render.js";
+import { resolveAccountTarget, failAccount } from "./util.js";
+import type { AccountCommandOptions, RemoteCommandContext } from "./util.js";
+
+export type CreateKeyOptions = AccountCommandOptions & {
+  project: string;
+};
+
+/** `agency remote keys` — list the account's API keys. */
+export async function runKeysList(
+  options: AccountCommandOptions,
+  context: RemoteCommandContext,
+): Promise<void> {
+  const target = resolveAccountTarget(context, options);
+  try {
+    const keys = await createAccountClient(target.origin, target.apiKey).listKeys();
+    console.log(renderKeys(keys));
+  } catch (error) {
+    failAccount(error, target.apiKeyEnvName);
+  }
+}
+
+/** `agency remote keys create <name> --project <slug>` — mint a project-scoped
+ *  key. `--project` is the public slug; the client resolves it to the internal
+ *  id. The plaintext key is printed once. */
+export async function runKeysCreate(
+  name: string,
+  options: CreateKeyOptions,
+  context: RemoteCommandContext,
+): Promise<void> {
+  const target = resolveAccountTarget(context, options);
+  try {
+    const created = await createAccountClient(target.origin, target.apiKey).createProjectKey({
+      name,
+      projectId: options.project,
+    });
+    console.log(renderCreatedKey(created));
+  } catch (error) {
+    failAccount(error, target.apiKeyEnvName);
+  }
+}

--- a/packages/agency-lang/lib/cli/remote/commands/projects.test.ts
+++ b/packages/agency-lang/lib/cli/remote/commands/projects.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import type { RemoteCommandContext } from "./util.js";
+
+const hoisted = vi.hoisted(() => {
+  class AccountRequestError extends Error {}
+  class AccountScopeError extends AccountRequestError {}
+  const client = {
+    listProjects: vi.fn(),
+    createProject: vi.fn(),
+  };
+  return { AccountRequestError, AccountScopeError, client, createAccountClient: vi.fn(() => client) };
+});
+
+vi.mock("../../statelog/accountClient.js", () => ({
+  createAccountClient: hoisted.createAccountClient,
+  AccountRequestError: hoisted.AccountRequestError,
+  AccountScopeError: hoisted.AccountScopeError,
+}));
+
+import { runProjectsList, runProjectsCreate } from "./projects.js";
+
+class ProcessExit extends Error {
+  constructor(readonly code: number) {
+    super(`exit ${code}`);
+  }
+}
+
+let dir: string;
+let configPath: string;
+let logs: string[];
+let errors: string[];
+
+function context(): RemoteCommandContext {
+  return { config: { log: { host: "https://host.example" } }, configPath };
+}
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "remote-projects-"));
+  configPath = path.join(dir, "agency.json");
+  process.env.STATELOG_API_KEY = "secret";
+  logs = [];
+  errors = [];
+  vi.spyOn(console, "log").mockImplementation((...a: unknown[]) => {
+    logs.push(a.join(" "));
+  });
+  vi.spyOn(console, "error").mockImplementation((...a: unknown[]) => {
+    errors.push(a.join(" "));
+  });
+  vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+    throw new ProcessExit(code ?? 0);
+  }) as never);
+  hoisted.createAccountClient.mockClear();
+  hoisted.client.listProjects.mockReset();
+  hoisted.client.createProject.mockReset();
+});
+
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+  delete process.env.STATELOG_API_KEY;
+  delete process.env.MYKEY;
+  vi.restoreAllMocks();
+});
+
+describe("runProjectsList", () => {
+  it("builds the client from the resolved target and prints projects", async () => {
+    hoisted.client.listProjects.mockResolvedValue([
+      { projectId: "p", name: "P", description: null },
+    ]);
+    await runProjectsList({}, context());
+    expect(hoisted.createAccountClient).toHaveBeenCalledWith("https://host.example", "secret");
+    expect(logs.join("\n")).toContain("p");
+  });
+
+  it("renders the empty state", async () => {
+    hoisted.client.listProjects.mockResolvedValue([]);
+    await runProjectsList({}, context());
+    expect(logs.join("\n")).toContain("No projects yet.");
+  });
+
+  it("names the resolved env var on a scope error", async () => {
+    process.env.MYKEY = "secret2";
+    hoisted.client.listProjects.mockRejectedValue(new hoisted.AccountScopeError("scope"));
+    await expect(runProjectsList({ apiKeyEnv: "MYKEY" }, context())).rejects.toBeInstanceOf(
+      ProcessExit,
+    );
+    expect(errors.join("\n")).toContain("$MYKEY");
+    expect(errors.join("\n")).not.toContain("$STATELOG_API_KEY");
+  });
+
+  it("exits once with a generic request error's message", async () => {
+    hoisted.client.listProjects.mockRejectedValue(new hoisted.AccountRequestError("server failed"));
+    await expect(runProjectsList({}, context())).rejects.toBeInstanceOf(ProcessExit);
+    expect(errors.join("\n")).toContain("server failed");
+  });
+});
+
+describe("runProjectsCreate", () => {
+  it("forwards name, slug, and description", async () => {
+    hoisted.client.createProject.mockResolvedValue({
+      projectId: "foo",
+      name: "Foo",
+      description: "d",
+    });
+    await runProjectsCreate("foo", { name: "Foo", description: "d" }, context());
+    expect(hoisted.client.createProject).toHaveBeenCalledWith({
+      name: "Foo",
+      projectId: "foo",
+      description: "d",
+    });
+    expect(logs.join("\n")).toContain("foo");
+  });
+
+  it.each(["Upper", "has space", "", "a".repeat(21)])(
+    "rejects an invalid project id before any client construction: %s",
+    async (badId) => {
+      await expect(runProjectsCreate(badId, { name: "Name" }, context())).rejects.toBeInstanceOf(
+        ProcessExit,
+      );
+      expect(hoisted.createAccountClient).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/agency-lang/lib/cli/remote/commands/projects.ts
+++ b/packages/agency-lang/lib/cli/remote/commands/projects.ts
@@ -1,0 +1,52 @@
+import { createAccountClient } from "../../statelog/accountClient.js";
+import { renderProjects, renderProjectCreated } from "../render.js";
+import { resolveAccountTarget, failAccount, fail } from "./util.js";
+import type { AccountCommandOptions, RemoteCommandContext } from "./util.js";
+
+// Matches statelog's server rule so a bad slug fails instantly, before any call.
+const PROJECT_ID_PATTERN = /^[a-z0-9-]+$/;
+const MAX_PROJECT_ID_LENGTH = 20;
+
+export type CreateProjectOptions = AccountCommandOptions & {
+  name: string;
+  description?: string;
+};
+
+/** `agency remote projects` — list the account's projects. */
+export async function runProjectsList(
+  options: AccountCommandOptions,
+  context: RemoteCommandContext,
+): Promise<void> {
+  const target = resolveAccountTarget(context, options);
+  try {
+    const projects = await createAccountClient(target.origin, target.apiKey).listProjects();
+    console.log(renderProjects(projects));
+  } catch (error) {
+    failAccount(error, target.apiKeyEnvName);
+  }
+}
+
+/** `agency remote projects create <project_id>` — create a project. */
+export async function runProjectsCreate(
+  projectId: string,
+  options: CreateProjectOptions,
+  context: RemoteCommandContext,
+): Promise<void> {
+  if (!PROJECT_ID_PATTERN.test(projectId) || projectId.length > MAX_PROJECT_ID_LENGTH) {
+    fail(
+      `Invalid project id "${projectId}" — lowercase letters, digits, and dashes only, ` +
+        `${MAX_PROJECT_ID_LENGTH} characters or fewer.`,
+    );
+  }
+  const target = resolveAccountTarget(context, options);
+  try {
+    const project = await createAccountClient(target.origin, target.apiKey).createProject({
+      name: options.name,
+      projectId,
+      description: options.description,
+    });
+    console.log(renderProjectCreated(project));
+  } catch (error) {
+    failAccount(error, target.apiKeyEnvName);
+  }
+}

--- a/packages/agency-lang/lib/cli/remote/commands/util.test.ts
+++ b/packages/agency-lang/lib/cli/remote/commands/util.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import type { AgencyConfig } from "@/config.js";
+import {
+  apiKeyOrExit,
+  resolveApiKey,
+  resolveAccountTarget,
+  type RemoteCommandContext,
+} from "./util.js";
+
+class ProcessExit extends Error {
+  constructor(readonly code: number) {
+    super(`exit ${code}`);
+  }
+}
+
+let dir: string;
+let configPath: string;
+let errors: string[];
+let exitSpy: ReturnType<typeof vi.spyOn>;
+
+function context(config: AgencyConfig = {}): RemoteCommandContext {
+  return { config, configPath };
+}
+
+function writeBinding(origin: string): void {
+  fs.writeFileSync(
+    configPath,
+    JSON.stringify({ remote: { serveUrl: `${origin}/serve/user/project/agent.agency` } }),
+  );
+}
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "remote-util-"));
+  configPath = path.join(dir, "agency.json");
+  process.env.STATELOG_API_KEY = "default-secret";
+  errors = [];
+  vi.spyOn(console, "error").mockImplementation((...a: unknown[]) => {
+    errors.push(a.join(" "));
+  });
+  exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+    throw new ProcessExit(code ?? 0);
+  }) as never);
+});
+
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+  delete process.env.STATELOG_API_KEY;
+  delete process.env.MY_ACCOUNT_KEY;
+  vi.restoreAllMocks();
+});
+
+describe("resolveAccountTarget", () => {
+  it("selects a valid --host ahead of config and binding", () => {
+    writeBinding("https://binding.example");
+    const result = resolveAccountTarget(
+      context({ log: { host: "https://config.example" } }),
+      { host: "https://flag.example/" },
+    );
+    expect(result).toEqual({
+      origin: "https://flag.example",
+      apiKey: "default-secret",
+      apiKeyEnvName: "STATELOG_API_KEY",
+    });
+  });
+
+  it("rejects an invalid --host instead of falling through", () => {
+    writeBinding("https://binding.example");
+    expect(() =>
+      resolveAccountTarget(context({ log: { host: "https://config.example" } }), {
+        host: "not-a-url",
+      }),
+    ).toThrow(ProcessExit);
+    expect(errors.join("\n")).toContain('Invalid statelog host "not-a-url"');
+  });
+
+  it("rejects invalid log.host instead of falling through to binding", () => {
+    writeBinding("https://binding.example");
+    expect(() =>
+      resolveAccountTarget(context({ log: { host: "ftp://bad" } }), {}),
+    ).toThrow(ProcessExit);
+    expect(errors.join("\n")).toContain('Invalid statelog host "ftp://bad"');
+  });
+
+  it("uses the already-canonical binding origin when flag and config are absent", () => {
+    writeBinding("https://binding.example");
+    expect(resolveAccountTarget(context(), {}).origin).toBe("https://binding.example");
+  });
+
+  it("fails clearly when no host source is present", () => {
+    expect(() => resolveAccountTarget(context(), {})).toThrow(ProcessExit);
+    expect(errors.join("\n")).toContain("No statelog host");
+  });
+});
+
+describe("resolveApiKey", () => {
+  it("resolves a custom key name and value in one operation", () => {
+    process.env.MY_ACCOUNT_KEY = "custom-secret";
+    expect(resolveApiKey({ apiKeyEnv: "MY_ACCOUNT_KEY" })).toEqual({
+      apiKey: "custom-secret",
+      apiKeyEnvName: "MY_ACCOUNT_KEY",
+    });
+    expect(apiKeyOrExit({ apiKeyEnv: "MY_ACCOUNT_KEY" })).toBe("custom-secret");
+  });
+
+  it("names the selected missing variable", () => {
+    expect(() => resolveApiKey({ apiKeyEnv: "MISSING_KEY" })).toThrow(ProcessExit);
+    expect(errors.join("\n")).toContain("Missing API key — set $MISSING_KEY.");
+  });
+});

--- a/packages/agency-lang/lib/cli/remote/commands/util.ts
+++ b/packages/agency-lang/lib/cli/remote/commands/util.ts
@@ -6,6 +6,7 @@ import { color } from "@/utils/termcolors.js";
 import type { AgencyConfig } from "@/config.js";
 import { readBinding } from "../binding.js";
 import { canonicalOrigin } from "../../statelog/serveUrl.js";
+import { AccountScopeError } from "../../statelog/accountClient.js";
 
 /** What every remote command needs: the resolved config and the exact path it
  *  came from (so a binding writes back to that file, not a re-derived one). */
@@ -26,6 +27,12 @@ export type ResolvedApiKey = {
 /** An account-management target: a canonical origin plus the resolved key. */
 export type AccountTarget = ResolvedApiKey & {
   origin: string;
+};
+
+/** Options common to every account-management command. */
+export type AccountCommandOptions = {
+  host?: string;
+  apiKeyEnv?: string;
 };
 
 /** Print an error and exit non-zero. Typed `never` so callers can use it in an
@@ -73,4 +80,19 @@ export function resolveAccountTarget(
     );
   }
   return { origin, ...resolveApiKey(options) };
+}
+
+/** Turn a client error into a clean CLI exit. An AccountScopeError becomes
+ *  guidance naming the resolved API-key variable — the one place that knows both
+ *  the scope error (from the client) and the variable name (from the target). */
+export function failAccount(error: unknown, apiKeyEnvName: string): never {
+  if (error instanceof AccountScopeError) {
+    fail(
+      `$${apiKeyEnvName} is a project-scoped key; this needs an account-scoped key. Create one in the statelog web UI.`,
+    );
+  }
+  if (error instanceof Error) {
+    fail(error.message);
+  }
+  fail(String(error));
 }

--- a/packages/agency-lang/lib/cli/remote/commands/util.ts
+++ b/packages/agency-lang/lib/cli/remote/commands/util.ts
@@ -1,8 +1,11 @@
-// Command-error presentation and API-key lookup, shared by the remote command
-// recipes. Owns exit/error output; never renders successful values.
+// Command-error presentation, API-key lookup, and account-target resolution,
+// shared by the remote command recipes. Owns exit/error output; never renders
+// successful values.
 
 import { color } from "@/utils/termcolors.js";
 import type { AgencyConfig } from "@/config.js";
+import { readBinding } from "../binding.js";
+import { canonicalOrigin } from "../../statelog/serveUrl.js";
 
 /** What every remote command needs: the resolved config and the exact path it
  *  came from (so a binding writes back to that file, not a re-derived one). */
@@ -13,6 +16,18 @@ export type RemoteCommandContext = {
 
 const DEFAULT_API_KEY_ENV = "STATELOG_API_KEY";
 
+/** The API key together with the environment variable it came from, so a command
+ *  can name that variable in its guidance without the HTTP client knowing it. */
+export type ResolvedApiKey = {
+  apiKey: string;
+  apiKeyEnvName: string;
+};
+
+/** An account-management target: a canonical origin plus the resolved key. */
+export type AccountTarget = ResolvedApiKey & {
+  origin: string;
+};
+
 /** Print an error and exit non-zero. Typed `never` so callers can use it in an
  *  expression position (`const x = maybe() ?? fail(...)`). */
 export function fail(message: string): never {
@@ -20,13 +35,42 @@ export function fail(message: string): never {
   process.exit(1);
 }
 
-/** The API key from its environment variable, or exit with a clear message.
- *  The key is only ever read from the environment, never a flag. */
-export function apiKeyOrExit(options: { apiKeyEnv?: string }): string {
-  const name = options.apiKeyEnv ?? DEFAULT_API_KEY_ENV;
-  const key = process.env[name];
-  if (!key) {
-    fail(`Missing API key — set $${name}.`);
+/** The API key and its variable name, or exit with a clear message. The key is
+ *  only ever read from the environment, never a flag. */
+export function resolveApiKey(options: { apiKeyEnv?: string }): ResolvedApiKey {
+  const apiKeyEnvName = options.apiKeyEnv ?? DEFAULT_API_KEY_ENV;
+  const apiKey = process.env[apiKeyEnvName];
+  if (!apiKey) {
+    fail(`Missing API key — set $${apiKeyEnvName}.`);
   }
-  return key;
+  return { apiKey, apiKeyEnvName };
+}
+
+/** The API key value alone, for callers that do not need the variable name. */
+export function apiKeyOrExit(options: { apiKeyEnv?: string }): string {
+  return resolveApiKey(options).apiKey;
+}
+
+/** Resolve where an account-management command talks to: a canonical origin (from
+ *  `--host`, then `agency.json` `log.host`, then an existing binding's origin)
+ *  and the resolved API key. Exits with a clear message on a missing or invalid
+ *  origin, or a missing key. */
+export function resolveAccountTarget(
+  context: RemoteCommandContext,
+  options: { host?: string; apiKeyEnv?: string },
+): AccountTarget {
+  const bindingOrigin = readBinding(context.configPath)?.origin;
+  const selected = options.host ?? context.config.log?.host ?? bindingOrigin;
+  if (!selected) {
+    fail(
+      "No statelog host. Set log.host in agency.json, pass --host, or link this directory first.",
+    );
+  }
+  const origin = canonicalOrigin(selected);
+  if (!origin) {
+    fail(
+      `Invalid statelog host "${selected}". Use an HTTP(S) origin with no path, credentials, query, or fragment.`,
+    );
+  }
+  return { origin, ...resolveApiKey(options) };
 }

--- a/packages/agency-lang/lib/cli/remote/commands/whoami.test.ts
+++ b/packages/agency-lang/lib/cli/remote/commands/whoami.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import type { RemoteCommandContext } from "./util.js";
+
+const hoisted = vi.hoisted(() => {
+  class AccountRequestError extends Error {}
+  class AccountScopeError extends AccountRequestError {}
+  const client = { whoami: vi.fn() };
+  return { AccountRequestError, AccountScopeError, client, createAccountClient: vi.fn(() => client) };
+});
+
+vi.mock("../../statelog/accountClient.js", () => ({
+  createAccountClient: hoisted.createAccountClient,
+  AccountRequestError: hoisted.AccountRequestError,
+  AccountScopeError: hoisted.AccountScopeError,
+}));
+
+import { runWhoami } from "./whoami.js";
+
+class ProcessExit extends Error {
+  constructor(readonly code: number) {
+    super(`exit ${code}`);
+  }
+}
+
+let dir: string;
+let configPath: string;
+let logs: string[];
+let errors: string[];
+
+function context(): RemoteCommandContext {
+  return { config: { log: { host: "https://host.example" } }, configPath };
+}
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "remote-whoami-"));
+  configPath = path.join(dir, "agency.json");
+  process.env.STATELOG_API_KEY = "secret";
+  logs = [];
+  errors = [];
+  vi.spyOn(console, "log").mockImplementation((...a: unknown[]) => {
+    logs.push(a.join(" "));
+  });
+  vi.spyOn(console, "error").mockImplementation((...a: unknown[]) => {
+    errors.push(a.join(" "));
+  });
+  vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+    throw new ProcessExit(code ?? 0);
+  }) as never);
+  hoisted.createAccountClient.mockClear();
+  hoisted.client.whoami.mockReset();
+});
+
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+  delete process.env.STATELOG_API_KEY;
+  vi.restoreAllMocks();
+});
+
+describe("runWhoami", () => {
+  it("builds the client from the resolved target and prints user and host", async () => {
+    hoisted.client.whoami.mockResolvedValue({ userId: "user-1" });
+    await runWhoami({ host: "https://host.example" }, context());
+    expect(hoisted.createAccountClient).toHaveBeenCalledWith("https://host.example", "secret");
+    const out = logs.join("\n");
+    expect(out).toContain("user-1");
+    expect(out).toContain("https://host.example");
+  });
+
+  it("exits cleanly on a client error", async () => {
+    hoisted.client.whoami.mockRejectedValue(new hoisted.AccountRequestError("boom"));
+    await expect(runWhoami({}, context())).rejects.toBeInstanceOf(ProcessExit);
+    expect(errors.join("\n")).toContain("boom");
+  });
+});

--- a/packages/agency-lang/lib/cli/remote/commands/whoami.ts
+++ b/packages/agency-lang/lib/cli/remote/commands/whoami.ts
@@ -1,0 +1,19 @@
+import { createAccountClient } from "../../statelog/accountClient.js";
+import { renderWhoami } from "../render.js";
+import { resolveAccountTarget, fail } from "./util.js";
+import type { AccountCommandOptions, RemoteCommandContext } from "./util.js";
+
+/** `agency remote whoami` — resolve and print the authenticated user. Accepts an
+ *  account- or project-scoped key, so it doubles as a "is my key valid" check. */
+export async function runWhoami(
+  options: AccountCommandOptions,
+  context: RemoteCommandContext,
+): Promise<void> {
+  const target = resolveAccountTarget(context, options);
+  try {
+    const { userId } = await createAccountClient(target.origin, target.apiKey).whoami();
+    console.log(renderWhoami(userId, target.origin));
+  } catch (error) {
+    fail(error instanceof Error ? error.message : String(error));
+  }
+}

--- a/packages/agency-lang/lib/cli/remote/render.test.ts
+++ b/packages/agency-lang/lib/cli/remote/render.test.ts
@@ -1,5 +1,15 @@
 import { describe, it, expect } from "vitest";
-import { renderManifest, renderResult, renderLink } from "./render.js";
+import {
+  renderManifest,
+  renderResult,
+  renderLink,
+  renderWhoami,
+  renderProjects,
+  renderProjectCreated,
+  renderKeys,
+  renderCreatedKey,
+} from "./render.js";
+import type { CreatedKey, KeySummary } from "../statelog/accountClient.js";
 
 // Colour wraps each token in ANSI codes; strip them so assertions read plainly.
 // eslint-disable-next-line no-control-regex
@@ -44,5 +54,97 @@ describe("renderLink", () => {
     expect(output).toContain("agent.agency");
     expect(output).toContain("proj");
     expect(output).toContain("https://h/serve/u/proj/agent.agency");
+  });
+});
+
+// Column start positions on a stripped line: index 0 and the char after any run
+// of 2+ spaces. Single spaces inside a cell (e.g. "Public Project") don't split.
+function colStarts(line: string): number[] {
+  const starts: number[] = [];
+  const re = /(?:^|\s{2,})(\S)/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(line)) !== null) {
+    starts.push(match.index + match[0].length - 1);
+  }
+  return starts;
+}
+
+describe("renderWhoami", () => {
+  it("shows the user id and host", () => {
+    const out = strip(renderWhoami("user-1", "https://host.example"));
+    expect(out).toContain("user-1");
+    expect(out).toContain("https://host.example");
+  });
+});
+
+describe("renderProjects", () => {
+  it("shows an empty-state line", () => {
+    expect(strip(renderProjects([]))).toContain("No projects yet.");
+  });
+
+  it("renders aligned rows with — for a null description", () => {
+    const out = strip(
+      renderProjects([
+        { projectId: "public-project", name: "Public Project", description: null },
+        { projectId: "p2", name: "Second", description: "has a desc" },
+      ]),
+    );
+    const lines = out.split("\n");
+    expect(lines[1]).toContain("public-project");
+    expect(lines[1]).toContain("—");
+    for (const line of lines) {
+      expect(colStarts(line)).toEqual(colStarts(lines[0] ?? ""));
+    }
+  });
+});
+
+describe("renderProjectCreated", () => {
+  it("shows the slug and name", () => {
+    const out = strip(renderProjectCreated({ projectId: "my-proj", name: "My Project", description: null }));
+    expect(out).toContain("my-proj");
+    expect(out).toContain("My Project");
+  });
+});
+
+describe("renderKeys", () => {
+  const keys: KeySummary[] = [
+    { id: "k1", name: null, scope: "project", projectId: "(unknown project)", createdAt: "2026-08-03" },
+    { id: "k2", name: "root", scope: "account", projectId: null, createdAt: "2026-08-03" },
+  ];
+
+  it("shows an empty-state line", () => {
+    expect(strip(renderKeys([]))).toContain("No API keys yet.");
+  });
+
+  it("renders — for a null name, the placeholder slug, and aligned columns", () => {
+    const out = strip(renderKeys(keys));
+    const lines = out.split("\n");
+    expect(lines[1]).toContain("—");
+    expect(lines[1]).toContain("(unknown project)");
+    expect(out).toContain("account");
+    for (const line of lines) {
+      expect(colStarts(line)).toEqual(colStarts(lines[0] ?? ""));
+    }
+  });
+});
+
+describe("renderCreatedKey", () => {
+  const createdKey: CreatedKey = {
+    id: "k1",
+    name: "CI",
+    scope: "project",
+    projectId: "my-proj",
+    createdAt: "2026-08-03",
+    plainKey: "plain-once",
+  };
+
+  it("shows the plaintext key exactly once with a one-time warning", () => {
+    const output = strip(renderCreatedKey(createdKey));
+    expect(output.match(/plain-once/g)).toHaveLength(1);
+    expect(output).toContain("will not be shown again");
+  });
+
+  it("never leaks the plaintext key into the list view", () => {
+    expect(strip(renderKeys([createdKey]))).not.toContain("plain-once");
   });
 });

--- a/packages/agency-lang/lib/cli/remote/render.ts
+++ b/packages/agency-lang/lib/cli/remote/render.ts
@@ -5,6 +5,13 @@
 import { color } from "@/utils/termcolors.js";
 import type { ServeManifest } from "../statelog/serveClient.js";
 import type { RemoteBinding } from "./binding.js";
+import type {
+  ProjectSummary,
+  KeySummary,
+  CreatedKey,
+} from "../statelog/accountClient.js";
+
+const NONE = "—";
 
 export function renderManifest(manifest: ServeManifest, binding: RemoteBinding): string {
   const lines: string[] = [
@@ -40,4 +47,65 @@ export function renderLink(binding: RemoteBinding): string {
 
 function effectsSuffix(interruptEffects: string[]): string {
   return interruptEffects.length ? color.dim(`  raises ${interruptEffects.join(", ")}`) : "";
+}
+
+export function renderWhoami(userId: string, origin: string): string {
+  return [
+    `${color.bold("User:")} ${userId}`,
+    `${color.bold("Host:")} ${color.dim(origin)}`,
+  ].join("\n");
+}
+
+export function renderProjects(projects: ProjectSummary[]): string {
+  if (projects.length === 0) {
+    return color.dim("No projects yet.");
+  }
+  const rows = projects.map((project) => [
+    project.projectId,
+    project.name,
+    project.description ?? NONE,
+  ]);
+  return formatStaticTable(["PROJECT", "NAME", "DESCRIPTION"], rows);
+}
+
+export function renderProjectCreated(project: ProjectSummary): string {
+  return `${color.green("Created project")} ${color.bold(project.projectId)} — ${project.name}`;
+}
+
+export function renderKeys(keys: KeySummary[]): string {
+  if (keys.length === 0) {
+    return color.dim("No API keys yet.");
+  }
+  const rows = keys.map((key) => [
+    key.name ?? NONE,
+    key.scope,
+    key.projectId ?? NONE,
+    key.createdAt,
+    key.id,
+  ]);
+  return formatStaticTable(["NAME", "SCOPE", "PROJECT", "CREATED", "ID"], rows);
+}
+
+export function renderCreatedKey(key: CreatedKey): string {
+  const project = key.scope === "project" ? ` · ${key.projectId}` : "";
+  return [
+    `${color.green("Created API key")} ${color.bold(key.name ?? NONE)} (${key.scope}${project})`,
+    "",
+    color.yellow("Copy this key now — it will not be shown again:"),
+    `  ${key.plainKey}`,
+  ].join("\n");
+}
+
+/** A plain, ANSI-free aligned table. Colour is applied around the table by the
+ *  renderers, never inside a cell, so byte-width never skews alignment. */
+function formatStaticTable(headers: string[], rows: string[][]): string {
+  const widths = headers.map((header, columnIndex) => {
+    const values = rows.map((row) => row[columnIndex] ?? "");
+    return Math.max(header.length, ...values.map((value) => value.length));
+  });
+  return [headers, ...rows]
+    .map((row) =>
+      row.map((value, index) => value.padEnd(widths[index] ?? 0)).join("  ").trimEnd(),
+    )
+    .join("\n");
 }

--- a/packages/agency-lang/lib/cli/statelog/accountClient.test.ts
+++ b/packages/agency-lang/lib/cli/statelog/accountClient.test.ts
@@ -154,3 +154,134 @@ describe("accountClient transport", () => {
     expect((error as Error).message).not.toContain("top-secret-key");
   });
 });
+
+function rawProjectKey(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+  return {
+    id: "key-1",
+    name: "CI",
+    scope: "project",
+    projectId: "db-project-1",
+    createdAt: "2026-08-03T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function rawAccountKey(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+  return {
+    id: "key-acc",
+    name: "root",
+    scope: "account",
+    projectId: null,
+    createdAt: "2026-08-03T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("accountClient keys and id translation", () => {
+  it("creates a project key by translating the slug to the private id", async () => {
+    fetchMock
+      .mockResolvedValueOnce(response(200, { success: true, value: [rawProject()] }))
+      .mockResolvedValueOnce(
+        response(200, { success: true, value: rawProjectKey({ plainKey: "plain-once" }) }),
+      );
+    const created = await client.createProjectKey({ name: "CI", projectId: "public-project" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://host.example/api/projects");
+    expect(fetchMock.mock.calls[1]).toEqual([
+      "https://host.example/api/api_keys",
+      {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer top-secret-key",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ name: "CI", scope: "project", projectId: "db-project-1" }),
+      },
+    ]);
+    expect(created).toEqual({
+      id: "key-1",
+      name: "CI",
+      scope: "project",
+      projectId: "public-project",
+      createdAt: "2026-08-03T00:00:00Z",
+      plainKey: "plain-once",
+    });
+    expect(JSON.stringify(created)).not.toContain("db-project-1");
+  });
+
+  it("fetches projects once and makes no POST for an unknown slug", async () => {
+    fetchMock.mockResolvedValueOnce(response(200, { success: true, value: [] }));
+    await expect(client.createProjectKey({ name: "CI", projectId: "missing" })).rejects.toThrow(
+      "unknown project 'missing'",
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://host.example/api/projects");
+  });
+
+  it("lists keys after one project fetch and returns only public slugs", async () => {
+    fetchMock
+      .mockResolvedValueOnce(response(200, { success: true, value: [rawProject()] }))
+      .mockResolvedValueOnce(response(200, { success: true, value: [rawProjectKey()] }));
+    const keys = await client.listKeys();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
+      "https://host.example/api/projects",
+      "https://host.example/api/api_keys",
+    ]);
+    expect(fetchMock.mock.calls[1]?.[1]).toEqual({
+      method: "GET",
+      headers: { Authorization: "Bearer top-secret-key" },
+    });
+    expect(keys[0]?.projectId).toBe("public-project");
+    expect(JSON.stringify(keys)).not.toContain("db-project-1");
+    expect(JSON.stringify(keys)).not.toContain("plainKey");
+  });
+
+  it("maps a key whose project no longer exists to the placeholder", async () => {
+    fetchMock
+      .mockResolvedValueOnce(response(200, { success: true, value: [] }))
+      .mockResolvedValueOnce(
+        response(200, { success: true, value: [rawProjectKey({ projectId: "db-gone" })] }),
+      );
+    const keys = await client.listKeys();
+    expect(keys[0]?.projectId).toBe("(unknown project)");
+    expect(JSON.stringify(keys)).not.toContain("db-gone");
+  });
+
+  it("keeps an account key's projectId null", async () => {
+    fetchMock
+      .mockResolvedValueOnce(response(200, { success: true, value: [] }))
+      .mockResolvedValueOnce(response(200, { success: true, value: [rawAccountKey()] }));
+    const keys = await client.listKeys();
+    expect(keys[0]).toMatchObject({ scope: "account", projectId: null });
+  });
+
+  it.each([
+    ["account key with a projectId", rawAccountKey({ projectId: "db-x" })],
+    ["project key with a null projectId", rawProjectKey({ projectId: null })],
+    ["unknown scope", rawProjectKey({ scope: "weird" })],
+    ["missing id", rawProjectKey({ id: undefined })],
+    ["missing createdAt", rawProjectKey({ createdAt: undefined })],
+  ])("rejects an impossible/invalid key: %s", async (_label, badKey) => {
+    fetchMock
+      .mockResolvedValueOnce(response(200, { success: true, value: [rawProject()] }))
+      .mockResolvedValueOnce(response(200, { success: true, value: [badKey] }));
+    await expect(client.listKeys()).rejects.toBeInstanceOf(AccountRequestError);
+  });
+
+  it("rejects a non-array key list", async () => {
+    fetchMock
+      .mockResolvedValueOnce(response(200, { success: true, value: [] }))
+      .mockResolvedValueOnce(response(200, { success: true, value: {} }));
+    await expect(client.listKeys()).rejects.toThrow(/api_keys must be an array/);
+  });
+
+  it("rejects a created key without a plainKey", async () => {
+    fetchMock
+      .mockResolvedValueOnce(response(200, { success: true, value: [rawProject()] }))
+      .mockResolvedValueOnce(response(200, { success: true, value: rawProjectKey() }));
+    await expect(
+      client.createProjectKey({ name: "CI", projectId: "public-project" }),
+    ).rejects.toThrow("created key missing plainKey");
+  });
+});

--- a/packages/agency-lang/lib/cli/statelog/accountClient.test.ts
+++ b/packages/agency-lang/lib/cli/statelog/accountClient.test.ts
@@ -285,3 +285,17 @@ describe("accountClient keys and id translation", () => {
     ).rejects.toThrow("created key missing plainKey");
   });
 });
+
+describe("accountClient id-map safety", () => {
+  it("resolves a project id like __proto__ without a prototype-chain collision", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        response(200, { success: true, value: [rawProject({ id: "__proto__", project_id: "polluted" })] }),
+      )
+      .mockResolvedValueOnce(
+        response(200, { success: true, value: [rawProjectKey({ projectId: "__proto__" })] }),
+      );
+    const keys = await client.listKeys();
+    expect(keys[0]?.projectId).toBe("polluted");
+  });
+});

--- a/packages/agency-lang/lib/cli/statelog/accountClient.test.ts
+++ b/packages/agency-lang/lib/cli/statelog/accountClient.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  createAccountClient,
+  AccountRequestError,
+  AccountScopeError,
+  type AccountClient,
+} from "./accountClient.js";
+
+function response(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: vi.fn().mockResolvedValue(body),
+  } as unknown as Response;
+}
+
+function rawProject(
+  overrides: Partial<Record<string, unknown>> = {},
+): Record<string, unknown> {
+  return {
+    id: "db-project-1",
+    project_id: "public-project",
+    name: "Public Project",
+    description: null,
+    ...overrides,
+  };
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+let client: AccountClient;
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock);
+  client = createAccountClient("https://host.example", "top-secret-key");
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("accountClient transport", () => {
+  it("GET whoami uses the exact route, bearer header, and no body", async () => {
+    fetchMock.mockResolvedValue(response(200, { success: true, value: { userId: "user-1" } }));
+    await expect(client.whoami()).resolves.toEqual({ userId: "user-1" });
+    expect(fetchMock).toHaveBeenCalledWith("https://host.example/api/whoami", {
+      method: "GET",
+      headers: { Authorization: "Bearer top-secret-key" },
+    });
+  });
+
+  it("lists projects through /api/projects and strips the private id", async () => {
+    fetchMock.mockResolvedValue(response(200, { success: true, value: [rawProject()] }));
+    const projects = await client.listProjects();
+    expect(projects).toEqual([
+      { projectId: "public-project", name: "Public Project", description: null },
+    ]);
+    expect(JSON.stringify(projects)).not.toContain("db-project-1");
+  });
+
+  it("POST projects sends content type and the exact wire body", async () => {
+    fetchMock.mockResolvedValue(response(200, { success: true, value: rawProject() }));
+    await client.createProject({ name: "Public Project", projectId: "public-project" });
+    expect(fetchMock).toHaveBeenCalledWith("https://host.example/api/projects", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer top-secret-key",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        name: "Public Project",
+        project_id: "public-project",
+        description: null,
+      }),
+    });
+  });
+
+  it("handles bare non-2xx JSON before envelope validation", async () => {
+    fetchMock.mockResolvedValue(response(401, { error: "Invalid API key" }));
+    await expect(client.whoami()).rejects.toThrow("Invalid API key");
+  });
+
+  it("types only the exact known scope error", async () => {
+    fetchMock.mockResolvedValue(
+      response(403, { error: "This endpoint requires an account-scoped API key" }),
+    );
+    await expect(client.listProjects()).rejects.toBeInstanceOf(AccountScopeError);
+  });
+
+  it("preserves a different 403 as a general request error", async () => {
+    fetchMock.mockResolvedValue(
+      response(403, { error: "Your account has not been approved yet." }),
+    );
+    const error = await client.listProjects().catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(AccountRequestError);
+    expect(error).not.toBeInstanceOf(AccountScopeError);
+    expect(error).toMatchObject({ message: "Your account has not been approved yet." });
+  });
+
+  it("falls back for a 401 with no server error string", async () => {
+    fetchMock.mockResolvedValue(response(401, {}));
+    await expect(client.whoami()).rejects.toThrow("not authenticated (HTTP 401)");
+  });
+
+  it("surfaces a success:false body's error", async () => {
+    fetchMock.mockResolvedValue(response(200, { success: false, error: "nope" }));
+    await expect(client.listProjects()).rejects.toThrow("nope");
+  });
+
+  it("rejects a success envelope missing userId", async () => {
+    fetchMock.mockResolvedValue(response(200, { success: true, value: {} }));
+    await expect(client.whoami()).rejects.toThrow(/userId/);
+  });
+
+  it("rejects a project missing a required field", async () => {
+    fetchMock.mockResolvedValue(
+      response(200, { success: true, value: [rawProject({ name: 42 })] }),
+    );
+    await expect(client.listProjects()).rejects.toBeInstanceOf(AccountRequestError);
+  });
+
+  it("rejects a non-JSON 200 body", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockRejectedValue(new SyntaxError("bad json")),
+    } as unknown as Response);
+    await expect(client.whoami()).rejects.toThrow(
+      "statelog returned a non-JSON response (HTTP 200)",
+    );
+  });
+
+  it("rejects a non-JSON 500 body", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: vi.fn().mockRejectedValue(new SyntaxError("bad json")),
+    } as unknown as Response);
+    await expect(client.whoami()).rejects.toThrow("statelog request failed (HTTP 500)");
+  });
+
+  it("rejects a malformed 200 envelope", async () => {
+    fetchMock.mockResolvedValue(response(200, { value: "no success flag" }));
+    await expect(client.whoami()).rejects.toThrow("unexpected account response shape");
+  });
+
+  it("wraps a network error without exposing the API key", async () => {
+    fetchMock.mockRejectedValue(new Error("socket closed"));
+    const error = await client.whoami().catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(AccountRequestError);
+    expect((error as Error).message).toContain("could not reach https://host.example");
+    expect((error as Error).message).toContain("socket closed");
+    expect((error as Error).message).not.toContain("top-secret-key");
+  });
+});

--- a/packages/agency-lang/lib/cli/statelog/accountClient.ts
+++ b/packages/agency-lang/lib/cli/statelog/accountClient.ts
@@ -1,0 +1,181 @@
+// The statelog account-management API, sealed here. This is the only file that
+// knows the `/api/*` routes, the `Result` envelope, statelog's wire field names,
+// and — critically — the split between the public project slug (`project_id`) and
+// the internal database id (`id`). Callers speak only the public slug; the
+// internal id never leaves this file. Every failure — network, HTTP, JSON,
+// schema, or a `success:false` body — surfaces as an AccountRequestError.
+
+export type ProjectSummary = {
+  projectId: string;
+  name: string;
+  description: string | null;
+};
+
+export type CreateProjectInput = {
+  name: string;
+  projectId: string;
+  description?: string;
+};
+
+/** A project as statelog sends it, with the internal id kept private. */
+type RawProject = {
+  id: string;
+  project_id: string;
+  name: string;
+  description: string | null;
+};
+
+/** Any account request that did not produce a usable result. */
+export class AccountRequestError extends Error {}
+/** A 403 whose server error is the known account-scope error. The command layer
+ *  decorates it with the resolved API-key env var name; this file never knows
+ *  that name. */
+export class AccountScopeError extends AccountRequestError {}
+
+const ACCOUNT_SCOPE_ERROR = "This endpoint requires an account-scoped API key";
+
+export type AccountClient = {
+  whoami(): Promise<{ userId: string }>;
+  listProjects(): Promise<ProjectSummary[]>;
+  createProject(input: CreateProjectInput): Promise<ProjectSummary>;
+};
+
+type AccountRoute = "whoami" | "projects" | "api_keys";
+
+function accountRouteUrl(origin: string, route: AccountRoute): string {
+  return new URL(`/api/${route}`, origin).toString();
+}
+
+export function createAccountClient(origin: string, apiKey: string): AccountClient {
+  async function request(
+    method: "GET" | "POST",
+    route: AccountRoute,
+    body?: unknown,
+  ): Promise<unknown> {
+    const headers: Record<string, string> = { Authorization: `Bearer ${apiKey}` };
+    const init: RequestInit = { method, headers };
+    if (method === "POST") {
+      headers["Content-Type"] = "application/json";
+      init.body = JSON.stringify(body ?? {});
+    }
+
+    let response: Response;
+    try {
+      response = await fetch(accountRouteUrl(origin, route), init);
+    } catch (error) {
+      throw new AccountRequestError(`could not reach ${origin} (${message(error)})`);
+    }
+
+    let json: unknown;
+    let parsed = true;
+    try {
+      json = await response.json();
+    } catch {
+      parsed = false;
+    }
+
+    // Non-2xx first: auth middleware returns a bare `{ error }`, not an envelope.
+    if (!response.ok) {
+      const serverError = parsed ? asObject(json)?.error : undefined;
+      if (response.status === 403 && serverError === ACCOUNT_SCOPE_ERROR) {
+        throw new AccountScopeError(ACCOUNT_SCOPE_ERROR);
+      }
+      if (typeof serverError === "string") {
+        throw new AccountRequestError(serverError);
+      }
+      if (response.status === 401) {
+        throw new AccountRequestError("not authenticated (HTTP 401)");
+      }
+      throw new AccountRequestError(`statelog request failed (HTTP ${response.status})`);
+    }
+
+    if (!parsed) {
+      throw new AccountRequestError(
+        `statelog returned a non-JSON response (HTTP ${response.status})`,
+      );
+    }
+    const envelope = asObject(json);
+    if (!envelope || typeof envelope.success !== "boolean") {
+      throw new AccountRequestError("unexpected account response shape");
+    }
+    if (!envelope.success) {
+      throw new AccountRequestError(
+        typeof envelope.error === "string" ? envelope.error : "account request failed",
+      );
+    }
+    return envelope.value;
+  }
+
+  async function listProjectsRaw(): Promise<RawProject[]> {
+    const value = await request("GET", "projects");
+    return asArray(value, "projects").map(validateRawProject);
+  }
+
+  return {
+    async whoami() {
+      return validateWhoami(await request("GET", "whoami"));
+    },
+    async listProjects() {
+      return (await listProjectsRaw()).map(toProjectSummary);
+    },
+    async createProject(input) {
+      const value = await request("POST", "projects", {
+        name: input.name,
+        project_id: input.projectId,
+        description: input.description ?? null,
+      });
+      return toProjectSummary(validateRawProject(value));
+    },
+  };
+}
+
+function toProjectSummary(raw: RawProject): ProjectSummary {
+  return { projectId: raw.project_id, name: raw.name, description: raw.description };
+}
+
+function validateWhoami(value: unknown): { userId: string } {
+  const obj = asObject(value);
+  if (!obj || typeof obj.userId !== "string") {
+    throw new AccountRequestError("whoami response missing userId");
+  }
+  return { userId: obj.userId };
+}
+
+function validateRawProject(value: unknown): RawProject {
+  const obj = asObject(value);
+  if (!obj) {
+    throw new AccountRequestError("each project entry must be an object");
+  }
+  const id = requireString(obj.id, "project id");
+  const project_id = requireString(obj.project_id, "project project_id");
+  const name = requireString(obj.name, "project name");
+  if (obj.description !== null && typeof obj.description !== "string") {
+    throw new AccountRequestError("project description must be a string or null");
+  }
+  return { id, project_id, name, description: obj.description };
+}
+
+function asObject(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function asArray(value: unknown, label: string): unknown[] {
+  if (!Array.isArray(value)) {
+    throw new AccountRequestError(`${label} must be an array`);
+  }
+  return value;
+}
+
+function requireString(value: unknown, label: string): string {
+  if (typeof value !== "string") {
+    throw new AccountRequestError(`${label} must be a string`);
+  }
+  return value;
+}
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/agency-lang/lib/cli/statelog/accountClient.ts
+++ b/packages/agency-lang/lib/cli/statelog/accountClient.ts
@@ -203,9 +203,11 @@ function validateRawProject(value: unknown): RawProject {
   return { id, project_id, name, description: obj.description };
 }
 
-/** internal id → public slug, so a listed key's project can be shown by slug. */
+/** internal id → public slug, so a listed key's project can be shown by slug.
+ *  Null-prototype: the keys are server-provided ids, so an id like `__proto__`
+ *  or `constructor` must be a plain data property, not a prototype write. */
 function slugByInternalId(projects: RawProject[]): Record<string, string> {
-  const map: Record<string, string> = {};
+  const map: Record<string, string> = Object.create(null);
   for (const project of projects) {
     map[project.id] = project.project_id;
   }

--- a/packages/agency-lang/lib/cli/statelog/accountClient.ts
+++ b/packages/agency-lang/lib/cli/statelog/accountClient.ts
@@ -17,6 +17,25 @@ export type CreateProjectInput = {
   description?: string;
 };
 
+type KeySummaryBase = {
+  id: string;
+  name: string | null;
+  createdAt: string;
+};
+
+/** A key summary in public terms: a project key's `projectId` is the slug (the
+ *  client has already translated it from the internal id). */
+export type KeySummary =
+  | (KeySummaryBase & { scope: "account"; projectId: null })
+  | (KeySummaryBase & { scope: "project"; projectId: string });
+
+export type CreatedKey = KeySummary & { plainKey: string };
+
+export type CreateProjectKeyInput = {
+  name: string;
+  projectId: string;
+};
+
 /** A project as statelog sends it, with the internal id kept private. */
 type RawProject = {
   id: string;
@@ -24,6 +43,12 @@ type RawProject = {
   name: string;
   description: string | null;
 };
+
+/** A key as statelog sends it: a project key's `projectId` is the internal
+ *  database id, never exposed past this file. */
+type RawKeySummary =
+  | (KeySummaryBase & { scope: "account"; projectId: null })
+  | (KeySummaryBase & { scope: "project"; projectId: string });
 
 /** Any account request that did not produce a usable result. */
 export class AccountRequestError extends Error {}
@@ -38,6 +63,8 @@ export type AccountClient = {
   whoami(): Promise<{ userId: string }>;
   listProjects(): Promise<ProjectSummary[]>;
   createProject(input: CreateProjectInput): Promise<ProjectSummary>;
+  listKeys(): Promise<KeySummary[]>;
+  createProjectKey(input: CreateProjectKeyInput): Promise<CreatedKey>;
 };
 
 type AccountRoute = "whoami" | "projects" | "api_keys";
@@ -126,6 +153,27 @@ export function createAccountClient(origin: string, apiKey: string): AccountClie
       });
       return toProjectSummary(validateRawProject(value));
     },
+    async listKeys() {
+      const projects = await listProjectsRaw();
+      const value = await request("GET", "api_keys");
+      const slugById = slugByInternalId(projects);
+      return asArray(value, "api_keys").map((entry) =>
+        toKeySummary(validateRawKeySummary(entry), slugById),
+      );
+    },
+    async createProjectKey(input) {
+      const projects = await listProjectsRaw();
+      const match = projects.find((project) => project.project_id === input.projectId);
+      if (!match) {
+        throw new AccountRequestError(`unknown project '${input.projectId}'`);
+      }
+      const value = await request("POST", "api_keys", {
+        name: input.name,
+        scope: "project",
+        projectId: match.id,
+      });
+      return validateCreatedKey(value, slugByInternalId(projects));
+    },
   };
 }
 
@@ -153,6 +201,62 @@ function validateRawProject(value: unknown): RawProject {
     throw new AccountRequestError("project description must be a string or null");
   }
   return { id, project_id, name, description: obj.description };
+}
+
+/** internal id → public slug, so a listed key's project can be shown by slug. */
+function slugByInternalId(projects: RawProject[]): Record<string, string> {
+  const map: Record<string, string> = {};
+  for (const project of projects) {
+    map[project.id] = project.project_id;
+  }
+  return map;
+}
+
+function validateRawKeySummary(value: unknown): RawKeySummary {
+  const obj = asObject(value);
+  if (!obj) {
+    throw new AccountRequestError("each key entry must be an object");
+  }
+  const id = requireString(obj.id, "key id");
+  if (obj.name !== null && typeof obj.name !== "string") {
+    throw new AccountRequestError("key name must be a string or null");
+  }
+  const createdAt = requireString(obj.createdAt, "key createdAt");
+  const base: KeySummaryBase = { id, name: obj.name, createdAt };
+  if (obj.scope === "account") {
+    if (obj.projectId !== null) {
+      throw new AccountRequestError("account key must have a null projectId");
+    }
+    return { ...base, scope: "account", projectId: null };
+  }
+  if (obj.scope === "project") {
+    return { ...base, scope: "project", projectId: requireString(obj.projectId, "project key projectId") };
+  }
+  throw new AccountRequestError(`unknown key scope ${String(obj.scope)}`);
+}
+
+/** Replace a project key's internal id with its public slug (or a placeholder
+ *  when the project no longer exists — never the raw id). */
+function toKeySummary(raw: RawKeySummary, slugById: Record<string, string>): KeySummary {
+  if (raw.scope === "account") {
+    return { id: raw.id, name: raw.name, createdAt: raw.createdAt, scope: "account", projectId: null };
+  }
+  return {
+    id: raw.id,
+    name: raw.name,
+    createdAt: raw.createdAt,
+    scope: "project",
+    projectId: slugById[raw.projectId] ?? "(unknown project)",
+  };
+}
+
+function validateCreatedKey(value: unknown, slugById: Record<string, string>): CreatedKey {
+  const summary = toKeySummary(validateRawKeySummary(value), slugById);
+  const obj = asObject(value);
+  if (!obj || typeof obj.plainKey !== "string") {
+    throw new AccountRequestError("created key missing plainKey");
+  }
+  return { ...summary, plainKey: obj.plainKey };
 }
 
 function asObject(value: unknown): Record<string, unknown> | null {

--- a/packages/agency-lang/lib/cli/statelog/serveUrl.test.ts
+++ b/packages/agency-lang/lib/cli/statelog/serveUrl.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  canonicalOrigin,
   resolveTrustedEndpointUrl,
   parseServeBaseUrl,
   serveRouteUrl,
@@ -103,5 +104,27 @@ describe("projectPageUrl", () => {
   it("builds the project page URL, encoding the decoded project id", () => {
     const address = parseServeBaseUrl(`${HOST}/serve/u/p%20q/a`)!;
     expect(projectPageUrl(address)).toBe(`${HOST}/projects/show?id=p+q`);
+  });
+});
+
+describe("canonicalOrigin", () => {
+  it.each([
+    ["https://host.example/", "https://host.example"],
+    ["https://host.example", "https://host.example"],
+    ["http://localhost:3000", "http://localhost:3000"],
+  ])("canonicalizes %s", (input, expected) => {
+    expect(canonicalOrigin(input)).toBe(expected);
+  });
+
+  it.each([
+    "",
+    "not a url",
+    "ftp://host.example",
+    "https://user:password@host.example",
+    "https://host.example/api",
+    "https://host.example?query=1",
+    "https://host.example#fragment",
+  ])("rejects %s", (input) => {
+    expect(canonicalOrigin(input)).toBeNull();
   });
 });

--- a/packages/agency-lang/lib/cli/statelog/serveUrl.ts
+++ b/packages/agency-lang/lib/cli/statelog/serveUrl.ts
@@ -103,3 +103,30 @@ export function projectPageUrl(address: ServeAddress): string {
   url.searchParams.set("id", address.projectId);
   return url.toString();
 }
+
+/** Reduce a host string to a bare origin (`scheme://host[:port]`), or null if it
+ *  is not a usable statelog origin. Account-management routes are built from this
+ *  with `new URL(...)`, so anything ambiguous is rejected: non-HTTP(S) schemes,
+ *  embedded credentials, a query or fragment, or a non-root path (statelog is
+ *  served at the root). A trailing slash is canonicalized away. */
+export function canonicalOrigin(host: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(host);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return null;
+  }
+  if (parsed.username || parsed.password) {
+    return null;
+  }
+  if (parsed.search || parsed.hash) {
+    return null;
+  }
+  if (parsed.pathname !== "/" && parsed.pathname !== "") {
+    return null;
+  }
+  return parsed.origin;
+}

--- a/packages/agency-lang/scripts/agency.test.ts
+++ b/packages/agency-lang/scripts/agency.test.ts
@@ -4,6 +4,28 @@ import * as os from "os";
 import * as path from "path";
 import { execFile } from "child_process";
 import { promisify } from "util";
+import type { Command } from "commander";
+
+// Replace only the three new remote-management recipe modules so registration
+// can be exercised with real `parseAsync` without hitting the network.
+const remoteRecipeMocks = vi.hoisted(() => ({
+  runWhoami: vi.fn(),
+  runProjectsList: vi.fn(),
+  runProjectsCreate: vi.fn(),
+  runKeysList: vi.fn(),
+  runKeysCreate: vi.fn(),
+}));
+vi.mock("@/cli/remote/commands/whoami.js", () => ({
+  runWhoami: remoteRecipeMocks.runWhoami,
+}));
+vi.mock("@/cli/remote/commands/projects.js", () => ({
+  runProjectsList: remoteRecipeMocks.runProjectsList,
+  runProjectsCreate: remoteRecipeMocks.runProjectsCreate,
+}));
+vi.mock("@/cli/remote/commands/keys.js", () => ({
+  runKeysList: remoteRecipeMocks.runKeysList,
+  runKeysCreate: remoteRecipeMocks.runKeysCreate,
+}));
 
 import {
   createProgram,
@@ -116,16 +138,19 @@ describe("agency CLI command tree", () => {
       .toBe("function");
   });
 
-  it("registers the remote command group with its five subcommands", () => {
+  it("registers the remote command group with its subcommands", () => {
     const program = createProgram();
     const remote = program.commands.find((command) => command.name() === "remote");
     expect(remote).toBeDefined();
     expect(remote?.commands.map((command) => command.name()).sort()).toEqual([
       "call",
       "deploy",
+      "keys",
       "link",
       "ls",
       "open",
+      "projects",
+      "whoami",
     ]);
   });
 
@@ -254,5 +279,108 @@ describe("injectAgentSeparator", () => {
   it("is a no-op for other subcommands", () => {
     const run = [...N, "run", "foo.agency", "--max-cost", "5"];
     expect(injectAgentSeparator(run)).toEqual(run);
+  });
+});
+
+describe("remote management command registration", () => {
+  const CONTEXT = expect.objectContaining({
+    config: expect.any(Object),
+    configPath: expect.any(String),
+  });
+
+  function exitOverrideAll(cmd: Command): void {
+    cmd.exitOverride();
+    for (const sub of cmd.commands) {
+      exitOverrideAll(sub);
+    }
+  }
+
+  beforeEach(() => {
+    for (const fn of Object.values(remoteRecipeMocks)) {
+      fn.mockReset();
+    }
+  });
+
+  it("remote whoami forwards options and context", async () => {
+    await createProgram().parseAsync([
+      "node", "agency", "remote", "whoami", "--host", "https://h", "--api-key-env", "ACCOUNT_KEY",
+    ]);
+    expect(remoteRecipeMocks.runWhoami).toHaveBeenCalledWith(
+      { host: "https://h", apiKeyEnv: "ACCOUNT_KEY" },
+      CONTEXT,
+    );
+  });
+
+  it("remote projects defaults to list", async () => {
+    await createProgram().parseAsync([
+      "node", "agency", "remote", "projects", "--host", "https://h", "--api-key-env", "ACCOUNT_KEY",
+    ]);
+    expect(remoteRecipeMocks.runProjectsList).toHaveBeenCalledWith(
+      { host: "https://h", apiKeyEnv: "ACCOUNT_KEY" },
+      CONTEXT,
+    );
+    expect(remoteRecipeMocks.runProjectsCreate).not.toHaveBeenCalled();
+  });
+
+  it("remote projects list runs explicitly", async () => {
+    await createProgram().parseAsync(["node", "agency", "remote", "projects", "list"]);
+    expect(remoteRecipeMocks.runProjectsList).toHaveBeenCalledTimes(1);
+  });
+
+  it("remote projects create forwards the slug and options", async () => {
+    await createProgram().parseAsync([
+      "node", "agency", "remote", "projects", "create", "foo",
+      "--name", "Foo", "--description", "Text", "--host", "https://h", "--api-key-env", "ACCOUNT_KEY",
+    ]);
+    expect(remoteRecipeMocks.runProjectsCreate).toHaveBeenCalledWith(
+      "foo",
+      { name: "Foo", description: "Text", host: "https://h", apiKeyEnv: "ACCOUNT_KEY" },
+      CONTEXT,
+    );
+  });
+
+  it("remote keys defaults to list", async () => {
+    await createProgram().parseAsync([
+      "node", "agency", "remote", "keys", "--host", "https://h", "--api-key-env", "ACCOUNT_KEY",
+    ]);
+    expect(remoteRecipeMocks.runKeysList).toHaveBeenCalledWith(
+      { host: "https://h", apiKeyEnv: "ACCOUNT_KEY" },
+      CONTEXT,
+    );
+  });
+
+  it("remote keys list runs explicitly", async () => {
+    await createProgram().parseAsync(["node", "agency", "remote", "keys", "list"]);
+    expect(remoteRecipeMocks.runKeysList).toHaveBeenCalledTimes(1);
+  });
+
+  it("remote keys create forwards the name and --project", async () => {
+    await createProgram().parseAsync([
+      "node", "agency", "remote", "keys", "create", "ci",
+      "--project", "foo", "--host", "https://h", "--api-key-env", "ACCOUNT_KEY",
+    ]);
+    expect(remoteRecipeMocks.runKeysCreate).toHaveBeenCalledWith(
+      "ci",
+      { project: "foo", host: "https://h", apiKeyEnv: "ACCOUNT_KEY" },
+      CONTEXT,
+    );
+  });
+
+  it("projects create requires --name", async () => {
+    const program = createProgram();
+    exitOverrideAll(program);
+    await expect(
+      program.parseAsync(["node", "agency", "remote", "projects", "create", "foo"]),
+    ).rejects.toMatchObject({ code: "commander.missingMandatoryOptionValue" });
+    expect(remoteRecipeMocks.runProjectsCreate).not.toHaveBeenCalled();
+  });
+
+  it("keys create requires --project", async () => {
+    const program = createProgram();
+    exitOverrideAll(program);
+    await expect(
+      program.parseAsync(["node", "agency", "remote", "keys", "create", "ci"]),
+    ).rejects.toMatchObject({ code: "commander.missingMandatoryOptionValue" });
+    expect(remoteRecipeMocks.runKeysCreate).not.toHaveBeenCalled();
   });
 });

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -22,6 +22,12 @@ import { runDeploy } from "@/cli/remote/commands/deploy.js";
 import { runLs } from "@/cli/remote/commands/ls.js";
 import { runCall } from "@/cli/remote/commands/call.js";
 import { runOpen } from "@/cli/remote/commands/open.js";
+import { runWhoami } from "@/cli/remote/commands/whoami.js";
+import { runProjectsList, runProjectsCreate } from "@/cli/remote/commands/projects.js";
+import type { CreateProjectOptions } from "@/cli/remote/commands/projects.js";
+import { runKeysList, runKeysCreate } from "@/cli/remote/commands/keys.js";
+import type { CreateKeyOptions } from "@/cli/remote/commands/keys.js";
+import type { AccountCommandOptions } from "@/cli/remote/commands/util.js";
 import type { RemoteCommandContext } from "@/cli/remote/commands/util.js";
 import { lintSource } from "@/linter/registry.js";
 import { formatFindings } from "@/cli/lint.js";
@@ -480,6 +486,57 @@ export function createProgram(deps: CliDependencies = {}): Command {
     .command("open")
     .description("Open the linked agent's project page in a browser")
     .action(() => runOpen(getConfigContext()));
+
+  const HOST_OPTION = "--host <origin>";
+  const HOST_DESC = "statelog host (overrides agency.json log.host)";
+  const API_KEY_ENV_OPTION = "--api-key-env <name>";
+  const API_KEY_ENV_DESC = "env var to read the API key from (default: STATELOG_API_KEY)";
+
+  remoteCmd
+    .command("whoami")
+    .description("Show the authenticated statelog user")
+    .option(HOST_OPTION, HOST_DESC)
+    .option(API_KEY_ENV_OPTION, API_KEY_ENV_DESC)
+    .action((opts: AccountCommandOptions) => runWhoami(opts, getConfigContext()));
+
+  const projectsCmd = remoteCmd
+    .command("projects")
+    .description("List or create statelog projects (account-scoped key)");
+  projectsCmd
+    .command("list", { isDefault: true })
+    .description("List the account's projects")
+    .option(HOST_OPTION, HOST_DESC)
+    .option(API_KEY_ENV_OPTION, API_KEY_ENV_DESC)
+    .action((opts: AccountCommandOptions) => runProjectsList(opts, getConfigContext()));
+  projectsCmd
+    .command("create <project_id>")
+    .description("Create a project")
+    .requiredOption("--name <name>", "human-readable project name")
+    .option("--description <text>", "optional project description")
+    .option(HOST_OPTION, HOST_DESC)
+    .option(API_KEY_ENV_OPTION, API_KEY_ENV_DESC)
+    .action((projectId: string, opts: CreateProjectOptions) =>
+      runProjectsCreate(projectId, opts, getConfigContext()),
+    );
+
+  const keysCmd = remoteCmd
+    .command("keys")
+    .description("List or create statelog API keys (account-scoped key)");
+  keysCmd
+    .command("list", { isDefault: true })
+    .description("List the account's API keys")
+    .option(HOST_OPTION, HOST_DESC)
+    .option(API_KEY_ENV_OPTION, API_KEY_ENV_DESC)
+    .action((opts: AccountCommandOptions) => runKeysList(opts, getConfigContext()));
+  keysCmd
+    .command("create <name>")
+    .description("Create a project-scoped API key")
+    .requiredOption("--project <slug>", "project slug the key is scoped to")
+    .option(HOST_OPTION, HOST_DESC)
+    .option(API_KEY_ENV_OPTION, API_KEY_ENV_DESC)
+    .action((name: string, opts: CreateKeyOptions) =>
+      runKeysCreate(name, opts, getConfigContext()),
+    );
 
   const traceCmd = program
     .command("trace")


### PR DESCRIPTION
## What

The agency-lang half of statelog's **Group-1 management API** — three new `agency remote` command groups that let a CLI (holding an API key) manage projects and keys without the web UI:

- **`remote whoami`** — the authenticated user.
- **`remote projects`** (list) / **`remote projects create <project_id> --name …`**
- **`remote keys`** (list) / **`remote keys create <name> --project <slug>`**

## Architecture

- **One sealed account client** (`lib/cli/statelog/accountClient.ts`) owns the `/api/*` routes, the `Result` envelope, and — the key subtlety — the translation between statelog's public `project_id` slug and its internal database `id`. `createProjectKey` resolves the slug to the internal id before POST (unknown slug fails first); `listKeys` enriches each project key's internal id back to its slug. The internal id never leaves this file.
- **`resolveAccountTarget`** picks a canonical origin (`--host` > `agency.json` `log.host` > an existing binding's origin) and the API key, returning the env-var name too so the command layer can name it in guidance.
- **Thin recipes** (`whoami`/`projects`/`keys`) resolve → call a semantic client method → pure renderer.

## Behaviour that matters

- **`whoami` accepts any key**; **projects and keys require an account-scoped key** — a project-scoped key gets a 403 that the CLI maps to guidance naming the resolved env var (`AccountScopeError`). Other 403s (e.g. unapproved account) preserve the server message.
- **`keys create` mints project-scoped keys only** — the server forbids minting account keys from a key.
- **A created key's plaintext is printed once** with a warning and never appears in the list view or in errors.
- **Non-2xx is handled before the `Result` envelope** (auth middleware returns a bare `{ error }`), and the API key never leaks into an error message.
- `project_id` is validated client-side (`^[a-z0-9-]+$`, ≤20) before any network call.

## Verification

- Touched tests: **110 passed** (3 build-gated skips) across the account client (transport ordering, 403 mapping, slug↔id translation, discriminated-union validation, secret safety), target/origin resolution, renderers (alignment, one-time key), recipes (scope-error env-var naming, invalid-id-before-network), and `parseAsync` registration (default `list`, `create`, required-option failures).
- `pnpm run typecheck` (source + tests + evals), `pnpm run lint:structure`, and `git diff --check` all clean.

Built from the reviewed spec and plan; scope is Group 1 only (Group 2 introspection and the `remote link --project` follow-up are out of scope). No statelog changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
