### PR TITLE
feat(serve): per-invocation usage seam for hosted spend tracking

### DIFF
--- a/packages/agency-lang/docs/dev/async-context.md
+++ b/packages/agency-lang/docs/dev/async-context.md
@@ -99,3 +99,13 @@ The two external entry points called from host TS code — `respondToInterrupts`
 - PR [#200](https://github.com/egonSchiele/agency-lang/pull/200) — explicit `threads:` on the Runner constructor so per-scope ALS frames carry the right `ThreadStore`.
 - PR [#201](https://github.com/egonSchiele/agency-lang/pull/201) — first accessor migration (`__threads()`), template for the rest of Phase 4 cleanup.
 - [docs/dev/adding-a-module-to-the-agency-stdlib.md](./adding-a-module-to-the-agency-stdlib.md) — step-by-step recipe for adding a new module.
+
+## Paid-usage accounting reads the frame
+
+`recordPaidUsage(delta)` (the ambient half of `lib/runtime/recordPaidUsage.ts`,
+used only by `addCost`) reads `{ ctx, stack }` from the active `agencyStore`
+frame via `getRuntimeContext()`. Out-of-frame callers — notably the IPC
+telemetry handler, which runs from an event-loop message callback outside any
+frame — must use the explicit-target `recordPaidUsageAt({ ctx, stack }, delta)`
+with `RunSession.ctx/stateStack` instead, never the ambient form. See the serve
+cost seam section of `hosted-agent-execution.md`.

--- a/packages/agency-lang/docs/dev/hosted-agent-execution.md
+++ b/packages/agency-lang/docs/dev/hosted-agent-execution.md
@@ -290,3 +290,63 @@ These are accepted for the current trusted, single-tenant posture and tracked in
 ## PR history (the arc, for context)
 
 The feature landed as a sequence of small PRs. In agency-lang: the `./serve` public API; per-agent observability (`withRuntimeConfigOverrides`, released in 0.11.0); `/list` function parameters; `compileSource(sourcePath)` (released in 0.12.0); `agency deploy` (single-file, then multi-file). In statelog: migration to the newer agency-lang, the `/list` + `/function` + `/node` + `/resume` serve host, per-agent auto-observability, the `endpointUrls`-point-at-`/serve` fix, and multi-file serve support. The dependency direction is one-way: statelog consumes published agency-lang versions, so an agency-lang change ships first (merge + publish), then statelog bumps the dependency.
+
+---
+
+## Serve cost seam — per-invocation usage
+
+A host that runs an agent (statelog, "platform pays") needs the **authoritative**
+cost of each hosted invocation, read from the run it executed — not from
+client-supplied `/api/logs` telemetry, which the tracked party can forge. Every
+post-execution serve `RouteResult` therefore carries a `usage` figure.
+
+**The meter.** Each execution context owns a fresh `InvocationUsageMeter`
+(`lib/runtime/invocationUsage.ts`), set in `createExecutionContext` and **never
+serialized or restored** from a checkpoint. Because each `/node`, `/function`,
+and `/resume` invocation builds its own execCtx, per-leg and concurrent isolation
+are structural: a resume leg starts at zero (it does **not** inherit the
+checkpoint-carried `stateStack.localCost`), and two concurrent requests never
+share a meter.
+
+**One accounting boundary.** Every paid unit of work submits one
+`InvocationUsageDelta` to `recordPaidUsageAt({ ctx, stack }, delta)`
+(`lib/runtime/recordPaidUsage.ts`), which bills the branch's cost guards (reusing
+`StateStack.billCharge`), merges the invocation meter, and relays the full delta
+upward once when this process is a subprocess. The three paid sites route through
+it: the LLM completion (`prompt.ts` → `accountCompletionUsage`), `addCost`
+(memory / image generation), and the IPC telemetry handler. So `pricedCost` means
+*all* trusted billable spend and never depends on execution topology (an
+`addCost` charge counts identically in-process and in a child). `addCost` throws
+on invalid input rather than silently dropping a real charge.
+
+**Pricing vs delivery completeness — two axes, never conflated.**
+`pricingComplete` (on the usage) is derived: `unknownCostCallCount === 0`. A
+finite `0` price is a KNOWN free price; only an *absent* price is unknown.
+`usageComplete` (on the snapshot) starts true and becomes permanently false when
+an **abnormal subprocess termination** (a kill, error, or unexpected close) means
+unsent child telemetry cannot be ruled out — making `usage` a trusted **lower
+bound**, relayed upward once. Normal `result`/`interrupted` completions stay
+complete (IPC FIFO guarantees all telemetry preceded the terminal message).
+
+**The invocation boundary.** `runNode` / `runExportedFunction` /
+`respondToInterrupts` each split into an internal core that returns a
+`ServedInvocationOutcome<T>` (`{ status:"returned", value } | { status:"threw",
+error }` plus the usage snapshot) and a public wrapper that unwraps-or-rethrows —
+so the CLI/debugger contract is unchanged. The `…ForServe` variants hand the
+outcome to the serve adapters. The lifecycle boundary starts the moment the
+execution context exists, so an already-aborted signal or a setup failure still
+yields an outcome-with-usage and still runs cleanup; the meter snapshot is taken
+**after** cleanup so cleanup-incurred paid work counts. User values and thrown
+errors are never mutated or wrapped (identity, `readCause`, stack, cause
+preserved).
+
+**The wire.** Generated modules export `__invokeNodeForServe` /
+`__invokeFunctionForServe` / `__respondToInterruptsForServe` (see
+`imports.mustache`); `discoverExports` **requires** them and fails fast with a
+recompile-required error otherwise (older bundles are already unsupported for
+served functions). The HTTP adapter's one `routeResultFor` mapper attaches
+`usage` (and `usageComplete`) to every post-execution `RouteResult` — success,
+interrupt, 402 `budgetExceeded`, generic failure, cancellation — and omits it on
+`/list`, 404, and validation 400. The host reads `usage` in-process; it is not
+part of the standalone HTTP body. MCP unwraps the outcome to the raw value (or
+rethrows) and does not expose usage in v1.

--- a/packages/agency-lang/docs/dev/hosted-agent-execution.md
+++ b/packages/agency-lang/docs/dev/hosted-agent-execution.md
@@ -342,11 +342,23 @@ preserved).
 
 **The wire.** Generated modules export `__invokeNodeForServe` /
 `__invokeFunctionForServe` / `__respondToInterruptsForServe` (see
-`imports.mustache`); `discoverExports` **requires** them and fails fast with a
-recompile-required error otherwise (older bundles are already unsupported for
-served functions). The HTTP adapter's one `routeResultFor` mapper attaches
-`usage` (and `usageComplete`) to every post-execution `RouteResult` — success,
-interrupt, 402 `budgetExceeded`, generic failure, cancellation — and omits it on
-`/list`, 404, and validation 400. The host reads `usage` in-process; it is not
-part of the standalone HTTP body. MCP unwraps the outcome to the raw value (or
-rethrows) and does not expose usage in v1.
+`imports.mustache`). The **public** `ExportedFunction.invoke` /
+`ExportedNode.invoke` keep their original raw contract (value-or-throw; node
+positional args) for host apps that construct/consume these directly; the serve
+adapters use a separate internal `invokeServed` that `discoverExports` wires to
+the `…ForServe` invokers. `discoverExports` requires each serve invoker **only
+for the kind actually exported** (a node-only bundle needs just the node one) and
+fails fast with a recompile-required error otherwise — **served bundles must be
+recompiled** to report usage. The HTTP adapter's one `routeResultFor` mapper
+attaches `usage` (and the sibling `usageComplete`) to every post-execution
+`RouteResult` — success, interrupt, 402 `budgetExceeded`, generic failure,
+cancellation — and omits both on `/list`, 404, and validation 400. The host
+reads them in-process; they are not part of the standalone HTTP body. MCP unwraps
+the outcome to the raw value (or rethrows) and does not expose usage in v1.
+
+**In-process dispatch failures count too.** Beyond a returned-but-unpriced
+completion, a provider request that is *dispatched and then times out / is
+cancelled / errors after dispatch* may have incurred untracked spend with no
+price metadata, so each such attempt (each retry is a fresh attempt, via
+`meteredDispatch`) adds one to `unknownCostCallCount` and flips `pricingComplete`
+false. A failure proven *before* dispatch counts nothing.

--- a/packages/agency-lang/docs/superpowers/plans/2026-08-04-serve-cost-seam.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-08-04-serve-cost-seam.md
@@ -1,0 +1,313 @@
+# Serve Cost Seam — Implementation Plan (agency-lang half)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Revision 3 (2026-08-04):** Incorporates both reviews and the focused `docs/dev/anti-patterns.md` audit. All ownership and compatibility decisions are now locked; no task defers an architectural choice to implementation.
+
+**Goal:** Surface trusted, fresh per-invocation usage on every post-execution HTTP serve outcome, including whether subprocess telemetry is complete, without changing ordinary node/function/resume or MCP wire semantics.
+
+**Architecture:** There are two declarative boundaries. Accounting sites submit an `InvocationUsageDelta` to `recordPaidUsageAt({ ctx, stack }, delta)`, which reuses `StateStack.billCharge` for branch/guard bookkeeping, merges the invocation meter, and relays the full delta once; `recordPaidUsage(delta)` is only an ambient convenience for TS helpers such as `addCost`. Runtime execution is owned by outcome-producing cores; existing public APIs unwrap-or-rethrow their `ServedInvocationOutcome`, while generated serve-only invokers return the outcome to HTTP/MCP adapters.
+
+**Tech Stack:** TypeScript runtime (`lib/runtime/`), typestache templates, HTTP/MCP serve adapters, Node IPC, Vitest.
+
+## Global Constraints
+
+- A meter is fresh for every execution context and is never serialized or restored from a checkpoint.
+- `pricedCost` includes every valid nonnegative amount that participates in `StateStack.billCharge`, including `addCost` and subprocess spend.
+- Finite zero is a known free price. An absent, negative, or non-finite completion price is unknown, contributes zero priced cost, and increments `unknownCostCallCount`.
+- Invalid `addCost` input throws; it is never silently normalized to zero.
+- Usage is present on success, interrupt, 402, generic failure, and cancellation after an execution context exists. `/list`, 404, and pre-context 400 responses omit it.
+- `usageComplete` describes telemetry delivery, while `pricingComplete` describes price availability. Never overload one for the other.
+- Returned values and thrown errors are never mutated or wrapped. Preserve error identity, `readCause`, stack, cause, runtime/statelog error reporting, and 402 classification.
+- Handler registration and cleanup order are safety infrastructure and must remain unchanged.
+- `recordPaidUsageAt` is synchronous. IPC telemetry handling must remain synchronous through billing and guard enforcement.
+- Modify `.mustache` template sources and run `pnpm run templates`; do not hand-edit generated template `.ts` files.
+- Follow `docs/dev/coding-standards.md` and `docs/dev/anti-patterns.md`: types not interfaces, objects not maps, arrays not sets, no dynamic imports.
+- Save test output to a file on every run so failures can be inspected without rerunning expensive tests.
+
+## Locked Contracts
+
+```ts
+export type InvocationUsage = {
+  pricedCost: number;
+  inputTokens: number;
+  outputTokens: number;
+  unknownCostCallCount: number;
+  pricingComplete: boolean;
+};
+
+export type InvocationUsageDelta = {
+  pricedCost: number;
+  inputTokens: number;
+  outputTokens: number;
+  unknownCostCallCount: number;
+};
+
+export type InvocationUsageSnapshot = {
+  usage: InvocationUsage;
+  usageComplete: boolean;
+};
+
+export type ServedInvocationOutcome<T> =
+  | ({ status: "returned"; value: T } & InvocationUsageSnapshot)
+  | ({ status: "threw"; error: unknown } & InvocationUsageSnapshot);
+
+export type InvocationAccountingTarget = {
+  ctx: RuntimeContext<GraphState>;
+  stack: StateStack;
+};
+```
+
+`pricingComplete` is derived from `unknownCostCallCount === 0`. `usageComplete` starts `true` and becomes permanently `false` if an abnormal subprocess termination means unsent usage cannot be ruled out. A `false` value makes `usage` a trusted lower bound, not an authoritative final total; the statelog consumer must treat that attempt conservatively.
+
+### Exact invocation compatibility seam
+
+The runtime exposes outcome-returning functions:
+
+```ts
+runNodeForServe(args): Promise<ServedInvocationOutcome<RunNodeResult<any>>>
+runExportedFunctionForServe(args): Promise<ServedInvocationOutcome<unknown>>
+respondToInterruptsForServe(args): Promise<ServedInvocationOutcome<RunNodeResult<any>>>
+```
+
+Existing `runNode`, `runExportedFunction`, and `respondToInterrupts` call the same internal cores and use `unwrapServedInvocationOutcome` to preserve their current raw return/throw contracts.
+
+Current compiled modules add three separate exports without changing existing exports:
+
+```ts
+__invokeNodeForServe(nodeName, data)
+__invokeFunctionForServe(fn, namedArgs)
+__respondToInterruptsForServe(interrupts, responses, opts?)
+```
+
+`discoverExports` requires these current-compile serve invokers. Old bundles without them fail fast with a recompile-required error; they cannot satisfy the usage contract. The existing exported node functions, `__invokeFunction`, and `respondToInterrupts` remain unchanged for CLI, debugger, subprocess, and other callers.
+
+---
+
+### Task 1: Usage types, validation, and meter
+
+**Files:**
+- Create: `lib/runtime/invocationUsage.ts`
+- Create: `lib/runtime/invocationUsage.test.ts`
+
+**Interfaces:**
+- Produces: all locked types above; `InvocationUsageMeter`; `completionUsageDelta`; `paidCostDelta`; `normalizeUsageDelta`; `unwrapServedInvocationOutcome`.
+
+```ts
+export class InvocationUsageMeter {
+  merge(delta: InvocationUsageDelta): void;
+  markIncomplete(): boolean; // true only on the first complete → incomplete transition
+  snapshot(): InvocationUsageSnapshot;
+}
+
+export function completionUsageDelta(args: {
+  cost: number | null | undefined;
+  inputTokens: number | null | undefined;
+  outputTokens: number | null | undefined;
+}): InvocationUsageDelta;
+
+export function paidCostDelta(amount: number): InvocationUsageDelta;
+export function normalizeUsageDelta(raw: unknown): InvocationUsageDelta | null;
+export function unwrapServedInvocationOutcome<T>(outcome: ServedInvocationOutcome<T>): T;
+```
+
+- [ ] **Step 1: Write failing unit tests.** Cover accumulation with `toBeCloseTo`; fresh completeness; permanent `markIncomplete`; `undefined`, `null`, zero, positive, negative, and `NaN` completion prices; absent tokens as zero; invalid tokens as zero; `paidCostDelta` rejecting negative/non-finite values; normalization preserving valid fields while converting an invalid cost into one unknown-cost call; and unwrap preserving thrown error identity, including strings and frozen objects.
+- [ ] **Step 2: Run the tests and verify failure.** Run `pnpm vitest run lib/runtime/invocationUsage.test.ts > /tmp/serve-cost-task1.log 2>&1; code=$?; cat /tmp/serve-cost-task1.log; exit $code`. Expected: failure because the module does not exist.
+- [ ] **Step 3: Implement the types and arithmetic.** Use private numeric fields in the meter. Validate token/count fields as finite nonnegative integers. Treat invalid completion cost as unknown; never as known-free zero.
+- [ ] **Step 4: Run the same command and verify it passes.**
+- [ ] **Step 5: Commit the task.**
+
+### Task 2: Fresh, non-serialized execution-context ownership
+
+**Files:**
+- Modify: `lib/runtime/state/context.ts`
+- Create: `lib/runtime/state/context.invocationUsage.test.ts`
+
+**Interfaces:**
+- Consumes: `InvocationUsageMeter`.
+- Produces: `RuntimeContext.invocationUsage: InvocationUsageMeter`.
+
+- [ ] **Step 1: Write failing context tests.** Assert that each `createExecutionContext` creates an independent complete zero meter; `restoreState` does not replace or hydrate it; checkpoint and `toJSON` output omit it.
+- [ ] **Step 2: Run and capture failure.** Run `pnpm vitest run lib/runtime/state/context.invocationUsage.test.ts > /tmp/serve-cost-task2.log 2>&1; code=$?; cat /tmp/serve-cost-task2.log; exit $code`.
+- [ ] **Step 3: Implement the field.** Initialize it explicitly inside `createExecutionContext`, which bypasses the constructor. Do not add it to checkpoint serialization or `restoreState`.
+- [ ] **Step 4: Run the same command and verify it passes.**
+- [ ] **Step 5: Commit the task.**
+
+### Task 3: One explicit-target accounting operation
+
+**Files:**
+- Create: `lib/runtime/recordPaidUsage.ts`
+- Modify: `lib/runtime/state/stateStack.ts`
+- Modify: `lib/runtime/prompt.ts`
+- Modify: `lib/runtime/cost.ts`
+- Modify: `lib/runtime/costTelemetry.ts`
+- Test: `lib/runtime/recordPaidUsage.test.ts`
+- Test: `lib/runtime/prompt.test.ts`
+- Test: `lib/runtime/agency.test.ts`
+- Test: `lib/runtime/costTelemetry.test.ts`
+
+**Interfaces:**
+- Consumes: `InvocationAccountingTarget`, `InvocationUsageDelta`, `completionUsageDelta`, `paidCostDelta`.
+- Produces:
+
+```ts
+export function recordPaidUsageAt(
+  target: InvocationAccountingTarget,
+  delta: InvocationUsageDelta,
+): void;
+
+export function recordPaidUsage(delta: InvocationUsageDelta): void;
+
+export function markInvocationUsageIncompleteAt(
+  ctx: RuntimeContext<GraphState>,
+): void;
+```
+
+**Implementation rule:** `StateStack.billCharge(amount)` remains the sole implementation of `localCost` plus guard charging, but no longer emits IPC. `recordPaidUsageAt` calls `target.stack.billCharge`, merges `target.ctx.invocationUsage`, then calls `sendInvocationUsageToParent(delta)` once. `markInvocationUsageIncompleteAt` relays `sendInvocationUsageIncompleteToParent()` only when `meter.markIncomplete()` reports the first transition. Do not duplicate `billCharge` as `localCost += ...` plus `chargeGuards(...)` in the new file. `recordPaidUsage` reads ALS and delegates; only `addCost` uses it. Prompt passes its existing explicit `ctx` and `targetStack`. IPC will pass `RunSession.ctx/stateStack` in Task 4.
+
+- [ ] **Step 1: Write failing accounting tests.** Prove one call bills local cost and guards once, merges once, and sends once; no IPC send occurs inside `billCharge`; `addCost(0.25)` records cost and still enforces; invalid `addCost` throws before mutation; an explicit branch target charges that branch rather than `ctx.stateStack`; an unpriced completion records tokens/unknown count without charging guards; and repeated incomplete marks emit one marker.
+- [ ] **Step 2: Run and capture failure.** Run `pnpm vitest run lib/runtime/recordPaidUsage.test.ts lib/runtime/prompt.test.ts lib/runtime/agency.test.ts lib/runtime/costTelemetry.test.ts > /tmp/serve-cost-task3.log 2>&1; code=$?; cat /tmp/serve-cost-task3.log; exit $code`.
+- [ ] **Step 3: Implement the full-delta sender and accounting boundary.** Define `sendInvocationUsageToParent(delta)` and `sendInvocationUsageIncompleteToParent()` in `costTelemetry.ts`. Preserve prompt's existing enforce-later behavior and `addCost`'s immediate `enforceGuards` behavior. Do not add an await.
+- [ ] **Step 4: Run the Step 2 command and verify pass.**
+- [ ] **Step 5: Commit the task.**
+
+### Task 4: Full IPC deltas, out-of-frame accounting, and delivery completeness
+
+**Files:**
+- Modify: `lib/runtime/ipc.ts`
+- Test: `lib/runtime/costTelemetry.test.ts`
+- Test: `lib/runtime/ipc.test.ts`
+
+**Interfaces:**
+- Consumes: `recordPaidUsageAt`, `markInvocationUsageIncompleteAt`, `normalizeUsageDelta`.
+- Produces a telemetry union containing a full usage delta and an incompleteness marker; retains legacy `{ type: "telemetry", costUsd }` receive compatibility.
+
+**Delivery rule:** normal child completion relies on IPC FIFO: usage messages precede the terminal result/interrupt message. Every abnormal child termination marks the owning invocation incomplete before settlement and relays an incompleteness marker if this process is itself a child. Hard-kill paths keep accepting already-delivered post-settle usage as a best-known lower bound. Do not claim `usageComplete: true` after a killed child, even if its `close` event arrives cleanly, because unsent child telemetry cannot be ruled out.
+
+- [ ] **Step 1: Write failing wire tests.** Cover full-delta serialization; zero-cost unpriced usage; legacy cost-only normalization; invalid cost becoming unknown rather than known-free; malformed token/count fields; sender failure remaining non-throwing; and an incompleteness marker.
+- [ ] **Step 2: Write failing handler tests.** Call `handleTelemetryMessage` without an ALS frame and assert it uses `s.ctx/s.stateStack`; assert exact one-child and grandchild totals; assert enforcement stays synchronous; assert any wall-clock kill, cancellation kill, guard-trip kill, child error, unexpected close, or non-observational IPC failure permanently marks usage incomplete and relays the marker upward.
+- [ ] **Step 3: Run `pnpm vitest run lib/runtime/costTelemetry.test.ts lib/runtime/ipc.test.ts > /tmp/serve-cost-task4.log 2>&1; code=$?; cat /tmp/serve-cost-task4.log; exit $code` and verify failure.**
+- [ ] **Step 4: Implement the wire and handlers.** Keep telemetry handling synchronous. An incompleteness marker is idempotent locally but each process relays a received marker once; no cost is billed for the marker.
+- [ ] **Step 5: Run the Step 3 command and verify pass.**
+- [ ] **Step 6: Commit the task.**
+
+### Task 5: Outcome-producing runtime cores with compatibility wrappers
+
+**Files:**
+- Modify: `lib/runtime/node.ts`
+- Modify: `lib/runtime/interrupts.ts`
+- Modify: `lib/runtime/index.ts`
+- Create: `lib/runtime/invocationOutcome.test.ts`
+
+**Interfaces:**
+- Consumes: `ServedInvocationOutcome`, `InvocationUsageSnapshot`, `unwrapServedInvocationOutcome`.
+- Produces: `runNodeForServe`, `runExportedFunctionForServe`, `respondToInterruptsForServe` with the exact signatures in “Locked Contracts”.
+
+**Lifecycle rule:** each runtime file extracts one internal core that creates the execution context and returns an outcome. Immediately after successful context creation, one outer lifecycle boundary covers initialization, handler registration, budgets, callbacks, abort wiring, execution, error telemetry, and cleanup. Existing public functions call that core and unwrap-or-rethrow. Serve functions return the outcome unchanged.
+
+For cleanup, retain the first execution error as the outcome error. Log a later cleanup error without replacing the first. If execution succeeded but cleanup failed, return a threw outcome containing the cleanup error. Take the final meter snapshot after cleanup attempts so cleanup-incurred paid usage is included. Preserve current statelog `runtimeError`/`agentEnd` emission and handler order.
+
+- [ ] **Step 1: Write failing outcome tests.** Cover object/primitive/`undefined` returns; ordinary `Error`, string, frozen object, guard trip, and `AgencyCancelledError`; already-aborted input; post-context initialization failure; cleanup failure after success; cleanup failure after an execution error; runtime/statelog error emission; handler installation order; and resume-leg isolation.
+- [ ] **Step 2: Add public compatibility tests.** Direct `runNode`, `runExportedFunction`, and `respondToInterrupts` calls must still return raw values and throw the identical original error.
+- [ ] **Step 3: Run `pnpm vitest run lib/runtime/invocationOutcome.test.ts > /tmp/serve-cost-task5.log 2>&1; code=$?; cat /tmp/serve-cost-task5.log; exit $code` and verify failure.**
+- [ ] **Step 4: Refactor into outcome cores and compatibility wrappers.** Do not wrap or mutate user errors. Keep handler registration inside the protected lifecycle.
+- [ ] **Step 5: Run `pnpm vitest run lib/runtime/invocationOutcome.test.ts lib/runtime/interrupts.test.ts lib/runtime/hooks.test.ts lib/runtime/rootBudget.test.ts > /tmp/serve-cost-task5-pass.log 2>&1; code=$?; cat /tmp/serve-cost-task5-pass.log; exit $code` and verify pass.**
+- [ ] **Step 6: Commit the task.**
+
+### Task 6: Generated serve-only invokers and discovery contract
+
+**Files:**
+- Modify: `lib/templates/backends/typescriptGenerator/imports.mustache`
+- Regenerate: `lib/templates/backends/typescriptGenerator/imports.ts` via `pnpm run templates`
+- Modify: `lib/serve/types.ts`
+- Modify: `lib/serve/discovery.ts`
+- Modify: `lib/serve/createServeHandler.ts`
+- Test: `lib/serve/discovery.test.ts`
+- Test: `lib/serve/createServeHandler.test.ts`
+
+**Interfaces:**
+- Consumes: the three runtime `*ForServe` functions.
+- Produces module exports `__invokeNodeForServe`, `__invokeFunctionForServe`, `__respondToInterruptsForServe`; discovered function/node invokers return `ServedInvocationOutcome<unknown>` whose returned `value` is already caller-facing data.
+
+**Generated shape:** `__invokeNodeForServe(nodeName, data)` calls `runNodeForServe` with `__globalCtx` and `__initializeGlobals`. Function and resume equivalents bind the same module context. Existing node exports, `__invokeFunction`, and `respondToInterrupts` remain byte-compatible. `discoverExports` maps a returned node `RunNodeResult` to its `.data` while retaining the same usage fields and leaves a threw outcome untouched.
+
+- [ ] **Step 1: Write failing discovery/factory tests.** Require all three serve invokers; return a clear “recompile with current Agency” error when absent; assert primitive function values, node `.data` mapping, unchanged errors, and preserved usage/completeness.
+- [ ] **Step 2: Run `pnpm vitest run lib/serve/discovery.test.ts lib/serve/createServeHandler.test.ts > /tmp/serve-cost-task6.log 2>&1; code=$?; cat /tmp/serve-cost-task6.log; exit $code` and verify failure.**
+- [ ] **Step 3: Modify only `imports.mustache`, then run `pnpm run templates`.** Inspect the generated `imports.ts`; do not edit it manually.
+- [ ] **Step 4: Implement typed discovery and factory wiring.** `createServeHandler` passes `__respondToInterruptsForServe`, not public `respondToInterrupts`.
+- [ ] **Step 5: Run the Step 2 test command, then `pnpm run typecheck > /tmp/serve-cost-task6-typecheck.log 2>&1; code=$?; cat /tmp/serve-cost-task6-typecheck.log; exit $code`; verify both pass.**
+- [ ] **Step 6: Commit the task.**
+
+### Task 7: Declarative HTTP and MCP adapter mapping
+
+**Files:**
+- Modify: `lib/serve/http/adapter.ts`
+- Modify: `lib/serve/mcp/adapter.ts`
+- Modify: `lib/serve/mcp/interruptLoop.ts`
+- Modify: `lib/cli/serve.ts`
+- Modify: `lib/templates/cli/standaloneHttp.mustache`
+- Modify: `lib/templates/cli/standaloneMcp.mustache`
+- Modify: `lib/templates/cli/standaloneMcpHttp.mustache`
+- Regenerate corresponding template `.ts` files via `pnpm run templates`
+- Test: `lib/serve/http/adapter.test.ts`
+- Test: `lib/serve/mcp/adapter.test.ts`
+- Test: `lib/serve/mcp/interruptLoop.test.ts`
+- Test: `lib/serve/createServeHandler.test.ts`
+
+**Interfaces:**
+- Consumes: `ServedInvocationOutcome<unknown>` from every discovered invocation and serve resume.
+- Produces HTTP `RouteResult` with optional `usage?: InvocationUsage` and `usageComplete?: boolean`; MCP wire remains unchanged.
+
+**HTTP rule:** one `routeResultFor(outcome, options)` accepts `{ renderReturned, logger, what }`. Function routes supply `renderReturned: ok`; node/resume routes supply a callback that preserves today's interrupt detection before calling `ok`. Thrown outcomes retain today's 402/generic classification and server-side logging. The mapper adds usage fields once; pre-execution helpers continue returning no usage fields. `readCause` runs on the original `outcome.error`.
+
+**MCP rule:** one local outcome-unwrapper returns `value` or throws `error` before entering the existing policy loop. Resume handlers call `__respondToInterruptsForServe`, unwrap the outcome, then unwrap `RunNodeResult.data`. MCP does not expose usage in v1. Preserve existing server-side/statelog error logging; converting an exception to an outcome is transport, not swallowing.
+
+- [ ] **Step 1: Write failing HTTP tests.** Assert usage and completeness on success, interrupt, 402, generic failure, and cancellation; omission on `/list`, 404, and validation 400; and otherwise unchanged response bodies.
+- [ ] **Step 2: Write failing MCP/CLI/template tests.** Assert function/node values and errors are wire-identical; policy-driven resume still works; generated standalone HTTP uses serve resume; generated standalone MCP variants unwrap serve resume.
+- [ ] **Step 3: Run `pnpm vitest run lib/serve/http/adapter.test.ts lib/serve/mcp/adapter.test.ts lib/serve/mcp/interruptLoop.test.ts lib/serve/createServeHandler.test.ts > /tmp/serve-cost-task7.log 2>&1; code=$?; cat /tmp/serve-cost-task7.log; exit $code` and verify failure.**
+- [ ] **Step 4: Implement the single HTTP mapper and MCP unwrapping.** Avoid duplicated per-branch usage decoration and nested ternaries.
+- [ ] **Step 5: Run `pnpm run templates > /tmp/serve-cost-task7-templates.log 2>&1`, the Step 3 test command, and `pnpm run typecheck > /tmp/serve-cost-task7-typecheck.log 2>&1`; inspect all three saved logs and verify pass.**
+- [ ] **Step 6: Commit the task.**
+
+### Task 8: End-to-end behavioral proof
+
+**Files:**
+- Create: `lib/serve/http/serveCostSeam.integration.test.ts`
+
+- [ ] **Step 1: Add compiled-module integration cases.** Through the real HTTP handler, prove exact usage for function/node success, interrupt, 402, generic throw, and cancellation; genuine zero price versus absent/invalid price; in-process versus child `addCost`; one child and one grandchild; two concurrent requests; and two resume legs that each exclude prior-leg usage.
+- [ ] **Step 2: Add completeness cases.** Normal subprocess completion returns `usageComplete: true`; forced child kill returns `false`; a delivered late telemetry delta remains in the lower-bound usage when observed before the outcome.
+- [ ] **Step 3: Run only this integration file into `/tmp/serve-cost-task8.log` and verify pass.** Do not run the full Agency execution suite.
+- [ ] **Step 4: Run `pnpm run lint:structure` and `pnpm run typecheck`, saving output, and fix only issues caused by this change.**
+- [ ] **Step 5: Commit the task.**
+
+### Task 9: Developer documentation
+
+**Files:**
+- Modify: `docs/dev/hosted-agent-execution.md`
+- Modify: `docs/dev/async-context.md`
+
+- [ ] **Step 1: Document the accounting boundary.** Explain explicit versus ambient ownership, `billCharge` reuse, per-leg/non-serialized meters, valid/unknown pricing, and exact-once IPC deltas.
+- [ ] **Step 2: Document the invocation boundary.** Explain public compatibility wrappers, generated serve-only exports, HTTP `usage`/`usageComplete`, MCP behavior, stale-bundle recompilation, and why abnormal child termination makes usage a trusted lower bound.
+- [ ] **Step 3: Run Markdown/diff checks and commit.** Do not edit generated `docs/site/**` pages.
+
+---
+
+## Self-Review Checklist
+
+- No placeholder or unresolved wrapper decision remains.
+- `recordPaidUsageAt` accepts explicit ownership; IPC never requires ALS.
+- `recordPaidUsageAt` reuses `StateStack.billCharge` instead of duplicating its mutable internals.
+- Prompt passes `targetStack`; IPC passes `RunSession.ctx/stateStack`; only `addCost` uses ambient ownership.
+- Function, node, and resume use the same outcome-core/compatibility-wrapper pattern.
+- Existing public runtime and MCP values/errors remain unchanged.
+- Existing runtime/statelog error logging remains inside the lifecycle core.
+- Pricing incompleteness and telemetry incompleteness are distinct.
+- Invalid prices cannot produce `pricingComplete: true`; invalid `addCost` cannot erase a charge silently.
+- Normal child telemetry is exact; abnormal child termination is explicitly marked incomplete and never presented as authoritative.
+- Handler registration is never skipped or restored from checkpoints.
+- Template source files, not generated files, are the hand-edited source of truth.
+- No full Agency test suite is run locally.
+
+## Deferred
+
+`runId` is not added to the usage result in v1. Correlation remains statelog-side and can be added separately without changing accounting correctness.

--- a/packages/agency-lang/lib/cli/serve.ts
+++ b/packages/agency-lang/lib/cli/serve.ts
@@ -20,7 +20,7 @@ import { startHttpServer } from "../serve/http/adapter.js";
 import { DEFAULT_HOST } from "../serve/http/security.js";
 import { createLogger } from "../logger.js";
 import { VERSION } from "../stdlib/version.js";
-import type { ExportedItem } from "../serve/types.js";
+import type { ServedExportedItem } from "../serve/types.js";
 import type { InterruptEffect } from "../symbolTable.js";
 import type { InterruptHandlers } from "../serve/mcp/interruptLoop.js";
 import { PolicyStore } from "../serve/policyStore.js";
@@ -65,7 +65,7 @@ function compileForServe(file: string, options: { quiet?: boolean } = {}): Compi
 
 async function loadAndDiscover(
   compileResult: CompileResult,
-): Promise<{ exports: ExportedItem[]; moduleExports: Record<string, unknown> }> {
+): Promise<{ exports: ServedExportedItem[]; moduleExports: Record<string, unknown> }> {
   const moduleUrl = pathToFileURL(path.resolve(compileResult.outputPath)).href;
   // eslint-disable-next-line no-restricted-syntax -- compiled module URL is only known at runtime
   const mod = await import(moduleUrl);

--- a/packages/agency-lang/lib/cli/serve.ts
+++ b/packages/agency-lang/lib/cli/serve.ts
@@ -6,6 +6,8 @@ import { loadConfig } from "./commands.js";
 import { compile } from "@/compiler/defaultSession.js";
 import { formatErrors } from "../typeChecker/index.js";
 import { collectServeMetadata } from "../serve/metadata.js";
+import { unwrapServedInvocationOutcome } from "../runtime/invocationUsage.js";
+import type { ServedInvocationOutcome } from "../runtime/invocationUsage.js";
 import { discoverExports } from "../serve/discovery.js";
 import { createMcpHandler, startStdioServer, mcpToolSummaryLines } from "../serve/mcp/adapter.js";
 import type { McpConfig } from "../serve/mcp/adapter.js";
@@ -136,16 +138,20 @@ export async function serveMcp(
   // returns { data: ... }. We normalize here so the interrupt loop sees a
   // consistent shape.
   const rawHasInterrupts = moduleExports.hasInterrupts as (data: unknown) => boolean;
-  const rawRespondToInterrupts = moduleExports.respondToInterrupts as (
+  const rawRespondToInterruptsForServe = moduleExports.__respondToInterruptsForServe as (
     interrupts: unknown[],
     responses: unknown[],
-  ) => Promise<{ data: unknown }>;
+  ) => Promise<ServedInvocationOutcome<{ data: unknown }>>;
 
   const interruptHandlers: InterruptHandlers = {
     hasInterrupts: rawHasInterrupts,
+    // Unwrap the serve outcome (rethrowing the original error) then the
+    // RunNodeResult's `{ data }`; MCP does not expose usage in v1.
     respondToInterrupts: async (interrupts, responses) => {
-      const wrapped = await rawRespondToInterrupts(interrupts, responses);
-      return wrapped.data;
+      const result = unwrapServedInvocationOutcome(
+        await rawRespondToInterruptsForServe(interrupts, responses),
+      );
+      return result.data;
     },
   };
 
@@ -321,10 +327,10 @@ export async function serveHttp(
     apiKey,
     logger,
     hasInterrupts: moduleExports.hasInterrupts as (data: unknown) => boolean,
-    respondToInterrupts: moduleExports.respondToInterrupts as (
+    respondToInterrupts: moduleExports.__respondToInterruptsForServe as (
       interrupts: unknown[],
       responses: unknown[],
-    ) => Promise<unknown>,
+    ) => Promise<ServedInvocationOutcome<unknown>>,
   });
 }
 

--- a/packages/agency-lang/lib/runtime/cost.ts
+++ b/packages/agency-lang/lib/runtime/cost.ts
@@ -1,15 +1,20 @@
 import { getRuntimeContext } from "./asyncContext.js";
+import { recordPaidUsage } from "./recordPaidUsage.js";
+import { paidCostDelta } from "./invocationUsage.js";
 
-/** Charge `amount` USD to the active branch, bill every active guard, and
- *  enforce limits — the exact sequence the built-in llm() path runs after each
- *  completion (see lib/runtime/prompt.ts). A TS helper wrapping its own paid
- *  call site calls this so the cost participates in getCost() / guard(cost:).
+/** Charge `amount` USD to the active branch: account it (guards + invocation
+ *  meter + subprocess relay) and enforce limits — the exact sequence the
+ *  built-in llm() path runs after each completion (see lib/runtime/prompt.ts). A
+ *  TS helper wrapping its own paid call site calls this so the cost participates
+ *  in getCost() / guard(cost:) / per-invocation usage accounting.
  *
- *  Throws (a guard-trip) if enforcement fails — callers must not swallow it. */
+ *  `amount` must be a finite, nonnegative number — invalid input THROWS (via
+ *  paidCostDelta) BEFORE any mutation, so a real charge is never silently
+ *  dropped. Throws (a guard-trip) if enforcement fails — callers must not
+ *  swallow it. */
 export function addCost(amount: number): void {
-  const stack = getRuntimeContext().stack;
-  stack.billCharge(amount);
-  stack.enforceGuards();
+  recordPaidUsage(paidCostDelta(amount));
+  getRuntimeContext().stack.enforceGuards();
 }
 
 /** Add `amount` tokens to the active branch accumulator. Sibling of addCost;

--- a/packages/agency-lang/lib/runtime/costTelemetry.test.ts
+++ b/packages/agency-lang/lib/runtime/costTelemetry.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { isPayableCost, sendCostTelemetryToParent } from "./costTelemetry.js";
+import {
+  isPayableCost,
+  sendInvocationUsageToParent,
+  sendInvocationUsageIncompleteToParent,
+} from "./costTelemetry.js";
 import { StateStack } from "./state/stateStack.js";
 import { CostGuard } from "./guard.js";
 
 // process.send has no vi.stubEnv equivalent — save/restore it manually.
-// Env vars are stubbed per test and reset via vi.unstubAllEnvs(): a leaked
-// AGENCY_IPC=1 would make every billCharge in later tests emit telemetry.
 const originalSend = process.send;
 
 afterEach(() => {
@@ -26,67 +28,66 @@ describe("isPayableCost", () => {
   });
 });
 
-describe("sendCostTelemetryToParent", () => {
-  it("sends the telemetry message when in IPC mode", () => {
+describe("sendInvocationUsageToParent", () => {
+  const delta = { pricedCost: 0.5, inputTokens: 100, outputTokens: 20, unknownCostCallCount: 0 };
+
+  it("sends the full delta when in IPC mode", () => {
     vi.stubEnv("AGENCY_IPC", "1");
     const send = vi.fn(() => true);
     process.send = send as any;
-    sendCostTelemetryToParent(0.5);
-    expect(send).toHaveBeenCalledExactlyOnceWith({ type: "telemetry", costUsd: 0.5 });
+    sendInvocationUsageToParent(delta);
+    expect(send).toHaveBeenCalledExactlyOnceWith({ type: "invocationUsage", ...delta });
+  });
+
+  it("sends a zero-cost unpriced delta (tokens/unknown must not be dropped)", () => {
+    vi.stubEnv("AGENCY_IPC", "1");
+    const send = vi.fn(() => true);
+    process.send = send as any;
+    sendInvocationUsageToParent({ pricedCost: 0, inputTokens: 3, outputTokens: 1, unknownCostCallCount: 1 });
+    expect(send).toHaveBeenCalledOnce();
+  });
+
+  it("skips an all-zero delta", () => {
+    vi.stubEnv("AGENCY_IPC", "1");
+    const send = vi.fn(() => true);
+    process.send = send as any;
+    sendInvocationUsageToParent({ pricedCost: 0, inputTokens: 0, outputTokens: 0, unknownCostCallCount: 0 });
+    expect(send).not.toHaveBeenCalled();
   });
 
   it("no-ops outside IPC mode", () => {
     const send = vi.fn(() => true);
     process.send = send as any;
-    sendCostTelemetryToParent(0.5);
-    expect(send).not.toHaveBeenCalled();
-  });
-
-  it("no-ops for zero, negative, and non-finite cost", () => {
-    vi.stubEnv("AGENCY_IPC", "1");
-    const send = vi.fn(() => true);
-    process.send = send as any;
-    sendCostTelemetryToParent(0);
-    sendCostTelemetryToParent(-1);
-    sendCostTelemetryToParent(NaN);
+    sendInvocationUsageToParent(delta);
     expect(send).not.toHaveBeenCalled();
   });
 
   it("swallows a dead-channel send error", () => {
     vi.stubEnv("AGENCY_IPC", "1");
     process.send = vi.fn(() => { throw new Error("channel closed"); }) as any;
-    expect(() => sendCostTelemetryToParent(0.5)).not.toThrow();
+    expect(() => sendInvocationUsageToParent(delta)).not.toThrow();
+  });
+});
+
+describe("sendInvocationUsageIncompleteToParent", () => {
+  it("sends the marker in IPC mode and no-ops otherwise", () => {
+    const send = vi.fn(() => true);
+    process.send = send as any;
+    sendInvocationUsageIncompleteToParent();
+    expect(send).not.toHaveBeenCalled();
+
+    vi.stubEnv("AGENCY_IPC", "1");
+    sendInvocationUsageIncompleteToParent();
+    expect(send).toHaveBeenCalledExactlyOnceWith({ type: "invocationUsageIncomplete" });
   });
 });
 
 describe("StateStack.billCharge", () => {
-  it("emits exactly once per charge, even with zero guards installed", () => {
-    // Emission must be unconditional on guards being present: a mid-tier
-    // relay process may have NO local guards but must still forward the
-    // grandchild spend upward.
+  it("no longer emits telemetry (relay rides the recordPaidUsageAt boundary)", () => {
     vi.stubEnv("AGENCY_IPC", "1");
     const send = vi.fn(() => true);
     process.send = send as any;
-    const stack = new StateStack();
-    stack.billCharge(0.25);
-    expect(send).toHaveBeenCalledExactlyOnceWith({ type: "telemetry", costUsd: 0.25 });
-  });
-
-  it("does not emit for a zero charge", () => {
-    vi.stubEnv("AGENCY_IPC", "1");
-    const send = vi.fn(() => true);
-    process.send = send as any;
-    new StateStack().billCharge(0);
-    expect(send).not.toHaveBeenCalled();
-  });
-
-  it("a direct chargeGuards call does NOT emit — emission rides the fresh-paid-charge semantic", () => {
-    // Pins the hoist: re-applying spend to guard accumulators (restore /
-    // reconciliation paths) must never double-bill the parent.
-    vi.stubEnv("AGENCY_IPC", "1");
-    const send = vi.fn(() => true);
-    process.send = send as any;
-    new StateStack().chargeGuards(0.25);
+    new StateStack().billCharge(0.25);
     expect(send).not.toHaveBeenCalled();
   });
 
@@ -96,8 +97,6 @@ describe("StateStack.billCharge", () => {
     stack.guards.push(guard);
     stack.billCharge(0.25);
     expect(stack.localCost).toBe(0.25);
-    // 0.25 > 0.1: check() reporting a trip proves the guard was charged,
-    // not just localCost.
     expect(guard.check(stack)).not.toBeNull();
   });
 });

--- a/packages/agency-lang/lib/runtime/costTelemetry.ts
+++ b/packages/agency-lang/lib/runtime/costTelemetry.ts
@@ -1,44 +1,94 @@
 /**
- * Fire-and-forget cost telemetry from a subprocess to its parent, so
- * parent-side cost guards see child LLM spend live (see
+ * Fire-and-forget usage telemetry from a subprocess to its parent, so
+ * parent-side cost guards see child LLM spend live AND the parent's
+ * per-invocation usage meter (the serve cost seam) accrues the child's
+ * cost/tokens/unknown-count (see
  * docs/superpowers/specs/2026-07-02-subprocess-cost-telemetry-design.md).
  *
- * Deliberately dependency-light (the subprocessRunInfo.ts layering
- * pattern — the only import IS subprocessRunInfo, itself dependency-free):
- * `StateStack.billCharge` calls this on every paid charge, and stateStack
- * must not import ipc.ts.
+ * Deliberately dependency-light (the subprocessRunInfo.ts layering pattern):
+ * the only runtime import is subprocessRunInfo; `InvocationUsageDelta` is a
+ * type-only import (erased at runtime), so this stays a leaf module.
+ * `recordPaidUsageAt` calls the sender here on every paid charge; stateStack /
+ * accounting must not import ipc.ts.
  *
- * Never blocks and never throws: there is no reply, no listener, and a
- * dead channel is swallowed — the bootstrap disconnect watchdog is about
- * to reap this process anyway.
+ * Never blocks and never throws: there is no reply, no listener, and a dead
+ * channel is swallowed — the bootstrap disconnect watchdog is about to reap
+ * this process anyway.
  */
 
 import { isIpcMode, ipcChildDebug } from "./subprocessRunInfo.js";
+import type { InvocationUsageDelta } from "./invocationUsage.js";
 
+/** Legacy cost-only telemetry message. No longer emitted by this codebase (the
+ *  full-delta message below supersedes it), but still ACCEPTED on receive so a
+ *  version-skewed child cannot silently drop cost. */
 export type IpcTelemetryMessage = {
   type: "telemetry";
   costUsd: number;
 };
 
-/** The wire contract for a billable cost: a positive finite number.
- * Shared by the sender and the parent-side handler so both ends of the
- * channel enforce the same rule (the receiving side matters more — the
- * child is the less-trusted party). */
+/** Full per-invocation usage delta relayed to the parent. A legal delta may
+ *  carry zero priced cost with nonzero tokens and/or one unknown-cost call (an
+ *  unpriced completion). */
+export type IpcInvocationUsageMessage = {
+  type: "invocationUsage";
+  pricedCost: number;
+  inputTokens: number;
+  outputTokens: number;
+  unknownCostCallCount: number;
+};
+
+/** Relayed once when a process can no longer guarantee that all of its (or a
+ *  descendant's) usage telemetry was delivered — makes the owning invocation's
+ *  usage a trusted lower bound. Carries no cost. */
+export type IpcInvocationUsageIncompleteMessage = {
+  type: "invocationUsageIncomplete";
+};
+
+export type IpcUsageMessage =
+  | IpcTelemetryMessage
+  | IpcInvocationUsageMessage
+  | IpcInvocationUsageIncompleteMessage;
+
+/** The wire contract for a legacy billable cost: a positive finite number.
+ *  Used only when normalizing a legacy `{ costUsd }` message on receive. */
 export function isPayableCost(costUsd: unknown): costUsd is number {
   return typeof costUsd === "number" && Number.isFinite(costUsd) && costUsd > 0;
 }
 
-export function sendCostTelemetryToParent(costUsd: number): void {
-  if (!isIpcMode() || typeof process.send !== "function") return;
-  if (!isPayableCost(costUsd)) return;
-  const msg: IpcTelemetryMessage = { type: "telemetry", costUsd };
+function canSend(): boolean {
+  return isIpcMode() && typeof process.send === "function";
+}
+
+function trySend(msg: IpcUsageMessage): void {
   try {
-    process.send(msg);
+    (process.send as (m: unknown) => boolean)(msg);
   } catch (err) {
     // Channel gone — parent died; the watchdog will exit this process.
-    // Deliberately swallowed (fire-and-forget invariant), but traceable via the
-    // shared child-debug logger (ipcLog is unreachable from this leaf module).
+    // Swallowed (fire-and-forget invariant), but traceable via the shared
+    // child-debug logger (ipcLog is unreachable from this leaf module).
     const detail = err instanceof Error ? err.message : String(err);
     ipcChildDebug(`send telemetry_send_failed ${detail}`);
   }
+}
+
+/** Relay a full usage delta to the parent, once. Skips an all-zero delta (a
+ *  no-op charge carries nothing worth relaying). */
+export function sendInvocationUsageToParent(delta: InvocationUsageDelta): void {
+  if (!canSend()) return;
+  if (
+    delta.pricedCost === 0 &&
+    delta.inputTokens === 0 &&
+    delta.outputTokens === 0 &&
+    delta.unknownCostCallCount === 0
+  ) {
+    return;
+  }
+  trySend({ type: "invocationUsage", ...delta });
+}
+
+/** Relay the incompleteness marker to the parent, once. */
+export function sendInvocationUsageIncompleteToParent(): void {
+  if (!canSend()) return;
+  trySend({ type: "invocationUsageIncomplete" });
 }

--- a/packages/agency-lang/lib/runtime/index.ts
+++ b/packages/agency-lang/lib/runtime/index.ts
@@ -88,6 +88,7 @@ export {
   pass,
   interruptWithHandlers,
   respondToInterrupts,
+  respondToInterruptsForServe,
 } from "./interrupts.js";
 
 export { checkPolicy, checkPolicyExplicit, validatePolicy } from "./policy.js";
@@ -130,7 +131,19 @@ export {
 } from "./state/checkpointStore.js";
 export type { Checkpoint } from "./state/checkpointStore.js";
 
-export { setupNode, setupFunction, runNode, runExportedFunction } from "./node.js";
+export {
+  setupNode,
+  setupFunction,
+  runNode,
+  runExportedFunction,
+  runNodeForServe,
+  runExportedFunctionForServe,
+} from "./node.js";
+export type {
+  InvocationUsage,
+  InvocationUsageSnapshot,
+  ServedInvocationOutcome,
+} from "./invocationUsage.js";
 export { reportBudgetExceededAndExit, formatBudgetExceeded } from "./budgetExit.js";
 export { Runner } from "./runner.js";
 

--- a/packages/agency-lang/lib/runtime/interrupts.ts
+++ b/packages/agency-lang/lib/runtime/interrupts.ts
@@ -25,8 +25,13 @@ import { loadProviderModules } from "./providerModules.js";
 import { installRunPolicyHandler } from "./runPolicyHandler.js";
 import { GlobalStore, GlobalStoreJSON } from "./state/globalStore.js";
 import { StateStack, StateStackJSON } from "./state/stateStack.js";
-import { Approved, GraphState, Rejected } from "./types.js";
+import { Approved, GraphState, Rejected, RunNodeResult } from "./types.js";
 import type { HandlerEntry } from "./types.js";
+import {
+  unwrapServedInvocationOutcome,
+  type ServedInvocationOutcome,
+} from "./invocationUsage.js";
+import { finishServedInvocation, type RawOutcome } from "./servedInvocationLifecycle.js";
 import { createReturnObject, deepClone } from "./utils.js";
 import { isIpcMode, sendInterruptToParent } from "./ipc.js";
 import {
@@ -737,13 +742,17 @@ async function runResumeLoop(
   }
 }
 
-export async function respondToInterrupts(args: {
+type RespondToInterruptsArgs = {
   ctx: RuntimeContext<GraphState>;
   interrupts: Interrupt[];
   responses: InterruptResponse[];
   overrides?: Record<string, unknown>;
   metadata?: Record<string, any>;
-}): Promise<any> {
+};
+
+async function respondToInterruptsCore(
+  args: RespondToInterruptsArgs,
+): Promise<ServedInvocationOutcome<RunNodeResult<any>>> {
   const { ctx, interrupts, responses, metadata = {} } = args;
   const responseMap = buildResponseMap(interrupts, responses);
 
@@ -762,72 +771,79 @@ export async function respondToInterrupts(args: {
   if (args.overrides) applyOverrides(checkpoint, args.overrides);
 
   const execCtx = await ctx.createExecutionContext(interrupt.runId);
-  // Re-install the CLI-driven root policy handler on the resumed exec context
-  // (handlers are never checkpointed). Guarded no-op unless AGENCY_RUN_POLICY
-  // is set and this is the root process. Mirrors the runNode install so the
-  // policy survives a resumed leg.
-  installRunPolicyHandler(execCtx);
-  // A cross-process resume starts with an empty provider registry (registration
-  // is process-global, not part of serialized checkpoint state), so re-register
-  // before resuming. Idempotent in-process via loadProviderModules' guard.
-  await loadProviderModules(execCtx);
-  // This is the first restore on this execCtx — record it as such.
-  execCtx._restoreCount++;
-  execCtx.statelogClient.checkpointRestored({
-    checkpointId: checkpoint.id,
-    restoreCount: execCtx._restoreCount,
-  });
-  // Each user response resolves a previously-thrown interrupt. Emit the
-  // lifecycle event so dashboards can pair every interruptThrown with a
-  // terminal interruptResolved. Suppressed in IPC mode: a resumed
-  // subprocess segment re-enters respondToInterrupts with the SAME
-  // preserved interrupt ids in the same inherited trace, and the root
-  // process already emitted the user resolution — a second (or, nested,
-  // N+1th) emission would break thrown↔resolved pairing for consumers.
-  if (!isIpcMode()) {
-    for (let i = 0; i < interrupts.length; i++) {
-      const intr = interrupts[i];
-      const resp = responses[i];
-      const outcome =
-        resp.type === "approve" ? "approved" : ("rejected" as const);
-      execCtx.statelogClient.interruptResolved({
-        interruptId: intr.interruptId,
-        outcome,
-        resolvedBy: "user",
-      });
-    }
-  }
-  // Re-register top-level callbacks BEFORE restoreState so the
-  // `_callbackImpl` routing check (`stateStack.isGlobalContext()`)
-  // sees the still-empty stack and pushes onto `ctx.topLevelCallbacks`.
-  // After `restoreState`, the stack carries the checkpoint frames and
-  // the same registration would instead bind to a caller frame and be
-  // popped immediately as the restored frames unwind.
-  //
-  // The bootstrap frame mirrors `runNode` — top-level callback
-  // registration runs Agency code that goes through `__call`, which
-  // reads ctx/threads/stack from ALS after the
-  // drop-per-call-context-plumbing migration. See lib/runtime/node.ts
-  // and lib/runtime/asyncContext.ts (`runInBootstrapFrame`).
-  await runInBootstrapFrame(
-    execCtx,
-    () => __initAllRegisteredCallbacks(execCtx),
-  );
-  execCtx.restoreState(checkpoint);
-  // Re-assert the root budget's LIMIT from the host context (the checkpoint's
-  // ceiling is caller-controllable on a stateless resume), while preserving the
-  // guard's accumulated spend so the trusted CLI resume path stays cumulative.
-  // No-op in IPC.
-  reinstallRootBudget(execCtx.stateStack, execCtx.budget);
-  execCtx.setInterruptResponses(responseMap);
-  if (metadata.callbacks) Object.assign(execCtx.callbacks, metadata.callbacks);
-  if (metadata.debugger) execCtx.debuggerState = metadata.debugger;
-
-  const agentRunSpanId = execCtx.statelogClient.startSpan("agentRun");
-  execCtx.statelogClient.agentStart({ entryNode: checkpoint.nodeId, args: {} });
+  // === Invocation started (context exists): a SINGLE lifecycle boundary covers
+  // all resume setup AND execution, so a setup failure still yields an
+  // outcome-with-usage and still runs cleanup. reinstallRootBudget and handler
+  // registration order are preserved. ===
   const agentStartTime = performance.now();
+  let agentRunSpanId: ReturnType<typeof execCtx.statelogClient.startSpan> | undefined;
+  let outcome: RawOutcome<RunNodeResult<any>>;
   try {
-    return await runResumeLoop(execCtx, checkpoint.nodeId, agentStartTime);
+    // Re-install the CLI-driven root policy handler on the resumed exec context
+    // (handlers are never checkpointed). Guarded no-op unless AGENCY_RUN_POLICY
+    // is set and this is the root process. Mirrors the runNode install so the
+    // policy survives a resumed leg.
+    installRunPolicyHandler(execCtx);
+    // A cross-process resume starts with an empty provider registry (registration
+    // is process-global, not part of serialized checkpoint state), so re-register
+    // before resuming. Idempotent in-process via loadProviderModules' guard.
+    await loadProviderModules(execCtx);
+    // This is the first restore on this execCtx — record it as such.
+    execCtx._restoreCount++;
+    execCtx.statelogClient.checkpointRestored({
+      checkpointId: checkpoint.id,
+      restoreCount: execCtx._restoreCount,
+    });
+    // Each user response resolves a previously-thrown interrupt. Emit the
+    // lifecycle event so dashboards can pair every interruptThrown with a
+    // terminal interruptResolved. Suppressed in IPC mode: a resumed
+    // subprocess segment re-enters respondToInterrupts with the SAME
+    // preserved interrupt ids in the same inherited trace, and the root
+    // process already emitted the user resolution — a second (or, nested,
+    // N+1th) emission would break thrown↔resolved pairing for consumers.
+    if (!isIpcMode()) {
+      for (let i = 0; i < interrupts.length; i++) {
+        const intr = interrupts[i];
+        const resp = responses[i];
+        const resolvedOutcome =
+          resp.type === "approve" ? "approved" : ("rejected" as const);
+        execCtx.statelogClient.interruptResolved({
+          interruptId: intr.interruptId,
+          outcome: resolvedOutcome,
+          resolvedBy: "user",
+        });
+      }
+    }
+    // Re-register top-level callbacks BEFORE restoreState so the
+    // `_callbackImpl` routing check (`stateStack.isGlobalContext()`)
+    // sees the still-empty stack and pushes onto `ctx.topLevelCallbacks`.
+    // After `restoreState`, the stack carries the checkpoint frames and
+    // the same registration would instead bind to a caller frame and be
+    // popped immediately as the restored frames unwind.
+    //
+    // The bootstrap frame mirrors `runNode` — top-level callback
+    // registration runs Agency code that goes through `__call`, which
+    // reads ctx/threads/stack from ALS after the
+    // drop-per-call-context-plumbing migration. See lib/runtime/node.ts
+    // and lib/runtime/asyncContext.ts (`runInBootstrapFrame`).
+    await runInBootstrapFrame(
+      execCtx,
+      () => __initAllRegisteredCallbacks(execCtx),
+    );
+    execCtx.restoreState(checkpoint);
+    // Re-assert the root budget's LIMIT from the host context (the checkpoint's
+    // ceiling is caller-controllable on a stateless resume), while preserving the
+    // guard's accumulated spend so the trusted CLI resume path stays cumulative.
+    // No-op in IPC.
+    reinstallRootBudget(execCtx.stateStack, execCtx.budget);
+    execCtx.setInterruptResponses(responseMap);
+    if (metadata.callbacks) Object.assign(execCtx.callbacks, metadata.callbacks);
+    if (metadata.debugger) execCtx.debuggerState = metadata.debugger;
+
+    agentRunSpanId = execCtx.statelogClient.startSpan("agentRun");
+    execCtx.statelogClient.agentStart({ entryNode: checkpoint.nodeId, args: {} });
+    const value = await runResumeLoop(execCtx, checkpoint.nodeId, agentStartTime);
+    outcome = { status: "returned", value };
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     execCtx.statelogClient.error({ errorType: "runtimeError", message: errorMessage });
@@ -835,10 +851,29 @@ export async function respondToInterrupts(args: {
       entryNode: checkpoint.nodeId,
       timeTaken: performance.now() - agentStartTime,
     });
-    throw error;
+    outcome = { status: "threw", error };
   } finally {
-    execCtx.statelogClient.endSpan(agentRunSpanId); // end agentRun span
-    execCtx.cleanup();
+    // Guarded: a setup failure before the span was opened leaves it undefined.
+    if (agentRunSpanId !== undefined) {
+      execCtx.statelogClient.endSpan(agentRunSpanId); // end agentRun span
+    }
   }
+  // Resume tears down with cleanup() (no memory-save/statelog-flush — that is
+  // the fresh-run path's finalizeExecCtx); wrap it to match the cleanup shape.
+  return finishServedInvocation(execCtx, outcome, async () => execCtx.cleanup());
+}
+
+/** Public entry point — unchanged contract: returns the resume result or throws
+ *  the identical original error. */
+export async function respondToInterrupts(args: RespondToInterruptsArgs): Promise<any> {
+  return unwrapServedInvocationOutcome(await respondToInterruptsCore(args));
+}
+
+/** Serve-only entry point: hands the resume outcome (result/error + usage
+ *  snapshot) to the serve adapter instead of unwrapping it. */
+export async function respondToInterruptsForServe(
+  args: RespondToInterruptsArgs,
+): Promise<ServedInvocationOutcome<RunNodeResult<any>>> {
+  return respondToInterruptsCore(args);
 }
 

--- a/packages/agency-lang/lib/runtime/invocationOutcome.test.ts
+++ b/packages/agency-lang/lib/runtime/invocationOutcome.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  runExportedFunction,
+  runExportedFunctionForServe,
+  runNodeForServe,
+} from "./node.js";
+import { finishServedInvocation } from "./servedInvocationLifecycle.js";
+import { RuntimeContext } from "./state/context.js";
+import { AgencyCancelledError } from "./errors.js";
+import { addCost } from "./cost.js";
+import type { GraphState } from "./types.js";
+import type { AgencyFunction } from "./agencyFunction.js";
+
+function makeCtx(budget?: { maxCost?: number; maxTimeMs?: number }) {
+  return new RuntimeContext<GraphState>({
+    statelogConfig: { host: "", apiKey: "", projectId: "", debugMode: false, observability: false },
+    smoltalkDefaults: {},
+    dirname: "/project",
+    budget,
+  });
+}
+
+/** A minimal exported function whose body runs `body` and returns its value. */
+function fakeFn(body: () => unknown | Promise<unknown>): AgencyFunction {
+  return { invoke: async () => body() } as unknown as AgencyFunction;
+}
+
+describe("runExportedFunctionForServe outcomes", () => {
+  it.each([
+    ["an object", { a: 1 }],
+    ["a primitive string", "hello"],
+    ["a number", 42],
+    ["undefined", undefined],
+  ])("returns a returned-outcome for %s, with a usage snapshot", async (_label, value) => {
+    const outcome = await runExportedFunctionForServe({ ctx: makeCtx(), fn: fakeFn(() => value), namedArgs: {} });
+    expect(outcome.status).toBe("returned");
+    if (outcome.status === "returned") expect(outcome.value).toEqual(value);
+    expect(outcome.usage).toMatchObject({ pricedCost: 0, pricingComplete: true });
+    expect(outcome.usageComplete).toBe(true);
+  });
+
+  it.each([
+    ["an Error", new Error("boom")],
+    ["a string", "thrown-string"],
+    ["a frozen object", Object.freeze({ code: "E" })],
+  ])("returns a threw-outcome preserving the identical error: %s", async (_label, err) => {
+    const outcome = await runExportedFunctionForServe({
+      ctx: makeCtx(),
+      fn: fakeFn(() => { throw err; }),
+      namedArgs: {},
+    });
+    expect(outcome.status).toBe("threw");
+    if (outcome.status === "threw") expect(outcome.error).toBe(err);
+    expect(outcome.usage).toBeDefined();
+  });
+
+  it("a budget trip yields a threw-outcome carrying the cost incurred up to the trip", async () => {
+    const outcome = await runExportedFunctionForServe({
+      ctx: makeCtx({ maxCost: 0 }),
+      fn: fakeFn(() => { addCost(1); return "unreached"; }),
+      namedArgs: {},
+    });
+    expect(outcome.status).toBe("threw");
+    expect(outcome.usage.pricedCost).toBeCloseTo(1);
+  });
+});
+
+describe("runExportedFunction (public compatibility)", () => {
+  it("returns the raw value", async () => {
+    await expect(runExportedFunction({ ctx: makeCtx(), fn: fakeFn(() => "x"), namedArgs: {} })).resolves.toBe("x");
+  });
+
+  it("throws the identical original error", async () => {
+    const err = new Error("orig");
+    await expect(
+      runExportedFunction({ ctx: makeCtx(), fn: fakeFn(() => { throw err; }), namedArgs: {} }),
+    ).rejects.toBe(err);
+  });
+});
+
+describe("runNodeForServe lifecycle boundary", () => {
+  it("an already-aborted signal yields a threw-outcome with usage (context existed)", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const outcome = await runNodeForServe({
+      ctx: makeCtx(),
+      nodeName: "main",
+      data: {},
+      abortSignal: controller.signal,
+    });
+    expect(outcome.status).toBe("threw");
+    if (outcome.status === "threw") expect(outcome.error).toBeInstanceOf(AgencyCancelledError);
+    expect(outcome.usage).toBeDefined();
+  });
+});
+
+describe("finishServedInvocation cleanup semantics", () => {
+  it("a cleanup failure after success becomes the outcome error", async () => {
+    const ctx = makeCtx();
+    const cleanupErr = new Error("cleanup boom");
+    const outcome = await finishServedInvocation(
+      ctx,
+      { status: "returned", value: "ok" },
+      async () => { throw cleanupErr; },
+    );
+    expect(outcome.status).toBe("threw");
+    if (outcome.status === "threw") expect(outcome.error).toBe(cleanupErr);
+  });
+
+  it("a cleanup failure after an execution error keeps the FIRST error and logs the cleanup one", async () => {
+    const ctx = makeCtx();
+    const firstErr = new Error("execution error");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const outcome = await finishServedInvocation(
+      ctx,
+      { status: "threw", error: firstErr },
+      async () => { throw new Error("cleanup boom"); },
+    );
+    expect(outcome.status).toBe("threw");
+    if (outcome.status === "threw") expect(outcome.error).toBe(firstErr);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("snapshots usage AFTER cleanup (cleanup-incurred paid work counts)", async () => {
+    const ctx = makeCtx();
+    const outcome = await finishServedInvocation(
+      ctx,
+      { status: "returned", value: "ok" },
+      async () => { ctx.invocationUsage.merge({ pricedCost: 0.5, inputTokens: 0, outputTokens: 0, unknownCostCallCount: 0 }); },
+    );
+    expect(outcome.usage.pricedCost).toBeCloseTo(0.5);
+  });
+});

--- a/packages/agency-lang/lib/runtime/invocationUsage.test.ts
+++ b/packages/agency-lang/lib/runtime/invocationUsage.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from "vitest";
+import {
+  InvocationUsageMeter,
+  completionUsageDelta,
+  paidCostDelta,
+  normalizeUsageDelta,
+  unwrapServedInvocationOutcome,
+  type ServedInvocationOutcome,
+} from "./invocationUsage.js";
+
+describe("InvocationUsageMeter", () => {
+  it("accumulates deltas and derives pricingComplete", () => {
+    const m = new InvocationUsageMeter();
+    m.merge({ pricedCost: 0.01, inputTokens: 100, outputTokens: 20, unknownCostCallCount: 0 });
+    m.merge({ pricedCost: 0.02, inputTokens: 5, outputTokens: 1, unknownCostCallCount: 0 });
+    const s = m.snapshot();
+    expect(s.usage.pricedCost).toBeCloseTo(0.03);
+    expect(s.usage.inputTokens).toBe(105);
+    expect(s.usage.outputTokens).toBe(21);
+    expect(s.usage.unknownCostCallCount).toBe(0);
+    expect(s.usage.pricingComplete).toBe(true);
+    expect(s.usageComplete).toBe(true);
+  });
+
+  it("a fresh meter is complete and zeroed", () => {
+    const s = new InvocationUsageMeter().snapshot();
+    expect(s.usage).toEqual({
+      pricedCost: 0, inputTokens: 0, outputTokens: 0, unknownCostCallCount: 0, pricingComplete: true,
+    });
+    expect(s.usageComplete).toBe(true);
+  });
+
+  it("any unknown-cost call flips pricingComplete false", () => {
+    const m = new InvocationUsageMeter();
+    m.merge({ pricedCost: 0, inputTokens: 3, outputTokens: 1, unknownCostCallCount: 1 });
+    expect(m.snapshot().usage.pricingComplete).toBe(false);
+  });
+
+  it("markIncomplete is permanent and reports only the first transition", () => {
+    const m = new InvocationUsageMeter();
+    expect(m.markIncomplete()).toBe(true);
+    expect(m.markIncomplete()).toBe(false);
+    expect(m.snapshot().usageComplete).toBe(false);
+  });
+});
+
+describe("completionUsageDelta", () => {
+  it("finite zero is a known free price (not unknown)", () => {
+    expect(completionUsageDelta({ cost: 0, inputTokens: 10, outputTokens: 2 })).toEqual({
+      pricedCost: 0, inputTokens: 10, outputTokens: 2, unknownCostCallCount: 0,
+    });
+  });
+
+  it("positive price is priced", () => {
+    expect(completionUsageDelta({ cost: 0.5, inputTokens: 1, outputTokens: 1 })).toEqual({
+      pricedCost: 0.5, inputTokens: 1, outputTokens: 1, unknownCostCallCount: 0,
+    });
+  });
+
+  it.each([
+    ["undefined", undefined],
+    ["null", null],
+    ["negative", -1],
+    ["NaN", NaN],
+    ["Infinity", Infinity],
+  ])("%s price is unknown, contributes no cost, one unknown call", (_label, cost) => {
+    expect(completionUsageDelta({ cost: cost as number, inputTokens: 4, outputTokens: 2 })).toEqual({
+      pricedCost: 0, inputTokens: 4, outputTokens: 2, unknownCostCallCount: 1,
+    });
+  });
+
+  it("absent or invalid tokens count as zero", () => {
+    expect(completionUsageDelta({ cost: 0.1, inputTokens: undefined, outputTokens: null })).toMatchObject({
+      inputTokens: 0, outputTokens: 0,
+    });
+    expect(completionUsageDelta({ cost: 0.1, inputTokens: -5, outputTokens: 1.5 })).toMatchObject({
+      inputTokens: 0, outputTokens: 0,
+    });
+  });
+});
+
+describe("paidCostDelta", () => {
+  it("wraps a valid nonnegative amount", () => {
+    expect(paidCostDelta(0.25)).toEqual({
+      pricedCost: 0.25, inputTokens: 0, outputTokens: 0, unknownCostCallCount: 0,
+    });
+    expect(paidCostDelta(0)).toMatchObject({ pricedCost: 0 });
+  });
+
+  it.each([-1, NaN, Infinity])("throws on invalid amount %s (never silently zero)", (amount) => {
+    expect(() => paidCostDelta(amount)).toThrow();
+  });
+});
+
+describe("normalizeUsageDelta", () => {
+  it("returns null for a non-object", () => {
+    expect(normalizeUsageDelta(null)).toBeNull();
+    expect(normalizeUsageDelta(42)).toBeNull();
+  });
+
+  it("passes through a valid delta", () => {
+    expect(normalizeUsageDelta({ pricedCost: 0.3, inputTokens: 9, outputTokens: 3, unknownCostCallCount: 1 })).toEqual({
+      pricedCost: 0.3, inputTokens: 9, outputTokens: 3, unknownCostCallCount: 1,
+    });
+  });
+
+  it("an invalid cost becomes one unknown-cost call while valid fields survive", () => {
+    expect(normalizeUsageDelta({ pricedCost: -5, inputTokens: 9, outputTokens: 3, unknownCostCallCount: 0 })).toEqual({
+      pricedCost: 0, inputTokens: 9, outputTokens: 3, unknownCostCallCount: 1,
+    });
+  });
+
+  it("invalid token/count fields become zero", () => {
+    expect(normalizeUsageDelta({ pricedCost: 0.1, inputTokens: "x", outputTokens: -2, unknownCostCallCount: 1.5 })).toEqual({
+      pricedCost: 0.1, inputTokens: 0, outputTokens: 0, unknownCostCallCount: 0,
+    });
+  });
+});
+
+describe("unwrapServedInvocationOutcome", () => {
+  it("returns the value for a returned outcome", () => {
+    const o: ServedInvocationOutcome<string> = {
+      status: "returned", value: "hi",
+      usage: { pricedCost: 0, inputTokens: 0, outputTokens: 0, unknownCostCallCount: 0, pricingComplete: true },
+      usageComplete: true,
+    };
+    expect(unwrapServedInvocationOutcome(o)).toBe("hi");
+  });
+
+  it("rethrows the identical error (string, frozen object)", () => {
+    const snap = {
+      usage: { pricedCost: 0, inputTokens: 0, outputTokens: 0, unknownCostCallCount: 0, pricingComplete: true },
+      usageComplete: true,
+    };
+    expect(() => unwrapServedInvocationOutcome({ status: "threw", error: "boom", ...snap })).toThrow("boom");
+    const frozen = Object.freeze(new Error("frozen"));
+    try {
+      unwrapServedInvocationOutcome({ status: "threw", error: frozen, ...snap });
+      expect.fail("should have thrown");
+    } catch (e) {
+      expect(e).toBe(frozen);
+    }
+  });
+});

--- a/packages/agency-lang/lib/runtime/invocationUsage.ts
+++ b/packages/agency-lang/lib/runtime/invocationUsage.ts
@@ -1,0 +1,159 @@
+// Per-invocation usage accounting for the serve cost seam.
+//
+// A hosted invocation (`/node`, `/function`, `/resume`) must report the
+// authoritative cost it just incurred so a host can attribute spend per
+// project. This file owns the value types and the arithmetic:
+//   - `InvocationUsageMeter` — a fresh, non-serialized accumulator that lives on
+//     each execution context (see state/context.ts). One per invocation/leg.
+//   - the delta helpers that turn a completion / an `addCost` charge / an
+//     untrusted IPC message into a normalized `InvocationUsageDelta`.
+//   - `ServedInvocationOutcome` — how a run core hands a value-or-error plus its
+//     usage snapshot to the serve adapters without ever mutating the user value
+//     or the thrown error.
+//
+// Two independent completeness axes, never conflated:
+//   - `pricingComplete` (on the usage) — did every call have a price? Derived
+//     from `unknownCostCallCount === 0`.
+//   - `usageComplete` (on the snapshot) — was all telemetry delivered? Becomes
+//     permanently false when an abnormal subprocess termination means we cannot
+//     rule out unsent child usage, making `usage` a trusted LOWER BOUND.
+
+import type { RuntimeContext } from "./state/context.js";
+import type { StateStack } from "./state/stateStack.js";
+import type { GraphState } from "./types.js";
+
+export type InvocationUsage = {
+  pricedCost: number;
+  inputTokens: number;
+  outputTokens: number;
+  unknownCostCallCount: number;
+  pricingComplete: boolean;
+};
+
+export type InvocationUsageDelta = {
+  pricedCost: number;
+  inputTokens: number;
+  outputTokens: number;
+  unknownCostCallCount: number;
+};
+
+export type InvocationUsageSnapshot = {
+  usage: InvocationUsage;
+  usageComplete: boolean;
+};
+
+export type ServedInvocationOutcome<T> =
+  | ({ status: "returned"; value: T } & InvocationUsageSnapshot)
+  | ({ status: "threw"; error: unknown } & InvocationUsageSnapshot);
+
+/** Explicit ownership for an accounting call: which invocation's meter to merge
+ *  into and which branch stack to bill. Passed explicitly so out-of-frame
+ *  callers (the IPC telemetry handler) never depend on AsyncLocalStorage. */
+export type InvocationAccountingTarget = {
+  ctx: RuntimeContext<GraphState>;
+  stack: StateStack;
+};
+
+/** A finite, nonnegative number (used for costs — `0` is a valid known price). */
+function isValidCost(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+/** A finite, nonnegative integer (used for token/count fields). */
+function isValidCount(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 && Number.isInteger(value);
+}
+
+/** Coerce an untrusted token/count field to a valid count, else 0. */
+function asCount(value: unknown): number {
+  return isValidCount(value) ? value : 0;
+}
+
+/** A fresh, non-serialized accumulator for one invocation/leg. */
+export class InvocationUsageMeter {
+  private pricedCost = 0;
+  private inputTokens = 0;
+  private outputTokens = 0;
+  private unknownCostCallCount = 0;
+  private usageComplete = true;
+
+  merge(delta: InvocationUsageDelta): void {
+    this.pricedCost += delta.pricedCost;
+    this.inputTokens += delta.inputTokens;
+    this.outputTokens += delta.outputTokens;
+    this.unknownCostCallCount += delta.unknownCostCallCount;
+  }
+
+  /** Mark telemetry delivery as no longer guaranteed complete. Idempotent;
+   *  returns true only on the first complete → incomplete transition, so a
+   *  caller can relay a single upward incompleteness marker. */
+  markIncomplete(): boolean {
+    if (!this.usageComplete) return false;
+    this.usageComplete = false;
+    return true;
+  }
+
+  snapshot(): InvocationUsageSnapshot {
+    return {
+      usage: {
+        pricedCost: this.pricedCost,
+        inputTokens: this.inputTokens,
+        outputTokens: this.outputTokens,
+        unknownCostCallCount: this.unknownCostCallCount,
+        pricingComplete: this.unknownCostCallCount === 0,
+      },
+      usageComplete: this.usageComplete,
+    };
+  }
+}
+
+/** A delta for a trusted LLM completion. A finite `0` cost is a known free price;
+ *  an absent/negative/non-finite cost is UNKNOWN (no priced cost, one unknown
+ *  call). Missing or invalid token counts contribute zero. */
+export function completionUsageDelta(args: {
+  cost: number | null | undefined;
+  inputTokens: number | null | undefined;
+  outputTokens: number | null | undefined;
+}): InvocationUsageDelta {
+  const priced = isValidCost(args.cost);
+  return {
+    pricedCost: priced ? (args.cost as number) : 0,
+    inputTokens: asCount(args.inputTokens),
+    outputTokens: asCount(args.outputTokens),
+    unknownCostCallCount: priced ? 0 : 1,
+  };
+}
+
+/** A delta for a trusted in-process paid charge (`addCost`). Invalid input
+ *  THROWS — an addCost caller must never silently drop a real charge. */
+export function paidCostDelta(amount: number): InvocationUsageDelta {
+  if (!isValidCost(amount)) {
+    throw new Error(`paidCostDelta: amount must be a finite, nonnegative number (got ${amount})`);
+  }
+  return { pricedCost: amount, inputTokens: 0, outputTokens: 0, unknownCostCallCount: 0 };
+}
+
+/** Normalize an UNTRUSTED delta (from an IPC message). Returns null only when the
+ *  input is not a usable object. Otherwise each field is validated
+ *  independently: an invalid `pricedCost` becomes zero priced cost plus one
+ *  unknown-cost call (never a silent known-free zero), and invalid token/count
+ *  fields become zero — valid metadata is preserved even when cost is bad. */
+export function normalizeUsageDelta(raw: unknown): InvocationUsageDelta | null {
+  if (raw === null || typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+  const costValid = isValidCost(obj.pricedCost);
+  const baseUnknown = asCount(obj.unknownCostCallCount);
+  return {
+    pricedCost: costValid ? (obj.pricedCost as number) : 0,
+    inputTokens: asCount(obj.inputTokens),
+    outputTokens: asCount(obj.outputTokens),
+    unknownCostCallCount: costValid ? baseUnknown : baseUnknown + 1,
+  };
+}
+
+/** Take a run core's outcome back to a raw value-or-throw, preserving the exact
+ *  thrown value's identity (strings, frozen objects, anything). */
+export function unwrapServedInvocationOutcome<T>(outcome: ServedInvocationOutcome<T>): T {
+  if (outcome.status === "returned") return outcome.value;
+  throw outcome.error;
+}

--- a/packages/agency-lang/lib/runtime/invocationUsage.ts
+++ b/packages/agency-lang/lib/runtime/invocationUsage.ts
@@ -39,6 +39,13 @@ export type InvocationUsageDelta = {
 
 export type InvocationUsageSnapshot = {
   usage: InvocationUsage;
+  /** ⚠️ A SIBLING of `usage`, not nested inside it — easy to miss. When `false`,
+   *  the whole `usage` figure (including `pricedCost`) is a trusted LOWER BOUND:
+   *  an abnormal subprocess termination means unsent child telemetry could not
+   *  be ruled out. A consumer MUST treat the dollar total conservatively
+   *  whenever this (or `usage.pricingComplete`) is false. Distinct axis from
+   *  `pricingComplete`: that is about price availability, this is about
+   *  telemetry delivery. */
   usageComplete: boolean;
 };
 

--- a/packages/agency-lang/lib/runtime/ipc.test.ts
+++ b/packages/agency-lang/lib/runtime/ipc.test.ts
@@ -8,6 +8,8 @@ import {
   resolveDepthCap,
   attachSessionHandlers,
   handleTelemetryMessage,
+  handleInvocationUsageMessage,
+  handleInvocationUsageIncompleteMessage,
   handleCallbackMessage,
   handleChildMessage,
   withParentStatelog,
@@ -16,6 +18,7 @@ import {
   SUBPROCESS_DEPTH_CEILING,
 } from "./ipc.js";
 import { State, StateStack } from "./state/stateStack.js";
+import { InvocationUsageMeter } from "./invocationUsage.js";
 import { AgencyAbort, AgencyCancelledError } from "./errors.js";
 import { CostGuard, isGuardExceededError } from "./guard.js";
 
@@ -170,7 +173,7 @@ const makeSession = (overrides: Record<string, any> = {}): any => ({
   sessionId: "test-session",
   child: { stdout: null, stderr: null, on: () => {}, send: () => true, connected: true, kill: () => true },
   limits: { wallClock: 1000, memory: 1, ipcPayload: 1, stdout: 1 },
-  ctx: { lockReleasers: {} },
+  ctx: { lockReleasers: {}, invocationUsage: new InvocationUsageMeter() },
   stateStack: {},
   resolvePromise: () => {},
   rejectPromise: () => {},
@@ -347,6 +350,106 @@ describe("handleTelemetryMessage", () => {
     handleTelemetryMessage(session, { type: "telemetry", costUsd: -5 } as any);
     handleTelemetryMessage(session, { type: "telemetry" } as any);
     expect(stack.localCost).toBe(0);
+  });
+});
+
+describe("handleInvocationUsageMessage (full delta)", () => {
+  const originalSend = process.send;
+  afterEach(() => {
+    process.send = originalSend;
+    vi.unstubAllEnvs();
+  });
+
+  const makeUsageSession = () => {
+    const stack = new StateStack();
+    const ctx = { lockReleasers: {}, invocationUsage: new InvocationUsageMeter() };
+    const rejections: any[] = [];
+    const kills: string[] = [];
+    const session = makeSession({
+      ctx,
+      stateStack: stack,
+      child: { kill: (sig: string) => { kills.push(sig); return true; }, connected: true },
+      rejectPromise: (err: any) => { rejections.push(err); },
+    });
+    return { session, ctx, stack, rejections, kills };
+  };
+
+  it("merges the full delta into the parent invocation meter and bills the stack", () => {
+    const { session, ctx, stack } = makeUsageSession();
+    handleInvocationUsageMessage(session, {
+      type: "invocationUsage", pricedCost: 0.5, inputTokens: 100, outputTokens: 20, unknownCostCallCount: 0,
+    });
+    expect(stack.localCost).toBeCloseTo(0.5);
+    const s = ctx.invocationUsage.snapshot();
+    expect(s.usage.pricedCost).toBeCloseTo(0.5);
+    expect(s.usage.inputTokens).toBe(100);
+    expect(s.usage.outputTokens).toBe(20);
+  });
+
+  it("accumulates exact totals across multiple child messages (one-child)", () => {
+    const { session, ctx } = makeUsageSession();
+    handleInvocationUsageMessage(session, { type: "invocationUsage", pricedCost: 0.1, inputTokens: 5, outputTokens: 1, unknownCostCallCount: 0 });
+    handleInvocationUsageMessage(session, { type: "invocationUsage", pricedCost: 0.2, inputTokens: 7, outputTokens: 2, unknownCostCallCount: 1 });
+    const s = ctx.invocationUsage.snapshot();
+    expect(s.usage.pricedCost).toBeCloseTo(0.3);
+    expect(s.usage.inputTokens).toBe(12);
+    expect(s.usage.outputTokens).toBe(3);
+    expect(s.usage.unknownCostCallCount).toBe(1);
+    expect(s.usage.pricingComplete).toBe(false);
+  });
+
+  it("re-relays the received delta upward once when this process is itself a child (grandchild path)", () => {
+    vi.stubEnv("AGENCY_IPC", "1");
+    const send = vi.fn(() => true);
+    process.send = send as any;
+    const { session } = makeUsageSession();
+    const delta = { pricedCost: 0.15, inputTokens: 3, outputTokens: 1, unknownCostCallCount: 1 };
+    handleInvocationUsageMessage(session, { type: "invocationUsage", ...delta });
+    expect(send).toHaveBeenCalledExactlyOnceWith({ type: "invocationUsage", ...delta });
+  });
+
+  it("normalizes an invalid cost to an unknown-cost call without dropping tokens", () => {
+    const { session, ctx, stack } = makeUsageSession();
+    handleInvocationUsageMessage(session, { type: "invocationUsage", pricedCost: -1, inputTokens: 9, outputTokens: 3, unknownCostCallCount: 0 } as any);
+    expect(stack.localCost).toBe(0);
+    const s = ctx.invocationUsage.snapshot();
+    expect(s.usage.inputTokens).toBe(9);
+    expect(s.usage.unknownCostCallCount).toBe(1);
+  });
+
+  it("a guard trip from a usage message kills+rejects AND marks the invocation incomplete", () => {
+    const { session, ctx, stack, rejections, kills } = makeUsageSession();
+    stack.guards.push(new CostGuard(0.1));
+    handleInvocationUsageMessage(session, { type: "invocationUsage", pricedCost: 0.2, inputTokens: 1, outputTokens: 1, unknownCostCallCount: 0 });
+    expect(kills).toEqual(["SIGKILL"]);
+    expect(rejections).toHaveLength(1);
+    expect(session.settled).toBe(true);
+    expect(ctx.invocationUsage.snapshot().usageComplete).toBe(false);
+  });
+
+  it("post-settle usage still merges (lower bound) but does not enforce", () => {
+    const { session, ctx, stack } = makeUsageSession();
+    session.settled = true;
+    handleInvocationUsageMessage(session, { type: "invocationUsage", pricedCost: 0.2, inputTokens: 0, outputTokens: 0, unknownCostCallCount: 0 });
+    expect(stack.localCost).toBeCloseTo(0.2);
+    expect(ctx.invocationUsage.snapshot().usage.pricedCost).toBeCloseTo(0.2);
+  });
+});
+
+describe("handleInvocationUsageIncompleteMessage", () => {
+  const originalSend = process.send;
+  afterEach(() => { process.send = originalSend; vi.unstubAllEnvs(); });
+
+  it("marks the invocation incomplete and relays the marker once when a child", () => {
+    vi.stubEnv("AGENCY_IPC", "1");
+    const send = vi.fn(() => true);
+    process.send = send as any;
+    const ctx = { lockReleasers: {}, invocationUsage: new InvocationUsageMeter() };
+    const session = makeSession({ ctx });
+    handleInvocationUsageIncompleteMessage(session);
+    handleInvocationUsageIncompleteMessage(session);
+    expect(ctx.invocationUsage.snapshot().usageComplete).toBe(false);
+    expect(send).toHaveBeenCalledExactlyOnceWith({ type: "invocationUsageIncomplete" });
   });
 });
 

--- a/packages/agency-lang/lib/runtime/ipc.ts
+++ b/packages/agency-lang/lib/runtime/ipc.ts
@@ -19,7 +19,13 @@ import { AgencyAbort, AgencyCancelledError } from "./errors.js";
 import type { State, StateStack } from "./state/stateStack.js";
 import { getSubprocessRunInfo, setSubprocessRunInfo, isIpcMode, type SubprocessRunInfo } from "./subprocessRunInfo.js";
 import { truncate } from "./truncate.js";
-import { isPayableCost, type IpcTelemetryMessage } from "./costTelemetry.js";
+import {
+  isPayableCost,
+  type IpcTelemetryMessage,
+  type IpcInvocationUsageMessage,
+} from "./costTelemetry.js";
+import { recordPaidUsageAt, markInvocationUsageIncompleteAt } from "./recordPaidUsage.js";
+import { normalizeUsageDelta, type InvocationUsageDelta } from "./invocationUsage.js";
 import { type IpcCallbackMessage, NON_FORWARDABLE_CALLBACKS } from "./callbackForwarding.js";
 import { invokeCallbacks } from "./hooks.js";
 import { VALID_CALLBACK_NAMES, type CallbackName } from "../types/function.js";
@@ -284,6 +290,8 @@ export type SubprocessToParent =
   | IpcLockAcquireMessage
   | IpcLockReleaseMessage
   | IpcTelemetryMessage
+  | IpcInvocationUsageMessage
+  | { type: "invocationUsageIncomplete" }
   | IpcCallbackMessage;
 export type ParentToSubprocess = IpcDecisionMessage | IpcLockGrantedMessage;
 
@@ -728,6 +736,12 @@ function killChildSafely(s: RunSession): void {
 
 function settle(s: RunSession, fn: (v: any) => void, value: any): void {
   if (s.settled) return;
+  // A reject settle is an abnormal termination (error, unexpected close,
+  // guard-trip kill, cancellation): the child did not complete normally, so
+  // unsent usage telemetry cannot be ruled out — mark this invocation's usage a
+  // trusted lower bound. Normal result/interrupted resolves keep it complete
+  // (IPC FIFO guarantees all telemetry preceded the terminal message).
+  if (fn === s.rejectPromise) markSessionUsageIncomplete(s);
   s.settled = true;
   clearTimer(s);
   if (s.detachAbortListener) {
@@ -753,6 +767,10 @@ function settleWithLimitFailure(
 ): void {
   if (s.settled) return;
   killChildSafely(s);
+  // A limit kill resolves with a structured failure (not a reject), so mark the
+  // usage incomplete here explicitly — the killed child may not have flushed all
+  // of its telemetry.
+  markSessionUsageIncomplete(s);
   settle(s, s.resolvePromise, {
     type: "result",
     value: makeLimitFailure(limit, threshold, value, extras),
@@ -929,9 +947,14 @@ function handleErrorMessage(s: RunSession, msg: any): void {
  * after a fork branch's cost delta has already propagated at join, so
  * getCost() may slightly undercount on abnormal termination. Budgets
  * never undercount; do not "fix" this by skipping post-settle billing. */
-export function handleTelemetryMessage(s: RunSession, msg: IpcTelemetryMessage): void {
-  if (!isPayableCost(msg.costUsd)) return;
-  s.stateStack.billCharge(msg.costUsd);
+/** Account a child's usage delta against THIS session's parent target (out of
+ * any ALS frame — we pass `s.ctx`/`s.stateStack` explicitly): bill the parent's
+ * cost guards, merge the parent's invocation meter, and re-relay the delta once
+ * if this process is itself a subprocess (grandchild propagation). Billing is
+ * unconditional (the spend already happened, even post-settle); enforcement only
+ * runs on a live session, and a trip kills the child and rejects the session. */
+function accountChildUsage(s: RunSession, delta: InvocationUsageDelta): void {
+  recordPaidUsageAt({ ctx: s.ctx, stack: s.stateStack }, delta);
   if (s.settled) return;
   try {
     s.stateStack.enforceGuards();
@@ -939,6 +962,34 @@ export function handleTelemetryMessage(s: RunSession, msg: IpcTelemetryMessage):
     killChildSafely(s);
     settle(s, s.rejectPromise, err);
   }
+}
+
+/** Legacy cost-only telemetry (version-skewed child). Bill only a payable
+ *  positive cost, preserving the old contract. */
+export function handleTelemetryMessage(s: RunSession, msg: IpcTelemetryMessage): void {
+  if (!isPayableCost(msg.costUsd)) return;
+  accountChildUsage(s, { pricedCost: msg.costUsd, inputTokens: 0, outputTokens: 0, unknownCostCallCount: 0 });
+}
+
+/** Full per-invocation usage delta from a child. Normalized (untrusted input;
+ *  an invalid cost becomes an unknown-cost call, valid tokens survive). */
+export function handleInvocationUsageMessage(s: RunSession, msg: IpcInvocationUsageMessage): void {
+  const delta = normalizeUsageDelta(msg);
+  if (!delta) return;
+  accountChildUsage(s, delta);
+}
+
+/** A child reported that its (or a descendant's) usage telemetry may be
+ *  incomplete. Mark this invocation's usage a lower bound and relay once. */
+export function handleInvocationUsageIncompleteMessage(s: RunSession): void {
+  markSessionUsageIncomplete(s);
+}
+
+/** Mark the owning invocation's usage as no longer guaranteed complete, guarding
+ *  a minimal test ctx. Used on every abnormal termination so a killed child's
+ *  unsent telemetry is never presented as an authoritative total. */
+function markSessionUsageIncomplete(s: RunSession): void {
+  if (s.ctx && s.ctx.invocationUsage) markInvocationUsageIncompleteAt(s.ctx);
 }
 
 function isForwardableCallbackName(name: unknown): name is CallbackName {
@@ -1085,6 +1136,10 @@ export async function handleChildMessage(s: RunSession, msg: any): Promise<void>
     settle(s, s.resolvePromise, { type: "interrupted", msg } satisfies SessionOutcome);
   } else if (msg.type === "telemetry") {
     handleTelemetryMessage(s, msg);
+  } else if (msg.type === "invocationUsage") {
+    handleInvocationUsageMessage(s, msg);
+  } else if (msg.type === "invocationUsageIncomplete") {
+    handleInvocationUsageIncompleteMessage(s);
   } else if (msg.type === "callback") {
     handleCallbackMessage(s, msg);
   } else if (msg.type === "error") {

--- a/packages/agency-lang/lib/runtime/node.ts
+++ b/packages/agency-lang/lib/runtime/node.ts
@@ -24,6 +24,11 @@ import { createReturnObject } from "./utils.js";
 import { color } from "@/utils/termcolors.js";
 import { nanoid } from "nanoid";
 import { hasInterrupts } from "./interrupts.js";
+import {
+  unwrapServedInvocationOutcome,
+  type ServedInvocationOutcome,
+} from "./invocationUsage.js";
+import { finishServedInvocation, type RawOutcome } from "./servedInvocationLifecycle.js";
 
 export function setupNode(args: { state: GraphState }): {
   stack: State;
@@ -256,23 +261,25 @@ async function finalizeExecCtx(execCtx: RuntimeContext<GraphState>): Promise<voi
  *     is no `RestoreSignal` handling here (a `catch` would risk swallowing
  *     that and other control-flow signals).
  */
-export async function runExportedFunction({
-  ctx,
-  fn,
-  namedArgs,
-  initializeGlobals,
-}: {
+type RunExportedFunctionArgs = {
   ctx: RuntimeContext<GraphState>;
   fn: AgencyFunction;
   namedArgs: Record<string, unknown>;
   initializeGlobals?: (ctx: RuntimeContext<GraphState>) => void | Promise<void>;
-}): Promise<unknown> {
-  const execCtx = await ctx.createExecutionContext(nanoid());
-  await initFreshExecCtx(execCtx, { initializeGlobals });
+};
 
-  const threadStore = ThreadStore.withDefaultActive(execCtx.statelogClient);
+/** The outcome-producing core. The lifecycle boundary starts the moment the
+ *  execution context exists (invocation started), so a bootstrap/setup failure
+ *  still yields an outcome with usage and still runs cleanup. */
+async function runExportedFunctionCore(
+  { ctx, fn, namedArgs, initializeGlobals }: RunExportedFunctionArgs,
+): Promise<ServedInvocationOutcome<unknown>> {
+  const execCtx = await ctx.createExecutionContext(nanoid());
+  let outcome: RawOutcome<unknown>;
   try {
-    return await agencyStore.run(
+    await initFreshExecCtx(execCtx, { initializeGlobals });
+    const threadStore = ThreadStore.withDefaultActive(execCtx.statelogClient);
+    const value = await agencyStore.run(
       {
         ctx: execCtx,
         stack: execCtx.stateStack,
@@ -280,24 +287,53 @@ export async function runExportedFunction({
         globals: execCtx.globals,
       },
       async () => {
-        const result = await fn.invoke({
-          type: "named",
-          positionalArgs: [],
-          namedArgs,
-        });
+        const result = await fn.invoke({ type: "named", positionalArgs: [], namedArgs });
         // Drain any async work the function spawned (async calls, pending
         // promises) before returning, mirroring runNode's awaitAll.
         await execCtx.pendingPromises.awaitAll();
         return result;
       },
     );
-  } finally {
-    await finalizeExecCtx(execCtx);
+    outcome = { status: "returned", value };
+  } catch (error) {
+    outcome = { status: "threw", error };
   }
+  return finishServedInvocation(execCtx, outcome, () => finalizeExecCtx(execCtx));
 }
 
+/** Public entry point — unchanged contract: returns the raw function value or
+ *  throws the identical original error. */
+export async function runExportedFunction(args: RunExportedFunctionArgs): Promise<unknown> {
+  return unwrapServedInvocationOutcome(await runExportedFunctionCore(args));
+}
+
+/** Serve-only entry point: the same execution, but the outcome (value/error +
+ *  usage snapshot) is handed to the serve adapter instead of unwrapped. */
+export async function runExportedFunctionForServe(
+  args: RunExportedFunctionArgs,
+): Promise<ServedInvocationOutcome<unknown>> {
+  return runExportedFunctionCore(args);
+}
+
+type RunNodeArgs = {
+  // global execution context
+  ctx: RuntimeContext<GraphState>;
+  // name of node to run
+  nodeName: string;
+  // arbitrary data to pass to the node
+  data: Record<string, any>;
+  // any message history to pass to the node
+  messages?: MessageJSON[];
+  callbacks?: AgencyCallbacks;
+  // initializes global variables on the execution context
+  initializeGlobals?: (ctx: RuntimeContext<GraphState>) => void | Promise<void>;
+  // An AbortSignal for cancelling the agent mid-execution. When aborted,
+  // in-flight LLM requests are torn down and an AgencyCancelledError is thrown.
+  abortSignal?: AbortSignal;
+};
+
 // eslint-disable-next-line max-lines-per-function -- core node-execution loop; refactor tracked separately
-export async function runNode({
+async function runNodeCore({
   ctx,
   nodeName,
   data,
@@ -305,29 +341,7 @@ export async function runNode({
   callbacks,
   initializeGlobals,
   abortSignal,
-}: {
-  // global execution context
-  ctx: RuntimeContext<GraphState>;
-
-  // name of node to run
-  nodeName: string;
-
-  // arbitrary data to pass to the node
-  data: Record<string, any>;
-
-  // any message history to pass to the node
-  // tbd how this gets used. Which message thread does it get added to?
-  messages?: MessageJSON[];
-
-  callbacks?: AgencyCallbacks;
-
-  // initializes global variables on the execution context
-  initializeGlobals?: (ctx: RuntimeContext<GraphState>) => void | Promise<void>;
-
-  // An AbortSignal for cancelling the agent mid-execution.
-  // When aborted, in-flight LLM requests are torn down and a AgencyCancelledError is thrown.
-  abortSignal?: AbortSignal;
-}): Promise<RunNodeResult<any>> {
+}: RunNodeArgs): Promise<ServedInvocationOutcome<RunNodeResult<any>>> {
   // Subprocesses INHERIT the parent's runId (seeded by the bootstrap from
   // the run instruction) so child statelog events land in the same trace —
   // runIds persist across pause/resume cycles, in-process and out.
@@ -345,51 +359,58 @@ export async function runNode({
   }
 
   const execCtx = await ctx.createExecutionContext(runId);
-  // Cross-module init, this module's globals, top-level callbacks, then the
-  // root run-policy handler and root cost/time budget — all inside
-  // initFreshExecCtx (see there for the full ordering rationale, e.g. the
-  // `node main() { route({ systemPrompt: foreignStatic }) }` foreign-static
-  // case), so nodes and served functions are bootstrapped and capped identically.
-  await initFreshExecCtx(execCtx, { initializeGlobals });
-  // Externally-passed callbacks are stored on ctx; hook execution merges them
-  // with scoped/top-level callbacks at call time.
-  if (callbacks) {
-    Object.assign(execCtx.callbacks, callbacks);
-  }
-
-  // Wire external abort signal to the execution context
-  const cancel = (reason?: string) => execCtx.cancel(reason);
-  if (abortSignal) {
-    if (abortSignal.aborted) {
-      throw new AgencyCancelledError();
-    }
-    abortSignal.addEventListener("abort", () => execCtx.cancel(), {
-      once: true,
-    });
-  }
-
-  // onAgentStart fires BEFORE any agent node has executed, so there is
-  // no real per-run ThreadStore yet — use a bootstrap frame so user
-  // callbacks that reach for thread/message builtins get a clear error
-  // instead of writing into a placeholder. `messages` is still
-  // available to the callback via `data.messages`.
-  await runInBootstrapFrame(
-    execCtx,
-    () =>
-      callHook({
-        ctx: execCtx,
-        name: "onAgentStart",
-        data: { nodeName, args: data, messages: messages || [], cancel },
-      }),
-  );
-
-  const agentRunSpanId = execCtx.statelogClient.startSpan("agentRun");
-  execCtx.statelogClient.agentStart({ entryNode: nodeName, args: data });
+  // === Invocation started (context exists). A SINGLE lifecycle boundary covers
+  // all remaining setup AND execution, so an already-aborted signal or a
+  // bootstrap/setup failure still yields an outcome-with-usage and still runs
+  // cleanup. Handler/budget registration order (inside initFreshExecCtx) is
+  // unchanged. ===
   const agentStartTime = performance.now();
-
-  let isResume = false;
-  let threadStore = ThreadStore.withDefaultActive(execCtx.statelogClient);
+  let agentRunSpanId: ReturnType<typeof execCtx.statelogClient.startSpan> | undefined;
+  let outcome: RawOutcome<RunNodeResult<any>>;
   try {
+    // Cross-module init, this module's globals, top-level callbacks, then the
+    // root run-policy handler and root cost/time budget — all inside
+    // initFreshExecCtx (see there for the full ordering rationale, e.g. the
+    // `node main() { route({ systemPrompt: foreignStatic }) }` foreign-static
+    // case), so nodes and served functions are bootstrapped and capped identically.
+    await initFreshExecCtx(execCtx, { initializeGlobals });
+    // Externally-passed callbacks are stored on ctx; hook execution merges them
+    // with scoped/top-level callbacks at call time.
+    if (callbacks) {
+      Object.assign(execCtx.callbacks, callbacks);
+    }
+
+    // Wire external abort signal to the execution context
+    const cancel = (reason?: string) => execCtx.cancel(reason);
+    if (abortSignal) {
+      if (abortSignal.aborted) {
+        throw new AgencyCancelledError();
+      }
+      abortSignal.addEventListener("abort", () => execCtx.cancel(), {
+        once: true,
+      });
+    }
+
+    // onAgentStart fires BEFORE any agent node has executed, so there is
+    // no real per-run ThreadStore yet — use a bootstrap frame so user
+    // callbacks that reach for thread/message builtins get a clear error
+    // instead of writing into a placeholder. `messages` is still
+    // available to the callback via `data.messages`.
+    await runInBootstrapFrame(
+      execCtx,
+      () =>
+        callHook({
+          ctx: execCtx,
+          name: "onAgentStart",
+          data: { nodeName, args: data, messages: messages || [], cancel },
+        }),
+    );
+
+    agentRunSpanId = execCtx.statelogClient.startSpan("agentRun");
+    execCtx.statelogClient.agentStart({ entryNode: nodeName, args: data });
+
+    let isResume = false;
+    let threadStore = ThreadStore.withDefaultActive(execCtx.statelogClient);
     while (true) {
       try {
         // Install an initial AsyncLocalStorage frame so stdlib helpers
@@ -462,7 +483,8 @@ export async function runNode({
           );
           await execCtx.closeTraceWriter();
         }
-        return returnObject;
+        outcome = { status: "returned", value: returnObject };
+        break;
       } catch (e) {
         if (e instanceof RestoreSignal) {
           execCtx._restoreCount++;
@@ -519,9 +541,26 @@ export async function runNode({
       timeTaken: performance.now() - agentStartTime,
       tokenStats: partialReturn.tokens,
     });
-    throw error;
+    outcome = { status: "threw", error };
   } finally {
-    execCtx.statelogClient.endSpan(agentRunSpanId); // end agentRun span
-    await finalizeExecCtx(execCtx);
+    // Guarded: a setup failure before the span was opened leaves it undefined.
+    if (agentRunSpanId !== undefined) {
+      execCtx.statelogClient.endSpan(agentRunSpanId); // end agentRun span
+    }
   }
+  return finishServedInvocation(execCtx, outcome, () => finalizeExecCtx(execCtx));
+}
+
+/** Public entry point — unchanged contract: returns the RunNodeResult or throws
+ *  the identical original error. */
+export async function runNode(args: RunNodeArgs): Promise<RunNodeResult<any>> {
+  return unwrapServedInvocationOutcome(await runNodeCore(args));
+}
+
+/** Serve-only entry point: hands the outcome (RunNodeResult/error + usage
+ *  snapshot) to the serve adapter instead of unwrapping it. */
+export async function runNodeForServe(
+  args: RunNodeArgs,
+): Promise<ServedInvocationOutcome<RunNodeResult<any>>> {
+  return runNodeCore(args);
 }

--- a/packages/agency-lang/lib/runtime/node.ts
+++ b/packages/agency-lang/lib/runtime/node.ts
@@ -221,10 +221,17 @@ async function finalizeExecCtx(execCtx: RuntimeContext<GraphState>): Promise<voi
       console.warn(`[memory] save failed: ${(err as Error).message}`);
     }
   }
-  // Remote statelog POSTs are fire-and-forget; drain any still in flight
-  // so telemetry is delivered before the context is released.
-  await execCtx.statelogClient.flush();
-  execCtx.cleanup();
+  // Remote statelog POSTs are fire-and-forget; drain any still in flight so
+  // telemetry is delivered before the context is released. cleanup() runs in a
+  // finally so a rejected flush never leaks the execution context — every
+  // invocation whose context was created releases it. A flush rejection still
+  // propagates (finishServedInvocation makes it the outcome when execution
+  // otherwise succeeded).
+  try {
+    await execCtx.statelogClient.flush();
+  } finally {
+    execCtx.cleanup();
+  }
 }
 
 /**

--- a/packages/agency-lang/lib/runtime/prompt.test.ts
+++ b/packages/agency-lang/lib/runtime/prompt.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect, vi } from "vitest";
 import { SmolError } from "smoltalk";
 import { _internal } from "./prompt.js";
 import { AgencyCancelledError, makeAbortCause, readCause } from "./errors.js";
+import { RuntimeContext } from "./state/context.js";
+import { meteredDispatch } from "./recordPaidUsage.js";
+import type { GraphState } from "./types.js";
 
 const {
   DEFAULT_TOOL_RESULT_CHARS,
@@ -463,5 +466,45 @@ describe("dropNullDefaultedArgs", () => {
       [P("cwd", true)],
     );
     expect(out).toEqual({ extra: null });
+  });
+});
+
+describe("meteredDispatch — provider-attempt unknown-cost accounting", () => {
+  function makeCtx() {
+    return new RuntimeContext<GraphState>({
+      statelogConfig: { host: "", apiKey: "", projectId: "", debugMode: false, observability: false },
+      smoltalkDefaults: {},
+      dirname: "/project",
+    });
+  }
+
+  it("a resolved dispatch records no unknown-cost attempt", async () => {
+    const ctx = makeCtx();
+    const out = await meteredDispatch(ctx, ctx.stateStack, async () => "ok");
+    expect(out).toBe("ok");
+    expect(ctx.invocationUsage.snapshot().usage.unknownCostCallCount).toBe(0);
+    expect(ctx.invocationUsage.snapshot().usage.pricingComplete).toBe(true);
+  });
+
+  it("a dispatched-but-unresolved throw records one unknown-cost attempt and rethrows", async () => {
+    const ctx = makeCtx();
+    const err = new Error("provider 500 after dispatch");
+    await expect(
+      meteredDispatch(ctx, ctx.stateStack, async () => { throw err; }),
+    ).rejects.toBe(err);
+    const s = ctx.invocationUsage.snapshot();
+    expect(s.usage.unknownCostCallCount).toBe(1);
+    expect(s.usage.pricedCost).toBe(0);
+    expect(s.usage.pricingComplete).toBe(false);
+  });
+
+  it("failed-retry-then-success counts exactly one unknown attempt (each dispatch is an attempt)", async () => {
+    const ctx = makeCtx();
+    // First attempt throws (e.g. a timeout), second resolves.
+    await expect(
+      meteredDispatch(ctx, ctx.stateStack, async () => { throw new Error("timeout"); }),
+    ).rejects.toThrow();
+    await meteredDispatch(ctx, ctx.stateStack, async () => "recovered");
+    expect(ctx.invocationUsage.snapshot().usage.unknownCostCallCount).toBe(1);
   });
 });

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -21,6 +21,8 @@ import {
   type BoundaryContext,
 } from "./turnBoundary.js";
 import { AgencyCancelledError, isAbortError, makeAbortCause, readCause } from "./errors.js";
+import { recordPaidUsageAt } from "./recordPaidUsage.js";
+import { completionUsageDelta } from "./invocationUsage.js";
 import { abortableSleep } from "../stdlib/abortable.js";
 import { decideRetry, decideValidationRetry, enrichSchemaLimitationError, resolveRetryPolicy } from "./llmRetry.js";
 import type { RetryPolicy, RetryConfig, LLMRetryReason } from "./llmRetry.js";
@@ -765,8 +767,20 @@ async function _runPrompt({
   // descendants' spend in real time; mid-fork trips fire on the next
   // enforceGuards() call. See docs/superpowers/specs/2026-05-20-thread-
   // builtins-and-stdlib-design.md.
-  const callCost = completion.cost?.totalCost ?? 0;
-  targetStack.billCharge(callCost);
+  // Account this completion through the single paid-usage boundary: it bills
+  // the branch's cost guards (via billCharge), merges the per-invocation usage
+  // meter (priced cost + input/output tokens + unknown-price count for the
+  // serve cost seam), and relays the full delta once if this is a subprocess.
+  recordPaidUsageAt(
+    { ctx, stack: targetStack },
+    completionUsageDelta({
+      cost: completion.cost?.totalCost,
+      inputTokens: completion.usage?.inputTokens,
+      outputTokens: completion.usage?.outputTokens,
+    }),
+  );
+  // Per-branch total-token accumulator, complementary to the meter above, so
+  // std::thread's getTokens() reports per-branch totals.
   targetStack.localTokens += completion.usage?.totalTokens ?? 0;
   // NOTE: no post-charge enforceGuards here anymore. A trip caused by
   // THIS charge is raised resumably at the caller's next guard gate

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -21,7 +21,7 @@ import {
   type BoundaryContext,
 } from "./turnBoundary.js";
 import { AgencyCancelledError, isAbortError, makeAbortCause, readCause } from "./errors.js";
-import { accountCompletionUsage } from "./recordPaidUsage.js";
+import { accountCompletionUsage, meteredDispatch } from "./recordPaidUsage.js";
 import { abortableSleep } from "../stdlib/abortable.js";
 import { decideRetry, decideValidationRetry, enrichSchemaLimitationError, resolveRetryPolicy } from "./llmRetry.js";
 import type { RetryPolicy, RetryConfig, LLMRetryReason } from "./llmRetry.js";
@@ -491,21 +491,25 @@ async function dispatchWithRetry(args: {
       callHook({ ctx, name: "onLLMTimeout", data }),
   };
 
+  const targetStack = stateStack ?? ctx.stateStack;
   return runWithRetry(
     (signal) =>
-      dispatchLLMRequest({
-        ctx,
-        promptConfig: { ...promptConfig, abortSignal: signal } as PromptConfig,
-        prompt,
-        stream,
-        stateStack,
-      }),
+      meteredDispatch(ctx, targetStack, () =>
+        dispatchLLMRequest({
+          ctx,
+          promptConfig: { ...promptConfig, abortSignal: signal } as PromptConfig,
+          prompt,
+          stream,
+          stateStack,
+        }),
+      ),
     retryPolicy,
     parentSignal,
     retryHooks,
     normalizeError,
   );
 }
+
 
 /** Test-only surface for the pure tool-result-cap helpers. Not part of
  *  the supported runtime API. */

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -21,8 +21,7 @@ import {
   type BoundaryContext,
 } from "./turnBoundary.js";
 import { AgencyCancelledError, isAbortError, makeAbortCause, readCause } from "./errors.js";
-import { recordPaidUsageAt } from "./recordPaidUsage.js";
-import { completionUsageDelta } from "./invocationUsage.js";
+import { accountCompletionUsage } from "./recordPaidUsage.js";
 import { abortableSleep } from "../stdlib/abortable.js";
 import { decideRetry, decideValidationRetry, enrichSchemaLimitationError, resolveRetryPolicy } from "./llmRetry.js";
 import type { RetryPolicy, RetryConfig, LLMRetryReason } from "./llmRetry.js";
@@ -767,21 +766,7 @@ async function _runPrompt({
   // descendants' spend in real time; mid-fork trips fire on the next
   // enforceGuards() call. See docs/superpowers/specs/2026-05-20-thread-
   // builtins-and-stdlib-design.md.
-  // Account this completion through the single paid-usage boundary: it bills
-  // the branch's cost guards (via billCharge), merges the per-invocation usage
-  // meter (priced cost + input/output tokens + unknown-price count for the
-  // serve cost seam), and relays the full delta once if this is a subprocess.
-  recordPaidUsageAt(
-    { ctx, stack: targetStack },
-    completionUsageDelta({
-      cost: completion.cost?.totalCost,
-      inputTokens: completion.usage?.inputTokens,
-      outputTokens: completion.usage?.outputTokens,
-    }),
-  );
-  // Per-branch total-token accumulator, complementary to the meter above, so
-  // std::thread's getTokens() reports per-branch totals.
-  targetStack.localTokens += completion.usage?.totalTokens ?? 0;
+  accountCompletionUsage(ctx, targetStack, completion);
   // NOTE: no post-charge enforceGuards here anymore. A trip caused by
   // THIS charge is raised resumably at the caller's next guard gate
   // (round.N.guardGate / guardGate.final in runPrompt) — the paid work

--- a/packages/agency-lang/lib/runtime/recordPaidUsage.test.ts
+++ b/packages/agency-lang/lib/runtime/recordPaidUsage.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import {
   recordPaidUsageAt,
   recordPaidUsage,
+  recordUnknownCostAttempt,
   markInvocationUsageIncompleteAt,
 } from "./recordPaidUsage.js";
 import { completionUsageDelta, paidCostDelta } from "./invocationUsage.js";
@@ -100,6 +101,29 @@ describe("recordPaidUsage / addCost (ambient target)", () => {
       recordPaidUsage(paidCostDelta(0.4));
     });
     expect(ctx.invocationUsage.snapshot().usage.pricedCost).toBeCloseTo(0.4);
+  });
+});
+
+describe("recordUnknownCostAttempt", () => {
+  it("adds one unknown-cost call, no cost, and flips pricingComplete false", () => {
+    const ctx = makeCtx();
+    recordUnknownCostAttempt(ctx, ctx.stateStack);
+    const s = ctx.invocationUsage.snapshot();
+    expect(s.usage.unknownCostCallCount).toBe(1);
+    expect(s.usage.pricedCost).toBe(0);
+    expect(s.usage.pricingComplete).toBe(false);
+    expect(ctx.stateStack.localCost).toBe(0);
+  });
+
+  it("relays the unknown-cost delta upward in IPC mode", () => {
+    vi.stubEnv("AGENCY_IPC", "1");
+    const send = vi.fn(() => true);
+    process.send = send as any;
+    const ctx = makeCtx();
+    recordUnknownCostAttempt(ctx, ctx.stateStack);
+    expect(send).toHaveBeenCalledExactlyOnceWith({
+      type: "invocationUsage", pricedCost: 0, inputTokens: 0, outputTokens: 0, unknownCostCallCount: 1,
+    });
   });
 });
 

--- a/packages/agency-lang/lib/runtime/recordPaidUsage.test.ts
+++ b/packages/agency-lang/lib/runtime/recordPaidUsage.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  recordPaidUsageAt,
+  recordPaidUsage,
+  markInvocationUsageIncompleteAt,
+} from "./recordPaidUsage.js";
+import { completionUsageDelta, paidCostDelta } from "./invocationUsage.js";
+import { addCost } from "./cost.js";
+import { RuntimeContext } from "./state/context.js";
+import { StateStack } from "./state/stateStack.js";
+import { ThreadStore } from "./state/threadStore.js";
+import { CostGuard } from "./guard.js";
+import { runInTestContext } from "./asyncContext.js";
+import type { GraphState } from "./types.js";
+
+function makeCtx() {
+  return new RuntimeContext<GraphState>({
+    statelogConfig: { host: "", apiKey: "", projectId: "", debugMode: false, observability: false },
+    smoltalkDefaults: {},
+    dirname: "/project",
+  });
+}
+
+const originalSend = process.send;
+afterEach(() => {
+  process.send = originalSend;
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe("recordPaidUsageAt (explicit target)", () => {
+  it("bills the given branch's cost + guards once and merges the meter once", () => {
+    const ctx = makeCtx();
+    const branch = new StateStack();
+    const guard = new CostGuard(1);
+    branch.guards.push(guard);
+    recordPaidUsageAt({ ctx, stack: branch }, { pricedCost: 0.25, inputTokens: 100, outputTokens: 20, unknownCostCallCount: 0 });
+
+    expect(branch.localCost).toBeCloseTo(0.25);
+    // The invocation meter, not ctx.stateStack, saw the spend.
+    expect(ctx.invocationUsage.snapshot().usage.pricedCost).toBeCloseTo(0.25);
+    expect(ctx.invocationUsage.snapshot().usage.inputTokens).toBe(100);
+    expect(ctx.stateStack.localCost).toBe(0);
+  });
+
+  it("relays the full delta once when in IPC mode", () => {
+    vi.stubEnv("AGENCY_IPC", "1");
+    const send = vi.fn(() => true);
+    process.send = send as any;
+    recordPaidUsageAt({ ctx: makeCtx(), stack: new StateStack() }, { pricedCost: 0.5, inputTokens: 1, outputTokens: 1, unknownCostCallCount: 0 });
+    expect(send).toHaveBeenCalledExactlyOnceWith({
+      type: "invocationUsage", pricedCost: 0.5, inputTokens: 1, outputTokens: 1, unknownCostCallCount: 0,
+    });
+  });
+
+  it("an unpriced completion records tokens/unknown without charging guards", () => {
+    const ctx = makeCtx();
+    const branch = new StateStack();
+    recordPaidUsageAt({ ctx, stack: branch }, completionUsageDelta({ cost: undefined, inputTokens: 5, outputTokens: 2 }));
+    expect(branch.localCost).toBe(0);
+    const s = ctx.invocationUsage.snapshot();
+    expect(s.usage.pricedCost).toBe(0);
+    expect(s.usage.inputTokens).toBe(5);
+    expect(s.usage.unknownCostCallCount).toBe(1);
+    expect(s.usage.pricingComplete).toBe(false);
+  });
+});
+
+describe("recordPaidUsage / addCost (ambient target)", () => {
+  it("addCost records cost against the invocation meter and enforces guards", async () => {
+    const ctx = makeCtx();
+    await runInTestContext(ctx, ctx.stateStack, new ThreadStore(), async () => {
+      addCost(0.25);
+    });
+    expect(ctx.invocationUsage.snapshot().usage.pricedCost).toBeCloseTo(0.25);
+    expect(ctx.stateStack.localCost).toBeCloseTo(0.25);
+  });
+
+  it("addCost with an over-budget charge trips the guard (enforcement preserved)", async () => {
+    const ctx = makeCtx();
+    ctx.stateStack.guards.push(new CostGuard(0.1));
+    await expect(
+      runInTestContext(ctx, ctx.stateStack, new ThreadStore(), async () => addCost(0.25)),
+    ).rejects.toBeTruthy();
+  });
+
+  it("invalid addCost throws before any mutation (never a silent dropped charge)", async () => {
+    const ctx = makeCtx();
+    await runInTestContext(ctx, ctx.stateStack, new ThreadStore(), async () => {
+      expect(() => addCost(-1)).toThrow();
+      expect(() => addCost(NaN)).toThrow();
+    });
+    expect(ctx.stateStack.localCost).toBe(0);
+    expect(ctx.invocationUsage.snapshot().usage.pricedCost).toBe(0);
+  });
+
+  it("recordPaidUsage delegates to the active frame", async () => {
+    const ctx = makeCtx();
+    await runInTestContext(ctx, ctx.stateStack, new ThreadStore(), async () => {
+      recordPaidUsage(paidCostDelta(0.4));
+    });
+    expect(ctx.invocationUsage.snapshot().usage.pricedCost).toBeCloseTo(0.4);
+  });
+});
+
+describe("markInvocationUsageIncompleteAt", () => {
+  it("relays the marker only on the first transition", () => {
+    vi.stubEnv("AGENCY_IPC", "1");
+    const send = vi.fn(() => true);
+    process.send = send as any;
+    const ctx = makeCtx();
+    markInvocationUsageIncompleteAt(ctx);
+    markInvocationUsageIncompleteAt(ctx);
+    expect(send).toHaveBeenCalledExactlyOnceWith({ type: "invocationUsageIncomplete" });
+    expect(ctx.invocationUsage.snapshot().usageComplete).toBe(false);
+  });
+});

--- a/packages/agency-lang/lib/runtime/recordPaidUsage.ts
+++ b/packages/agency-lang/lib/runtime/recordPaidUsage.ts
@@ -1,0 +1,48 @@
+// The single accounting boundary for the serve cost seam.
+//
+// Every paid unit of work — an LLM completion (prompt.ts), an `addCost` charge
+// (cost.ts; memory and image generation pay through it), and a subprocess's
+// relayed usage (ipc.ts) — submits one `InvocationUsageDelta` here. This is the
+// ONE place that (1) bills the branch's cost guards via `StateStack.billCharge`,
+// (2) merges the invocation's usage meter, and (3) relays the full delta upward
+// exactly once when this process is itself a subprocess. Because all three
+// happen together, "authoritative cost" never depends on execution topology: the
+// same charge counts identically in-process and in a child.
+
+import { getRuntimeContext } from "./asyncContext.js";
+import type { RuntimeContext } from "./state/context.js";
+import type { GraphState } from "./types.js";
+import type { InvocationAccountingTarget, InvocationUsageDelta } from "./invocationUsage.js";
+import {
+  sendInvocationUsageToParent,
+  sendInvocationUsageIncompleteToParent,
+} from "./costTelemetry.js";
+
+/** Account one paid delta against an EXPLICIT target (out-of-frame callers such
+ *  as the IPC telemetry handler pass `RunSession.ctx/stateStack`, never relying
+ *  on AsyncLocalStorage). Bills guards, merges the meter, relays once. */
+export function recordPaidUsageAt(
+  target: InvocationAccountingTarget,
+  delta: InvocationUsageDelta,
+): void {
+  target.stack.billCharge(delta.pricedCost);
+  target.ctx.invocationUsage.merge(delta);
+  sendInvocationUsageToParent(delta);
+}
+
+/** Ambient convenience for in-frame TS helpers (only `addCost`): reads the
+ *  active `{ ctx, stack }` from the execution frame and delegates. */
+export function recordPaidUsage(delta: InvocationUsageDelta): void {
+  const { ctx, stack } = getRuntimeContext();
+  recordPaidUsageAt({ ctx, stack }, delta);
+}
+
+/** Mark this invocation's usage as no longer guaranteed complete (an abnormal
+ *  subprocess termination). Relays the marker upward once, only on the first
+ *  transition, so a mid-tier process forwards a descendant's incompleteness
+ *  without spamming. */
+export function markInvocationUsageIncompleteAt(ctx: RuntimeContext<GraphState>): void {
+  if (ctx.invocationUsage.markIncomplete()) {
+    sendInvocationUsageIncompleteToParent();
+  }
+}

--- a/packages/agency-lang/lib/runtime/recordPaidUsage.ts
+++ b/packages/agency-lang/lib/runtime/recordPaidUsage.ts
@@ -84,20 +84,21 @@ export function recordUnknownCostAttempt(
  *  is a fresh attempt). A resolved dispatch is priced later at the completion
  *  site; a dispatched-but-UNRESOLVED attempt (timeout/cancel/provider error
  *  after dispatch — possible spend, no price) records one unknown-cost attempt
- *  so pricingComplete goes false. A pre-dispatch failure never enters here. */
-export async function meteredDispatch<T>(
+ *  so pricingComplete goes false. A pre-dispatch failure never enters here.
+ *
+ *  Returns the dispatch promise UNCHANGED (not wrapped in await/then): the
+ *  unknown-cost record is a fire-and-forget side effect on rejection, so this
+ *  adds no microtask tick to the caller's timing. That matters — race()
+ *  determinism (which loser calls complete before the abort fires) is timing-
+ *  sensitive, and wrapping the dispatch would shift it. */
+export function meteredDispatch<T>(
   ctx: RuntimeContext<GraphState>,
   targetStack: StateStack,
   dispatch: () => Promise<T>,
 ): Promise<T> {
-  let resolved = false;
-  try {
-    const result = await dispatch();
-    resolved = true;
-    return result;
-  } finally {
-    if (!resolved) recordUnknownCostAttempt(ctx, targetStack);
-  }
+  const pending = dispatch();
+  void pending.catch(() => recordUnknownCostAttempt(ctx, targetStack));
+  return pending;
 }
 
 /** Mark this invocation's usage as no longer guaranteed complete (an abnormal

--- a/packages/agency-lang/lib/runtime/recordPaidUsage.ts
+++ b/packages/agency-lang/lib/runtime/recordPaidUsage.ts
@@ -11,8 +11,13 @@
 
 import { getRuntimeContext } from "./asyncContext.js";
 import type { RuntimeContext } from "./state/context.js";
+import type { StateStack } from "./state/stateStack.js";
 import type { GraphState } from "./types.js";
-import type { InvocationAccountingTarget, InvocationUsageDelta } from "./invocationUsage.js";
+import {
+  completionUsageDelta,
+  type InvocationAccountingTarget,
+  type InvocationUsageDelta,
+} from "./invocationUsage.js";
 import {
   sendInvocationUsageToParent,
   sendInvocationUsageIncompleteToParent,
@@ -35,6 +40,28 @@ export function recordPaidUsageAt(
 export function recordPaidUsage(delta: InvocationUsageDelta): void {
   const { ctx, stack } = getRuntimeContext();
   recordPaidUsageAt({ ctx, stack }, delta);
+}
+
+/** Account one LLM completion through the paid-usage boundary (guards + meter +
+ *  subprocess relay) and update the per-branch total-token accumulator that
+ *  std::thread's getTokens() reports. Called from the prompt completion site. */
+export function accountCompletionUsage(
+  ctx: RuntimeContext<GraphState>,
+  targetStack: StateStack,
+  completion: {
+    cost?: { totalCost?: number } | null;
+    usage?: { inputTokens?: number; outputTokens?: number; totalTokens?: number } | null;
+  },
+): void {
+  recordPaidUsageAt(
+    { ctx, stack: targetStack },
+    completionUsageDelta({
+      cost: completion.cost?.totalCost,
+      inputTokens: completion.usage?.inputTokens,
+      outputTokens: completion.usage?.outputTokens,
+    }),
+  );
+  targetStack.localTokens += completion.usage?.totalTokens ?? 0;
 }
 
 /** Mark this invocation's usage as no longer guaranteed complete (an abnormal

--- a/packages/agency-lang/lib/runtime/recordPaidUsage.ts
+++ b/packages/agency-lang/lib/runtime/recordPaidUsage.ts
@@ -64,6 +64,42 @@ export function accountCompletionUsage(
   targetStack.localTokens += completion.usage?.totalTokens ?? 0;
 }
 
+/** Record one UNKNOWN-cost provider attempt: a request that was dispatched to
+ *  the provider but did not resolve to a priced completion (timeout / cancel /
+ *  provider error after dispatch — possible spend, no price metadata). Adds one
+ *  to unknownCostCallCount (no cost, no tokens) so pricingComplete goes false;
+ *  relays upward once if this is a subprocess. A failure PROVEN before dispatch
+ *  never calls this. */
+export function recordUnknownCostAttempt(
+  ctx: RuntimeContext<GraphState>,
+  targetStack: StateStack,
+): void {
+  recordPaidUsageAt(
+    { ctx, stack: targetStack },
+    { pricedCost: 0, inputTokens: 0, outputTokens: 0, unknownCostCallCount: 1 },
+  );
+}
+
+/** Run one provider dispatch as a metered attempt (serve cost seam; each retry
+ *  is a fresh attempt). A resolved dispatch is priced later at the completion
+ *  site; a dispatched-but-UNRESOLVED attempt (timeout/cancel/provider error
+ *  after dispatch — possible spend, no price) records one unknown-cost attempt
+ *  so pricingComplete goes false. A pre-dispatch failure never enters here. */
+export async function meteredDispatch<T>(
+  ctx: RuntimeContext<GraphState>,
+  targetStack: StateStack,
+  dispatch: () => Promise<T>,
+): Promise<T> {
+  let resolved = false;
+  try {
+    const result = await dispatch();
+    resolved = true;
+    return result;
+  } finally {
+    if (!resolved) recordUnknownCostAttempt(ctx, targetStack);
+  }
+}
+
 /** Mark this invocation's usage as no longer guaranteed complete (an abnormal
  *  subprocess termination). Relays the marker upward once, only on the first
  *  transition, so a mid-tier process forwards a descendant's incompleteness

--- a/packages/agency-lang/lib/runtime/servedInvocationLifecycle.ts
+++ b/packages/agency-lang/lib/runtime/servedInvocationLifecycle.ts
@@ -1,0 +1,41 @@
+// Shared lifecycle tail for the outcome-producing run cores (runNode /
+// runExportedFunction / respondToInterrupts). Kept in its own module so both
+// node.ts and interrupts.ts can use it without a circular import.
+
+import type { RuntimeContext } from "./state/context.js";
+import type { GraphState } from "./types.js";
+import type { ServedInvocationOutcome } from "./invocationUsage.js";
+
+/** A bare value-or-error, before the usage snapshot is attached. */
+export type RawOutcome<T> =
+  | { status: "returned"; value: T }
+  | { status: "threw"; error: unknown };
+
+/**
+ * Close a served invocation's lifecycle: run cleanup, then snapshot the meter.
+ *
+ * - The FIRST execution error wins as the outcome error. A later cleanup error
+ *   is logged, not substituted, so the real cause is never hidden.
+ * - If execution SUCCEEDED but cleanup failed, the cleanup error becomes the
+ *   outcome (a failed teardown is a real failure).
+ * - The meter snapshot is taken AFTER cleanup, so paid work incurred during
+ *   cleanup (e.g. memory persistence) is counted.
+ */
+export async function finishServedInvocation<T>(
+  execCtx: RuntimeContext<GraphState>,
+  outcome: RawOutcome<T>,
+  cleanup: () => Promise<void>,
+): Promise<ServedInvocationOutcome<T>> {
+  let finalOutcome = outcome;
+  try {
+    await cleanup();
+  } catch (cleanupError) {
+    if (finalOutcome.status === "returned") {
+      finalOutcome = { status: "threw", error: cleanupError };
+    } else {
+      const detail = cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
+      console.warn(`[invocation] cleanup failed after an execution error: ${detail}`);
+    }
+  }
+  return { ...finalOutcome, ...execCtx.invocationUsage.snapshot() };
+}

--- a/packages/agency-lang/lib/runtime/state/context.invocationUsage.test.ts
+++ b/packages/agency-lang/lib/runtime/state/context.invocationUsage.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { RuntimeContext } from "./context.js";
+import type { Checkpoint } from "./checkpointStore.js";
+
+// The invocation meter is per-execCtx and must NOT survive a checkpoint restore
+// (a resume leg starts fresh), nor appear in any serialization.
+function makeContext() {
+  return new RuntimeContext({
+    statelogConfig: { host: "", apiKey: "", projectId: "", debugMode: false, observability: false },
+    smoltalkDefaults: {},
+    dirname: "/project",
+  });
+}
+
+describe("execution-context invocation meter", () => {
+  it("each createExecutionContext gets an independent, complete, zeroed meter", async () => {
+    const parent = makeContext();
+    const a = await parent.createExecutionContext("run-a");
+    const b = await parent.createExecutionContext("run-b");
+
+    expect(a.invocationUsage.snapshot()).toEqual({
+      usage: { pricedCost: 0, inputTokens: 0, outputTokens: 0, unknownCostCallCount: 0, pricingComplete: true },
+      usageComplete: true,
+    });
+
+    a.invocationUsage.merge({ pricedCost: 1, inputTokens: 10, outputTokens: 2, unknownCostCallCount: 1 });
+    // b is untouched by a's spend (concurrent-invocation isolation).
+    expect(b.invocationUsage.snapshot().usage.pricedCost).toBe(0);
+    expect(b.invocationUsage.snapshot().usage.pricingComplete).toBe(true);
+  });
+
+  it("restoreState neither resets nor hydrates the meter (resume-leg isolation is structural)", async () => {
+    const execCtx = await makeContext().createExecutionContext("run-1");
+    execCtx.invocationUsage.merge({ pricedCost: 0.5, inputTokens: 7, outputTokens: 3, unknownCostCallCount: 0 });
+
+    const checkpoint = execCtx.stateToJSON() as unknown as Checkpoint;
+    execCtx.restoreState(checkpoint);
+
+    // The meter is exactly what it was — restore did not touch it. (In real
+    // resume the FRESH execCtx is what gives per-leg isolation; here we prove
+    // restore itself carries no meter state.)
+    expect(execCtx.invocationUsage.snapshot().usage.pricedCost).toBeCloseTo(0.5);
+  });
+
+  it("no serialization includes the meter", async () => {
+    const execCtx = await makeContext().createExecutionContext("run-2");
+    execCtx.invocationUsage.merge({ pricedCost: 9.99, inputTokens: 1, outputTokens: 1, unknownCostCallCount: 0 });
+    expect(JSON.stringify(execCtx.toJSON())).not.toContain("invocationUsage");
+    expect(JSON.stringify(execCtx.stateToJSON())).not.toContain("9.99");
+  });
+});

--- a/packages/agency-lang/lib/runtime/state/context.ts
+++ b/packages/agency-lang/lib/runtime/state/context.ts
@@ -11,6 +11,7 @@ import type { AbortCause } from "../errors.js";
 import { Clock, realClock, FakeClock } from "../clock.js";
 import { agencyStore } from "../asyncContext.js";
 import { DEFAULT_MAX_CALL_DEPTH } from "../callDepth.js";
+import { InvocationUsageMeter } from "../invocationUsage.js";
 import { getSubprocessRunInfo } from "../subprocessRunInfo.js";
 import type { AgencyCallbacks } from "../hooks.js";
 import type { InterruptResponse } from "../interrupts.js";
@@ -221,6 +222,15 @@ export class RuntimeContext<T> {
    *  env vars alone. */
   budget?: { maxCost?: number; maxTimeMs?: number };
 
+  /** Fresh per-invocation usage meter for the serve cost seam. One per
+   *  execution context, so each `/node` / `/function` / `/resume` leg meters
+   *  only its own newly-incurred spend. Deliberately NOT serialized and NOT
+   *  restored from a checkpoint — a resume leg must start at zero, never
+   *  inherit the checkpoint-carried cumulative cost. Set both here (for a
+   *  directly-`new`'d context) and explicitly in `createExecutionContext`
+   *  (which bypasses the constructor via Object.create). */
+  invocationUsage: InvocationUsageMeter = new InvocationUsageMeter();
+
   // Memory layer (resolved decisions in
   // docs/superpowers/plans/2026-05-12-memory-layer.md and
   // docs/superpowers/plans/2026-05-29-memory-config-in-code.md).
@@ -387,6 +397,9 @@ export class RuntimeContext<T> {
     // installRootBudget, which reads execCtx.budget, actually sees the resolved
     // config/override budget. Without this the root budget is a silent no-op.
     execCtx.budget = this.budget;
+    // Fresh meter per invocation/leg (Object.create bypasses the field
+    // initializer). Never carried from the parent context or a checkpoint.
+    execCtx.invocationUsage = new InvocationUsageMeter();
     execCtx.checkpoints = new CheckpointStore(this.maxRestores);
     // The execution context is built via Object.create, bypassing the
     // constructor, so carry the clock over from the global context. Without

--- a/packages/agency-lang/lib/runtime/state/stateStack.ts
+++ b/packages/agency-lang/lib/runtime/state/stateStack.ts
@@ -2,7 +2,6 @@ import type { Guard, GuardExceededError, GuardJSON } from "../guard.js";
 import type { HandlerEntry } from "../types.js";
 import type { ReplyAttachmentPart } from "../replyAttachments.js";
 import { guardFromJSON, TimeGuard } from "../guard.js";
-import { sendCostTelemetryToParent } from "../costTelemetry.js";
 import { Checkpoint } from "../index.js";
 import { MemoryFrame } from "../memory/frame.js";
 import { deepClone } from "../utils.js";
@@ -931,7 +930,10 @@ export class StateStack {
   billCharge(amount: number): void {
     this.localCost += amount;
     this.chargeGuards(amount);
-    sendCostTelemetryToParent(amount);
+    // NOTE: no telemetry/usage relay here anymore — it rides the
+    // recordPaidUsageAt accounting boundary (recordPaidUsage.ts), which owns
+    // the invocation-meter merge and the exactly-once upward relay of the full
+    // usage delta. billCharge is purely localCost + guard accumulation.
   }
 
   /**

--- a/packages/agency-lang/lib/serve/createServeHandler.test.ts
+++ b/packages/agency-lang/lib/serve/createServeHandler.test.ts
@@ -45,6 +45,21 @@ export function hasInterrupts(data) {
 export async function respondToInterrupts(interrupts, responses) {
   return { data: { resumed: true, responses } };
 }
+// Serve-only invokers (a current compile exports these; discoverExports and
+// createServeHandler now require them). Each returns a ServedInvocationOutcome.
+const __zeroUsage = { pricedCost: 0, inputTokens: 0, outputTokens: 0, unknownCostCallCount: 0, pricingComplete: true };
+function __returned(value) { return { status: "returned", value, usage: __zeroUsage, usageComplete: true }; }
+export async function __invokeFunctionForServe(fn, namedArgs) {
+  return __returned(__invokeFunction(fn, namedArgs));
+}
+export async function __invokeNodeForServe(nodeName, data) {
+  if (nodeName === "main") return __returned(await main(data.message));
+  if (nodeName === "needsApproval") return __returned(await needsApproval());
+  throw new Error("unknown node: " + nodeName);
+}
+export async function __respondToInterruptsForServe(interrupts, responses) {
+  return __returned(await respondToInterrupts(interrupts, responses));
+}
 `;
 }
 

--- a/packages/agency-lang/lib/serve/createServeHandler.ts
+++ b/packages/agency-lang/lib/serve/createServeHandler.ts
@@ -4,6 +4,7 @@ import type { AgencyFunction } from "../runtime/agencyFunction.js";
 import type { InterruptEffect } from "../symbolTable.js";
 import { createLogger } from "../logger.js";
 import type { Logger } from "../logger.js";
+import type { ServedInvocationOutcome } from "../runtime/invocationUsage.js";
 import { discoverExports } from "./discovery.js";
 import { createHttpHandler } from "./http/adapter.js";
 import type { RouteResult } from "./http/adapter.js";
@@ -64,15 +65,16 @@ export async function createServeHandler(
 
   // Public boundary check: fail fast with a clear message if the target is not
   // a compiled Agency serve module. `hasInterrupts` is called unguarded on the
-  // /node path and `respondToInterrupts` on /resume, so a non-Agency or stale
-  // bundle missing them would otherwise surface as a confusing runtime error.
+  // /node path and `__respondToInterruptsForServe` on /resume, so a non-Agency
+  // or stale bundle missing them would otherwise surface as a confusing runtime
+  // error. (discoverExports additionally requires the serve invokers.)
   if (
     typeof moduleExports.hasInterrupts !== "function" ||
-    typeof moduleExports.respondToInterrupts !== "function"
+    typeof moduleExports.__respondToInterruptsForServe !== "function"
   ) {
     throw new Error(
       `createServeHandler: ${compiledPath} is not a compiled Agency serve module ` +
-        `(missing hasInterrupts/respondToInterrupts exports).`,
+        `(missing hasInterrupts / serve exports — recompile with the current Agency).`,
     );
   }
 
@@ -90,12 +92,12 @@ export async function createServeHandler(
   return createHttpHandler({
     exports,
     logger,
-    // Passed RAW: the HTTP adapter unwraps respondToInterrupts's `{ data }`
-    // internally. Do not unwrap here (that is the MCP path's normalization).
+    // The serve resume returns a ServedInvocationOutcome (value/error + usage);
+    // the HTTP adapter maps it (and unwraps the RunNodeResult's `{ data }`).
     hasInterrupts: moduleExports.hasInterrupts as (data: unknown) => boolean,
-    respondToInterrupts: moduleExports.respondToInterrupts as (
+    respondToInterrupts: moduleExports.__respondToInterruptsForServe as (
       interrupts: unknown[],
       responses: unknown[],
-    ) => Promise<unknown>,
+    ) => Promise<ServedInvocationOutcome<unknown>>,
   });
 }

--- a/packages/agency-lang/lib/serve/discovery.test.ts
+++ b/packages/agency-lang/lib/serve/discovery.test.ts
@@ -1,8 +1,23 @@
 import { describe, expect, it } from "vitest";
 import { discoverExports } from "./discovery.js";
 import { AgencyFunction } from "../runtime/agencyFunction.js";
+import { returnedOutcome } from "./testOutcome.js";
+
+// A current compile exports the three serve invokers; discoverExports requires
+// them. Fixtures spread these stubs so they exercise the normal path.
+const serveStubs = {
+  __invokeFunctionForServe: async () => returnedOutcome(undefined),
+  __invokeNodeForServe: async () => returnedOutcome({ data: undefined }),
+  __respondToInterruptsForServe: async () => returnedOutcome({ data: undefined }),
+};
 
 describe("discoverExports", () => {
+  it("fails fast when the bundle lacks the serve invokers (recompile required)", () => {
+    expect(() =>
+      discoverExports({ toolRegistry: {}, moduleExports: {}, moduleId: "test" }),
+    ).toThrow(/predates the serve cost seam|Recompile/);
+  });
+
   it("returns exported functions from tool registry", () => {
     const registry: Record<string, AgencyFunction> = {};
     AgencyFunction.create(
@@ -41,7 +56,7 @@ describe("discoverExports", () => {
 
     const exports = discoverExports({
       toolRegistry: registry,
-      moduleExports: {},
+      moduleExports: { ...serveStubs },
       moduleId: "test",
     });
     const functions = exports.filter((e) => e.kind === "function");
@@ -72,7 +87,7 @@ describe("discoverExports", () => {
 
     const exports = discoverExports({
       toolRegistry: registry,
-      moduleExports: {},
+      moduleExports: { ...serveStubs },
       moduleId: "test",
     });
     const fn = exports.find((e) => e.name === "boundFn");
@@ -107,7 +122,7 @@ describe("discoverExports", () => {
 
     const exports = discoverExports({
       toolRegistry: registry,
-      moduleExports: {},
+      moduleExports: { ...serveStubs },
       moduleId: "myModule",
     });
     expect(exports).toHaveLength(1);
@@ -117,6 +132,7 @@ describe("discoverExports", () => {
   it("returns exported nodes from module exports", () => {
     const mockNodeFn = async () => ({ data: "result" });
     const moduleExports = {
+      ...serveStubs,
       main: mockNodeFn,
       __mainNodeParams: ["message"],
     };
@@ -138,6 +154,7 @@ describe("discoverExports", () => {
 
   it("skips non-exported nodes", () => {
     const moduleExports = {
+      ...serveStubs,
       main: async () => {},
       __mainNodeParams: [],
       helper: async () => {},
@@ -156,7 +173,7 @@ describe("discoverExports", () => {
 
   it("returns empty array when no exports found", () => {
     expect(
-      discoverExports({ toolRegistry: {}, moduleExports: {}, moduleId: "test" }),
+      discoverExports({ toolRegistry: {}, moduleExports: { ...serveStubs }, moduleId: "test" }),
     ).toEqual([]);
   });
 
@@ -177,6 +194,7 @@ describe("discoverExports", () => {
     const exports = discoverExports({
       toolRegistry: registry,
       moduleExports: {
+        ...serveStubs,
         checkout: async () => ({ data: "ok" }),
         __checkoutNodeParams: [],
       },

--- a/packages/agency-lang/lib/serve/discovery.test.ts
+++ b/packages/agency-lang/lib/serve/discovery.test.ts
@@ -12,10 +12,29 @@ const serveStubs = {
 };
 
 describe("discoverExports", () => {
-  it("fails fast when the bundle lacks the serve invokers (recompile required)", () => {
+  it("fails fast when a bundle EXPORTS a function but lacks its serve invoker (recompile required)", () => {
+    const registry: Record<string, AgencyFunction> = {};
+    AgencyFunction.create(
+      { name: "f", module: "test", fn: async () => {}, params: [], toolDefinition: { name: "f", description: "", schema: null }, exported: true },
+      registry,
+    );
     expect(() =>
-      discoverExports({ toolRegistry: {}, moduleExports: {}, moduleId: "test" }),
+      discoverExports({ toolRegistry: registry, moduleExports: {}, moduleId: "test" }),
     ).toThrow(/predates the serve cost seam|Recompile/);
+  });
+
+  it("an empty bundle (no functions, no nodes) requires no serve invokers", () => {
+    expect(discoverExports({ toolRegistry: {}, moduleExports: {}, moduleId: "test" })).toEqual([]);
+  });
+
+  it("a node-only bundle needs only the node serve invoker, not the function one", () => {
+    const exports = discoverExports({
+      toolRegistry: {},
+      moduleExports: { main: async () => {}, __mainNodeParams: [], __invokeNodeForServe: async () => returnedOutcome({ data: undefined }) },
+      moduleId: "test",
+      exportedNodeNames: ["main"],
+    });
+    expect(exports.map((e) => e.name)).toEqual(["main"]);
   });
 
   it("returns exported functions from tool registry", () => {

--- a/packages/agency-lang/lib/serve/discovery.ts
+++ b/packages/agency-lang/lib/serve/discovery.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type { AgencyFunction } from "../runtime/agencyFunction.js";
 import type { InterruptEffect } from "../symbolTable.js";
 import type { ExportedFunction, ExportedNode, ExportedItem } from "./types.js";
+import type { ServedInvocationOutcome } from "../runtime/invocationUsage.js";
 
 export type DiscoverOptions = {
   toolRegistry: Record<string, AgencyFunction>;
@@ -11,48 +12,26 @@ export type DiscoverOptions = {
   interruptEffectsByName?: Record<string, InterruptEffect[]>;
 };
 
-/**
- * The compiled module's generated `__invokeFunction`: runs an exported
- * function inside a node-grade execution frame. Optional because modules
- * compiled before it existed won't export it.
- */
-type ModuleInvokeFunction = (
+/** The compiled module's generated serve-only invokers (see imports.mustache):
+ *  they run a function / node inside a node-grade frame and return a
+ *  `ServedInvocationOutcome` (value/error + per-invocation usage). */
+type ServeFunctionInvoker = (
   fn: AgencyFunction,
   namedArgs: Record<string, unknown>,
-) => Promise<unknown>;
+) => Promise<ServedInvocationOutcome<unknown>>;
+type ServeNodeInvoker = (
+  nodeName: string,
+  data: Record<string, any>,
+) => Promise<ServedInvocationOutcome<unknown>>;
 
 function isExportedFromModule(fn: AgencyFunction, moduleId: string): boolean {
   return !!fn.exported && !!fn.toolDefinition && fn.module === moduleId;
 }
 
-/**
- * Build the per-request invoker for a function. Prefers the compiled
- * module's `__invokeFunction`, which runs the body inside a node-grade
- * execution frame (generated function bodies throw without an ambient
- * Agency frame). Falls back to a bare `agencyFunction.invoke` when the
- * module predates `__invokeFunction`.
- *
- * The fallback preserves the prior (broken) behavior for such stale
- * bundles rather than masking it: a pre-`__invokeFunction` module will
- * keep throwing "getRuntimeContext() called outside an Agency execution
- * frame" on function calls until it is recompiled. Recompiling is the
- * fix; the fallback only avoids a hard crash here (and keeps the path
- * working for the plain-JS function bodies used in adapter unit tests).
- */
-function makeInvoker(
-  fn: AgencyFunction,
-  moduleInvoke: ModuleInvokeFunction | undefined,
-): (namedArgs: Record<string, unknown>) => Promise<unknown> {
-  if (moduleInvoke) {
-    return (namedArgs) => moduleInvoke(fn, namedArgs);
-  }
-  return (namedArgs) => fn.invoke({ type: "named", positionalArgs: [], namedArgs });
-}
-
 function toExportedFunction(
   fn: AgencyFunction,
   interruptEffects: InterruptEffect[],
-  moduleInvoke: ModuleInvokeFunction | undefined,
+  serveFn: ServeFunctionInvoker,
 ): ExportedFunction {
   return {
     kind: "function",
@@ -65,24 +44,39 @@ function toExportedFunction(
       .map((param) => ({ name: param.name })),
     agencyFunction: fn,
     interruptEffects,
-    invoke: makeInvoker(fn, moduleInvoke),
+    invoke: (namedArgs) => serveFn(fn, namedArgs),
   };
+}
+
+/** A node's serve outcome carries a `RunNodeResult`; the caller-facing value is
+ *  its `.data` (which is the interrupt array on a pause). Unwrap it while
+ *  keeping the usage snapshot; a threw-outcome passes through untouched. */
+function unwrapNodeOutcome(
+  outcome: ServedInvocationOutcome<unknown>,
+): ServedInvocationOutcome<unknown> {
+  if (outcome.status === "returned") {
+    const result = outcome.value as { data?: unknown } | undefined;
+    return { ...outcome, value: result?.data };
+  }
+  return outcome;
 }
 
 function toExportedNode(
   nodeName: string,
   moduleExports: Record<string, unknown>,
   interruptEffects: InterruptEffect[],
+  serveNode: ServeNodeInvoker,
 ): ExportedNode | null {
-  const nodeFn = moduleExports[nodeName];
-  if (typeof nodeFn !== "function") return null;
+  // The node export still exists for CLI/debugger callers; use it only as an
+  // existence check — serve invocation goes through __invokeNodeForServe.
+  if (typeof moduleExports[nodeName] !== "function") return null;
   const raw = moduleExports[`__${nodeName}NodeParams`];
   const params = raw != null ? z.array(z.string()).parse(raw) : [];
   return {
     kind: "node",
     name: nodeName,
     parameters: params.map((name) => ({ name })),
-    invoke: nodeFn as (...args: unknown[]) => Promise<unknown>,
+    invoke: async (data) => unwrapNodeOutcome(await serveNode(nodeName, data)),
     interruptEffects,
   };
 }
@@ -90,14 +84,23 @@ function toExportedNode(
 export function discoverExports(options: DiscoverOptions): ExportedItem[] {
   const { toolRegistry, moduleExports, moduleId, exportedNodeNames = [], interruptEffectsByName = {} } = options;
 
-  const moduleInvoke = moduleExports.__invokeFunction as ModuleInvokeFunction | undefined;
+  const serveFn = moduleExports.__invokeFunctionForServe as ServeFunctionInvoker | undefined;
+  const serveNode = moduleExports.__invokeNodeForServe as ServeNodeInvoker | undefined;
+  // A bundle without the serve invokers predates the serve cost seam and cannot
+  // report authoritative usage — fail fast rather than serve it uncounted.
+  if (!serveFn || !serveNode || typeof moduleExports.__respondToInterruptsForServe !== "function") {
+    throw new Error(
+      "This agent bundle predates the serve cost seam and cannot be served. " +
+        "Recompile with the current Agency (agency deploy / build) and try again.",
+    );
+  }
 
   const functions = Object.values(toolRegistry)
     .filter((fn) => isExportedFromModule(fn, moduleId))
-    .map((fn) => toExportedFunction(fn, interruptEffectsByName[fn.name] ?? [], moduleInvoke));
+    .map((fn) => toExportedFunction(fn, interruptEffectsByName[fn.name] ?? [], serveFn));
 
   const nodes = exportedNodeNames
-    .map((name) => toExportedNode(name, moduleExports, interruptEffectsByName[name] ?? []))
+    .map((name) => toExportedNode(name, moduleExports, interruptEffectsByName[name] ?? [], serveNode))
     .filter((n): n is ExportedNode => n !== null);
 
   return [...functions, ...nodes];

--- a/packages/agency-lang/lib/serve/discovery.ts
+++ b/packages/agency-lang/lib/serve/discovery.ts
@@ -12,9 +12,15 @@ export type DiscoverOptions = {
   interruptEffectsByName?: Record<string, InterruptEffect[]>;
 };
 
-/** The compiled module's generated serve-only invokers (see imports.mustache):
- *  they run a function / node inside a node-grade frame and return a
- *  `ServedInvocationOutcome` (value/error + per-invocation usage). */
+/** The compiled module's generated `__invokeFunction`: runs an exported function
+ *  inside a node-grade frame and returns its RAW value (the public contract). */
+type ModuleInvokeFunction = (
+  fn: AgencyFunction,
+  namedArgs: Record<string, unknown>,
+) => Promise<unknown>;
+
+/** The generated serve-only invokers: same execution, returning a
+ *  `ServedInvocationOutcome` (value/error + usage) for the adapters. */
 type ServeFunctionInvoker = (
   fn: AgencyFunction,
   namedArgs: Record<string, unknown>,
@@ -28,9 +34,20 @@ function isExportedFromModule(fn: AgencyFunction, moduleId: string): boolean {
   return !!fn.exported && !!fn.toolDefinition && fn.module === moduleId;
 }
 
+/** The public raw invoker: prefer the module's `__invokeFunction`, falling back
+ *  to a bare `agencyFunction.invoke` for older bundles / plain-JS test bodies. */
+function makeRawInvoker(
+  fn: AgencyFunction,
+  moduleInvoke: ModuleInvokeFunction | undefined,
+): (namedArgs: Record<string, unknown>) => Promise<unknown> {
+  if (moduleInvoke) return (namedArgs) => moduleInvoke(fn, namedArgs);
+  return (namedArgs) => fn.invoke({ type: "named", positionalArgs: [], namedArgs });
+}
+
 function toExportedFunction(
   fn: AgencyFunction,
   interruptEffects: InterruptEffect[],
+  moduleInvoke: ModuleInvokeFunction | undefined,
   serveFn: ServeFunctionInvoker,
 ): ExportedFunction {
   return {
@@ -44,13 +61,14 @@ function toExportedFunction(
       .map((param) => ({ name: param.name })),
     agencyFunction: fn,
     interruptEffects,
-    invoke: (namedArgs) => serveFn(fn, namedArgs),
+    invoke: makeRawInvoker(fn, moduleInvoke),
+    invokeServed: (namedArgs) => serveFn(fn, namedArgs),
   };
 }
 
 /** A node's serve outcome carries a `RunNodeResult`; the caller-facing value is
- *  its `.data` (which is the interrupt array on a pause). Unwrap it while
- *  keeping the usage snapshot; a threw-outcome passes through untouched. */
+ *  its `.data` (the interrupt array on a pause). Unwrap it while keeping the
+ *  usage snapshot; a threw-outcome passes through untouched. */
 function unwrapNodeOutcome(
   outcome: ServedInvocationOutcome<unknown>,
 ): ServedInvocationOutcome<unknown> {
@@ -67,40 +85,52 @@ function toExportedNode(
   interruptEffects: InterruptEffect[],
   serveNode: ServeNodeInvoker,
 ): ExportedNode | null {
-  // The node export still exists for CLI/debugger callers; use it only as an
-  // existence check — serve invocation goes through __invokeNodeForServe.
-  if (typeof moduleExports[nodeName] !== "function") return null;
+  const rawNodeFn = moduleExports[nodeName];
+  if (typeof rawNodeFn !== "function") return null;
   const raw = moduleExports[`__${nodeName}NodeParams`];
   const params = raw != null ? z.array(z.string()).parse(raw) : [];
   return {
     kind: "node",
     name: nodeName,
     parameters: params.map((name) => ({ name })),
-    invoke: async (data) => unwrapNodeOutcome(await serveNode(nodeName, data)),
+    // Public: the raw node export (positional args → RunNodeResult).
+    invoke: rawNodeFn as (...args: unknown[]) => Promise<unknown>,
+    // Internal: serve invoker (data object → outcome, node .data unwrapped).
+    invokeServed: async (data) => unwrapNodeOutcome(await serveNode(nodeName, data)),
     interruptEffects,
   };
 }
 
+const RECOMPILE_HINT =
+  "Recompile with the current Agency (agency deploy / build) and try again — " +
+  "served bundles must be recompiled to report per-invocation usage.";
+
 export function discoverExports(options: DiscoverOptions): ExportedItem[] {
   const { toolRegistry, moduleExports, moduleId, exportedNodeNames = [], interruptEffectsByName = {} } = options;
 
+  const moduleInvoke = moduleExports.__invokeFunction as ModuleInvokeFunction | undefined;
   const serveFn = moduleExports.__invokeFunctionForServe as ServeFunctionInvoker | undefined;
   const serveNode = moduleExports.__invokeNodeForServe as ServeNodeInvoker | undefined;
-  // A bundle without the serve invokers predates the serve cost seam and cannot
-  // report authoritative usage — fail fast rather than serve it uncounted.
-  if (!serveFn || !serveNode || typeof moduleExports.__respondToInterruptsForServe !== "function") {
-    throw new Error(
-      "This agent bundle predates the serve cost seam and cannot be served. " +
-        "Recompile with the current Agency (agency deploy / build) and try again.",
-    );
+
+  const exportedFns = Object.values(toolRegistry).filter((fn) => isExportedFromModule(fn, moduleId));
+
+  // Require each serve invoker ONLY for the kind actually present, so a
+  // node-only bundle need not carry the function invoker (and vice versa). A
+  // bundle that predates the seam for a kind it exports fails fast rather than
+  // serving that kind uncounted.
+  if (exportedFns.length > 0 && !serveFn) {
+    throw new Error(`This agent bundle predates the serve cost seam (no __invokeFunctionForServe). ${RECOMPILE_HINT}`);
+  }
+  const presentNodes = exportedNodeNames.filter((name) => typeof moduleExports[name] === "function");
+  if (presentNodes.length > 0 && !serveNode) {
+    throw new Error(`This agent bundle predates the serve cost seam (no __invokeNodeForServe). ${RECOMPILE_HINT}`);
   }
 
-  const functions = Object.values(toolRegistry)
-    .filter((fn) => isExportedFromModule(fn, moduleId))
-    .map((fn) => toExportedFunction(fn, interruptEffectsByName[fn.name] ?? [], serveFn));
-
+  const functions = exportedFns.map((fn) =>
+    toExportedFunction(fn, interruptEffectsByName[fn.name] ?? [], moduleInvoke, serveFn!),
+  );
   const nodes = exportedNodeNames
-    .map((name) => toExportedNode(name, moduleExports, interruptEffectsByName[name] ?? [], serveNode))
+    .map((name) => toExportedNode(name, moduleExports, interruptEffectsByName[name] ?? [], serveNode!))
     .filter((n): n is ExportedNode => n !== null);
 
   return [...functions, ...nodes];

--- a/packages/agency-lang/lib/serve/discovery.ts
+++ b/packages/agency-lang/lib/serve/discovery.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { AgencyFunction } from "../runtime/agencyFunction.js";
 import type { InterruptEffect } from "../symbolTable.js";
-import type { ExportedFunction, ExportedNode, ExportedItem } from "./types.js";
+import type { ServedExportedFunction, ServedExportedNode, ServedExportedItem } from "./types.js";
 import type { ServedInvocationOutcome } from "../runtime/invocationUsage.js";
 
 export type DiscoverOptions = {
@@ -49,7 +49,7 @@ function toExportedFunction(
   interruptEffects: InterruptEffect[],
   moduleInvoke: ModuleInvokeFunction | undefined,
   serveFn: ServeFunctionInvoker,
-): ExportedFunction {
+): ServedExportedFunction {
   return {
     kind: "function",
     name: fn.name,
@@ -84,7 +84,7 @@ function toExportedNode(
   moduleExports: Record<string, unknown>,
   interruptEffects: InterruptEffect[],
   serveNode: ServeNodeInvoker,
-): ExportedNode | null {
+): ServedExportedNode | null {
   const rawNodeFn = moduleExports[nodeName];
   if (typeof rawNodeFn !== "function") return null;
   const raw = moduleExports[`__${nodeName}NodeParams`];
@@ -105,7 +105,7 @@ const RECOMPILE_HINT =
   "Recompile with the current Agency (agency deploy / build) and try again — " +
   "served bundles must be recompiled to report per-invocation usage.";
 
-export function discoverExports(options: DiscoverOptions): ExportedItem[] {
+export function discoverExports(options: DiscoverOptions): ServedExportedItem[] {
   const { toolRegistry, moduleExports, moduleId, exportedNodeNames = [], interruptEffectsByName = {} } = options;
 
   const moduleInvoke = moduleExports.__invokeFunction as ModuleInvokeFunction | undefined;
@@ -131,7 +131,7 @@ export function discoverExports(options: DiscoverOptions): ExportedItem[] {
   );
   const nodes = exportedNodeNames
     .map((name) => toExportedNode(name, moduleExports, interruptEffectsByName[name] ?? [], serveNode!))
-    .filter((n): n is ExportedNode => n !== null);
+    .filter((n): n is ServedExportedNode => n !== null);
 
   return [...functions, ...nodes];
 }

--- a/packages/agency-lang/lib/serve/http/adapter.test.ts
+++ b/packages/agency-lang/lib/serve/http/adapter.test.ts
@@ -5,7 +5,7 @@ import { createHttpHandler, startHttpServer } from "./adapter.js";
 import { AgencyFunction } from "../../runtime/agencyFunction.js";
 import { interrupt } from "../../runtime/interrupts.js";
 import type { Interrupt } from "../../runtime/interrupts.js";
-import type { ExportedItem } from "../types.js";
+import type { ServedExportedItem } from "../types.js";
 import { returnedOutcome, threwOutcome, unusedPublicInvoke } from "../testOutcome.js";
 import { createLogger } from "../../logger.js";
 import type { Logger } from "../../logger.js";
@@ -43,7 +43,7 @@ function makeSpyHandler(): {
 }
 
 function makeExports(): {
-  exports: ExportedItem[];
+  exports: ServedExportedItem[];
 } {
   const registry: Record<string, AgencyFunction> = {};
   const addFn = AgencyFunction.create(
@@ -65,7 +65,7 @@ function makeExports(): {
     registry,
   );
 
-  const exports: ExportedItem[] = [
+  const exports: ServedExportedItem[] = [
     {
       kind: "function", ...unusedPublicInvoke,
       name: "add",
@@ -180,7 +180,7 @@ describe("HTTP adapter", () => {
         },
         registry,
       );
-    const exports: ExportedItem[] = (
+    const exports: ServedExportedItem[] = (
       [
         ["rm", { destructive: true }],
         ["lookup", { idempotent: true }],
@@ -463,7 +463,7 @@ describe("startHttpServer auth and host validation", () => {
       },
       registry,
     );
-    const exportsWithFail: ExportedItem[] = [
+    const exportsWithFail: ServedExportedItem[] = [
       ...exports,
       {
         kind: "function", ...unusedPublicInvoke,
@@ -534,7 +534,7 @@ describe("root-budget trips surface as a typed budgetExceeded", () => {
   const silent = createLogger("error");
 
   function handlerFor(invoke: () => Promise<unknown>): ReturnType<typeof createHttpHandler> {
-    const node: ExportedItem = {
+    const node: ServedExportedItem = {
       kind: "node", ...unusedPublicInvoke,
       name: "run",
       parameters: [],

--- a/packages/agency-lang/lib/serve/http/adapter.test.ts
+++ b/packages/agency-lang/lib/serve/http/adapter.test.ts
@@ -6,7 +6,7 @@ import { AgencyFunction } from "../../runtime/agencyFunction.js";
 import { interrupt } from "../../runtime/interrupts.js";
 import type { Interrupt } from "../../runtime/interrupts.js";
 import type { ExportedItem } from "../types.js";
-import { returnedOutcome, threwOutcome } from "../testOutcome.js";
+import { returnedOutcome, threwOutcome, unusedPublicInvoke } from "../testOutcome.js";
 import { createLogger } from "../../logger.js";
 import type { Logger } from "../../logger.js";
 import { GuardExceededError } from "../../runtime/guard.js";
@@ -67,21 +67,21 @@ function makeExports(): {
 
   const exports: ExportedItem[] = [
     {
-      kind: "function",
+      kind: "function", ...unusedPublicInvoke,
       name: "add",
       description: "Add two numbers",
       parameters: [{ name: "a" }, { name: "b" }],
       agencyFunction: addFn,
       interruptEffects: [],
-      invoke: async (namedArgs) => returnedOutcome(await addFn.invoke({ type: "named", positionalArgs: [], namedArgs })),
+      invokeServed: async (namedArgs) => returnedOutcome(await addFn.invoke({ type: "named", positionalArgs: [], namedArgs })),
     },
     {
-      kind: "node",
+      kind: "node", ...unusedPublicInvoke,
       name: "main",
       parameters: [{ name: "message" }],
       // Serve node invoke: named args as a data object; value is the
       // caller-facing data (discovery would have unwrapped RunNodeResult.data).
-      invoke: async (data) => returnedOutcome({ echo: (data as { message?: unknown }).message }),
+      invokeServed: async (data) => returnedOutcome({ echo: (data as { message?: unknown }).message }),
       interruptEffects: [],
     },
   ];
@@ -187,13 +187,13 @@ describe("HTTP adapter", () => {
         ["plainFn", undefined],
       ] as const
     ).map(([name, markers]) => ({
-      kind: "function",
+      kind: "function", ...unusedPublicInvoke,
       name,
       description: name,
       parameters: [],
       agencyFunction: mk(name, markers),
       interruptEffects: [],
-      invoke: async (namedArgs: Record<string, unknown>) =>
+      invokeServed: async (namedArgs: Record<string, unknown>) =>
         returnedOutcome(await mk(name, markers).invoke({ type: "named", positionalArgs: [], namedArgs })),
     }));
     const h = createHttpHandler({
@@ -346,13 +346,13 @@ describe("HTTP adapter", () => {
     const h = createHttpHandler({
       exports: [
         {
-          kind: "function",
+          kind: "function", ...unusedPublicInvoke,
           name: "deploy",
           description: "Deploy",
           parameters: [],
           agencyFunction: deployFn,
           interruptEffects: [{ effect: "myapp::deploy" }],
-          invoke: async (namedArgs) => returnedOutcome(await deployFn.invoke({ type: "named", positionalArgs: [], namedArgs })),
+          invokeServed: async (namedArgs) => returnedOutcome(await deployFn.invoke({ type: "named", positionalArgs: [], namedArgs })),
         },
       ],
       logger: createLogger("error"),
@@ -466,13 +466,13 @@ describe("startHttpServer auth and host validation", () => {
     const exportsWithFail: ExportedItem[] = [
       ...exports,
       {
-        kind: "function",
+        kind: "function", ...unusedPublicInvoke,
         name: "fail",
         description: "",
         parameters: [],
         agencyFunction: failFn,
         interruptEffects: [],
-        invoke: async (namedArgs) => returnedOutcome(await failFn.invoke({ type: "named", positionalArgs: [], namedArgs })),
+        invokeServed: async (namedArgs) => returnedOutcome(await failFn.invoke({ type: "named", positionalArgs: [], namedArgs })),
       },
     ];
     await withServer(baseConfig({ exports: exportsWithFail }), async (port) => {
@@ -535,13 +535,13 @@ describe("root-budget trips surface as a typed budgetExceeded", () => {
 
   function handlerFor(invoke: () => Promise<unknown>): ReturnType<typeof createHttpHandler> {
     const node: ExportedItem = {
-      kind: "node",
+      kind: "node", ...unusedPublicInvoke,
       name: "run",
       parameters: [],
       interruptEffects: [],
       // The core turns a thrown guard trip / error into a threw-outcome; model
       // that here so the adapter maps it (402 / generic) with a usage snapshot.
-      invoke: async () => {
+      invokeServed: async () => {
         try {
           return returnedOutcome(await invoke());
         } catch (err) {

--- a/packages/agency-lang/lib/serve/http/adapter.test.ts
+++ b/packages/agency-lang/lib/serve/http/adapter.test.ts
@@ -6,6 +6,7 @@ import { AgencyFunction } from "../../runtime/agencyFunction.js";
 import { interrupt } from "../../runtime/interrupts.js";
 import type { Interrupt } from "../../runtime/interrupts.js";
 import type { ExportedItem } from "../types.js";
+import { returnedOutcome, threwOutcome } from "../testOutcome.js";
 import { createLogger } from "../../logger.js";
 import type { Logger } from "../../logger.js";
 import { GuardExceededError } from "../../runtime/guard.js";
@@ -31,7 +32,7 @@ function makeSpyHandler(): {
   respondSpy: ReturnType<typeof vi.fn>;
 } {
   const { exports } = makeExports();
-  const respondSpy = vi.fn(async () => ({ data: "resumed" }));
+  const respondSpy = vi.fn(async () => returnedOutcome({ data: "resumed" }));
   const handler = createHttpHandler({
     exports,
     logger: createLogger("error"),
@@ -72,16 +73,15 @@ function makeExports(): {
       parameters: [{ name: "a" }, { name: "b" }],
       agencyFunction: addFn,
       interruptEffects: [],
-      invoke: (namedArgs) => addFn.invoke({ type: "named", positionalArgs: [], namedArgs }),
+      invoke: async (namedArgs) => returnedOutcome(await addFn.invoke({ type: "named", positionalArgs: [], namedArgs })),
     },
     {
       kind: "node",
       name: "main",
       parameters: [{ name: "message" }],
-      invoke: async (message: unknown) => ({
-        data: { echo: message },
-        messages: {},
-      }),
+      // Serve node invoke: named args as a data object; value is the
+      // caller-facing data (discovery would have unwrapped RunNodeResult.data).
+      invoke: async (data) => returnedOutcome({ echo: (data as { message?: unknown }).message }),
       interruptEffects: [],
     },
   ];
@@ -95,7 +95,7 @@ function makeHandler() {
     exports,
     logger: createLogger("error"),
     hasInterrupts: () => false,
-    respondToInterrupts: async () => ({ data: "resumed" }),
+    respondToInterrupts: async () => returnedOutcome({ data: "resumed" }),
   });
 }
 
@@ -193,14 +193,14 @@ describe("HTTP adapter", () => {
       parameters: [],
       agencyFunction: mk(name, markers),
       interruptEffects: [],
-      invoke: (namedArgs: Record<string, unknown>) =>
-        mk(name, markers).invoke({ type: "named", positionalArgs: [], namedArgs }),
+      invoke: async (namedArgs: Record<string, unknown>) =>
+        returnedOutcome(await mk(name, markers).invoke({ type: "named", positionalArgs: [], namedArgs })),
     }));
     const h = createHttpHandler({
       exports,
       logger: createLogger("error"),
       hasInterrupts: () => false,
-      respondToInterrupts: async () => ({ data: "resumed" }),
+      respondToInterrupts: async () => returnedOutcome({ data: "resumed" }),
     });
     const body = (await h("GET", "/list", undefined)).body as any;
     const byName = (n: string) => body.functions.find((f: any) => f.name === n);
@@ -352,12 +352,12 @@ describe("HTTP adapter", () => {
           parameters: [],
           agencyFunction: deployFn,
           interruptEffects: [{ effect: "myapp::deploy" }],
-          invoke: (namedArgs) => deployFn.invoke({ type: "named", positionalArgs: [], namedArgs }),
+          invoke: async (namedArgs) => returnedOutcome(await deployFn.invoke({ type: "named", positionalArgs: [], namedArgs })),
         },
       ],
       logger: createLogger("error"),
       hasInterrupts: () => false,
-      respondToInterrupts: async () => ({ data: "ok" }),
+      respondToInterrupts: async () => returnedOutcome({ data: "ok" }),
     });
     const result = await h("GET", "/list", undefined);
     const body = result.body as any;
@@ -373,7 +373,7 @@ describe("startHttpServer auth and host validation", () => {
       port: 0,
       logger: createLogger("error"),
       hasInterrupts: () => false,
-      respondToInterrupts: async () => ({ data: "resumed" }),
+      respondToInterrupts: async () => returnedOutcome({ data: "resumed" }),
       ...overrides,
     };
   }
@@ -442,7 +442,7 @@ describe("startHttpServer auth and host validation", () => {
         host: "0.0.0.0",
         logger: createLogger("error"),
         hasInterrupts: () => false,
-        respondToInterrupts: async () => ({ data: "x" }),
+        respondToInterrupts: async () => returnedOutcome({ data: "x" }),
       }),
     ).toThrow(/Refusing to start.*non-loopback/);
   });
@@ -472,7 +472,7 @@ describe("startHttpServer auth and host validation", () => {
         parameters: [],
         agencyFunction: failFn,
         interruptEffects: [],
-        invoke: (namedArgs) => failFn.invoke({ type: "named", positionalArgs: [], namedArgs }),
+        invoke: async (namedArgs) => returnedOutcome(await failFn.invoke({ type: "named", positionalArgs: [], namedArgs })),
       },
     ];
     await withServer(baseConfig({ exports: exportsWithFail }), async (port) => {
@@ -512,7 +512,7 @@ describe("startHttpServer route logging", () => {
         port: 0,
         logger,
         hasInterrupts: () => false,
-        respondToInterrupts: async () => ({ data: "resumed" }),
+        respondToInterrupts: async () => returnedOutcome({ data: "resumed" }),
       },
       async () => {
         // server is listening; the listen callback has already logged routes
@@ -539,13 +539,21 @@ describe("root-budget trips surface as a typed budgetExceeded", () => {
       name: "run",
       parameters: [],
       interruptEffects: [],
-      invoke,
+      // The core turns a thrown guard trip / error into a threw-outcome; model
+      // that here so the adapter maps it (402 / generic) with a usage snapshot.
+      invoke: async () => {
+        try {
+          return returnedOutcome(await invoke());
+        } catch (err) {
+          return threwOutcome(err);
+        }
+      },
     };
     return createHttpHandler({
       exports: [node],
       logger: silent,
       hasInterrupts: () => false,
-      respondToInterrupts: async () => ({ data: undefined }),
+      respondToInterrupts: async () => returnedOutcome({ data: undefined }),
     });
   }
 

--- a/packages/agency-lang/lib/serve/http/adapter.ts
+++ b/packages/agency-lang/lib/serve/http/adapter.ts
@@ -1,5 +1,5 @@
 import http from "http";
-import type { ExportedItem, ExportedFunction, ExportedNode } from "../types.js";
+import type { ServedExportedItem, ServedExportedFunction, ServedExportedNode } from "../types.js";
 import { errorMessage, toArgs, parseJsonBody } from "../util.js";
 import { validateResumeBatch } from "../../runtime/interrupts.js";
 import { readCause } from "../../runtime/errors.js";
@@ -18,7 +18,7 @@ import {
 } from "./security.js";
 
 export type HandlerConfig = {
-  exports: ExportedItem[];
+  exports: ServedExportedItem[];
   logger: Logger;
   hasInterrupts: (data: unknown) => boolean;
   respondToInterrupts: (
@@ -135,7 +135,7 @@ function routeResultFor(
 }
 
 async function callFunction(
-  fn: ExportedFunction,
+  fn: ServedExportedFunction,
   body: unknown,
   logger: Logger,
 ): Promise<RouteResult> {
@@ -151,7 +151,7 @@ async function callFunction(
 }
 
 async function callNode(
-  node: ExportedNode,
+  node: ServedExportedNode,
   body: unknown,
   hasInterrupts: (data: unknown) => boolean,
   logger: Logger,
@@ -220,16 +220,16 @@ export function createHttpHandler(config: HandlerConfig): (
   // plain object would let a name like `/function/toString` resolve to an
   // inherited Object.prototype method, bypass the "unknown" 404 check, and
   // surface as a generic tool failure instead.
-  const functions: Record<string, ExportedFunction> = Object.assign(
+  const functions: Record<string, ServedExportedFunction> = Object.assign(
     Object.create(null),
     Object.fromEntries(
-      exports.filter((e): e is ExportedFunction => e.kind === "function").map((e) => [e.name, e]),
+      exports.filter((e): e is ServedExportedFunction => e.kind === "function").map((e) => [e.name, e]),
     ),
   );
-  const nodes: Record<string, ExportedNode> = Object.assign(
+  const nodes: Record<string, ServedExportedNode> = Object.assign(
     Object.create(null),
     Object.fromEntries(
-      exports.filter((e): e is ExportedNode => e.kind === "node").map((e) => [e.name, e]),
+      exports.filter((e): e is ServedExportedNode => e.kind === "node").map((e) => [e.name, e]),
     ),
   );
 

--- a/packages/agency-lang/lib/serve/http/adapter.ts
+++ b/packages/agency-lang/lib/serve/http/adapter.ts
@@ -141,7 +141,7 @@ async function callFunction(
 ): Promise<RouteResult> {
   let outcome: ServedInvocationOutcome<unknown>;
   try {
-    outcome = await fn.invoke(toArgs(body));
+    outcome = await fn.invokeServed(toArgs(body));
   } catch (err) {
     // A throw here is a pre-outcome internal failure (the core normally converts
     // agent errors into a threw-outcome), so there is no usage to report.
@@ -160,7 +160,7 @@ async function callNode(
   try {
     // The node receives its named args as a data object; the serve invoker maps
     // them to the node's params and returns the caller-facing data as the value.
-    outcome = await node.invoke(toArgs(body));
+    outcome = await node.invokeServed(toArgs(body));
   } catch (err) {
     return errorResult(err, logger, `node ${node.name}`);
   }

--- a/packages/agency-lang/lib/serve/http/adapter.ts
+++ b/packages/agency-lang/lib/serve/http/adapter.ts
@@ -1,5 +1,5 @@
 import http from "http";
-import type { ServedExportedItem, ServedExportedFunction, ServedExportedNode } from "../types.js";
+import type { ExportedItem, ServedExportedItem, ServedExportedFunction, ServedExportedNode } from "../types.js";
 import { errorMessage, toArgs, parseJsonBody } from "../util.js";
 import { validateResumeBatch } from "../../runtime/interrupts.js";
 import { readCause } from "../../runtime/errors.js";
@@ -17,7 +17,23 @@ import {
   makeGuardedRequestListener,
 } from "./security.js";
 
+/** PUBLIC config type (re-exported from `agency-lang/serve`) — kept
+ *  byte-compatible with the pre-seam contract: raw `ExportedItem`s and a
+ *  `respondToInterrupts` returning `Promise<unknown>`. Host apps that import
+ *  this type keep type-checking. The adapters run on the internal
+ *  `ServedHandlerConfig` below; `createServeHandler` builds that from a
+ *  discovered module. */
 export type HandlerConfig = {
+  exports: ExportedItem[];
+  logger: Logger;
+  hasInterrupts: (data: unknown) => boolean;
+  respondToInterrupts: (interrupts: unknown[], responses: unknown[]) => Promise<unknown>;
+};
+
+/** INTERNAL adapter config: the served contract the HTTP adapter actually runs
+ *  on — usage-bearing `ServedExportedItem`s and a `respondToInterrupts` that
+ *  returns a `ServedInvocationOutcome`. Not part of the public surface. */
+type ServedHandlerConfig = {
   exports: ServedExportedItem[];
   logger: Logger;
   hasInterrupts: (data: unknown) => boolean;
@@ -27,7 +43,7 @@ export type HandlerConfig = {
   ) => Promise<ServedInvocationOutcome<unknown>>;
 };
 
-export type HttpConfig = HandlerConfig & {
+export type HttpConfig = ServedHandlerConfig & {
   port: number;
   apiKey?: string;
   /** Interface to bind to. Default "127.0.0.1" (loopback only). */
@@ -209,7 +225,7 @@ async function resumeInterrupts(
 const FUNCTION_ROUTE = /^\/function\/([^/]+)$/;
 const NODE_ROUTE = /^\/node\/([^/]+)$/;
 
-export function createHttpHandler(config: HandlerConfig): (
+export function createHttpHandler(config: ServedHandlerConfig): (
   method: string,
   path: string,
   body: unknown,

--- a/packages/agency-lang/lib/serve/http/adapter.ts
+++ b/packages/agency-lang/lib/serve/http/adapter.ts
@@ -4,6 +4,10 @@ import { errorMessage, toArgs, parseJsonBody } from "../util.js";
 import { validateResumeBatch } from "../../runtime/interrupts.js";
 import { readCause } from "../../runtime/errors.js";
 import { formatBudgetExceeded } from "../../runtime/budgetExit.js";
+import type {
+  ServedInvocationOutcome,
+  InvocationUsageSnapshot,
+} from "../../runtime/invocationUsage.js";
 import type { Logger } from "../../logger.js";
 import {
   DEFAULT_HOST,
@@ -17,7 +21,10 @@ export type HandlerConfig = {
   exports: ExportedItem[];
   logger: Logger;
   hasInterrupts: (data: unknown) => boolean;
-  respondToInterrupts: (interrupts: unknown[], responses: unknown[]) => Promise<unknown>;
+  respondToInterrupts: (
+    interrupts: unknown[],
+    responses: unknown[],
+  ) => Promise<ServedInvocationOutcome<unknown>>;
 };
 
 export type HttpConfig = HandlerConfig & {
@@ -38,6 +45,12 @@ export type HttpConfig = HandlerConfig & {
 export type RouteResult = {
   status: number;
   body: unknown;
+  /** Per-invocation usage for the serve cost seam, present on every
+   *  post-execution outcome (success/interrupt/402/failure/cancel) and absent
+   *  on pre-execution results (/list, 404, validation 400). Read in-process by
+   *  the host (statelog); not part of the standalone HTTP body. */
+  usage?: InvocationUsageSnapshot["usage"];
+  usageComplete?: boolean;
 };
 
 function ok(value: unknown): RouteResult {
@@ -100,17 +113,41 @@ function errorResult(err: unknown, logger: Logger, what: string): RouteResult {
   return fail(TOOL_ERROR_MESSAGE);
 }
 
+/** Attach a per-invocation usage snapshot to any post-execution route result. */
+function withUsage(base: RouteResult, outcome: InvocationUsageSnapshot): RouteResult {
+  return { ...base, usage: outcome.usage, usageComplete: outcome.usageComplete };
+}
+
+/** Map one served outcome to a route result: `renderReturned` shapes the success
+ *  body (function → `ok`; node/resume → interrupt-aware), and a threw-outcome
+ *  runs the existing 402/generic classification on the ORIGINAL error (identity
+ *  preserved, so `readCause` still recognizes a guard trip). Usage is attached
+ *  once, here, for every branch. */
+function routeResultFor(
+  outcome: ServedInvocationOutcome<unknown>,
+  opts: { renderReturned: (value: unknown) => RouteResult; logger: Logger; what: string },
+): RouteResult {
+  const base =
+    outcome.status === "returned"
+      ? opts.renderReturned(outcome.value)
+      : errorResult(outcome.error, opts.logger, opts.what);
+  return withUsage(base, outcome);
+}
+
 async function callFunction(
   fn: ExportedFunction,
   body: unknown,
   logger: Logger,
 ): Promise<RouteResult> {
+  let outcome: ServedInvocationOutcome<unknown>;
   try {
-    const result = await fn.invoke(toArgs(body));
-    return ok(result);
+    outcome = await fn.invoke(toArgs(body));
   } catch (err) {
+    // A throw here is a pre-outcome internal failure (the core normally converts
+    // agent errors into a threw-outcome), so there is no usage to report.
     return errorResult(err, logger, `function ${fn.name}`);
   }
+  return routeResultFor(outcome, { renderReturned: ok, logger, what: `function ${fn.name}` });
 }
 
 async function callNode(
@@ -119,19 +156,23 @@ async function callNode(
   hasInterrupts: (data: unknown) => boolean,
   logger: Logger,
 ): Promise<RouteResult> {
+  let outcome: ServedInvocationOutcome<unknown>;
   try {
-    const args = toArgs(body);
-    const positional = node.parameters.map((p) => args[p.name]);
-    const result = (await node.invoke(...positional)) as { data: unknown };
-    if (hasInterrupts(result.data)) return interruptResult(result.data);
-    return ok(result.data);
+    // The node receives its named args as a data object; the serve invoker maps
+    // them to the node's params and returns the caller-facing data as the value.
+    outcome = await node.invoke(toArgs(body));
   } catch (err) {
     return errorResult(err, logger, `node ${node.name}`);
   }
+  return routeResultFor(outcome, {
+    renderReturned: (data) => (hasInterrupts(data) ? interruptResult(data) : ok(data)),
+    logger,
+    what: `node ${node.name}`,
+  });
 }
 
 async function resumeInterrupts(
-  respondToInterrupts: (i: unknown[], r: unknown[]) => Promise<unknown>,
+  respondToInterrupts: (i: unknown[], r: unknown[]) => Promise<ServedInvocationOutcome<unknown>>,
   hasInterrupts: (data: unknown) => boolean,
   body: unknown,
   logger: Logger,
@@ -149,13 +190,20 @@ async function resumeInterrupts(
     // reach the resume path, where an unknown type continues past the interrupt.
     return { status: 400, body: { error: validationError } };
   }
+  let outcome: ServedInvocationOutcome<unknown>;
   try {
-    const result = (await respondToInterrupts(interrupts, responses)) as { data: unknown };
-    if (hasInterrupts(result.data)) return interruptResult(result.data);
-    return ok(result.data);
+    outcome = await respondToInterrupts(interrupts, responses);
   } catch (err) {
     return errorResult(err, logger, "resume");
   }
+  return routeResultFor(outcome, {
+    renderReturned: (value) => {
+      const data = (value as { data: unknown }).data;
+      return hasInterrupts(data) ? interruptResult(data) : ok(data);
+    },
+    logger,
+    what: "resume",
+  });
 }
 
 const FUNCTION_ROUTE = /^\/function\/([^/]+)$/;

--- a/packages/agency-lang/lib/serve/http/functionBudget.test.ts
+++ b/packages/agency-lang/lib/serve/http/functionBudget.test.ts
@@ -3,7 +3,7 @@ import { createHttpHandler } from "./adapter.js";
 import { createLogger } from "../../logger.js";
 import { RuntimeContext } from "../../runtime/state/context.js";
 import { runExportedFunctionForServe } from "../../runtime/node.js";
-import { returnedOutcome } from "../testOutcome.js";
+import { returnedOutcome, unusedPublicInvoke } from "../testOutcome.js";
 import { addCost } from "../../runtime/cost.js";
 import type { GraphState } from "../../runtime/types.js";
 import type { AgencyFunction } from "../../runtime/agencyFunction.js";
@@ -68,13 +68,13 @@ describe("a served function respects the baked root budget", () => {
       },
     } as unknown as AgencyFunction;
     return {
-      kind: "function",
+      kind: "function", ...unusedPublicInvoke,
       name: "spend",
       description: "charges $1",
       parameters: [],
       agencyFunction: fn,
       interruptEffects: [],
-      invoke: (namedArgs) => runExportedFunctionForServe({ ctx, fn, namedArgs }),
+      invokeServed: (namedArgs) => runExportedFunctionForServe({ ctx, fn, namedArgs }),
     };
   }
 

--- a/packages/agency-lang/lib/serve/http/functionBudget.test.ts
+++ b/packages/agency-lang/lib/serve/http/functionBudget.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { createHttpHandler } from "./adapter.js";
 import { createLogger } from "../../logger.js";
 import { RuntimeContext } from "../../runtime/state/context.js";
-import { runExportedFunction } from "../../runtime/node.js";
+import { runExportedFunctionForServe } from "../../runtime/node.js";
+import { returnedOutcome } from "../testOutcome.js";
 import { addCost } from "../../runtime/cost.js";
 import type { GraphState } from "../../runtime/types.js";
 import type { AgencyFunction } from "../../runtime/agencyFunction.js";
@@ -73,7 +74,7 @@ describe("a served function respects the baked root budget", () => {
       parameters: [],
       agencyFunction: fn,
       interruptEffects: [],
-      invoke: (namedArgs) => runExportedFunction({ ctx, fn, namedArgs }),
+      invoke: (namedArgs) => runExportedFunctionForServe({ ctx, fn, namedArgs }),
     };
   }
 
@@ -82,7 +83,7 @@ describe("a served function respects the baked root budget", () => {
       exports: [spendingFunction(ctx)],
       logger: createLogger("error"),
       hasInterrupts: () => false,
-      respondToInterrupts: async () => ({ data: undefined }),
+      respondToInterrupts: async () => returnedOutcome({ data: undefined }),
     });
   }
 

--- a/packages/agency-lang/lib/serve/http/functionBudget.test.ts
+++ b/packages/agency-lang/lib/serve/http/functionBudget.test.ts
@@ -7,7 +7,7 @@ import { returnedOutcome, unusedPublicInvoke } from "../testOutcome.js";
 import { addCost } from "../../runtime/cost.js";
 import type { GraphState } from "../../runtime/types.js";
 import type { AgencyFunction } from "../../runtime/agencyFunction.js";
-import type { ExportedFunction } from "../types.js";
+import type { ServedExportedFunction } from "../types.js";
 
 /**
  * Regression test for the root budget on the *served-function* path.
@@ -60,7 +60,7 @@ describe("a served function respects the baked root budget", () => {
   // A minimal exported function whose body charges $1, routed through the real
   // runExportedFunction so it runs inside a node-grade frame with the budget
   // installed.
-  function spendingFunction(ctx: RuntimeContext<GraphState>): ExportedFunction {
+  function spendingFunction(ctx: RuntimeContext<GraphState>): ServedExportedFunction {
     const fn = {
       invoke: async () => {
         addCost(1);

--- a/packages/agency-lang/lib/serve/http/functionFrame.integration.test.ts
+++ b/packages/agency-lang/lib/serve/http/functionFrame.integration.test.ts
@@ -7,6 +7,7 @@ import { discoverExports } from "../discovery.js";
 import { createHttpHandler } from "./adapter.js";
 import { createLogger } from "../../logger.js";
 import type { AgencyFunction } from "../../runtime/agencyFunction.js";
+import type { ServedInvocationOutcome } from "../../runtime/invocationUsage.js";
 
 /**
  * Regression test for `agency serve` invoking exported FUNCTIONS.
@@ -79,10 +80,10 @@ describe("serve http invokes exported functions inside a runtime frame", () => {
       exports,
       logger: createLogger("error"),
       hasInterrupts: mod.hasInterrupts as (data: unknown) => boolean,
-      respondToInterrupts: mod.respondToInterrupts as (
+      respondToInterrupts: mod.__respondToInterruptsForServe as (
         i: unknown[],
         r: unknown[],
-      ) => Promise<unknown>,
+      ) => Promise<ServedInvocationOutcome<unknown>>,
     });
   });
 

--- a/packages/agency-lang/lib/serve/http/serveCostSeam.integration.test.ts
+++ b/packages/agency-lang/lib/serve/http/serveCostSeam.integration.test.ts
@@ -4,7 +4,7 @@ import { createLogger } from "../../logger.js";
 import { RuntimeContext } from "../../runtime/state/context.js";
 import { runExportedFunctionForServe } from "../../runtime/node.js";
 import { addCost } from "../../runtime/cost.js";
-import { returnedOutcome } from "../testOutcome.js";
+import { returnedOutcome, unusedPublicInvoke } from "../testOutcome.js";
 import type { GraphState } from "../../runtime/types.js";
 import type { AgencyFunction } from "../../runtime/agencyFunction.js";
 import type { ExportedFunction } from "../types.js";
@@ -39,13 +39,13 @@ describe("serve cost seam — end to end", () => {
   ): ExportedFunction {
     const fn = { invoke: async () => body() } as unknown as AgencyFunction;
     return {
-      kind: "function",
+      kind: "function", ...unusedPublicInvoke,
       name: "run",
       description: "run",
       parameters: [],
       agencyFunction: fn,
       interruptEffects: [],
-      invoke: (namedArgs) => runExportedFunctionForServe({ ctx, fn, namedArgs }),
+      invokeServed: (namedArgs) => runExportedFunctionForServe({ ctx, fn, namedArgs }),
     };
   }
 

--- a/packages/agency-lang/lib/serve/http/serveCostSeam.integration.test.ts
+++ b/packages/agency-lang/lib/serve/http/serveCostSeam.integration.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { createHttpHandler } from "./adapter.js";
+import { createLogger } from "../../logger.js";
+import { RuntimeContext } from "../../runtime/state/context.js";
+import { runExportedFunctionForServe } from "../../runtime/node.js";
+import { addCost } from "../../runtime/cost.js";
+import { returnedOutcome } from "../testOutcome.js";
+import type { GraphState } from "../../runtime/types.js";
+import type { AgencyFunction } from "../../runtime/agencyFunction.js";
+import type { ExportedFunction } from "../types.js";
+
+// End-to-end usage accounting through the REAL HTTP adapter + the real
+// runExportedFunctionForServe core. Priced work is a fake `addCost` charge (the
+// same billCharge path an LLM completion uses) so no live model is needed. The
+// compiled-module + real-LLM path (and subprocess/grandchild propagation) are
+// covered by functionFrame.integration (CI) and the ipc / invocationUsage unit
+// tests; this file pins the cross-cutting adapter-level properties.
+describe("serve cost seam — end to end", () => {
+  const BUDGET_ENV = ["AGENCY_IPC", "AGENCY_MAX_COST", "AGENCY_MAX_TIME"] as const;
+  const saved: Record<string, string | undefined> = {};
+  const setup = () => BUDGET_ENV.forEach((k) => { saved[k] = process.env[k]; delete process.env[k]; });
+  afterEach(() => BUDGET_ENV.forEach((k) => {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }));
+
+  function makeCtx(budget?: { maxCost?: number; maxTimeMs?: number }) {
+    return new RuntimeContext<GraphState>({
+      statelogConfig: { host: "", apiKey: "", projectId: "", debugMode: false, observability: false },
+      smoltalkDefaults: {},
+      dirname: process.cwd(),
+      budget,
+    });
+  }
+
+  function servedFunction(
+    ctx: RuntimeContext<GraphState>,
+    body: () => unknown,
+  ): ExportedFunction {
+    const fn = { invoke: async () => body() } as unknown as AgencyFunction;
+    return {
+      kind: "function",
+      name: "run",
+      description: "run",
+      parameters: [],
+      agencyFunction: fn,
+      interruptEffects: [],
+      invoke: (namedArgs) => runExportedFunctionForServe({ ctx, fn, namedArgs }),
+    };
+  }
+
+  function handlerFor(ctx: RuntimeContext<GraphState>, body: () => unknown) {
+    return createHttpHandler({
+      exports: [servedFunction(ctx, body)],
+      logger: createLogger("error"),
+      hasInterrupts: () => false,
+      respondToInterrupts: async () => returnedOutcome({ data: undefined }),
+    });
+  }
+
+  it("success carries the exact priced cost and reads complete", async () => {
+    setup();
+    const result = await handlerFor(makeCtx(), () => { addCost(0.03); return "done"; })("POST", "/function/run", {});
+    expect(result.status).toBe(200);
+    expect(result.body).toEqual({ success: true, value: "done" });
+    expect(result.usage?.pricedCost).toBeCloseTo(0.03);
+    expect(result.usage?.pricingComplete).toBe(true);
+    expect(result.usageComplete).toBe(true);
+  });
+
+  it("two concurrent invocations report independent usage (own execCtx each)", async () => {
+    setup();
+    const cheap = handlerFor(makeCtx(), () => { addCost(0.01); return "a"; })("POST", "/function/run", {});
+    const dear = handlerFor(makeCtx(), () => { addCost(0.5); return "b"; })("POST", "/function/run", {});
+    const [a, b] = await Promise.all([cheap, dear]);
+    expect(a.usage?.pricedCost).toBeCloseTo(0.01);
+    expect(b.usage?.pricedCost).toBeCloseTo(0.5);
+  });
+
+  it("a function that spends then throws still reports the pre-throw cost", async () => {
+    setup();
+    const result = await handlerFor(makeCtx(), () => {
+      addCost(0.02);
+      throw new Error("kaboom");
+    })("POST", "/function/run", {});
+    expect(result.status).toBe(200);
+    expect(result.body).toEqual({ success: false, error: "Tool execution failed" });
+    expect(result.usage?.pricedCost).toBeCloseTo(0.02);
+  });
+
+  it("a baked budget trip returns 402 carrying the cost up to the trip", async () => {
+    setup();
+    const result = await handlerFor(makeCtx({ maxCost: 0 }), () => { addCost(1); return "x"; })("POST", "/function/run", {});
+    expect(result.status).toBe(402);
+    expect(result.body).toMatchObject({ code: "budgetExceeded", dimension: "cost", limit: 0 });
+    expect(result.usage?.pricedCost).toBeCloseTo(1);
+  });
+
+  it("/list carries no usage (no invocation started)", async () => {
+    setup();
+    const result = await handlerFor(makeCtx(), () => "x")("GET", "/list", undefined);
+    expect(result.usage).toBeUndefined();
+    expect(result.usageComplete).toBeUndefined();
+  });
+});

--- a/packages/agency-lang/lib/serve/http/serveCostSeam.integration.test.ts
+++ b/packages/agency-lang/lib/serve/http/serveCostSeam.integration.test.ts
@@ -7,7 +7,7 @@ import { addCost } from "../../runtime/cost.js";
 import { returnedOutcome, unusedPublicInvoke } from "../testOutcome.js";
 import type { GraphState } from "../../runtime/types.js";
 import type { AgencyFunction } from "../../runtime/agencyFunction.js";
-import type { ExportedFunction } from "../types.js";
+import type { ServedExportedFunction } from "../types.js";
 
 // End-to-end usage accounting through the REAL HTTP adapter + the real
 // runExportedFunctionForServe core. Priced work is a fake `addCost` charge (the
@@ -36,7 +36,7 @@ describe("serve cost seam — end to end", () => {
   function servedFunction(
     ctx: RuntimeContext<GraphState>,
     body: () => unknown,
-  ): ExportedFunction {
+  ): ServedExportedFunction {
     const fn = { invoke: async () => body() } as unknown as AgencyFunction;
     return {
       kind: "function", ...unusedPublicInvoke,

--- a/packages/agency-lang/lib/serve/mcp/adapter.test.ts
+++ b/packages/agency-lang/lib/serve/mcp/adapter.test.ts
@@ -2,14 +2,14 @@ import { describe, expect, it, beforeEach, afterEach } from "vitest";
 import { z } from "zod";
 import { createMcpHandler, mcpToolSummaryLines } from "./adapter.js";
 import { AgencyFunction } from "../../runtime/agencyFunction.js";
-import type { ExportedItem } from "../types.js";
+import type { ServedExportedItem } from "../types.js";
 import { returnedOutcome, unusedPublicInvoke } from "../testOutcome.js";
 import { PolicyStore } from "../policyStore.js";
 import { mkdtempSync, rmSync } from "fs";
 import path from "path";
 import os from "os";
 
-function makeTestExports(): ExportedItem[] {
+function makeTestExports(): ServedExportedItem[] {
   const registry: Record<string, AgencyFunction> = {};
   const addFn = AgencyFunction.create(
     {

--- a/packages/agency-lang/lib/serve/mcp/adapter.test.ts
+++ b/packages/agency-lang/lib/serve/mcp/adapter.test.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { createMcpHandler, mcpToolSummaryLines } from "./adapter.js";
 import { AgencyFunction } from "../../runtime/agencyFunction.js";
 import type { ExportedItem } from "../types.js";
-import { returnedOutcome } from "../testOutcome.js";
+import { returnedOutcome, unusedPublicInvoke } from "../testOutcome.js";
 import { PolicyStore } from "../policyStore.js";
 import { mkdtempSync, rmSync } from "fs";
 import path from "path";
@@ -33,19 +33,19 @@ function makeTestExports(): ExportedItem[] {
 
   return [
     {
-      kind: "function",
+      kind: "function", ...unusedPublicInvoke,
       name: "add",
       description: "Add two numbers",
       parameters: [{ name: "a" }, { name: "b" }],
       agencyFunction: addFn,
       interruptEffects: [],
-      invoke: async (namedArgs) => returnedOutcome(await addFn.invoke({ type: "named", positionalArgs: [], namedArgs })),
+      invokeServed: async (namedArgs) => returnedOutcome(await addFn.invoke({ type: "named", positionalArgs: [], namedArgs })),
     },
     {
-      kind: "node",
+      kind: "node", ...unusedPublicInvoke,
       name: "main",
       parameters: [{ name: "city" }, { name: "country" }],
-      invoke: async (data: Record<string, unknown>) => returnedOutcome(`${data.city}, ${data.country}`),
+      invokeServed: async (data: Record<string, unknown>) => returnedOutcome(`${data.city}, ${data.country}`),
       interruptEffects: [],
     },
   ];
@@ -172,13 +172,13 @@ describe("MCP adapter", () => {
       serverVersion: "1.0.0",
       exports: [
         {
-          kind: "function",
+          kind: "function", ...unusedPublicInvoke,
           name: "deploy",
           description: "Deploy app",
           parameters: [],
           agencyFunction: deployFn,
           interruptEffects: [{ effect: "myapp::deploy" }, { effect: "myapp::approve" }],
-          invoke: async (namedArgs) => returnedOutcome(await deployFn.invoke({ type: "named", positionalArgs: [], namedArgs })),
+          invokeServed: async (namedArgs) => returnedOutcome(await deployFn.invoke({ type: "named", positionalArgs: [], namedArgs })),
         },
       ],
     });
@@ -220,12 +220,13 @@ describe("MCP adapter", () => {
       const fn = makeFn(name, opts);
       return {
         kind: "function" as const,
+        ...unusedPublicInvoke,
         name,
         description: name,
         parameters: [],
         agencyFunction: fn,
         interruptEffects: [],
-        invoke: async (namedArgs: Record<string, unknown>) => returnedOutcome(await fn.invoke({ type: "named", positionalArgs: [], namedArgs })),
+        invokeServed: async (namedArgs: Record<string, unknown>) => returnedOutcome(await fn.invoke({ type: "named", positionalArgs: [], namedArgs })),
       };
     });
     const handler = createMcpHandler({
@@ -409,7 +410,7 @@ describe("MCP adapter — policy tools", () => {
       serverName: "test",
       serverVersion: "1.0.0",
       exports: [
-        { kind: "function", name: "greet", description: "Greet someone", parameters: [{ name: "name" }], agencyFunction: greetFn, interruptEffects: [{ effect: "test::greet" }], invoke: async (namedArgs) => returnedOutcome(await greetFn.invoke({ type: "named", positionalArgs: [], namedArgs })) },
+        { kind: "function", ...unusedPublicInvoke, name: "greet", description: "Greet someone", parameters: [{ name: "name" }], agencyFunction: greetFn, interruptEffects: [{ effect: "test::greet" }], invokeServed: async (namedArgs) => returnedOutcome(await greetFn.invoke({ type: "named", positionalArgs: [], namedArgs })) },
       ],
       policyConfig: {
         policyStore: new PolicyStore("test", tmpDir),
@@ -459,7 +460,7 @@ describe("MCP adapter — policy tools", () => {
       serverName: "test",
       serverVersion: "1.0.0",
       exports: [
-        { kind: "function", name: "sendEmail", description: "Send an email", parameters: [], agencyFunction: sendFn, interruptEffects: [{ effect: "email::send" }], invoke: async (namedArgs) => returnedOutcome(await sendFn.invoke({ type: "named", positionalArgs: [], namedArgs })) },
+        { kind: "function", ...unusedPublicInvoke, name: "sendEmail", description: "Send an email", parameters: [], agencyFunction: sendFn, interruptEffects: [{ effect: "email::send" }], invokeServed: async (namedArgs) => returnedOutcome(await sendFn.invoke({ type: "named", positionalArgs: [], namedArgs })) },
       ],
       policyConfig: {
         policyStore: store,

--- a/packages/agency-lang/lib/serve/mcp/adapter.test.ts
+++ b/packages/agency-lang/lib/serve/mcp/adapter.test.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { createMcpHandler, mcpToolSummaryLines } from "./adapter.js";
 import { AgencyFunction } from "../../runtime/agencyFunction.js";
 import type { ExportedItem } from "../types.js";
+import { returnedOutcome } from "../testOutcome.js";
 import { PolicyStore } from "../policyStore.js";
 import { mkdtempSync, rmSync } from "fs";
 import path from "path";
@@ -38,13 +39,13 @@ function makeTestExports(): ExportedItem[] {
       parameters: [{ name: "a" }, { name: "b" }],
       agencyFunction: addFn,
       interruptEffects: [],
-      invoke: (namedArgs) => addFn.invoke({ type: "named", positionalArgs: [], namedArgs }),
+      invoke: async (namedArgs) => returnedOutcome(await addFn.invoke({ type: "named", positionalArgs: [], namedArgs })),
     },
     {
       kind: "node",
       name: "main",
       parameters: [{ name: "city" }, { name: "country" }],
-      invoke: async (...args: unknown[]) => ({ data: `${args[0]}, ${args[1]}` }),
+      invoke: async (data: Record<string, unknown>) => returnedOutcome(`${data.city}, ${data.country}`),
       interruptEffects: [],
     },
   ];
@@ -177,7 +178,7 @@ describe("MCP adapter", () => {
           parameters: [],
           agencyFunction: deployFn,
           interruptEffects: [{ effect: "myapp::deploy" }, { effect: "myapp::approve" }],
-          invoke: (namedArgs) => deployFn.invoke({ type: "named", positionalArgs: [], namedArgs }),
+          invoke: async (namedArgs) => returnedOutcome(await deployFn.invoke({ type: "named", positionalArgs: [], namedArgs })),
         },
       ],
     });
@@ -224,8 +225,7 @@ describe("MCP adapter", () => {
         parameters: [],
         agencyFunction: fn,
         interruptEffects: [],
-        invoke: (namedArgs: Record<string, unknown>) =>
-          fn.invoke({ type: "named", positionalArgs: [], namedArgs }),
+        invoke: async (namedArgs: Record<string, unknown>) => returnedOutcome(await fn.invoke({ type: "named", positionalArgs: [], namedArgs })),
       };
     });
     const handler = createMcpHandler({
@@ -409,7 +409,7 @@ describe("MCP adapter — policy tools", () => {
       serverName: "test",
       serverVersion: "1.0.0",
       exports: [
-        { kind: "function", name: "greet", description: "Greet someone", parameters: [{ name: "name" }], agencyFunction: greetFn, interruptEffects: [{ effect: "test::greet" }], invoke: (namedArgs) => greetFn.invoke({ type: "named", positionalArgs: [], namedArgs }) },
+        { kind: "function", name: "greet", description: "Greet someone", parameters: [{ name: "name" }], agencyFunction: greetFn, interruptEffects: [{ effect: "test::greet" }], invoke: async (namedArgs) => returnedOutcome(await greetFn.invoke({ type: "named", positionalArgs: [], namedArgs })) },
       ],
       policyConfig: {
         policyStore: new PolicyStore("test", tmpDir),
@@ -459,7 +459,7 @@ describe("MCP adapter — policy tools", () => {
       serverName: "test",
       serverVersion: "1.0.0",
       exports: [
-        { kind: "function", name: "sendEmail", description: "Send an email", parameters: [], agencyFunction: sendFn, interruptEffects: [{ effect: "email::send" }], invoke: (namedArgs) => sendFn.invoke({ type: "named", positionalArgs: [], namedArgs }) },
+        { kind: "function", name: "sendEmail", description: "Send an email", parameters: [], agencyFunction: sendFn, interruptEffects: [{ effect: "email::send" }], invoke: async (namedArgs) => returnedOutcome(await sendFn.invoke({ type: "named", positionalArgs: [], namedArgs })) },
       ],
       policyConfig: {
         policyStore: store,

--- a/packages/agency-lang/lib/serve/mcp/adapter.ts
+++ b/packages/agency-lang/lib/serve/mcp/adapter.ts
@@ -184,7 +184,7 @@ async function handleToolCall(
   if (fn) {
     return runToolInvocation(
       id,
-      () => fn.invoke(args as Record<string, unknown>).then(unwrapServedInvocationOutcome),
+      () => fn.invokeServed(args as Record<string, unknown>).then(unwrapServedInvocationOutcome),
       policyConfig,
     );
   }
@@ -193,7 +193,7 @@ async function handleToolCall(
   if (node) {
     return runToolInvocation(
       id,
-      () => node.invoke(args as Record<string, unknown>).then(unwrapServedInvocationOutcome),
+      () => node.invokeServed(args as Record<string, unknown>).then(unwrapServedInvocationOutcome),
       policyConfig,
     );
   }

--- a/packages/agency-lang/lib/serve/mcp/adapter.ts
+++ b/packages/agency-lang/lib/serve/mcp/adapter.ts
@@ -5,6 +5,7 @@ import type { PolicyStore } from "../policyStore.js";
 import type { InterruptHandlers } from "./interruptLoop.js";
 import { runWithPolicy } from "./interruptLoop.js";
 import { errorMessage } from "../util.js";
+import { unwrapServedInvocationOutcome } from "../../runtime/invocationUsage.js";
 
 function formatToolDescription(description: string, interruptEffects: InterruptEffect[]): string {
   if (interruptEffects.length === 0) return description;
@@ -144,14 +145,13 @@ async function runToolInvocation(
   id: string | number | null,
   invoke: () => Promise<unknown>,
   policyConfig: McpConfig["policyConfig"],
-  extractData: (result: unknown) => unknown = (r) => r,
 ): Promise<JsonRpcMessage> {
   try {
     const result = policyConfig
       ? await runWithPolicy(invoke, policyConfig.policyStore, policyConfig.interruptHandlers)
       : await invoke();
     return success(id, {
-      content: [{ type: "text", text: JSON.stringify(extractData(result), null, 2) }],
+      content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
       isError: false,
     });
   } catch (err) {
@@ -177,23 +177,24 @@ async function handleToolCall(
     if (policyResult) return success(id, policyResult);
   }
 
+  // Both invokers return a ServedInvocationOutcome; MCP unwraps to the raw value
+  // (or rethrows the original error) before the policy loop, and does not expose
+  // usage in v1. Discovery already unwrapped a node's RunNodeResult to its data.
   const fn = functionsByName[name];
   if (fn) {
     return runToolInvocation(
       id,
-      () => fn.invoke(args as Record<string, unknown>),
+      () => fn.invoke(args as Record<string, unknown>).then(unwrapServedInvocationOutcome),
       policyConfig,
     );
   }
 
   const node = nodesByName[name];
   if (node) {
-    const positional = node.parameters.map((p) => args[p.name]);
     return runToolInvocation(
       id,
-      () => node.invoke(...positional),
+      () => node.invoke(args as Record<string, unknown>).then(unwrapServedInvocationOutcome),
       policyConfig,
-      (r) => (r && typeof r === "object" && "data" in r ? (r as any).data : r),
     );
   }
 

--- a/packages/agency-lang/lib/serve/mcp/adapter.ts
+++ b/packages/agency-lang/lib/serve/mcp/adapter.ts
@@ -1,6 +1,6 @@
 import process from "process";
 import type { InterruptEffect } from "../../symbolTable.js";
-import type { ExportedFunction, ExportedNode, ExportedItem } from "../types.js";
+import type { ServedExportedFunction, ServedExportedNode, ServedExportedItem } from "../types.js";
 import type { PolicyStore } from "../policyStore.js";
 import type { InterruptHandlers } from "./interruptLoop.js";
 import { runWithPolicy } from "./interruptLoop.js";
@@ -52,7 +52,7 @@ export type PolicyConfig = {
 export type McpConfig = {
   serverName: string;
   serverVersion: string;
-  exports: ExportedItem[];
+  exports: ServedExportedItem[];
   policyConfig?: PolicyConfig;
 };
 
@@ -164,8 +164,8 @@ async function runToolInvocation(
 
 async function handleToolCall(
   message: JsonRpcMessage,
-  functionsByName: Record<string, ExportedFunction>,
-  nodesByName: Record<string, ExportedNode>,
+  functionsByName: Record<string, ServedExportedFunction>,
+  nodesByName: Record<string, ServedExportedNode>,
   policyConfig: McpConfig["policyConfig"],
 ): Promise<JsonRpcMessage> {
   const name = message.params?.name;
@@ -216,8 +216,8 @@ type ToolEntry = {
  */
 function buildToolsListPayload(config: McpConfig): ToolEntry[] {
   const { exports, policyConfig } = config;
-  const functions = exports.filter((e): e is ExportedFunction => e.kind === "function");
-  const nodes = exports.filter((e): e is ExportedNode => e.kind === "node");
+  const functions = exports.filter((e): e is ServedExportedFunction => e.kind === "function");
+  const nodes = exports.filter((e): e is ServedExportedNode => e.kind === "node");
 
   const functionToolEntries: ToolEntry[] = functions.map((f) => {
     const entry: ToolEntry = {
@@ -285,8 +285,8 @@ export function mcpToolSummaryLines(config: McpConfig): string[] {
 export function createMcpHandler(config: McpConfig): McpHandler {
   const { serverName, serverVersion, exports } = config;
 
-  const functions = exports.filter((e): e is ExportedFunction => e.kind === "function");
-  const nodes = exports.filter((e): e is ExportedNode => e.kind === "node");
+  const functions = exports.filter((e): e is ServedExportedFunction => e.kind === "function");
+  const nodes = exports.filter((e): e is ServedExportedNode => e.kind === "node");
   const functionsByName = Object.fromEntries(functions.map((f) => [f.name, f]));
   const nodesByName = Object.fromEntries(nodes.map((n) => [n.name, n]));
 

--- a/packages/agency-lang/lib/serve/mcp/httpTransport.test.ts
+++ b/packages/agency-lang/lib/serve/mcp/httpTransport.test.ts
@@ -4,7 +4,7 @@ import { AddressInfo } from "net";
 import { startMcpHttpServer } from "./httpTransport.js";
 import { createMcpHandler } from "./adapter.js";
 import { AgencyFunction } from "../../runtime/agencyFunction.js";
-import type { ExportedItem } from "../types.js";
+import type { ServedExportedItem } from "../types.js";
 import { returnedOutcome, unusedPublicInvoke } from "../testOutcome.js";
 import { createLogger } from "../../logger.js";
 
@@ -24,7 +24,7 @@ function makeHandler() {
     },
     registry,
   );
-  const exports: ExportedItem[] = [
+  const exports: ServedExportedItem[] = [
     {
       kind: "function", ...unusedPublicInvoke,
       name: "add",

--- a/packages/agency-lang/lib/serve/mcp/httpTransport.test.ts
+++ b/packages/agency-lang/lib/serve/mcp/httpTransport.test.ts
@@ -5,6 +5,7 @@ import { startMcpHttpServer } from "./httpTransport.js";
 import { createMcpHandler } from "./adapter.js";
 import { AgencyFunction } from "../../runtime/agencyFunction.js";
 import type { ExportedItem } from "../types.js";
+import { returnedOutcome } from "../testOutcome.js";
 import { createLogger } from "../../logger.js";
 
 function makeHandler() {
@@ -31,7 +32,7 @@ function makeHandler() {
       parameters: [{ name: "a" }, { name: "b" }],
       agencyFunction: addFn,
       interruptEffects: [],
-      invoke: (namedArgs) => addFn.invoke({ type: "named", positionalArgs: [], namedArgs }),
+      invoke: async (namedArgs) => returnedOutcome(await addFn.invoke({ type: "named", positionalArgs: [], namedArgs })),
     },
   ];
   return createMcpHandler({

--- a/packages/agency-lang/lib/serve/mcp/httpTransport.test.ts
+++ b/packages/agency-lang/lib/serve/mcp/httpTransport.test.ts
@@ -5,7 +5,7 @@ import { startMcpHttpServer } from "./httpTransport.js";
 import { createMcpHandler } from "./adapter.js";
 import { AgencyFunction } from "../../runtime/agencyFunction.js";
 import type { ExportedItem } from "../types.js";
-import { returnedOutcome } from "../testOutcome.js";
+import { returnedOutcome, unusedPublicInvoke } from "../testOutcome.js";
 import { createLogger } from "../../logger.js";
 
 function makeHandler() {
@@ -26,13 +26,13 @@ function makeHandler() {
   );
   const exports: ExportedItem[] = [
     {
-      kind: "function",
+      kind: "function", ...unusedPublicInvoke,
       name: "add",
       description: "Add two numbers",
       parameters: [{ name: "a" }, { name: "b" }],
       agencyFunction: addFn,
       interruptEffects: [],
-      invoke: async (namedArgs) => returnedOutcome(await addFn.invoke({ type: "named", positionalArgs: [], namedArgs })),
+      invokeServed: async (namedArgs) => returnedOutcome(await addFn.invoke({ type: "named", positionalArgs: [], namedArgs })),
     },
   ];
   return createMcpHandler({

--- a/packages/agency-lang/lib/serve/testOutcome.ts
+++ b/packages/agency-lang/lib/serve/testOutcome.ts
@@ -23,3 +23,12 @@ export function threwOutcome(
 ): ServedInvocationOutcome<never> {
   return { status: "threw", error, ...ZERO_SNAPSHOT, ...overrides };
 }
+
+/** The PUBLIC raw `invoke` member on an ExportedFunction/Node. Adapter tests
+ *  drive the served path (`invokeServed`), never the public `invoke`, so a fake
+ *  can spread this stub to satisfy the type; calling it is a test bug. */
+export const unusedPublicInvoke = {
+  invoke: (async () => {
+    throw new Error("public invoke is not exercised in this test (use invokeServed)");
+  }) as (...args: any[]) => Promise<any>,
+};

--- a/packages/agency-lang/lib/serve/testOutcome.ts
+++ b/packages/agency-lang/lib/serve/testOutcome.ts
@@ -1,0 +1,25 @@
+// Test-only builders for ServedInvocationOutcome, so adapter/discovery unit
+// tests can supply plain-JS invokers without spinning up a real runtime.
+import type { ServedInvocationOutcome } from "../runtime/invocationUsage.js";
+
+const ZERO_SNAPSHOT = {
+  usage: { pricedCost: 0, inputTokens: 0, outputTokens: 0, unknownCostCallCount: 0, pricingComplete: true },
+  usageComplete: true,
+} as const;
+
+/** A returned outcome carrying a fixed usage snapshot (override `usage` when a
+ *  test asserts specific figures). */
+export function returnedOutcome<T>(
+  value: T,
+  overrides: Partial<Pick<ServedInvocationOutcome<T>, "usage" | "usageComplete">> = {},
+): ServedInvocationOutcome<T> {
+  return { status: "returned", value, ...ZERO_SNAPSHOT, ...overrides };
+}
+
+/** A threw outcome carrying the identical error. */
+export function threwOutcome(
+  error: unknown,
+  overrides: Partial<Pick<ServedInvocationOutcome<never>, "usage" | "usageComplete">> = {},
+): ServedInvocationOutcome<never> {
+  return { status: "threw", error, ...ZERO_SNAPSHOT, ...overrides };
+}

--- a/packages/agency-lang/lib/serve/types.ts
+++ b/packages/agency-lang/lib/serve/types.ts
@@ -12,31 +12,41 @@ export type ExportedFunction = {
   agencyFunction: AgencyFunction;
   interruptEffects: InterruptEffect[];
   /**
-   * PUBLIC contract, unchanged: invoke the function for a single request and
-   * return its raw value, or throw the identical error. This is the member host
-   * apps that construct/consume `ExportedFunction` directly depend on.
+   * Invoke the function for a single request and return its raw value, or throw
+   * the identical error. Unchanged public contract — the member host apps that
+   * construct/consume `ExportedFunction` directly depend on.
    */
   invoke: (namedArgs: Record<string, unknown>) => Promise<unknown>;
-  /**
-   * INTERNAL, for the serve adapters: the same execution as `invoke`, but the
-   * value-or-error is returned inside a `ServedInvocationOutcome` alongside a
-   * per-invocation usage snapshot (never mutating the value/error). Populated by
-   * `discoverExports` from the compiled module's `__invokeFunctionForServe`.
-   */
-  invokeServed: (namedArgs: Record<string, unknown>) => Promise<ServedInvocationOutcome<unknown>>;
 };
 
 export type ExportedNode = {
   kind: "node";
   name: string;
   parameters: Array<{ name: string }>;
-  /** PUBLIC contract, unchanged: positional args → raw `RunNodeResult`, or throw. */
+  /** Positional args → raw `RunNodeResult`, or throw. Unchanged public contract. */
   invoke: (...args: unknown[]) => Promise<unknown>;
-  /** INTERNAL, for the serve adapters: named args as a data object → a
-   *  `ServedInvocationOutcome` whose `value` is the node's caller-facing data
-   *  (`RunNodeResult.data`, already unwrapped by `discoverExports`) + usage. */
-  invokeServed: (data: Record<string, unknown>) => Promise<ServedInvocationOutcome<unknown>>;
   interruptEffects: InterruptEffect[];
 };
 
 export type ExportedItem = ExportedFunction | ExportedNode;
+
+// --- Internal, NOT part of the public `agency-lang/serve` surface. ---
+//
+// The serve adapters additionally need a usage-bearing invoker. Rather than add
+// a required member to the PUBLIC `ExportedFunction`/`ExportedNode` (which would
+// break host apps that construct them), the adapters use these internal
+// `Served*` supertypes: the same shape plus `invokeServed`, which
+// `discoverExports` populates from the compiled module's `…ForServe` invokers.
+// `invokeServed` returns the value-or-error inside a `ServedInvocationOutcome`
+// (never mutating either) with a per-invocation usage snapshot; a node's value
+// is its caller-facing `RunNodeResult.data`, already unwrapped by discovery.
+
+export type ServedExportedFunction = ExportedFunction & {
+  invokeServed: (namedArgs: Record<string, unknown>) => Promise<ServedInvocationOutcome<unknown>>;
+};
+
+export type ServedExportedNode = ExportedNode & {
+  invokeServed: (data: Record<string, unknown>) => Promise<ServedInvocationOutcome<unknown>>;
+};
+
+export type ServedExportedItem = ServedExportedFunction | ServedExportedNode;

--- a/packages/agency-lang/lib/serve/types.ts
+++ b/packages/agency-lang/lib/serve/types.ts
@@ -12,25 +12,30 @@ export type ExportedFunction = {
   agencyFunction: AgencyFunction;
   interruptEffects: InterruptEffect[];
   /**
-   * Invoke the function for a single request, given its named arguments, and
-   * return a `ServedInvocationOutcome`: the raw function value (on `returned`)
-   * or the identical thrown error (on `threw`), plus a per-invocation usage
-   * snapshot. Populated by `discoverExports` from the compiled module's
-   * generated `__invokeFunctionForServe`, which runs the body inside a
-   * node-grade execution frame. An adapter unit test may supply a plain-JS
-   * invoke that returns an outcome directly.
+   * PUBLIC contract, unchanged: invoke the function for a single request and
+   * return its raw value, or throw the identical error. This is the member host
+   * apps that construct/consume `ExportedFunction` directly depend on.
    */
-  invoke: (namedArgs: Record<string, unknown>) => Promise<ServedInvocationOutcome<unknown>>;
+  invoke: (namedArgs: Record<string, unknown>) => Promise<unknown>;
+  /**
+   * INTERNAL, for the serve adapters: the same execution as `invoke`, but the
+   * value-or-error is returned inside a `ServedInvocationOutcome` alongside a
+   * per-invocation usage snapshot (never mutating the value/error). Populated by
+   * `discoverExports` from the compiled module's `__invokeFunctionForServe`.
+   */
+  invokeServed: (namedArgs: Record<string, unknown>) => Promise<ServedInvocationOutcome<unknown>>;
 };
 
 export type ExportedNode = {
   kind: "node";
   name: string;
   parameters: Array<{ name: string }>;
-  /** Invoke the node with its named args as a data object, returning a
+  /** PUBLIC contract, unchanged: positional args → raw `RunNodeResult`, or throw. */
+  invoke: (...args: unknown[]) => Promise<unknown>;
+  /** INTERNAL, for the serve adapters: named args as a data object → a
    *  `ServedInvocationOutcome` whose `value` is the node's caller-facing data
-   *  (the `RunNodeResult.data`, already unwrapped by `discoverExports`). */
-  invoke: (data: Record<string, unknown>) => Promise<ServedInvocationOutcome<unknown>>;
+   *  (`RunNodeResult.data`, already unwrapped by `discoverExports`) + usage. */
+  invokeServed: (data: Record<string, unknown>) => Promise<ServedInvocationOutcome<unknown>>;
   interruptEffects: InterruptEffect[];
 };
 

--- a/packages/agency-lang/lib/serve/types.ts
+++ b/packages/agency-lang/lib/serve/types.ts
@@ -1,5 +1,6 @@
 import type { AgencyFunction } from "../runtime/agencyFunction.js";
 import type { InterruptEffect } from "../symbolTable.js";
+import type { ServedInvocationOutcome } from "../runtime/invocationUsage.js";
 
 export type ExportedFunction = {
   kind: "function";
@@ -11,22 +12,25 @@ export type ExportedFunction = {
   agencyFunction: AgencyFunction;
   interruptEffects: InterruptEffect[];
   /**
-   * Invoke the function for a single request, given its named arguments.
-   * Populated by `discoverExports` from the compiled module's generated
-   * `__invokeFunction`, which runs the body inside a node-grade execution
-   * frame — generated function bodies require an ambient Agency frame and
-   * throw without one. Falls back to a bare `agencyFunction.invoke` for
-   * modules compiled before `__invokeFunction` existed (and for tests that
-   * build `ExportedFunction` from plain JS bodies that need no frame).
+   * Invoke the function for a single request, given its named arguments, and
+   * return a `ServedInvocationOutcome`: the raw function value (on `returned`)
+   * or the identical thrown error (on `threw`), plus a per-invocation usage
+   * snapshot. Populated by `discoverExports` from the compiled module's
+   * generated `__invokeFunctionForServe`, which runs the body inside a
+   * node-grade execution frame. An adapter unit test may supply a plain-JS
+   * invoke that returns an outcome directly.
    */
-  invoke: (namedArgs: Record<string, unknown>) => Promise<unknown>;
+  invoke: (namedArgs: Record<string, unknown>) => Promise<ServedInvocationOutcome<unknown>>;
 };
 
 export type ExportedNode = {
   kind: "node";
   name: string;
   parameters: Array<{ name: string }>;
-  invoke: (...args: unknown[]) => Promise<unknown>;
+  /** Invoke the node with its named args as a data object, returning a
+   *  `ServedInvocationOutcome` whose `value` is the node's caller-facing data
+   *  (the `RunNodeResult.data`, already unwrapped by `discoverExports`). */
+  invoke: (data: Record<string, unknown>) => Promise<ServedInvocationOutcome<unknown>>;
   interruptEffects: InterruptEffect[];
 };
 

--- a/packages/agency-lang/lib/stdlib/image.test.ts
+++ b/packages/agency-lang/lib/stdlib/image.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { agencyStore } from "../runtime/asyncContext.js";
+import { InvocationUsageMeter } from "../runtime/invocationUsage.js";
 import { _generateImage } from "./image.js";
 
 type ImageImpl = (input: any, config: any) => Promise<any>;
@@ -29,7 +30,9 @@ async function withClient(
   const stack = makeStack();
   const imageGeneration = vi.fn().mockResolvedValue(undefined);
   const store = {
-    ctx: { llmClient: { image: imageImpl }, statelogClient: { imageGeneration } },
+    // A real meter: image generation pays via addCost → recordPaidUsage, which
+    // merges ctx.invocationUsage (the serve cost seam's accounting boundary).
+    ctx: { llmClient: { image: imageImpl }, statelogClient: { imageGeneration }, invocationUsage: new InvocationUsageMeter() },
     stack,
     threads: {},
     globals: {},

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -56,6 +59,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
@@ -19,8 +19,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -61,6 +64,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // \`agency serve\` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. \`discoverExports\`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/lib/templates/cli/standaloneHttp.mustache
+++ b/packages/agency-lang/lib/templates/cli/standaloneHttp.mustache
@@ -31,7 +31,7 @@ try {
     apiKey,
     logger: createLogger("info"),
     hasInterrupts: mod.hasInterrupts,
-    respondToInterrupts: mod.respondToInterrupts,
+    respondToInterrupts: mod.__respondToInterruptsForServe,
   });
 } catch (err) {
   console.error(err instanceof Error ? err.message : String(err));

--- a/packages/agency-lang/lib/templates/cli/standaloneHttp.ts
+++ b/packages/agency-lang/lib/templates/cli/standaloneHttp.ts
@@ -36,7 +36,7 @@ try {
     apiKey,
     logger: createLogger("info"),
     hasInterrupts: mod.hasInterrupts,
-    respondToInterrupts: mod.respondToInterrupts,
+    respondToInterrupts: mod.__respondToInterruptsForServe,
   });
 } catch (err) {
   console.error(err instanceof Error ? err.message : String(err));

--- a/packages/agency-lang/lib/templates/cli/standaloneMcp.mustache
+++ b/packages/agency-lang/lib/templates/cli/standaloneMcp.mustache
@@ -20,8 +20,9 @@ const policyStore = new PolicyStore(serverName);
 const interruptHandlers = {
   hasInterrupts: mod.hasInterrupts,
   respondToInterrupts: async (interrupts, responses) => {
-    const wrapped = await mod.respondToInterrupts(interrupts, responses);
-    return wrapped.data;
+    const outcome = await mod.__respondToInterruptsForServe(interrupts, responses);
+    if (outcome.status === "threw") throw outcome.error;
+    return outcome.value.data;
   },
 };
 

--- a/packages/agency-lang/lib/templates/cli/standaloneMcp.ts
+++ b/packages/agency-lang/lib/templates/cli/standaloneMcp.ts
@@ -25,8 +25,9 @@ const policyStore = new PolicyStore(serverName);
 const interruptHandlers = {
   hasInterrupts: mod.hasInterrupts,
   respondToInterrupts: async (interrupts, responses) => {
-    const wrapped = await mod.respondToInterrupts(interrupts, responses);
-    return wrapped.data;
+    const outcome = await mod.__respondToInterruptsForServe(interrupts, responses);
+    if (outcome.status === "threw") throw outcome.error;
+    return outcome.value.data;
   },
 };
 

--- a/packages/agency-lang/lib/templates/cli/standaloneMcpHttp.mustache
+++ b/packages/agency-lang/lib/templates/cli/standaloneMcpHttp.mustache
@@ -22,8 +22,9 @@ const policyStore = new PolicyStore(serverName);
 const interruptHandlers = {
   hasInterrupts: mod.hasInterrupts,
   respondToInterrupts: async (interrupts, responses) => {
-    const wrapped = await mod.respondToInterrupts(interrupts, responses);
-    return wrapped.data;
+    const outcome = await mod.__respondToInterruptsForServe(interrupts, responses);
+    if (outcome.status === "threw") throw outcome.error;
+    return outcome.value.data;
   },
 };
 

--- a/packages/agency-lang/lib/templates/cli/standaloneMcpHttp.ts
+++ b/packages/agency-lang/lib/templates/cli/standaloneMcpHttp.ts
@@ -27,8 +27,9 @@ const policyStore = new PolicyStore(serverName);
 const interruptHandlers = {
   hasInterrupts: mod.hasInterrupts,
   respondToInterrupts: async (interrupts, responses) => {
-    const wrapped = await mod.respondToInterrupts(interrupts, responses);
-    return wrapped.data;
+    const outcome = await mod.__respondToInterruptsForServe(interrupts, responses);
+    if (outcome.status === "threw") throw outcome.error;
+    return outcome.value.data;
   },
 };
 

--- a/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptBuilder/simple.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/simple.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/array.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/array.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/codeLiteral.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/codeLiteral.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/comments.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comments.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/comprehension.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comprehension.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/destructiveBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/destructiveBlock.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/destructiveNested.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/destructiveNested.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -94,6 +97,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/goto.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/goto.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/imports.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/imports.mjs
@@ -29,8 +29,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -108,6 +111,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/input.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/input.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/intersectionTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/intersectionTypes.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlockBlockArms.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlockBlockArms.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/matchExpression.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchExpression.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/recursiveTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recursiveTypes.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/schemaChaining.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaChaining.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
@@ -15,8 +15,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -94,6 +97,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/simple.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/simple.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/skill.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/skill.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/slice.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/slice.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/splat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/splat.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/static.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/static.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/type-patterns.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/type-patterns.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/typeOperators.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeOperators.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/utilityTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/utilityTypes.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
@@ -14,8 +14,11 @@ import {
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
+  respondToInterruptsForServe as _respondToInterruptsForServe,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
+  runExportedFunctionForServe as _runExportedFunctionForServe,
+  runNodeForServe as _runNodeForServe,
   RestoreSignal,
   AgencyAbort,
   AbortedResult,
@@ -93,6 +96,14 @@ export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unk
 // `agency serve` to call a function from an HTTP/MCP request — outside any
 // Agency execution frame, which generated function bodies otherwise require.
 export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+
+// Serve-only invokers: identical execution to the entries above, but they hand
+// back a ServedInvocationOutcome (value/error + per-invocation usage snapshot)
+// so the serve adapters can report authoritative cost. `discoverExports`
+// requires all three; a bundle without them must be recompiled.
+export const __invokeFunctionForServe = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunctionForServe({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals });
+export const __invokeNodeForServe = (nodeName: string, data: Record<string, any>) => _runNodeForServe({ ctx: __globalCtx, nodeName, data, initializeGlobals: __initializeGlobals });
+export const __respondToInterruptsForServe = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterruptsForServe({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level


### PR DESCRIPTION
## What

The agency-lang half of statelog's **Group 4 per-project spend tracking** — the "serve cost seam". Every post-execution serve outcome now carries a trusted, fresh **per-invocation usage** figure (priced cost + tokens + unknown-price count + completeness), read in-process by the host from the run agency-lang executed, so a project owner cannot under-report. Built from the reviewed plan (Revision 3), one task per commit.

## The two declarative boundaries

**Accounting** — one op `recordPaidUsageAt({ ctx, stack }, delta)` bills the branch's cost guards (reusing `billCharge`), merges the invocation meter, and relays the full delta upward exactly once when this process is a subprocess. All three paid sites route through it: the LLM completion, `addCost` (memory/image), and the IPC telemetry handler. So `pricedCost` is *all* trusted spend and is topology-independent — an `addCost` charge counts identically in-process and in a child. (`billCharge` no longer relays; the relay moved to this boundary.)

**Invocation** — `runNode` / `runExportedFunction` / `respondToInterrupts` split into an internal core returning a `ServedInvocationOutcome<T>` (`returned{value}` | `threw{error}` + usage snapshot) and a public wrapper that unwraps-or-rethrows (CLI/debugger contract unchanged). New `…ForServe` variants + generated `__invoke{Function,Node}ForServe` / `__respondToInterruptsForServe` hand the outcome to the adapters. User values and thrown errors are **never** mutated or wrapped — identity, `readCause`, stack, and the 402 classification are preserved.

## Key properties

- **Fresh, non-serialized meter** per execution context → resume-leg and concurrent isolation are structural (a resume leg starts at zero, not the checkpoint-carried `localCost`).
- **Two completeness axes, never conflated:** `pricingComplete` (derived from `unknownCostCallCount === 0`; a finite `0` is a known free price, only an *absent* price is unknown) vs `usageComplete` (goes permanently false on an abnormal subprocess termination, making `usage` a trusted lower bound, relayed once).
- **Usage on every post-execution outcome** (success/interrupt/402/failure/cancel) and **absent** on `/list`, 404, validation 400. The lifecycle boundary starts when the execution context exists, so an already-aborted signal or a setup failure still yields usage and runs cleanup; the snapshot is taken after cleanup.
- **Subprocess propagation:** the IPC wire carries a full `InvocationUsageDelta` (a legal delta may be zero-cost with tokens/unknown), validated per-field; a middle process re-relays it once so grandchild totals are exact.
- **`discoverExports` requires the serve invokers** — a bundle without them fails fast with a recompile-required error (older bundles were already unsupported for served functions).
- **MCP** unwraps the outcome to the raw value (or rethrows) and does not expose usage in v1; the standalone HTTP/MCP templates use the serve resume.

## Out of scope

Everything statelog-side (the `usage_events` table, spend API/CSV, execution-attempt id, reliability/idempotency) — that consumes this seam. Also: per-call/per-model breakdown (v1 is per-invocation totals); `runId` on the result (deferred).

## Verification

- `pnpm run typecheck` (source + tests + evals), `pnpm run lint:structure`, and `git diff --check` all clean.
- ~180 new/updated tests across 12 files (meter arithmetic; fresh/non-serialized context; the accounting op incl. topology-independence; IPC full-delta + exact grandchild totals + incompleteness marking; outcome cores incl. primitive/frozen throws, already-aborted, setup/cleanup failure; adapter mapping incl. 402 + usage-omission; discovery recompile-gate; a source-based end-to-end integration file). The touched-area suites pass (386 tests).
- Codegen verified to emit the three serve invokers; `serveCostSeam.integration` verified against a built `dist`. The `functionFrame.integration` suite needs the full `make` stdlib build, so it is left to CI (as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
