### PR TITLE
fix(budget): actually enforce per-agent spend controls (propagate, resume, typed error)

### DIFF
--- a/packages/agency-lang/lib/runtime/interrupts.ts
+++ b/packages/agency-lang/lib/runtime/interrupts.ts
@@ -814,9 +814,10 @@ export async function respondToInterrupts(args: {
     () => __initAllRegisteredCallbacks(execCtx),
   );
   execCtx.restoreState(checkpoint);
-  // Re-assert the root budget from the host context, dropping the checkpoint's
-  // serialized root guard (its limit/spend are caller-controllable on a
-  // stateless resume). Mirrors runNode's install; no-op in IPC.
+  // Re-assert the root budget's LIMIT from the host context (the checkpoint's
+  // ceiling is caller-controllable on a stateless resume), while preserving the
+  // guard's accumulated spend so the trusted CLI resume path stays cumulative.
+  // No-op in IPC.
   reinstallRootBudget(execCtx.stateStack, execCtx.budget);
   execCtx.setInterruptResponses(responseMap);
   if (metadata.callbacks) Object.assign(execCtx.callbacks, metadata.callbacks);

--- a/packages/agency-lang/lib/runtime/interrupts.ts
+++ b/packages/agency-lang/lib/runtime/interrupts.ts
@@ -10,6 +10,7 @@ import type {
 } from "./interruptResponse.js";
 import { runInBootstrapFrame } from "./asyncContext.js";
 import { __initAllRegisteredCallbacks } from "./crossModuleInitRegistry.js";
+import { reinstallRootBudget } from "./rootBudget.js";
 import {
   AgencyCancelledError,
   HandlerRecursionError,
@@ -813,6 +814,10 @@ export async function respondToInterrupts(args: {
     () => __initAllRegisteredCallbacks(execCtx),
   );
   execCtx.restoreState(checkpoint);
+  // Re-assert the root budget from the host context, dropping the checkpoint's
+  // serialized root guard (its limit/spend are caller-controllable on a
+  // stateless resume). Mirrors runNode's install; no-op in IPC.
+  reinstallRootBudget(execCtx.stateStack, execCtx.budget);
   execCtx.setInterruptResponses(responseMap);
   if (metadata.callbacks) Object.assign(execCtx.callbacks, metadata.callbacks);
   if (metadata.debugger) execCtx.debuggerState = metadata.debugger;

--- a/packages/agency-lang/lib/runtime/rootBudget.test.ts
+++ b/packages/agency-lang/lib/runtime/rootBudget.test.ts
@@ -130,12 +130,12 @@ describe("installRootBudget with a context budget (config, no flag)", () => {
 });
 
 describe("reinstallRootBudget (resume: host-authoritative limit)", () => {
-  test("drops a restored root guard and re-installs from the context budget", () => {
+  test("clamps the restored root guard's limit to the host value, keeping the guard", () => {
     const stack = new StateStack();
     // A restored root guard whose limit the client inflated to 999.
-    const stale = new CostGuard(999);
-    stale.isRootBudget = true;
-    stack.pushGuard(stale);
+    const restored = new CostGuard(999);
+    restored.isRootBudget = true;
+    stack.pushGuard(restored);
 
     reinstallRootBudget(stack, { maxCost: 1 });
 
@@ -143,9 +143,35 @@ describe("reinstallRootBudget (resume: host-authoritative limit)", () => {
       (g): g is CostGuard => g instanceof CostGuard && g.isRootBudget,
     );
     expect(roots).toHaveLength(1);
-    expect(roots[0]).not.toBe(stale);
-    // The fresh guard carries the HOST limit, not the client's 999.
+    // SAME instance (so its accumulated spend survives), with the HOST limit.
+    expect(roots[0]).toBe(restored);
     expect(roots[0].costLimit).toBe(1);
+  });
+
+  test("clamps a restored time guard's limit too", () => {
+    const stack = new StateStack();
+    const restored = new TimeGuard(999_999);
+    restored.isRootBudget = true;
+    stack.pushGuard(restored);
+
+    reinstallRootBudget(stack, { maxTimeMs: 5000 });
+
+    const roots = stack.guards.filter(
+      (g): g is TimeGuard => g instanceof TimeGuard && g.isRootBudget,
+    );
+    expect(roots).toHaveLength(1);
+    expect(roots[0]).toBe(restored);
+    expect(roots[0].timeLimit).toBe(5000);
+  });
+
+  test("installs a fresh root guard when the checkpoint had none but the host caps", () => {
+    const stack = new StateStack();
+    reinstallRootBudget(stack, { maxCost: 2 });
+    const roots = stack.guards.filter(
+      (g): g is CostGuard => g instanceof CostGuard && g.isRootBudget,
+    );
+    expect(roots).toHaveLength(1);
+    expect(roots[0].costLimit).toBe(2);
   });
 
   test("preserves a non-root (user) guard", () => {
@@ -158,11 +184,11 @@ describe("reinstallRootBudget (resume: host-authoritative limit)", () => {
     expect(stack.guards).toContain(userGuard);
   });
 
-  test("no host budget: drops the restored root guard, installs nothing", () => {
+  test("no host budget: drops the restored root guard", () => {
     const stack = new StateStack();
-    const stale = new CostGuard(999);
-    stale.isRootBudget = true;
-    stack.pushGuard(stale);
+    const restored = new CostGuard(999);
+    restored.isRootBudget = true;
+    stack.pushGuard(restored);
 
     reinstallRootBudget(stack, undefined);
 
@@ -172,12 +198,13 @@ describe("reinstallRootBudget (resume: host-authoritative limit)", () => {
   test("no-op in IPC mode (parent owns the budget)", () => {
     process.env.AGENCY_IPC = "1";
     const stack = new StateStack();
-    const stale = new CostGuard(999);
-    stale.isRootBudget = true;
-    stack.pushGuard(stale);
+    const restored = new CostGuard(999);
+    restored.isRootBudget = true;
+    stack.pushGuard(restored);
 
     reinstallRootBudget(stack, { maxCost: 1 });
 
-    expect(stack.guards).toEqual([stale]);
+    expect(stack.guards).toEqual([restored]);
+    expect(restored.costLimit).toBe(999);
   });
 });

--- a/packages/agency-lang/lib/runtime/rootBudget.test.ts
+++ b/packages/agency-lang/lib/runtime/rootBudget.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, afterEach } from "vitest";
-import { installRootBudget } from "@/runtime/rootBudget.js";
+import { installRootBudget, reinstallRootBudget } from "@/runtime/rootBudget.js";
 import { StateStack } from "@/runtime/state/stateStack.js";
 import { CostGuard, TimeGuard } from "@/runtime/guard.js";
 import { AGENCY_MAX_COST, AGENCY_MAX_TIME } from "@/constants.js";
@@ -126,5 +126,58 @@ describe("installRootBudget with a context budget (config, no flag)", () => {
     expect(() => installRootBudget(new StateStack(), { maxTimeMs: Infinity })).toThrow(
       /budget\.maxTime is not a finite number/,
     );
+  });
+});
+
+describe("reinstallRootBudget (resume: host-authoritative limit)", () => {
+  test("drops a restored root guard and re-installs from the context budget", () => {
+    const stack = new StateStack();
+    // A restored root guard whose limit the client inflated to 999.
+    const stale = new CostGuard(999);
+    stale.isRootBudget = true;
+    stack.pushGuard(stale);
+
+    reinstallRootBudget(stack, { maxCost: 1 });
+
+    const roots = stack.guards.filter(
+      (g): g is CostGuard => g instanceof CostGuard && g.isRootBudget,
+    );
+    expect(roots).toHaveLength(1);
+    expect(roots[0]).not.toBe(stale);
+    // The fresh guard carries the HOST limit, not the client's 999.
+    expect(roots[0].costLimit).toBe(1);
+  });
+
+  test("preserves a non-root (user) guard", () => {
+    const stack = new StateStack();
+    const userGuard = new CostGuard(5); // isRootBudget defaults to false
+    stack.pushGuard(userGuard);
+
+    reinstallRootBudget(stack, { maxCost: 1 });
+
+    expect(stack.guards).toContain(userGuard);
+  });
+
+  test("no host budget: drops the restored root guard, installs nothing", () => {
+    const stack = new StateStack();
+    const stale = new CostGuard(999);
+    stale.isRootBudget = true;
+    stack.pushGuard(stale);
+
+    reinstallRootBudget(stack, undefined);
+
+    expect(stack.guards.some((g) => g.isRootBudget)).toBe(false);
+  });
+
+  test("no-op in IPC mode (parent owns the budget)", () => {
+    process.env.AGENCY_IPC = "1";
+    const stack = new StateStack();
+    const stale = new CostGuard(999);
+    stale.isRootBudget = true;
+    stack.pushGuard(stale);
+
+    reinstallRootBudget(stack, { maxCost: 1 });
+
+    expect(stack.guards).toEqual([stale]);
   });
 });

--- a/packages/agency-lang/lib/runtime/rootBudget.ts
+++ b/packages/agency-lang/lib/runtime/rootBudget.ts
@@ -55,6 +55,31 @@ export function installRootBudget(
   }
 }
 
+/** Re-assert the root budget on a RESUMED exec context. The root guard is
+ *  serialized with the checkpoint, so on a stateless resume its limit and
+ *  accumulated spend arrive from the (client-controllable) checkpoint. Drop any
+ *  restored root guard and re-install from the host-authoritative `contextBudget`
+ *  (the CLI env flag still wins), so the ceiling cannot be raised from the
+ *  client on a resumed leg. Same root-only gating as installRootBudget — a no-op
+ *  in IPC, where the parent owns the budget.
+ *
+ *  This resets accumulated spend for the leg: a stateless resume carries no
+ *  authoritative running total. Preventing per-leg reset needs host-side state
+ *  (server-stored checkpoints or signed, anti-replay envelopes) — out of scope
+ *  here. See docs/dev/checkpointing.md and the spend-controls handoff. */
+export function reinstallRootBudget(
+  stack: StateStack,
+  contextBudget?: { maxCost?: number; maxTimeMs?: number },
+): void {
+  if (isIpcMode()) return;
+  const withoutRoot = stack.guards.filter((g) => !g.isRootBudget);
+  if (withoutRoot.length !== stack.guards.length) {
+    stack.guards = withoutRoot;
+    stack.rebuildAbortSignal();
+  }
+  installRootBudget(stack, contextBudget);
+}
+
 /** FAIL CLOSED on a malformed budget value. The env is an internal
  *  carrier and the CLI validates before setting it, so a non-finite
  *  value here means a hand-set env or a bug — and for a cost-control

--- a/packages/agency-lang/lib/runtime/rootBudget.ts
+++ b/packages/agency-lang/lib/runtime/rootBudget.ts
@@ -3,29 +3,18 @@ import { CostGuard, TimeGuard } from "./guard.js";
 import { isIpcMode } from "./subprocessRunInfo.js";
 import type { StateStack } from "./state/stateStack.js";
 
-/** Install a root cost/time guard from the CLI flags (AGENCY_MAX_COST /
- *  AGENCY_MAX_TIME env vars) or, when a flag is absent for that dimension, the
- *  resolved config `budget` (passed as `contextBudget`). The flag wins per
- *  dimension, so `agency run --max-cost` still overrides an `agency.json`
- *  budget; a served agent, which has no flag, is governed by the budget its
- *  host bound via runtime-config overrides.
- *
- *  Applies the disable rule: cost < 0 installs nothing; time <= 0 installs
- *  nothing (cost 0 IS a real limit — no paid spend, local-models-only).
- *  Called once at the root, next to installRunPolicyHandler, before the
- *  node body runs, so the budget is outermost and cannot be bypassed.
- *  No-op in IPC subprocesses — a child's budget is owned by the parent's
- *  guard, which meters the subprocess through the branch clone.
- *
- *  pushGuard() installs immediately, so a time budget's clock starts at
- *  run start — the intended whole-run semantics. Interrupt halts and
- *  input() waits still pause it like any other time guard. */
-export function installRootBudget(
-  stack: StateStack,
-  contextBudget?: { maxCost?: number; maxTimeMs?: number },
-): void {
-  if (isIpcMode()) return;
-
+/** The host-authoritative root limits: the CLI flag (AGENCY_MAX_COST /
+ *  AGENCY_MAX_TIME env vars) if set, else the resolved config `budget`. The flag
+ *  wins per dimension, so `agency run --max-cost` still overrides an
+ *  `agency.json` budget; a served agent, which has no flag, is governed by the
+ *  budget its host bound via runtime-config overrides. `undefined` means "no
+ *  cap this dimension"; a value still passes through the disable rule at the
+ *  call site (cost < 0 / time <= 0 install nothing). FAILS CLOSED on a
+ *  malformed value. */
+function resolveRootLimits(contextBudget?: {
+  maxCost?: number;
+  maxTimeMs?: number;
+}): { cost?: number; timeMs?: number } {
   const rawCost = process.env[AGENCY_MAX_COST];
   const cost =
     rawCost !== undefined
@@ -33,51 +22,96 @@ export function installRootBudget(
       : contextBudget?.maxCost !== undefined
         ? finiteContextBudget(contextBudget.maxCost, "budget.maxCost")
         : undefined;
-  if (cost !== undefined && cost >= 0) {
-    const g = new CostGuard(cost);
-    // The operator's ceiling: never raises an interrupt, never
-    // extendable by user code. Serialized with the guard.
-    g.isRootBudget = true;
-    stack.pushGuard(g);
-  }
-
   const rawTime = process.env[AGENCY_MAX_TIME];
-  const ms =
+  const timeMs =
     rawTime !== undefined
       ? parseBudgetValue(rawTime, AGENCY_MAX_TIME)
       : contextBudget?.maxTimeMs !== undefined
         ? finiteContextBudget(contextBudget.maxTimeMs, "budget.maxTime")
         : undefined;
-  if (ms !== undefined && ms > 0) {
-    const g = new TimeGuard(ms);
-    g.isRootBudget = true;
-    stack.pushGuard(g);
-  }
+  return { cost, timeMs };
+}
+
+function pushRootGuard(stack: StateStack, guard: CostGuard | TimeGuard): void {
+  // The operator's ceiling: never raises an interrupt, never extendable by user
+  // code. Serialized with the guard.
+  guard.isRootBudget = true;
+  stack.pushGuard(guard);
+}
+
+/** Install a root cost/time budget. Applies the disable rule: cost < 0 installs
+ *  nothing; time <= 0 installs nothing (cost 0 IS a real limit — no paid spend,
+ *  local-models-only). Called once at the root, next to installRunPolicyHandler,
+ *  before the node body runs, so the budget is outermost and cannot be bypassed.
+ *  No-op in IPC subprocesses — a child's budget is owned by the parent's guard,
+ *  which meters the subprocess through the branch clone.
+ *
+ *  pushGuard() installs immediately, so a time budget's clock starts at run
+ *  start — the intended whole-run semantics. Interrupt halts and input() waits
+ *  still pause it like any other time guard. */
+export function installRootBudget(
+  stack: StateStack,
+  contextBudget?: { maxCost?: number; maxTimeMs?: number },
+): void {
+  if (isIpcMode()) return;
+  const { cost, timeMs } = resolveRootLimits(contextBudget);
+  if (cost !== undefined && cost >= 0) pushRootGuard(stack, new CostGuard(cost));
+  if (timeMs !== undefined && timeMs > 0) pushRootGuard(stack, new TimeGuard(timeMs));
 }
 
 /** Re-assert the root budget on a RESUMED exec context. The root guard is
- *  serialized with the checkpoint, so on a stateless resume its limit and
- *  accumulated spend arrive from the (client-controllable) checkpoint. Drop any
- *  restored root guard and re-install from the host-authoritative `contextBudget`
- *  (the CLI env flag still wins), so the ceiling cannot be raised from the
- *  client on a resumed leg. Same root-only gating as installRootBudget — a no-op
- *  in IPC, where the parent owns the budget.
+ *  serialized with the checkpoint, so on a stateless served resume its limit
+ *  arrives from a client-controllable payload — a crafted resume could raise the
+ *  ceiling. Clamp the restored root guard's LIMIT to the host value while
+ *  KEEPING the guard (and its accumulated spend/elapsed):
  *
- *  This resets accumulated spend for the leg: a stateless resume carries no
- *  authoritative running total. Preventing per-leg reset needs host-side state
- *  (server-stored checkpoints or signed, anti-replay envelopes) — out of scope
- *  here. See docs/dev/checkpointing.md and the spend-controls handoff. */
+ *  - the limit becomes host-authoritative and un-raisable from the client;
+ *  - accumulated spend is preserved, so the trusted in-process CLI resume path
+ *    stays cumulative across legs — no regression — and a served client that
+ *    lowers its own reported spend only hurts itself (same residual gap a
+ *    stateless resume always has);
+ *  - arming is untouched (restored guards are un-armed by restoreState), so this
+ *    can't reintroduce a timer pop-race.
+ *
+ *  A dimension the host no longer caps has its restored root guard dropped
+ *  (through `uninstall`); a dimension the host caps but the checkpoint had no
+ *  root guard for gets a fresh guard. No-op in IPC. */
 export function reinstallRootBudget(
   stack: StateStack,
   contextBudget?: { maxCost?: number; maxTimeMs?: number },
 ): void {
   if (isIpcMode()) return;
-  const withoutRoot = stack.guards.filter((g) => !g.isRootBudget);
-  if (withoutRoot.length !== stack.guards.length) {
-    stack.guards = withoutRoot;
+  const { cost, timeMs } = resolveRootLimits(contextBudget);
+  const hostCost = cost !== undefined && cost >= 0 ? cost : undefined;
+  const hostTimeMs = timeMs !== undefined && timeMs > 0 ? timeMs : undefined;
+
+  let sawCost = false;
+  let sawTime = false;
+  const dropped: (CostGuard | TimeGuard)[] = [];
+  for (const guard of stack.guards) {
+    if (!guard.isRootBudget) continue;
+    if (guard instanceof CostGuard) {
+      sawCost = true;
+      // Direct clamp (not extendBudget, which only grants upward): the host
+      // ceiling replaces whatever the checkpoint carried, preserving `spent`.
+      if (hostCost !== undefined) guard.costLimit = hostCost;
+      else dropped.push(guard);
+    } else if (guard instanceof TimeGuard) {
+      sawTime = true;
+      if (hostTimeMs !== undefined) guard.timeLimit = hostTimeMs;
+      else dropped.push(guard);
+    }
+  }
+
+  if (dropped.length > 0) {
+    for (const guard of dropped) guard.uninstall(stack);
+    stack.guards = stack.guards.filter((g) => !dropped.includes(g as CostGuard | TimeGuard));
     stack.rebuildAbortSignal();
   }
-  installRootBudget(stack, contextBudget);
+
+  // The host caps a dimension the checkpoint had no root guard for.
+  if (!sawCost && hostCost !== undefined) pushRootGuard(stack, new CostGuard(hostCost));
+  if (!sawTime && hostTimeMs !== undefined) pushRootGuard(stack, new TimeGuard(hostTimeMs));
 }
 
 /** FAIL CLOSED on a malformed budget value. The env is an internal

--- a/packages/agency-lang/lib/runtime/state/context.budget.test.ts
+++ b/packages/agency-lang/lib/runtime/state/context.budget.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { RuntimeContext } from "./context.js";
+
+// Regression guard for the RuntimeContext → execCtx handoff: installRootBudget
+// reads `execCtx.budget`, and createExecutionContext copies fields one by one.
+// If `budget` is not copied, the whole config/override budget is a silent no-op.
+function makeContext(budget?: { maxCost?: number; maxTimeMs?: number }) {
+  return new RuntimeContext({
+    statelogConfig: { host: "", apiKey: "", projectId: "", debugMode: false, observability: false },
+    smoltalkDefaults: {},
+    dirname: "/project",
+    budget,
+  });
+}
+
+describe("createExecutionContext budget propagation", () => {
+  it("copies the resolved budget onto the execution context", async () => {
+    const execCtx = await makeContext({ maxCost: 0.5, maxTimeMs: 1000 }).createExecutionContext("run-1");
+    expect(execCtx.budget).toEqual({ maxCost: 0.5, maxTimeMs: 1000 });
+  });
+
+  it("leaves budget undefined when none is configured", async () => {
+    const execCtx = await makeContext().createExecutionContext("run-2");
+    expect(execCtx.budget).toBeUndefined();
+  });
+});

--- a/packages/agency-lang/lib/runtime/state/context.ts
+++ b/packages/agency-lang/lib/runtime/state/context.ts
@@ -383,6 +383,10 @@ export class RuntimeContext<T> {
     execCtx.maxRestores = this.maxRestores;
     execCtx.maxCallDepth = this.maxCallDepth;
     execCtx.failurePropagation = this.failurePropagation;
+    // Non-serialized field — must be copied here (see the class comment) so
+    // installRootBudget, which reads execCtx.budget, actually sees the resolved
+    // config/override budget. Without this the root budget is a silent no-op.
+    execCtx.budget = this.budget;
     execCtx.checkpoints = new CheckpointStore(this.maxRestores);
     // The execution context is built via Object.create, bypassing the
     // constructor, so carry the clock over from the global context. Without

--- a/packages/agency-lang/lib/serve/http/adapter.test.ts
+++ b/packages/agency-lang/lib/serve/http/adapter.test.ts
@@ -8,6 +8,7 @@ import type { Interrupt } from "../../runtime/interrupts.js";
 import type { ExportedItem } from "../types.js";
 import { createLogger } from "../../logger.js";
 import type { Logger } from "../../logger.js";
+import { GuardExceededError } from "../../runtime/guard.js";
 
 // A fully-formed interrupt, as the runtime produces one — every identity field
 // present. Resume validation now requires these, so tests build real interrupts
@@ -526,5 +527,50 @@ describe("startHttpServer route logging", () => {
     // node `main` takes a single param
     expect(joined).toContain("POST  /node/main (message)");
     expect(joined).toContain("POST  /resume (interrupts, responses)");
+  });
+});
+
+describe("root-budget trips surface as a typed budgetExceeded", () => {
+  const silent = createLogger("error");
+
+  function handlerFor(invoke: () => Promise<unknown>): ReturnType<typeof createHttpHandler> {
+    const node: ExportedItem = {
+      kind: "node",
+      name: "run",
+      parameters: [],
+      interruptEffects: [],
+      invoke,
+    };
+    return createHttpHandler({
+      exports: [node],
+      logger: silent,
+      hasInterrupts: () => false,
+      respondToInterrupts: async () => ({ data: undefined }),
+    });
+  }
+
+  it("returns a 402 budgetExceeded with dimension/limit/spent", async () => {
+    const handler = handlerFor(async () => {
+      throw new GuardExceededError("cost", 1, 2, "g1");
+    });
+    const result = await handler("POST", "/node/run", {});
+    expect(result.status).toBe(402);
+    expect(result.body).toMatchObject({
+      success: false,
+      code: "budgetExceeded",
+      dimension: "cost",
+      limit: 1,
+      spent: 2,
+    });
+    expect((result.body as { error: string }).error).toContain("cost limit");
+  });
+
+  it("leaves a non-budget error as the generic tool error", async () => {
+    const handler = handlerFor(async () => {
+      throw new Error("kaboom");
+    });
+    const result = await handler("POST", "/node/run", {});
+    expect(result.status).toBe(200);
+    expect(result.body).toEqual({ success: false, error: "Tool execution failed" });
   });
 });

--- a/packages/agency-lang/lib/serve/http/adapter.ts
+++ b/packages/agency-lang/lib/serve/http/adapter.ts
@@ -2,6 +2,8 @@ import http from "http";
 import type { ExportedItem, ExportedFunction, ExportedNode } from "../types.js";
 import { errorMessage, toArgs, parseJsonBody } from "../util.js";
 import { validateResumeBatch } from "../../runtime/interrupts.js";
+import { readCause } from "../../runtime/errors.js";
+import { formatBudgetExceeded } from "../../runtime/budgetExit.js";
 import type { Logger } from "../../logger.js";
 import {
   DEFAULT_HOST,
@@ -61,6 +63,43 @@ function interruptResult(data: unknown): RouteResult {
  */
 const TOOL_ERROR_MESSAGE = "Tool execution failed";
 
+/** A tripped ROOT budget is a spend/time stop, not a generic tool failure.
+ *  Return a typed, structured result (HTTP 402) carrying the dimension, limit,
+ *  and spend, so a caller and traces can tell it apart without string-matching
+ *  the generic message. Unlike other errors, the budget numbers are safe to
+ *  surface — they are the operator's own limit, not server internals. */
+function budgetExceeded(cause: {
+  dimension: "cost" | "time";
+  limit: number;
+  spent: number;
+}): RouteResult {
+  return {
+    status: 402,
+    body: {
+      success: false,
+      code: "budgetExceeded",
+      error: formatBudgetExceeded(cause),
+      dimension: cause.dimension,
+      limit: cause.limit,
+      spent: cause.spent,
+    },
+  };
+}
+
+/** Map a thrown error to a route result: a root-budget trip becomes a typed
+ *  budgetExceeded (402); anything else is logged and returned as the generic
+ *  tool error so no server detail leaks. Detection is by CAUSE (mirrors
+ *  budgetExit), so it catches a root trip however it surfaced. */
+function errorResult(err: unknown, logger: Logger, what: string): RouteResult {
+  const cause = readCause(err);
+  if (cause?.kind === "guardTrip") {
+    logger.error(`${what}: ${formatBudgetExceeded(cause)}`);
+    return budgetExceeded(cause);
+  }
+  logger.error(`${what} threw: ${errorMessage(err)}`);
+  return fail(TOOL_ERROR_MESSAGE);
+}
+
 async function callFunction(
   fn: ExportedFunction,
   body: unknown,
@@ -70,8 +109,7 @@ async function callFunction(
     const result = await fn.invoke(toArgs(body));
     return ok(result);
   } catch (err) {
-    logger.error(`function ${fn.name} threw: ${errorMessage(err)}`);
-    return fail(TOOL_ERROR_MESSAGE);
+    return errorResult(err, logger, `function ${fn.name}`);
   }
 }
 
@@ -88,8 +126,7 @@ async function callNode(
     if (hasInterrupts(result.data)) return interruptResult(result.data);
     return ok(result.data);
   } catch (err) {
-    logger.error(`node ${node.name} threw: ${errorMessage(err)}`);
-    return fail(TOOL_ERROR_MESSAGE);
+    return errorResult(err, logger, `node ${node.name}`);
   }
 }
 
@@ -117,8 +154,7 @@ async function resumeInterrupts(
     if (hasInterrupts(result.data)) return interruptResult(result.data);
     return ok(result.data);
   } catch (err) {
-    logger.error(`resume threw: ${errorMessage(err)}`);
-    return fail(TOOL_ERROR_MESSAGE);
+    return errorResult(err, logger, "resume");
   }
 }
 


### PR DESCRIPTION
## What

The three agency-lang fixes from `2026-08-03-agency-lang-changes-for-spend-controls.md`, so statelog's per-agent `budget` (set via `withRuntimeConfigOverrides({ budget })`) actually enforces.

## Change 1 — propagate `budget` into the execution context (blocking)

`RuntimeContext` resolved the override budget into `this.budget`, but `createExecutionContext` copies non-serialized fields one by one and **never copied `budget`**. So `execCtx.budget` was `undefined`, `installRootBudget` installed nothing, and the feature was a **silent no-op** for every run. Fixed by copying it next to `maxCallDepth`/`failurePropagation`, with a test for the `RuntimeContext` → `execCtx` handoff my #792 tests missed.

## Change 2 — re-assert the root budget on resume (host-authoritative limit, spend preserved)

The root guard is serialized **with the checkpoint**, so on a stateless served resume its limit arrives from a caller-controllable payload — a crafted resume could raise the ceiling. On resume, `reinstallRootBudget` now **clamps the restored root guard's limit to the host value while keeping the guard and its accumulated spend/elapsed** (per review):

- the ceiling is host-authoritative and un-raisable from a client checkpoint;
- accumulated spend is preserved, so the trusted in-process CLI resume path (`agency run --max-cost` across a pause) **stays cumulative — no regression**; a served client that lowers its own reported spend only hurts itself (the residual stateless gap a stateless resume always has);
- arming is untouched (restored guards are un-armed by `restoreState`), so no timer pop-race is reintroduced.

A dimension the host no longer caps drops its restored guard through `uninstall()`; a dimension the host caps but the checkpoint lacked gets a fresh guard. No-op in IPC.

## Change 3 — typed `budgetExceeded` from the serve adapter (recommended)

A root-budget trip threw and the adapter returned the generic `"Tool execution failed"`. It now detects the `guardTrip` cause (mirroring `budgetExit`) and returns a typed **HTTP 402** `{ success: false, code: "budgetExceeded", dimension, limit, spent, error }`; other errors keep the generic message so no server detail leaks.

## Handoff question

> can agency-lang expose the authoritative accumulated spend for a run?

Yes — the root `CostGuard`'s serialized `spent` (and `StateStack.localCost`), already in the checkpoint. statelog can read it from the checkpoint it stores for the stateful path.

## Verification

`pnpm run typecheck` (source + tests + evals), `pnpm run lint:structure`, `git diff --check` — clean. New/affected tests pass: the `createExecutionContext` budget copy; `reinstallRootBudget` (clamp keeps the instance + host limit, time clamp, fresh-install edge, non-root preserved, host-removed drop, IPC no-op); the serve adapter's 402 vs generic error; `interrupts`/`configOverrides` unchanged-green. (`functionFrame.integration.test.ts` is build-gated, runs in CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)