### PR TITLE
feat(remote): agency remote spend — hosted spend from the CLI

### DIFF
--- a/packages/agency-lang/docs/superpowers/plans/2026-08-04-agency-remote-spend.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-08-04-agency-remote-spend.md
@@ -1,0 +1,442 @@
+# `agency remote spend` — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `agency remote spend [project]` — a read-only CLI command that prints one project's, or the whole account's, hosted spend from statelog's Group 4 endpoints.
+
+**Architecture:** A thin command over the existing two-client split. A pure `resolveSpendWindow` turns the time flags into validated epoch-ms bounds plus a display label; the project/account clients gain a `getSpend`/`getAccountSpend` method (shared zod types + query serializer); renderers format the result; the command only selects scope and orchestrates.
+
+**Tech Stack:** TypeScript CLI (`lib/cli/remote`, `lib/cli/statelog`), commander, zod, Vitest.
+
+**Spec:** `docs/superpowers/specs/2026-08-04-agency-remote-spend-design.md` (v3, post-two-reviews).
+
+## Global Constraints
+
+- NEVER use dynamic imports. Use objects not maps, arrays not sets, `type` not `interface`.
+- Do NOT edit `docs/site/**` (user-facing docs are out of scope for a feature PR). Do NOT edit `CHANGELOG.md`. Do NOT commit to `main`; work on the task branch. Owner squash-merges the PR — do not merge it yourself.
+- Lint (enforced): 1250 lines/file, 150 lines/function (style target 1000/100 per `docs/dev/coding-standards.md` — keep new files small and focused).
+- Follow `docs/dev/anti-patterns.md`: keep transport mechanics private, use one request path per client, use descriptive variable names, and put braces around every `if` body.
+- Commit messages / PR bodies go in a FILE passed with `git commit -F <file>`. Follow the repo's commit conventions (this environment appends the `Co-Authored-By: Claude Opus 4.8` trailer).
+- **Before any push and at finish: run BOTH `pnpm run typecheck` AND the full `pnpm test:run`.** (Lesson from the last PR: `make` skips test-file typechecking, and scoped per-file test runs miss untouched files. `typecheck` = `tsc --noEmit && tsc -p tsconfig.tests.json && tsc -p tsconfig.evals.json`.) During a task, also run the task's own test file with `pnpm test:run <path>`.
+- No codegen / no `make fixtures` / no `make` needed — this is CLI TypeScript only.
+- Reuse existing fixtures/conventions, do not invent: remote command tests use a hoisted `vi.mock` of the client module + a `context()` returning `{ config, configPath }`, spy `console.log`/`console.error`, and mock `process.exit` to throw; `--json` writes via `printJson` → **`process.stdout.write`** (spy that, not `console.log`). See `lib/cli/remote/commands/projects.test.ts`.
+
+---
+
+### Task 1: Shared spend types + query serializer
+
+The single source of truth: zod schemas with numeric invariants, TS types inferred from them, the `SpendWindow` bounds type, and the null-omitting query serializer both clients share.
+
+**Files:**
+- Create: `lib/cli/statelog/spendTypes.ts`
+- Test: `lib/cli/statelog/spendTypes.test.ts`
+
+**Interfaces — Produces:** `ProjectSpend`, `AccountSpendRow` (both `z.infer`'d), `projectSpendSchema`, `accountSpendRowSchema`, `SpendWindow`, `toSpendQuery`.
+
+- [ ] **Step 1: Write the failing test** (`spendTypes.test.ts`)
+
+```ts
+import { describe, it, expect } from "vitest";
+import { projectSpendSchema, accountSpendRowSchema, toSpendQuery } from "./spendTypes.js";
+
+const valid = { pricedCost: 0.5, inputTokens: 10, outputTokens: 2, invocationCount: 3, unpricedCallCount: 0, pricingComplete: true, usageComplete: true };
+
+describe("projectSpendSchema", () => {
+  it("accepts a valid spend", () => { expect(projectSpendSchema.parse(valid)).toEqual(valid); });
+  it("rejects non-finite/negative cost, unsafe/negative counts, contradictory completeness", () => {
+    expect(() => projectSpendSchema.parse({ ...valid, pricedCost: -1 })).toThrow();
+    expect(() => projectSpendSchema.parse({ ...valid, pricedCost: Number.NaN })).toThrow();
+    expect(() => projectSpendSchema.parse({ ...valid, pricedCost: Number.POSITIVE_INFINITY })).toThrow();
+    expect(() => projectSpendSchema.parse({ ...valid, inputTokens: -1 })).toThrow();
+    expect(() => projectSpendSchema.parse({ ...valid, outputTokens: 2 ** 53 })).toThrow();
+    expect(() => projectSpendSchema.parse({ ...valid, invocationCount: 2 ** 53 })).toThrow();
+    expect(() => projectSpendSchema.parse({ ...valid, unpricedCallCount: 1, pricingComplete: true })).toThrow();
+  });
+});
+
+describe("accountSpendRowSchema", () => {
+  it("accepts null and ISO deletedAt, rejects junk", () => {
+    expect(accountSpendRowSchema.parse({ projectSlug: "p", deletedAt: null, spend: valid }).deletedAt).toBeNull();
+    expect(accountSpendRowSchema.parse({ projectSlug: "p", deletedAt: "2026-08-01T00:00:00.000Z", spend: valid }).deletedAt).toBe("2026-08-01T00:00:00.000Z");
+    expect(() => accountSpendRowSchema.parse({ projectSlug: "p", deletedAt: "nope", spend: valid })).toThrow();
+  });
+});
+
+describe("toSpendQuery", () => {
+  it("omits null bounds, serializes present ones as decimals", () => {
+    expect(toSpendQuery({ from: null, to: null })).toEqual({});
+    expect(toSpendQuery({ from: 1000, to: null })).toEqual({ from: "1000" });
+    expect(toSpendQuery({ from: 1000, to: 2000 })).toEqual({ from: "1000", to: "2000" });
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify fail** — `pnpm test:run lib/cli/statelog/spendTypes.test.ts` → FAIL (module missing).
+
+- [ ] **Step 3: Implement** `lib/cli/statelog/spendTypes.ts` per the spec's File 1 section: schemas with `nonNegInt` refined by `Number.isSafeInteger`, `pricedCost` finite+nonnegative, the `pricingComplete === (unpricedCallCount === 0)` refinement, `deletedAt` as `z.string().datetime().nullable()`, inferred types, `SpendWindow`, and `toSpendQuery`. Use descriptive production names in the callbacks and serializer:
+
+```ts
+}).refine(
+  (spend) => spend.pricingComplete === (spend.unpricedCallCount === 0),
+  "pricingComplete must equal (unpricedCallCount === 0)",
+);
+
+export function toSpendQuery(window: SpendWindow): Record<string, string> {
+  const query: Record<string, string> = {};
+  if (window.from !== null) {
+    query.from = String(window.from);
+  }
+  if (window.to !== null) {
+    query.to = String(window.to);
+  }
+  return query;
+}
+```
+
+- [ ] **Step 4: Run to verify pass** — same command → PASS.
+
+- [ ] **Step 5: Commit** — `feat(remote): shared spend wire types + query serializer`
+
+---
+
+### Task 2: `resolveSpendWindow` — pure time-flag parsing
+
+**Files:**
+- Create: `lib/cli/remote/commands/spendWindow.ts`
+- Test: `lib/cli/remote/commands/spendWindow.test.ts`
+
+**Interfaces:**
+- Consumes: `parseDurationMs` (`lib/duration.ts`), `SpendWindow` (Task 1).
+- Produces: `SpendWindowOptions`, `ResolvedSpendWindow = SpendWindow & { description: string }`, `resolveSpendWindow(options, now?)` — **returns or throws `Error`; never calls `fail()`/exits.**
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { resolveSpendWindow } from "./spendWindow.js";
+
+const NOW = 1_800_000_000_000; // fixed for determinism
+
+describe("resolveSpendWindow", () => {
+  it("--since sets [now-Δ, now] and a label", () => {
+    const resolved = resolveSpendWindow({ since: "7d" }, NOW);
+    expect(resolved.to).toBe(NOW);
+    expect(resolved.from).toBe(NOW - 7 * 24 * 3600 * 1000);
+    expect(resolved.description).toBe("last 7d");
+  });
+  it("throws when --since combines with --from/--to", () => {
+    expect(() => resolveSpendWindow({ since: "1d", from: "1000" }, NOW)).toThrow(/cannot be combined/);
+  });
+  it.each(["-1h", "0h", "0.1ms"])("throws on a non-positive/fractional --since %s", (duration) => {
+    expect(() => resolveSpendWindow({ since: duration }, NOW)).toThrow();
+  });
+  it("throws when --since reaches before the epoch", () => {
+    expect(() => resolveSpendWindow({ since: "9999d" }, 1000)).toThrow();
+  });
+  it("throws on a malformed --since string (parseDurationMs)", () => {
+    expect(() => resolveSpendWindow({ since: "banana" }, NOW)).toThrow();
+  });
+  it("accepts --since 0.5s as 500ms", () => {
+    expect(resolveSpendWindow({ since: "0.5s" }, NOW).from).toBe(NOW - 500);
+  });
+  it("trims --since before parsing and displaying it", () => {
+    expect(resolveSpendWindow({ since: " 7d " }, NOW).description).toBe("last 7d");
+  });
+  it("rejects an invalid injected current time before using it", () => {
+    expect(() => resolveSpendWindow({ since: "1s" }, 1000.5)).toThrow(/current time/);
+  });
+  it("parses --from epoch-ms and YYYY-MM-DD (UTC midnight)", () => {
+    expect(resolveSpendWindow({ from: "1000" }, NOW).from).toBe(1000);
+    expect(resolveSpendWindow({ from: "2026-07-01" }, NOW).from).toBe(Date.parse("2026-07-01T00:00:00Z"));
+  });
+  it("requires a Z/offset on a datetime, rejects bare local + junk + out-of-range", () => {
+    expect(() => resolveSpendWindow({ from: "2026-07-01T12:00:00" }, NOW)).toThrow();
+    expect(() => resolveSpendWindow({ from: "not-a-date" }, NOW)).toThrow();
+    expect(() => resolveSpendWindow({ from: "99999999999999999" }, NOW)).toThrow();
+    expect(resolveSpendWindow({ from: "2026-07-01T12:00:00Z" }, NOW).from).toBe(Date.parse("2026-07-01T12:00:00Z"));
+  });
+  it("rejects nonexistent calendar dates instead of normalizing them", () => {
+    expect(() => resolveSpendWindow({ from: "2026-02-30" }, NOW)).toThrow(/valid date/);
+    expect(() => resolveSpendWindow({ from: "2026-13-01" }, NOW)).toThrow(/valid date/);
+    expect(() => resolveSpendWindow({ from: "2026-02-30T12:00:00Z" }, NOW)).toThrow(/valid date/);
+  });
+  it("rejects from >= to", () => {
+    expect(() => resolveSpendWindow({ from: "2000", to: "1000" }, NOW)).toThrow(/before/);
+  });
+  it("resolves one-sided windows", () => {
+    expect(resolveSpendWindow({ from: "1000" }, NOW)).toMatchObject({ from: 1000, to: null });
+    expect(resolveSpendWindow({ to: "2000" }, NOW)).toMatchObject({ from: null, to: 2000 });
+  });
+  it("no flags → all time", () => {
+    expect(resolveSpendWindow({}, NOW)).toEqual({ from: null, to: null, description: "all time" });
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify fail.**
+
+- [ ] **Step 3: Implement**
+
+```ts
+import { parseDurationMs } from "@/duration.js";
+import type { SpendWindow } from "@/cli/statelog/spendTypes.js";
+
+export type SpendWindowOptions = { since?: string; from?: string; to?: string };
+export type ResolvedSpendWindow = SpendWindow & { description: string };
+
+const MAX_DATE_TIMESTAMP_MS = 8.64e15;
+const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+const DATETIME_WITH_ZONE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d{1,3})?)?(?:Z|[+-]\d{2}:\d{2})$/;
+
+function requireInstant(milliseconds: number, label: string): number {
+  if (
+    !Number.isSafeInteger(milliseconds)
+    || milliseconds < 0
+    || milliseconds > MAX_DATE_TIMESTAMP_MS
+  ) {
+    throw new Error(`${label} is out of range`);
+  }
+  return milliseconds;
+}
+
+function requireCalendarDate(value: string, label: string): void {
+  const milliseconds = Date.parse(`${value}T00:00:00Z`);
+  if (
+    Number.isNaN(milliseconds)
+    || new Date(milliseconds).toISOString().slice(0, 10) !== value
+  ) {
+    throw new Error(`${label} is not a valid date`);
+  }
+}
+
+function parseInstant(value: string, label: string): number {
+  if (/^\d+$/.test(value)) {
+    return requireInstant(Number(value), label);
+  }
+  if (DATE_ONLY.test(value)) {
+    requireCalendarDate(value, label);
+    return requireInstant(Date.parse(`${value}T00:00:00Z`), label);
+  }
+  if (DATETIME_WITH_ZONE.test(value)) {
+    requireCalendarDate(value.slice(0, 10), label);
+    const milliseconds = Date.parse(value);
+    if (Number.isNaN(milliseconds)) {
+      throw new Error(`${label} is not a valid datetime`);
+    }
+    return requireInstant(milliseconds, label);
+  }
+  throw new Error(
+    `${label} must be epoch-ms, YYYY-MM-DD, or YYYY-MM-DDTHH:mm[:ss[.sss]] with Z/±HH:mm (got "${value}")`,
+  );
+}
+
+function describe(from: number | null, to: number | null): string {
+  if (from !== null && to !== null) {
+    return `from ${new Date(from).toISOString()} to ${new Date(to).toISOString()}`;
+  }
+  if (from !== null) {
+    return `from ${new Date(from).toISOString()}`;
+  }
+  if (to !== null) {
+    return `until ${new Date(to).toISOString()}`;
+  }
+  return "all time";
+}
+
+export function resolveSpendWindow(options: SpendWindowOptions, now: number = Date.now()): ResolvedSpendWindow {
+  const { since, from, to } = options;
+  if (since !== undefined && (from !== undefined || to !== undefined)) {
+    throw new Error("--since cannot be combined with --from/--to");
+  }
+  if (since !== undefined) {
+    const normalizedSince = since.trim();
+    const durationMs = parseDurationMs(normalizedSince, "--since");
+    if (!Number.isSafeInteger(durationMs) || durationMs <= 0) {
+      throw new Error("--since must be a positive whole-millisecond duration");
+    }
+    const currentTime = requireInstant(now, "current time");
+    return {
+      from: requireInstant(currentTime - durationMs, "--since window start"),
+      to: currentTime,
+      description: `last ${normalizedSince}`,
+    };
+  }
+  const fromMs = from !== undefined ? parseInstant(from, "--from") : null;
+  const toMs = to !== undefined ? parseInstant(to, "--to") : null;
+  if (fromMs !== null && toMs !== null && fromMs >= toMs) {
+    throw new Error("--from must be before --to");
+  }
+  return { from: fromMs, to: toMs, description: describe(fromMs, toMs) };
+}
+```
+
+- [ ] **Step 4: Run to verify pass.**
+
+- [ ] **Step 5: Commit** — `feat(remote): pure spend time-window resolver`
+
+---
+
+### Task 3: `projectClient.getSpend` + query support + spend-unsupported 404
+
+**Files:**
+- Modify: `lib/cli/statelog/projectClient.ts`
+- Test: `lib/cli/statelog/projectClient.test.ts` (extend; if absent, create following the account client test style)
+
+**Interfaces — Produces:** `ProjectClient.getSpend(window: SpendWindow): Promise<ProjectSpend>`. Route compatibility detection remains private to `projectClient.ts`.
+
+- [ ] **Step 1: Write the failing tests** (mock `fetch`; mirror existing client tests)
+
+Cover: `getSpend` GETs `/api/projects/:slug/spend?from=&to=` with bounds present, and **omits** each when null (from-only / to-only / neither); validates and **rejects** a malformed wire shape through `ProjectRequestError`; a `404 {error:"Project not found"}` → error message contains "not found"; both JSON and non-JSON unknown 404s on `spend` → message "does not support the spend API"; **a non-JSON 5xx stays a server error** (message contains "HTTP 503", not "spend API"). Retain the existing `pullSource` project-not-found regression test.
+
+- [ ] **Step 2: Run to verify fail.**
+
+- [ ] **Step 3: Implement**
+- Replace the rest-parameter request signature with one private, declarative transport input; update existing methods to use it. Do **not** add a second fetch/parse/error path:
+  ```ts
+  type ProjectRequest = {
+    segments: string[];
+    query?: Record<string, string>;
+    unsupportedRouteMessage?: string;
+  };
+
+  async function request(input: ProjectRequest): Promise<unknown>;
+  ```
+- Have `projectRouteUrl` append `new URLSearchParams(input.query)` when non-empty, while `request` remains the only owner of fetch, auth, JSON/envelope parsing, and errors.
+- In `request`'s 404 branch, preserve the exact `{ error: "Project not found" }` message first. If `input.unsupportedRouteMessage` is present, throw `ProjectRequestError(input.unsupportedRouteMessage)` for any other 404. With no compatibility message, preserve the existing project-not-found behavior for existing methods. No route-not-found class is exported or needed.
+- `getSpend`:
+  ```ts
+  async getSpend(window) {
+    const value = await request({
+      segments: ["spend"],
+      query: toSpendQuery(window),
+      unsupportedRouteMessage: "this statelog host does not support the spend API (upgrade the host)",
+    });
+    return parseWire(projectSpendSchema, value);
+  }
+  ```
+- Add `getSpend` to the exported `ProjectClient` type.
+
+- [ ] **Step 4: Run to verify pass.**
+
+- [ ] **Step 5: Commit** — `feat(remote): projectClient.getSpend with spend-unsupported host detection`
+
+---
+
+### Task 4: `accountClient.getAccountSpend` + query support + `"spend"` route
+
+**Files:**
+- Modify: `lib/cli/statelog/accountClient.ts`
+- Test: `lib/cli/statelog/accountClient.test.ts` (extend)
+
+**Interfaces — Produces:** `AccountClient.getAccountSpend(window): Promise<AccountSpendRow[]>`; `AccountRoute` gains `"spend"`. Route compatibility detection remains private to `accountClient.ts`.
+
+- [ ] **Step 1: Write the failing tests** — `getAccountSpend` GETs `/api/spend?from=&to=` (bounds omitted when null); validates the array shape and rejects a malformed row through `AccountRequestError`; both `404 {error:"Not Found"}` and a non-JSON spend-route **404** → "does not support the spend API"; a non-JSON **5xx** stays a server error. Retain existing account-scope and server-message regression tests.
+
+- [ ] **Step 2: Run to verify fail.**
+
+- [ ] **Step 3: Implement**
+- Add `"spend"` to `type AccountRoute`.
+- Give `request` one declarative options value and update existing POST calls to use it:
+  ```ts
+  type AccountRequestOptions = {
+    body?: unknown;
+    query?: Record<string, string>;
+    unsupportedRouteMessage?: string;
+  };
+
+  async function request(
+    method: "GET" | "POST",
+    route: AccountRoute,
+    options: AccountRequestOptions = {},
+  ): Promise<unknown>;
+  ```
+- `accountRouteUrl` appends `options.query` as a search string; `request` remains the only fetch/auth/JSON/envelope/error implementation. POST serialization reads `options.body`.
+- Preserve the account-scope 403 check first. Then, when `response.status === 404 && options.unsupportedRouteMessage !== undefined`, throw `AccountRequestError(options.unsupportedRouteMessage)` **before** the generic string-server-error branch. Existing routes pass no compatibility message and retain their current handling. Do not export an internal route-not-found class.
+- `getAccountSpend`:
+  ```ts
+  async getAccountSpend(window) {
+    const value = await request("GET", "spend", {
+      query: toSpendQuery(window),
+      unsupportedRouteMessage: "this statelog host does not support the spend API (upgrade the host)",
+    });
+    return parseValue(z.array(accountSpendRowSchema), value);
+  }
+  ```
+  (Use the account client's existing `parseValue`, not `parseWire`.)
+- Add `getAccountSpend` to the exported `AccountClient` type.
+
+- [ ] **Step 4: Run to verify pass.**
+
+- [ ] **Step 5: Commit** — `feat(remote): accountClient.getAccountSpend`
+
+---
+
+### Task 5: Renderers + adaptive money formatting
+
+**Files:**
+- Modify: `lib/cli/remote/render.ts`
+- Test: `lib/cli/remote/render.test.ts` (extend)
+
+**Interfaces — Produces:** `renderProjectSpend(slug, spend, description)`, `renderAccountSpend(rows, description)`.
+
+- [ ] **Step 1: Write the failing tests** (strip ANSI as the existing render tests do)
+
+Cover: `renderProjectSpend` shows the `≥`/lower-bound note only when `usageComplete=false`, the `Unpriced` line only when `unpricedCallCount>0`; **zero cost → `$0.0000`; a tiny positive (`0.00004`) → `<$0.0001`** (separate cases); `renderAccountSpend`: assert the promised project/cost/token/invocation/unpriced headers and representative row values, active-by-cost-desc then deleted-by-cost-desc with `projectSlug` tie-break (assert equal-cost ordering), a correct `TOTAL`, and — with exactly one incomplete or unpriced row — a **visibly degraded total** (`≥` + summed unpriced note); empty array → `No projects yet.`
+
+- [ ] **Step 2: Run to verify fail.**
+
+- [ ] **Step 3: Implement** the `formatUsd`/`formatCount`/`lowerBound` helpers and the two renderers per the spec's File 5 section (using the existing `color` helper). Use descriptive names such as `amount`, `spend`, `rows`, and `totals`, never single-character production names. Keep each renderer focused; extract a `spendTotals(rows)` helper for the account aggregation (`Σ` cost/tokens/invocations/unpriced + `every(usageComplete)`).
+
+- [ ] **Step 4: Run to verify pass.**
+
+- [ ] **Step 5: Commit** — `feat(remote): render project + account spend`
+
+---
+
+### Task 6: The `spend` command + registration
+
+**Files:**
+- Create: `lib/cli/remote/commands/spend.ts`
+- Test: `lib/cli/remote/commands/spend.test.ts`
+- Modify: `scripts/agency.ts` (register `remote spend`)
+- Modify: `scripts/agency.test.ts` (mock the recipe module, add `"spend"` to the asserted subcommand list, and test Commander forwarding)
+
+**Interfaces:**
+- Consumes: `resolveSpendWindow` (T2), both clients (T3/T4), renderers (T5), `resolveAccountTarget`/`resolveProjectTarget`/`failAccount`/`failProjectCommand`/`fail`/`printJson` (util).
+- Produces: `SpendOptions = AccountCommandOptions & SpendWindowOptions & { json?: boolean }`, `runSpend(project, options, context)`.
+
+- [ ] **Step 1: Write the failing test** (`spend.test.ts` — mirror `projects.test.ts`: hoisted mocks of BOTH `accountClient.js` and `projectClient.js`; `context()`; spy `console.log`, `process.exit`→throw, and `process.stdout.write` for `--json`)
+
+Cover in `spend.test.ts`: no project → `getAccountSpend(window)` called, `renderAccountSpend` output logged; `<project>` → `createProjectClient(origin, "my-proj", key)` + `getSpend(window)`; an **invalid time flag** (e.g. `{ since: "banana" }`) → the thrown window error is converted to a `fail()` exit and **no client method is called**; account path with a project-scoped key surfaces the hint via `failAccount`; `--json` writes exactly the value via `process.stdout.write` and logs nothing else; the resolved `{from,to}` is passed to the client unchanged.
+
+Cover in `scripts/agency.test.ts`:
+- parse `remote spend my-project --since 7d --json --host https://h --api-key-env SPEND_KEY` and assert `runSpend` receives `"my-project"`, `{ since: "7d", json: true, host: "https://h", apiKeyEnv: "SPEND_KEY" }`, and the config context;
+- parse bare `remote spend` and assert the positional argument is `undefined`;
+- keep the sorted subcommand-name assertion.
+
+- [ ] **Step 2: Run to verify fail.**
+
+- [ ] **Step 3: Implement** `spend.ts` per the spec's File 6 section (the `try { window = resolveSpendWindow(options) } catch { fail(...) }` boundary; positional `undefined` → account branch; else `resolveProjectTarget(context, { ...options, project })` and use `target.projectSlug`). Register in `scripts/agency.ts` per File 7. In `scripts/agency.test.ts`: add `runSpend` to `remoteRecipeMocks` + `vi.mock("@/cli/remote/commands/spend.js", …)`, insert `"spend"` into the expected sorted subcommand array (between `"pull"` and `"whoami"`), and add both Commander-forwarding cases from Step 1.
+
+- [ ] **Step 4: Run to verify pass** — `pnpm test:run lib/cli/remote/commands/spend.test.ts scripts/agency.test.ts`.
+
+- [ ] **Step 5: Commit** — `feat(remote): agency remote spend command`
+
+---
+
+### Task 7: Full verification + finish
+
+- [ ] **Step 1: Typecheck** — `pnpm run typecheck` (main + tests + evals configs). Expected: clean. Fix any test-file type errors here, not after pushing.
+- [ ] **Step 2: Full suite** — `pnpm test:run`. Expected: 0 failures (catches any untouched file that referenced the client/render surfaces).
+- [ ] **Step 3: Optional manual smoke** — if a built CLI is handy, `pnpm run build` then `node dist/scripts/agency.js remote spend --help` to eyeball the flags. Not required for correctness (covered by the registration test).
+- [ ] **Step 4: Prepare the branch for handoff** — Use superpowers:finishing-a-development-branch with base branch `main`. Present the available integration options; do not push or open a PR unless the user explicitly authorizes that shared action.
+
+---
+
+## Self-review notes (author)
+
+- **Spec coverage:** T1 → File 1 (shared types); T2 → File 2 (window); T3/T4 → Files 3/4 (clients, 404 policy, query); T5 → File 5 (renderers, money); T6 → Files 6/7 (command, registration). Every spec test bullet maps to a step: window edge cases (T2), wire invariants + one-sided windows + 404 + 5xx regression (T3/T4/T1), money zero-vs-tiny + total degradation + sort (T5), scope + window-error→fail + `--json` (T6).
+- **Type consistency:** `ProjectSpend`/`AccountSpendRow` inferred once in `spendTypes.ts`; `SpendWindow`/`toSpendQuery` shared by both clients; `ResolvedSpendWindow` flows command→renderer as `description`; `target.projectSlug` (not `.slug`); account client uses `parseValue`, project client `parseWire`.
+- **Review points baked in:** positional-only scope (no `--project`/binding scope); pure returns-or-throws window with strict calendar validation and a `runSpend` `fail()` boundary; route-specific 404-only unsupported-host classification with JSON/non-JSON 404 and 5xx regression tests; `"spend"` added to the sealed `AccountRoute`; one query-capable request path per client; private compatibility mechanics; adaptive money; refined wire invariants; actual Commander forwarding coverage.
+- **Anti-pattern check:** declarative domain interfaces remain the primary architecture. Request options replace positional placeholders, route markers stay private, no transport implementation is duplicated, production variables are descriptive, and all prescribed `if` statements use braces.
+- **No codegen/docs:** CLI TS only; `docs/site/**` untouched.

--- a/packages/agency-lang/docs/superpowers/specs/2026-08-04-agency-remote-spend-design-REVIEW-2.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-08-04-agency-remote-spend-design-REVIEW-2.md
@@ -1,0 +1,105 @@
+# Re-review: `agency remote spend` Design
+
+## Verdict
+
+The revision resolves every substantive issue from the first review. Scope selection is now deterministic, window resolution has a single declarative output, account totals preserve both completeness signals, small positive costs remain visible, wire schemas state their numeric invariants, ordering and empty-account behavior are explicit, and the tests cover the important edge cases.
+
+The architecture is ready for implementation planning after correcting the small but implementation-breaking API mismatches below. These do not require redesign.
+
+## Resolved from the first review
+
+- Bare invocation is unambiguously account-scoped; only the positional argument selects project scope.
+- `--since`, explicit bounds, timezone handling, `Date` range, safe integers, pre-epoch values, and `from < to` are specified.
+- `ResolvedSpendWindow` cleanly encapsulates imperative parsing and presents validated bounds plus one display description.
+- Both renderers consume the resolved description rather than raw Commander options.
+- Account totals aggregate incomplete usage and unpriced-call information instead of presenting an unjustifiably exact total.
+- Adaptive currency formatting distinguishes zero from tiny positive spend.
+- Zod schemas are the type source of truth and enforce finite, nonnegative, safe-integer, date, and completeness invariants.
+- Unsupported-host behavior, deterministic sorting, precise empty-account wording, shared query serialization, and one-sided-window tests are now covered.
+
+## Remaining corrections
+
+### 1. The command pseudocode uses a nonexistent `ProjectTarget.slug`
+
+`resolveProjectTarget` returns:
+
+```ts
+type ProjectTarget = AccountTarget & {
+  projectSlug: string;
+};
+```
+
+The proposed command instead passes `target.slug` to both `createProjectClient` and `renderProjectSpend`. That will not type-check. Use `target.projectSlug` in both places:
+
+```ts
+const spend = await createProjectClient(
+  target.origin,
+  target.projectSlug,
+  target.apiKey,
+).getSpend(window);
+
+console.log(renderProjectSpend(target.projectSlug, spend, window.description));
+```
+
+Also use `projectSlug` consistently in the architecture diagram so the plan does not perpetuate the wrong property name.
+
+### 2. The account-client sketch names an unavailable validator and omits the route-union change
+
+`accountClient.ts` has a private `parseValue(...)`, not `parseWire(...)`. The proposed `getAccountSpend` sketch therefore does not compile as written. It should use the existing account error boundary:
+
+```ts
+return parseValue(
+  z.array(accountSpendRowSchema),
+  await request("GET", withQuery("spend", toSpendQuery(window))),
+);
+```
+
+The file also currently seals route names with:
+
+```ts
+type AccountRoute = "whoami" | "projects" | "api_keys";
+```
+
+Explicitly add `"spend"` to that union (or have the new query-aware route builder retain an equally narrow route type). Likewise, state that `ProjectClient` and `AccountClient` gain the corresponding public methods. These are straightforward changes, but they belong in the design because the clients intentionally use closed declarative interfaces.
+
+### 3. Restrict “unsupported host” classification to an HTTP 404
+
+The project-client section currently says:
+
+> a 404 (or any non-envelope response) on the `spend` route ... means the host predates the spend API
+
+“Any non-envelope response” is too broad. A reverse proxy can return HTML for a 502/503, and that should remain a reachability/server failure rather than being mislabeled as an old host. Define the rule narrowly:
+
+- `404` plus exact `{ error: "Project not found" }` → project not found;
+- any other `404` from a spend endpoint → host does not support the spend API;
+- non-404 failures retain the clients' existing status/server-error/non-JSON handling.
+
+Add a non-JSON 5xx regression case to the client tests so the new route-specific handling cannot swallow operational failures.
+
+### 4. Do not describe `resolveSpendWindow` as pure if it calls `fail()`
+
+The spec calls the parser “Pure” while requiring each invalid input to call `fail()`. The existing `fail()` writes to stderr and exits the process, so those claims are incompatible. More importantly, `parseDurationMs` throws; the design must state where that error becomes a clean CLI failure rather than an uncaught stack trace.
+
+Prefer keeping the declarative parser genuinely pure:
+
+```ts
+resolveSpendWindow(options, now): ResolvedSpendWindow // returns or throws Error
+```
+
+Then let `runSpend` convert parsing errors through the command's `fail(...)` boundary. This keeps validation reusable and unit-testable without process-exit mocking. If direct `fail()` calls are intentionally preferred, remove “Pure” and explicitly require `parseDurationMs` errors to be caught and converted to `fail()`.
+
+## Declarative-interface assessment
+
+Yes. The revised design now places imperative complexity behind coherent declarative interfaces:
+
+- raw time flags become one validated `ResolvedSpendWindow`;
+- schemas define and validate transport values while inferred types expose them to callers;
+- each client owns route construction, authentication, envelope parsing, and transport failures;
+- renderers accept domain values and a resolved description rather than reconstructing CLI semantics;
+- the command is limited to scope selection and orchestration.
+
+That is the right decomposition. Correcting the parser's stated error boundary will make the implementation fully match the design's declarative intent.
+
+## Recommendation
+
+Make the four focused corrections above, then proceed to the implementation plan. No architectural rewrite or additional feature work is needed.

--- a/packages/agency-lang/docs/superpowers/specs/2026-08-04-agency-remote-spend-design-REVIEW.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-08-04-agency-remote-spend-design-REVIEW.md
@@ -1,0 +1,166 @@
+# Review: `agency remote spend` Design
+
+## Verdict
+
+The command is well scoped and follows the correct ownership path: time parsing belongs outside the HTTP clients, each client seals its own route and wire schema, the command selects account versus project scope, and rendering remains separate from transport. I also checked the stated server contract against statelog PR #18. The endpoint paths, response fields, epoch-millisecond half-open window, project/account authorization split, zero-event account rows, and soft-deleted-project behavior are accurate.
+
+Do not write the implementation plan from this version yet. The scope-selection contract contradicts itself, the proposed time parser can emit values the server rejects, and the renderer signatures do not agree with the command pseudocode. The account renderer also fails to carry the two trust axes into its total.
+
+## Blocking: project selection has two incompatible meanings
+
+Decision 1 says:
+
+- no positional project means account rollup;
+- a positional project means one project.
+
+That is clear. But the command type and later text introduce the existing project fallback chain:
+
+```ts
+type SpendOptions = ProjectCommandOptions & ...
+```
+
+and:
+
+> the project slug resolves from the arg, then `--project`, then the binding
+
+The registration does not define `--project`, and `runSpend` chooses account mode solely from `project === undefined`. Therefore a hypothetical `--project` value would be ignored for mode selection. A binding also cannot be a fallback without changing the meaning of bare `agency remote spend` from “account” to “linked project.”
+
+Keep the positional-only design. Make `SpendOptions` extend `AccountCommandOptions`, not `ProjectCommandOptions`. In the project branch, pass the positional slug explicitly to `resolveProjectTarget`:
+
+```ts
+resolveProjectTarget(context, { ...options, project });
+```
+
+Remove the `--project` and binding-fallback claim. The binding may still provide the host, but it must not silently select project scope. If `--project` is desired as an alias, redesign mode selection explicitly and document how bare invocation remains account-scoped.
+
+## Blocking: `resolveSpendWindow` can produce server-invalid query values
+
+The server accepts only non-negative, safe integer epoch milliseconds within the JavaScript `Date` range. The proposed parser does not enforce that contract on every path.
+
+### `--since` inherits behavior that is unsafe for this use
+
+`parseDurationMs` intentionally accepts negative and fractional durations. Consequently:
+
+- `--since -1h` produces a future `from`;
+- `--since 0h` produces an empty window;
+- `--since 0.1ms` produces a fractional epoch value;
+- a duration greater than `now` produces a negative `from`.
+
+The first two may be caught by the later `from >= to` check, but the latter two can still be sent to statelog and rejected there. Reuse `parseDurationMs`, then validate the result for this command: it must resolve to a positive, safe integer number of milliseconds, and `now - duration` must be a non-negative safe integer in the `Date` range. Add tests for negative, zero, fractional-millisecond, overflow, and pre-epoch windows. A duration such as `0.5s` may remain valid because it resolves to the integer `500`.
+
+### The explicit-bound path validates only `NaN`
+
+The ISO branch currently says `Date.parse` followed only by a `NaN` check. That accepts implementation-specific non-ISO strings, negative pre-epoch values, and timestamps whose intended timezone is ambiguous. It also does not apply the same safe-integer/range validation as the raw epoch branch.
+
+Lock the syntax:
+
+- raw digits: non-negative safe integer and valid `Date` range;
+- date-only ISO (`YYYY-MM-DD`): interpret as UTC midnight;
+- datetime ISO: require an explicit `Z` or numeric offset so results do not depend on the machine timezone;
+- after parsing either form: require a non-negative safe integer and valid `Date` range.
+
+If broad `Date.parse` input and local-time datetimes are intentional, stop calling the input ISO-8601 and document the timezone-dependent behavior. The strict option is safer for a remote accounting query.
+
+## Blocking: renderer inputs are inconsistent and leak raw CLI options
+
+The file section defines:
+
+```ts
+renderProjectSpend(slug, spend, window)
+renderAccountSpend(rows, window)
+```
+
+but the command calls:
+
+```ts
+renderProjectSpend(target.slug, spend, options)
+renderAccountSpend(rows, options)
+```
+
+The explanation then says `describeWindow(window, options)` needs both values. These are three different contracts.
+
+Resolve the user input once and pass a declarative view value downstream. For example:
+
+```ts
+type ResolvedSpendWindow = {
+  from: number | null;
+  to: number | null;
+  description: string;
+};
+```
+
+`resolveSpendWindow` owns the relationship between raw flags, the captured `now`, query bounds, and the human label (`last 7d`, `since ...`, `all time`). Clients can consume `{ from, to }`; renderers consume `description`. Renderers should not inspect raw Commander options or re-derive time semantics. This gives the imperative parsing one home and exposes a clean declarative result.
+
+## Important: the account total does not preserve trust semantics
+
+Decision 4 says both trust axes are always surfaced. The account renderer only specifies a trailing `≥` on incomplete project rows, while the `TOTAL` line sums cost, tokens, and invocations. It does not say how the total reports:
+
+- `usageComplete = rows.every(row => row.spend.usageComplete)`;
+- `pricingComplete = rows.every(row => row.spend.pricingComplete)`; or
+- total `unpricedCallCount`.
+
+A total made from one incomplete row is also a lower bound. A total with unpriced calls can understate cost. Add an `UNPRICED` column or another explicit per-row signal, sum `unpricedCallCount`, and mark the total as a lower bound whenever any row has incomplete usage. Include a one-line account-level note for each degraded axis, equivalent to the project view. Add tests where only one of several projects is incomplete or unpriced and assert that the total remains visibly degraded.
+
+Prefer `≥ $0.4212` over a trailing `≥`; it directly states that actual cost is at least the displayed value.
+
+## Important: four decimal places can turn real spend into zero
+
+`toFixed(4)` renders any positive cost below `$0.00005` as `$0.0000`. That is especially misleading in a command intended to expose sub-cent hosted costs.
+
+Use adaptive formatting that never renders positive spend as zero. For example:
+
+- ordinary values: four decimal places;
+- `0 < cost < 0.0001`: `<$0.0001`; or
+- enough decimal places to preserve the smallest accounting precision the server supports.
+
+Apply the same rule to project rows and totals, and test zero separately from a tiny positive value.
+
+## Important: specify numeric wire invariants, not only field types
+
+The proposed Zod schema “mirrors `ProjectSpend`,” but a plain `z.number()` / `z.number().int()` still permits values the renderer should never accept. Define the boundary precisely:
+
+- `pricedCost`: finite and non-negative;
+- token and invocation counts: non-negative safe integers;
+- `unpricedCallCount`: non-negative safe integer;
+- `deletedAt`: `null` or a valid ISO datetime.
+
+Also either refine or explicitly trust the server invariant `pricingComplete === (unpricedCallCount === 0)`. A refinement is preferable because the CLI uses both fields to decide what warning to print. Client tests should reject negative cost/counts, unsafe counts, invalid dates, and a contradictory completeness pair.
+
+The cleanest shared interface is to define the Zod schemas in `spendTypes.ts` and infer `ProjectSpend` / `AccountSpendRow` from them. That prevents a hand-written type and its runtime validator from drifting.
+
+## Important: the unsupported-host promise has no implementation
+
+The final coupling note promises a clear error for a host without the spend endpoint. No file section defines that behavior or a test for it. The existing project client maps every HTTP 404 to:
+
+> project '<slug>' not found
+
+so an older host returning 404 for `/spend` will currently be misreported as a missing project. The account client will produce only a generic HTTP 404 error.
+
+Choose an exact policy and include it in the client tasks. One workable distinction is:
+
+- preserve “project not found” when the project route returns the known JSON `{ error: "Project not found" }` response;
+- treat a non-JSON route-level 404 from either spend endpoint as “this statelog host does not support the spend API.”
+
+Add project and account client tests for both cases. If the server cannot reliably distinguish them, remove the promise and document the generic 404 limitation instead.
+
+## Smaller corrections
+
+1. **Account ordering needs a total order.** “Cost descending, deleted last” should mean active rows by cost descending, followed by deleted rows by cost descending, with `projectSlug` as a deterministic tie-breaker. Test equal-cost rows.
+2. **Capture `now` once.** `resolveSpendWindow` already accepts `now`; the command should call it once and use its returned bounds and description everywhere. Do not call `Date.now()` again while rendering.
+3. **Keep query construction shared.** Both clients need identical null omission and decimal serialization. Put `SpendWindow` and `toSpendQuery` in the shared spend module rather than implementing subtly different copies.
+4. **Make empty-account wording precise.** The server returns one zero row for every project, so `rows.length === 0` means “no projects,” not necessarily “no spend recorded.” Either print `No projects yet.` for an empty array or filter zero rows deliberately before claiming no spend.
+5. **Test one-sided windows.** Client and parser tests should cover from-only and to-only requests, not only both or neither.
+
+## What is already strong
+
+- The command is read-only and additive.
+- The positional scope split is simpler than artificial subcommands once its fallback contradiction is removed.
+- Reusing `parseDurationMs` is appropriate after command-specific positivity/integer/range validation.
+- The project/account client split matches the server's authorization boundaries.
+- A shared schema/type module is the right source of truth.
+- Separating pure window resolution, HTTP transport, command orchestration, and rendering keeps imperative work behind understandable interfaces.
+- The test categories cover all major layers and require no network or LLM calls.
+
+## Recommendation
+
+Revise the scope contract, make window resolution produce only server-valid bounds plus one presentation description, and define account-level completeness aggregation. Then tighten money formatting, wire validation, unsupported-host errors, and the listed edge-case tests. After those changes, this design will be ready for an implementation plan.

--- a/packages/agency-lang/docs/superpowers/specs/2026-08-04-agency-remote-spend-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-08-04-agency-remote-spend-design.md
@@ -1,0 +1,271 @@
+# `agency remote spend` — Design
+
+> Revised after review (`2026-08-04-agency-remote-spend-design-REVIEW.md`).
+> Changes from v1: positional-only scope (no `--project`/binding scope fallback);
+> `resolveSpendWindow` produces only server-valid bounds **plus** a presentation
+> `description`, with strict positivity/safe-integer/range/timezone validation;
+> renderers consume that `description`, never raw CLI options; the account TOTAL
+> aggregates both trust axes (lower-bound + summed unpriced); adaptive money
+> formatting never renders positive spend as `$0.0000`; wire schemas enforce
+> numeric invariants and are the source of truth for the types; the
+> unsupported-host error is specified with a concrete 404 policy.
+>
+> Changes from v2 (second review): use the real API names — `ProjectTarget.projectSlug`,
+> the account client's `parseValue` (project client keeps `parseWire`), and add
+> `"spend"` to the sealed `AccountRoute` union + the client interface types;
+> narrow the unsupported-host classification to an **HTTP 404 only** (a proxy's
+> non-JSON 5xx stays a server/reachability error); and make `resolveSpendWindow`
+> genuinely pure — it returns-or-throws, and `runSpend` converts the throw
+> (including `parseDurationMs`'s) through the command `fail()` boundary.
+
+## Background: what this is and why now
+
+Statelog can host an agent and, as of its Group 4 work (statelog PR #18), it records the cost of every hosted invocation into a `usage_events` ledger and exposes two read endpoints that aggregate it:
+
+- `GET /api/projects/:slug/spend` — one project's total spend.
+- `GET /api/spend` — the whole account's spend, per project.
+
+These are the read surface the serve cost seam (agency-lang #801) and per-model breakdown (#802) were built to feed. On the agency-lang side there is **no CLI command that reads them** — a user who wants "how much has this agent cost?" must open the statelog web UI. Every neighbouring endpoint already has a CLI (`whoami`, `projects`, `keys`, `logs`, `pull`, `call`, `deploy`, `ls`, `open`, `link`). Spend is the gap.
+
+This spec adds `agency remote spend` — a thin, read-only command in the `agency remote` family that prints a project's, or the whole account's, spend.
+
+## What the server returns (verified against statelog #18)
+
+Both endpoints return statelog's `Result` envelope wrapping a `ProjectSpend`:
+
+```ts
+type ProjectSpend = {
+  pricedCost: number;        // dollars, the authoritative total
+  inputTokens: number;
+  outputTokens: number;
+  invocationCount: number;   // hosted invocations in the window
+  unpricedCallCount: number; // LLM calls with no price metadata
+  pricingComplete: boolean;  // === (unpricedCallCount === 0)
+  usageComplete: boolean;    // false ⇒ pricedCost is a trusted LOWER BOUND
+};
+```
+
+- Per-project → one `ProjectSpend`.
+- Account → `{ projectSlug: string, deletedAt: string | null, spend: ProjectSpend }[]`, **one row per project the account owns** (a project with no events returns a zero-filled `ProjectSpend`, not an absent row). `deletedAt` is set for a soft-deleted project whose billing ledger is preserved.
+
+Both accept an optional half-open window `[from, to)` as query params **`from` / `to` in epoch milliseconds** — non-negative integers within `Date`'s representable range; either bound omittable; out-of-range rejected server-side.
+
+The two trust axes are the serve cost seam's: `pricingComplete` (were all calls priced?) and `usageComplete` (was all telemetry delivered — if false, the dollar figure is a lower bound). The CLI must surface both honestly rather than print a bare number that looks exact.
+
+## Decisions baked in
+
+1. **Positional-only scope. No `--project`, no binding scope-fallback.** `agency remote spend` (no argument) = the **account rollup**; `agency remote spend <project-slug>` = **one project**. Mode is chosen solely by whether the positional argument is present. `SpendOptions extends AccountCommandOptions` (NOT `ProjectCommandOptions`) — there is no `--project` flag and the linked-directory binding must **not** silently turn bare `spend` into "the linked project." The binding may still supply the **host** (origin); it never selects project scope. In the project branch the positional slug is passed explicitly: `resolveProjectTarget(context, { ...options, project })`.
+
+2. **Human-friendly time flags; epoch-ms is internal.** `--since <duration>` (`24h`, `7d`, `2w`) sets `to = now`, `from = now − duration`. `--from <when>` / `--to <when>` take an ISO-8601 date/datetime **or** raw epoch-ms. No flag → all time. `--since` is mutually exclusive with `--from`/`--to`. All inputs are validated to produce only server-valid bounds (see `resolveSpendWindow`).
+
+3. **`resolveSpendWindow` emits validated bounds *and* one presentation label.** To end the earlier signature confusion, window resolution returns a single declarative value:
+   ```ts
+   type ResolvedSpendWindow = { from: number | null; to: number | null; description: string };
+   ```
+   Clients consume `{ from, to }`; renderers consume `description` (e.g. `last 7d`, `since 2026-07-01T00:00:00Z`, `all time`). Renderers never inspect raw Commander options or re-derive time semantics, and `now` is captured exactly once.
+
+4. **Both trust axes are always surfaced — including on the account TOTAL.** A project figure with `usageComplete=false` prints as a lower bound (`≥ $x`, plus a one-line note); `unpricedCallCount>0` is shown. The account TOTAL is itself degraded whenever *any* row is: `usageComplete(total) = rows.every(r => r.spend.usageComplete)`, `unpricedCallCount(total) = Σ`, and the total prints `≥` + a note when degraded.
+
+5. **Flat totals only; per-model is out of scope** (the server aggregate has no per-model field yet — see "Out of scope"). The renderer is shaped so a future `models` field slots in.
+
+6. **`--json` for machines, human table by default** (same dual-output convention as `remote logs`).
+
+## Architecture
+
+A thin command over the existing two-client split — mirrors `whoami`/`projects` (account-scoped) and `pull`/`logs` (project-scoped).
+
+```
+agency remote spend [project]
+        │  resolveSpendWindow(opts) → { from, to, description }   (once)
+        │
+        ├─ no project ─► resolveAccountTarget ─► accountClient.getAccountSpend({from,to}) ─► GET /api/spend
+        │                    (account-scoped key)                                             ─► renderAccountSpend(rows, description) / printJson
+        │
+        └─ <project>  ─► resolveProjectTarget ─► projectClient.getSpend({from,to})          ─► GET /api/projects/:projectSlug/spend
+                             (project or account key)                                          ─► renderProjectSpend(projectSlug, spend, description) / printJson
+```
+
+**Auth nuance (already handled by the shared helpers):** the account rollup needs an **account-scoped** key; `failAccount` already prints the "this is a project-scoped key; you need an account-scoped one" hint. The per-project endpoint works with a project or account key (`projectReadAccess`).
+
+## File-by-file changes
+
+### 1. `lib/cli/statelog/spendTypes.ts` (new) — the source of truth
+
+Zod schemas with numeric invariants; the TS types are **inferred** from them so a hand-written type and its validator cannot drift.
+
+```ts
+import { z } from "zod";
+
+const nonNegInt = z.number().int().nonnegative().refine(Number.isSafeInteger, "must be a safe integer");
+
+export const projectSpendSchema = z.object({
+  pricedCost: z.number().finite().nonnegative(),
+  inputTokens: nonNegInt,
+  outputTokens: nonNegInt,
+  invocationCount: nonNegInt,
+  unpricedCallCount: nonNegInt,
+  pricingComplete: z.boolean(),
+  usageComplete: z.boolean(),
+}).refine(
+  (s) => s.pricingComplete === (s.unpricedCallCount === 0),
+  "pricingComplete must equal (unpricedCallCount === 0)",   // both fields drive warnings; a contradictory pair is a server bug we reject
+);
+export type ProjectSpend = z.infer<typeof projectSpendSchema>;
+
+export const accountSpendRowSchema = z.object({
+  projectSlug: z.string().min(1),
+  deletedAt: z.string().datetime().nullable(),
+  spend: projectSpendSchema,
+});
+export type AccountSpendRow = z.infer<typeof accountSpendRowSchema>;
+
+export type SpendWindow = { from: number | null; to: number | null };
+
+/** Shared so both clients serialize the window identically (null bounds omitted,
+ *  decimal ms). */
+export function toSpendQuery(w: SpendWindow): Record<string, string> {
+  const q: Record<string, string> = {};
+  if (w.from !== null) q.from = String(w.from);
+  if (w.to !== null) q.to = String(w.to);
+  return q;
+}
+```
+
+### 2. `lib/cli/remote/commands/spendWindow.ts` (new) — parse the time flags
+
+Genuinely pure and unit-testable: it **returns** a `ResolvedSpendWindow` or **throws** an `Error` on invalid input. It never calls `fail()` or exits — so its tests assert on thrown messages with no process-exit mocking. `runSpend` catches and routes the message through the command `fail()` boundary. `parseDurationMs` also throws (a bad duration string); that throw is caught the same way, so it becomes a clean CLI error rather than a stack trace.
+
+```ts
+export type SpendWindowOptions = { since?: string; from?: string; to?: string };
+export function resolveSpendWindow(options: SpendWindowOptions, now = Date.now()): ResolvedSpendWindow; // returns or throws Error
+```
+
+Rules (each violation → `throw new Error(...)` with a clear message):
+- **Mutual exclusion:** `--since` with `--from` or `--to` → throw.
+- **`--since d`:** `ms = parseDurationMs(d, "--since")` (may itself throw on a malformed string), then require `Number.isSafeInteger(ms) && ms > 0` (rejects `parseDurationMs`'s permitted negative / zero / fractional durations — e.g. `-1h`, `0h`, `0.1ms`; a duration like `0.5s` → integer `500` is fine). Compute `from = now - ms`; require `from` a non-negative safe integer in `Date` range (rejects a duration larger than `now`, i.e. a pre-epoch window). `to = now`. description = `last <d>`.
+- **`--from` / `--to`:** each via `parseInstant(value, label)`:
+  - all-digits → epoch-ms: require a non-negative safe integer within `Date` range.
+  - `YYYY-MM-DD` → UTC midnight (`Date.parse(value + "T00:00:00Z")`).
+  - datetime → require an explicit `Z` or numeric offset (reject a bare local datetime, so the result never depends on the machine timezone); parse and require a valid, in-range instant.
+  - anything else → throw (do NOT fall through to a permissive `Date.parse`).
+  - If both present, require `from < to`. description = `from <iso>`, `until <iso>`, or `from <iso> to <iso>`; a one-sided window keeps its single bound.
+- **No flag:** `{ from: null, to: null, description: "all time" }`.
+
+### 3. `lib/cli/statelog/projectClient.ts` — `getSpend` + query support + spend-unsupported 404
+
+`request(...segments)` builds a path only; add query support (a `requestWithQuery(segments, query)` that appends a `URLSearchParams` when non-empty). Add `getSpend` to the exported `ProjectClient` type and implement it with the existing `parseWire` validator:
+
+```ts
+async getSpend(window: SpendWindow): Promise<ProjectSpend> {
+  return parseWire(projectSpendSchema, await requestWithQuery(["spend"], toSpendQuery(window)));
+}
+```
+
+**404 policy (fixes the misreport), narrowed to HTTP 404.** The current 404 branch throws "project not found" unconditionally. Change *only the 404 branch*: a **404** whose JSON body is exactly `{ error: "Project not found" }` keeps the "project '<slug>' not found — check the slug, or that it's deployed" message; **any other 404** from the `spend` route means the host predates the spend API → throw "this statelog host does not support the spend API (upgrade the host)". Non-404 failures keep the client's existing handling untouched — a proxy's HTML `502`/`503` stays a reachability/server error and is **not** relabelled as an old host. (Verified: statelog returns `404 {error:"Project not found"}` for a missing project via `projectAccess`, and has no JSON catch-all for an unmatched route, so the two 404s are distinguishable.)
+
+### 4. `lib/cli/statelog/accountClient.ts` — `getAccountSpend` + query support
+
+Add `"spend"` to the sealed `AccountRoute` union (`"whoami" | "projects" | "api_keys" | "spend"`) and add `getAccountSpend` to the exported `AccountClient` type. `request("GET"|"POST", route, body?)` gains query support (append the search string to `route`). Use the account client's existing validator, **`parseValue`** (not `parseWire`, which is the project client's):
+
+```ts
+async getAccountSpend(window: SpendWindow): Promise<AccountSpendRow[]> {
+  return parseValue(z.array(accountSpendRowSchema), await request("GET", withQuery("spend", toSpendQuery(window))));
+}
+```
+
+The account route has no project-not-found case, so a spend-route **404** → "host does not support the spend API"; non-404 failures keep the client's existing status/server-error/non-JSON handling.
+
+### 5. `lib/cli/remote/render.ts` — `renderProjectSpend`, `renderAccountSpend`, money helper
+
+Match the existing `color` style. Money via an **adaptive** helper that never renders positive spend as zero:
+
+```ts
+function formatUsd(n: number): string {           // n >= 0
+  if (n === 0) return "$0.0000";
+  if (n < 0.0001) return "<$0.0001";
+  return `$${n.toFixed(4)}`;
+}
+function lowerBound(n: number, complete: boolean): string {
+  return complete ? formatUsd(n) : `≥ ${formatUsd(n)}`;
+}
+```
+
+- `renderProjectSpend(slug, spend, description)`:
+  ```
+  Spend: my-agent  (last 7d)
+    Cost:         ≥ $0.4212   (lower bound — some telemetry incomplete)
+    Tokens:       ↑ 12,400  ↓ 3,010
+    Invocations:  87
+    Unpriced:     2 calls (cost may be understated)
+  ```
+  The `≥`/lower-bound note appears only when `usageComplete=false`; the `Unpriced` line only when `unpricedCallCount>0`. Counts via a `formatCount` (thousands separators).
+
+- `renderAccountSpend(rows, description)`:
+  - Empty array → `No projects yet.` (an account WITH projects but no spend still returns zero-filled rows, so an empty array means no projects — not "no spend").
+  - Otherwise a table with an `UNPRICED` column, one row per project; **total order:** active rows by `pricedCost` desc, then deleted rows (`(deleted)`) by `pricedCost` desc, `projectSlug` ascending as the tie-break.
+  - A `TOTAL` line: cost = `lowerBound(Σ pricedCost, rows.every(r => r.spend.usageComplete))`; summed tokens / invocations / unpriced; a one-line note per degraded axis (any incomplete usage → lower-bound note; total unpriced > 0 → understated-cost note).
+
+### 6. `lib/cli/remote/commands/spend.ts` (new)
+
+```ts
+export type SpendOptions = AccountCommandOptions & SpendWindowOptions & { json?: boolean };
+
+export async function runSpend(project: string | undefined, options: SpendOptions, context: RemoteCommandContext): Promise<void> {
+  let window: ResolvedSpendWindow;
+  try {
+    window = resolveSpendWindow(options);              // captures `now` once; throws on invalid flags / bad duration
+  } catch (error) {
+    fail(error instanceof Error ? error.message : String(error));   // the single window-error → CLI boundary
+  }
+  if (project === undefined) {
+    const target = resolveAccountTarget(context, options);
+    try {
+      const rows = await createAccountClient(target.origin, target.apiKey).getAccountSpend(window);
+      options.json ? printJson(rows) : console.log(renderAccountSpend(rows, window.description));
+    } catch (error) { failAccount(error, target.apiKeyEnvName); }
+    return;
+  }
+  const target = resolveProjectTarget(context, { ...options, project });   // ProjectTarget.projectSlug
+  try {
+    const spend = await createProjectClient(target.origin, target.projectSlug, target.apiKey).getSpend(window);
+    options.json ? printJson(spend) : console.log(renderProjectSpend(target.projectSlug, spend, window.description));
+  } catch (error) { failProjectCommand(error); }
+}
+```
+
+### 7. `scripts/agency.ts` — register the subcommand
+
+```ts
+remoteCmd
+  .command("spend")
+  .description("Show hosted spend for a project (or the whole account)")
+  .argument("[project]", "project slug (omit for the account-wide rollup)")
+  .option("--since <duration>", "window ending now, e.g. 24h, 7d, 2w")
+  .option("--from <when>", "window start — ISO-8601 (UTC/offset) or epoch-ms")
+  .option("--to <when>", "window end — ISO-8601 (UTC/offset) or epoch-ms")
+  .option("--json", "emit JSON for machine use")
+  .option(HOST_OPTION, HOST_DESC)
+  .option(API_KEY_ENV_OPTION, API_KEY_ENV_DESC)
+  .action((project: string | undefined, opts: SpendOptions) => runSpend(project, opts, getConfigContext()));
+```
+
+## Testing (deterministic, no network — mock the client)
+
+**`spendWindow.test.ts`** (asserts on thrown `Error` messages — no process-exit mocking, since the parser never calls `fail()`): `--since 7d` → `[now-Δ, now]` + `last 7d`; `--since` + `--from` → throws; `--since -1h` / `0h` / `0.1ms` → throws; `--since` larger than `now` (pre-epoch) → throws; a malformed `--since` string (the `parseDurationMs` throw) → throws; `--since 0.5s` → ms `500` accepted; `--from` epoch-ms and `--from 2026-07-01` (UTC midnight) both parse; bare local datetime (no `Z`/offset) → throws; non-ISO junk → throws; out-of-`Date`-range epoch → throws; `from >= to` → throws; **from-only** and **to-only** windows resolve (single bound, other `null`); no flags → `{null,null,"all time"}`.
+
+**`spend.test.ts`:** no project → `getAccountSpend(window)` then render/`--json`; `<project>` → `getSpend(window)`; **an invalid time flag → `runSpend` converts the thrown window error to `fail()` and makes no client call**; account path surfaces the project-scoped-key hint via `failAccount`; `--json` prints exactly the value via `printJson` and nothing else; the resolved window is passed to the client unchanged.
+
+**`render.test.ts`:** `renderProjectSpend` shows the `≥`/lower-bound note only when `usageComplete=false`, the `Unpriced` line only when `unpricedCallCount>0`; **zero cost → `$0.0000`, tiny positive (`0.00004`) → `<$0.0001`** (separate cases); `renderAccountSpend` total-order sort with an equal-cost tie-break, deleted-last, correct TOTAL; **a single incomplete/unpriced row makes the TOTAL visibly degraded** (lower-bound + summed unpriced); empty array → `No projects yet.`
+
+**Client tests (`projectClient`/`accountClient`):** `getSpend`/`getAccountSpend` build the URL with `from`/`to` present, and **omit** each when null (from-only / to-only / neither); reject a malformed wire shape — negative cost, unsafe/negative counts, invalid `deletedAt`, and a contradictory `pricingComplete`/`unpricedCallCount` pair; **404 policy:** known `{error:"Project not found"}` JSON → project-not-found message; any other `404` on `spend` → "host does not support the spend API"; **regression:** a non-JSON `5xx` (e.g. a proxy's `503` HTML) stays a reachability/server error and is **not** relabelled unsupported-host.
+
+## Out of scope — and the follow-up it sets up
+
+**Per-model breakdown.** The server's `ProjectSpend` is flat — Group 4 was built against the #801 seam before the #802 per-model breakdown landed, so the runtime already *sends* `models`/`unattributed`/`modelAttributionComplete` but statelog does not yet record or aggregate them. `agency remote spend` shows flat totals now. The next step is a **statelog follow-up**: extend the `usage_events` ledger + `sumProjectSpend`/`sumAccountSpend` + `ProjectSpend` to carry per-model, after which this command grows a `--by-model` view (and a third trust marker for `modelAttributionComplete`) — the renderer is shaped to accept it. That follow-up is the real consumer of #802; this command is the client that motivates it.
+
+Also out of scope: any write/settings op (read-only), CSV export (statelog dropped it; `--json` is the machine surface), and enforced spend caps (the budget-guard feature).
+
+## Consumer/coupling notes
+
+- Purely additive: one shared types module, two client methods, one window parser, two renderers, one command, one registration. No existing command changes.
+- Requires a statelog serving the spend endpoints (Group 4 / #18). Against an older host the spend routes return a non-spend 404, which the client now reports as "host does not support the spend API" rather than a misleading "project not found."

--- a/packages/agency-lang/lib/cli/remote/commands/spend.test.ts
+++ b/packages/agency-lang/lib/cli/remote/commands/spend.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import type { RemoteCommandContext } from "./util.js";
+
+const hoisted = vi.hoisted(() => {
+  class AccountRequestError extends Error {}
+  class AccountScopeError extends AccountRequestError {}
+  class ProjectRequestError extends Error {}
+  const accountClient = { getAccountSpend: vi.fn() };
+  const projectClient = { getSpend: vi.fn() };
+  return {
+    AccountRequestError,
+    AccountScopeError,
+    ProjectRequestError,
+    accountClient,
+    projectClient,
+    createAccountClient: vi.fn(() => accountClient),
+    createProjectClient: vi.fn(() => projectClient),
+  };
+});
+
+vi.mock("../../statelog/accountClient.js", () => ({
+  createAccountClient: hoisted.createAccountClient,
+  AccountRequestError: hoisted.AccountRequestError,
+  AccountScopeError: hoisted.AccountScopeError,
+}));
+vi.mock("../../statelog/projectClient.js", () => ({
+  createProjectClient: hoisted.createProjectClient,
+  ProjectRequestError: hoisted.ProjectRequestError,
+}));
+
+import { runSpend } from "./spend.js";
+
+class ProcessExit extends Error {
+  constructor(readonly code: number) {
+    super(`exit ${code}`);
+  }
+}
+
+const spend = { pricedCost: 0.5, inputTokens: 10, outputTokens: 2, invocationCount: 3, unpricedCallCount: 0, pricingComplete: true, usageComplete: true };
+const accountRows = [{ projectSlug: "p", deletedAt: null, spend }];
+
+let dir: string;
+let configPath: string;
+let logs: string[];
+let stdout: string[];
+
+function context(): RemoteCommandContext {
+  return { config: { log: { host: "https://host.example" } }, configPath } as unknown as RemoteCommandContext;
+}
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "remote-spend-"));
+  configPath = path.join(dir, "agency.json");
+  process.env.STATELOG_API_KEY = "secret";
+  logs = [];
+  stdout = [];
+  vi.spyOn(console, "log").mockImplementation((...a: unknown[]) => { logs.push(a.join(" ")); });
+  vi.spyOn(process.stdout, "write").mockImplementation(((chunk: unknown) => { stdout.push(String(chunk)); return true; }) as never);
+  vi.spyOn(process, "exit").mockImplementation(((code?: number) => { throw new ProcessExit(code ?? 0); }) as never);
+  hoisted.createAccountClient.mockClear();
+  hoisted.createProjectClient.mockClear();
+  hoisted.accountClient.getAccountSpend.mockReset();
+  hoisted.projectClient.getSpend.mockReset();
+});
+
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+  delete process.env.STATELOG_API_KEY;
+  vi.restoreAllMocks();
+});
+
+describe("runSpend", () => {
+  it("no project → account rollup, passing the resolved window unchanged", async () => {
+    hoisted.accountClient.getAccountSpend.mockResolvedValue(accountRows);
+    await runSpend(undefined, { from: "1000", to: "2000" }, context());
+    expect(hoisted.createAccountClient).toHaveBeenCalledWith("https://host.example", "secret");
+    expect(hoisted.accountClient.getAccountSpend).toHaveBeenCalledWith(expect.objectContaining({ from: 1000, to: 2000 }));
+    expect(logs.join("\n")).toContain("PROJECT");
+  });
+
+  it("<project> → per-project spend via the project client", async () => {
+    hoisted.projectClient.getSpend.mockResolvedValue(spend);
+    await runSpend("my-proj", { since: "7d" }, context());
+    expect(hoisted.createProjectClient).toHaveBeenCalledWith("https://host.example", "my-proj", "secret");
+    expect(hoisted.projectClient.getSpend).toHaveBeenCalledTimes(1);
+    expect(logs.join("\n")).toContain("my-proj"); // slug is un-colored; the label is bold-wrapped
+  });
+
+  it("an invalid time flag exits without calling any client", async () => {
+    await expect(runSpend(undefined, { since: "banana" }, context())).rejects.toBeInstanceOf(ProcessExit);
+    expect(hoisted.createAccountClient).not.toHaveBeenCalled();
+    expect(hoisted.createProjectClient).not.toHaveBeenCalled();
+  });
+
+  it("account path surfaces the project-scoped-key hint", async () => {
+    hoisted.accountClient.getAccountSpend.mockRejectedValue(new hoisted.AccountScopeError("scope"));
+    await expect(runSpend(undefined, {}, context())).rejects.toBeInstanceOf(ProcessExit);
+  });
+
+  it("--json writes exactly the value to stdout and logs nothing", async () => {
+    hoisted.projectClient.getSpend.mockResolvedValue(spend);
+    await runSpend("my-proj", { json: true }, context());
+    expect(stdout.join("")).toBe(`${JSON.stringify(spend)}\n`);
+    expect(logs).toEqual([]);
+  });
+});

--- a/packages/agency-lang/lib/cli/remote/commands/spend.ts
+++ b/packages/agency-lang/lib/cli/remote/commands/spend.ts
@@ -1,0 +1,65 @@
+// `agency remote spend [project]` — print hosted spend for one project, or the
+// whole account when no project is given. Read-only. The command only selects
+// scope and orchestrates: the window is resolved (and validated) by
+// resolveSpendWindow, the figures come from the sealed clients, and formatting
+// lives in render.
+
+import { createAccountClient } from "../../statelog/accountClient.js";
+import { createProjectClient } from "../../statelog/projectClient.js";
+import { renderAccountSpend, renderProjectSpend } from "../render.js";
+import {
+  resolveSpendWindow,
+  type ResolvedSpendWindow,
+  type SpendWindowOptions,
+} from "./spendWindow.js";
+import {
+  resolveAccountTarget,
+  resolveProjectTarget,
+  failAccount,
+  failProjectCommand,
+  fail,
+  printJson,
+} from "./util.js";
+import type { AccountCommandOptions, RemoteCommandContext } from "./util.js";
+
+export type SpendOptions = AccountCommandOptions & SpendWindowOptions & { json?: boolean };
+
+export async function runSpend(
+  project: string | undefined,
+  options: SpendOptions,
+  context: RemoteCommandContext,
+): Promise<void> {
+  let window: ResolvedSpendWindow;
+  try {
+    window = resolveSpendWindow(options); // captures `now` once; throws on invalid flags / bad duration
+  } catch (error) {
+    fail(error instanceof Error ? error.message : String(error));
+  }
+
+  if (project === undefined) {
+    const target = resolveAccountTarget(context, options);
+    try {
+      const rows = await createAccountClient(target.origin, target.apiKey).getAccountSpend(window);
+      if (options.json) {
+        printJson(rows);
+      } else {
+        console.log(renderAccountSpend(rows, window.description));
+      }
+    } catch (error) {
+      failAccount(error, target.apiKeyEnvName);
+    }
+    return;
+  }
+
+  const target = resolveProjectTarget(context, { ...options, project });
+  try {
+    const spend = await createProjectClient(target.origin, target.projectSlug, target.apiKey).getSpend(window);
+    if (options.json) {
+      printJson(spend);
+    } else {
+      console.log(renderProjectSpend(target.projectSlug, spend, window.description));
+    }
+  } catch (error) {
+    failProjectCommand(error);
+  }
+}

--- a/packages/agency-lang/lib/cli/remote/commands/spendWindow.test.ts
+++ b/packages/agency-lang/lib/cli/remote/commands/spendWindow.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { resolveSpendWindow } from "./spendWindow.js";
+
+const NOW = 1_800_000_000_000; // fixed for determinism
+
+describe("resolveSpendWindow", () => {
+  it("--since sets [now-Δ, now] and a label", () => {
+    const resolved = resolveSpendWindow({ since: "7d" }, NOW);
+    expect(resolved.to).toBe(NOW);
+    expect(resolved.from).toBe(NOW - 7 * 24 * 3600 * 1000);
+    expect(resolved.description).toBe("last 7d");
+  });
+  it("throws when --since combines with --from/--to", () => {
+    expect(() => resolveSpendWindow({ since: "1d", from: "1000" }, NOW)).toThrow(/cannot be combined/);
+  });
+  it.each(["-1h", "0h", "0.1ms"])("throws on a non-positive/fractional --since %s", (duration) => {
+    expect(() => resolveSpendWindow({ since: duration }, NOW)).toThrow();
+  });
+  it("throws when --since reaches before the epoch", () => {
+    expect(() => resolveSpendWindow({ since: "9999d" }, 1000)).toThrow();
+  });
+  it("throws on a malformed --since string (parseDurationMs)", () => {
+    expect(() => resolveSpendWindow({ since: "banana" }, NOW)).toThrow();
+  });
+  it("accepts --since 0.5s as 500ms", () => {
+    expect(resolveSpendWindow({ since: "0.5s" }, NOW).from).toBe(NOW - 500);
+  });
+  it("trims --since before parsing and displaying it", () => {
+    expect(resolveSpendWindow({ since: " 7d " }, NOW).description).toBe("last 7d");
+  });
+  it("rejects an invalid injected current time before using it", () => {
+    expect(() => resolveSpendWindow({ since: "1s" }, 1000.5)).toThrow(/current time/);
+  });
+  it("parses --from epoch-ms and YYYY-MM-DD (UTC midnight)", () => {
+    expect(resolveSpendWindow({ from: "1000" }, NOW).from).toBe(1000);
+    expect(resolveSpendWindow({ from: "2026-07-01" }, NOW).from).toBe(Date.parse("2026-07-01T00:00:00Z"));
+  });
+  it("requires a Z/offset on a datetime, rejects bare local + junk + out-of-range", () => {
+    expect(() => resolveSpendWindow({ from: "2026-07-01T12:00:00" }, NOW)).toThrow();
+    expect(() => resolveSpendWindow({ from: "not-a-date" }, NOW)).toThrow();
+    expect(() => resolveSpendWindow({ from: "99999999999999999" }, NOW)).toThrow();
+    expect(resolveSpendWindow({ from: "2026-07-01T12:00:00Z" }, NOW).from).toBe(Date.parse("2026-07-01T12:00:00Z"));
+  });
+  it("rejects nonexistent calendar dates instead of normalizing them", () => {
+    expect(() => resolveSpendWindow({ from: "2026-02-30" }, NOW)).toThrow(/valid date/);
+    expect(() => resolveSpendWindow({ from: "2026-13-01" }, NOW)).toThrow(/valid date/);
+    expect(() => resolveSpendWindow({ from: "2026-02-30T12:00:00Z" }, NOW)).toThrow(/valid date/);
+  });
+  it("rejects from >= to", () => {
+    expect(() => resolveSpendWindow({ from: "2000", to: "1000" }, NOW)).toThrow(/before/);
+  });
+  it("resolves one-sided windows", () => {
+    expect(resolveSpendWindow({ from: "1000" }, NOW)).toMatchObject({ from: 1000, to: null });
+    expect(resolveSpendWindow({ to: "2000" }, NOW)).toMatchObject({ from: null, to: 2000 });
+  });
+  it("no flags → all time", () => {
+    expect(resolveSpendWindow({}, NOW)).toEqual({ from: null, to: null, description: "all time" });
+  });
+});

--- a/packages/agency-lang/lib/cli/remote/commands/spendWindow.ts
+++ b/packages/agency-lang/lib/cli/remote/commands/spendWindow.ts
@@ -1,0 +1,97 @@
+// Pure resolution of the `agency remote spend` time flags into a validated
+// half-open epoch-ms window plus a human display label. It RETURNS a
+// `ResolvedSpendWindow` or THROWS an `Error` — it never calls `fail()` or exits,
+// so it is unit-testable without process-exit mocking; `runSpend` converts a
+// throw at the command boundary. Every path produces only server-valid bounds
+// (non-negative safe integers within Date's representable range).
+
+import { parseDurationMs } from "@/duration.js";
+import type { SpendWindow } from "@/cli/statelog/spendTypes.js";
+
+export type SpendWindowOptions = { since?: string; from?: string; to?: string };
+export type ResolvedSpendWindow = SpendWindow & { description: string };
+
+const MAX_DATE_TIMESTAMP_MS = 8.64e15;
+const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+const DATETIME_WITH_ZONE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d{1,3})?)?(?:Z|[+-]\d{2}:\d{2})$/;
+
+function requireInstant(milliseconds: number, label: string): number {
+  if (
+    !Number.isSafeInteger(milliseconds)
+    || milliseconds < 0
+    || milliseconds > MAX_DATE_TIMESTAMP_MS
+  ) {
+    throw new Error(`${label} is out of range`);
+  }
+  return milliseconds;
+}
+
+function requireCalendarDate(value: string, label: string): void {
+  const milliseconds = Date.parse(`${value}T00:00:00Z`);
+  if (
+    Number.isNaN(milliseconds)
+    || new Date(milliseconds).toISOString().slice(0, 10) !== value
+  ) {
+    throw new Error(`${label} is not a valid date`);
+  }
+}
+
+function parseInstant(value: string, label: string): number {
+  if (/^\d+$/.test(value)) {
+    return requireInstant(Number(value), label);
+  }
+  if (DATE_ONLY.test(value)) {
+    requireCalendarDate(value, label);
+    return requireInstant(Date.parse(`${value}T00:00:00Z`), label);
+  }
+  if (DATETIME_WITH_ZONE.test(value)) {
+    requireCalendarDate(value.slice(0, 10), label);
+    const milliseconds = Date.parse(value);
+    if (Number.isNaN(milliseconds)) {
+      throw new Error(`${label} is not a valid datetime`);
+    }
+    return requireInstant(milliseconds, label);
+  }
+  throw new Error(
+    `${label} must be epoch-ms, YYYY-MM-DD, or YYYY-MM-DDTHH:mm[:ss[.sss]] with Z/±HH:mm (got "${value}")`,
+  );
+}
+
+function describe(from: number | null, to: number | null): string {
+  if (from !== null && to !== null) {
+    return `from ${new Date(from).toISOString()} to ${new Date(to).toISOString()}`;
+  }
+  if (from !== null) {
+    return `from ${new Date(from).toISOString()}`;
+  }
+  if (to !== null) {
+    return `until ${new Date(to).toISOString()}`;
+  }
+  return "all time";
+}
+
+export function resolveSpendWindow(options: SpendWindowOptions, now: number = Date.now()): ResolvedSpendWindow {
+  const { since, from, to } = options;
+  if (since !== undefined && (from !== undefined || to !== undefined)) {
+    throw new Error("--since cannot be combined with --from/--to");
+  }
+  if (since !== undefined) {
+    const normalizedSince = since.trim();
+    const durationMs = parseDurationMs(normalizedSince, "--since");
+    if (!Number.isSafeInteger(durationMs) || durationMs <= 0) {
+      throw new Error("--since must be a positive whole-millisecond duration");
+    }
+    const currentTime = requireInstant(now, "current time");
+    return {
+      from: requireInstant(currentTime - durationMs, "--since window start"),
+      to: currentTime,
+      description: `last ${normalizedSince}`,
+    };
+  }
+  const fromMs = from !== undefined ? parseInstant(from, "--from") : null;
+  const toMs = to !== undefined ? parseInstant(to, "--to") : null;
+  if (fromMs !== null && toMs !== null && fromMs >= toMs) {
+    throw new Error("--from must be before --to");
+  }
+  return { from: fromMs, to: toMs, description: describe(fromMs, toMs) };
+}

--- a/packages/agency-lang/lib/cli/remote/render.test.ts
+++ b/packages/agency-lang/lib/cli/remote/render.test.ts
@@ -10,8 +10,11 @@ import {
   renderCreatedKey,
   renderTraceList,
   renderPullSummary,
+  renderProjectSpend,
+  renderAccountSpend,
 } from "./render.js";
 import type { CreatedKey, KeySummary } from "../statelog/accountClient.js";
+import type { ProjectSpend, AccountSpendRow } from "../statelog/spendTypes.js";
 
 // Colour wraps each token in ANSI codes; strip them so assertions read plainly.
 // eslint-disable-next-line no-control-regex
@@ -171,5 +174,71 @@ describe("renderPullSummary", () => {
     expect(out).toContain("Pulled 2 files to /out");
     expect(out).toContain("main.agency");
     expect(out).toContain("helper.agency");
+  });
+});
+
+const spend = (overrides: Partial<ProjectSpend> = {}): ProjectSpend => ({
+  pricedCost: 0.4212, inputTokens: 12400, outputTokens: 3010, invocationCount: 87, unpricedCallCount: 0, pricingComplete: true, usageComplete: true, ...overrides,
+});
+
+describe("renderProjectSpend", () => {
+  it("shows cost, tokens, invocations, and the window label; no lower-bound/unpriced lines when complete", () => {
+    const out = strip(renderProjectSpend("my-agent", spend(), "last 7d"));
+    expect(out).toContain("Spend: my-agent");
+    expect(out).toContain("(last 7d)");
+    expect(out).toContain("$0.4212");
+    expect(out).toContain("↑ 12,400");
+    expect(out).toContain("↓ 3,010");
+    expect(out).toContain("Invocations:  87");
+    expect(out).not.toContain("lower bound");
+    expect(out).not.toContain("unpriced");
+  });
+  it("marks a lower bound when usage is incomplete", () => {
+    const out = strip(renderProjectSpend("a", spend({ usageComplete: false }), "all time"));
+    expect(out).toContain("≥ $0.4212");
+    expect(out).toContain("lower bound");
+  });
+  it("notes unpriced calls", () => {
+    const out = strip(renderProjectSpend("a", spend({ unpricedCallCount: 2, pricingComplete: false }), "all time"));
+    expect(out).toContain("2 unpriced call(s)");
+  });
+  it("shows $0.0000 for true zero and <$0.0001 for a tiny positive", () => {
+    expect(strip(renderProjectSpend("a", spend({ pricedCost: 0 }), "all time"))).toContain("$0.0000");
+    expect(strip(renderProjectSpend("a", spend({ pricedCost: 0.00004 }), "all time"))).toContain("<$0.0001");
+  });
+});
+
+const row = (slug: string, pricedCost: number, over: Partial<ProjectSpend> = {}, deletedAt: string | null = null): AccountSpendRow => ({
+  projectSlug: slug, deletedAt, spend: spend({ pricedCost, ...over }),
+});
+
+describe("renderAccountSpend", () => {
+  it("empty → no projects", () => {
+    expect(strip(renderAccountSpend([], "all time"))).toBe("No projects yet.");
+  });
+  it("sorts active by cost desc then deleted, with slug tie-break, and totals correctly", () => {
+    const out = strip(renderAccountSpend([
+      row("b-cheap", 0.10),
+      row("gone", 0.99, {}, "2026-08-01T00:00:00.000Z"),
+      row("a-tie", 0.50),
+      row("b-tie", 0.50),
+    ], "last 7d"));
+    const lines = out.split("\n");
+    const order = lines.filter((l) => /a-tie|b-tie|b-cheap|gone|TOTAL/.test(l)).map((l) => l.trim().split(/\s+/)[0]);
+    expect(order).toEqual(["a-tie", "b-tie", "b-cheap", "gone", "TOTAL"]);
+    expect(out).toContain("PROJECT");
+    expect(out).toContain("UNPRICED");
+    expect(out).toContain("$2.0900"); // 0.10+0.99+0.50+0.50, all complete
+    expect(out).toContain("gone (deleted)");
+  });
+  it("degrades the TOTAL when a single row is incomplete or unpriced", () => {
+    const out = strip(renderAccountSpend([
+      row("ok", 1),
+      row("bad", 2, { usageComplete: false, unpricedCallCount: 3, pricingComplete: false }),
+    ], "all time"));
+    const total = out.split("\n").find((l) => l.includes("TOTAL")) ?? "";
+    expect(total).toContain("≥ $3.0000");
+    expect(out).toContain("incomplete telemetry");
+    expect(out).toContain("3 unpriced call(s) total");
   });
 });

--- a/packages/agency-lang/lib/cli/remote/render.test.ts
+++ b/packages/agency-lang/lib/cli/remote/render.test.ts
@@ -206,6 +206,11 @@ describe("renderProjectSpend", () => {
     expect(strip(renderProjectSpend("a", spend({ pricedCost: 0 }), "all time"))).toContain("$0.0000");
     expect(strip(renderProjectSpend("a", spend({ pricedCost: 0.00004 }), "all time"))).toContain("<$0.0001");
   });
+  it("never emits the incoherent '≥ <$0.0001' for a tiny incomplete amount", () => {
+    const out = strip(renderProjectSpend("a", spend({ pricedCost: 0.00004, usageComplete: false }), "all time"));
+    expect(out).not.toContain("≥ <");
+    expect(out).toContain("≥ $0.0000");
+  });
 });
 
 const row = (slug: string, pricedCost: number, over: Partial<ProjectSpend> = {}, deletedAt: string | null = null): AccountSpendRow => ({

--- a/packages/agency-lang/lib/cli/remote/render.ts
+++ b/packages/agency-lang/lib/cli/remote/render.ts
@@ -11,6 +11,7 @@ import type {
   KeySummary,
   CreatedKey,
 } from "../statelog/accountClient.js";
+import type { ProjectSpend, AccountSpendRow } from "../statelog/spendTypes.js";
 
 const NONE = "—";
 
@@ -110,6 +111,118 @@ export function renderTraceList(traces: TraceSummary[]): string {
 export function renderPullSummary(names: string[], outputDir: string): string {
   const header = `${color.green("Pulled")} ${names.length} file${names.length === 1 ? "" : "s"} to ${outputDir}`;
   return [header, ...names.map((name) => `  ${name}`)].join("\n");
+}
+
+/** A dollar amount that never renders a positive spend as `$0.0000` — a sub-cent
+ *  hosted cost must stay visible. */
+function formatUsd(amount: number): string {
+  if (amount === 0) {
+    return "$0.0000";
+  }
+  if (amount < 0.0001) {
+    return "<$0.0001";
+  }
+  return `$${amount.toFixed(4)}`;
+}
+
+/** A count with thousands separators, in a fixed locale for deterministic output. */
+function formatCount(count: number): string {
+  return count.toLocaleString("en-US");
+}
+
+/** Prefix `≥` when the figure is a trusted lower bound (telemetry incomplete). */
+function lowerBound(amount: number, complete: boolean): string {
+  return complete ? formatUsd(amount) : `≥ ${formatUsd(amount)}`;
+}
+
+export function renderProjectSpend(slug: string, spend: ProjectSpend, description: string): string {
+  const lines = [
+    `${color.bold("Spend:")} ${slug}  ${color.dim(`(${description})`)}`,
+    `  ${color.bold("Cost:")}         ${lowerBound(spend.pricedCost, spend.usageComplete)}`,
+    `  ${color.bold("Tokens:")}       ↑ ${formatCount(spend.inputTokens)}  ↓ ${formatCount(spend.outputTokens)}`,
+    `  ${color.bold("Invocations:")}  ${formatCount(spend.invocationCount)}`,
+  ];
+  if (!spend.usageComplete) {
+    lines.push(color.dim("  (lower bound — some telemetry incomplete)"));
+  }
+  if (spend.unpricedCallCount > 0) {
+    lines.push(color.dim(`  ${formatCount(spend.unpricedCallCount)} unpriced call(s) — cost may be understated`));
+  }
+  return lines.join("\n");
+}
+
+type SpendTotals = {
+  pricedCost: number;
+  inputTokens: number;
+  outputTokens: number;
+  invocationCount: number;
+  unpricedCallCount: number;
+  usageComplete: boolean;
+};
+
+function spendTotals(rows: AccountSpendRow[]): SpendTotals {
+  return rows.reduce<SpendTotals>(
+    (totals, row) => ({
+      pricedCost: totals.pricedCost + row.spend.pricedCost,
+      inputTokens: totals.inputTokens + row.spend.inputTokens,
+      outputTokens: totals.outputTokens + row.spend.outputTokens,
+      invocationCount: totals.invocationCount + row.spend.invocationCount,
+      unpricedCallCount: totals.unpricedCallCount + row.spend.unpricedCallCount,
+      usageComplete: totals.usageComplete && row.spend.usageComplete,
+    }),
+    { pricedCost: 0, inputTokens: 0, outputTokens: 0, invocationCount: 0, unpricedCallCount: 0, usageComplete: true },
+  );
+}
+
+/** Active projects first (by cost desc), then deleted ones (by cost desc), with
+ *  the slug as a deterministic tie-break. */
+function sortAccountRows(rows: AccountSpendRow[]): AccountSpendRow[] {
+  return [...rows].sort((left, right) => {
+    const leftDeleted = left.deletedAt !== null;
+    const rightDeleted = right.deletedAt !== null;
+    if (leftDeleted !== rightDeleted) {
+      return leftDeleted ? 1 : -1;
+    }
+    if (right.spend.pricedCost !== left.spend.pricedCost) {
+      return right.spend.pricedCost - left.spend.pricedCost;
+    }
+    return left.projectSlug < right.projectSlug ? -1 : left.projectSlug > right.projectSlug ? 1 : 0;
+  });
+}
+
+export function renderAccountSpend(rows: AccountSpendRow[], description: string): string {
+  if (rows.length === 0) {
+    return color.dim("No projects yet.");
+  }
+  const sorted = sortAccountRows(rows);
+  const tableRows = sorted.map((row) => [
+    row.deletedAt === null ? row.projectSlug : `${row.projectSlug} (deleted)`,
+    lowerBound(row.spend.pricedCost, row.spend.usageComplete),
+    formatCount(row.spend.inputTokens),
+    formatCount(row.spend.outputTokens),
+    formatCount(row.spend.invocationCount),
+    formatCount(row.spend.unpricedCallCount),
+  ]);
+  const totals = spendTotals(rows);
+  tableRows.push([
+    "TOTAL",
+    lowerBound(totals.pricedCost, totals.usageComplete),
+    formatCount(totals.inputTokens),
+    formatCount(totals.outputTokens),
+    formatCount(totals.invocationCount),
+    formatCount(totals.unpricedCallCount),
+  ]);
+  const lines = [
+    color.dim(`(${description})`),
+    formatStaticTable(["PROJECT", "COST", "↑IN", "↓OUT", "INVOCATIONS", "UNPRICED"], tableRows),
+  ];
+  if (!totals.usageComplete) {
+    lines.push(color.dim("Some projects have incomplete telemetry; totals are lower bounds."));
+  }
+  if (totals.unpricedCallCount > 0) {
+    lines.push(color.dim(`${formatCount(totals.unpricedCallCount)} unpriced call(s) total — cost may be understated.`));
+  }
+  return lines.join("\n");
 }
 
 function formatStaticTable(headers: string[], rows: string[][]): string {

--- a/packages/agency-lang/lib/cli/remote/render.ts
+++ b/packages/agency-lang/lib/cli/remote/render.ts
@@ -130,9 +130,18 @@ function formatCount(count: number): string {
   return count.toLocaleString("en-US");
 }
 
-/** Prefix `≥` when the figure is a trusted lower bound (telemetry incomplete). */
+/** Prefix `≥` when the figure is a trusted lower bound (telemetry incomplete).
+ *  A lower bound never uses the `<$0.0001` sentinel — `≥ <$0.0001` ("at least
+ *  less than") is incoherent — so a sub-$0.0001 lower bound floors to
+ *  `≥ $0.0000` (still true: the total is at least ~zero and may be higher). */
 function lowerBound(amount: number, complete: boolean): string {
-  return complete ? formatUsd(amount) : `≥ ${formatUsd(amount)}`;
+  if (complete) {
+    return formatUsd(amount);
+  }
+  if (amount > 0 && amount < 0.0001) {
+    return "≥ $0.0000";
+  }
+  return `≥ ${formatUsd(amount)}`;
 }
 
 export function renderProjectSpend(slug: string, spend: ProjectSpend, description: string): string {
@@ -186,7 +195,13 @@ function sortAccountRows(rows: AccountSpendRow[]): AccountSpendRow[] {
     if (right.spend.pricedCost !== left.spend.pricedCost) {
       return right.spend.pricedCost - left.spend.pricedCost;
     }
-    return left.projectSlug < right.projectSlug ? -1 : left.projectSlug > right.projectSlug ? 1 : 0;
+    if (left.projectSlug < right.projectSlug) {
+      return -1;
+    }
+    if (left.projectSlug > right.projectSlug) {
+      return 1;
+    }
+    return 0;
   });
 }
 

--- a/packages/agency-lang/lib/cli/statelog/accountClient.test.ts
+++ b/packages/agency-lang/lib/cli/statelog/accountClient.test.ts
@@ -299,3 +299,34 @@ describe("accountClient id-map safety", () => {
     expect(keys[0]?.projectId).toBe("polluted");
   });
 });
+
+describe("accountClient.getAccountSpend", () => {
+  const validSpend = { pricedCost: 0.5, inputTokens: 10, outputTokens: 2, invocationCount: 3, unpricedCallCount: 0, pricingComplete: true, usageComplete: true };
+  const okRows = { success: true, value: [{ projectSlug: "p", deletedAt: null, spend: validSpend }] };
+
+  it("GETs /api/spend with both bounds, omitting null ones", async () => {
+    fetchMock.mockResolvedValue(response(200, okRows));
+    const rows = await client.getAccountSpend({ from: 1000, to: 2000 });
+    expect(fetchMock).toHaveBeenCalledWith("https://host.example/api/spend?from=1000&to=2000", expect.any(Object));
+    expect(rows[0]?.projectSlug).toBe("p");
+    await client.getAccountSpend({ from: null, to: null });
+    expect(fetchMock).toHaveBeenLastCalledWith("https://host.example/api/spend", expect.any(Object));
+  });
+
+  it("rejects a malformed row as an AccountRequestError", async () => {
+    fetchMock.mockResolvedValue(response(200, { success: true, value: [{ projectSlug: "p", deletedAt: null, spend: { ...validSpend, pricedCost: -1 } }] }));
+    await expect(client.getAccountSpend({ from: null, to: null })).rejects.toBeInstanceOf(AccountRequestError);
+  });
+
+  it("reports an unsupported host for a spend-route 404 (JSON and non-JSON)", async () => {
+    fetchMock.mockResolvedValue(response(404, { error: "Not Found" }));
+    await expect(client.getAccountSpend({ from: null, to: null })).rejects.toThrow(/does not support the spend API/);
+    fetchMock.mockResolvedValue({ ok: false, status: 404, json: vi.fn().mockRejectedValue(new SyntaxError("bad")) } as unknown as Response);
+    await expect(client.getAccountSpend({ from: null, to: null })).rejects.toThrow(/does not support the spend API/);
+  });
+
+  it("leaves a non-JSON 5xx as a server error", async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 503, json: vi.fn().mockRejectedValue(new SyntaxError("bad")) } as unknown as Response);
+    await expect(client.getAccountSpend({ from: null, to: null })).rejects.toThrow("statelog request failed (HTTP 503)");
+  });
+});

--- a/packages/agency-lang/lib/cli/statelog/accountClient.ts
+++ b/packages/agency-lang/lib/cli/statelog/accountClient.ts
@@ -6,6 +6,12 @@
 // schema, or a `success:false` body — surfaces as an AccountRequestError.
 
 import { z } from "zod";
+import {
+  accountSpendRowSchema,
+  toSpendQuery,
+  type AccountSpendRow,
+  type SpendWindow,
+} from "./spendTypes.js";
 
 export type ProjectSummary = {
   projectId: string;
@@ -85,30 +91,46 @@ export type AccountClient = {
   createProject(input: CreateProjectInput): Promise<ProjectSummary>;
   listKeys(): Promise<KeySummary[]>;
   createProjectKey(input: CreateProjectKeyInput): Promise<CreatedKey>;
+  getAccountSpend(window: SpendWindow): Promise<AccountSpendRow[]>;
 };
 
-type AccountRoute = "whoami" | "projects" | "api_keys";
+type AccountRoute = "whoami" | "projects" | "api_keys" | "spend";
 
-function accountRouteUrl(origin: string, route: AccountRoute): string {
-  return new URL(`/api/${route}`, origin).toString();
+/** One account request: a POST body, an optional query, and — for a route a host
+ *  may not have yet — the message to raise on a 404 that means the route is
+ *  unsupported. */
+type AccountRequestOptions = {
+  body?: unknown;
+  query?: Record<string, string>;
+  unsupportedRouteMessage?: string;
+};
+
+function accountRouteUrl(origin: string, route: AccountRoute, query: Record<string, string> | undefined): string {
+  const url = new URL(`/api/${route}`, origin);
+  if (query) {
+    for (const [key, value] of Object.entries(query)) {
+      url.searchParams.set(key, value);
+    }
+  }
+  return url.toString();
 }
 
 export function createAccountClient(origin: string, apiKey: string): AccountClient {
   async function request(
     method: "GET" | "POST",
     route: AccountRoute,
-    body?: unknown,
+    options: AccountRequestOptions = {},
   ): Promise<unknown> {
     const headers: Record<string, string> = { Authorization: `Bearer ${apiKey}` };
     const init: RequestInit = { method, headers };
     if (method === "POST") {
       headers["Content-Type"] = "application/json";
-      init.body = JSON.stringify(body ?? {});
+      init.body = JSON.stringify(options.body ?? {});
     }
 
     let response: Response;
     try {
-      response = await fetch(accountRouteUrl(origin, route), init);
+      response = await fetch(accountRouteUrl(origin, route, options.query), init);
     } catch (error) {
       throw new AccountRequestError(`could not reach ${origin} (${message(error)})`);
     }
@@ -126,6 +148,12 @@ export function createAccountClient(origin: string, apiKey: string): AccountClie
       const serverError = parsed ? asObject(json)?.error : undefined;
       if (response.status === 403 && serverError === ACCOUNT_SCOPE_ERROR) {
         throw new AccountScopeError(ACCOUNT_SCOPE_ERROR);
+      }
+      // A 404 on a route the caller flagged host-optional means the host predates
+      // it — before the generic server-error branch, so a `{error}` 404 body does
+      // not mask it (account routes have no project-not-found case).
+      if (response.status === 404 && options.unsupportedRouteMessage !== undefined) {
+        throw new AccountRequestError(options.unsupportedRouteMessage);
       }
       if (typeof serverError === "string") {
         throw new AccountRequestError(serverError);
@@ -167,9 +195,11 @@ export function createAccountClient(origin: string, apiKey: string): AccountClie
     },
     async createProject(input) {
       const value = await request("POST", "projects", {
-        name: input.name,
-        project_id: input.projectId,
-        description: input.description ?? null,
+        body: {
+          name: input.name,
+          project_id: input.projectId,
+          description: input.description ?? null,
+        },
       });
       return toProjectSummary(validateRawProject(value));
     },
@@ -188,11 +218,20 @@ export function createAccountClient(origin: string, apiKey: string): AccountClie
         throw new AccountRequestError(`unknown project '${input.projectId}'`);
       }
       const value = await request("POST", "api_keys", {
-        name: input.name,
-        scope: "project",
-        projectId: match.id,
+        body: {
+          name: input.name,
+          scope: "project",
+          projectId: match.id,
+        },
       });
       return validateCreatedKey(value, slugByInternalId(projects));
+    },
+    async getAccountSpend(window) {
+      const value = await request("GET", "spend", {
+        query: toSpendQuery(window),
+        unsupportedRouteMessage: "this statelog host does not support the spend API (upgrade the host)",
+      });
+      return parseValue(z.array(accountSpendRowSchema), value);
     },
   };
 }

--- a/packages/agency-lang/lib/cli/statelog/projectClient.test.ts
+++ b/packages/agency-lang/lib/cli/statelog/projectClient.test.ts
@@ -168,3 +168,52 @@ describe("projectClient envelope/transport edge cases", () => {
     await expect(client().pullSource()).rejects.toThrow("statelog request failed (HTTP 500)");
   });
 });
+
+describe("projectClient.getSpend", () => {
+  const okSpend = {
+    success: true,
+    value: { pricedCost: 0.5, inputTokens: 10, outputTokens: 2, invocationCount: 3, unpricedCallCount: 0, pricingComplete: true, usageComplete: true },
+  };
+
+  it("GETs the spend route with both bounds as query params", async () => {
+    fetchMock.mockResolvedValue(response(200, okSpend));
+    const spend = await client().getSpend({ from: 1000, to: 2000 });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://h/api/projects/proj/spend?from=1000&to=2000",
+      { method: "GET", headers: { Authorization: "Bearer key" } },
+    );
+    expect(spend.pricedCost).toBe(0.5);
+  });
+
+  it("omits a null bound (from-only, to-only, neither)", async () => {
+    fetchMock.mockResolvedValue(response(200, okSpend));
+    await client().getSpend({ from: 1000, to: null });
+    expect(fetchMock).toHaveBeenLastCalledWith("https://h/api/projects/proj/spend?from=1000", expect.any(Object));
+    await client().getSpend({ from: null, to: 2000 });
+    expect(fetchMock).toHaveBeenLastCalledWith("https://h/api/projects/proj/spend?to=2000", expect.any(Object));
+    await client().getSpend({ from: null, to: null });
+    expect(fetchMock).toHaveBeenLastCalledWith("https://h/api/projects/proj/spend", expect.any(Object));
+  });
+
+  it("rejects a malformed spend shape as a ProjectRequestError", async () => {
+    fetchMock.mockResolvedValue(response(200, { success: true, value: { ...okSpend.value, pricedCost: -1 } }));
+    await expect(client().getSpend({ from: null, to: null })).rejects.toBeInstanceOf(ProjectRequestError);
+  });
+
+  it("keeps project-not-found for the known JSON 404", async () => {
+    fetchMock.mockResolvedValue(response(404, { error: "Project not found" }));
+    await expect(client().getSpend({ from: null, to: null })).rejects.toThrow(/not found — check the slug/);
+  });
+
+  it("reports an unsupported host for any other 404 (JSON and non-JSON)", async () => {
+    fetchMock.mockResolvedValue(response(404, { error: "Not Found" }));
+    await expect(client().getSpend({ from: null, to: null })).rejects.toThrow(/does not support the spend API/);
+    fetchMock.mockResolvedValue({ ok: false, status: 404, json: vi.fn().mockRejectedValue(new SyntaxError("bad")) } as unknown as Response);
+    await expect(client().getSpend({ from: null, to: null })).rejects.toThrow(/does not support the spend API/);
+  });
+
+  it("leaves a non-JSON 5xx as a server error (not unsupported host)", async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 503, json: vi.fn().mockRejectedValue(new SyntaxError("bad")) } as unknown as Response);
+    await expect(client().getSpend({ from: null, to: null })).rejects.toThrow("statelog request failed (HTTP 503)");
+  });
+});

--- a/packages/agency-lang/lib/cli/statelog/projectClient.ts
+++ b/packages/agency-lang/lib/cli/statelog/projectClient.ts
@@ -5,6 +5,12 @@
 // validated typed values; every failure surfaces as a ProjectRequestError.
 
 import { z } from "zod";
+import {
+  projectSpendSchema,
+  toSpendQuery,
+  type ProjectSpend,
+  type SpendWindow,
+} from "./spendTypes.js";
 
 export type SourceFile = { name: string; contents: string };
 
@@ -52,13 +58,35 @@ export type ProjectClient = {
   pullSource(): Promise<SourceFile[]>;
   listTraces(): Promise<TraceSummary[]>;
   traceLogs(traceId: string): Promise<TraceLog[]>;
+  getSpend(window: SpendWindow): Promise<ProjectSpend>;
+};
+
+/** A single project request: the path segments after `/api/projects/:slug`, an
+ *  optional query, and — for a route a host may not have yet — the message to
+ *  raise when an unknown 404 means the route is unsupported. */
+type ProjectRequest = {
+  segments: string[];
+  query?: Record<string, string>;
+  unsupportedRouteMessage?: string;
 };
 
 /** Build a `/api/projects/:slug/…` URL, encoding the slug and every segment
- *  independently — never concatenate a partly-encoded pathname. */
-function projectRouteUrl(origin: string, slug: string, ...segments: string[]): string {
+ *  independently — never concatenate a partly-encoded pathname — then append any
+ *  query params. */
+function projectRouteUrl(
+  origin: string,
+  slug: string,
+  segments: string[],
+  query: Record<string, string> | undefined,
+): string {
   const path = ["api", "projects", slug, ...segments].map(encodeURIComponent).join("/");
-  return new URL(`/${path}`, origin).toString();
+  const url = new URL(`/${path}`, origin);
+  if (query) {
+    for (const [key, value] of Object.entries(query)) {
+      url.searchParams.set(key, value);
+    }
+  }
+  return url.toString();
 }
 
 export function createProjectClient(
@@ -66,10 +94,10 @@ export function createProjectClient(
   projectSlug: string,
   apiKey: string,
 ): ProjectClient {
-  async function request(...segments: string[]): Promise<unknown> {
+  async function request(input: ProjectRequest): Promise<unknown> {
     let response: Response;
     try {
-      response = await fetch(projectRouteUrl(origin, projectSlug, ...segments), {
+      response = await fetch(projectRouteUrl(origin, projectSlug, input.segments, input.query), {
         method: "GET",
         headers: { Authorization: `Bearer ${apiKey}` },
       });
@@ -83,6 +111,13 @@ export function createProjectClient(
     if (!response.ok) {
       const serverError = parsed.ok ? asObject(parsed.value)?.error : undefined;
       if (response.status === 404) {
+        // A missing project always carries statelog's known JSON error. Any
+        // OTHER 404 on a route the caller flagged as host-optional means the
+        // host predates that route; without such a flag, keep the historical
+        // project-not-found message.
+        if (serverError !== "Project not found" && input.unsupportedRouteMessage !== undefined) {
+          throw new ProjectRequestError(input.unsupportedRouteMessage);
+        }
         throw new ProjectRequestError(
           `project '${projectSlug}' not found — check the slug, or that it's deployed`,
         );
@@ -112,10 +147,10 @@ export function createProjectClient(
 
   return {
     async pullSource() {
-      return parseWire(sourceBundleSchema, await request("source")).files;
+      return parseWire(sourceBundleSchema, await request({ segments: ["source"] })).files;
     },
     async listTraces() {
-      return parseWire(z.array(traceSummarySchema), await request("traces"));
+      return parseWire(z.array(traceSummarySchema), await request({ segments: ["traces"] }));
     },
     async traceLogs(traceId) {
       // Validate the argument BEFORE the request (an empty id would pass the
@@ -124,7 +159,10 @@ export function createProjectClient(
         z.string().min(1, "trace id must not be empty"),
         traceId,
       );
-      const logs = parseWire(z.array(traceLogSchema), await request("traces", requested, "logs"));
+      const logs = parseWire(
+        z.array(traceLogSchema),
+        await request({ segments: ["traces", requested, "logs"] }),
+      );
       for (const log of logs) {
         if (log.traceId !== requested) {
           throw new ProjectRequestError(
@@ -133,6 +171,14 @@ export function createProjectClient(
         }
       }
       return logs;
+    },
+    async getSpend(window) {
+      const value = await request({
+        segments: ["spend"],
+        query: toSpendQuery(window),
+        unsupportedRouteMessage: "this statelog host does not support the spend API (upgrade the host)",
+      });
+      return parseWire(projectSpendSchema, value);
     },
   };
 }

--- a/packages/agency-lang/lib/cli/statelog/spendTypes.test.ts
+++ b/packages/agency-lang/lib/cli/statelog/spendTypes.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { projectSpendSchema, accountSpendRowSchema, toSpendQuery } from "./spendTypes.js";
+
+const valid = { pricedCost: 0.5, inputTokens: 10, outputTokens: 2, invocationCount: 3, unpricedCallCount: 0, pricingComplete: true, usageComplete: true };
+
+describe("projectSpendSchema", () => {
+  it("accepts a valid spend", () => { expect(projectSpendSchema.parse(valid)).toEqual(valid); });
+  it("rejects non-finite/negative cost, unsafe/negative counts, contradictory completeness", () => {
+    expect(() => projectSpendSchema.parse({ ...valid, pricedCost: -1 })).toThrow();
+    expect(() => projectSpendSchema.parse({ ...valid, pricedCost: Number.NaN })).toThrow();
+    expect(() => projectSpendSchema.parse({ ...valid, pricedCost: Number.POSITIVE_INFINITY })).toThrow();
+    expect(() => projectSpendSchema.parse({ ...valid, inputTokens: -1 })).toThrow();
+    expect(() => projectSpendSchema.parse({ ...valid, outputTokens: 2 ** 53 })).toThrow();
+    expect(() => projectSpendSchema.parse({ ...valid, invocationCount: 2 ** 53 })).toThrow();
+    expect(() => projectSpendSchema.parse({ ...valid, unpricedCallCount: 1, pricingComplete: true })).toThrow();
+  });
+});
+
+describe("accountSpendRowSchema", () => {
+  it("accepts null and ISO deletedAt, rejects junk", () => {
+    expect(accountSpendRowSchema.parse({ projectSlug: "p", deletedAt: null, spend: valid }).deletedAt).toBeNull();
+    expect(accountSpendRowSchema.parse({ projectSlug: "p", deletedAt: "2026-08-01T00:00:00.000Z", spend: valid }).deletedAt).toBe("2026-08-01T00:00:00.000Z");
+    expect(() => accountSpendRowSchema.parse({ projectSlug: "p", deletedAt: "nope", spend: valid })).toThrow();
+  });
+});
+
+describe("toSpendQuery", () => {
+  it("omits null bounds, serializes present ones as decimals", () => {
+    expect(toSpendQuery({ from: null, to: null })).toEqual({});
+    expect(toSpendQuery({ from: 1000, to: null })).toEqual({ from: "1000" });
+    expect(toSpendQuery({ from: 1000, to: 2000 })).toEqual({ from: "1000", to: "2000" });
+  });
+});

--- a/packages/agency-lang/lib/cli/statelog/spendTypes.ts
+++ b/packages/agency-lang/lib/cli/statelog/spendTypes.ts
@@ -1,0 +1,53 @@
+// The statelog spend wire types — the single source of truth for the shape the
+// per-project and account spend endpoints return, and the query serializer both
+// clients share. The Zod schemas own the numeric invariants; the TypeScript
+// types are inferred from them so a hand-written type cannot drift from its
+// runtime validator.
+
+import { z } from "zod";
+
+const nonNegativeSafeInt = z
+  .number()
+  .int()
+  .nonnegative()
+  .refine(Number.isSafeInteger, "must be a safe integer");
+
+export const projectSpendSchema = z
+  .object({
+    pricedCost: z.number().finite().nonnegative(),
+    inputTokens: nonNegativeSafeInt,
+    outputTokens: nonNegativeSafeInt,
+    invocationCount: nonNegativeSafeInt,
+    unpricedCallCount: nonNegativeSafeInt,
+    pricingComplete: z.boolean(),
+    usageComplete: z.boolean(),
+  })
+  .refine(
+    (spend) => spend.pricingComplete === (spend.unpricedCallCount === 0),
+    "pricingComplete must equal (unpricedCallCount === 0)",
+  );
+export type ProjectSpend = z.infer<typeof projectSpendSchema>;
+
+export const accountSpendRowSchema = z.object({
+  projectSlug: z.string().min(1),
+  deletedAt: z.string().datetime().nullable(),
+  spend: projectSpendSchema,
+});
+export type AccountSpendRow = z.infer<typeof accountSpendRowSchema>;
+
+/** A half-open `[from, to)` window in epoch milliseconds; either bound may be
+ *  null (open on that side). */
+export type SpendWindow = { from: number | null; to: number | null };
+
+/** Serialize a window to the endpoints' query params — a bound is included only
+ *  when set, as a decimal string. Shared so both clients serialize identically. */
+export function toSpendQuery(window: SpendWindow): Record<string, string> {
+  const query: Record<string, string> = {};
+  if (window.from !== null) {
+    query.from = String(window.from);
+  }
+  if (window.to !== null) {
+    query.to = String(window.to);
+  }
+  return query;
+}

--- a/packages/agency-lang/scripts/agency.test.ts
+++ b/packages/agency-lang/scripts/agency.test.ts
@@ -14,6 +14,7 @@ const remoteRecipeMocks = vi.hoisted(() => ({
   runProjectsCreate: vi.fn(),
   runKeysList: vi.fn(),
   runKeysCreate: vi.fn(),
+  runSpend: vi.fn(),
   runPull: vi.fn(),
   runLogs: vi.fn(),
 }));
@@ -27,6 +28,9 @@ vi.mock("@/cli/remote/commands/projects.js", () => ({
 vi.mock("@/cli/remote/commands/keys.js", () => ({
   runKeysList: remoteRecipeMocks.runKeysList,
   runKeysCreate: remoteRecipeMocks.runKeysCreate,
+}));
+vi.mock("@/cli/remote/commands/spend.js", () => ({
+  runSpend: remoteRecipeMocks.runSpend,
 }));
 // pull/logs recipes are mocked; logsMode and util stay REAL so the
 // registration's mode/TTY preflight and clean-exit are exercised.
@@ -158,8 +162,30 @@ describe("agency CLI command tree", () => {
       "open",
       "projects",
       "pull",
+      "spend",
       "whoami",
     ]);
+  });
+
+  it("forwards `remote spend <project>` args to runSpend", async () => {
+    remoteRecipeMocks.runSpend.mockClear();
+    const program = createProgram();
+    await program.parseAsync(
+      ["remote", "spend", "my-project", "--since", "7d", "--json", "--host", "https://h", "--api-key-env", "SPEND_KEY"],
+      { from: "user" },
+    );
+    expect(remoteRecipeMocks.runSpend).toHaveBeenCalledTimes(1);
+    const [project, options] = remoteRecipeMocks.runSpend.mock.calls[0];
+    expect(project).toBe("my-project");
+    expect(options).toMatchObject({ since: "7d", json: true, host: "https://h", apiKeyEnv: "SPEND_KEY" });
+  });
+
+  it("forwards bare `remote spend` with an undefined project", async () => {
+    remoteRecipeMocks.runSpend.mockClear();
+    const program = createProgram();
+    await program.parseAsync(["remote", "spend"], { from: "user" });
+    expect(remoteRecipeMocks.runSpend).toHaveBeenCalledTimes(1);
+    expect(remoteRecipeMocks.runSpend.mock.calls[0][0]).toBeUndefined();
   });
 
   it("no longer registers a top-level deploy command (moved to remote deploy)", () => {

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -27,6 +27,8 @@ import { runProjectsList, runProjectsCreate } from "@/cli/remote/commands/projec
 import type { CreateProjectOptions } from "@/cli/remote/commands/projects.js";
 import { runKeysList, runKeysCreate } from "@/cli/remote/commands/keys.js";
 import type { CreateKeyOptions } from "@/cli/remote/commands/keys.js";
+import { runSpend } from "@/cli/remote/commands/spend.js";
+import type { SpendOptions } from "@/cli/remote/commands/spend.js";
 import { runPull } from "@/cli/remote/commands/pull.js";
 import type { PullOptions } from "@/cli/remote/commands/pull.js";
 import { runLogs } from "@/cli/remote/commands/logs.js";
@@ -552,6 +554,18 @@ export function createProgram(deps: CliDependencies = {}): Command {
     .action((name: string, opts: CreateKeyOptions) =>
       runKeysCreate(name, opts, getConfigContext()),
     );
+
+  remoteCmd
+    .command("spend")
+    .description("Show hosted spend for a project (or the whole account)")
+    .argument("[project]", "project slug (omit for the account-wide rollup)")
+    .option("--since <duration>", "window ending now, e.g. 24h, 7d, 2w")
+    .option("--from <when>", "window start — ISO-8601 (UTC/offset) or epoch-ms")
+    .option("--to <when>", "window end — ISO-8601 (UTC/offset) or epoch-ms")
+    .option("--json", "emit JSON for machine use")
+    .option(HOST_OPTION, HOST_DESC)
+    .option(API_KEY_ENV_OPTION, API_KEY_ENV_DESC)
+    .action((project: string | undefined, opts: SpendOptions) => runSpend(project, opts, getConfigContext()));
 
   const PROJECT_OPTION = "--project <slug>";
   const PROJECT_DESC = "project slug (default: the linked project)";


### PR DESCRIPTION
## Summary

Adds `agency remote spend [project]` — a read-only CLI command that prints hosted spend from statelog's Group 4 spend endpoints. This is the client that surfaces the serve cost seam (#801) and per-model breakdown (#802) work: how much a hosted agent cost, without opening the statelog UI.

- `agency remote spend` → the account-wide rollup (all projects), one row each.
- `agency remote spend <project>` → one project's spend.
- `--since 7d` (or `--from`/`--to` as ISO-8601/epoch-ms) scopes a time window; `--json` for machines.

## Design

A thin command over the existing two-client split — mirrors how `whoami`/`projects` (account) and `pull`/`logs` (project) already work.

- **`resolveSpendWindow`** (pure) turns the time flags into a validated half-open epoch-ms window plus a display label; it returns-or-throws (never exits), and `runSpend` converts a throw at the `fail()` boundary. Rejects non-positive/fractional/overflow/pre-epoch `--since`, bare-local datetimes (requires a `Z`/offset), and nonexistent calendar dates.
- **Shared `spendTypes.ts`** is the source of truth: Zod schemas enforce the numeric invariants (finite non-negative cost, non-negative safe-integer counts, `deletedAt` null|ISO, and `pricingComplete === (unpricedCallCount === 0)`); the TS types are inferred from them; `toSpendQuery` is the one query serializer both clients use.
- **Clients** gain `getSpend`/`getAccountSpend` behind a single declarative request input per client (query support + private route-compatibility detection — no second transport path, no exported error class). An unknown 404 on a spend route is reported as "host does not support the spend API" (narrowed to HTTP 404 so a proxy's non-JSON 5xx stays a server error); a project's known `{error:"Project not found"}` 404 keeps its message.
- **Renderers** use adaptive money formatting (`$0.0000` only for true zero, `<$0.0001` for tiny positive), and the account TOTAL carries both trust axes — a lower-bound `≥` when any row's usage is incomplete, plus summed unpriced-call notes. Rows sort active-by-cost-desc, then deleted, with the slug as tie-break.

## Scope / non-goals

- Read-only; public wire/CLI conventions unchanged; purely additive (one shared types module, two client methods, one window parser, two renderers, one command).
- **Per-model breakdown is out of scope**: the server's `ProjectSpend` is still flat (Group 4 predates #802). The runtime already sends the per-model data; the next step is a statelog follow-up to aggregate it, after which this command grows a `--by-model` view (the renderer is shaped to accept it).
- No CSV (statelog dropped it; `--json` is the machine surface).

## Testing

Full TDD, deterministic, no network/LLM: `spendTypes`, `spendWindow` (all window edge cases), both client methods (query building incl. one-sided windows, wire-invariant rejection, the 404 policy + a non-JSON-5xx regression), the renderers (zero-vs-tiny money, degraded totals, sort/tie-break, empty), the command (scope selection, invalid-flag → `fail` with no client call, project-scoped-key hint, `--json` to stdout only), and Commander forwarding in `scripts/agency.test.ts`. `pnpm run typecheck` clean; full `pnpm test:run` green (740 files) after a build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
