### PR TITLE
agency <file>: the shorthand takes a command line like run does

### DIFF
--- a/packages/agency-lang/docs/dev/cli-arguments.md
+++ b/packages/agency-lang/docs/dev/cli-arguments.md
@@ -229,21 +229,33 @@ command, not a mistake.
 The walk itself — arity, attached values, short bundles — lives in one place, so
 a fix to short-option parsing reaches both.
 
-## Known limitation: the shorthand takes no program arguments
+## The shorthand is `run` with the word left out
 
-`agency greet.agency` is a shorthand for `agency run greet.agency`. It is a
-hidden default command declaring only `[file]`, with no variadic argument, so it
-cannot forward anything:
+`agency greet.agency` is a hidden default command. It carries the same options
+as `run` and the same boundary policy, so everything on this page applies to it
+unchanged:
 
 ```
-agency greet.agency --name bob      # error: unknown option '--name'
-agency greet.agency bob             # error: too many arguments for 'default'
+agency greet.agency --name alice
+agency --policy strict greet.agency --name alice
+agency greet.agency --max-cost 5     # same warning as run
 ```
 
-This predates the position rule and was not changed by it. Anyone who needs to
-pass arguments must write `agency run` in full. Fixing it means giving the
-default command the same `[nodeArgs...]` argument, pass-through, and guard that
-`run` has.
+Two things make it different from a named command, and both are in the policy
+rather than in the walk.
+
+**It has no command word to step over.** Its `command` is `null`, and the walk
+starts on the filename itself rather than one token later.
+
+**Its flags sit at the top level.** In `agency --policy strict greet.agency`,
+`--policy` appears where a root flag would. So the scan that locates the
+subcommand is given every option agency owns anywhere, not just the root's —
+otherwise it stops on `strict` and treats that as the filename.
+
+That second point is why `splitCommandLine` also takes the list of command
+names: without it, the shorthand policy would claim real commands, and
+`agency compile a.agency b.agency` would get a separator pushed into its file
+list. Aliases are included, so `agency fmt x.agency -i` stays a format run.
 
 ## Testing
 

--- a/packages/agency-lang/docs/dev/cli-arguments.md
+++ b/packages/agency-lang/docs/dev/cli-arguments.md
@@ -203,19 +203,23 @@ that doing so would break any program that legitimately wants positional
 arguments beginning with a dash, which is the reason POSIX has the convention at
 all.
 
-## One splitter, two policies
+## One splitter, three policies
 
-`agency agent` needs the same boundary for a different shape: it takes no
-filename, and it forwards its whole command line to an agent that has its own
-flag parser. It used to have its own copy of the walk, with a hand-written list
-of the flags to keep on agency's side.
+`agency agent` and the bare `agency greet.agency` shorthand need the same
+boundary in different shapes. The agent takes no filename and forwards its whole
+command line to a program with its own flag parser; it used to carry a second
+copy of the walk over a hand-written list of flags.
 
-Both now go through `splitCommandLine` with a policy each:
+All three now go through `splitCommandLine` with a policy each:
 
 ```ts
 { command: "run",   ownedPositionals: 1, options: run + root, warnOnCollision: true  }
 { command: "agent", ownedPositionals: 0, options: agent only, warnOnCollision: false }
+{ command: null,    ownedPositionals: 1, options: run + root, warnOnCollision: true  }
 ```
+
+The third is the shorthand, `agency greet.agency`; see below for what `null`
+means and why it needs the list of command names.
 
 `ownedPositionals` is the difference that matters: `run` owns the filename, so
 the line falls after it; `agent` owns nothing, so the line falls at the first
@@ -227,7 +231,7 @@ because forwarding a flag agency also defines is the entire point of the
 command, not a mistake.
 
 The walk itself — arity, attached values, short bundles — lives in one place, so
-a fix to short-option parsing reaches both.
+a fix to short-option parsing reaches all three.
 
 ## The shorthand is `run` with the word left out
 

--- a/packages/agency-lang/docs/site/cli/run.md
+++ b/packages/agency-lang/docs/site/cli/run.md
@@ -19,6 +19,9 @@ This is also the default if no command is specified:
 agency foo.agency
 ```
 
+The shorthand takes the same options and splits its command line the same way,
+so `agency greet.agency --name alice` works exactly like the `run` form below.
+
 Note: This compiles the file to JavaScript and immediately executes it under the same Node binary that's running the CLI. You can also pass `--resume <statefile>` to resume a previously saved execution, or `--trace` to write an execution trace.
 
 ## Options

--- a/packages/agency-lang/lib/cli/commandLine.test.ts
+++ b/packages/agency-lang/lib/cli/commandLine.test.ts
@@ -24,8 +24,11 @@ const RUN_OPTIONS: CliOption[] = [
   { long: "--trace-file", arity: "required" },
 ];
 
+const COMMAND_NAMES = ["run", "agent", "compile", "build", "format", "fmt"];
+
 const BOUNDARIES: Boundary[] = [
   { command: "run", ownedPositionals: 1, options: RUN_OPTIONS, warnOnCollision: true },
+  { command: null, ownedPositionals: 1, options: RUN_OPTIONS, warnOnCollision: true },
   {
     command: "agent",
     ownedPositionals: 0,
@@ -36,7 +39,7 @@ const BOUNDARIES: Boundary[] = [
 
 const N = ["node", "agency"];
 const split = (...words: string[]) =>
-  splitCommandLine([...N, ...words], ROOT, BOUNDARIES);
+  splitCommandLine([...N, ...words], ROOT, BOUNDARIES, COMMAND_NAMES);
 
 describe("splitCommandLine: run", () => {
   it("draws the line after the filename", () => {
@@ -81,7 +84,9 @@ describe("splitCommandLine: run", () => {
       [...N, "run", "greet.agency"],
       [...N, "run", "-v", "greet.agency"],
     ]) {
-      expect(splitCommandLine(argv, ROOT, BOUNDARIES)).toEqual({ argv });
+      expect(splitCommandLine(argv, ROOT, BOUNDARIES, COMMAND_NAMES)).toEqual({
+        argv,
+      });
     }
   });
 
@@ -116,7 +121,9 @@ describe("splitCommandLine: run", () => {
 
   it("stays quiet when the user claimed the flag with a separator", () => {
     const argv = [...N, "run", "greet.agency", "--", "--max-cost", "5"];
-    expect(splitCommandLine(argv, ROOT, BOUNDARIES)).toEqual({ argv });
+    expect(splitCommandLine(argv, ROOT, BOUNDARIES, COMMAND_NAMES)).toEqual({
+      argv,
+    });
   });
 
   it("matches commander on what an optional value swallows", () => {
@@ -175,10 +182,52 @@ describe("splitCommandLine: agent", () => {
   });
 });
 
+describe("splitCommandLine: the shorthand", () => {
+  it("splits `agency greet.agency` exactly like `agency run greet.agency`", () => {
+    expect(split("greet.agency", "--name", "alice")).toEqual({
+      argv: [...N, "greet.agency", "--", "--name", "alice"],
+    });
+    expect(split("--policy", "strict", "greet.agency", "--name", "a")).toEqual({
+      argv: [...N, "--policy", "strict", "greet.agency", "--", "--name", "a"],
+    });
+  });
+
+  it("warns about a misplaced agency flag, like run", () => {
+    expect(split("greet.agency", "--max-cost", "5").warning).toContain(
+      "--max-cost went to your program",
+    );
+  });
+
+  it("adds nothing when there are no program arguments", () => {
+    for (const argv of [[...N, "greet.agency"], [...N]]) {
+      expect(splitCommandLine(argv, ROOT, BOUNDARIES, COMMAND_NAMES)).toEqual({
+        argv,
+      });
+    }
+  });
+
+  it("does not claim a real command, including an alias", () => {
+    for (const words of [
+      ["compile", "a.agency", "b.agency"],
+      ["build", "a.agency", "b.agency"],
+      ["fmt", "a.agency", "-i"],
+      ["format", "a.agency", "-i"],
+    ]) {
+      const argv = [...N, ...words];
+      expect(splitCommandLine(argv, ROOT, BOUNDARIES, COMMAND_NAMES)).toEqual({
+        argv,
+      });
+    }
+  });
+});
+
 describe("splitCommandLine: other commands", () => {
   it("leaves a command with no boundary untouched", () => {
+    // `label` is a real command, so the shorthand policy must not claim it.
     const argv = [...N, "label", "ingest", "--store", "/tmp/s"];
-    expect(splitCommandLine(argv, ROOT, BOUNDARIES)).toEqual({ argv });
+    expect(
+      splitCommandLine(argv, ROOT, [...BOUNDARIES], ["label", ...COMMAND_NAMES]),
+    ).toEqual({ argv });
   });
 });
 

--- a/packages/agency-lang/lib/cli/commandLine.ts
+++ b/packages/agency-lang/lib/cli/commandLine.ts
@@ -11,19 +11,21 @@
  * So the boundary is drawn before commander runs, by inserting `--`. Commander
  * removes the separator itself, so the program never sees it.
  *
- * Two commands need this and differ only in their policy, which is why they
+ * Three commands need this and differ only in their policy, which is why they
  * share one walk rather than one each:
  *
- *   run    one owned positional (the filename); warns on a collision
- *   agent  no owned positionals; forwards its own flags without comment
+ *   run       one owned positional (the filename); warns on a collision
+ *   agent     no owned positionals; forwards its own flags without comment
+ *   shorthand `agency greet.agency` — run without the word `run`
  */
 export type Arity = "none" | "required" | "optional";
 
 export type CliOption = { short?: string; long?: string; arity: Arity };
 
 export type Boundary = {
-  /** Subcommand this applies to. */
-  command: string;
+  /** Subcommand this applies to, or null for the bare `agency greet.agency`
+   *  form, which is whatever is left when the first word names no command. */
+  command: string | null;
   /** Agency's own positional arguments, which sit before the program's. */
   ownedPositionals: number;
   /** Options agency parses before the boundary. */
@@ -44,15 +46,33 @@ export function splitCommandLine(
   argv: string[],
   rootOptions: CliOption[],
   boundaries: Boundary[],
+  /** Every command and alias the CLI knows, so a filename can be told from a
+   *  command name. Without it `agency compile a.agency b.agency` would look
+   *  like the shorthand and have a separator pushed into its file list. */
+  commandNames: string[] = [],
 ): SplitCommandLine {
-  const subcommand = findSubcommandIndex(argv, rootOptions);
+  // The shorthand puts run's flags at the top level, so the scan for the
+  // subcommand has to recognize every flag agency owns anywhere — not just the
+  // root's. Otherwise `agency --policy strict greet.agency` stops on `strict`
+  // and treats it as the filename.
+  const subcommand = findSubcommandIndex(argv, [
+    ...rootOptions,
+    ...boundaries.flatMap((b) => b.options),
+  ]);
   if (subcommand === -1) return { argv };
-  const boundary = boundaries.find((b) => b.command === argv[subcommand]);
+  const named = boundaries.find((b) => b.command === argv[subcommand]);
+  const boundary =
+    named ??
+    (commandNames.includes(argv[subcommand])
+      ? undefined
+      : boundaries.find((b) => b.command === null));
   if (boundary === undefined) return { argv };
 
   // Agency's flags come first, then its own positionals. Anything after that
   // is the program's, flags included — which is what the position rule means.
-  let i = subcommand + 1;
+  // The shorthand has no command word to step over, so its walk starts on the
+  // filename itself.
+  let i = subcommand + (boundary.command === null ? 0 : 1);
   while (isFlag(argv[i])) {
     // The user drew the line themselves.
     if (argv[i] === "--") return { argv };

--- a/packages/agency-lang/lib/cli/help.ts
+++ b/packages/agency-lang/lib/cli/help.ts
@@ -12,7 +12,7 @@ Usage:
   agency ast [input]                    Parse .agency file and show AST (reads from stdin if no input)
   agency preprocess [input]             Parse .agency file and show AST after preprocessing (reads from stdin if no input)
   agency graph [input]                  Render Mermaid graph from .agency file (reads from stdin if no input)
-  agency <input>                        Compile and run .agency file (shorthand)
+  agency <input> [args...]              Compile and run .agency file (shorthand for run)
 
 Arguments:
   input                                 Path to .agency input file or directory (or omit to read from stdin for format/parse)
@@ -43,6 +43,6 @@ Examples:
   agency format -i ./scripts            Format all .agency files in directory in-place
   cat script.agency | agency format     Format from stdin
   echo "x = 5" | agency parse           Parse from stdin
-  agency script.agency                  Compile and run (shorthand)
+  agency script.agency --name alice     Compile and run; flags after the file go to it
 `);
 }

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -1960,17 +1960,27 @@ export function createProgram(deps: CliDependencies = {}): Command {
       interruptsCmd(config, file);
     });
 
+  // `agency greet.agency` is `agency run greet.agency` with the word left out,
+  // so it takes the same options and splits its command line the same way.
   addRunOptions(
     program
       .command("default", { isDefault: true, hidden: true })
-      .argument("[file]"),
-  ).action((file: string | undefined, options: RunOptions) => {
+      .argument("[file]")
+      .argument(
+        "[nodeArgs...]",
+        "Arguments after the filename go to the program; read them with std::args",
+      ),
+  ).action((
+    file: string | undefined,
+    nodeArgs: string[],
+    options: RunOptions,
+  ) => {
     if (!file) {
       program.help();
       return;
     }
     if (file.endsWith(".agency") || fs.existsSync(file)) {
-      runWithOptions(file, options);
+      runWithOptions(file, options, nodeArgs);
     } else {
       console.error(`Error: Unknown command '${file}'`);
       console.error("Run 'agency help' for usage information");
@@ -2006,12 +2016,30 @@ export async function runCli(
   // The flag list comes from commander itself. A hand-written copy would drift
   // the moment someone adds an option to addRunOptions, and it would fail
   // silently: the new flag would be forwarded to the program and do nothing.
+  const runOptions = [
+    ...optionsOf(commandNamed(program, "run")),
+    ...optionsOf(program),
+  ];
+  // Every name commander answers to, so the shorthand policy does not claim a
+  // command. Aliases count: `agency fmt x.agency` must stay a format run.
+  const commandNames = program.commands.flatMap((cmd) => [
+    cmd.name(),
+    ...cmd.aliases(),
+  ]);
   const prepared = splitCommandLine(argv, optionsOf(program), [
     {
       command: "run",
       // The filename. Everything after it is the program's command line.
       ownedPositionals: 1,
-      options: [...optionsOf(commandNamed(program, "run")), ...optionsOf(program)],
+      options: runOptions,
+      warnOnCollision: true,
+    },
+    {
+      // `agency greet.agency --name alice`. Identical to run in every way that
+      // shows: same options, same owned filename, same warning.
+      command: null,
+      ownedPositionals: 1,
+      options: runOptions,
       warnOnCollision: true,
     },
     {
@@ -2024,7 +2052,7 @@ export async function runCli(
       options: optionsOf(commandNamed(program, "agent")),
       warnOnCollision: false,
     },
-  ]);
+  ], commandNames);
   if (prepared.warning !== undefined) console.warn(prepared.warning);
   await program.parseAsync(prepared.argv);
 }

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -2022,10 +2022,15 @@ export async function runCli(
   ];
   // Every name commander answers to, so the shorthand policy does not claim a
   // command. Aliases count: `agency fmt x.agency` must stay a format run.
-  const commandNames = program.commands.flatMap((cmd) => [
-    cmd.name(),
-    ...cmd.aliases(),
-  ]);
+  //
+  // Two sources, because neither is complete. `program.commands` omits the
+  // implicit `help` command commander adds itself, which would make
+  // `agency help --version` look like a program called `help`.
+  // `visibleCommands` has `help` but drops hidden commands such as `remote`.
+  const commandNames = [
+    ...program.commands,
+    ...program.createHelp().visibleCommands(program),
+  ].flatMap((cmd) => [cmd.name(), ...cmd.aliases()]);
   const prepared = splitCommandLine(argv, optionsOf(program), [
     {
       command: "run",

--- a/packages/agency-lang/tests/integration/cli/test.mjs
+++ b/packages/agency-lang/tests/integration/cli/test.mjs
@@ -353,6 +353,35 @@ node main() {
     "./node_modules/.bin/agency run argful.agency ignored",
   );
   assertIncludes(withoutMappedArg, "got: undefined");
+  // --- The shorthand behaves exactly like `agency run` ---
+  // `agency greet.agency` is documented as shorthand for `agency run
+  // greet.agency`, so every case above must hold with the word left out.
+  const shortGreeted = run(dir, "./node_modules/.bin/agency greet.agency --name alice");
+  assertIncludes(shortGreeted, "Hello, alice!");
+
+  const shortWithAgencyFlag = run(
+    dir,
+    "./node_modules/.bin/agency --max-cost 5 greet.agency --name alice",
+  );
+  assertIncludes(shortWithAgencyFlag, "Hello, alice!");
+
+  const shortSeparator = run(
+    dir,
+    "./node_modules/.bin/agency greet.agency -- --name alice",
+  );
+  assertIncludes(shortSeparator, "Hello, alice!");
+
+  const shortWarned = run(
+    dir,
+    "./node_modules/.bin/agency greet.agency --max-cost 5 2>&1",
+    { expectFail: true },
+  );
+  assertIncludes(shortWarned, "Warning: --max-cost went to your program");
+
+  // A real command must not be mistaken for a filename. compile takes a list of
+  // files, so a separator pushed in here would break it.
+  run(dir, "./node_modules/.bin/agency compile greet.agency basic.agency");
+
   console.log("Test 8 passed");
 
   // --- Test 8b: a node parameter default applies on the direct-run path ---

--- a/packages/agency-lang/tests/integration/cli/test.mjs
+++ b/packages/agency-lang/tests/integration/cli/test.mjs
@@ -382,6 +382,21 @@ node main() {
   // files, so a separator pushed in here would break it.
   run(dir, "./node_modules/.bin/agency compile greet.agency basic.agency");
 
+  // Including commander's implicit `help`, which is not in program.commands.
+  // Treating it as a filename turns these into failed runs of a missing
+  // program instead of printing help and the version.
+  const helpHelp = run(dir, "./node_modules/.bin/agency help --help 2>&1");
+  assertIncludes(helpHelp, "Usage: agency");
+  const helpVersion = run(dir, "./node_modules/.bin/agency help --version 2>&1");
+  if (helpVersion.includes("Warning:")) {
+    throw new Error(`the implicit help command was treated as a file: ${helpVersion}`);
+  }
+  // And a hidden command, which visibleCommands leaves out.
+  const remoteHelp = run(dir, "./node_modules/.bin/agency remote --help 2>&1");
+  if (remoteHelp.includes("Warning:")) {
+    throw new Error(`a hidden command was treated as a file: ${remoteHelp}`);
+  }
+
   console.log("Test 8 passed");
 
   // --- Test 8b: a node parameter default applies on the direct-run path ---


### PR DESCRIPTION
## What this does

`agency greet.agency` is documented as shorthand for `agency run greet.agency`, but that equivalence was false the moment your program took arguments:

```
agency greet.agency --name bob   # error: unknown option '--name'
agency greet.agency bob          # error: too many arguments for 'default'
```

It was a hidden default command declaring only `[file]` — no variadic to forward, and no boundary policy. It now has both, sharing `run`'s options and `run`'s policy, so every form works the same way:

```
agency greet.agency --name alice                      # Hello, alice!
agency --policy strict greet.agency --name alice      # Hello, alice!
agency greet.agency -- --name alice                   # Hello, alice!
agency -c custom.json greet.agency --name alice       # Hello, alice!

agency greet.agency --max-cost 5
Warning: --max-cost went to your program, not to agency.
```

The first two used to fail.

## How

One new policy, in the same shared splitter #805 introduced:

```ts
{ command: null, ownedPositionals: 1, options: runOptions, warnOnCollision: true }
```

Two things about the shorthand differ from a named command, and both live in the policy rather than in the walk.

**No command word to step over.** `command: null`, so the walk starts on the filename itself rather than one token later.

**Its flags sit at the top level.** In `agency --policy strict greet.agency`, `--policy` appears where a root flag would. The scan that locates the subcommand is therefore given every option agency owns anywhere, not just the root's. Without that it stops on `strict` and runs a file by that name — which is how I found it, since a test caught it.

`splitCommandLine` also takes the list of command names now, aliases included. Otherwise the shorthand policy would claim real commands and push a separator into `agency compile a.agency b.agency`.

## Testing

- `lib/cli/commandLine.test.ts` — the shorthand splitting like `run`, agency flags before the filename, the warning, and a case per command/alias proving `compile`, `build`, `fmt` and `format` are left alone
- `tests/integration/cli/test.mjs` — the real binary over all five forms above, plus `agency compile a.agency b.agency` to prove a two-file command still works

Green locally: those, the three spawn suites, `labelCommand.test.ts`, `scripts/agency.test.ts`, and the CLI, statelog and eval-run integration suites.

## Docs

`docs/dev/cli-arguments.md` — the "Known limitation" section becomes a description of how the shorthand works, since it is no longer a limitation. Plus `docs/site/cli/run.md` and the `agency help` text, which both described a shorthand that could not take arguments.

## Not in this PR

The investigation also turned up two smaller gaps in `agency agent`: a misplaced `--max-cost` is forwarded to the agent, and root flags like `-c` cannot reach agency at all. Both currently produce a clear error from the agent rather than failing silently, so I left them out of this change. Happy to do them next if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
