### PR TITLE
Per-file stdlib dependency tracking in the build manifest

### DIFF
--- a/packages/agency-lang/docs/dev/incremental-builds.md
+++ b/packages/agency-lang/docs/dev/incremental-builds.md
@@ -19,11 +19,56 @@ in a field can only cause an unnecessary rebuild, never a stale skip.
 |---|---|
 | `sourceHash` | The module's own bytes. Also the soundness anchor: imports are part of the source, so an unchanged `sourceHash` implies the recorded `deps` list is still the module's true deps. |
 | `deps` + `depsHash` | Transitive agency imports (paths + one hash over their contents, built by `computeDepsHash` — the single shared construction). Freshness also requires every recorded dep to have a manifest entry whose OUTPUT exists: a skip never recurses into deps, so a deleted dep `.js` would otherwise ship a broken import. |
-| `stdlibHash` | One hash over all stdlib sources. The closure walker excludes `std::` imports, so `depsHash` cannot see stdlib edits — yet stdlib content genuinely shapes output (`resolveReExports` bakes resolved stdlib paths in). Any stdlib edit rebuilds the world. |
-| `hasPkgImports` | Modules whose import subtree touches `pkg::` are NEVER skipped: package content shapes emitted imports and is invisible to the manifest. Detection shares the closure walker's edge extraction (`programHasPkgImport`), covering plain imports, node imports, and re-exports. |
+| `stdlibHash` | Two flavors, selected per entry by `stdlibHashFor` (schema v2). NON-stdlib entries store one hash over all stdlib source CONTENTS: the closure walker excludes `std::` imports, so `depsHash` cannot see stdlib edits — yet stdlib content genuinely shapes their output (`resolveReExports` bakes resolved stdlib paths in), so any stdlib edit rebuilds their world. STDLIB-RESIDENT entries store a names-only hash (`computeStdlibNamesHash`, the sorted file list with no contents): their `deps` DO carry real `std::`-resolved per-file edges, so editing one stdlib file rebuilds only its importers, while adding/removing/renaming a stdlib file still rebuilds all of stdlib (path resolution could shift). This is what makes `agency compile stdlib/` incremental for the everyday one-file edit. |
+| `hasPkgImports` | Modules whose import subtree touches `pkg::` are NEVER skipped: package content shapes emitted imports and is invisible to the manifest. Detection shares the closure walker's edge extraction (`programHasPkgImport`), covering plain imports, node imports, and re-exports; the fingerprint walk (below) reports it subtree-wide. |
+| `cacheable` | `false` when dependency discovery could not fully establish the module's subtree — recorded (so `outputFor` keeps working) but never fresh. Set by the fingerprint walk for: a splice anywhere in the subtree (splices expand at compile time and may legally emit top-level imports, so raw-parse edges are not the true edges there), or an unparseable/missing reachable file (its own imports are unknowable). |
 | `compilerStamp` | Content hash of the compiled compiler (`dist/lib` excluding `runtime/` — generated text does not depend on runtime internals — and `agents/`, which are the agency compiler's own output; including them would make every build invalidate the next). Content, not mtimes: `tsc-alias` rewrites the whole outDir every build. |
 | `configKey` | Compiled output bakes config in. Canonical because configs pass through zod (schema shape order). |
 | `outputPath` | Where the `.js` landed; a missing output is stale. |
+
+## The dependency fingerprint (stdlib-resident modules)
+
+Stdlib modules compile closure-free by design (the init-plan analysis
+deliberately never roots at a stdlib file), so their deps cannot come from
+the session closure. They come from `dependencyFingerprint`
+(`lib/compiler/depFingerprint.ts`): a breadth-first walk over
+`parseAgencyFileCached` + `agencyImportTargets(…, { resolveStdlib: true })`
+that returns `{ deps, hasPkgImports, cacheable }`. It is a shared contract
+(the planned doc cache consumes it too), and it makes no freshness
+decisions — the tracker interprets the data.
+
+Completeness is data, not an exception. A missing direct target stays in
+`deps` (a missing file hashes to null at check time, so the entry stays
+stale while the file is absent) but marks the fingerprint
+`cacheable: false`, as do unparseable reachable files and splices anywhere
+in the subtree. The walk never throws for *discovery* reasons — it runs on
+the record path, after the module already compiled and emitted, and must
+not turn that success into a failure. "Discovery reasons" is an enumerated
+errno list (`ENOENT`, `EACCES`, `EPERM`, `EIO`, `EBUSY`, `EMFILE`,
+`ENFILE`, `EISDIR`, `ENOTDIR`, `ELOOP`, `ESTALE` — the stat-then-read race
+classes), never "has a `code` property": programming errors like
+`ERR_INVALID_ARG_TYPE` carry string codes too and must surface, or a real
+bug would silently pin modules stale forever. Resolver throws are a vacuous
+class in this walk — `pkg::` (the only throwing resolution path) is
+filtered before resolution; if a throwing resolver path ever appears for
+`std::`/relative targets, extend the classifier.
+
+The residual soundness assumption, mirrored from the user-module side: a
+stdlib module's output does not depend on the *contents* of a stdlib file
+it does not transitively import (structural changes are separately covered
+by the names hash).
+
+**The single-file guarantee boundary:** `agency compile stdlib/math.agency`
+records an entry, but `compileEntry` does not recurse into `std::` imports,
+so the deps only have manifest entries (and outputs) after a directory
+compile created them. Until then the dep-entry freshness clause keeps the
+file stale — safe over-rebuilding; do not weaken that clause to "fix" it.
+Precise per-file freshness is guaranteed after a complete
+`agency compile stdlib/`.
+
+**Schema migration:** the `cacheable` field and the two-hash-flavor rule
+bumped the manifest to version 2. Old manifests are discarded on load —
+one full rebuild after upgrading, never a misread.
 
 ## Freshness modes and the tracker
 

--- a/packages/agency-lang/lib/compiler/buildManifest.test.ts
+++ b/packages/agency-lang/lib/compiler/buildManifest.test.ts
@@ -262,9 +262,13 @@ describe("isEntryFresh — each field is load-bearing", () => {
 
 describe("stdlib hash flavors", () => {
   test("stdlibHashFlavor: names inside stdlibDir, contents outside, boundary exact", () => {
-    expect(stdlibHashFlavor("/m/stdlib/math.agency", "/m/stdlib", "N", "C")).toBe("N");
-    expect(stdlibHashFlavor("/m/src/app.agency", "/m/stdlib", "N", "C")).toBe("C");
-    expect(stdlibHashFlavor("/m/stdlib-copy/x.agency", "/m/stdlib", "N", "C")).toBe("C");
+    // path.join throughout: production compares with path.sep appended,
+    // so hard-coded "/" separators would miss the boundary on Windows.
+    const m = path.join(os.tmpdir(), "m");
+    const stdlibDir = path.join(m, "stdlib");
+    expect(stdlibHashFlavor(path.join(stdlibDir, "math.agency"), stdlibDir, "N", "C")).toBe("N");
+    expect(stdlibHashFlavor(path.join(m, "src", "app.agency"), stdlibDir, "N", "C")).toBe("C");
+    expect(stdlibHashFlavor(path.join(m, "stdlib-copy", "x.agency"), stdlibDir, "N", "C")).toBe("C");
   });
 
   test("computeStdlibNamesHash: edits invisible; add/rename visible; recursive; .agency-only; order-insensitive", () => {

--- a/packages/agency-lang/lib/compiler/buildManifest.test.ts
+++ b/packages/agency-lang/lib/compiler/buildManifest.test.ts
@@ -9,9 +9,11 @@ import {
   loadManifest,
   saveManifest,
   computeStdlibHash,
+  computeStdlibNamesHash,
   computeCompilerStamp,
   isEntryFresh,
   manifestDirFor,
+  stdlibHashFlavor,
   MANIFEST_DIR_NAME,
   type BuildManifest,
   type FreshnessContext,
@@ -33,11 +35,12 @@ function freshFixture(): { dir: string; manifest: BuildManifest; ctx: FreshnessC
   const shared = {
     stdlibHash: "STDLIB",
     hasPkgImports: false,
+    cacheable: true,
     configKey: "{}",
     compilerStamp: "COMPILER",
   };
   const manifest: BuildManifest = {
-    version: 1,
+    version: 2,
     entries: {
       "main.agency": {
         ...shared,
@@ -58,6 +61,10 @@ function freshFixture(): { dir: string; manifest: BuildManifest; ctx: FreshnessC
   const ctx: FreshnessContext = {
     manifestDir: dir,
     stdlibHash: "STDLIB",
+    stdlibNamesHash: "NAMES",
+    // A subdir the fixture modules are NOT in, so they carry the contents
+    // flavor and every pre-existing expectation holds unchanged.
+    stdlibDir: path.join(dir, "stdlib"),
     compilerStamp: "COMPILER",
     configKey: "{}",
   };
@@ -80,7 +87,7 @@ describe("manifest IO", () => {
 
   test("saveManifest round-trips atomically and leaves no tmp file", () => {
     const dir = tmp();
-    const manifest: BuildManifest = { version: 1, entries: {} };
+    const manifest: BuildManifest = { version: 2, entries: {} };
     saveManifest(dir, manifest);
     expect(loadManifest(dir)).toEqual(manifest);
     expect(fs.readdirSync(path.join(dir, MANIFEST_DIR_NAME))).toEqual(["manifest.json"]);
@@ -213,5 +220,88 @@ describe("isEntryFresh — each field is load-bearing", () => {
     const { dir, manifest, ctx } = freshFixture();
     fs.unlinkSync(path.join(dir, "main.js"));
     expect(isEntryFresh("main.agency", manifest, ctx)).toBe(false);
+  });
+
+  test("cacheable:false → never fresh; true restores", () => {
+    const { manifest, ctx } = freshFixture();
+    manifest.entries["main.agency"].cacheable = false;
+    expect(isEntryFresh("main.agency", manifest, ctx)).toBe(false);
+    manifest.entries["main.agency"].cacheable = true;
+    expect(isEntryFresh("main.agency", manifest, ctx)).toBe(true);
+  });
+
+  test("stdlib-resident module compares against the NAMES flavor", () => {
+    const { dir, manifest, ctx } = freshFixture();
+    // Relocate the fixture module under ctx.stdlibDir so the flavor flips.
+    fs.mkdirSync(ctx.stdlibDir, { recursive: true });
+    for (const f of ["main.agency", "dep.agency", "main.js", "dep.js"]) {
+      fs.renameSync(path.join(dir, f), path.join(ctx.stdlibDir, f));
+    }
+    const relocate = (rel: string) => path.join("stdlib", rel);
+    const entries = manifest.entries;
+    manifest.entries = {
+      [relocate("main.agency")]: {
+        ...entries["main.agency"],
+        deps: [relocate("dep.agency")],
+        outputPath: relocate("main.js"),
+        stdlibHash: "NAMES",
+      },
+      [relocate("dep.agency")]: {
+        ...entries["dep.agency"],
+        outputPath: relocate("dep.js"),
+        stdlibHash: "NAMES",
+      },
+    };
+    expect(isEntryFresh(relocate("main.agency"), manifest, ctx)).toBe(true);
+    // Contents flavor changing does NOT stale a stdlib-resident entry…
+    expect(isEntryFresh(relocate("main.agency"), manifest, { ...ctx, stdlibHash: "OTHER" })).toBe(true);
+    // …but the names flavor changing does.
+    expect(isEntryFresh(relocate("main.agency"), manifest, { ...ctx, stdlibNamesHash: "OTHER" })).toBe(false);
+  });
+});
+
+describe("stdlib hash flavors", () => {
+  test("stdlibHashFlavor: names inside stdlibDir, contents outside, boundary exact", () => {
+    expect(stdlibHashFlavor("/m/stdlib/math.agency", "/m/stdlib", "N", "C")).toBe("N");
+    expect(stdlibHashFlavor("/m/src/app.agency", "/m/stdlib", "N", "C")).toBe("C");
+    expect(stdlibHashFlavor("/m/stdlib-copy/x.agency", "/m/stdlib", "N", "C")).toBe("C");
+  });
+
+  test("computeStdlibNamesHash: edits invisible; add/rename visible; recursive; .agency-only; order-insensitive", () => {
+    const dir = tmp();
+    fs.writeFileSync(path.join(dir, "a.agency"), "v1");
+    fs.mkdirSync(path.join(dir, "web"));
+    fs.writeFileSync(path.join(dir, "web", "n.agency"), "nested");
+    const h1 = computeStdlibNamesHash(dir);
+    fs.writeFileSync(path.join(dir, "a.agency"), "v2 different content");
+    expect(computeStdlibNamesHash(dir)).toBe(h1); // edit invisible
+    fs.writeFileSync(path.join(dir, "notes.md"), "x");
+    expect(computeStdlibNamesHash(dir)).toBe(h1); // non-.agency ignored
+    fs.renameSync(path.join(dir, "web", "n.agency"), path.join(dir, "web", "m.agency"));
+    const h2 = computeStdlibNamesHash(dir);
+    expect(h2).not.toBe(h1); // NESTED rename visible
+    fs.rmSync(path.join(dir, "web", "m.agency"));
+    const h3 = computeStdlibNamesHash(dir);
+    expect(h3).not.toBe(h2); // nested delete visible
+    fs.writeFileSync(path.join(dir, "b.agency"), "new");
+    expect(computeStdlibNamesHash(dir)).not.toBe(h3); // add visible
+    // Equivalent trees hash identically regardless of creation order.
+    const dir2 = tmp();
+    fs.writeFileSync(path.join(dir2, "b.agency"), "other content");
+    fs.writeFileSync(path.join(dir2, "a.agency"), "yet more");
+    const dir3 = tmp();
+    fs.writeFileSync(path.join(dir3, "a.agency"), "1");
+    fs.writeFileSync(path.join(dir3, "b.agency"), "2");
+    expect(computeStdlibNamesHash(dir2)).toBe(computeStdlibNamesHash(dir3));
+  });
+
+  test("version-1 (or any wrong-version) manifest is discarded", () => {
+    const dir = tmp();
+    fs.mkdirSync(path.join(dir, MANIFEST_DIR_NAME), { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, MANIFEST_DIR_NAME, "manifest.json"),
+      JSON.stringify({ version: 1, entries: { "x.agency": { sourceHash: "s" } } }),
+    );
+    expect(loadManifest(dir).entries).toEqual({});
   });
 });

--- a/packages/agency-lang/lib/compiler/buildManifest.ts
+++ b/packages/agency-lang/lib/compiler/buildManifest.ts
@@ -19,12 +19,22 @@
  *    Freshness ALSO requires every recorded dep to have a manifest entry
  *    whose OUTPUT exists: a skip never recurses into deps, so a deleted
  *    dep .js would otherwise survive the skip and ship a broken import.
- *  - stdlibHash: the closure walker EXCLUDES std:: imports, so no depsHash
- *    can see a stdlib edit — yet stdlib content genuinely shapes emitted
- *    output (resolveReExports bakes resolved stdlib paths in). Any stdlib
- *    edit rebuilds the world.
+ *  - stdlibHash, two flavors selected by stdlibHashFor: NON-stdlib entries
+ *    store the full-content stdlib hash — the closure walker excludes
+ *    std:: imports, so no depsHash can see a stdlib edit, yet stdlib
+ *    content shapes their output (resolveReExports bakes resolved stdlib
+ *    paths in); any stdlib edit rebuilds their world. STDLIB-RESIDENT
+ *    entries instead store the names-only hash (computeStdlibNamesHash):
+ *    their deps DO include std::-resolved per-file edges (recorded via
+ *    dependencyFingerprint), so content changes are tracked per file and
+ *    only add/remove/rename of a stdlib file rebuilds all of stdlib.
  *  - hasPkgImports: pkg:: imports are likewise closure-invisible and shape
- *    emitted imports; modules touching pkg:: are NEVER skipped.
+ *    emitted imports; modules touching pkg:: are NEVER skipped. Subtree-
+ *    wide when recorded via dependencyFingerprint.
+ *  - cacheable: false when dependency discovery could not fully establish
+ *    the subtree — a splice anywhere in it (splices expand at compile time
+ *    and may legally emit imports, so raw-parse edges are not the true
+ *    edges), or an unparseable/missing reachable file. Never fresh.
  *  - compilerStamp: content hash of the compiled compiler (dist/lib minus
  *    runtime/ and agents/). runtime/ because generated TEXT does not
  *    depend on runtime internals; agents/ because those are the agency
@@ -48,6 +58,10 @@ export type ManifestEntry = {
   depsHash: string;
   stdlibHash: string;
   hasPkgImports: boolean;
+  /** False when dependency discovery could not fully establish the
+   *  subtree (splice anywhere in it, unparseable/missing reachable file).
+   *  Such entries are recorded (outputFor keeps working) but never fresh. */
+  cacheable: boolean;
   configKey: string;
   compilerStamp: string;
   /** Manifest-dir-relative output path. */
@@ -55,7 +69,7 @@ export type ManifestEntry = {
 };
 
 export type BuildManifest = {
-  version: 1;
+  version: 2;
   /** Keyed by manifest-dir-relative module path. */
   entries: Record<string, ManifestEntry>;
 };
@@ -76,7 +90,7 @@ export function manifestDirFor(entryFile: string): string {
 }
 
 function emptyManifest(): BuildManifest {
-  return { version: 1, entries: Object.create(null) };
+  return { version: 2, entries: Object.create(null) };
 }
 
 export function loadManifest(manifestDir: string): BuildManifest {
@@ -86,10 +100,10 @@ export function loadManifest(manifestDir: string): BuildManifest {
   }
   try {
     const parsed = JSON.parse(fs.readFileSync(file, "utf-8"));
-    if (parsed?.version !== 1 || typeof parsed.entries !== "object" || parsed.entries === null) {
+    if (parsed?.version !== 2 || typeof parsed.entries !== "object" || parsed.entries === null) {
       return emptyManifest();
     }
-    return { version: 1, entries: Object.assign(Object.create(null), parsed.entries) };
+    return { version: 2, entries: Object.assign(Object.create(null), parsed.entries) };
   } catch (e) {
     // A corrupt manifest only costs a full rebuild; log for traceability.
     console.warn(`agency: ignoring corrupt build manifest at ${file}: ${e}`);
@@ -171,6 +185,20 @@ export function computeStdlibHash(stdlibDir: string): string {
   return hashTree(stdlibDir, ".agency", []);
 }
 
+/** Stdlib STRUCTURE only (sorted file list, no contents). Stdlib-resident
+ *  entries carry this flavor: their per-file `deps` already track stdlib
+ *  CONTENT, but re-export resolution bakes resolved stdlib PATHS into
+ *  emitted output, so add/remove/rename must still rebuild the stdlib
+ *  world while a plain edit no longer does. */
+export function computeStdlibNamesHash(stdlibDir: string): string {
+  const hash = crypto.createHash("sha256");
+  for (const file of walkFiles(stdlibDir, ".agency", [])) {
+    hash.update(path.relative(stdlibDir, file));
+    hash.update("\0");
+  }
+  return hash.digest("hex");
+}
+
 export function computeCompilerStamp(distLibDir: string): string {
   return hashTree(distLibDir, ".js", ["runtime", "agents"]);
 }
@@ -178,9 +206,32 @@ export function computeCompilerStamp(distLibDir: string): string {
 export type FreshnessContext = {
   manifestDir: string;
   stdlibHash: string;
+  /** Names-only flavor (computeStdlibNamesHash) for stdlib-resident
+   *  entries; see stdlibHashFor. */
+  stdlibNamesHash: string;
+  /** Canonical absolute stdlib dir. Supplied by the tracker so this file
+   *  never imports importPaths.ts (leaf-ness, see the header). */
+  stdlibDir: string;
   compilerStamp: string;
   configKey: string;
 };
+
+/** ONE selection rule for which stdlib-hash flavor an entry carries.
+ *  Pure and argument-only so non-compile consumers (the doc cache) can
+ *  use it without fabricating a FreshnessContext. Writer and checker
+ *  both route through it — never inline the comparison. */
+export function stdlibHashFlavor(
+  absModule: string,
+  stdlibDir: string,
+  namesHash: string,
+  contentsHash: string,
+): string {
+  return absModule.startsWith(stdlibDir + path.sep) ? namesHash : contentsHash;
+}
+
+export function stdlibHashFor(absModule: string, ctx: FreshnessContext): string {
+  return stdlibHashFlavor(absModule, ctx.stdlibDir, ctx.stdlibNamesHash, ctx.stdlibHash);
+}
 
 /**
  * The skip algorithm, from the manifest alone — no parsing:
@@ -203,6 +254,7 @@ function entryHasValidShape(entry: ManifestEntry): boolean {
     typeof entry.depsHash === "string" &&
     typeof entry.stdlibHash === "string" &&
     typeof entry.hasPkgImports === "boolean" &&
+    typeof entry.cacheable === "boolean" &&
     typeof entry.configKey === "string" &&
     typeof entry.compilerStamp === "string" &&
     typeof entry.outputPath === "string"
@@ -221,7 +273,10 @@ export function isEntryFresh(
   if (entry.hasPkgImports) {
     return false;
   }
-  if (entry.stdlibHash !== ctx.stdlibHash) {
+  if (entry.cacheable === false) {
+    return false;
+  }
+  if (entry.stdlibHash !== stdlibHashFor(path.join(ctx.manifestDir, moduleRel), ctx)) {
     return false;
   }
   if (entry.compilerStamp !== ctx.compilerStamp) {

--- a/packages/agency-lang/lib/compiler/buildSession.ts
+++ b/packages/agency-lang/lib/compiler/buildSession.ts
@@ -40,6 +40,7 @@ import {
   type ManifestTracker,
 } from "./manifestTracker.js";
 import { deriveConfigKey } from "./buildManifest.js";
+import { dependencyFingerprint } from "./depFingerprint.js";
 import { transformSync } from "esbuild";
 import * as fs from "fs";
 import * as path from "path";
@@ -255,7 +256,8 @@ export class BuildSession {
   }
 
   /** BFS over the closure import graph. Stdlib entries have no closure —
-   *  their deps are [] by construction (stdlibHash covers them). */
+   *  their deps come from dependencyFingerprint on the record path
+   *  instead (std::-resolved, per-file). */
   private transitiveDeps(absModule: string): string[] {
     const programs = this.currentClosure?.programs;
     if (!programs || !programs[absModule]) {
@@ -553,24 +555,28 @@ export class BuildSession {
       fs.writeFileSync(outputFile, result.code, "utf-8");
       const esbuildEndTime = performance.now();
       logTime({ label: `Transformed code for ${absoluteInputFile} with esbuild`, start: esbuildStartTime, end: esbuildEndTime, verbose });
-      // Record ONLY when the module's deps are knowable: covered by the
-      // session closure, or a stdlib module (compiled closure-free by
-      // design; deps [] is correct because stdlibHash covers all of
-      // stdlib). A module compiled with a caller-threaded symbolTable and
-      // no closure (agency serve) has REAL imports the session cannot see
-      // — recording deps: [] would poison the manifest with an entry that
-      // skips despite edited imports.
+      // Record ONLY when the module's deps are knowable. Stdlib modules
+      // compile closure-free by design; their deps come from
+      // dependencyFingerprint (std::-resolved), which also reports whether
+      // the subtree is safely cacheable (splices / unparseable reachable
+      // files are not). A module compiled with a caller-threaded
+      // symbolTable and no closure (agency serve) has REAL imports the
+      // session cannot see — recording deps: [] would poison the manifest
+      // with an entry that skips despite edited imports.
       const isStdlibModule = absoluteInputFile.startsWith(getStdlibDir() + path.sep);
-      const depsKnowable =
-        isStdlibModule || this.currentClosure?.programs[absoluteInputFile] !== undefined;
-      if (depsKnowable) {
-        const transitiveDeps = this.transitiveDeps(absoluteInputFile);
+      if (isStdlibModule) {
         this.tracker.record(
           absoluteInputFile,
           path.resolve(outputFile),
-          transitiveDeps,
-          subtreeHasPkgImport(this.currentClosure, absoluteInputFile, transitiveDeps),
+          dependencyFingerprint(absoluteInputFile, config, { resolveStdlib: true }),
         );
+      } else if (this.currentClosure?.programs[absoluteInputFile] !== undefined) {
+        const transitiveDeps = this.transitiveDeps(absoluteInputFile);
+        this.tracker.record(absoluteInputFile, path.resolve(outputFile), {
+          deps: transitiveDeps,
+          hasPkgImports: subtreeHasPkgImport(this.currentClosure, absoluteInputFile, transitiveDeps),
+          cacheable: true,
+        });
       }
     }
     const compileEndTime = performance.now();

--- a/packages/agency-lang/lib/compiler/compileClosure.test.ts
+++ b/packages/agency-lang/lib/compiler/compileClosure.test.ts
@@ -3,11 +3,13 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import {
+  agencyImportTargets,
   buildCompiledClosure,
   CompileClosureError,
   programHasPkgImport,
 } from "./compileClosure.js";
 import { parseAgency } from "../parser.js";
+import { getStdlibDir } from "../importPaths.js";
 
 let dir: string;
 
@@ -206,5 +208,45 @@ describe("programHasPkgImport", () => {
         parse('import { map } from "std::index"\nimport { y } from "./local.agency"\n'),
       ),
     ).toBe(false);
+  });
+});
+
+describe("agencyImportTargets resolveStdlib option", () => {
+  function parse(source: string) {
+    const result = parseAgency(source, {}, false);
+    if (!result.success) {
+      throw new Error("fixture parse failed");
+    }
+    return result.result;
+  }
+  const src = `import { getAgentCwd } from "std::index"\nexport { glob } from "std::shell"\n`;
+
+  test("default drops std:: targets (regression pin)", () => {
+    expect(agencyImportTargets(parse(src), "/x/mod.agency")).toEqual([]);
+  });
+
+  test("resolveStdlib maps std:: to absolute stdlib paths, incl. re-exports", () => {
+    expect(
+      agencyImportTargets(parse(src), "/x/mod.agency", { resolveStdlib: true }),
+    ).toEqual([
+      path.join(getStdlibDir(), "index.agency"),
+      path.join(getStdlibDir(), "shell.agency"),
+    ]);
+  });
+
+  test("node-import std:: edge resolves too", () => {
+    expect(
+      agencyImportTargets(parse(`import node { main } from "std::shell"\n`), "/x/mod.agency", {
+        resolveStdlib: true,
+      }),
+    ).toEqual([path.join(getStdlibDir(), "shell.agency")]);
+  });
+
+  test("pkg:: dropped even with resolveStdlib (regression pin)", () => {
+    expect(
+      agencyImportTargets(parse(`import { x } from "pkg::toolbox"\n`), "/x/mod.agency", {
+        resolveStdlib: true,
+      }),
+    ).toEqual([]);
   });
 });

--- a/packages/agency-lang/lib/compiler/compileClosure.ts
+++ b/packages/agency-lang/lib/compiler/compileClosure.ts
@@ -268,12 +268,22 @@ function loadModule(
 export function agencyImportTargets(
   program: AgencyProgram,
   moduleId: string,
+  opts?: { resolveStdlib?: boolean },
 ): string[] {
   const out: string[] = [];
   for (const node of program.nodes) {
     const target = agencyImportTarget(node);
     if (!target) continue;
-    if (isStdlibImport(target) || isPkgImport(target)) continue;
+    if (isPkgImport(target)) continue;
+    if (isStdlibImport(target)) {
+      // Resolved only for the manifest's dependency fingerprint of
+      // stdlib-resident modules; the closure/init machinery keeps
+      // skipping std:: edges.
+      if (opts?.resolveStdlib) {
+        out.push(resolveAgencyImportPath(target, moduleId));
+      }
+      continue;
+    }
     if (!isAgencyImport(target)) continue;
     out.push(resolveAgencyImportPath(target, moduleId));
   }

--- a/packages/agency-lang/lib/compiler/depFingerprint.test.ts
+++ b/packages/agency-lang/lib/compiler/depFingerprint.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, beforeEach, vi } from "vitest";
+import { describe, expect, test, beforeEach, afterEach, vi } from "vitest";
 import fs from "fs";
 import os from "os";
 import path from "path";
@@ -31,13 +31,22 @@ vi.mock("../parseCache.js", async (importOriginal) => {
 import { dependencyFingerprint } from "./depFingerprint.js";
 import { getStdlibDir } from "../importPaths.js";
 
+const createdTrees: string[] = [];
+
 beforeEach(() => {
   seam.throwNext = null;
   seam.calls.length = 0;
 });
 
+afterEach(() => {
+  for (const dir of createdTrees.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 function tree(files: Record<string, string>): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-fp-"));
+  createdTrees.push(dir);
   for (const [rel, content] of Object.entries(files)) {
     const p = path.join(dir, rel);
     fs.mkdirSync(path.dirname(p), { recursive: true });

--- a/packages/agency-lang/lib/compiler/depFingerprint.test.ts
+++ b/packages/agency-lang/lib/compiler/depFingerprint.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, test, beforeEach, vi } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import type { AgencyConfig } from "../config.js";
+
+// Hoisted seam: exercises the classifier's actual CATCH path (a missing
+// file never reaches it — parseAgencyFileCached converts that to a failed
+// result), and records the applyTemplate policy per walked file. A dynamic
+// vi.spyOn after import would not reach the static production binding.
+const seam = vi.hoisted(() => ({
+  throwNext: null as Error | null,
+  calls: [] as Array<[string, boolean]>, // [absPath, applyTemplate]
+}));
+vi.mock("../parseCache.js", async (importOriginal) => {
+  const real = await importOriginal<typeof import("../parseCache.js")>();
+  return {
+    ...real,
+    parseAgencyFileCached: (p: string, c?: AgencyConfig, t?: boolean) => {
+      seam.calls.push([p, t ?? true]);
+      if (seam.throwNext) {
+        const e = seam.throwNext;
+        seam.throwNext = null;
+        throw e;
+      }
+      return real.parseAgencyFileCached(p, c, t);
+    },
+  };
+});
+
+import { dependencyFingerprint } from "./depFingerprint.js";
+import { getStdlibDir } from "../importPaths.js";
+
+beforeEach(() => {
+  seam.throwNext = null;
+  seam.calls.length = 0;
+});
+
+function tree(files: Record<string, string>): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-fp-"));
+  for (const [rel, content] of Object.entries(files)) {
+    const p = path.join(dir, rel);
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, content);
+  }
+  return dir;
+}
+
+describe("dependencyFingerprint", () => {
+  test("transitive relative deps: sorted, unique, root excluded", () => {
+    const dir = tree({
+      "a.agency": `import { b } from "./b.agency"\nimport { c } from "./c.agency"\n`,
+      "b.agency": `import { c } from "./c.agency"\nexport def b(): number { return 1 }\n`,
+      "c.agency": `export def c(): number { return 2 }\n`,
+    });
+    expect(
+      dependencyFingerprint(path.join(dir, "a.agency"), {}, { resolveStdlib: false }),
+    ).toMatchObject({
+      deps: [path.join(dir, "b.agency"), path.join(dir, "c.agency")].sort(),
+      hasPkgImports: false,
+      cacheable: true,
+    });
+  });
+
+  test("cycles terminate; deps exclude the root", () => {
+    const dir = tree({
+      "a.agency": `import { b } from "./b.agency"\n`,
+      "b.agency": `import { a } from "./a.agency"\n`,
+    });
+    expect(
+      dependencyFingerprint(path.join(dir, "a.agency"), {}, { resolveStdlib: false }).deps,
+    ).toEqual([path.join(dir, "b.agency")]);
+  });
+
+  test("node-import edges are discovered", () => {
+    const dir = tree({
+      "a.agency": `import node { main } from "./b.agency"\n`,
+      "b.agency": `node main() { return 1 }\n`,
+    });
+    expect(
+      dependencyFingerprint(path.join(dir, "a.agency"), {}, { resolveStdlib: false }).deps,
+    ).toEqual([path.join(dir, "b.agency")]);
+  });
+
+  test("missing direct target: included in deps, cacheable false", () => {
+    const dir = tree({ "a.agency": `import { b } from "./gone.agency"\n` });
+    const fp = dependencyFingerprint(path.join(dir, "a.agency"), {}, { resolveStdlib: false });
+    expect(fp.deps).toEqual([path.join(dir, "gone.agency")]);
+    expect(fp.cacheable).toBe(false);
+  });
+
+  test("unparseable reachable module: walk continues, cacheable false", () => {
+    const dir = tree({
+      "a.agency": `import { b } from "./bad.agency"\nimport { c } from "./c.agency"\n`,
+      "bad.agency": `def {{{{ nope`,
+      "c.agency": `export def c(): number { return 2 }\n`,
+    });
+    const fp = dependencyFingerprint(path.join(dir, "a.agency"), {}, { resolveStdlib: false });
+    expect(fp.cacheable).toBe(false);
+    expect(fp.deps).toContain(path.join(dir, "c.agency"));
+  });
+
+  test("splice in root / in transitive dep ⇒ cacheable false", () => {
+    const d1 = tree({ "a.agency": `const x = $( codegen() )\n` });
+    expect(
+      dependencyFingerprint(path.join(d1, "a.agency"), {}, { resolveStdlib: false }).cacheable,
+    ).toBe(false);
+    const d2 = tree({
+      "a.agency": `import { b } from "./b.agency"\n`,
+      "b.agency": `const x = $( codegen() )\n`,
+    });
+    expect(
+      dependencyFingerprint(path.join(d2, "a.agency"), {}, { resolveStdlib: false }).cacheable,
+    ).toBe(false);
+  });
+
+  test("pkg:: detected through all three edge forms, incl. transitive", () => {
+    for (const form of [
+      `import { x } from "pkg::toolbox"\n`,
+      `import node { main } from "pkg::toolbox"\n`,
+      `export { x } from "pkg::toolbox"\n`,
+    ]) {
+      const dir = tree({
+        "a.agency": `import { b } from "./b.agency"\n`,
+        "b.agency": form,
+      });
+      expect(
+        dependencyFingerprint(path.join(dir, "a.agency"), {}, { resolveStdlib: false })
+          .hasPkgImports,
+      ).toBe(true);
+    }
+  });
+
+  test("resolveStdlib false omits every std:: path", () => {
+    const dir = tree({ "a.agency": `import { getAgentCwd } from "std::index"\n` });
+    const fp = dependencyFingerprint(path.join(dir, "a.agency"), {}, { resolveStdlib: false });
+    expect(fp.deps).toEqual([]);
+    expect(fp.cacheable).toBe(true);
+  });
+
+  test("resolveStdlib true follows into the real stdlib (prelude edge)", () => {
+    const dir = tree({ "a.agency": `import { join } from "std::path"\n` });
+    const fp = dependencyFingerprint(path.join(dir, "a.agency"), {}, { resolveStdlib: true });
+    expect(fp.deps).toContain(path.join(getStdlibDir(), "path.agency"));
+    // path.agency is templated ⇒ its prelude edge pulls in index.agency.
+    expect(fp.deps).toContain(path.join(getStdlibDir(), "index.agency"));
+  });
+});
+
+describe("dependencyFingerprint failure contract", () => {
+  // The TEST'S oracle, independent of the production classifier: if
+  // production drops a code, its row stays here and fails.
+  const EXPECTED_DISCOVERY_FS_CODES = [
+    "ENOENT", "EACCES", "EPERM", "EIO", "EBUSY", "EMFILE", "ENFILE", "EISDIR",
+    "ENOTDIR", "ELOOP", "ESTALE",
+  ] as const;
+
+  test.each(EXPECTED_DISCOVERY_FS_CODES)("thrown %s is absorbed ⇒ cacheable false", (code) => {
+    const dir = tree({ "a.agency": `` });
+    const e = new Error(code) as NodeJS.ErrnoException;
+    e.code = code;
+    seam.throwNext = e;
+    const fp = dependencyFingerprint(path.join(dir, "a.agency"), {}, { resolveStdlib: false });
+    expect(fp.cacheable).toBe(false);
+  });
+
+  test("TypeError propagates", () => {
+    const dir = tree({ "a.agency": `` });
+    seam.throwNext = new TypeError("bug");
+    expect(() =>
+      dependencyFingerprint(path.join(dir, "a.agency"), {}, { resolveStdlib: false }),
+    ).toThrow(TypeError);
+  });
+
+  test("string code alone is not enough: ERR_INVALID_ARG_TYPE propagates", () => {
+    const dir = tree({ "a.agency": `` });
+    const e = new TypeError("bad arg") as NodeJS.ErrnoException;
+    e.code = "ERR_INVALID_ARG_TYPE";
+    seam.throwNext = e;
+    expect(() =>
+      dependencyFingerprint(path.join(dir, "a.agency"), {}, { resolveStdlib: false }),
+    ).toThrow(/bad arg/);
+  });
+
+  test("carve-outs: index.agency and array.agency are walked non-templated, others templated", () => {
+    dependencyFingerprint(path.join(getStdlibDir(), "array.agency"), {}, { resolveStdlib: true });
+    const byPath = Object.fromEntries(seam.calls);
+    expect(byPath[path.join(getStdlibDir(), "array.agency")]).toBe(false);
+    expect(byPath[path.join(getStdlibDir(), "index.agency")]).toBe(false); // reached via re-export
+    seam.calls.length = 0;
+    dependencyFingerprint(path.join(getStdlibDir(), "path.agency"), {}, { resolveStdlib: true });
+    expect(Object.fromEntries(seam.calls)[path.join(getStdlibDir(), "path.agency")]).toBe(true);
+  });
+});

--- a/packages/agency-lang/lib/compiler/depFingerprint.ts
+++ b/packages/agency-lang/lib/compiler/depFingerprint.ts
@@ -1,0 +1,117 @@
+/**
+ * The dependency-fingerprint contract shared by the compile manifest and
+ * the doc cache: what does this module transitively depend on, and can
+ * that answer be trusted for caching?
+ *
+ * Classified discovery failures (parse failures, filesystem errors while
+ * reading candidates) degrade to `cacheable: false`; anything else
+ * propagates — a blanket catch would hide resolver/AST bugs by silently
+ * pinning modules stale. Splice-containing subtrees are never cacheable:
+ * splices expand during compilation and may legally emit imports, so
+ * raw-parse edges are not the true edges there.
+ *
+ * Runs on the record path, after the module already compiled and emitted;
+ * a discovery problem must degrade to "don't cache this entry", never turn
+ * that success into a failure.
+ */
+import { AgencyConfig } from "@/config.js";
+import { parseAgencyFileCached } from "@/parseCache.js";
+import { isNonTemplatedStdlib, isPkgImport } from "@/importPaths.js";
+import { walkNodes } from "@/utils/node.js";
+import { agencyImportTarget, agencyImportTargets } from "./compileClosure.js";
+
+export type DependencyFingerprint = {
+  /** Transitive .agency deps, absolute, unique, sorted, root excluded. */
+  deps: string[];
+  /** True if ANY module in the subtree (root included) has a pkg:: edge. */
+  hasPkgImports: boolean;
+  /** False when the subtree could not be fully established. */
+  cacheable: boolean;
+  /** Why cacheable is false — diagnostics/tests only, never persisted. */
+  reason?: string;
+};
+
+/** Errors the walk absorbs: an ENUMERATED set of filesystem errnos from
+ *  stat/read races behind parseAgencyFileCached. Everything else —
+ *  including string-coded programming errors like ERR_INVALID_ARG_TYPE —
+ *  must surface; a has-a-code check would silently pin modules stale on
+ *  real bugs. (Resolver throws are a vacuous class here: pkg:: is
+ *  filtered before resolution — see docs/dev/incremental-builds.md.) */
+const DISCOVERY_FS_CODES = [
+  "ENOENT", "EACCES", "EPERM", "EIO", "EBUSY", "EMFILE", "ENFILE", "EISDIR",
+  // The stat-then-read race can also surface these (ancestor replaced by a
+  // file, symlink loop appears, network-fs handle goes stale):
+  "ENOTDIR", "ELOOP", "ESTALE",
+];
+
+function isDiscoveryFsError(e: unknown): boolean {
+  return DISCOVERY_FS_CODES.includes((e as NodeJS.ErrnoException)?.code ?? "");
+}
+
+export function dependencyFingerprint(
+  rootAbsPath: string,
+  config: AgencyConfig,
+  opts: { resolveStdlib: boolean },
+): DependencyFingerprint {
+  const visited: Record<string, true> = {};
+  let hasPkgImports = false;
+  let cacheable = true;
+  let reason: string | undefined;
+  const flag = (why: string) => {
+    cacheable = false;
+    reason ??= why;
+  };
+
+  const queue = [rootAbsPath];
+  while (queue.length > 0) {
+    const file = queue.shift()!;
+    if (visited[file]) continue;
+    visited[file] = true;
+
+    let parsed;
+    try {
+      parsed = parseAgencyFileCached(file, config, !isNonTemplatedStdlib(file));
+    } catch (e) {
+      if (!isDiscoveryFsError(e)) throw e;
+      flag(`read failed for ${file}: ${e}`);
+      continue;
+    }
+    if (!parsed.success) {
+      // Missing or unparseable: it stays in deps (missing ⇒ null hash ⇒
+      // stale at check time), but its own imports are unknowable.
+      flag(`parse failed for ${file}: ${parsed.message ?? "unknown"}`);
+      continue;
+    }
+    const program = parsed.result;
+
+    for (const { node } of walkNodes(program.nodes)) {
+      if (node.type === "splice") {
+        flag(`splice in ${file}`);
+        break;
+      }
+    }
+    for (const node of program.nodes) {
+      const target = agencyImportTarget(node);
+      if (target && isPkgImport(target)) {
+        hasPkgImports = true;
+      }
+    }
+
+    // Not wrapped: pkg:: (the only throwing resolution class) is filtered
+    // inside agencyImportTargets before resolution; std::/relative
+    // resolution is pure path arithmetic.
+    for (const target of agencyImportTargets(program, file, {
+      resolveStdlib: opts.resolveStdlib,
+    })) {
+      if (!visited[target]) queue.push(target);
+    }
+  }
+
+  delete visited[rootAbsPath];
+  return {
+    deps: Object.keys(visited).sort(),
+    hasPkgImports,
+    cacheable,
+    reason,
+  };
+}

--- a/packages/agency-lang/lib/compiler/depFingerprint.ts
+++ b/packages/agency-lang/lib/compiler/depFingerprint.ts
@@ -53,7 +53,9 @@ export function dependencyFingerprint(
   config: AgencyConfig,
   opts: { resolveStdlib: boolean },
 ): DependencyFingerprint {
-  const visited: Record<string, true> = {};
+  // Null-prototype: keyed by absolute file paths, which can legally
+  // collide with inherited keys like __proto__.
+  const visited: Record<string, true> = Object.create(null);
   let hasPkgImports = false;
   let cacheable = true;
   let reason: string | undefined;

--- a/packages/agency-lang/lib/compiler/manifestTracker.test.ts
+++ b/packages/agency-lang/lib/compiler/manifestTracker.test.ts
@@ -17,7 +17,7 @@ describe("createManifestTracker policy resolution", () => {
     const dir = tmp();
     const tracker = createManifestTracker({}, path.join(dir, "main.agency"), "always");
     expect(tracker).toBe(NOOP_TRACKER);
-    tracker.record(path.join(dir, "main.agency"), path.join(dir, "main.js"), [], false);
+    tracker.record(path.join(dir, "main.agency"), path.join(dir, "main.js"), { deps: [], hasPkgImports: false, cacheable: true });
     tracker.flush();
     expect(fs.existsSync(path.join(dir, MANIFEST_DIR_NAME))).toBe(false);
   });
@@ -27,7 +27,7 @@ describe("createManifestTracker policy resolution", () => {
     const entry = path.join(dir, "main.agency");
     const writer = createManifestTracker({}, entry, "incremental");
     expect(writer.isFresh(entry)).toBe(false); // nothing recorded yet
-    writer.record(entry, path.join(dir, "main.js"), [], false);
+    writer.record(entry, path.join(dir, "main.js"), { deps: [], hasPkgImports: false, cacheable: true });
     writer.flush();
     const reader = createManifestTracker({}, entry, "incremental");
     expect(reader.isFresh(entry)).toBe(true);
@@ -39,11 +39,11 @@ describe("createManifestTracker policy resolution", () => {
     const dir = tmp();
     const entry = path.join(dir, "main.agency");
     const writer = createManifestTracker({}, entry, "incremental");
-    writer.record(entry, path.join(dir, "main.js"), [], false);
+    writer.record(entry, path.join(dir, "main.js"), { deps: [], hasPkgImports: false, cacheable: true });
     writer.flush();
     const forced = createManifestTracker({}, entry, "force");
     expect(forced.isFresh(entry)).toBe(false);
-    forced.record(entry, path.join(dir, "main.js"), [], false);
+    forced.record(entry, path.join(dir, "main.js"), { deps: [], hasPkgImports: false, cacheable: true });
     forced.flush();
     expect(loadManifest(dir).entries["main.agency"]).toBeDefined();
   });
@@ -52,7 +52,7 @@ describe("createManifestTracker policy resolution", () => {
     const dir = tmp();
     const entry = path.join(dir, "main.agency");
     const writer = createManifestTracker({}, entry, "incremental");
-    writer.record(entry, path.join(dir, "main.js"), [], false);
+    writer.record(entry, path.join(dir, "main.js"), { deps: [], hasPkgImports: false, cacheable: true });
     writer.flush();
     const other = createManifestTracker({ verbose: true }, entry, "incremental");
     expect(other.isFresh(entry)).toBe(false);
@@ -62,7 +62,7 @@ describe("createManifestTracker policy resolution", () => {
     const dir = tmp();
     const entry = path.join(dir, "main.agency");
     const writer = createManifestTracker({}, entry, "incremental");
-    writer.record(entry, path.join(dir, "main.js"), [], true);
+    writer.record(entry, path.join(dir, "main.js"), { deps: [], hasPkgImports: true, cacheable: true });
     writer.flush();
     const reader = createManifestTracker({}, entry, "incremental");
     expect(reader.isFresh(entry)).toBe(false);
@@ -73,6 +73,21 @@ describe("createManifestTracker policy resolution", () => {
     createManifestTracker({}, path.join(dir, "main.agency"), "incremental").flush();
     expect(fs.existsSync(path.join(dir, MANIFEST_DIR_NAME))).toBe(false);
   });
+
+  test("cacheable:false records but never reads fresh; re-record true recovers", () => {
+    const dir = tmp();
+    const entry = path.join(dir, "main.agency");
+    const w = createManifestTracker({}, entry, "incremental");
+    w.record(entry, path.join(dir, "main.js"), { deps: [], hasPkgImports: false, cacheable: false });
+    w.flush();
+    const r1 = createManifestTracker({}, entry, "incremental");
+    expect(r1.isFresh(entry)).toBe(false);
+    expect(r1.outputFor(entry)).toBe(path.join(dir, "main.js")); // still recorded
+    const w2 = createManifestTracker({}, entry, "incremental");
+    w2.record(entry, path.join(dir, "main.js"), { deps: [], hasPkgImports: false, cacheable: true });
+    w2.flush();
+    expect(createManifestTracker({}, entry, "incremental").isFresh(entry)).toBe(true);
+  });
 });
 
 describe("malformed manifest resilience", () => {
@@ -80,7 +95,7 @@ describe("malformed manifest resilience", () => {
     const dir = tmp();
     const entry = path.join(dir, "main.agency");
     const writer = createManifestTracker({}, entry, "incremental");
-    writer.record(entry, path.join(dir, "main.js"), [], false);
+    writer.record(entry, path.join(dir, "main.js"), { deps: [], hasPkgImports: false, cacheable: true });
     writer.flush();
     const file = path.join(dir, MANIFEST_DIR_NAME, "manifest.json");
     const raw = JSON.parse(fs.readFileSync(file, "utf-8"));
@@ -95,7 +110,7 @@ describe("malformed manifest resilience", () => {
     const dir = tmp();
     const entry = path.join(dir, "main.agency");
     const writer = createManifestTracker({}, entry, "incremental");
-    writer.record(entry, path.join(dir, "main.js"), [], false);
+    writer.record(entry, path.join(dir, "main.js"), { deps: [], hasPkgImports: false, cacheable: true });
     writer.flush();
     const file = path.join(dir, MANIFEST_DIR_NAME, "manifest.json");
     const raw = JSON.parse(fs.readFileSync(file, "utf-8"));

--- a/packages/agency-lang/lib/compiler/manifestTracker.ts
+++ b/packages/agency-lang/lib/compiler/manifestTracker.ts
@@ -15,15 +15,18 @@ import {
   computeCompilerStamp,
   computeDepsHash,
   computeStdlibHash,
+  computeStdlibNamesHash,
   deriveConfigKey,
   hashFile,
   isEntryFresh,
   loadManifest,
   manifestDirFor,
   saveManifest,
+  stdlibHashFor,
   type BuildManifest,
   type FreshnessContext,
 } from "./buildManifest.js";
+import type { DependencyFingerprint } from "./depFingerprint.js";
 
 /** "incremental" consults and records the manifest; "force" recompiles
  *  everything but rewrites it (--force); "always" is internal
@@ -37,9 +40,15 @@ export type ManifestTracker = {
   allFresh(absModules: string[]): boolean;
   /** The recorded output path for a module (fast-path return value). */
   outputFor(absModule: string): string | null;
-  /** No-op unless policy allows writes. deps/hasPkgImports supplied by the
-   *  session (it owns the closure); the tracker owns hashing and storage. */
-  record(absModule: string, absOutput: string, deps: string[], hasPkgImports: boolean): void;
+  /** No-op unless policy allows writes. The fingerprint is supplied by the
+   *  session (it owns dependency discovery — closure walk for user
+   *  modules, dependencyFingerprint for stdlib-resident ones); the tracker
+   *  owns hashing and storage. */
+  record(
+    absModule: string,
+    absOutput: string,
+    fp: Pick<DependencyFingerprint, "deps" | "hasPkgImports" | "cacheable">,
+  ): void;
   /** Persist (atomic). No-op unless something was recorded. */
   flush(): void;
 };
@@ -73,6 +82,8 @@ class RealManifestTracker implements ManifestTracker {
     this.ctx = {
       manifestDir,
       stdlibHash: computeStdlibHash(getStdlibDir()),
+      stdlibNamesHash: computeStdlibNamesHash(getStdlibDir()),
+      stdlibDir: getStdlibDir(),
       compilerStamp: computeCompilerStamp(distLib),
       configKey,
     };
@@ -107,15 +118,23 @@ class RealManifestTracker implements ManifestTracker {
     return path.join(this.manifestDir, entry.outputPath);
   }
 
-  record(absModule: string, absOutput: string, deps: string[], hasPkgImports: boolean): void {
-    const relDeps = deps.map((d) => path.relative(this.manifestDir, d)).sort();
+  record(
+    absModule: string,
+    absOutput: string,
+    fp: Pick<DependencyFingerprint, "deps" | "hasPkgImports" | "cacheable">,
+  ): void {
+    // Relativize, THEN sort, THEN hash in exactly that stored order —
+    // isEntryFresh re-hashes the stored list in list order, and sorting
+    // absolute paths can differ from sorting relative ones.
+    const relDeps = fp.deps.map((d) => path.relative(this.manifestDir, d)).sort();
     const depHashes = relDeps.map((d) => hashFile(path.join(this.manifestDir, d)) ?? "");
     this.manifest.entries[path.relative(this.manifestDir, absModule)] = {
       sourceHash: hashFile(absModule) ?? "",
       deps: relDeps,
       depsHash: computeDepsHash(depHashes),
-      stdlibHash: this.ctx.stdlibHash,
-      hasPkgImports,
+      stdlibHash: stdlibHashFor(absModule, this.ctx),
+      hasPkgImports: fp.hasPkgImports,
+      cacheable: fp.cacheable,
       configKey: this.ctx.configKey,
       compilerStamp: this.ctx.compilerStamp,
       outputPath: path.relative(this.manifestDir, absOutput),

--- a/packages/agency-lang/lib/compiler/stdlibDeps.test.ts
+++ b/packages/agency-lang/lib/compiler/stdlibDeps.test.ts
@@ -9,16 +9,24 @@ import path from "path";
 // one. isNonTemplatedStdlib reports EVERY fixture file as non-templated so
 // real compiles need no prelude surface (the templated prelude edge is
 // covered against the real stdlib in depFingerprint.test.ts).
-const fake = vi.hoisted(() => ({ stdlibDir: "", fixtureRoot: "" }));
+const fake = vi.hoisted(() => ({
+  stdlibDir: "",
+  fixtureRoot: "",
+  /** Absolute fixture paths that KEEP template application (they get the
+   *  auto-prelude import), for the templated-edge wiring test. */
+  templated: [] as string[],
+}));
 vi.mock("../importPaths.js", async (importOriginal) => {
   const real = await importOriginal<typeof import("../importPaths.js")>();
   return {
     ...real,
     getStdlibDir: () => fake.stdlibDir,
-    // EVERY fixture file (stdlib and user alike) is non-templated, so no
-    // fixture needs the ~30-name prelude surface stubbed out.
+    // Fixture files default to non-templated, so most fixtures need no
+    // prelude surface; files listed in fake.templated opt back in.
     isNonTemplatedStdlib: (p: string) =>
-      fake.fixtureRoot !== "" && p.startsWith(fake.fixtureRoot + path.sep),
+      fake.fixtureRoot !== "" &&
+      p.startsWith(fake.fixtureRoot + path.sep) &&
+      !fake.templated.includes(p),
     resolveAgencyImportPath: (importPath: string, fromFile: string) =>
       real.isStdlibImport(importPath)
         ? path.join(fake.stdlibDir, real.normalizeStdlibPath(importPath) + ".agency")
@@ -44,12 +52,18 @@ beforeEach(() => {
   root = fs.mkdtempSync(path.join(process.cwd(), ".agency-tmp", "stdlibdeps-"));
   fake.fixtureRoot = root;
   fake.stdlibDir = path.join(root, "stdlib");
+  fake.templated = [];
   clearSpliceCache();
 });
 
 afterEach(() => {
   clearSpliceCache();
-  safeDeleteDirectory(root, false);
+  // Guard the empty-string state (beforeEach failed before assigning):
+  // safeDeleteDirectory("") would resolve to the package root itself.
+  if (root !== "") {
+    safeDeleteDirectory(root, false);
+    root = "";
+  }
 });
 
 // index ← helper ← consumer; index ← other. All non-templated under the
@@ -236,6 +250,32 @@ describe("production manifest wiring", () => {
     clearSpliceCache();
     compileDir();
     expect(rewrittenJs()).toContain("spliceUser.js"); // never skipped
+  });
+
+  test("TEMPLATED stdlib module records the implicit prelude index.agency dep", async () => {
+    // The other fixtures are all non-templated (a deliberate harness
+    // simplification), so this is the one case proving the
+    // session→fingerprint→manifest path for the template-added
+    // `std::index` edge. The fake index stubs the full prelude surface so
+    // the templated file's auto-import resolves.
+    const { PRELUDE_NAMES } = await import("../prelude.js");
+    const stubs = PRELUDE_NAMES.map((n) => `export def ${n}(): number { return 0 }`).join("\n");
+    makeFixture({
+      ...BASE_FIXTURE,
+      "index.agency": `export def i(): number { return 1 }\n${stubs}\n`,
+      "tpl.agency": `export def t(): number { return 1 }\n`,
+    });
+    fake.templated = [path.join(fake.stdlibDir, "tpl.agency")];
+    compileDir();
+    const entry = loadManifest(root).entries[stdlibRel("tpl.agency")];
+    expect(entry).toBeDefined();
+    expect(entry.deps).toEqual([stdlibRel("index.agency")]);   // prelude edge, nothing else
+    expect(entry.cacheable).toBe(true);
+    // And the edge is load-bearing: editing index stales tpl.
+    backdateAllJs();
+    write("index.agency", `export def i(): number { return 2 }\n${stubs}\n`);
+    compileDir();
+    expect(rewrittenJs()).toContain("tpl.js");
   });
 
   test("stdlib-copy sibling gets contents flavor and no std:: deps", () => {

--- a/packages/agency-lang/lib/compiler/stdlibDeps.test.ts
+++ b/packages/agency-lang/lib/compiler/stdlibDeps.test.ts
@@ -1,0 +1,349 @@
+import { describe, expect, test, beforeEach, afterEach, vi } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+// Redirect the stdlib to a per-test fixture. Mocking getStdlibDir alone is
+// NOT enough: resolveAgencyImportPath calls the module-local getStdlibDir
+// inside importPaths.ts, which an export mock cannot reach — so the
+// resolver is overridden too, delegating non-std:: targets to the real
+// one. isNonTemplatedStdlib reports EVERY fixture file as non-templated so
+// real compiles need no prelude surface (the templated prelude edge is
+// covered against the real stdlib in depFingerprint.test.ts).
+const fake = vi.hoisted(() => ({ stdlibDir: "", fixtureRoot: "" }));
+vi.mock("../importPaths.js", async (importOriginal) => {
+  const real = await importOriginal<typeof import("../importPaths.js")>();
+  return {
+    ...real,
+    getStdlibDir: () => fake.stdlibDir,
+    // EVERY fixture file (stdlib and user alike) is non-templated, so no
+    // fixture needs the ~30-name prelude surface stubbed out.
+    isNonTemplatedStdlib: (p: string) =>
+      fake.fixtureRoot !== "" && p.startsWith(fake.fixtureRoot + path.sep),
+    resolveAgencyImportPath: (importPath: string, fromFile: string) =>
+      real.isStdlibImport(importPath)
+        ? path.join(fake.stdlibDir, real.normalizeStdlibPath(importPath) + ".agency")
+        : real.resolveAgencyImportPath(importPath, fromFile),
+  };
+});
+
+import { createBuildSession } from "./buildSession.js";
+import { loadManifest, hashFile, MANIFEST_DIR_NAME } from "./buildManifest.js";
+import { evictParseCache } from "../parseCache.js";
+import { clearSpliceCache } from "./splice/cache.js";
+
+const EPOCH = new Date(0);
+
+let root = "";
+
+beforeEach(() => {
+  // Under the package dir (like runGenerator.test.ts), NOT os.tmpdir():
+  // splice generators execute in a subprocess whose runner imports the
+  // agency-lang package, which only resolves from inside the repo tree.
+  fs.mkdirSync(path.join(process.cwd(), ".agency-tmp"), { recursive: true });
+  root = fs.mkdtempSync(path.join(process.cwd(), ".agency-tmp", "stdlibdeps-"));
+  fake.fixtureRoot = root;
+  fake.stdlibDir = path.join(root, "stdlib");
+  clearSpliceCache();
+});
+
+afterEach(() => {
+  clearSpliceCache();
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+// index ← helper ← consumer; index ← other. All non-templated under the
+// mock, so edges are exactly the explicit imports.
+const BASE_FIXTURE: Record<string, string> = {
+  "index.agency": `export def i(): number { return 1 }\n`,
+  "helper.agency": `import { i } from "std::index"\nexport def h(): number { return i() }\n`,
+  "consumer.agency": `import { h } from "std::helper"\nexport def c(): number { return h() }\n`,
+  "other.agency": `import { i } from "std::index"\nexport def o(): number { return i() }\n`,
+};
+
+function makeFixture(files: Record<string, string> = BASE_FIXTURE): void {
+  fs.mkdirSync(fake.stdlibDir, { recursive: true });
+  // Anchor manifestDirFor at the fixture root: without a project marker,
+  // findProjectRoot would walk up and find the PACKAGE's agency.json
+  // (fixtures live under <pkg>/.agency-tmp), putting the manifest there.
+  fs.writeFileSync(path.join(root, "agency.json"), "{}\n");
+  for (const [rel, content] of Object.entries(files)) {
+    write(rel, content);
+  }
+}
+
+/** Manifest lives at the fixture ROOT (agency.json anchor); entries are
+ *  keyed root-relative, e.g. "stdlib/consumer.agency". */
+const stdlibRel = (f: string) => path.join("stdlib", f);
+
+function write(rel: string, content: string): void {
+  const abs = path.join(fake.stdlibDir, rel);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, content);
+  evictParseCache(abs);
+}
+
+function rmSource(rel: string): void {
+  const abs = path.join(fake.stdlibDir, rel);
+  fs.rmSync(abs);
+  evictParseCache(abs);
+}
+
+function compileDir(): void {
+  // Fresh session per logical CLI invocation: a reused session's
+  // compiledFiles dedup can skip compilation independently of the
+  // manifest and fake incremental results.
+  createBuildSession().compile({}, { entries: [fake.stdlibDir], freshness: "incremental", quiet: true });
+}
+
+function jsFiles(): string[] {
+  return fs
+    .readdirSync(fake.stdlibDir)
+    .filter((f) => f.endsWith(".js"))
+    .map((f) => path.join(fake.stdlibDir, f));
+}
+
+function backdateAllJs(): void {
+  for (const f of jsFiles()) {
+    fs.utimesSync(f, EPOCH, EPOCH);
+  }
+}
+
+/** Outputs whose mtime moved off the backdated epoch. */
+function rewrittenJs(): string[] {
+  return jsFiles()
+    .filter((f) => fs.statSync(f).mtimeMs > 0)
+    .map((f) => path.basename(f))
+    .sort();
+}
+
+/** { basename → bytes } for outputs derived from CURRENT sources only.
+ *  Deliberately not a directory listing: after delete/rename the
+ *  incremental dir legitimately keeps the old orphan .js (output
+ *  reconciliation is out of scope), which a clean force run can never
+ *  reproduce. */
+function jsSnapshotForSources(): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const f of fs.readdirSync(fake.stdlibDir)) {
+    if (!f.endsWith(".agency")) continue;
+    const js = f.replace(/\.agency$/, ".js");
+    out[js] = fs.readFileSync(path.join(fake.stdlibDir, js), "utf-8");
+  }
+  return out;
+}
+
+describe("BuildSession rewrite sets (selective recompilation)", () => {
+  test("warm run rewrites nothing", () => {
+    makeFixture();
+    compileDir();
+    backdateAllJs();
+    compileDir();
+    expect(rewrittenJs()).toEqual([]);
+  });
+
+  test("edit helper → helper + consumer only", () => {
+    makeFixture();
+    compileDir();
+    backdateAllJs();
+    write("helper.agency", `import { i } from "std::index"\nexport def h(): number { return i() + 1 }\n`);
+    compileDir();
+    expect(rewrittenJs()).toEqual(["consumer.js", "helper.js"]);
+  });
+
+  test("edit index → all four", () => {
+    makeFixture();
+    compileDir();
+    backdateAllJs();
+    write("index.agency", `export def i(): number { return 2 }\n`);
+    compileDir();
+    expect(rewrittenJs()).toEqual(["consumer.js", "helper.js", "index.js", "other.js"]);
+  });
+
+  test("add a source → all current outputs rewrite (names hash)", () => {
+    makeFixture();
+    compileDir();
+    backdateAllJs();
+    write("extra.agency", `export def e(): number { return 9 }\n`);
+    compileDir();
+    expect(rewrittenJs()).toEqual(["consumer.js", "extra.js", "helper.js", "index.js", "other.js"]);
+  });
+
+  test("delete an unimported source → all remaining outputs rewrite", () => {
+    makeFixture();
+    compileDir();
+    backdateAllJs();
+    rmSource("other.agency");
+    compileDir();
+    // other.js survives as an orphan but is not rewritten.
+    expect(rewrittenJs()).toEqual(["consumer.js", "helper.js", "index.js"]);
+  });
+
+  test("deleted dep output → dep and its importer re-emit", () => {
+    makeFixture();
+    compileDir();
+    backdateAllJs();
+    fs.rmSync(path.join(fake.stdlibDir, "helper.js"));
+    // Explicit entry order (consumer first): compileEntry runs
+    // sequentially, and if helper compiled first it would recreate
+    // helper.js before consumer's freshness check ran, making the
+    // expected set traversal-order-dependent.
+    const entry = (f: string) => path.join(fake.stdlibDir, f);
+    createBuildSession().compile({}, {
+      entries: [entry("consumer.agency"), entry("helper.agency"), entry("index.agency"), entry("other.agency")],
+      freshness: "incremental",
+      quiet: true,
+    });
+    expect(rewrittenJs()).toEqual(["consumer.js", "helper.js"]);
+  });
+});
+
+describe("production manifest wiring", () => {
+  test("entries record real std:: deps, transitively", () => {
+    makeFixture();
+    compileDir();
+    const manifest = loadManifest(root);
+    const consumer = manifest.entries[stdlibRel("consumer.agency")];
+    expect(consumer.deps).toEqual([stdlibRel("helper.agency"), stdlibRel("index.agency")]);
+    expect(consumer.cacheable).toBe(true);
+    expect(consumer.hasPkgImports).toBe(false);
+    const other = manifest.entries[stdlibRel("other.agency")];
+    expect(other.deps).toEqual([stdlibRel("index.agency")]);
+    for (const entry of Object.values(manifest.entries)) {
+      for (const dep of entry.deps) {
+        expect(hashFile(path.join(root, dep))).not.toBeNull();
+      }
+    }
+  });
+
+  test("splice-containing stdlib source records cacheable:false and re-emits every run", () => {
+    makeFixture({
+      ...BASE_FIXTURE,
+      // The established declaration-splice shape
+      // (tests/agency/splices/declarationSplice*.agency), minus the Code
+      // type annotation: an std::agency import would make the compiled
+      // generator import the real stdlib's agency.js, which does not
+      // exist in an unbuilt tree (typechecking is off here, so the
+      // annotation carries no weight anyway).
+      "spliceGen.agency": `export def makeGreeter() {\n  return [|\n    def greet(): string {\n      return "generated"\n    }\n  |]\n}\n`,
+      "spliceUser.agency": `import { makeGreeter } from "./spliceGen.agency"\n$( makeGreeter() )\nnode main(): string { return greet() }\n`,
+    });
+    compileDir();
+    // Fixture validity first: the splice actually expanded and emitted.
+    expect(fs.existsSync(path.join(fake.stdlibDir, "spliceUser.js"))).toBe(true);
+    const manifest = loadManifest(root);
+    expect(manifest.entries[stdlibRel("spliceUser.agency")].cacheable).toBe(false);
+    backdateAllJs();
+    clearSpliceCache();
+    compileDir();
+    expect(rewrittenJs()).toContain("spliceUser.js"); // never skipped
+  });
+
+  test("stdlib-copy sibling gets contents flavor and no std:: deps", () => {
+    makeFixture();
+    const copyDir = path.join(root, "stdlib-copy");
+    fs.mkdirSync(copyDir, { recursive: true });
+    fs.writeFileSync(path.join(copyDir, "app.agency"), `export def a(): number { return 1 }\n`);
+    createBuildSession().compile({}, {
+      entries: [path.join(copyDir, "app.agency")],
+      freshness: "incremental",
+      quiet: true,
+    });
+    const manifest = loadManifest(root);
+    const entry = manifest.entries[path.join("stdlib-copy", "app.agency")];
+    expect(entry).toBeDefined();
+    expect(entry.deps).toEqual([]);
+    // Contents flavor: an edit to a fixture-stdlib FILE changes the
+    // recorded hash a fresh tracker computes, so the entry goes stale.
+    const before = createBuildSession().compile({}, {
+      entries: [path.join(copyDir, "app.agency")],
+      freshness: "incremental",
+      quiet: true,
+    });
+    expect(before).toBe(path.join(copyDir, "app.js")); // fresh fast-path
+    write("index.agency", `export def i(): number { return 42 }\n`);
+    const out = path.join(copyDir, "app.js");
+    fs.utimesSync(out, EPOCH, EPOCH);
+    createBuildSession().compile({}, {
+      entries: [path.join(copyDir, "app.agency")],
+      freshness: "incremental",
+      quiet: true,
+    });
+    expect(fs.statSync(out).mtimeMs).toBeGreaterThan(0); // re-emitted
+  });
+});
+
+describe("single-file guarantee boundary", () => {
+  test("re-emits until directory build exists, skips after", () => {
+    makeFixture();
+    const consumer = path.join(fake.stdlibDir, "consumer.agency");
+    createBuildSession().compile({}, { entries: [consumer], freshness: "incremental", quiet: true });
+    const out = path.join(fake.stdlibDir, "consumer.js");
+    fs.utimesSync(out, EPOCH, EPOCH);
+    // Dep entries (helper, index) missing → still stale → re-emits.
+    createBuildSession().compile({}, { entries: [consumer], freshness: "incremental", quiet: true });
+    expect(fs.statSync(out).mtimeMs).toBeGreaterThan(0);
+    // After a full directory build, the same single-file compile skips.
+    compileDir();
+    fs.utimesSync(out, EPOCH, EPOCH);
+    createBuildSession().compile({}, { entries: [consumer], freshness: "incremental", quiet: true });
+    expect(fs.statSync(out).mtimeMs).toBe(0);
+  });
+});
+
+describe("incremental emit is byte-identical to force emit", () => {
+  function forceSnapshot(): Record<string, string> {
+    fs.rmSync(path.join(root, MANIFEST_DIR_NAME), { recursive: true, force: true });
+    createBuildSession().compile({}, { entries: [fake.stdlibDir], freshness: "force", quiet: true });
+    return jsSnapshotForSources();
+  }
+
+  const mutations: Array<[string, () => void]> = [
+    ["edit leaf (helper)", () => write("helper.agency", `import { i } from "std::index"\nexport def h(): number { return i() * 2 }\n`)],
+    ["edit hub (index)", () => write("index.agency", `export def i(): number { return 7 }\n`)],
+    ["edit a re-export edge", () => write("reexport.agency", `export { h } from "std::helper"\n`)],
+    ["edit a cycle pair member", () => write("cycA.agency", `import { cb } from "std::cycB"\nexport def ca(): number { return 10 }\n`)],
+    ["add a file", () => write("added.agency", `export def added(): number { return 5 }\n`)],
+    ["delete an unimported file", () => rmSource("other.agency")],
+    ["rename an unimported file", () => {
+      const from = path.join(fake.stdlibDir, "other.agency");
+      const to = path.join(fake.stdlibDir, "renamed.agency");
+      fs.renameSync(from, to);
+      evictParseCache(from);
+      evictParseCache(to);
+    }],
+    ["seeded version-1 manifest", () => {
+      const file = path.join(root, MANIFEST_DIR_NAME, "manifest.json");
+      const raw = JSON.parse(fs.readFileSync(file, "utf-8"));
+      raw.version = 1;
+      fs.writeFileSync(file, JSON.stringify(raw));
+    }],
+  ];
+
+  test.each(mutations)("%s", (_name, mutate) => {
+    makeFixture({
+      ...BASE_FIXTURE,
+      // Legal def-only import cycle (no static initializers) and a
+      // re-export edge, so those rows mutate real structures.
+      "reexport.agency": `export { i } from "std::index"\n`,
+      "cycA.agency": `import { cb } from "std::cycB"\nexport def ca(): number { return 1 }\n`,
+      "cycB.agency": `import { ca } from "std::cycA"\nexport def cb(): number { return 2 }\n`,
+    });
+    compileDir();
+    mutate();
+    compileDir();
+    const incremental = jsSnapshotForSources();
+    expect(forceSnapshot()).toEqual(incremental);
+  });
+
+  test("seeded v1 manifest re-emits everything (migration)", () => {
+    makeFixture();
+    compileDir();
+    const file = path.join(root, MANIFEST_DIR_NAME, "manifest.json");
+    const raw = JSON.parse(fs.readFileSync(file, "utf-8"));
+    raw.version = 1;
+    fs.writeFileSync(file, JSON.stringify(raw));
+    backdateAllJs();
+    compileDir();
+    expect(rewrittenJs()).toEqual(["consumer.js", "helper.js", "index.js", "other.js"]);
+  });
+});

--- a/packages/agency-lang/lib/compiler/stdlibDeps.test.ts
+++ b/packages/agency-lang/lib/compiler/stdlibDeps.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test, beforeEach, afterEach, vi } from "vitest";
 import fs from "fs";
-import os from "os";
 import path from "path";
 
 // Redirect the stdlib to a per-test fixture. Mocking getStdlibDir alone is
@@ -31,6 +30,7 @@ import { createBuildSession } from "./buildSession.js";
 import { loadManifest, hashFile, MANIFEST_DIR_NAME } from "./buildManifest.js";
 import { evictParseCache } from "../parseCache.js";
 import { clearSpliceCache } from "./splice/cache.js";
+import { safeDeleteDirectory } from "../utils.js";
 
 const EPOCH = new Date(0);
 
@@ -49,7 +49,7 @@ beforeEach(() => {
 
 afterEach(() => {
   clearSpliceCache();
-  fs.rmSync(root, { recursive: true, force: true });
+  safeDeleteDirectory(root, false);
 });
 
 // index ← helper ← consumer; index ← other. All non-templated under the


### PR DESCRIPTION
Implements the approved spec `2026-08-04-stdlib-deps-manifest-spec.md`: editing one standard-library file makes `agency compile stdlib/` rebuild only that file and its transitive importers, instead of all 83.

## Why

Stdlib files import each other via `std::`, which the closure walker deliberately skips, so their manifest `deps` were empty and the all-contents `stdlibHash` invalidated every entry on any one-file edit. Measured before this change: a one-file edit cost a ~6s full rebuild of all 83 files.

## What changed

- `agencyImportTargets` gains an opt-in `resolveStdlib` flag that maps `std::` targets to absolute stdlib file paths (default behavior unchanged).
- New `lib/compiler/depFingerprint.ts`: `dependencyFingerprint` walks a module's transitive imports and returns `{ deps, hasPkgImports, cacheable }`. Completeness is data: a splice anywhere in the subtree, or an unparseable/missing reachable file, marks the fingerprint uncacheable (recorded but never fresh). Discovery absorbs an enumerated errno list only; programming errors (incl. string-coded ones like `ERR_INVALID_ARG_TYPE`) propagate.
- Manifest schema v2: new `cacheable` field, and two `stdlibHash` flavors selected by the shared `stdlibHashFor` rule — stdlib-resident entries store a names-only hash (add/remove/rename still rebuilds all of stdlib; a content edit invalidates per file via the new real deps), non-stdlib entries keep the full-content hash. Old manifests are discarded (one full rebuild).
- `BuildSession` records stdlib modules via the fingerprint; user modules keep the closure-derived path, now with subtree-accurate `hasPkgImports` and `cacheable: true`.
- `docs/dev/incremental-builds.md` updated (flavors, fingerprint contract, single-file guarantee boundary, migration).

## Measured on this branch (real stdlib)

| scenario | before | after |
|---|---|---|
| warm, nothing changed | ~0.6s | ~0.6s ("83 file(s) up to date") |
| edit `math.agency` (leaf) | ~6s, all 83 | **0.55s, exactly 1 file** |
| edit `agency.agency` (hub) | ~6s, all 83 | **2.2s, 17 files (its true importer set)** |
| incremental vs `--force` emit | — | byte-identical (all 83 `.js` diffed) |

Splice census: zero splices in the current stdlib, so no file is pinned uncacheable today.

## Tests

71 unit tests across the extractor, fingerprint (incl. the errno table and carve-outs against the real stdlib), manifest, and tracker, plus 19 end-to-end tests against a redirected fixture stdlib: exact BuildSession rewrite sets per mutation (backdated-mtime detection), production manifest wiring (transitive `std::` deps, a real executed declaration splice recording `cacheable: false`, the `stdlib-copy` boundary), the single-file guarantee boundary through the public session, and incremental-vs-force byte parity across 8 mutations including a seeded v1-manifest migration row.

## Plan deviations

- The plan's Task 0 timing spike was skipped (its one-line hack + two `make build` runs); execution was already approved and the real implementation's measurements above supersede the spike's approximation. The splice census ran (zero splices).
- The full `make` was not run locally (per instruction); `pnpm run build` built dist for the splice-runner subprocess, and CI's unit job runs `make` before vitest.
- End-to-end fixtures live under `.agency-tmp/` in the package (not `os.tmpdir()`): splice generators execute in a subprocess that must resolve the `agency-lang` package and dist. Fixture files are all non-templated via the mock (incl. the stdlib-copy user file — several prelude names are parser keywords, so stubbing the prelude surface is not possible), and each fixture root carries its own `agency.json` so `manifestDirFor` anchors there.
- The splice generator drops the `import { Code } from "std::agency"` annotation: the compiled generator would import the real stdlib's `agency.js`, which does not exist in an unbuilt tree (typechecking is off in these tests, so the annotation carries no weight).

Spec: `packages/agency-lang/2026-08-04-stdlib-deps-manifest-spec.md` · Plan: `packages/agency-lang/2026-08-04-stdlib-deps-manifest-plan.md` (both in the main checkout, untracked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
