### PR TITLE
feat(serve): full cost and token breakdown per invocation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,7 @@ Pipeline and architecture:
 - `docs/dev/template-agency.md` — Template Agency internals: the Hole node and per-position parsing, `Code` fragment kinds, the never-parse lifting rule and its two escaping conventions, scope-keyed hygiene with `__hyg` seeding, AG8001/AG8002 refusals, and the walker-completeness tripwire
 - `docs/dev/hosted-agent-execution.md` — Hosting agents on statelog (`agency deploy` + the `./serve` API): the serve wire contract and moduleId gotcha, per-agent observability via `withRuntimeConfigOverrides`, `compileSource(sourcePath)` for multi-file, the deploy CLI's module layout, the statelog host pieces, and the known limitations
 - `docs/dev/eval-labeling.md` — The human-label store behind `agency eval label`: why it lives outside `runs/`, occurrence vs content identity, immutable checklist revisions, the per-question annotation fold, the sign-off commit protocol and its recovery boundaries, and why validation is strict where grading is tolerant
+- `docs/dev/invocation-usage-accounting.md` — The serve cost seam's full cost/token breakdown: the authoritative-flat-total vs best-effort-attribution split, the valid-price and kind-specific-token rules, the one `recordUsageDelta` sink, untrusted IPC recovery that never drops money, the #809 rejected-promise boundary, and the `agency remote spend` schema/rendering
 
 Other references:
 - `docs/misc/TESTING.md` — Full testing guide (unit tests, fixtures, execution tests, agency-js tests)

--- a/packages/agency-lang/docs/dev/invocation-usage-accounting.md
+++ b/packages/agency-lang/docs/dev/invocation-usage-accounting.md
@@ -1,0 +1,129 @@
+# Invocation usage accounting (the serve cost seam)
+
+A hosted invocation must report the complete money-and-token breakdown it
+incurred, so `statelog` can bill it and show per-model spend. This note covers
+how a charge travels from a provider result to that breakdown, and how the
+breakdown survives a subprocess boundary.
+
+## The two figures
+
+Every invocation carries two things that must not be confused:
+
+- **The authoritative flat total** — `usage.cost` (a full `CostBreakdown`) and
+  `usage.tokens` (a full `TokenBreakdown`). This is what gets billed. It is
+  always trusted as long as `usageComplete` is true.
+- **The best-effort attribution** — `usage.entries`, one entry per `(kind,
+  model)`. This is a convenience for "which model cost what". It is reconciled
+  against the flat total only when telemetry is complete; the flat total is
+  never derived from summing entries.
+
+`kind` is the API verb: `"completion" | "embedding" | "image" | "manual"`.
+`"manual"` is an `addCost()` charge; its `model` is the sentinel `""` (never
+null, so a database `UNIQUE(invocation_id, kind, model)` works without
+`NULLS NOT DISTINCT`). Provider kinds always carry a non-empty model.
+
+Two independent completeness axes ride alongside:
+
+- `usage.pricingComplete === (usage.unknownCostCallCount === 0)` — did every
+  call arrive with a usable USD price? A call with no price still counts its
+  tokens; it just bumps `unknownCostCallCount`.
+- `usageComplete` (a SIBLING of `usage`, not nested) — did all telemetry arrive?
+  A killed subprocess or a degraded IPC recovery flips this false, making the
+  whole figure a trusted LOWER BOUND.
+
+## The value layer — `lib/runtime/invocationUsage.ts`
+
+Pure, no I/O. Three domain observations feed one normalizer:
+
+```ts
+type UsageObservation =
+  | { type: "provider"; kind; reportedModel?; configuredModel?; cost?; tokens? }
+  | { type: "attempt"; kind }          // dispatched, never resolved to a price
+  | { type: "manual"; amount };        // addCost()
+```
+
+`normalizeObservation(obs)` returns a `NormalizedDelta`. The rules that are easy
+to get wrong:
+
+- **A price is valid only when `totalCost` is finite-nonnegative AND
+  `currency === "USD"`.** Otherwise all six cost fields become zero and
+  `unknownCostCallCount` bumps — even if the named components look fine.
+  `totalCost: 0` is known-free (priced), not unknown.
+- **Named cost components are best-effort.** Each is copied only if it is a
+  finite nonnegative number; absent/negative/NaN/±Infinity → 0. They are never
+  reconciled to `totalCost`.
+- **`totalTokens` is authoritative when present and valid.** When it is absent,
+  fall back to a kind-specific sum: completion adds all four counters;
+  embedding/image add only input+output, because their cache counters may
+  OVERLAP input (never sum them). A present-but-malformed `totalTokens` uses the
+  fallback AND sets `attributionLost` (the snapshot is now a lower bound).
+- All count arithmetic is checked-add saturating at `Number.MAX_SAFE_INTEGER`;
+  a saturation degrades `usageComplete`.
+
+`InvocationUsageMeter` accumulates deltas. `merge(delta)` returns `true` ONLY on
+the first count-overflow transition to incomplete, so a caller relays exactly
+one upward marker. Attribution buckets live in a nested null-prototype index
+`Record<UsageKind, Record<string, number>>` pointing into the first-seen
+`entries` array (no composite string key). `snapshot()` deep-copies.
+
+`normalizeIpcUsageDelta(raw)` is the untrusted-input twin: it recovers every
+independently-valid field, omits an unusable entry while KEEPING the flat money,
+sets `attributionLost`, and returns `null` only when the whole message is not an
+object. It never silently drops money.
+
+## The one sink — `lib/runtime/recordPaidUsage.ts`
+
+`recordUsageDelta` (private) is the single place a delta is accounted:
+
+1. `stack.billCharge(delta.cost.totalCost)` — localCost + guard accumulators (no
+   throw).
+2. `ctx.invocationUsage.merge(delta)` — once.
+3. if `delta.attributionLost`, `markIncomplete()`.
+4. relay the delta upward, THEN (only on a first meter transition) one
+   `invocationUsageIncomplete` marker AFTER it — FIFO preserves the recovered
+   money before the ancestor degrades.
+
+Public entry points: `recordUsage` (normalizes an observation),
+`recordUnresolvedAttempt`, `recordNormalizedUsageDelta` (the IPC path — does NOT
+re-normalize and does NOT enforce guards), `recordCompletionUsage` (prompt.ts —
+also does the branch-local `localTokens` compatibility update),
+`meteredDispatch` (runs a provider dispatch, records one attempt on rejection,
+returns the promise UNCHANGED so it adds no microtask tick), and
+`markInvocationUsageIncompleteAt`. `addCost` (`cost.ts`) validates
+finite-nonnegative first (else throws `addCost: amount must be a finite,
+non-negative number`), records a `manual` observation, then enforces guards.
+
+Sources wired in: `prompt.ts` (completion), `memory/manager.ts` (completion +
+embedding, no-ops without an ALS frame, re-raises guard errors), `stdlib/image.ts`
+(records + tokens for BOTH a returned image and an empty result — the provider
+charged either way — but emits the `imageGeneration` event only when there is an
+image).
+
+## Across the subprocess boundary — `costTelemetry.ts` / `ipc.ts`
+
+The child sends `{ type: "invocationUsage", ...delta }` (the full nested
+`NormalizedDelta`) fire-and-forget; an all-zero delta is suppressed. The parent
+receives an UNTRUSTED shape, runs `normalizeIpcUsageDelta`, then feeds the
+recovered delta to `recordNormalizedUsageDelta` and enforces live-session guards
+— all synchronous, no `await` between accounting and settlement (FIFO ordering
+of telemetry-before-terminal-message depends on it). A mid-tier process re-relays
+what it received, so grandchild spend reaches the root with no explicit plumbing.
+
+### #809 boundary
+
+Only a REJECTED provider promise counts as an unresolved attempt. A resolved
+`Result.failure` records nothing, because smoltalk cannot yet distinguish a
+pre-dispatch failure (no spend) from a post-dispatch one (real spend). Closing
+that gap is deferred to agency-lang #809.
+
+## The spend CLI — `lib/cli/statelog/spendTypes.ts` and friends
+
+`ProjectSpend` mirrors the invocation breakdown: `cost`, `tokens`,
+`invocationCount`, `unpricedCallCount`, `pricingComplete`, `usageComplete`, and a
+`breakdown: ModelKindSpend[]`. Strict Zod schemas own every invariant and the
+TS types are inferred from them, so the sealed `ProjectClient.getSpend` /
+`AccountClient.getAccountSpend` return types cannot drift from their validators.
+`agency remote spend [project]` renders it; `--by-model` / `--by-kind` group the
+breakdown (both → per pair), sorted by cost desc then model then kind. Totals
+gain a `≥` prefix when EITHER completeness flag is false. This side pairs with
+the companion statelog schema; ship the two repos as a pinned pair.

--- a/packages/agency-lang/docs/superpowers/plans/2026-08-04-full-cost-token-breakdown-agency.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-08-04-full-cost-token-breakdown-agency.md
@@ -1,0 +1,377 @@
+# Full Cost & Token Breakdown — agency-lang Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Produce a complete hosted-invocation cost and token breakdown, preserve recoverable accounting across subprocess IPC, and expose project and account spend through `agency remote spend`.
+
+**Architecture:** Provider, attempt, and manual observations pass through one normalizer and one synchronous accounting sink. The meter keeps authoritative flat totals and best-effort `(kind, model)` attribution; IPC independently recovers untrusted fields before calling that same sink. A new shared spend schema supports project and account clients, a pure window parser, renderers, and a thin Commander command.
+
+**Tech Stack:** TypeScript, smoltalk, Node IPC, AsyncLocalStorage, Commander, Zod, Vitest.
+
+**Companion plan:** `/Users/adityabhargava/statelog/docs/superpowers/plans/2026-08-04-full-cost-token-breakdown-statelog.md`. Task 1's snapshot is statelog's recorder input. Task 6's `ProjectSpend` and `AccountSpendRow` exactly mirror statelog Task 4. Ship both repositories as a pinned pair.
+
+**Spec:** `docs/superpowers/specs/2026-08-04-full-cost-token-breakdown-design.md` (current revision 4 content).
+
+## Global Constraints
+
+- Use `type`, plain objects, and arrays. Do not use interfaces, maps, sets, dynamic imports, unbraced `if` statements, or single-character production names.
+- Keep `getModelCosts()`, `__tokenStats`, `updateTokenStats`, `getCost()`, `getTokens()`, and `RunNodeResult.tokens` unchanged.
+- Keep `usageComplete` beside `usage`. Keep USD as the only currency. Use `totalCost` and `totalTokens` as authoritative values; never derive them from component sums.
+- Keep the approved #809 boundary visible: count rejected provider promises as unresolved attempts. Do not count resolved `Result.failure` values because smoltalk cannot yet distinguish pre-dispatch from post-dispatch failures. Implementing that distinction remains deferred to agency-lang #809.
+- Save every expensive verification command to its own output file. Do not edit `docs/site/**`, `CHANGELOG.md`, generated templates, or fixtures unless a task explicitly names them.
+
+---
+
+### Task 1: Value types, exact normalization, and the meter
+
+**Files:**
+- Rewrite: `lib/runtime/invocationUsage.ts`
+- Test: `lib/runtime/invocationUsage.test.ts`
+
+**Interfaces — Produces:**
+
+```ts
+import type { EmbedResult, ImageGenResult, PromptResult } from "smoltalk";
+
+type SmoltalkCost = NonNullable<
+  PromptResult["cost"] | EmbedResult["costEstimate"] | ImageGenResult["costEstimate"]
+>;
+type SmoltalkTokens = NonNullable<
+  PromptResult["usage"] | EmbedResult["tokenUsage"] | ImageGenResult["tokenUsage"]
+>;
+
+export type ProviderUsageKind = "completion" | "embedding" | "image";
+export type UsageKind = ProviderUsageKind | "manual";
+export type CostBreakdown = {
+  inputCost: number;
+  outputCost: number;
+  cachedInputCost: number;
+  cacheCreationInputCost: number;
+  hostedToolsCost: number;
+  totalCost: number;
+  currency: "USD";
+};
+export type TokenBreakdown = {
+  inputTokens: number;
+  outputTokens: number;
+  cachedInputTokens: number;
+  cacheCreationInputTokens: number;
+  totalTokens: number;
+};
+export type UsageEntry = {
+  kind: UsageKind;
+  model: string;
+  cost: CostBreakdown;
+  tokens: TokenBreakdown;
+};
+export type InvocationUsage = {
+  cost: CostBreakdown;
+  tokens: TokenBreakdown;
+  unknownCostCallCount: number;
+  pricingComplete: boolean;
+  entries: UsageEntry[];
+};
+export type InvocationUsageSnapshot = {
+  usage: InvocationUsage;
+  usageComplete: boolean;
+};
+export type UsageObservation =
+  | {
+      type: "provider";
+      kind: ProviderUsageKind;
+      reportedModel?: string | null;
+      configuredModel?: string | null;
+      cost?: SmoltalkCost | null;
+      tokens?: SmoltalkTokens | null;
+    }
+  | { type: "attempt"; kind: ProviderUsageKind }
+  | { type: "manual"; amount: number };
+export type NormalizedDelta = {
+  entry?: UsageEntry;
+  cost: CostBreakdown;
+  tokens: TokenBreakdown;
+  unknownCostCallCount: number;
+  attributionLost: boolean;
+};
+export function normalizeObservation(observation: UsageObservation): NormalizedDelta;
+export function normalizeIpcUsageDelta(raw: unknown): NormalizedDelta | null;
+export function usageReconcileTolerance(total: number): number;
+export class InvocationUsageMeter {
+  merge(delta: NormalizedDelta): boolean; // true only when this merge newly makes usage incomplete
+  markIncomplete(): boolean;
+  snapshot(): InvocationUsageSnapshot;
+}
+```
+
+Use `MAX_COUNT = Number.MAX_SAFE_INTEGER`. Apply this count policy everywhere:
+
+| Boundary | Policy |
+|---|---|
+| Trusted provider token field | Accept a nonnegative safe integer. An absent component becomes `0` without degradation. A present malformed component becomes `0` and sets `attributionLost=true`; if a present `totalTokens` is malformed, use the kind-specific fallback from the normalized components and set `attributionLost=true`. The provider entry remains attributed, but the snapshot is a lower bound. |
+| Trusted derived `totalTokens` | Add with a checked saturating helper. If the exact fallback exceeds `MAX_COUNT`, return `MAX_COUNT` and set `attributionLost=true`; the provider entry remains attributed and the sink degrades `usageComplete`. |
+| Untrusted IPC token or unknown-count field | Accept only a nonnegative safe integer. An absent or malformed field becomes `0` and sets `attributionLost=true`; independently valid fields survive. |
+| Invalid IPC cost bump | Add one to normalized `unknownCostCallCount`. Saturate at `MAX_COUNT`; saturation sets `attributionLost=true`. |
+| Meter accumulation, every token field and unknown count | Checked-add each pair. If the exact sum exceeds `MAX_COUNT`, store `MAX_COUNT`, transition the meter to incomplete, and have `merge` return `true` only for that first transition. Never perform the unsafe addition first. The sink relays the incompleteness marker upward after the normalized delta, so every ancestor preserves the safe-integer lower-bound contract. |
+
+Named provider cost components follow an independent rule: copy a component only when it is a finite nonnegative number; map absent, negative, `NaN`, and either infinity to `0`. Do not reconcile components to `totalCost`. A provider price is valid only when `totalCost` is finite and nonnegative and `currency === "USD"`. Otherwise all six cost fields become zero and `unknownCostCallCount` increases by one, even when named components look valid. A valid total keeps each independently normalized component. `totalCost: 0` is known-free.
+
+Use a nested null-prototype index for bucketing: `Record<UsageKind, Record<string, number>>`, with both levels created through `Object.create(null)`. The outer key is `kind`; the inner key is the unmodified model. The stored number indexes the stable first-seen `entries` array. Do not use a concatenated composite key.
+
+- [ ] **Step 1: Write failing normalizer tests.** Cover valid USD cost; each absent component; each component as negative, `NaN`, `Infinity`, and `-Infinity`; valid `totalCost` with malformed components; and invalid/non-USD `totalCost` with apparently valid components. Assert the authoritative valid total survives while malformed named components become zero, and invalid total makes the whole call unpriced.
+- [ ] **Step 2: Add failing token-limit tests.** For every `TokenBreakdown` field and `unknownCostCallCount`, cover `MAX_COUNT`, `MAX_COUNT + 1` as an individual input, and accumulation of `MAX_COUNT + 1`. Assert every output remains a safe integer. Assert a present malformed trusted count and fallback saturation set `NormalizedDelta.attributionLost=true`; after merging and marking that delta, the snapshot has `usageComplete:false`. Assert accumulation saturation makes the snapshot incomplete and `merge` returns `true` only for the first overflow-driven complete→incomplete transition. Cover completion fallback saturation and embedding/image `input + output` saturation. Task 2 separately verifies upward marker relay from these transitions.
+- [ ] **Step 3: Add the remaining failing value-layer tests.** Cover reported/configured/`"unknown model"` resolution; manual `model:""`; attempt with no entry; provider-total and kind-specific token fallback; cached-image overlap; separate `(kind, model)` buckets; first-seen order; conditional reconciliation only when `usageComplete`; and deep-copy snapshots including nested cost and token objects.
+- [ ] **Step 4: Run the focused test and save failure output.** Run `pnpm test:run lib/runtime/invocationUsage.test.ts > .tmp-cost-t1-fail.log 2>&1`. Expected: FAIL on the new contracts.
+- [ ] **Step 5: Implement the types, helpers, normalizer, and meter.** Remove `models`, `unattributed`, `modelAttributionComplete`, `UsageAttribution`, `completionUsageDelta`, and `paidCostDelta`. Keep helpers pure. Never add unsafe integers before checking `left > MAX_COUNT - right`.
+- [ ] **Step 6: Run `pnpm test:run lib/runtime/invocationUsage.test.ts > .tmp-cost-t1-pass.log 2>&1`.** Expected: PASS.
+- [ ] **Step 7: Commit with message** `feat(serve): add full cost and token usage values`.
+
+---
+
+### Task 2: One accounting sink, public observations, and guarded manual cost
+
+**Files:**
+- Modify: `lib/runtime/recordPaidUsage.ts`
+- Modify: `lib/runtime/cost.ts`
+- Test: `lib/runtime/recordPaidUsage.test.ts`
+
+**Interfaces — Produces:**
+
+```ts
+function recordUsageDelta(
+  target: { ctx: RuntimeContext<GraphState>; stack: StateStack },
+  delta: NormalizedDelta,
+): void;
+export function recordUsage(
+  ctx: RuntimeContext<GraphState>,
+  stack: StateStack,
+  observation: UsageObservation,
+): void;
+export function recordUnresolvedAttempt(
+  ctx: RuntimeContext<GraphState>,
+  stack: StateStack,
+  kind: ProviderUsageKind,
+): void;
+export function recordNormalizedUsageDelta(
+  ctx: RuntimeContext<GraphState>,
+  stack: StateStack,
+  delta: NormalizedDelta,
+): void;
+export function addCost(amount: number): void;
+```
+
+`recordUsageDelta` is private to `recordPaidUsage.ts`. It synchronously calls `billCharge(delta.cost.totalCost)`, merges once, and marks usage incomplete when `attributionLost`. It then attempts one parent relay of the normalized delta. If either `merge` reported its first overflow-driven transition or `markIncomplete()` returned true for attribution loss, it attempts one `invocationUsageIncomplete` relay **after** the delta; FIFO therefore preserves recovered money before degrading the ancestor. Never send the marker more than once for the same meter transition. `recordNormalizedUsageDelta` is the narrow IPC entry point into that sink. It must not normalize again and must not enforce guards.
+
+- [ ] **Step 1: Write failing tests.** Assert sink order with spies: bill, merge/mark, delta relay attempt, then incompleteness-marker attempt. Distinguish a relay attempt from an emitted IPC message: outside IPC mode or for an all-zero delta, `process.send` emits nothing. Assert one sink invocation per observation. Assert malformed trusted-token and overflow transitions emit at most one upward incompleteness marker while preserving the normalized delta first. Test manual cost, unknown attempt, two models, and `addCost` rejection for negative and non-finite values with `addCost: amount must be a finite, non-negative number`.
+- [ ] **Step 2: Run `pnpm test:run lib/runtime/recordPaidUsage.test.ts > .tmp-cost-t2-fail.log 2>&1`.** Expected: FAIL.
+- [ ] **Step 3: Implement the sink and wrappers.** `addCost` validates first, calls `recordUsage(..., { type:"manual", amount })`, then calls `stack.enforceGuards()` exactly once.
+- [ ] **Step 4: Run `pnpm test:run lib/runtime/recordPaidUsage.test.ts > .tmp-cost-t2-pass.log 2>&1`.** Expected: PASS.
+- [ ] **Step 5: Commit with message** `feat(serve): centralize invocation usage accounting`.
+
+---
+
+### Task 3: Wire currently observable provider outcomes into all sources
+
+**Files:**
+- Modify: `lib/runtime/prompt.ts`
+- Modify: `lib/runtime/memory/manager.ts`
+- Modify: `lib/stdlib/image.ts`
+- Test: `lib/runtime/prompt.test.ts`
+- Test: `lib/runtime/memory/manager.test.ts`
+- Test: `lib/stdlib/image.test.ts`
+
+**Interfaces — Consumes:** `recordUsage`, `recordUnresolvedAttempt`, and the Task 1 observation union.
+
+- [ ] **Step 1: Write the currently observable provider-outcome tests.** For completion, embedding, and image, cover priced, priced-zero, invalid/non-USD price, and rejected promise. A rejected promise records one attempt. A resolved `Result.failure` records nothing pending #809. Assert one sink invocation/relay attempt, not one emitted IPC message unless the test explicitly enables IPC and spies on `process.send`. Assert old scalar accounting is absent.
+- [ ] **Step 2: Add ordering tests.** Prompt calls `recordUsage` first, then preserves the current `targetStack.localTokens += completion.usage?.totalTokens ?? 0` branch-local update exactly once, then continues to memory hooks; enforcement remains in its existing surrounding flow. Assert `getTokens()`/branch-local token totals are unchanged for provider totals, missing totals, and repeated completions. The memory helper no-ops when `agencyStore.getStore()` has no frame. With a frame, it obtains `ctx` and `stack`, records exactly once, then calls `stack.enforceGuards()`; best-effort catches must rethrow guard errors.
+- [ ] **Step 3: Specify and test image success ordering.** For a successful provider result with an image: `recordUsage` first; `addTokens` exactly once; `imageGeneration` statelog event; `stack.enforceGuards()` last; then encode and return the image. For a successful provider result with no image: `recordUsage` first; `addTokens` exactly once; do not emit `imageGeneration` because its contract requires an image result; `stack.enforceGuards()` last; then return `failure("Image generation returned no images.")`. A guard trip wins over either return and propagates. Provider failure performs none of these success side effects.
+- [ ] **Step 4: Run focused tests.** Run `pnpm test:run lib/runtime/prompt.test.ts lib/runtime/memory lib/stdlib/image.test.ts > .tmp-cost-t3-fail.log 2>&1`. Expected: FAIL before implementation.
+- [ ] **Step 5: Implement source observations.** Prompt uses completion model/cost/usage, then performs the existing branch-local `localTokens` update after recording and before memory hooks; do not move that compatibility side effect into the general sink. Memory text uses completion fields; embedding uses `EmbedResult.model`, `costEstimate`, and `tokenUsage`. Replace `chargeCostIfInFrame` with a provider-observation wrapper that explicitly enforces the active stack after recording. Image uses the result model/configured model, cost estimate, and token usage. Remove replaced `addCost` calls.
+- [ ] **Step 6: Run the same focused command to `.tmp-cost-t3-pass.log`.** Expected: PASS.
+- [ ] **Step 7: Commit with message** `feat(serve): observe usage from every provider source`.
+
+---
+
+### Task 4: Recover and relay untrusted IPC usage
+
+**Files:**
+- Modify: `lib/runtime/costTelemetry.ts`
+- Modify: `lib/runtime/ipc.ts`
+- Test: `lib/runtime/costTelemetry.test.ts`
+- Test: `lib/runtime/ipc.test.ts`
+
+**Interfaces — Produces:**
+
+```ts
+export type IpcInvocationUsageMessage = {
+  type: "invocationUsage";
+  cost?: unknown;
+  tokens?: unknown;
+  unknownCostCallCount?: unknown;
+  entry?: unknown;
+  attributionLost?: unknown;
+};
+
+// Trusted send-side payload after removing `type`:
+export type IpcInvocationUsagePayload = NormalizedDelta;
+```
+
+The message type describes untrusted receive data. `sendInvocationUsageToParent(delta: NormalizedDelta)` sends `{ type:"invocationUsage", ...delta }`. `normalizeIpcUsageDelta` applies this field-by-field table:
+
+| Field | Recovery |
+|---|---|
+| Non-object message | Return `null`; nothing is recoverable. |
+| `cost` | Normalize each named component independently to finite nonnegative or zero. A finite nonnegative USD `totalCost` is authoritative. Invalid/missing/non-USD total makes all cost fields zero and checked-bumps unknown count once. |
+| `tokens` | Normalize each count independently under Task 1's IPC policy. Valid token fields survive malformed cost and malformed sibling token fields. |
+| `unknownCostCallCount` | Valid nonnegative safe integer survives. Invalid/missing becomes zero and sets `attributionLost=true`; malformed cost then applies its checked bump. |
+| `entry.kind` | Accept only the four `UsageKind` literals. Invalid/missing kind omits the entire entry and sets `attributionLost=true`. |
+| `entry.model` | Require `""` exactly for manual and a nonempty string for provider kinds. Violation omits the entry and sets `attributionLost=true`. |
+| `entry.cost` and `entry.tokens` | Never override flat totals. Normalize independently. Invalid entry cost becomes zero, invalid entry token fields become zero, and either sets `attributionLost=true`; the entry survives when kind/model are valid. |
+| Top-level `attributionLost` | Only literal `true` is accepted as true. Any other value contributes false; local recovery findings still set true. |
+
+Token-only attribution is mandatory: valid flat tokens plus valid entry kind/model preserve an entry with normalized tokens and zero cost. Invalid flat cost increments unknown count exactly once. Valid flat cost/tokens with invalid kind/model preserve flat totals, omit the entry, and set `attributionLost=true`. The sink relays this normalized recovered delta once, including its `attributionLost` value.
+
+- [ ] **Step 1: Write send-side tests.** Assert the complete nested payload and all-zero suppression. Distinguish sink relay attempts from actual messages by enabling IPC and spying on `process.send` only in emission tests.
+- [ ] **Step 2: Write receive normalization tests.** Cover every row of the table, every count at `MAX_COUNT`, malformed-cost bump at `MAX_COUNT`, malformed entry components that leave flat fields untouched, token-only entry survival, unusable kind/model, and a wholly non-object message.
+- [ ] **Step 3: Add IPC-flow tests.** Cover child accounting, grandchild normalized relay, malformed-kind relay with `usageComplete=false`, two-session isolation, parent guard enforcement, and terminal FIFO ordering. Assert normalization, sink accounting, relay, and guard enforcement are synchronous with no `await` between them.
+- [ ] **Step 4: Run `pnpm test:run lib/runtime/costTelemetry.test.ts lib/runtime/ipc.test.ts > .tmp-cost-t4-fail.log 2>&1`.** Expected: FAIL.
+- [ ] **Step 5: Implement the transition inventory.** Update every message union and `handleChildMessage` branch. Replace the receive branch with `normalizeIpcUsageDelta(msg)` followed by `recordNormalizedUsageDelta(...)`, then enforce live-session guards. Remove legacy `{ costUsd }`, `IpcTelemetryMessage`, `isPayableCost`, and every `modelAttributionIncomplete` type, sender, handler, import, and test. Keep accounting before terminal settlement and introduce no await.
+- [ ] **Step 6: Run the same tests to `.tmp-cost-t4-pass.log`.** Expected: PASS.
+- [ ] **Step 7: Commit with message** `feat(serve): recover and relay full usage over IPC`.
+
+---
+
+### Task 5: Surface the snapshot on every serve outcome
+
+**Files:**
+- Verify only: `lib/serve/http/adapter.ts`
+- Test: `lib/serve/http/adapter.test.ts`
+- Test: `lib/serve/http/serveCostSeam.integration.test.ts`
+
+**Interfaces — Consumes:** `InvocationUsageSnapshot`; the adapter copies `usage` and sibling `usageComplete` without recomputation.
+
+- [ ] **Step 1: Add tests.** Cover success with manual cost, thrown outcomes, interrupt/resume, authoritative totals, manual entry, and `usageComplete` as a sibling rather than a child of `usage`.
+- [ ] **Step 2: Run `pnpm test:run lib/serve/http/adapter.test.ts lib/serve/http/serveCostSeam.integration.test.ts > .tmp-cost-t5.log 2>&1`.** Expected: PASS without adapter logic changes. If a test exposes stale shape-only code, change only that shape copy.
+- [ ] **Step 3: Commit tests with message** `test(serve): cover full usage on every route outcome`.
+
+---
+
+### Task 6: Build the spend wire, clients, window, rendering, and command
+
+**Files** (all six spend files + the client `getSpend`/`getAccountSpend` methods already exist from #806 with the OLD flat `ProjectSpend`; this task **replaces** the shape, not greenfield):
+- Rewrite: `lib/cli/statelog/spendTypes.ts` (replace the flat `ProjectSpend` with the full-breakdown shape)
+- Rewrite: `lib/cli/statelog/spendTypes.test.ts`
+- Modify: `lib/cli/statelog/projectClient.ts` (`getSpend` return type → new `ProjectSpend`; keep the one request path)
+- Modify: `lib/cli/statelog/projectClient.test.ts`
+- Modify: `lib/cli/statelog/accountClient.ts` (`getAccountSpend` return type → new `AccountSpendRow[]`)
+- Modify: `lib/cli/statelog/accountClient.test.ts`
+- Reuse/verify: `lib/cli/remote/commands/spendWindow.ts` (window logic unchanged from #806 — likely no edit; add `--by-model`/`--by-kind` only in `spend.ts`)
+- Reuse/verify: `lib/cli/remote/commands/spendWindow.test.ts`
+- Rewrite: `lib/cli/remote/commands/spend.ts` (render the new shape; wire `--by-model`/`--by-kind`)
+- Rewrite: `lib/cli/remote/commands/spend.test.ts`
+- Modify: `lib/cli/remote/render.ts` (replace `renderProjectSpend`/`renderAccountSpend` for the new shape)
+- Modify: `lib/cli/remote/render.test.ts`
+- Modify: `scripts/agency.ts` (add `--by-model`/`--by-kind`)
+- Modify: `scripts/agency.test.ts`
+
+**Interfaces — Produces:**
+
+```ts
+export type ModelKindSpend = {
+  model: string;
+  kind: UsageKind;
+  cost: CostBreakdown;
+  tokens: TokenBreakdown;
+};
+export type ProjectSpend = {
+  cost: CostBreakdown;
+  tokens: TokenBreakdown;
+  invocationCount: number;
+  unpricedCallCount: number;
+  pricingComplete: boolean;
+  usageComplete: boolean;
+  breakdown: ModelKindSpend[];
+};
+export type AccountSpendRow = {
+  projectSlug: string;
+  deletedAt: string | null;
+  spend: ProjectSpend;
+};
+export type SpendWindow = { from: number | null; to: number | null };
+export type SpendWindowOptions = { since?: string; from?: string; to?: string };
+export type ResolvedSpendWindow = SpendWindow & { description: string };
+export type SpendOptions = AccountCommandOptions & SpendWindowOptions & {
+  json?: boolean;
+  byModel?: boolean;
+  byKind?: boolean;
+};
+export function resolveSpendWindow(options: SpendWindowOptions, now?: number): ResolvedSpendWindow;
+export function toSpendQuery(window: SpendWindow): Record<string, string>;
+export function runSpend(
+  project: string | undefined,
+  options: SpendOptions,
+  context: RemoteCommandContext,
+): Promise<void>;
+```
+
+Own transport in the existing sealed clients. Add `ProjectClient.getSpend(window): Promise<ProjectSpend>` to `projectClient.ts` and `AccountClient.getAccountSpend(window): Promise<AccountSpendRow[]>` to `accountClient.ts`; do not create a third HTTP client. Both clients send `Authorization: Bearer <key>`, parse statelog's existing `{ success, value, error }` envelope, and validate the camelCase envelope value with strict Zod schemas. Statelog Task 4 emits these camelCase values; there is no spend-specific snake-case transformation.
+
+Project mode uses `GET /api/projects/:encodedSlug/spend?from=<epoch-ms>&to=<epoch-ms>` and accepts a project- or account-scoped key. Account mode uses `GET /api/spend?...` and requires an account-scoped key. Preserve the existing known 403 as `AccountScopeError`, so `failAccount` prints the account-key hint. On either spend route, an unmatched 404 means `this statelog host does not support the spend API (upgrade the host)`; project `404 { error:"Project not found" }` retains the project-not-found error. Non-404 HTML/non-JSON responses retain normal HTTP errors. A successful incompatible shape throws the client-specific request error containing `incompatible statelog version`.
+
+Use strict schemas for every object. Costs must be finite and nonnegative, currency must equal USD, all counts must be nonnegative safe integers, `pricingComplete` must equal `unpricedCallCount === 0`, kinds and model sentinel must match, `deletedAt` must be null or ISO datetime, and no extra fields are accepted. The project empty identity is all cost/token/count values zero, both completeness flags true, and `breakdown: []`. Account JSON is the raw `AccountSpendRow[]`, including deleted and zero-event projects; project JSON is the raw `ProjectSpend`.
+
+Selection is positional-only: bare `agency remote spend` always selects account mode. `agency remote spend <project>` selects that slug. A linked directory may provide host/key defaults but never changes bare account mode into project mode. Project resolution calls `resolveProjectTarget(context, { ...options, project })`; account resolution calls `resolveAccountTarget(context, options)`.
+
+Window contract: no flags means `{from:null,to:null,description:"all time"}`. `--since <duration>` uses `parseDurationMs`, requires a positive whole-millisecond safe integer, cannot combine with `--from` or `--to`, and produces `[now-duration, now)`. `--from` and `--to` accept nonnegative safe epoch milliseconds, `YYYY-MM-DD` at UTC midnight, or ISO datetime with explicit `Z`/offset. Reject invalid calendar dates, local datetimes, out-of-Date-range values, and `from >= to`. Omit null query keys; serialize present keys as decimal `from` and `to`.
+
+Commander registration is exactly:
+
+```ts
+remoteCmd
+  .command("spend")
+  .description("Show hosted spend for a project or the whole account")
+  .argument("[project]", "project slug; omit for the account-wide rollup")
+  .option("--since <duration>", "window ending now, for example 24h, 7d, or 2w")
+  .option("--from <when>", "window start as ISO-8601 with zone or epoch-ms")
+  .option("--to <when>", "window end as ISO-8601 with zone or epoch-ms")
+  .option("--json", "emit JSON for machine use")
+  .option("--by-model", "group the breakdown by model")
+  .option("--by-kind", "group the breakdown by operation kind")
+  .option(HOST_OPTION, HOST_DESC)
+  .option(API_KEY_ENV_OPTION, API_KEY_ENV_DESC)
+  .action((project: string | undefined, options: SpendOptions) =>
+    runSpend(project, options, getConfigContext()),
+  );
+```
+
+Human output always shows authoritative cost component lines, token components and total, invocation count, USD, and trust markers. `--by-model` groups by model; `--by-kind` groups by kind; both group by the pair. Sort groups by `cost.totalCost` descending, then model and kind ascending. Label model `""` as `(manual)`. Render adaptive money (`$0.0000` only for zero; `<$0.0001` for positive values below that threshold). Prefix totals with `≥` when either completeness flag is false, and print separate telemetry-incomplete and unknown-price notes. A zero-spend project prints `No spend in <description>.`; account mode still prints one row for every returned project, marks deleted rows, and includes zero-event rows.
+
+- [ ] **Step 1: Write schema and window tests.** Cover every field invariant, strict extras, complete empty identities, account row metadata, all accepted window forms, every rejection above, and exact query omission/serialization.
+- [ ] **Step 2: Write client tests.** Cover exact encoded URLs, envelopes, project/account key behavior, account-scope hint translation, project-not-found versus unsupported-host 404, non-JSON 5xx, incompatible-version schema errors, deleted projects, and zero-event projects.
+- [ ] **Step 3: Write renderer and command tests.** Cover component lines, both notes independently and together, adaptive money, each grouping mode and tie-break, manual label, project empty output, account deleted/zero rows, raw project JSON object, raw account JSON array, positional selection, linked-project non-selection, host/key forwarding, and invalid-window failure before any request.
+- [ ] **Step 4: Write Commander tests.** Parse the full option set and assert exact `runSpend` arguments. Parse bare `remote spend` and assert `project === undefined`. Add `spend` to the sorted remote-subcommand assertion.
+- [ ] **Step 5: Run focused tests to `.tmp-cost-t6-fail.log`.** Run `pnpm test:run lib/cli/statelog/spendTypes.test.ts lib/cli/statelog/projectClient.test.ts lib/cli/statelog/accountClient.test.ts lib/cli/remote/commands/spendWindow.test.ts lib/cli/remote/commands/spend.test.ts lib/cli/remote/render.test.ts scripts/agency.test.ts > .tmp-cost-t6-fail.log 2>&1`. Expected: FAIL.
+- [ ] **Step 6: Implement the schemas, existing-client extensions, pure window parser, renderers, command, and registration.** Keep one request path in each client and infer wire types from Zod schemas.
+- [ ] **Step 7: Run the same focused command to `.tmp-cost-t6-pass.log`.** Expected: PASS.
+- [ ] **Step 8: Commit with message** `feat(remote): add full breakdown spend command`.
+
+---
+
+### Task 7: Verification
+
+- [ ] Run `pnpm run typecheck > .tmp-cost-typecheck.log 2>&1`. Expected: exit 0 and no diagnostics.
+- [ ] Run `pnpm run lint:structure > .tmp-cost-structure.log 2>&1`. Expected: exit 0.
+- [ ] Run `make > .tmp-cost-make.log 2>&1`. Expected: exit 0; runtime and stdlib artifacts build successfully.
+- [ ] Run `pnpm test:run > .tmp-cost-tests.log 2>&1`. Expected: exit 0 and zero failed tests. Do not run watch mode.
+- [ ] Inspect each log independently. Do not overwrite one command's evidence with another command.
+- [ ] Remove `.tmp-cost-t1-fail.log`, `.tmp-cost-t1-pass.log`, `.tmp-cost-t2-fail.log`, `.tmp-cost-t2-pass.log`, `.tmp-cost-t3-fail.log`, `.tmp-cost-t3-pass.log`, `.tmp-cost-t4-fail.log`, `.tmp-cost-t4-pass.log`, `.tmp-cost-t5.log`, `.tmp-cost-t6-fail.log`, `.tmp-cost-t6-pass.log`, `.tmp-cost-typecheck.log`, `.tmp-cost-structure.log`, `.tmp-cost-make.log`, and `.tmp-cost-tests.log` after recording the results in the handoff.
+- [ ] Report the pinned statelog version requirement and the #809 limitation. Do not claim resolved `Result.failure` coverage.
+
+## Self-review
+
+- Cost components normalize independently; malformed named components cannot persist, and invalid/non-USD totals remain unpriced regardless of component appearance.
+- Trusted input, IPC input, malformed-cost bumps, fallback arithmetic, and meter accumulation all have one exact safe-integer policy with boundary tests for every count; every lossy normalization or saturation degrades and relays `usageComplete` exactly once.
+- IPC has a concrete untrusted wire shape and recovery table. Token-only attribution survives, authoritative flat values survive malformed attribution, and the normalized recovered delta relays once.
+- Image success-with-image and success-without-image have explicit side effects and ordering. Memory explicitly records then enforces the active stack guard.
+- The CLI extends the two existing sealed clients. Project/account schemas, camelCase wire values, auth, scope selection, windows, errors, JSON shapes, deleted/zero rows, and Commander registration are complete.
+- Bucketing uses nested null-prototype objects without a composite delimiter. Verification commands use distinct output paths.
+- The approved #809 defer remains out of scope and visible in tests, implementation instructions, and handoff documentation.

--- a/packages/agency-lang/docs/superpowers/specs/2026-08-04-full-cost-token-breakdown-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-08-04-full-cost-token-breakdown-design.md
@@ -1,0 +1,433 @@
+# Full Cost & Token Breakdown, Per Model — Design (agency + statelog)
+
+> Spans **agency-lang** (produce + propagate) and **statelog** (store + aggregate).
+> The hosted **spend ledger** has no consumers yet, so its schema is a clean
+> breaking change. But several *runtime* surfaces (below) do have users and are
+> kept. Rev 3 — rewritten to address the two design reviews; the accounting
+> contract is the point of this document, so it is specified here, not deferred
+> to the plan.
+
+## Goal
+
+Capture, per hosted invocation, the complete cost and token information smoltalk
+produces — input / output / cached-read / cache-write / hosted-tools costs, and
+input / output / cached-read / cache-write / total tokens — attributed per model
+and per API verb, with a **single authoritative billing total** that the
+attribution breakdown reconciles to but never redefines.
+
+## What smoltalk gives us
+
+`completion.cost` / `.usage` (also on embed and image results) —
+`smoltalk/dist/types/{costEstimate,tokenUsage}.d.ts`:
+
+```ts
+CostEstimate = { inputCost, outputCost, cachedInputCost?, cacheCreationInputCost?, hostedToolsCost?, totalCost, currency }
+TokenUsage   = { inputTokens, outputTokens, cachedInputTokens?, cacheCreationInputTokens?, totalTokens? }
+```
+
+- smoltalk computes `totalCost` from the components and rounds each to 6 dp
+  (`model.js`), so `totalCost` is the authoritative figure and the components may
+  miss it by sub-microdollar rounding.
+- `hostedToolsCost` has **no** token counterpart.
+- `totalTokens` is provider-authoritative; the four token counters **may
+  overlap** depending on source (completion clients normalize cached vs ordinary
+  input into disjoint buckets; the image path can report `cachedInputTokens` as a
+  *subset* of `inputTokens`). Never derive a total by summing the four.
+- `currency` is `"USD"` from every current provider.
+
+Every internal source already holds this and discards all but `.totalCost`:
+agent turns (`prompt.ts:773`), memory text — extraction/compaction/recall — and
+memory embeddings (`memory/manager.ts:292,370`), image gen (`image.ts:96`); only
+the public `addCost(amount)` (`cost.ts:15`) is a bare scalar.
+
+## Core model: three observations → one boundary → authoritative totals + reconciled attribution
+
+Call sites never build dense breakdown objects or decide completeness. They emit
+one of three **domain observations**; one normalization layer turns each into an
+internal delta; one boundary bills guards, merges the meter, and relays once.
+
+```ts
+type ProviderUsageKind = "completion" | "embedding" | "image";   // provider calls; always have a model
+type UsageKind = ProviderUsageKind | "manual";                   // stored kind
+
+type UsageObservation =
+  // reportedModel/configuredModel go to central resolution — call sites don't pick the model
+  | { type: "provider"; kind: ProviderUsageKind; reportedModel?: string | null; configuredModel?: string | null; cost?: CostEstimate; tokens?: TokenUsage }
+  | { type: "attempt"; kind: ProviderUsageKind }  // a provider request dispatched but not resolved
+  | { type: "manual"; amount: number };           // a program-declared addCost cost
+
+recordUsage(target, observation): void;   // the one PUBLIC boundary → normalize → recordUsageDelta
+```
+
+The union makes impossible states unrepresentable: only a `provider`/`attempt`
+observation carries a `ProviderUsageKind`, and only the `manual` builder produces
+`{ kind:"manual" }`. Malformed IPC input is NOT this trusted union — it is a
+separate normalized transport delta with optional fields (IPC section).
+
+The four provider outcomes are resolved **once, centrally** (not per call site):
+
+1. **Success, valid price** (`cost` present, finite, USD) — priced; build the entry.
+   `totalCost === 0` is a *known free* price (no counter bump).
+2. **Success, no/invalid/non-USD price** — keep `model` + `tokens` as an entry
+   with zero cost, increment `unknownCostCallCount`, `pricingComplete` becomes
+   false. Never invent a cost.
+3. **Dispatched-but-unresolved attempt** (`type:"attempt"`) — no entry,
+   increment `unknownCostCallCount` (→ `pricingComplete=false`); `usageComplete`
+   stays true (the attempt was observed reliably). Each retry is a fresh attempt.
+   **Applies to completion, embedding, and image alike.**
+   > **Known limitation — tracked by agency-lang #809.** `LLMClient.{text,embed,
+   > image}` return `Promise<Result<…>>`, and a `Result.failure` covers **both** a
+   > pre-dispatch failure (no spend) and a post-dispatch one (possible spend),
+   > indistinguishably. So for now agency counts an attempt only on a **rejected
+   > promise** (today's `meteredDispatch` behavior); a resolved `Result.failure`
+   > is not yet counted. The real fix is smoltalk exposing whether the request was
+   > dispatched (#809), after which we count exactly the dispatched-but-failed
+   > calls. Do not implement "count every resolved failure" — it over-flags
+   > pre-dispatch failures.
+4. **Proven pre-dispatch failure** — no observation at all.
+
+**Exactly once.** Each successful paid operation submits exactly one `provider`
+observation and nothing else. Memory and image **replace** their `addCost(total)`
+call with a `provider` observation (they must not do both, or they double-charge).
+`manual` is reserved for user-declared / external costs via the public `addCost`.
+
+## Cost & token value types
+
+```ts
+// `totalCost` is AUTHORITATIVE. The five named components are smoltalk's split —
+// a BEST-EFFORT estimate that MAY NOT sum to totalCost (a manual/total-only charge
+// has all components 0 and total = the amount; rounding also means a provider
+// split may miss the total by a sub-microdollar). No reconciliation invariant on
+// components, and no residual/"unallocated" field. Consumers wanting a split use
+// the components; anyone billing uses totalCost.
+type CostBreakdown = {
+  inputCost; outputCost; cachedInputCost; cacheCreationInputCost; hostedToolsCost; totalCost;
+  currency: "USD";
+};
+
+// totalTokens is AUTHORITATIVE (provider value, else kind-specific fallback — see
+// below). The four counters are as smoltalk reports them and MAY overlap;
+// consumers must use totalTokens for the total, never the sum.
+type TokenBreakdown = {
+  inputTokens; outputTokens; cachedInputTokens; cacheCreationInputTokens; totalTokens;
+};
+
+// model is a plain string — "" is the sentinel for a manual charge (never null),
+// so a DB UNIQUE(invocation_id, kind, model) actually catches duplicates.
+type UsageEntry = { kind: UsageKind; model: string; cost: CostBreakdown; tokens: TokenBreakdown };
+```
+
+**Token total fallback is kind-specific** (a single `input+output` formula is
+wrong for cached completions and double-counts images): use the provider
+`totalTokens` when present; else **completion** = input + output + cache-read +
+cache-write (the completion adapter normalizes those into disjoint buckets);
+**embedding**/**image** = input + output (image cache counts may be a subset of
+input). All counts are non-negative safe integers.
+
+**Currency: USD-only.** The boundary asserts `currency === "USD"` on a priced
+observation; a non-USD price is treated as case 2 (unpriced) rather than summed
+into a USD total. `currency:"USD"` is carried through runtime, wire, DB, API, and
+display. (Multi-currency would require grouping every total by currency — out of
+scope; no provider needs it.)
+
+**Model identity.** Central resolution only: the normalizer runs
+`resolveCompletionModel(reportedModel, configuredModel)` (provider → configured →
+`"unknown model"`) for every provider observation, so a real provider entry
+always has a non-empty model. Call sites never pick the model. `model` is `""`
+only for a `manual` entry. Memory's `_text` path (extraction, compaction, recall)
+is a `completion`; its embeddings are `embedding` — the model disambiguates them.
+
+## The snapshot — authoritative totals + attribution, with `usageComplete` a sibling
+
+```ts
+type InvocationUsage = {
+  cost: CostBreakdown;         // AUTHORITATIVE flat totals, accumulated in call order (the billed figure)
+  tokens: TokenBreakdown;      // AUTHORITATIVE flat totals
+  unknownCostCallCount: number;
+  pricingComplete: boolean;    // === (unknownCostCallCount === 0)
+  entries: UsageEntry[];       // reconciled attribution, one per (kind, model); NOT the billing source
+};
+
+type InvocationUsageSnapshot = {
+  usage: InvocationUsage;
+  usageComplete: boolean;      // SIBLING of usage (unchanged from #801): telemetry delivery / lower-bound flag
+};
+```
+
+- **Authoritative vs attribution.** `usage.cost.totalCost`/`usage.tokens.totalTokens`
+  are the truth (accumulated per charge in call order, #801-style). `entries` are a
+  BEST-EFFORT attribution: `sum(entries.cost.totalCost) ≈ usage.cost.totalCost`
+  within `usageReconcileTolerance` **only when telemetry is complete**. The
+  individual cost *components* carry no reconciliation guarantee. A discrepancy
+  never changes a billed total, and a `usageComplete=false` snapshot keeps and
+  surfaces its authoritative totals even when entries do not reconcile — downstream
+  persistence must not reject it for that.
+- **`usageComplete` stays a sibling** (not nested in `usage`) — the HTTP
+  adapter/outcome/route contract already carry it there, so **Part 1's adapter
+  needs no change** (it copies `usage` + `usageComplete`).
+- **Retired** vs #802: `pricedCost` scalar (→ `usage.cost.totalCost`), the
+  `models` map + `unattributed` field (→ `entries`), `modelAttributionComplete`
+  and the version-skew machinery (dropped: no ledger consumers, and a `run()`
+  child shares the parent's version).
+
+## IPC: preserve valid money, degrade completeness — never silently drop
+
+`normalizeUsageDelta` (untrusted process-boundary input) validates each field
+independently: invalid cost → an unknown-cost attempt (never a known-free zero),
+keeping valid tokens; counts coerced to nonnegative safe integers. **A delta
+carrying real money that cannot be fully attributed (e.g. an unusable `kind`) is
+still counted in the authoritative flat totals, gets no attribution entry, and
+sets `usageComplete = false` (relayed upward).** Only a wholly unparseable
+message (not an object) is dropped, and it carries nothing to preserve. Money is
+never lost while `usageComplete` stays true. (This is why removing
+`modelAttributionComplete` is safe: lost attribution degrades `usageComplete`.)
+
+---
+
+# Part 1 — agency-lang (producer + transport)
+
+- **`lib/runtime/invocationUsage.ts`** — `CostBreakdown`, `TokenBreakdown`,
+  `UsageKind`, `UsageEntry`, the new `InvocationUsage`/snapshot; the observation→
+  delta normalizer (the four cases + central model resolution + USD + kind-specific totalTokens
+  derivation); `InvocationUsageMeter` owns validation, `(kind,model)` bucketing,
+  call-order flat accumulation, copy-on-snapshot, and reconciliation. Delete the
+  `models`/`unattributed`/`modelAttributionComplete` machinery.
+- **`lib/runtime/recordPaidUsage.ts`** — ONE private sink
+  `recordUsageDelta(target, normalizedDelta)` does, synchronously and in order:
+  (1) `billCharge(cost.totalCost)`; (2) merge authoritative flat fields + any valid
+  entry; (3) relay the delta upward once. Public `recordUsage(ctx, stack,
+  observation)` normalizes a trusted observation then calls the sink; IPC (Task 4)
+  independently normalizes untrusted fields then calls the **same** sink. Do **not**
+  claim end-to-end "exactly once" transport — `process.send` is fire-and-forget with
+  no ack; the enforceable invariant is one relay attempt per locally recorded delta,
+  plus `usageComplete=false` on abnormal child termination.
+- **Sources** feed observations (each **replacing** its old scalar charge, exactly
+  once, preserving existing ordering): `prompt.ts:773` accounts the completion where
+  it does today (before memory hooks; enforcement stays in the surrounding flow, NOT
+  moved into `recordUsage`); `memory/manager.ts:292` → `completion`, `:370` →
+  `embedding` (the new helper keeps `chargeCostIfInFrame`'s no-op-without-a-frame and
+  guard-rethrow behavior); `image.ts:96` → `image`, recording on the successful
+  provider result (even when `images[0]` is absent — the spend already happened) and
+  keeping branch-token accounting + the cost-last guard-trip ordering.
+- **`cost.ts` `addCost(amount)`** (public, kept) — validates its argument
+  up-front and **rejects a negative or non-finite amount with a clear,
+  addCost-facing error** (today the throw is buried in `paidCostDelta` and names
+  that internal helper), then emits `{manual, amount}`.
+- **`costTelemetry.ts` / `ipc.ts`** — `IpcInvocationUsageMessage` carries the
+  full delta; receive path normalizes as above (preserve money, degrade
+  `usageComplete`). **Removed**: the legacy `{costUsd}` message + handler and the
+  `modelAttributionIncomplete` marker.
+- **`serve/http/adapter.ts`** — no logic change (`usage` + sibling
+  `usageComplete` already copied).
+- **`lib/cli/remote/*`** — `spendTypes.ts` + renderers updated to the new
+  `ProjectSpend` (Part 2 / API section). Breaking; validated via zod so an
+  incompatible host response fails with a clear error.
+
+## Runtime compatibility inventory (surfaces that DO have users)
+
+| Surface | Decision |
+|---|---|
+| `std::thread getCost()/getTokens()` (branch `localCost`/`localTokens`, `totalTokens`) | **Retained** — unaffected; `totalTokens` preserved |
+| `getModelCosts()` / `__tokenStats` / `updateTokenStats` (`/cost` footer) | **Retained as-is** — Part 1.7 (per-model cost-type parity there) is **deferred**: changing `getModelCosts()` is a breaking stdlib-API change with real users, for marginal gain. It keeps its current process-cumulative shape. |
+| `RunNodeResult.tokens` (= `__tokenStats`) | **Retained** (unchanged, since `__tokenStats` is) |
+| serve `RouteResult.usage` | **Adapted (breaking)** — new shape; only consumer is the `agency remote spend` CLI, rewritten in lockstep |
+| subprocess IPC usage message | **Adapted (breaking)** — new wire; runtime ships as one version |
+| statelog spend API + validators, CLI JSON, fixtures | **Adapted (breaking)** — Part 2 |
+
+---
+
+# Part 2 — statelog (storage + query + API)
+
+Two tables. The **parent is the authoritative billing fact**; the child is
+attribution detail. (Replaces Group-4's single aggregate `usage_events`.)
+
+All columns `NOT NULL` (a bare `CHECK (x >= 0)` still admits `NULL`); ids are
+repo-native **text/`nanoid`**, not UUID; costs `numeric(20,10)` (exact for
+smoltalk's 6-dp; max just under 10^10 — test overflow), tokens `bigint`.
+
+```
+hosted_invocations                    -- one per hosted invocation (the billing fact)
+  id                     text PK                       -- nanoid
+  execution_attempt_id   text NOT NULL UNIQUE          -- runtime occurrence id → idempotency key (host-minted nanoid)
+  project_id             … FK → projects(id) ON DELETE RESTRICT   -- retention-safe: never cascade away billing
+  trace_id               text NULL                     -- nullable: RouteResult carries no trace id today
+  created_at             timestamptz NOT NULL DEFAULT now()   -- the spend-window timestamp
+  input_cost … cache_creation_input_cost, hosted_tools_cost, total_cost  numeric NOT NULL DEFAULT 0 CHECK (>= 0)
+  input_tokens … cache_creation_input_tokens, total_tokens               bigint  NOT NULL DEFAULT 0 CHECK (>= 0)
+  currency               text NOT NULL CHECK (currency = 'USD')
+  unknown_cost_call_count int NOT NULL DEFAULT 0 CHECK (>= 0)
+  usage_complete         boolean NOT NULL
+  -- pricing_complete is DERIVED (unknown_cost_call_count = 0) in the API, not stored
+
+usage_events                          -- attribution detail; zero-or-more per invocation
+  id            text PK                              -- nanoid
+  invocation_id text NOT NULL FK → hosted_invocations(id) ON DELETE CASCADE
+  kind          text NOT NULL CHECK (kind IN ('completion','embedding','image','manual'))
+  model         text NOT NULL                        -- '' sentinel for manual (never NULL)
+  input_cost … hosted_tools_cost, total_cost         numeric NOT NULL DEFAULT 0 CHECK (>= 0)
+  input_tokens … total_tokens                        bigint  NOT NULL DEFAULT 0 CHECK (>= 0)
+  currency      text NOT NULL CHECK (currency = 'USD')
+  CHECK ( (kind = 'manual' AND model = '') OR (kind <> 'manual' AND model <> '') )
+  UNIQUE (invocation_id, kind, model)   -- works because model is NOT NULL ('' for manual): one row per bucket
+  INDEX (invocation_id), INDEX (model), INDEX (kind)
+```
+
+The `''`-sentinel + `NOT NULL` model is what makes `UNIQUE (invocation_id, kind,
+model)` actually enforce one row per bucket — a plain unique over a nullable
+`model` would let duplicate manual rows through (Postgres treats each `NULL` as
+distinct), and it needs no PostgreSQL-version-specific `NULLS NOT DISTINCT`.
+
+**Testability — a thin store over pure logic (no CI database needed).** All logic
+is pure and unit-tested with plain objects; only a small `SpendStore` touches
+Postgres, shaped so the fan-out bug cannot be written:
+```ts
+type SpendStore = {
+  saveInvocation(parent: InvocationRow, details: UsageEventRow[]): Promise<void>; // one idempotent transaction
+  sumInvocationTotals(projectId, from, to): Promise<InvocationTotals>;  // aggregates ONE table (parents)
+  groupUsageEvents(projectId, from, to): Promise<UsageGroupRow[]>;      // aggregates ONE table (details)
+};
+// pure, DB-free:
+function toInvocationRows(snapshot, ids): { parent: InvocationRow; details: UsageEventRow[] };
+function assembleProjectSpend(totals: InvocationTotals, groups: UsageGroupRow[]): ProjectSpend;  // empties→0, pricingComplete, sort, breakdown
+```
+Because each store method aggregates **one table**, the dangerous "join parent to
+detail then `SUM(parent)`" pattern (which multiplies the bill) is never expressible;
+`assembleProjectSpend` just combines two already-aggregated small results. The
+untested surface is three tiny SQL methods, coverable with an **in-memory Postgres
+(`pg-mem`)** in unit tests — no CI DB service or containers.
+
+**Recorder — `recordHostedInvocation(snapshot, ids)`** = `toInvocationRows` (pure)
++ `store.saveInvocation` (one transaction). Idempotency is **insert-or-read-and-
+compare**, not blind `DO NOTHING`: on an existing `execution_attempt_id`, read the
+stored parent and return `duplicate` only if the immutable payload (project + every
+authoritative amount, compared after numeric normalization) matches; a **different
+payload under the same key is a loud failure** (hides corruption otherwise). Signature:
+no `trx` → open one `db.transaction()`; caller `trx` → run in it without nesting;
+throw inside the callback on any detail failure so Kysely cannot commit a partial
+parent; convert to `Result` only outside the transaction. Persistence stays
+**best-effort** (the host logs a failure and still responds — an accepted rare
+undercount, stated explicitly); making it blocking is a separate behavioral change.
+
+**Aggregation — join-safe.** Two single-table aggregates combined purely
+(`assembleProjectSpend`); the parent query **never** joins `usage_events`. For the
+**account** rollup: (1) `projects LEFT JOIN hosted_invocations` (window predicates
+in the JOIN) grouped by internal project id → one row per project incl. deleted &
+zero-event; (2) a detail aggregate grouped by internal project id + `(model, kind)`;
+(3) merge in app code keyed on **internal project id** (not the mutable slug), `[]`
+breakdown for projects with no detail. Empty identity is explicit: all costs/tokens
+`0`, counts `0`, both completeness flags `true`, `breakdown: []` (`SUM`/`bool_and`
+return `NULL` on empty). Deterministic breakdown order (model asc, then kind).
+
+The spec forbids `SUM(hosted_invocations.total_cost)` or `COUNT` after joining
+detail rows (fan-out would multiply the billed total per detail row).
+
+**API types (`apiTypes/spend.ts`, breaking replacement):**
+
+```ts
+type ProjectSpend = {
+  cost: CostBreakdown;          // from parent totals (authoritative); currency lives HERE only
+  tokens: TokenBreakdown;       // from parent totals
+  invocationCount: number;
+  unpricedCallCount: number;    // SUM(unknown_cost_call_count)
+  pricingComplete: boolean;     // unpricedCallCount === 0
+  usageComplete: boolean;       // bool_and(usage_complete)
+  breakdown: ModelKindSpend[];  // GROUP BY (model, kind)
+};
+type ModelKindSpend = { model: string; kind: UsageKind; cost: CostBreakdown; tokens: TokenBreakdown };  // model "" = manual
+```
+
+Routes/window unchanged (`/api/projects/:slug/spend`, `/api/spend`, epoch-ms
+`[from,to)`). `ProjectSpend` is **replaced**, not extended — the CLI validates it
+with zod and fails clearly against an incompatible host.
+
+## CLI (`agency remote spend`) — fully specified
+
+- Default: the authoritative totals — cost (with its component breakdown lines),
+  token totals, invocationCount — plus trust markers.
+- `--by-model` / `--by-kind`: render `breakdown` grouped by model / by kind
+  (combinable → grouped by both). Sorted by `cost.totalCost` desc, tie-break
+  `(model, kind)` ascending; a `model: ""` (manual) row is labelled `(manual)`.
+- `--json`: the raw `ProjectSpend` verbatim (machine surface).
+- Money via the adaptive formatter (`$0.0000` only for true zero, `<$0.0001`
+  tiny); currency shown as `USD`.
+- A total is a lower bound (`≥`) when **either** `usageComplete === false`
+  (telemetry loss) **or** `pricingComplete === false` (unknown-priced calls) — with
+  a separate one-line note for each axis;
+  `unpricedCallCount > 0` → an unpriced-calls note. Empty window → `No spend in <window>.`
+- Account rollup: one row per project (deleted projects marked, per the existing
+  command), each carrying the same shape.
+
+## Migration / rollout
+
+A **new** migration drops Group-4's `usage_events` and creates
+`hosted_invocations` + `usage_events` (do not edit applied migration history).
+Explicit deployment assumption: no production spend data exists, so the policy is
+drop-and-rebuild. Ship the agency-lang runtime and the statelog host as a **pinned
+pair**; version skew between them is unsupported and fails clearly (zod
+validation), not silently.
+
+## Reconciliation & trust axes
+
+- **Cost**: `totalCost` authoritative and billed. The five components are a
+  **best-effort estimate with no sum-to-total invariant** (manual/total-only = 0
+  components; rounding). The only reconciliation is at the attribution level and
+  **only when telemetry is complete**: `sum(entries.cost.totalCost) ≈
+  usage.cost.totalCost` within `usageReconcileTolerance`. A `usageComplete=false`
+  snapshot keeps its authoritative totals even when entries don't reconcile.
+- **Tokens**: `totalTokens` authoritative (kind-specific fallback when absent);
+  component counters may overlap and are never summed for the total; all counts
+  nonnegative safe integers.
+- **Two completeness axes only**: `pricingComplete` (price availability, derived
+  from `unknownCostCallCount`) and sibling `usageComplete` (telemetry delivery /
+  lower-bound). `modelAttributionComplete` is gone.
+
+## Decisions
+
+1. `kind` = API verb (`completion|embedding|image|manual`). RESOLVED.
+2. No version-skew defense; but **malformed IPC degrades `usageComplete`, it is
+   not dropped** (money preserved in the authoritative total). RESOLVED.
+3. Two tables; parent authoritative, child attribution; join-safe aggregation. RESOLVED.
+4. **Cost components are best-effort** — no sum-to-total invariant, no residual/`unallocated` field; `totalCost` is the separate authoritative figure. `hostedToolsCost` has no token counterpart. RESOLVED.
+5. `hostedToolsCost` carried. RESOLVED.
+6. `numeric(20,10)` (exact for 6-dp; test overflow near 10^10).
+7. Currency USD-only, asserted at the boundary, carried through. Single source: `CostBreakdown.currency` only — NOT duplicated at `ProjectSpend.currency`. RESOLVED.
+8. `usageComplete` is a snapshot sibling, not nested. RESOLVED.
+9. **`model` is a plain string; `""` is the manual sentinel** (never null) — makes the DB `UNIQUE(invocation_id, kind, model)` enforce one row per bucket without version-specific `NULLS NOT DISTINCT`. RESOLVED.
+11. **Failed-call dispatch detection deferred to smoltalk** (agency-lang #809): count promise rejections now; resolved `Result.failure` later. RESOLVED.
+12. **Statelog tested via a thin `SpendStore` over pure logic** (most tests DB-free); the store/migration integration tests run against **real PostgreSQL 16** locally and in CI (a CI Postgres service), superseding the earlier `pg-mem` suggestion. RESOLVED.
+13. **Persistence best-effort** (log + respond, accept rare undercount); blocking is a separate change. RESOLVED.
+10. Part 1.7 (`__tokenStats`/`getModelCosts` per-model cost-type parity) **deferred** — `getModelCosts` stays as-is (breaking a used stdlib API isn't worth it). RESOLVED.
+
+## Testing
+
+**agency**: the four provider outcomes (priced / priced-zero / unpriced / attempt)
+for completion + embedding + image; `manual` shape (`model:""`) + `addCost` rejects
+negative & non-finite with an addCost-facing message; cost components are stored
+as-is with **no sum-to-total assertion**; central model resolution
+(reported→configured→"unknown model"); kind-specific `totalTokens` fallback and a
+**cached-image case that fails if input+cache are summed twice**; USD asserted
+(non-USD → unpriced); each source records **exactly once** (no memory/image
+double-charge, preserving branch-token/guard/no-frame ordering); meter
+`(kind,model)` bucketing + attribution reconciliation (only when complete) +
+safe-int guards; IPC round-trip preserves valid money and sets `usageComplete=false`
+on an unusable-kind delta (never drops), incl. **grandchild relay**; snapshot
+returns deep copies (top-level cost/tokens, an entry, nested entry fields) with
+sibling `usageComplete` and deterministic entry order.
+
+**statelog**: `recordHostedInvocation` writes parent + N details in one
+transaction; duplicate `execution_attempt_id` is a no-op; a failed detail insert
+rolls back; **a tolerated detail discrepancy does not change the billed project
+total** (billed from parent); join-safe aggregation does not fan-out multiply;
+per-model/per-kind breakdown correct; zero-spend and attempt-only invocations
+counted; `usageComplete=false` on any invocation ⇒ lower-bound project total;
+non-USD/negative rejected by constraints.
+
+## Effort
+
+agency: a focused rewrite of the invocationUsage value layer + the observation
+API + four call sites + IPC + tests — it *removes* the #802
+`unattributed`/`modelAttributionComplete`/version-skew special-casing.
+statelog: a new migration + `recordHostedInvocation` + join-safe aggregation +
+API/CLI — the larger half, but the schema is plain columns and query-friendly.
+Deliver as two plans (agency producer/transport; statelog storage/query/API) with
+a pinned rollout order.

--- a/packages/agency-lang/lib/cli/remote/commands/spend.test.ts
+++ b/packages/agency-lang/lib/cli/remote/commands/spend.test.ts
@@ -39,7 +39,9 @@ class ProcessExit extends Error {
   }
 }
 
-const spend = { pricedCost: 0.5, inputTokens: 10, outputTokens: 2, invocationCount: 3, unpricedCallCount: 0, pricingComplete: true, usageComplete: true };
+const usd = { inputCost: 0.3, outputCost: 0.2, cachedInputCost: 0, cacheCreationInputCost: 0, hostedToolsCost: 0, totalCost: 0.5, currency: "USD" };
+const tok = { inputTokens: 10, outputTokens: 2, cachedInputTokens: 0, cacheCreationInputTokens: 0, totalTokens: 12 };
+const spend = { cost: usd, tokens: tok, invocationCount: 3, unpricedCallCount: 0, pricingComplete: true, usageComplete: true, breakdown: [] };
 const accountRows = [{ projectSlug: "p", deletedAt: null, spend }];
 
 let dir: string;

--- a/packages/agency-lang/lib/cli/remote/commands/spend.ts
+++ b/packages/agency-lang/lib/cli/remote/commands/spend.ts
@@ -22,7 +22,11 @@ import {
 } from "./util.js";
 import type { AccountCommandOptions, RemoteCommandContext } from "./util.js";
 
-export type SpendOptions = AccountCommandOptions & SpendWindowOptions & { json?: boolean };
+export type SpendOptions = AccountCommandOptions & SpendWindowOptions & {
+  json?: boolean;
+  byModel?: boolean;
+  byKind?: boolean;
+};
 
 export async function runSpend(
   project: string | undefined,
@@ -57,7 +61,10 @@ export async function runSpend(
     if (options.json) {
       printJson(spend);
     } else {
-      console.log(renderProjectSpend(target.projectSlug, spend, window.description));
+      console.log(renderProjectSpend(target.projectSlug, spend, window.description, {
+        byModel: options.byModel ?? false,
+        byKind: options.byKind ?? false,
+      }));
     }
   } catch (error) {
     failProjectCommand(error);

--- a/packages/agency-lang/lib/cli/remote/render.test.ts
+++ b/packages/agency-lang/lib/cli/remote/render.test.ts
@@ -275,14 +275,29 @@ describe("renderAccountSpend", () => {
     expect(out).toContain("$2.0900"); // 0.10+0.99+0.50+0.50, all complete
     expect(out).toContain("gone (deleted)");
   });
-  it("degrades the TOTAL when a single row is incomplete or unpriced", () => {
+  it("degrades the TOTAL cost AND token columns when a single row is incomplete or unpriced", () => {
     const out = strip(renderAccountSpend([
       row("ok", 1),
-      row("bad", 2, { usageComplete: false, unpricedCallCount: 3, pricingComplete: false }),
+      row("bad", 2, { usageComplete: false, unpricedCallCount: 3, pricingComplete: false, tokens: toks(999, 111) }),
     ], "all time"));
     const total = out.split("\n").find((l) => l.includes("TOTAL")) ?? "";
+    const badRow = out.split("\n").find((l) => l.includes("bad")) ?? "";
     expect(total).toContain("≥ $3.0000");
+    // Tokens are a lower bound too when telemetry is incomplete — cost is not the
+    // only degraded column.
+    expect(badRow).toContain("≥ 999");
+    expect(total).toContain("≥ ");
     expect(out).toContain("incomplete telemetry");
     expect(out).toContain("3 unpriced call(s) total");
+  });
+
+  it("does NOT mark token columns as lower bounds for an unpriced-but-complete row", () => {
+    // Unpriced affects cost, not token counts: the token column stays exact.
+    const out = strip(renderAccountSpend([
+      row("only-unpriced", 1, { usageComplete: true, unpricedCallCount: 2, pricingComplete: false, tokens: toks(500, 50) }),
+    ], "all time"));
+    const dataRow = out.split("\n").find((l) => l.includes("only-unpriced")) ?? "";
+    expect(dataRow).toContain("500"); // exact, no ≥
+    expect(dataRow).not.toMatch(/≥ 500/);
   });
 });

--- a/packages/agency-lang/lib/cli/remote/render.test.ts
+++ b/packages/agency-lang/lib/cli/remote/render.test.ts
@@ -177,44 +177,83 @@ describe("renderPullSummary", () => {
   });
 });
 
+function usd(totalCost: number) {
+  return { inputCost: totalCost, outputCost: 0, cachedInputCost: 0, cacheCreationInputCost: 0, hostedToolsCost: 0, totalCost, currency: "USD" as const };
+}
+function toks(input: number, output: number) {
+  return { inputTokens: input, outputTokens: output, cachedInputTokens: 0, cacheCreationInputTokens: 0, totalTokens: input + output };
+}
+const NONE_GROUP = { byModel: false, byKind: false };
+
 const spend = (overrides: Partial<ProjectSpend> = {}): ProjectSpend => ({
-  pricedCost: 0.4212, inputTokens: 12400, outputTokens: 3010, invocationCount: 87, unpricedCallCount: 0, pricingComplete: true, usageComplete: true, ...overrides,
+  cost: usd(0.4212), tokens: toks(12400, 3010), invocationCount: 87, unpricedCallCount: 0, pricingComplete: true, usageComplete: true, breakdown: [], ...overrides,
 });
 
 describe("renderProjectSpend", () => {
-  it("shows cost, tokens, invocations, and the window label; no lower-bound/unpriced lines when complete", () => {
-    const out = strip(renderProjectSpend("my-agent", spend(), "last 7d"));
+  it("shows cost, token components/total, invocations, and the window label; no notes when complete", () => {
+    const out = strip(renderProjectSpend("my-agent", spend(), "last 7d", NONE_GROUP));
     expect(out).toContain("Spend: my-agent");
     expect(out).toContain("(last 7d)");
     expect(out).toContain("$0.4212");
-    expect(out).toContain("↑ 12,400");
-    expect(out).toContain("↓ 3,010");
+    expect(out).toContain("12,400"); // input-token component
+    expect(out).toContain("3,010"); // output-token component
+    expect(out).toContain("15,410 total"); // authoritative total tokens
     expect(out).toContain("Invocations:  87");
     expect(out).not.toContain("lower bound");
     expect(out).not.toContain("unpriced");
   });
+  it("prints No spend for a zero-invocation project", () => {
+    expect(strip(renderProjectSpend("a", spend({ invocationCount: 0, cost: usd(0), tokens: toks(0, 0) }), "last 7d", NONE_GROUP)))
+      .toBe("No spend in last 7d.");
+  });
   it("marks a lower bound when usage is incomplete", () => {
-    const out = strip(renderProjectSpend("a", spend({ usageComplete: false }), "all time"));
+    const out = strip(renderProjectSpend("a", spend({ usageComplete: false }), "all time", NONE_GROUP));
     expect(out).toContain("≥ $0.4212");
     expect(out).toContain("lower bound");
   });
-  it("notes unpriced calls", () => {
-    const out = strip(renderProjectSpend("a", spend({ unpricedCallCount: 2, pricingComplete: false }), "all time"));
+  it("marks a lower bound when a call was unpriced, and notes it separately", () => {
+    const out = strip(renderProjectSpend("a", spend({ unpricedCallCount: 2, pricingComplete: false }), "all time", NONE_GROUP));
+    expect(out).toContain("≥ $0.4212");
     expect(out).toContain("2 unpriced call(s)");
+    expect(out).not.toContain("lower bound"); // telemetry note only fires on !usageComplete
   });
   it("shows $0.0000 for true zero and <$0.0001 for a tiny positive", () => {
-    expect(strip(renderProjectSpend("a", spend({ pricedCost: 0 }), "all time"))).toContain("$0.0000");
-    expect(strip(renderProjectSpend("a", spend({ pricedCost: 0.00004 }), "all time"))).toContain("<$0.0001");
+    expect(strip(renderProjectSpend("a", spend({ cost: usd(0) }), "all time", NONE_GROUP))).toContain("$0.0000");
+    expect(strip(renderProjectSpend("a", spend({ cost: usd(0.00004) }), "all time", NONE_GROUP))).toContain("<$0.0001");
   });
   it("never emits the incoherent '≥ <$0.0001' for a tiny incomplete amount", () => {
-    const out = strip(renderProjectSpend("a", spend({ pricedCost: 0.00004, usageComplete: false }), "all time"));
+    const out = strip(renderProjectSpend("a", spend({ cost: usd(0.00004), usageComplete: false }), "all time", NONE_GROUP));
     expect(out).not.toContain("≥ <");
     expect(out).toContain("≥ $0.0000");
+  });
+  it("groups the breakdown by model, sorts by cost desc, and labels the manual sentinel", () => {
+    const breakdown = [
+      { model: "opus", kind: "completion" as const, cost: usd(0.1), tokens: toks(10, 2) },
+      { model: "", kind: "manual" as const, cost: usd(0.9), tokens: toks(0, 0) },
+    ];
+    const out = strip(renderProjectSpend("a", spend({ breakdown }), "all time", { byModel: true, byKind: false }));
+    expect(out).toContain("MODEL");
+    expect(out).toContain("(manual)");
+    const bodyLines = out.split("\n").filter((l) => /opus|\(manual\)/.test(l));
+    // (manual) at $0.9000 sorts above opus at $0.1000.
+    expect(bodyLines[0]).toContain("(manual)");
+    expect(bodyLines[1]).toContain("opus");
+  });
+  it("groups by kind when only --by-kind is set", () => {
+    const breakdown = [
+      { model: "opus", kind: "completion" as const, cost: usd(0.1), tokens: toks(10, 2) },
+      { model: "ada", kind: "embedding" as const, cost: usd(0.2), tokens: toks(5, 0) },
+    ];
+    const out = strip(renderProjectSpend("a", spend({ breakdown }), "all time", { byModel: false, byKind: true }));
+    expect(out).toContain("KIND");
+    expect(out).toContain("embedding");
+    expect(out).toContain("completion");
+    expect(out).not.toContain("MODEL");
   });
 });
 
 const row = (slug: string, pricedCost: number, over: Partial<ProjectSpend> = {}, deletedAt: string | null = null): AccountSpendRow => ({
-  projectSlug: slug, deletedAt, spend: spend({ pricedCost, ...over }),
+  projectSlug: slug, deletedAt, spend: spend({ cost: usd(pricedCost), ...over }),
 });
 
 describe("renderAccountSpend", () => {

--- a/packages/agency-lang/lib/cli/remote/render.test.ts
+++ b/packages/agency-lang/lib/cli/remote/render.test.ts
@@ -229,6 +229,13 @@ describe("renderProjectSpend", () => {
     // Must NOT floor a known positive amount to zero.
     expect(costLine).not.toMatch(/≥ \$0\.0000(?!\d)/);
   });
+  it("keeps a positive lower bound below 1e-8 visible via scientific notation", () => {
+    const out = strip(renderProjectSpend("a", spend({ cost: usd(1e-10), usageComplete: false }), "all time", NONE_GROUP));
+    const costLine = out.split("\n").find((l) => l.includes("Cost:")) ?? "";
+    expect(costLine).toContain("≥ $");
+    expect(costLine).toMatch(/e-\d+/); // scientific notation, not a floored $0
+    expect(costLine).not.toMatch(/≥ \$0\b/);
+  });
   it("groups the breakdown by model, sorts by cost desc, and labels the manual sentinel", () => {
     const breakdown = [
       { model: "opus", kind: "completion" as const, cost: usd(0.1), tokens: toks(10, 2) },
@@ -242,6 +249,18 @@ describe("renderProjectSpend", () => {
     expect(bodyLines[0]).toContain("(manual)");
     expect(bodyLines[1]).toContain("opus");
   });
+  it("aggregates grouped breakdown token counters as bigint across the safe-integer boundary", () => {
+    const big = Number.MAX_SAFE_INTEGER; // 9,007,199,254,740,991
+    const breakdown = [
+      { model: "opus", kind: "completion" as const, cost: usd(0.1), tokens: { inputTokens: big, outputTokens: 0, cachedInputTokens: 0, cacheCreationInputTokens: 0, totalTokens: big } },
+      { model: "sonnet", kind: "completion" as const, cost: usd(0.2), tokens: { inputTokens: 2, outputTokens: 0, cachedInputTokens: 0, cacheCreationInputTokens: 0, totalTokens: 2 } },
+    ];
+    // Grouped by kind → both models collapse into one "completion" group.
+    const out = strip(renderProjectSpend("a", spend({ breakdown }), "all time", { byModel: false, byKind: true }));
+    expect(out).toContain("9,007,199,254,740,993");
+    expect(out).not.toContain("9,007,199,254,740,992");
+  });
+
   it("groups by kind when only --by-kind is set", () => {
     const breakdown = [
       { model: "opus", kind: "completion" as const, cost: usd(0.1), tokens: toks(10, 2) },

--- a/packages/agency-lang/lib/cli/remote/render.test.ts
+++ b/packages/agency-lang/lib/cli/remote/render.test.ts
@@ -221,10 +221,13 @@ describe("renderProjectSpend", () => {
     expect(strip(renderProjectSpend("a", spend({ cost: usd(0) }), "all time", NONE_GROUP))).toContain("$0.0000");
     expect(strip(renderProjectSpend("a", spend({ cost: usd(0.00004) }), "all time", NONE_GROUP))).toContain("<$0.0001");
   });
-  it("never emits the incoherent '≥ <$0.0001' for a tiny incomplete amount", () => {
+  it("keeps a tiny positive lower bound visible (neither '≥ <$0.0001' nor a floored '≥ $0.0000')", () => {
     const out = strip(renderProjectSpend("a", spend({ cost: usd(0.00004), usageComplete: false }), "all time", NONE_GROUP));
-    expect(out).not.toContain("≥ <");
-    expect(out).toContain("≥ $0.0000");
+    const costLine = out.split("\n").find((l) => l.includes("Cost:")) ?? "";
+    expect(costLine).not.toContain("≥ <");
+    expect(costLine).toContain("≥ $0.00004");
+    // Must NOT floor a known positive amount to zero.
+    expect(costLine).not.toMatch(/≥ \$0\.0000(?!\d)/);
   });
   it("groups the breakdown by model, sorts by cost desc, and labels the manual sentinel", () => {
     const breakdown = [
@@ -289,6 +292,18 @@ describe("renderAccountSpend", () => {
     expect(total).toContain("≥ ");
     expect(out).toContain("incomplete telemetry");
     expect(out).toContain("3 unpriced call(s) total");
+  });
+
+  it("sums token counts as bigint so a TOTAL crossing MAX_SAFE_INTEGER stays exact", () => {
+    const big = Number.MAX_SAFE_INTEGER; // 9,007,199,254,740,991
+    const out = strip(renderAccountSpend([
+      row("a", 1, { tokens: { inputTokens: big, outputTokens: 0, cachedInputTokens: 0, cacheCreationInputTokens: 0, totalTokens: big } }),
+      row("b", 1, { tokens: { inputTokens: 2, outputTokens: 0, cachedInputTokens: 0, cacheCreationInputTokens: 0, totalTokens: 2 } }),
+    ], "all time"));
+    const total = out.split("\n").find((l) => l.includes("TOTAL")) ?? "";
+    // big + 2 = 9,007,199,254,740,993 exactly; Number addition rounds to ...992.
+    expect(total).toContain("9,007,199,254,740,993");
+    expect(total).not.toContain("9,007,199,254,740,992");
   });
 
   it("does NOT mark token columns as lower bounds for an unpriced-but-complete row", () => {

--- a/packages/agency-lang/lib/cli/remote/render.ts
+++ b/packages/agency-lang/lib/cli/remote/render.ts
@@ -132,28 +132,38 @@ function formatUsd(amount: number): string {
   return `$${amount.toFixed(4)}`;
 }
 
-/** A count with thousands separators, in a fixed locale for deterministic output. */
-function formatCount(count: number): string {
+/** A count with thousands separators, in a fixed locale for deterministic
+ *  output. Accepts `bigint` so aggregate totals can be summed without crossing
+ *  `Number.MAX_SAFE_INTEGER`. */
+function formatCount(count: number | bigint): string {
   return count.toLocaleString("en-US");
+}
+
+/** A sub-$0.0001 dollar amount rendered with enough precision that a positive
+ *  value never collapses to `$0.0000`. Trailing zeros are trimmed. */
+function formatTinyUsd(amount: number): string {
+  const fixed = amount.toFixed(8).replace(/0+$/, "").replace(/\.$/, "");
+  return `$${fixed}`;
 }
 
 /** Prefix `≥` when the figure is a trusted lower bound (telemetry incomplete).
  *  A lower bound never uses the `<$0.0001` sentinel — `≥ <$0.0001` ("at least
- *  less than") is incoherent — so a sub-$0.0001 lower bound floors to
- *  `≥ $0.0000` (still true: the total is at least ~zero and may be higher). */
+ *  less than") is incoherent — but it must not floor a positive amount to
+ *  `≥ $0.0000` either (that hides a known positive spend), so a sub-$0.0001
+ *  lower bound keeps extra precision (e.g. `≥ $0.00004`). */
 function lowerBound(amount: number, complete: boolean): string {
   if (complete) {
     return formatUsd(amount);
   }
   if (amount > 0 && amount < 0.0001) {
-    return "≥ $0.0000";
+    return `≥ ${formatTinyUsd(amount)}`;
   }
   return `≥ ${formatUsd(amount)}`;
 }
 
 /** A count that keeps a lower-bound `≥` prefix when the figure is not trusted
  *  complete (telemetry incomplete or price unknown). */
-function lowerBoundCount(count: number, complete: boolean): string {
+function lowerBoundCount(count: number | bigint, complete: boolean): string {
   return complete ? formatCount(count) : `≥ ${formatCount(count)}`;
 }
 
@@ -304,10 +314,12 @@ function trustNotes(
 
 type SpendTotals = {
   totalCost: number;
-  inputTokens: number;
-  outputTokens: number;
-  invocationCount: number;
-  unpricedCallCount: number;
+  // Counters accumulate as bigint: each row's value is a safe integer, but a sum
+  // across many projects can cross Number.MAX_SAFE_INTEGER and silently round.
+  inputTokens: bigint;
+  outputTokens: bigint;
+  invocationCount: bigint;
+  unpricedCallCount: bigint;
   usageComplete: boolean;
   pricingComplete: boolean;
 };
@@ -316,14 +328,14 @@ function spendTotals(rows: AccountSpendRow[]): SpendTotals {
   return rows.reduce<SpendTotals>(
     (totals, row) => ({
       totalCost: totals.totalCost + row.spend.cost.totalCost,
-      inputTokens: totals.inputTokens + row.spend.tokens.inputTokens,
-      outputTokens: totals.outputTokens + row.spend.tokens.outputTokens,
-      invocationCount: totals.invocationCount + row.spend.invocationCount,
-      unpricedCallCount: totals.unpricedCallCount + row.spend.unpricedCallCount,
+      inputTokens: totals.inputTokens + BigInt(row.spend.tokens.inputTokens),
+      outputTokens: totals.outputTokens + BigInt(row.spend.tokens.outputTokens),
+      invocationCount: totals.invocationCount + BigInt(row.spend.invocationCount),
+      unpricedCallCount: totals.unpricedCallCount + BigInt(row.spend.unpricedCallCount),
       usageComplete: totals.usageComplete && row.spend.usageComplete,
       pricingComplete: totals.pricingComplete && row.spend.pricingComplete,
     }),
-    { totalCost: 0, inputTokens: 0, outputTokens: 0, invocationCount: 0, unpricedCallCount: 0, usageComplete: true, pricingComplete: true },
+    { totalCost: 0, inputTokens: 0n, outputTokens: 0n, invocationCount: 0n, unpricedCallCount: 0n, usageComplete: true, pricingComplete: true },
   );
 }
 
@@ -380,7 +392,7 @@ export function renderAccountSpend(rows: AccountSpendRow[], description: string)
   if (!totals.usageComplete) {
     lines.push(color.dim("Some projects have incomplete telemetry; totals are lower bounds."));
   }
-  if (totals.unpricedCallCount > 0) {
+  if (totals.unpricedCallCount > 0n) {
     lines.push(color.dim(`${formatCount(totals.unpricedCallCount)} unpriced call(s) total — cost may be understated.`));
   }
   return lines.join("\n");

--- a/packages/agency-lang/lib/cli/remote/render.ts
+++ b/packages/agency-lang/lib/cli/remote/render.ts
@@ -225,7 +225,7 @@ function groupBreakdown(rows: ModelKindSpend[], grouping: SpendGrouping): SpendG
   for (const row of rows) {
     const model = grouping.byModel ? row.model : null;
     const kind = grouping.byKind ? row.kind : null;
-    const key = `${model ?? ""} ${kind ?? ""}`;
+    const key = JSON.stringify([model, kind]);
     let group = groups[key];
     if (group === undefined) {
       group = { model, kind, cost: zeroCost(), tokens: zeroTokens() };
@@ -357,8 +357,10 @@ export function renderAccountSpend(rows: AccountSpendRow[], description: string)
   const tableRows = sorted.map((row) => [
     row.deletedAt === null ? row.projectSlug : `${row.projectSlug} (deleted)`,
     lowerBound(row.spend.cost.totalCost, spendIsComplete(row.spend)),
-    formatCount(row.spend.tokens.inputTokens),
-    formatCount(row.spend.tokens.outputTokens),
+    // Token counts are a lower bound whenever telemetry is incomplete — that is
+    // `usageComplete` alone (unpriced calls affect cost, not counts).
+    lowerBoundCount(row.spend.tokens.inputTokens, row.spend.usageComplete),
+    lowerBoundCount(row.spend.tokens.outputTokens, row.spend.usageComplete),
     formatCount(row.spend.invocationCount),
     formatCount(row.spend.unpricedCallCount),
   ]);
@@ -366,8 +368,8 @@ export function renderAccountSpend(rows: AccountSpendRow[], description: string)
   tableRows.push([
     "TOTAL",
     lowerBound(totals.totalCost, totals.usageComplete && totals.pricingComplete),
-    formatCount(totals.inputTokens),
-    formatCount(totals.outputTokens),
+    lowerBoundCount(totals.inputTokens, totals.usageComplete),
+    lowerBoundCount(totals.outputTokens, totals.usageComplete),
     formatCount(totals.invocationCount),
     formatCount(totals.unpricedCallCount),
   ]);

--- a/packages/agency-lang/lib/cli/remote/render.ts
+++ b/packages/agency-lang/lib/cli/remote/render.ts
@@ -11,7 +11,14 @@ import type {
   KeySummary,
   CreatedKey,
 } from "../statelog/accountClient.js";
-import type { ProjectSpend, AccountSpendRow } from "../statelog/spendTypes.js";
+import type {
+  ProjectSpend,
+  AccountSpendRow,
+  CostBreakdown,
+  TokenBreakdown,
+  ModelKindSpend,
+  UsageKind,
+} from "../statelog/spendTypes.js";
 
 const NONE = "—";
 
@@ -144,42 +151,179 @@ function lowerBound(amount: number, complete: boolean): string {
   return `≥ ${formatUsd(amount)}`;
 }
 
-export function renderProjectSpend(slug: string, spend: ProjectSpend, description: string): string {
+/** A count that keeps a lower-bound `≥` prefix when the figure is not trusted
+ *  complete (telemetry incomplete or price unknown). */
+function lowerBoundCount(count: number, complete: boolean): string {
+  return complete ? formatCount(count) : `≥ ${formatCount(count)}`;
+}
+
+/** A project's figures are only a trusted exact total when BOTH the telemetry
+ *  arrived complete AND every call was priced. Either false makes it a lower
+ *  bound (the `≥` marker). */
+function spendIsComplete(spend: { usageComplete: boolean; pricingComplete: boolean }): boolean {
+  return spend.usageComplete && spend.pricingComplete;
+}
+
+function zeroCost(): CostBreakdown {
+  return { inputCost: 0, outputCost: 0, cachedInputCost: 0, cacheCreationInputCost: 0, hostedToolsCost: 0, totalCost: 0, currency: "USD" };
+}
+function zeroTokens(): TokenBreakdown {
+  return { inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, cacheCreationInputTokens: 0, totalTokens: 0 };
+}
+function addCostInto(target: CostBreakdown, add: CostBreakdown): void {
+  target.inputCost += add.inputCost;
+  target.outputCost += add.outputCost;
+  target.cachedInputCost += add.cachedInputCost;
+  target.cacheCreationInputCost += add.cacheCreationInputCost;
+  target.hostedToolsCost += add.hostedToolsCost;
+  target.totalCost += add.totalCost;
+}
+function addTokensInto(target: TokenBreakdown, add: TokenBreakdown): void {
+  target.inputTokens += add.inputTokens;
+  target.outputTokens += add.outputTokens;
+  target.cachedInputTokens += add.cachedInputTokens;
+  target.cacheCreationInputTokens += add.cacheCreationInputTokens;
+  target.totalTokens += add.totalTokens;
+}
+
+/** Human label for a breakdown model — the manual sentinel `""` reads as
+ *  `(manual)`. */
+function modelLabel(model: string): string {
+  return model === "" ? "(manual)" : model;
+}
+
+/** The authoritative cost-component and token-component detail lines under a
+ *  total. Components are best-effort detail; the totals above carry the `≥`. */
+function costComponentLines(cost: CostBreakdown): string[] {
+  return [
+    `    input         ${formatUsd(cost.inputCost)}`,
+    `    output        ${formatUsd(cost.outputCost)}`,
+    `    cached in     ${formatUsd(cost.cachedInputCost)}`,
+    `    cache write   ${formatUsd(cost.cacheCreationInputCost)}`,
+    `    hosted tools  ${formatUsd(cost.hostedToolsCost)}`,
+  ];
+}
+function tokenComponentLines(tokens: TokenBreakdown): string[] {
+  return [
+    `    input         ${formatCount(tokens.inputTokens)}`,
+    `    output        ${formatCount(tokens.outputTokens)}`,
+    `    cached in     ${formatCount(tokens.cachedInputTokens)}`,
+    `    cache write   ${formatCount(tokens.cacheCreationInputTokens)}`,
+  ];
+}
+
+export type SpendGrouping = { byModel: boolean; byKind: boolean };
+
+type SpendGroup = { model: string | null; kind: UsageKind | null; cost: CostBreakdown; tokens: TokenBreakdown };
+
+/** Fold the raw `(model, kind)` breakdown into the requested grouping. Both
+ *  flags → one group per pair; one flag → collapse the other axis; the caller
+ *  only reaches here when at least one flag is set. Sorted by total cost
+ *  descending, then model then kind ascending. */
+function groupBreakdown(rows: ModelKindSpend[], grouping: SpendGrouping): SpendGroup[] {
+  const groups: Record<string, SpendGroup> = Object.create(null);
+  for (const row of rows) {
+    const model = grouping.byModel ? row.model : null;
+    const kind = grouping.byKind ? row.kind : null;
+    const key = `${model ?? ""} ${kind ?? ""}`;
+    let group = groups[key];
+    if (group === undefined) {
+      group = { model, kind, cost: zeroCost(), tokens: zeroTokens() };
+      groups[key] = group;
+    }
+    addCostInto(group.cost, row.cost);
+    addTokensInto(group.tokens, row.tokens);
+  }
+  return Object.values(groups).sort((left, right) => {
+    if (right.cost.totalCost !== left.cost.totalCost) {
+      return right.cost.totalCost - left.cost.totalCost;
+    }
+    const modelCmp = (left.model ?? "").localeCompare(right.model ?? "");
+    if (modelCmp !== 0) {
+      return modelCmp;
+    }
+    return (left.kind ?? "").localeCompare(right.kind ?? "");
+  });
+}
+
+function renderGroupTable(groups: SpendGroup[], grouping: SpendGrouping): string {
+  const headers: string[] = [];
+  if (grouping.byModel) headers.push("MODEL");
+  if (grouping.byKind) headers.push("KIND");
+  headers.push("COST", "↑IN", "↓OUT");
+  const tableRows = groups.map((group) => {
+    const cells: string[] = [];
+    if (grouping.byModel) cells.push(modelLabel(group.model ?? ""));
+    if (grouping.byKind) cells.push(group.kind ?? "");
+    cells.push(formatUsd(group.cost.totalCost), formatCount(group.tokens.inputTokens), formatCount(group.tokens.outputTokens));
+    return cells;
+  });
+  return formatStaticTable(headers, tableRows);
+}
+
+export function renderProjectSpend(
+  slug: string,
+  spend: ProjectSpend,
+  description: string,
+  grouping: SpendGrouping,
+): string {
+  if (spend.invocationCount === 0) {
+    return `No spend in ${description}.`;
+  }
+  const complete = spendIsComplete(spend);
   const lines = [
     `${color.bold("Spend:")} ${slug}  ${color.dim(`(${description})`)}`,
-    `  ${color.bold("Cost:")}         ${lowerBound(spend.pricedCost, spend.usageComplete)}`,
-    `  ${color.bold("Tokens:")}       ↑ ${formatCount(spend.inputTokens)}  ↓ ${formatCount(spend.outputTokens)}`,
+    `  ${color.bold("Cost:")}         ${lowerBound(spend.cost.totalCost, complete)}`,
+    ...costComponentLines(spend.cost),
+    `  ${color.bold("Tokens:")}       ${lowerBoundCount(spend.tokens.totalTokens, complete)} total`,
+    ...tokenComponentLines(spend.tokens),
     `  ${color.bold("Invocations:")}  ${formatCount(spend.invocationCount)}`,
   ];
-  if (!spend.usageComplete) {
-    lines.push(color.dim("  (lower bound — some telemetry incomplete)"));
+  if (grouping.byModel || grouping.byKind) {
+    lines.push("", renderGroupTable(groupBreakdown(spend.breakdown, grouping), grouping));
   }
-  if (spend.unpricedCallCount > 0) {
-    lines.push(color.dim(`  ${formatCount(spend.unpricedCallCount)} unpriced call(s) — cost may be understated`));
-  }
+  lines.push(...trustNotes(spend, "  "));
   return lines.join("\n");
 }
 
+/** The separate telemetry-incomplete and unknown-price notes. Independent axes:
+ *  a run can be complete-but-unpriced, or priced-but-incomplete, or both. */
+function trustNotes(
+  spend: { usageComplete: boolean; unpricedCallCount: number },
+  indent: string,
+): string[] {
+  const notes: string[] = [];
+  if (!spend.usageComplete) {
+    notes.push(color.dim(`${indent}(lower bound — some telemetry incomplete)`));
+  }
+  if (spend.unpricedCallCount > 0) {
+    notes.push(color.dim(`${indent}${formatCount(spend.unpricedCallCount)} unpriced call(s) — cost may be understated`));
+  }
+  return notes;
+}
+
 type SpendTotals = {
-  pricedCost: number;
+  totalCost: number;
   inputTokens: number;
   outputTokens: number;
   invocationCount: number;
   unpricedCallCount: number;
   usageComplete: boolean;
+  pricingComplete: boolean;
 };
 
 function spendTotals(rows: AccountSpendRow[]): SpendTotals {
   return rows.reduce<SpendTotals>(
     (totals, row) => ({
-      pricedCost: totals.pricedCost + row.spend.pricedCost,
-      inputTokens: totals.inputTokens + row.spend.inputTokens,
-      outputTokens: totals.outputTokens + row.spend.outputTokens,
+      totalCost: totals.totalCost + row.spend.cost.totalCost,
+      inputTokens: totals.inputTokens + row.spend.tokens.inputTokens,
+      outputTokens: totals.outputTokens + row.spend.tokens.outputTokens,
       invocationCount: totals.invocationCount + row.spend.invocationCount,
       unpricedCallCount: totals.unpricedCallCount + row.spend.unpricedCallCount,
       usageComplete: totals.usageComplete && row.spend.usageComplete,
+      pricingComplete: totals.pricingComplete && row.spend.pricingComplete,
     }),
-    { pricedCost: 0, inputTokens: 0, outputTokens: 0, invocationCount: 0, unpricedCallCount: 0, usageComplete: true },
+    { totalCost: 0, inputTokens: 0, outputTokens: 0, invocationCount: 0, unpricedCallCount: 0, usageComplete: true, pricingComplete: true },
   );
 }
 
@@ -192,8 +336,8 @@ function sortAccountRows(rows: AccountSpendRow[]): AccountSpendRow[] {
     if (leftDeleted !== rightDeleted) {
       return leftDeleted ? 1 : -1;
     }
-    if (right.spend.pricedCost !== left.spend.pricedCost) {
-      return right.spend.pricedCost - left.spend.pricedCost;
+    if (right.spend.cost.totalCost !== left.spend.cost.totalCost) {
+      return right.spend.cost.totalCost - left.spend.cost.totalCost;
     }
     if (left.projectSlug < right.projectSlug) {
       return -1;
@@ -212,16 +356,16 @@ export function renderAccountSpend(rows: AccountSpendRow[], description: string)
   const sorted = sortAccountRows(rows);
   const tableRows = sorted.map((row) => [
     row.deletedAt === null ? row.projectSlug : `${row.projectSlug} (deleted)`,
-    lowerBound(row.spend.pricedCost, row.spend.usageComplete),
-    formatCount(row.spend.inputTokens),
-    formatCount(row.spend.outputTokens),
+    lowerBound(row.spend.cost.totalCost, spendIsComplete(row.spend)),
+    formatCount(row.spend.tokens.inputTokens),
+    formatCount(row.spend.tokens.outputTokens),
     formatCount(row.spend.invocationCount),
     formatCount(row.spend.unpricedCallCount),
   ]);
   const totals = spendTotals(rows);
   tableRows.push([
     "TOTAL",
-    lowerBound(totals.pricedCost, totals.usageComplete),
+    lowerBound(totals.totalCost, totals.usageComplete && totals.pricingComplete),
     formatCount(totals.inputTokens),
     formatCount(totals.outputTokens),
     formatCount(totals.invocationCount),

--- a/packages/agency-lang/lib/cli/remote/render.ts
+++ b/packages/agency-lang/lib/cli/remote/render.ts
@@ -140,9 +140,14 @@ function formatCount(count: number | bigint): string {
 }
 
 /** A sub-$0.0001 dollar amount rendered with enough precision that a positive
- *  value never collapses to `$0.0000`. Trailing zeros are trimmed. */
+ *  value never collapses to `$0.0000`. Trailing zeros are trimmed; a value below
+ *  the fixed 8-decimal resolution falls back to scientific notation (e.g.
+ *  `$1e-10`) rather than rounding a known positive spend to zero. */
 function formatTinyUsd(amount: number): string {
   const fixed = amount.toFixed(8).replace(/0+$/, "").replace(/\.$/, "");
+  if (Number(fixed) === 0) {
+    return `$${amount.toExponential()}`;
+  }
   return `$${fixed}`;
 }
 
@@ -174,28 +179,6 @@ function spendIsComplete(spend: { usageComplete: boolean; pricingComplete: boole
   return spend.usageComplete && spend.pricingComplete;
 }
 
-function zeroCost(): CostBreakdown {
-  return { inputCost: 0, outputCost: 0, cachedInputCost: 0, cacheCreationInputCost: 0, hostedToolsCost: 0, totalCost: 0, currency: "USD" };
-}
-function zeroTokens(): TokenBreakdown {
-  return { inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, cacheCreationInputTokens: 0, totalTokens: 0 };
-}
-function addCostInto(target: CostBreakdown, add: CostBreakdown): void {
-  target.inputCost += add.inputCost;
-  target.outputCost += add.outputCost;
-  target.cachedInputCost += add.cachedInputCost;
-  target.cacheCreationInputCost += add.cacheCreationInputCost;
-  target.hostedToolsCost += add.hostedToolsCost;
-  target.totalCost += add.totalCost;
-}
-function addTokensInto(target: TokenBreakdown, add: TokenBreakdown): void {
-  target.inputTokens += add.inputTokens;
-  target.outputTokens += add.outputTokens;
-  target.cachedInputTokens += add.cachedInputTokens;
-  target.cacheCreationInputTokens += add.cacheCreationInputTokens;
-  target.totalTokens += add.totalTokens;
-}
-
 /** Human label for a breakdown model — the manual sentinel `""` reads as
  *  `(manual)`. */
 function modelLabel(model: string): string {
@@ -224,7 +207,10 @@ function tokenComponentLines(tokens: TokenBreakdown): string[] {
 
 export type SpendGrouping = { byModel: boolean; byKind: boolean };
 
-type SpendGroup = { model: string | null; kind: UsageKind | null; cost: CostBreakdown; tokens: TokenBreakdown };
+// Token counters accumulate as bigint: a grouping can collapse many individually
+// safe breakdown rows, and the sum can cross Number.MAX_SAFE_INTEGER. Cost is a
+// float total (money, not an integer count), so it stays a number.
+type SpendGroup = { model: string | null; kind: UsageKind | null; totalCost: number; inputTokens: bigint; outputTokens: bigint };
 
 /** Fold the raw `(model, kind)` breakdown into the requested grouping. Both
  *  flags → one group per pair; one flag → collapse the other axis; the caller
@@ -238,15 +224,16 @@ function groupBreakdown(rows: ModelKindSpend[], grouping: SpendGrouping): SpendG
     const key = JSON.stringify([model, kind]);
     let group = groups[key];
     if (group === undefined) {
-      group = { model, kind, cost: zeroCost(), tokens: zeroTokens() };
+      group = { model, kind, totalCost: 0, inputTokens: 0n, outputTokens: 0n };
       groups[key] = group;
     }
-    addCostInto(group.cost, row.cost);
-    addTokensInto(group.tokens, row.tokens);
+    group.totalCost += row.cost.totalCost;
+    group.inputTokens += BigInt(row.tokens.inputTokens);
+    group.outputTokens += BigInt(row.tokens.outputTokens);
   }
   return Object.values(groups).sort((left, right) => {
-    if (right.cost.totalCost !== left.cost.totalCost) {
-      return right.cost.totalCost - left.cost.totalCost;
+    if (right.totalCost !== left.totalCost) {
+      return right.totalCost - left.totalCost;
     }
     const modelCmp = (left.model ?? "").localeCompare(right.model ?? "");
     if (modelCmp !== 0) {
@@ -265,7 +252,7 @@ function renderGroupTable(groups: SpendGroup[], grouping: SpendGrouping): string
     const cells: string[] = [];
     if (grouping.byModel) cells.push(modelLabel(group.model ?? ""));
     if (grouping.byKind) cells.push(group.kind ?? "");
-    cells.push(formatUsd(group.cost.totalCost), formatCount(group.tokens.inputTokens), formatCount(group.tokens.outputTokens));
+    cells.push(formatUsd(group.totalCost), formatCount(group.inputTokens), formatCount(group.outputTokens));
     return cells;
   });
   return formatStaticTable(headers, tableRows);

--- a/packages/agency-lang/lib/cli/statelog/accountClient.test.ts
+++ b/packages/agency-lang/lib/cli/statelog/accountClient.test.ts
@@ -301,7 +301,9 @@ describe("accountClient id-map safety", () => {
 });
 
 describe("accountClient.getAccountSpend", () => {
-  const validSpend = { pricedCost: 0.5, inputTokens: 10, outputTokens: 2, invocationCount: 3, unpricedCallCount: 0, pricingComplete: true, usageComplete: true };
+  const usd = { inputCost: 0.3, outputCost: 0.2, cachedInputCost: 0, cacheCreationInputCost: 0, hostedToolsCost: 0, totalCost: 0.5, currency: "USD" };
+  const tok = { inputTokens: 10, outputTokens: 2, cachedInputTokens: 0, cacheCreationInputTokens: 0, totalTokens: 12 };
+  const validSpend = { cost: usd, tokens: tok, invocationCount: 3, unpricedCallCount: 0, pricingComplete: true, usageComplete: true, breakdown: [] };
   const okRows = { success: true, value: [{ projectSlug: "p", deletedAt: null, spend: validSpend }] };
 
   it("GETs /api/spend with both bounds, omitting null ones", async () => {
@@ -314,7 +316,7 @@ describe("accountClient.getAccountSpend", () => {
   });
 
   it("rejects a malformed row as an AccountRequestError", async () => {
-    fetchMock.mockResolvedValue(response(200, { success: true, value: [{ projectSlug: "p", deletedAt: null, spend: { ...validSpend, pricedCost: -1 } }] }));
+    fetchMock.mockResolvedValue(response(200, { success: true, value: [{ projectSlug: "p", deletedAt: null, spend: { ...validSpend, cost: { ...usd, totalCost: -1 } } }] }));
     await expect(client.getAccountSpend({ from: null, to: null })).rejects.toBeInstanceOf(AccountRequestError);
   });
 

--- a/packages/agency-lang/lib/cli/statelog/projectClient.test.ts
+++ b/packages/agency-lang/lib/cli/statelog/projectClient.test.ts
@@ -170,9 +170,11 @@ describe("projectClient envelope/transport edge cases", () => {
 });
 
 describe("projectClient.getSpend", () => {
+  const usd = { inputCost: 0.3, outputCost: 0.2, cachedInputCost: 0, cacheCreationInputCost: 0, hostedToolsCost: 0, totalCost: 0.5, currency: "USD" };
+  const tok = { inputTokens: 10, outputTokens: 2, cachedInputTokens: 0, cacheCreationInputTokens: 0, totalTokens: 12 };
   const okSpend = {
     success: true,
-    value: { pricedCost: 0.5, inputTokens: 10, outputTokens: 2, invocationCount: 3, unpricedCallCount: 0, pricingComplete: true, usageComplete: true },
+    value: { cost: usd, tokens: tok, invocationCount: 3, unpricedCallCount: 0, pricingComplete: true, usageComplete: true, breakdown: [] },
   };
 
   it("GETs the spend route with both bounds as query params", async () => {
@@ -182,7 +184,7 @@ describe("projectClient.getSpend", () => {
       "https://h/api/projects/proj/spend?from=1000&to=2000",
       { method: "GET", headers: { Authorization: "Bearer key" } },
     );
-    expect(spend.pricedCost).toBe(0.5);
+    expect(spend.cost.totalCost).toBe(0.5);
   });
 
   it("omits a null bound (from-only, to-only, neither)", async () => {
@@ -196,7 +198,7 @@ describe("projectClient.getSpend", () => {
   });
 
   it("rejects a malformed spend shape as a ProjectRequestError", async () => {
-    fetchMock.mockResolvedValue(response(200, { success: true, value: { ...okSpend.value, pricedCost: -1 } }));
+    fetchMock.mockResolvedValue(response(200, { success: true, value: { ...okSpend.value, cost: { ...usd, totalCost: -1 } } }));
     await expect(client().getSpend({ from: null, to: null })).rejects.toBeInstanceOf(ProjectRequestError);
   });
 

--- a/packages/agency-lang/lib/cli/statelog/spendTypes.test.ts
+++ b/packages/agency-lang/lib/cli/statelog/spendTypes.test.ts
@@ -1,18 +1,55 @@
 import { describe, it, expect } from "vitest";
 import { projectSpendSchema, accountSpendRowSchema, toSpendQuery } from "./spendTypes.js";
 
-const valid = { pricedCost: 0.5, inputTokens: 10, outputTokens: 2, invocationCount: 3, unpricedCallCount: 0, pricingComplete: true, usageComplete: true };
+const usd = { inputCost: 0.3, outputCost: 0.2, cachedInputCost: 0, cacheCreationInputCost: 0, hostedToolsCost: 0, totalCost: 0.5, currency: "USD" as const };
+const tok = { inputTokens: 10, outputTokens: 2, cachedInputTokens: 0, cacheCreationInputTokens: 0, totalTokens: 12 };
+const valid = {
+  cost: usd,
+  tokens: tok,
+  invocationCount: 3,
+  unpricedCallCount: 0,
+  pricingComplete: true,
+  usageComplete: true,
+  breakdown: [{ model: "opus", kind: "completion" as const, cost: usd, tokens: tok }],
+};
+const empty = {
+  cost: { inputCost: 0, outputCost: 0, cachedInputCost: 0, cacheCreationInputCost: 0, hostedToolsCost: 0, totalCost: 0, currency: "USD" as const },
+  tokens: { inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, cacheCreationInputTokens: 0, totalTokens: 0 },
+  invocationCount: 0,
+  unpricedCallCount: 0,
+  pricingComplete: true,
+  usageComplete: true,
+  breakdown: [],
+};
 
 describe("projectSpendSchema", () => {
-  it("accepts a valid spend", () => { expect(projectSpendSchema.parse(valid)).toEqual(valid); });
-  it("rejects non-finite/negative cost, unsafe/negative counts, contradictory completeness", () => {
-    expect(() => projectSpendSchema.parse({ ...valid, pricedCost: -1 })).toThrow();
-    expect(() => projectSpendSchema.parse({ ...valid, pricedCost: Number.NaN })).toThrow();
-    expect(() => projectSpendSchema.parse({ ...valid, pricedCost: Number.POSITIVE_INFINITY })).toThrow();
-    expect(() => projectSpendSchema.parse({ ...valid, inputTokens: -1 })).toThrow();
-    expect(() => projectSpendSchema.parse({ ...valid, outputTokens: 2 ** 53 })).toThrow();
+  it("accepts a valid spend and the complete empty identity", () => {
+    expect(projectSpendSchema.parse(valid)).toEqual(valid);
+    expect(projectSpendSchema.parse(empty)).toEqual(empty);
+  });
+
+  it("rejects non-finite/negative cost, non-USD currency, unsafe/negative counts", () => {
+    expect(() => projectSpendSchema.parse({ ...valid, cost: { ...usd, totalCost: -1 } })).toThrow();
+    expect(() => projectSpendSchema.parse({ ...valid, cost: { ...usd, totalCost: Number.NaN } })).toThrow();
+    expect(() => projectSpendSchema.parse({ ...valid, cost: { ...usd, inputCost: Number.POSITIVE_INFINITY } })).toThrow();
+    expect(() => projectSpendSchema.parse({ ...valid, cost: { ...usd, currency: "EUR" } })).toThrow();
+    expect(() => projectSpendSchema.parse({ ...valid, tokens: { ...tok, inputTokens: -1 } })).toThrow();
+    expect(() => projectSpendSchema.parse({ ...valid, tokens: { ...tok, outputTokens: 2 ** 53 } })).toThrow();
     expect(() => projectSpendSchema.parse({ ...valid, invocationCount: 2 ** 53 })).toThrow();
+  });
+
+  it("enforces pricingComplete === (unpricedCallCount === 0)", () => {
     expect(() => projectSpendSchema.parse({ ...valid, unpricedCallCount: 1, pricingComplete: true })).toThrow();
+    expect(() => projectSpendSchema.parse({ ...valid, unpricedCallCount: 0, pricingComplete: false })).toThrow();
+    expect(projectSpendSchema.parse({ ...valid, unpricedCallCount: 1, pricingComplete: false }).pricingComplete).toBe(false);
+  });
+
+  it("rejects extra fields and a mismatched model sentinel", () => {
+    expect(() => projectSpendSchema.parse({ ...valid, surprise: 1 })).toThrow();
+    // manual rows must use model "" and provider rows a non-empty model.
+    expect(() => projectSpendSchema.parse({ ...valid, breakdown: [{ model: "x", kind: "manual", cost: usd, tokens: tok }] })).toThrow();
+    expect(() => projectSpendSchema.parse({ ...valid, breakdown: [{ model: "", kind: "completion", cost: usd, tokens: tok }] })).toThrow();
+    expect(projectSpendSchema.parse({ ...valid, breakdown: [{ model: "", kind: "manual", cost: usd, tokens: tok }] }).breakdown[0].kind).toBe("manual");
   });
 });
 
@@ -21,6 +58,11 @@ describe("accountSpendRowSchema", () => {
     expect(accountSpendRowSchema.parse({ projectSlug: "p", deletedAt: null, spend: valid }).deletedAt).toBeNull();
     expect(accountSpendRowSchema.parse({ projectSlug: "p", deletedAt: "2026-08-01T00:00:00.000Z", spend: valid }).deletedAt).toBe("2026-08-01T00:00:00.000Z");
     expect(() => accountSpendRowSchema.parse({ projectSlug: "p", deletedAt: "nope", spend: valid })).toThrow();
+  });
+
+  it("accepts a zero-event deleted project row", () => {
+    const row = accountSpendRowSchema.parse({ projectSlug: "gone", deletedAt: "2026-08-01T00:00:00.000Z", spend: empty });
+    expect(row.spend.invocationCount).toBe(0);
   });
 });
 

--- a/packages/agency-lang/lib/cli/statelog/spendTypes.ts
+++ b/packages/agency-lang/lib/cli/statelog/spendTypes.ts
@@ -1,8 +1,9 @@
 // The statelog spend wire types — the single source of truth for the shape the
 // per-project and account spend endpoints return, and the query serializer both
-// clients share. The Zod schemas own the numeric invariants; the TypeScript
-// types are inferred from them so a hand-written type cannot drift from its
-// runtime validator.
+// clients share. The Zod schemas own the invariants; the TypeScript types are
+// inferred from them so a hand-written type cannot drift from its runtime
+// validator. Values are the camelCase full cost/token breakdown statelog emits
+// (there is no snake-case transform for spend).
 
 import { z } from "zod";
 
@@ -11,28 +12,80 @@ const nonNegativeSafeInt = z
   .int()
   .nonnegative()
   .refine(Number.isSafeInteger, "must be a safe integer");
+const nonNegativeFinite = z.number().finite().nonnegative();
+
+/** The authoritative money breakdown. Every component is finite and nonnegative;
+ *  `totalCost` is authoritative (never derived from the components); currency is
+ *  USD only. No extra fields are accepted. */
+export const costBreakdownSchema = z
+  .object({
+    inputCost: nonNegativeFinite,
+    outputCost: nonNegativeFinite,
+    cachedInputCost: nonNegativeFinite,
+    cacheCreationInputCost: nonNegativeFinite,
+    hostedToolsCost: nonNegativeFinite,
+    totalCost: nonNegativeFinite,
+    currency: z.literal("USD"),
+  })
+  .strict();
+export type CostBreakdown = z.infer<typeof costBreakdownSchema>;
+
+/** The token breakdown. Every count is a nonnegative safe integer; `totalTokens`
+ *  is authoritative. No extra fields are accepted. */
+export const tokenBreakdownSchema = z
+  .object({
+    inputTokens: nonNegativeSafeInt,
+    outputTokens: nonNegativeSafeInt,
+    cachedInputTokens: nonNegativeSafeInt,
+    cacheCreationInputTokens: nonNegativeSafeInt,
+    totalTokens: nonNegativeSafeInt,
+  })
+  .strict();
+export type TokenBreakdown = z.infer<typeof tokenBreakdownSchema>;
+
+export const usageKindSchema = z.enum(["completion", "embedding", "image", "manual"]);
+export type UsageKind = z.infer<typeof usageKindSchema>;
+
+/** One `(model, kind)` attribution row. The model sentinel `""` marks manual
+ *  charges (`addCost`); provider kinds always carry a non-empty model. */
+export const modelKindSpendSchema = z
+  .object({
+    model: z.string(),
+    kind: usageKindSchema,
+    cost: costBreakdownSchema,
+    tokens: tokenBreakdownSchema,
+  })
+  .strict()
+  .refine(
+    (row) => (row.kind === "manual" ? row.model === "" : row.model.length > 0),
+    "manual rows use model '' and provider rows use a non-empty model",
+  );
+export type ModelKindSpend = z.infer<typeof modelKindSpendSchema>;
 
 export const projectSpendSchema = z
   .object({
-    pricedCost: z.number().finite().nonnegative(),
-    inputTokens: nonNegativeSafeInt,
-    outputTokens: nonNegativeSafeInt,
+    cost: costBreakdownSchema,
+    tokens: tokenBreakdownSchema,
     invocationCount: nonNegativeSafeInt,
     unpricedCallCount: nonNegativeSafeInt,
     pricingComplete: z.boolean(),
     usageComplete: z.boolean(),
+    breakdown: z.array(modelKindSpendSchema),
   })
+  .strict()
   .refine(
     (spend) => spend.pricingComplete === (spend.unpricedCallCount === 0),
     "pricingComplete must equal (unpricedCallCount === 0)",
   );
 export type ProjectSpend = z.infer<typeof projectSpendSchema>;
 
-export const accountSpendRowSchema = z.object({
-  projectSlug: z.string().min(1),
-  deletedAt: z.string().datetime().nullable(),
-  spend: projectSpendSchema,
-});
+export const accountSpendRowSchema = z
+  .object({
+    projectSlug: z.string().min(1),
+    deletedAt: z.string().datetime().nullable(),
+    spend: projectSpendSchema,
+  })
+  .strict();
 export type AccountSpendRow = z.infer<typeof accountSpendRowSchema>;
 
 /** A half-open `[from, to)` window in epoch milliseconds; either bound may be

--- a/packages/agency-lang/lib/runtime/cost.ts
+++ b/packages/agency-lang/lib/runtime/cost.ts
@@ -1,20 +1,23 @@
 import { getRuntimeContext } from "./asyncContext.js";
-import { recordPaidUsage } from "./recordPaidUsage.js";
-import { paidCostDelta } from "./invocationUsage.js";
+import { recordUsage } from "./recordPaidUsage.js";
 
 /** Charge `amount` USD to the active branch: account it (guards + invocation
  *  meter + subprocess relay) and enforce limits — the exact sequence the
  *  built-in llm() path runs after each completion (see lib/runtime/prompt.ts). A
  *  TS helper wrapping its own paid call site calls this so the cost participates
- *  in getCost() / guard(cost:) / per-invocation usage accounting.
+ *  in getCost() / guard(cost:) / per-invocation usage accounting. The charge is
+ *  recorded as a `manual` observation (model sentinel `""`).
  *
- *  `amount` must be a finite, nonnegative number — invalid input THROWS (via
- *  paidCostDelta) BEFORE any mutation, so a real charge is never silently
- *  dropped. Throws (a guard-trip) if enforcement fails — callers must not
- *  swallow it. */
+ *  `amount` must be a finite, nonnegative number — invalid input THROWS BEFORE
+ *  any mutation, so a real charge is never silently dropped. Throws (a
+ *  guard-trip) if enforcement fails — callers must not swallow it. */
 export function addCost(amount: number): void {
-  recordPaidUsage(paidCostDelta(amount));
-  getRuntimeContext().stack.enforceGuards();
+  if (typeof amount !== "number" || !Number.isFinite(amount) || amount < 0) {
+    throw new Error("addCost: amount must be a finite, non-negative number");
+  }
+  const { ctx, stack } = getRuntimeContext();
+  recordUsage(ctx, stack, { type: "manual", amount });
+  stack.enforceGuards();
 }
 
 /** Add `amount` tokens to the active branch accumulator. Sibling of addCost;

--- a/packages/agency-lang/lib/runtime/costTelemetry.test.ts
+++ b/packages/agency-lang/lib/runtime/costTelemetry.test.ts
@@ -80,6 +80,24 @@ describe("sendInvocationUsageToParent", () => {
     expect(send).toHaveBeenCalledOnce();
   });
 
+  it("sends a known-free result whose total is zero but a named component is not", () => {
+    vi.stubEnv("AGENCY_IPC", "1");
+    const send = vi.fn(() => true);
+    process.send = send as any;
+    // { inputCost: 0.01, totalCost: 0 } — retained in-process, so it must survive
+    // the subprocess boundary too (the component detail is real).
+    sendInvocationUsageToParent(delta({ cost: cost({ inputCost: 0.01, totalCost: 0 }) }));
+    expect(send).toHaveBeenCalledOnce();
+  });
+
+  it("sends an all-zero PROVIDER entry (it still carries a (kind, model) bucket)", () => {
+    vi.stubEnv("AGENCY_IPC", "1");
+    const send = vi.fn(() => true);
+    process.send = send as any;
+    sendInvocationUsageToParent(delta({ entry: { kind: "completion", model: "opus", cost: cost(), tokens: tokens() } }));
+    expect(send).toHaveBeenCalledOnce();
+  });
+
   it("no-ops outside IPC mode", () => {
     const send = vi.fn(() => true);
     process.send = send as any;

--- a/packages/agency-lang/lib/runtime/costTelemetry.test.ts
+++ b/packages/agency-lang/lib/runtime/costTelemetry.test.ts
@@ -64,6 +64,22 @@ describe("sendInvocationUsageToParent", () => {
     expect(send).not.toHaveBeenCalled();
   });
 
+  it("skips an all-zero manual entry (addCost(0) must not spam the channel)", () => {
+    vi.stubEnv("AGENCY_IPC", "1");
+    const send = vi.fn(() => true);
+    process.send = send as any;
+    sendInvocationUsageToParent(delta({ entry: { kind: "manual", model: "", cost: cost(), tokens: tokens() } }));
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("sends a manual entry that DOES carry cost", () => {
+    vi.stubEnv("AGENCY_IPC", "1");
+    const send = vi.fn(() => true);
+    process.send = send as any;
+    sendInvocationUsageToParent(delta({ cost: cost({ totalCost: 0.03 }), entry: { kind: "manual", model: "", cost: cost({ totalCost: 0.03 }), tokens: tokens() } }));
+    expect(send).toHaveBeenCalledOnce();
+  });
+
   it("no-ops outside IPC mode", () => {
     const send = vi.fn(() => true);
     process.send = send as any;

--- a/packages/agency-lang/lib/runtime/costTelemetry.test.ts
+++ b/packages/agency-lang/lib/runtime/costTelemetry.test.ts
@@ -1,13 +1,11 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import {
-  isPayableCost,
   sendInvocationUsageToParent,
   sendInvocationUsageIncompleteToParent,
-  sendModelAttributionIncompleteToParent,
 } from "./costTelemetry.js";
-import { completionUsageDelta, paidCostDelta } from "./invocationUsage.js";
 import { StateStack } from "./state/stateStack.js";
 import { CostGuard } from "./guard.js";
+import type { CostBreakdown, NormalizedDelta, TokenBreakdown } from "./invocationUsage.js";
 
 // process.send has no vi.stubEnv equivalent — save/restore it manually.
 const originalSend = process.send;
@@ -18,53 +16,43 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe("isPayableCost", () => {
-  it("accepts positive finite numbers only", () => {
-    expect(isPayableCost(0.5)).toBe(true);
-    expect(isPayableCost(0)).toBe(false);
-    expect(isPayableCost(-1)).toBe(false);
-    expect(isPayableCost(NaN)).toBe(false);
-    expect(isPayableCost(Infinity)).toBe(false);
-    expect(isPayableCost("0.5")).toBe(false);
-    expect(isPayableCost(undefined)).toBe(false);
-  });
-});
+function cost(over: Partial<CostBreakdown> = {}): CostBreakdown {
+  return { inputCost: 0, outputCost: 0, cachedInputCost: 0, cacheCreationInputCost: 0, hostedToolsCost: 0, totalCost: 0, currency: "USD", ...over };
+}
+function tokens(over: Partial<TokenBreakdown> = {}): TokenBreakdown {
+  return { inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, cacheCreationInputTokens: 0, totalTokens: 0, ...over };
+}
+function delta(over: Partial<NormalizedDelta> = {}): NormalizedDelta {
+  return { cost: cost(), tokens: tokens(), unknownCostCallCount: 0, attributionLost: false, ...over };
+}
 
 describe("sendInvocationUsageToParent", () => {
-  const delta = { pricedCost: 0.5, inputTokens: 100, outputTokens: 20, unknownCostCallCount: 0 };
-
-  it("sends the full delta when in IPC mode", () => {
+  it("sends the complete nested delta when in IPC mode", () => {
     vi.stubEnv("AGENCY_IPC", "1");
     const send = vi.fn(() => true);
     process.send = send as any;
-    sendInvocationUsageToParent(delta);
-    expect(send).toHaveBeenCalledExactlyOnceWith({ type: "invocationUsage", ...delta });
-  });
-
-  it("relays attribution for a completion and an addCost charge", () => {
-    vi.stubEnv("AGENCY_IPC", "1");
-    const send = vi.fn(() => true);
-    process.send = send as any;
-
-    sendInvocationUsageToParent(completionUsageDelta({ cost: 0.1, inputTokens: 1, outputTokens: 1, model: "opus" }));
-    expect(send).toHaveBeenCalledWith(expect.objectContaining({
-      type: "invocationUsage",
-      attribution: { kind: "model", model: "opus" },
-    }));
-
-    send.mockClear();
-    sendInvocationUsageToParent(paidCostDelta(0.03));
-    expect(send).toHaveBeenCalledWith(expect.objectContaining({
-      type: "invocationUsage",
-      attribution: { kind: "unattributed" },
-    }));
+    const d = delta({
+      cost: cost({ totalCost: 0.5, inputCost: 0.3, outputCost: 0.2 }),
+      tokens: tokens({ inputTokens: 100, outputTokens: 20, totalTokens: 120 }),
+      entry: { kind: "completion", model: "opus", cost: cost({ totalCost: 0.5 }), tokens: tokens({ totalTokens: 120 }) },
+    });
+    sendInvocationUsageToParent(d);
+    expect(send).toHaveBeenCalledExactlyOnceWith({ type: "invocationUsage", ...d });
   });
 
   it("sends a zero-cost unpriced delta (tokens/unknown must not be dropped)", () => {
     vi.stubEnv("AGENCY_IPC", "1");
     const send = vi.fn(() => true);
     process.send = send as any;
-    sendInvocationUsageToParent({ pricedCost: 0, inputTokens: 3, outputTokens: 1, unknownCostCallCount: 1 });
+    sendInvocationUsageToParent(delta({ tokens: tokens({ inputTokens: 3, totalTokens: 4 }), unknownCostCallCount: 1 }));
+    expect(send).toHaveBeenCalledOnce();
+  });
+
+  it("sends a delta that carries only an attribution-loss flag", () => {
+    vi.stubEnv("AGENCY_IPC", "1");
+    const send = vi.fn(() => true);
+    process.send = send as any;
+    sendInvocationUsageToParent(delta({ attributionLost: true }));
     expect(send).toHaveBeenCalledOnce();
   });
 
@@ -72,21 +60,21 @@ describe("sendInvocationUsageToParent", () => {
     vi.stubEnv("AGENCY_IPC", "1");
     const send = vi.fn(() => true);
     process.send = send as any;
-    sendInvocationUsageToParent({ pricedCost: 0, inputTokens: 0, outputTokens: 0, unknownCostCallCount: 0 });
+    sendInvocationUsageToParent(delta());
     expect(send).not.toHaveBeenCalled();
   });
 
   it("no-ops outside IPC mode", () => {
     const send = vi.fn(() => true);
     process.send = send as any;
-    sendInvocationUsageToParent(delta);
+    sendInvocationUsageToParent(delta({ cost: cost({ totalCost: 0.5 }) }));
     expect(send).not.toHaveBeenCalled();
   });
 
   it("swallows a dead-channel send error", () => {
     vi.stubEnv("AGENCY_IPC", "1");
     process.send = vi.fn(() => { throw new Error("channel closed"); }) as any;
-    expect(() => sendInvocationUsageToParent(delta)).not.toThrow();
+    expect(() => sendInvocationUsageToParent(delta({ cost: cost({ totalCost: 0.5 }) }))).not.toThrow();
   });
 });
 
@@ -103,21 +91,8 @@ describe("sendInvocationUsageIncompleteToParent", () => {
   });
 });
 
-describe("sendModelAttributionIncompleteToParent", () => {
-  it("sends the marker in IPC mode and no-ops otherwise", () => {
-    const send = vi.fn(() => true);
-    process.send = send as any;
-    sendModelAttributionIncompleteToParent();
-    expect(send).not.toHaveBeenCalled();
-
-    vi.stubEnv("AGENCY_IPC", "1");
-    sendModelAttributionIncompleteToParent();
-    expect(send).toHaveBeenCalledExactlyOnceWith({ type: "modelAttributionIncomplete" });
-  });
-});
-
 describe("StateStack.billCharge", () => {
-  it("no longer emits telemetry (relay rides the recordPaidUsageAt boundary)", () => {
+  it("no longer emits telemetry (relay rides the recordPaidUsage boundary)", () => {
     vi.stubEnv("AGENCY_IPC", "1");
     const send = vi.fn(() => true);
     process.send = send as any;

--- a/packages/agency-lang/lib/runtime/costTelemetry.ts
+++ b/packages/agency-lang/lib/runtime/costTelemetry.ts
@@ -70,17 +70,35 @@ function tokensAreZero(tokens: NormalizedDelta["tokens"]): boolean {
   );
 }
 
-/** A delta carries nothing worth relaying: no cost, no tokens, no unknown-cost
- *  call, no attribution loss, and — crucially — no VALUE-BEARING entry. A no-op
- *  charge such as `addCost(0)` still produces a manual entry, but with all-zero
- *  cost and tokens, so it too is skipped and never spams the parent channel. */
+/** Every named cost component AND the total is zero. Checking the whole
+ *  breakdown — not just `totalCost` — matters because a known-free provider
+ *  result (e.g. `{ inputCost: 0.01, totalCost: 0 }`) carries real component
+ *  detail that must survive the subprocess boundary. */
+function costIsZero(cost: NormalizedDelta["cost"]): boolean {
+  return (
+    cost.inputCost === 0 &&
+    cost.outputCost === 0 &&
+    cost.cachedInputCost === 0 &&
+    cost.cacheCreationInputCost === 0 &&
+    cost.hostedToolsCost === 0 &&
+    cost.totalCost === 0
+  );
+}
+
+/** A delta carries nothing worth relaying: no cost (any component), no tokens,
+ *  no unknown-cost call, no attribution loss, and no attribution the parent
+ *  needs. A no-op `addCost(0)` produces an all-zero MANUAL entry (no attribution
+ *  worth keeping), so it is suppressed. But an all-zero PROVIDER entry still
+ *  carries a `(kind, model)` bucket that must stay topology-invariant, so it is
+ *  never suppressed. */
 function isNoOpDelta(delta: NormalizedDelta): boolean {
   if (delta.attributionLost) return false;
   if (delta.unknownCostCallCount !== 0) return false;
-  if (delta.cost.totalCost !== 0) return false;
+  if (!costIsZero(delta.cost)) return false;
   if (!tokensAreZero(delta.tokens)) return false;
-  if (delta.entry !== undefined && (delta.entry.cost.totalCost !== 0 || !tokensAreZero(delta.entry.tokens))) {
-    return false;
+  if (delta.entry !== undefined) {
+    if (delta.entry.kind !== "manual") return false;
+    if (!costIsZero(delta.entry.cost) || !tokensAreZero(delta.entry.tokens)) return false;
   }
   return true;
 }

--- a/packages/agency-lang/lib/runtime/costTelemetry.ts
+++ b/packages/agency-lang/lib/runtime/costTelemetry.ts
@@ -1,15 +1,15 @@
 /**
  * Fire-and-forget usage telemetry from a subprocess to its parent, so
  * parent-side cost guards see child LLM spend live AND the parent's
- * per-invocation usage meter (the serve cost seam) accrues the child's
- * cost/tokens/unknown-count (see
- * docs/superpowers/specs/2026-07-02-subprocess-cost-telemetry-design.md).
+ * per-invocation usage meter (the serve cost seam) accrues the child's full
+ * cost/token/attribution breakdown (see
+ * docs/superpowers/specs/2026-08-04-full-cost-token-breakdown-design.md).
  *
  * Deliberately dependency-light (the subprocessRunInfo.ts layering pattern):
- * the only runtime import is subprocessRunInfo; `InvocationUsageDelta` is a
- * type-only import (erased at runtime), so this stays a leaf module.
- * `recordPaidUsageAt` calls the sender here on every paid charge; stateStack /
- * accounting must not import ipc.ts.
+ * the only runtime import is subprocessRunInfo; `NormalizedDelta` is a type-only
+ * import (erased at runtime), so this stays a leaf module. The recordPaidUsage
+ * sink calls the sender here on every accounted delta; stateStack / accounting
+ * must not import ipc.ts.
  *
  * Never blocks and never throws: there is no reply, no listener, and a dead
  * channel is swallowed — the bootstrap disconnect watchdog is about to reap
@@ -17,28 +17,20 @@
  */
 
 import { isIpcMode, ipcChildDebug } from "./subprocessRunInfo.js";
-import type { InvocationUsageDelta, UsageAttribution } from "./invocationUsage.js";
+import type { NormalizedDelta } from "./invocationUsage.js";
 
-/** Legacy cost-only telemetry message. No longer emitted by this codebase (the
- *  full-delta message below supersedes it), but still ACCEPTED on receive so a
- *  version-skewed child cannot silently drop cost. */
-export type IpcTelemetryMessage = {
-  type: "telemetry";
-  costUsd: number;
-};
-
-/** Full per-invocation usage delta relayed to the parent. A legal delta may
- *  carry zero priced cost with nonzero tokens and/or one unknown-cost call (an
- *  unpriced completion). `attribution` rides along so the parent can bucket the
- *  charge per model; its ABSENCE on a measurable message means an older child
- *  lost the model (the parent flags `modelAttributionComplete`). */
+/** The UNTRUSTED wire shape a parent receives on `invocationUsage`. Every field
+ *  is `unknown`: a version-skewed or malicious child may send anything, so the
+ *  parent recovers it field-by-field via `normalizeIpcUsageDelta` before it
+ *  reaches the accounting sink. The trusted SEND-side payload is a
+ *  `NormalizedDelta` (this message minus `type`). */
 export type IpcInvocationUsageMessage = {
   type: "invocationUsage";
-  pricedCost: number;
-  inputTokens: number;
-  outputTokens: number;
-  unknownCostCallCount: number;
-  attribution?: UsageAttribution;
+  cost?: unknown;
+  tokens?: unknown;
+  unknownCostCallCount?: unknown;
+  entry?: unknown;
+  attributionLost?: unknown;
 };
 
 /** Relayed once when a process can no longer guarantee that all of its (or a
@@ -48,24 +40,9 @@ export type IpcInvocationUsageIncompleteMessage = {
   type: "invocationUsageIncomplete";
 };
 
-/** Relayed once when a process booked priced spend to `unattributed` because a
- *  descendant lost the charge's model (a version-skewed child) — flags the
- *  owning invocation's `modelAttributionComplete` false. Carries no cost. */
-export type IpcModelAttributionIncompleteMessage = {
-  type: "modelAttributionIncomplete";
-};
-
 export type IpcUsageMessage =
-  | IpcTelemetryMessage
   | IpcInvocationUsageMessage
-  | IpcInvocationUsageIncompleteMessage
-  | IpcModelAttributionIncompleteMessage;
-
-/** The wire contract for a legacy billable cost: a positive finite number.
- *  Used only when normalizing a legacy `{ costUsd }` message on receive. */
-export function isPayableCost(costUsd: unknown): costUsd is number {
-  return typeof costUsd === "number" && Number.isFinite(costUsd) && costUsd > 0;
-}
+  | IpcInvocationUsageIncompleteMessage;
 
 function canSend(): boolean {
   return isIpcMode() && typeof process.send === "function";
@@ -83,18 +60,30 @@ function trySend(msg: IpcUsageMessage): void {
   }
 }
 
-/** Relay a full usage delta to the parent, once. Skips an all-zero delta (a
- *  no-op charge carries nothing worth relaying). */
-export function sendInvocationUsageToParent(delta: InvocationUsageDelta): void {
+/** A delta carries nothing worth relaying: no cost, no tokens, no unknown-cost
+ *  call, no attribution entry, and no attribution loss. A no-op charge (e.g.
+ *  `addCost(0)`) is skipped so it never spams the parent channel. */
+function isNoOpDelta(delta: NormalizedDelta): boolean {
+  if (delta.entry !== undefined) return false;
+  if (delta.attributionLost) return false;
+  if (delta.unknownCostCallCount !== 0) return false;
+  if (delta.cost.totalCost !== 0) return false;
+  const t = delta.tokens;
+  return (
+    t.inputTokens === 0 &&
+    t.outputTokens === 0 &&
+    t.cachedInputTokens === 0 &&
+    t.cacheCreationInputTokens === 0 &&
+    t.totalTokens === 0
+  );
+}
+
+/** Relay a full normalized usage delta to the parent, once. Sends the complete
+ *  nested breakdown (`cost`, `tokens`, `entry`, `unknownCostCallCount`,
+ *  `attributionLost`). Skips an all-zero delta. */
+export function sendInvocationUsageToParent(delta: NormalizedDelta): void {
   if (!canSend()) return;
-  if (
-    delta.pricedCost === 0 &&
-    delta.inputTokens === 0 &&
-    delta.outputTokens === 0 &&
-    delta.unknownCostCallCount === 0
-  ) {
-    return;
-  }
+  if (isNoOpDelta(delta)) return;
   trySend({ type: "invocationUsage", ...delta });
 }
 
@@ -102,10 +91,4 @@ export function sendInvocationUsageToParent(delta: InvocationUsageDelta): void {
 export function sendInvocationUsageIncompleteToParent(): void {
   if (!canSend()) return;
   trySend({ type: "invocationUsageIncomplete" });
-}
-
-/** Relay the model-attribution-incomplete marker to the parent, once. */
-export function sendModelAttributionIncompleteToParent(): void {
-  if (!canSend()) return;
-  trySend({ type: "modelAttributionIncomplete" });
 }

--- a/packages/agency-lang/lib/runtime/costTelemetry.ts
+++ b/packages/agency-lang/lib/runtime/costTelemetry.ts
@@ -60,22 +60,29 @@ function trySend(msg: IpcUsageMessage): void {
   }
 }
 
+function tokensAreZero(tokens: NormalizedDelta["tokens"]): boolean {
+  return (
+    tokens.inputTokens === 0 &&
+    tokens.outputTokens === 0 &&
+    tokens.cachedInputTokens === 0 &&
+    tokens.cacheCreationInputTokens === 0 &&
+    tokens.totalTokens === 0
+  );
+}
+
 /** A delta carries nothing worth relaying: no cost, no tokens, no unknown-cost
- *  call, no attribution entry, and no attribution loss. A no-op charge (e.g.
- *  `addCost(0)`) is skipped so it never spams the parent channel. */
+ *  call, no attribution loss, and — crucially — no VALUE-BEARING entry. A no-op
+ *  charge such as `addCost(0)` still produces a manual entry, but with all-zero
+ *  cost and tokens, so it too is skipped and never spams the parent channel. */
 function isNoOpDelta(delta: NormalizedDelta): boolean {
-  if (delta.entry !== undefined) return false;
   if (delta.attributionLost) return false;
   if (delta.unknownCostCallCount !== 0) return false;
   if (delta.cost.totalCost !== 0) return false;
-  const t = delta.tokens;
-  return (
-    t.inputTokens === 0 &&
-    t.outputTokens === 0 &&
-    t.cachedInputTokens === 0 &&
-    t.cacheCreationInputTokens === 0 &&
-    t.totalTokens === 0
-  );
+  if (!tokensAreZero(delta.tokens)) return false;
+  if (delta.entry !== undefined && (delta.entry.cost.totalCost !== 0 || !tokensAreZero(delta.entry.tokens))) {
+    return false;
+  }
+  return true;
 }
 
 /** Relay a full normalized usage delta to the parent, once. Sends the complete

--- a/packages/agency-lang/lib/runtime/deterministicClient.ts
+++ b/packages/agency-lang/lib/runtime/deterministicClient.ts
@@ -277,7 +277,12 @@ export class DeterministicClient implements LLMClient {
           { data: new Uint8Array(Buffer.from(pngBase64, "base64")), mimeType: "image/png" },
         ],
         model: "deterministic-image",
-        costEstimate: { totalCost: DETERMINISTIC_IMAGE_COST } as any,
+        costEstimate: {
+          inputCost: 0,
+          outputCost: DETERMINISTIC_IMAGE_COST,
+          totalCost: DETERMINISTIC_IMAGE_COST,
+          currency: "USD",
+        },
       },
     };
   }

--- a/packages/agency-lang/lib/runtime/image-client.test.ts
+++ b/packages/agency-lang/lib/runtime/image-client.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from "vitest";
 import { DeterministicClient } from "./deterministicClient.js";
 import { DETERMINISTIC_IMAGE_COST } from "../constants.js";
+import { _generateImage } from "../stdlib/image.js";
+import { agencyStore } from "./asyncContext.js";
+import { StateStack } from "./state/stateStack.js";
+import { CostGuard } from "./guard.js";
+import { InvocationUsageMeter } from "./invocationUsage.js";
 
 // Note: SmoltalkClient.image's `{ model: DEFAULT_IMAGE_MODEL, ...config }` spread
 // (default applied only when config sets no model) is trivial by construction and
@@ -19,6 +24,40 @@ describe("DeterministicClient.image", () => {
       // Real PNG signature — proves the base64 decodes to actual PNG bytes.
       expect(Array.from(img.data.slice(0, 8))).toEqual([137, 80, 78, 71, 13, 10, 26, 10]);
       expect(r.value.costEstimate?.totalCost).toBe(DETERMINISTIC_IMAGE_COST);
+      // Regression: the estimate must be a VALID USD price. Omitting `currency`
+      // (the old `as any` cast) makes the serve cost seam treat it as unpriced,
+      // so getCost() stays zero and image guards never trip.
+      expect(r.value.costEstimate?.currency).toBe("USD");
     }
+  });
+});
+
+function imageFrame(stack: StateStack) {
+  const client = new DeterministicClient([]);
+  return {
+    ctx: { llmClient: client, statelogClient: { imageGeneration: () => {} }, invocationUsage: new InvocationUsageMeter() },
+    stack,
+    threads: {},
+    globals: {},
+    callsite: { moduleId: "t", scopeName: "main", stepPath: "" },
+  } as any;
+}
+
+describe("deterministic image cost/guard path (regression)", () => {
+  it("bills the deterministic image cost against the branch", async () => {
+    const stack = new StateStack();
+    await agencyStore.run(imageFrame(stack), async () => {
+      const r = await _generateImage("a red bike", "", "", "", "", [], "", "");
+      expect(r.success).toBe(true);
+    });
+    expect(stack.localCost).toBeCloseTo(DETERMINISTIC_IMAGE_COST);
+  });
+
+  it("trips a guard tighter than the deterministic image cost", async () => {
+    const stack = new StateStack();
+    stack.guards.push(new CostGuard(DETERMINISTIC_IMAGE_COST / 2));
+    await agencyStore.run(imageFrame(stack), async () => {
+      await expect(_generateImage("x", "", "", "", "", [], "", "")).rejects.toBeTruthy();
+    });
   });
 });

--- a/packages/agency-lang/lib/runtime/invocationOutcome.test.ts
+++ b/packages/agency-lang/lib/runtime/invocationOutcome.test.ts
@@ -35,7 +35,7 @@ describe("runExportedFunctionForServe outcomes", () => {
     const outcome = await runExportedFunctionForServe({ ctx: makeCtx(), fn: fakeFn(() => value), namedArgs: {} });
     expect(outcome.status).toBe("returned");
     if (outcome.status === "returned") expect(outcome.value).toEqual(value);
-    expect(outcome.usage).toMatchObject({ pricedCost: 0, pricingComplete: true });
+    expect(outcome.usage).toMatchObject({ cost: { totalCost: 0 }, pricingComplete: true });
     expect(outcome.usageComplete).toBe(true);
   });
 
@@ -61,7 +61,7 @@ describe("runExportedFunctionForServe outcomes", () => {
       namedArgs: {},
     });
     expect(outcome.status).toBe("threw");
-    expect(outcome.usage.pricedCost).toBeCloseTo(1);
+    expect(outcome.usage.cost.totalCost).toBeCloseTo(1);
   });
 });
 
@@ -127,8 +127,15 @@ describe("finishServedInvocation cleanup semantics", () => {
     const outcome = await finishServedInvocation(
       ctx,
       { status: "returned", value: "ok" },
-      async () => { ctx.invocationUsage.merge({ pricedCost: 0.5, inputTokens: 0, outputTokens: 0, unknownCostCallCount: 0 }); },
+      async () => {
+        ctx.invocationUsage.merge({
+          cost: { inputCost: 0, outputCost: 0, cachedInputCost: 0, cacheCreationInputCost: 0, hostedToolsCost: 0, totalCost: 0.5, currency: "USD" },
+          tokens: { inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, cacheCreationInputTokens: 0, totalTokens: 0 },
+          unknownCostCallCount: 0,
+          attributionLost: false,
+        });
+      },
     );
-    expect(outcome.usage.pricedCost).toBeCloseTo(0.5);
+    expect(outcome.usage.cost.totalCost).toBeCloseTo(0.5);
   });
 });

--- a/packages/agency-lang/lib/runtime/invocationUsage.test.ts
+++ b/packages/agency-lang/lib/runtime/invocationUsage.test.ts
@@ -1,56 +1,130 @@
 import { describe, it, expect } from "vitest";
 import {
   InvocationUsageMeter,
-  completionUsageDelta,
-  paidCostDelta,
-  normalizeUsageDelta,
+  normalizeObservation,
+  normalizeIpcUsageDelta,
   usageReconcileTolerance,
   unwrapServedInvocationOutcome,
+  type NormalizedDelta,
   type ServedInvocationOutcome,
 } from "./invocationUsage.js";
 
-type Usage = ReturnType<InvocationUsageMeter["snapshot"]>["usage"];
-function rowSumCost(usage: Usage) {
-  const modelCost = Object.values(usage.models ?? {})
-    .reduce((total, row) => total + row.pricedCost, 0);
-  return modelCost + (usage.unattributed?.pricedCost ?? 0);
-}
-function reconciles(usage: Usage) {
-  return Math.abs(rowSumCost(usage) - usage.pricedCost)
-    <= usageReconcileTolerance(usage.pricedCost);
-}
+const MAX = Number.MAX_SAFE_INTEGER;
+const fullCost = { inputCost: 0.1, outputCost: 0.2, cachedInputCost: 0.03, cacheCreationInputCost: 0.04, hostedToolsCost: 0.05, totalCost: 0.42, currency: "USD" };
+const fullTokens = { inputTokens: 100, outputTokens: 20, cachedInputTokens: 5, cacheCreationInputTokens: 3, totalTokens: 128 };
+
+describe("normalizeObservation — provider cost", () => {
+  it("keeps each component and the authoritative total for a valid USD cost", () => {
+    const d = normalizeObservation({ type: "provider", kind: "completion", reportedModel: "opus", cost: fullCost as any, tokens: fullTokens as any });
+    expect(d.cost).toEqual(fullCost);
+    expect(d.unknownCostCallCount).toBe(0);
+    expect(d.attributionLost).toBe(false);
+    expect(d.entry).toMatchObject({ kind: "completion", model: "opus" });
+  });
+  it("maps absent/negative/NaN/±Infinity components to 0 without touching the total", () => {
+    const d = normalizeObservation({ type: "provider", kind: "completion", reportedModel: "m", cost: { totalCost: 0.42, currency: "USD", inputCost: -1, outputCost: Number.NaN, cachedInputCost: Number.POSITIVE_INFINITY, cacheCreationInputCost: Number.NEGATIVE_INFINITY } as any });
+    expect(d.cost.totalCost).toBe(0.42);
+    expect(d.cost.inputCost).toBe(0);
+    expect(d.cost.outputCost).toBe(0);
+    expect(d.cost.cachedInputCost).toBe(0);
+    expect(d.cost.cacheCreationInputCost).toBe(0);
+    expect(d.cost.hostedToolsCost).toBe(0);
+  });
+  it("treats an invalid or non-USD total as unpriced (all cost zero, +1 unknown) but keeps the entry+tokens", () => {
+    const nonUsd = normalizeObservation({ type: "provider", kind: "completion", reportedModel: "m", cost: { ...fullCost, currency: "EUR" } as any, tokens: fullTokens as any });
+    expect(nonUsd.cost).toEqual({ inputCost: 0, outputCost: 0, cachedInputCost: 0, cacheCreationInputCost: 0, hostedToolsCost: 0, totalCost: 0, currency: "USD" });
+    expect(nonUsd.unknownCostCallCount).toBe(1);
+    expect(nonUsd.entry?.tokens.totalTokens).toBe(128);
+    const noCost = normalizeObservation({ type: "provider", kind: "completion", reportedModel: "m" });
+    expect(noCost.unknownCostCallCount).toBe(1);
+    expect(noCost.cost.totalCost).toBe(0);
+  });
+  it("known-free (totalCost 0) is priced", () => {
+    const d = normalizeObservation({ type: "provider", kind: "embedding", reportedModel: "e", cost: { totalCost: 0, currency: "USD" } as any });
+    expect(d.unknownCostCallCount).toBe(0);
+    expect(d.cost.totalCost).toBe(0);
+  });
+});
+
+describe("normalizeObservation — tokens & model", () => {
+  it("uses the provider totalTokens verbatim (cached-image not double-counted)", () => {
+    const d = normalizeObservation({ type: "provider", kind: "image", reportedModel: "img", tokens: { inputTokens: 100, outputTokens: 0, cachedInputTokens: 30, totalTokens: 100 } as any });
+    expect(d.tokens.totalTokens).toBe(100);
+  });
+  it("kind-specific fallback when totalTokens absent", () => {
+    const comp = normalizeObservation({ type: "provider", kind: "completion", reportedModel: "c", tokens: { inputTokens: 10, outputTokens: 2, cachedInputTokens: 5, cacheCreationInputTokens: 3 } as any });
+    expect(comp.tokens.totalTokens).toBe(20);
+    const img = normalizeObservation({ type: "provider", kind: "image", reportedModel: "i", tokens: { inputTokens: 10, outputTokens: 2, cachedInputTokens: 5 } as any });
+    expect(img.tokens.totalTokens).toBe(12);
+  });
+  it("present-malformed totalTokens falls back and degrades", () => {
+    const d = normalizeObservation({ type: "provider", kind: "completion", reportedModel: "c", tokens: { inputTokens: 4, outputTokens: 2, totalTokens: -1 } as any });
+    expect(d.tokens.totalTokens).toBe(6);
+    expect(d.attributionLost).toBe(true);
+  });
+  it("resolves reported → configured → unknown model", () => {
+    expect(normalizeObservation({ type: "provider", kind: "completion", reportedModel: "opus", configuredModel: "sonnet" }).entry?.model).toBe("opus");
+    expect(normalizeObservation({ type: "provider", kind: "completion", reportedModel: "", configuredModel: "sonnet" }).entry?.model).toBe("sonnet");
+    expect(normalizeObservation({ type: "provider", kind: "completion" }).entry?.model).toBe("unknown model");
+  });
+});
+
+describe("normalizeObservation — manual & attempt", () => {
+  it("manual → entry with model '' and totalCost=amount", () => {
+    const d = normalizeObservation({ type: "manual", amount: 0.03 });
+    expect(d.entry).toMatchObject({ kind: "manual", model: "" });
+    expect(d.entry?.cost.totalCost).toBe(0.03);
+    expect(d.cost.totalCost).toBe(0.03);
+    expect(d.unknownCostCallCount).toBe(0);
+  });
+  it("attempt → no entry, +1 unknown, zero money", () => {
+    const d = normalizeObservation({ type: "attempt", kind: "completion" });
+    expect(d.entry).toBeUndefined();
+    expect(d.unknownCostCallCount).toBe(1);
+    expect(d.cost.totalCost).toBe(0);
+  });
+});
 
 describe("InvocationUsageMeter", () => {
-  it("accumulates deltas and derives pricingComplete", () => {
+  it("keeps separate (kind, model) buckets in first-seen order and reconciles when complete", () => {
     const m = new InvocationUsageMeter();
-    m.merge({ pricedCost: 0.01, inputTokens: 100, outputTokens: 20, unknownCostCallCount: 0 });
-    m.merge({ pricedCost: 0.02, inputTokens: 5, outputTokens: 1, unknownCostCallCount: 0 });
+    m.merge(normalizeObservation({ type: "provider", kind: "completion", reportedModel: "opus", cost: { totalCost: 0.1, currency: "USD" } as any }));
+    m.merge(normalizeObservation({ type: "provider", kind: "embedding", reportedModel: "opus", cost: { totalCost: 0.2, currency: "USD" } as any }));
+    m.merge(normalizeObservation({ type: "provider", kind: "completion", reportedModel: "opus", cost: { totalCost: 0.05, currency: "USD" } as any }));
+    const { usage, usageComplete } = m.snapshot();
+    expect(usageComplete).toBe(true);
+    expect(usage.entries.map((e) => `${e.kind}:${e.model}`)).toEqual(["completion:opus", "embedding:opus"]);
+    expect(usage.cost.totalCost).toBeCloseTo(0.35);
+    const sum = usage.entries.reduce((a, e) => a + e.cost.totalCost, 0);
+    expect(Math.abs(sum - usage.cost.totalCost)).toBeLessThanOrEqual(usageReconcileTolerance(usage.cost.totalCost));
+  });
+  it("snapshot returns deep copies (top-level + nested entry fields)", () => {
+    const m = new InvocationUsageMeter();
+    m.merge(normalizeObservation({ type: "provider", kind: "completion", reportedModel: "opus", cost: { totalCost: 0.1, currency: "USD" } as any, tokens: { inputTokens: 5, outputTokens: 1, totalTokens: 6 } as any }));
+    const a = m.snapshot();
+    a.usage.cost.totalCost = 999;
+    a.usage.tokens.inputTokens = 999;
+    a.usage.entries[0].cost.totalCost = 999;
+    a.usage.entries[0].tokens.inputTokens = 999;
+    a.usage.entries.push({ kind: "manual", model: "", cost: {} as any, tokens: {} as any });
+    const b = m.snapshot();
+    expect(b.usage.cost.totalCost).toBeCloseTo(0.1);
+    expect(b.usage.entries).toHaveLength(1);
+    expect(b.usage.entries[0].cost.totalCost).toBeCloseTo(0.1);
+    expect(b.usage.entries[0].tokens.inputTokens).toBe(5);
+  });
+  it("saturates a token overflow, marks incomplete, and merge reports only the first transition", () => {
+    const m = new InvocationUsageMeter();
+    const near: NormalizedDelta = { cost: { inputCost: 0, outputCost: 0, cachedInputCost: 0, cacheCreationInputCost: 0, hostedToolsCost: 0, totalCost: 0, currency: "USD" }, tokens: { inputTokens: MAX, outputTokens: 0, cachedInputTokens: 0, cacheCreationInputTokens: 0, totalTokens: MAX }, unknownCostCallCount: 0, attributionLost: false };
+    const one: NormalizedDelta = { ...near, tokens: { inputTokens: 1, outputTokens: 0, cachedInputTokens: 0, cacheCreationInputTokens: 0, totalTokens: 1 } };
+    expect(m.merge(near)).toBe(false);
+    expect(m.merge(one)).toBe(true);
+    expect(m.merge(one)).toBe(false);
     const s = m.snapshot();
-    expect(s.usage.pricedCost).toBeCloseTo(0.03);
-    expect(s.usage.inputTokens).toBe(105);
-    expect(s.usage.outputTokens).toBe(21);
-    expect(s.usage.unknownCostCallCount).toBe(0);
-    expect(s.usage.pricingComplete).toBe(true);
-    expect(s.usageComplete).toBe(true);
+    expect(s.usageComplete).toBe(false);
+    expect(s.usage.tokens.inputTokens).toBe(MAX);
   });
-
-  it("a fresh meter is complete and zeroed", () => {
-    const s = new InvocationUsageMeter().snapshot();
-    expect(s.usage).toEqual({
-      pricedCost: 0, inputTokens: 0, outputTokens: 0, unknownCostCallCount: 0, pricingComplete: true,
-      models: {}, unattributed: { pricedCost: 0, inputTokens: 0, outputTokens: 0 },
-      modelAttributionComplete: true,
-    });
-    expect(s.usageComplete).toBe(true);
-  });
-
-  it("any unknown-cost call flips pricingComplete false", () => {
-    const m = new InvocationUsageMeter();
-    m.merge({ pricedCost: 0, inputTokens: 3, outputTokens: 1, unknownCostCallCount: 1 });
-    expect(m.snapshot().usage.pricingComplete).toBe(false);
-  });
-
-  it("markIncomplete is permanent and reports only the first transition", () => {
+  it("markIncomplete is idempotent", () => {
     const m = new InvocationUsageMeter();
     expect(m.markIncomplete()).toBe(true);
     expect(m.markIncomplete()).toBe(false);
@@ -58,251 +132,42 @@ describe("InvocationUsageMeter", () => {
   });
 });
 
-describe("completionUsageDelta", () => {
-  it("finite zero is a known free price (not unknown)", () => {
-    expect(completionUsageDelta({ cost: 0, inputTokens: 10, outputTokens: 2, model: "m" })).toEqual({
-      pricedCost: 0, inputTokens: 10, outputTokens: 2, unknownCostCallCount: 0,
-      attribution: { kind: "model", model: "m" },
-    });
+describe("normalizeIpcUsageDelta — recover, never drop", () => {
+  it("recovers a well-formed delta", () => {
+    const d = normalizeIpcUsageDelta({ cost: fullCost, tokens: fullTokens, unknownCostCallCount: 0, entry: { kind: "completion", model: "opus", cost: fullCost, tokens: fullTokens } });
+    expect(d?.cost.totalCost).toBe(0.42);
+    expect(d?.entry?.model).toBe("opus");
+    expect(d?.attributionLost).toBe(false);
   });
-
-  it("positive price is priced", () => {
-    expect(completionUsageDelta({ cost: 0.5, inputTokens: 1, outputTokens: 1, model: "m" })).toEqual({
-      pricedCost: 0.5, inputTokens: 1, outputTokens: 1, unknownCostCallCount: 0,
-      attribution: { kind: "model", model: "m" },
-    });
+  it("invalid cost + valid tokens → keep tokens, +1 unknown, not a known-free zero", () => {
+    const d = normalizeIpcUsageDelta({ cost: { totalCost: -1, currency: "USD" }, tokens: { inputTokens: 5, outputTokens: 1, cachedInputTokens: 0, cacheCreationInputTokens: 0, totalTokens: 6 }, unknownCostCallCount: 0 });
+    expect(d?.cost.totalCost).toBe(0);
+    expect(d?.unknownCostCallCount).toBe(1);
+    expect(d?.tokens.inputTokens).toBe(5);
   });
-
-  it.each([
-    ["undefined", undefined],
-    ["null", null],
-    ["negative", -1],
-    ["NaN", NaN],
-    ["Infinity", Infinity],
-  ])("%s price is unknown, contributes no cost, one unknown call", (_label, cost) => {
-    expect(completionUsageDelta({ cost: cost as number, inputTokens: 4, outputTokens: 2, model: "m" })).toEqual({
-      pricedCost: 0, inputTokens: 4, outputTokens: 2, unknownCostCallCount: 1,
-      attribution: { kind: "model", model: "m" },
-    });
+  it("unusable entry kind → preserve flat money, omit entry, degrade", () => {
+    const d = normalizeIpcUsageDelta({ cost: fullCost, tokens: fullTokens, unknownCostCallCount: 0, entry: { kind: "nope", model: "x", cost: fullCost, tokens: fullTokens } });
+    expect(d?.cost.totalCost).toBe(0.42);
+    expect(d?.entry).toBeUndefined();
+    expect(d?.attributionLost).toBe(true);
   });
-
-  it("absent or invalid tokens count as zero", () => {
-    expect(completionUsageDelta({ cost: 0.1, inputTokens: undefined, outputTokens: null, model: "m" })).toMatchObject({
-      inputTokens: 0, outputTokens: 0,
-    });
-    expect(completionUsageDelta({ cost: 0.1, inputTokens: -5, outputTokens: 1.5, model: "m" })).toMatchObject({
-      inputTokens: 0, outputTokens: 0,
-    });
+  it("token-only entry (valid kind/model, invalid entry cost) survives with zero cost", () => {
+    const d = normalizeIpcUsageDelta({ cost: fullCost, tokens: fullTokens, unknownCostCallCount: 0, entry: { kind: "completion", model: "opus", cost: { totalCost: -1, currency: "USD" }, tokens: fullTokens } });
+    expect(d?.entry?.model).toBe("opus");
+    expect(d?.entry?.cost.totalCost).toBe(0);
+    expect(d?.entry?.tokens.totalTokens).toBe(128);
   });
-});
-
-describe("paidCostDelta", () => {
-  it("wraps a valid nonnegative amount as unattributed", () => {
-    expect(paidCostDelta(0.25)).toEqual({
-      pricedCost: 0.25, inputTokens: 0, outputTokens: 0, unknownCostCallCount: 0,
-      attribution: { kind: "unattributed" },
-    });
-    expect(paidCostDelta(0)).toMatchObject({ pricedCost: 0 });
-  });
-
-  it.each([-1, NaN, Infinity])("throws on invalid amount %s (never silently zero)", (amount) => {
-    expect(() => paidCostDelta(amount)).toThrow();
-  });
-});
-
-describe("normalizeUsageDelta", () => {
-  it("returns null for a non-object", () => {
-    expect(normalizeUsageDelta(null)).toBeNull();
-    expect(normalizeUsageDelta(42)).toBeNull();
-  });
-
-  it("passes through a valid delta", () => {
-    expect(normalizeUsageDelta({ pricedCost: 0.3, inputTokens: 9, outputTokens: 3, unknownCostCallCount: 1 })).toEqual({
-      pricedCost: 0.3, inputTokens: 9, outputTokens: 3, unknownCostCallCount: 1,
-    });
-  });
-
-  it("an invalid cost becomes one unknown-cost call while valid fields survive", () => {
-    expect(normalizeUsageDelta({ pricedCost: -5, inputTokens: 9, outputTokens: 3, unknownCostCallCount: 0 })).toEqual({
-      pricedCost: 0, inputTokens: 9, outputTokens: 3, unknownCostCallCount: 1,
-    });
-  });
-
-  it("invalid token/count fields become zero", () => {
-    expect(normalizeUsageDelta({ pricedCost: 0.1, inputTokens: "x", outputTokens: -2, unknownCostCallCount: 1.5 })).toEqual({
-      pricedCost: 0.1, inputTokens: 0, outputTokens: 0, unknownCostCallCount: 0,
-    });
+  it("a non-object message is dropped", () => {
+    expect(normalizeIpcUsageDelta(42)).toBeNull();
+    expect(normalizeIpcUsageDelta(null)).toBeNull();
   });
 });
 
 describe("unwrapServedInvocationOutcome", () => {
-  it("returns the value for a returned outcome", () => {
-    const o: ServedInvocationOutcome<string> = {
-      status: "returned", value: "hi",
-      usage: { pricedCost: 0, inputTokens: 0, outputTokens: 0, unknownCostCallCount: 0, pricingComplete: true },
-      usageComplete: true,
-    };
-    expect(unwrapServedInvocationOutcome(o)).toBe("hi");
-  });
-
-  it("rethrows the identical error (string, frozen object)", () => {
-    const snap = {
-      usage: { pricedCost: 0, inputTokens: 0, outputTokens: 0, unknownCostCallCount: 0, pricingComplete: true },
-      usageComplete: true,
-    };
-    expect(() => unwrapServedInvocationOutcome({ status: "threw", error: "boom", ...snap })).toThrow("boom");
-    const frozen = Object.freeze(new Error("frozen"));
-    try {
-      unwrapServedInvocationOutcome({ status: "threw", error: frozen, ...snap });
-      expect.fail("should have thrown");
-    } catch (e) {
-      expect(e).toBe(frozen);
-    }
-  });
-});
-
-describe("InvocationUsageMeter per-model breakdown", () => {
-  it("files a priced completion under its model row and reconciles", () => {
-    const meter = new InvocationUsageMeter();
-    meter.merge(completionUsageDelta({ cost: 0.1, inputTokens: 100, outputTokens: 20, model: "opus" }));
-    const { usage } = meter.snapshot();
-    expect(usage.models!["opus"]).toEqual({ pricedCost: 0.1, inputTokens: 100, outputTokens: 20 });
-    expect(reconciles(usage)).toBe(true);
-  });
-
-  it("routes addCost spend to unattributed, not models", () => {
-    const meter = new InvocationUsageMeter();
-    meter.merge(paidCostDelta(0.03));
-    const { usage } = meter.snapshot();
-    expect(usage.models).toEqual({});
-    expect(usage.unattributed).toEqual({ pricedCost: 0.03, inputTokens: 0, outputTokens: 0 });
-    expect(reconciles(usage)).toBe(true);
-  });
-
-  it("mixes a model row and unattributed", () => {
-    const meter = new InvocationUsageMeter();
-    meter.merge(completionUsageDelta({ cost: 0.1, inputTokens: 1, outputTokens: 1, model: "opus" }));
-    meter.merge(paidCostDelta(0.03));
-    const { usage } = meter.snapshot();
-    expect(usage.models!["opus"].pricedCost).toBeCloseTo(0.1);
-    expect(usage.unattributed!.pricedCost).toBeCloseTo(0.03);
-    expect(reconciles(usage)).toBe(true);
-  });
-
-  it("makes no row for a pure unknown-cost delta and keeps attribution complete", () => {
-    const meter = new InvocationUsageMeter();
-    meter.merge({ pricedCost: 0, inputTokens: 0, outputTokens: 0, unknownCostCallCount: 1 });
-    const { usage } = meter.snapshot();
-    expect(usage.models).toEqual({});
-    expect(usage.unattributed).toEqual({ pricedCost: 0, inputTokens: 0, outputTokens: 0 });
-    expect(usage.pricingComplete).toBe(false);
-    expect(usage.modelAttributionComplete).toBe(true);
-  });
-
-  it("treats __proto__ as a plain own key", () => {
-    const meter = new InvocationUsageMeter();
-    meter.merge(completionUsageDelta({ cost: 0.01, inputTokens: 1, outputTokens: 1, model: "__proto__" }));
-    expect(Object.prototype.hasOwnProperty.call(meter.snapshot().usage.models, "__proto__")).toBe(true);
-    expect(({} as any).pricedCost).toBeUndefined();
-  });
-
-  it("aggregates repeated charges for one model into one row", () => {
-    const meter = new InvocationUsageMeter();
-    meter.merge(completionUsageDelta({ cost: 0.01, inputTokens: 10, outputTokens: 2, model: "opus" }));
-    meter.merge(completionUsageDelta({ cost: 0.02, inputTokens: 20, outputTokens: 4, model: "opus" }));
-    expect(meter.snapshot().usage.models!["opus"]).toEqual({ pricedCost: 0.03, inputTokens: 30, outputTokens: 6 });
-  });
-
-  it("reconciles a regrouping-sensitive interleave within tolerance where === fails", () => {
-    const meter = new InvocationUsageMeter();
-    const sequence: [string, number][] = [
-      ["alpha", 0.1], ["beta", 0.1], ["alpha", 0.1], ["beta", 0.1], ["alpha", 0.1], ["beta", 0.1], ["alpha", 0.1],
-    ];
-    for (const [model, cost] of sequence) {
-      meter.merge(completionUsageDelta({ cost, inputTokens: 1, outputTokens: 1, model }));
-    }
-    const { usage } = meter.snapshot();
-    const rowSum = usage.models!["alpha"].pricedCost + usage.models!["beta"].pricedCost;
-    expect(rowSum).not.toBe(usage.pricedCost);                 // 0.7000000000000001 vs 0.7
-    expect(Math.abs(rowSum - usage.pricedCost)).toBeLessThanOrEqual(usageReconcileTolerance(usage.pricedCost));
-  });
-
-  it("keeps a real model named 'unknown model' as an ordinary row", () => {
-    const meter = new InvocationUsageMeter();
-    meter.merge(completionUsageDelta({ cost: 0.01, inputTokens: 1, outputTokens: 1, model: "unknown model" }));
-    const { usage } = meter.snapshot();
-    expect(usage.models!["unknown model"].pricedCost).toBeCloseTo(0.01);
-    expect(usage.unattributed).toEqual({ pricedCost: 0, inputTokens: 0, outputTokens: 0 });
-  });
-
-  it("returns independent copies from snapshot", () => {
-    const meter = new InvocationUsageMeter();
-    meter.merge(completionUsageDelta({ cost: 0.1, inputTokens: 1, outputTokens: 1, model: "opus" }));
-    const firstSnapshot = meter.snapshot().usage;
-    firstSnapshot.models!["opus"].pricedCost = 999;
-    firstSnapshot.models!["extra"] = { pricedCost: 5, inputTokens: 0, outputTokens: 0 };
-    firstSnapshot.unattributed!.pricedCost = 999;
-
-    const secondSnapshot = meter.snapshot().usage;
-    expect(secondSnapshot.models!["opus"].pricedCost).toBeCloseTo(0.1);
-    expect(secondSnapshot.models!["extra"]).toBeUndefined();
-    expect(secondSnapshot.unattributed!.pricedCost).toBe(0);
-  });
-
-  it("flips modelAttributionComplete once, idempotently", () => {
-    const meter = new InvocationUsageMeter();
-    expect(meter.snapshot().usage.modelAttributionComplete).toBe(true);
-    expect(meter.markModelAttributionIncomplete()).toBe(true);
-    expect(meter.markModelAttributionIncomplete()).toBe(false);
-    expect(meter.snapshot().usage.modelAttributionComplete).toBe(false);
-  });
-
-  it("fails reconciliation when a row is corrupted above tolerance (check has teeth)", () => {
-    const meter = new InvocationUsageMeter();
-    meter.merge(completionUsageDelta({ cost: 0.1, inputTokens: 1, outputTokens: 1, model: "opus" }));
-    const { usage } = meter.snapshot();
-    usage.models!["opus"].pricedCost -= 2 * usageReconcileTolerance(usage.pricedCost) + 0.001;
-    expect(reconciles(usage)).toBe(false);
-  });
-});
-
-describe("normalizeUsageDelta attribution", () => {
-  it("preserves model and unattributed, drops malformed/absent to undefined", () => {
-    const modelDelta = normalizeUsageDelta({
-      pricedCost: 0.1, inputTokens: 1, outputTokens: 1, unknownCostCallCount: 0,
-      attribution: { kind: "model", model: "opus" },
-    });
-    expect(modelDelta?.attribution).toEqual({ kind: "model", model: "opus" });
-
-    const unattributedDelta = normalizeUsageDelta({
-      pricedCost: 0.1, inputTokens: 1, outputTokens: 1, unknownCostCallCount: 0,
-      attribution: { kind: "unattributed" },
-    });
-    expect(unattributedDelta?.attribution).toEqual({ kind: "unattributed" });
-
-    const malformedAttributions = [undefined, null, 42, { kind: "model" }, { kind: "model", model: "" }, { kind: "nope" }];
-    for (const malformedAttribution of malformedAttributions) {
-      const normalized = normalizeUsageDelta({
-        pricedCost: 0.1, inputTokens: 1, outputTokens: 1, unknownCostCallCount: 0,
-        attribution: malformedAttribution,
-      });
-      expect(normalized?.attribution).toBeUndefined();
-    }
-  });
-
-  it("rejects an out-of-safe-range token count so exact-token reconciliation holds", () => {
-    // 2**53 is Number.isInteger but NOT safe; above it integer addition loses
-    // precision, which would break the exact-token reconciliation between the
-    // flat totals and the per-model rows. Untrusted IPC can send it.
-    const normalized = normalizeUsageDelta({
-      pricedCost: 0.1, inputTokens: 2 ** 53, outputTokens: 1, unknownCostCallCount: 0,
-    });
-    expect(normalized?.inputTokens).toBe(0);
-    expect(normalized?.outputTokens).toBe(1);
-    const meter = new InvocationUsageMeter();
-    meter.merge(normalized!);
-    const { usage } = meter.snapshot();
-    expect(usage.inputTokens).toBe(0);
-    expect(usage.unattributed!.inputTokens).toBe(0);
+  const snap = { usage: { cost: {} as any, tokens: {} as any, unknownCostCallCount: 0, pricingComplete: true, entries: [] }, usageComplete: true };
+  it("returns / rethrows identity", () => {
+    expect(unwrapServedInvocationOutcome({ status: "returned", value: "hi", ...snap } as ServedInvocationOutcome<string>)).toBe("hi");
+    const frozen = Object.freeze(new Error("x"));
+    try { unwrapServedInvocationOutcome({ status: "threw", error: frozen, ...snap }); expect.fail("throw"); } catch (e) { expect(e).toBe(frozen); }
   });
 });

--- a/packages/agency-lang/lib/runtime/invocationUsage.test.ts
+++ b/packages/agency-lang/lib/runtime/invocationUsage.test.ts
@@ -157,6 +157,41 @@ describe("normalizeIpcUsageDelta — recover, never drop", () => {
     expect(d?.entry?.cost.totalCost).toBe(0);
     expect(d?.entry?.tokens.totalTokens).toBe(128);
   });
+  it("recovers a missing total as an input+output lower bound (never sums cache) and degrades", () => {
+    // The trusted completion fallback would give 130; the untrusted boundary must
+    // not — cache may overlap input, so the safe lower bound is input+output.
+    const d = normalizeIpcUsageDelta({ cost: fullCost, unknownCostCallCount: 0, tokens: { inputTokens: 100, outputTokens: 0, cachedInputTokens: 30, cacheCreationInputTokens: 0 }, entry: { kind: "image", model: "img", cost: fullCost, tokens: fullTokens } });
+    expect(d?.tokens.totalTokens).toBe(100);
+    expect(d?.attributionLost).toBe(true);
+  });
+  it("an absent IPC token field becomes zero and degrades (no benign absence here)", () => {
+    const d = normalizeIpcUsageDelta({ cost: fullCost, tokens: { inputTokens: 5, outputTokens: 1, totalTokens: 6 }, unknownCostCallCount: 0, entry: { kind: "completion", model: "m", cost: fullCost, tokens: fullTokens } });
+    expect(d?.tokens.cachedInputTokens).toBe(0);
+    expect(d?.attributionLost).toBe(true);
+  });
+  it("a measurable flat delta with NO entry degrades (attribution lost in transit)", () => {
+    const d = normalizeIpcUsageDelta({ cost: fullCost, tokens: fullTokens, unknownCostCallCount: 0 });
+    expect(d?.entry).toBeUndefined();
+    expect(d?.cost.totalCost).toBe(0.42);
+    expect(d?.attributionLost).toBe(true);
+  });
+  it("an all-zero unresolved attempt with no entry stays complete", () => {
+    const d = normalizeIpcUsageDelta({ cost: { totalCost: 0, currency: "USD" }, tokens: { inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, cacheCreationInputTokens: 0, totalTokens: 0 }, unknownCostCallCount: 1 });
+    expect(d?.entry).toBeUndefined();
+    expect(d?.unknownCostCallCount).toBe(1);
+    expect(d?.attributionLost).toBe(false);
+  });
+  it("a valid-kind/model entry with malformed components survives but degrades", () => {
+    const d = normalizeIpcUsageDelta({ cost: fullCost, tokens: fullTokens, unknownCostCallCount: 0, entry: { kind: "completion", model: "opus", cost: { totalCost: -1, currency: "USD" }, tokens: fullTokens } });
+    expect(d?.entry?.model).toBe("opus");
+    expect(d?.entry?.cost.totalCost).toBe(0);
+    expect(d?.attributionLost).toBe(true);
+  });
+  it("a malformed-cost bump that saturates unknownCostCallCount degrades", () => {
+    const d = normalizeIpcUsageDelta({ cost: { totalCost: -1, currency: "USD" }, tokens: { inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, cacheCreationInputTokens: 0, totalTokens: 0 }, unknownCostCallCount: MAX });
+    expect(d?.unknownCostCallCount).toBe(MAX);
+    expect(d?.attributionLost).toBe(true);
+  });
   it("a non-object message is dropped", () => {
     expect(normalizeIpcUsageDelta(42)).toBeNull();
     expect(normalizeIpcUsageDelta(null)).toBeNull();

--- a/packages/agency-lang/lib/runtime/invocationUsage.ts
+++ b/packages/agency-lang/lib/runtime/invocationUsage.ts
@@ -216,6 +216,60 @@ function buildTokens(raw: unknown, kind: UsageKind, absentDegrades: boolean): { 
   return { tokens: { ...partial, totalTokens }, malformed };
 }
 
+/** One UNTRUSTED IPC token field: a nonnegative safe integer survives; anything
+ *  else (absent, negative, NaN, non-number) becomes 0 and degrades. Distinct
+ *  from `tokenCounter`: at this boundary an absent field is never benign, and
+ *  there is NO provider-kind fallback (a well-formed sender always transmits a
+ *  full `NormalizedDelta`, so a gap is a broken/skewed child). */
+function ipcCounter(value: unknown): { value: number; malformed: boolean } {
+  if (isSafeCount(value)) {
+    return { value, malformed: false };
+  }
+  return { value: 0, malformed: true };
+}
+
+/** Recover a token breakdown from UNTRUSTED IPC input, field by field. Each
+ *  component follows the strict IPC rule (`ipcCounter`). `totalTokens`, when
+ *  absent or malformed, falls back to a CONSERVATIVE `input + output` lower
+ *  bound — never summing cache counters (they may overlap input) and never a
+ *  provider-kind fallback — and degrades. */
+function buildIpcTokens(raw: unknown): { tokens: TokenBreakdown; malformed: boolean } {
+  const obj = raw && typeof raw === "object" ? (raw as Record<string, unknown>) : undefined;
+  const input = ipcCounter(obj?.inputTokens);
+  const output = ipcCounter(obj?.outputTokens);
+  const cachedInput = ipcCounter(obj?.cachedInputTokens);
+  const cacheCreation = ipcCounter(obj?.cacheCreationInputTokens);
+  let malformed = input.malformed || output.malformed || cachedInput.malformed || cacheCreation.malformed;
+
+  let totalTokens: number;
+  if (isSafeCount(obj?.totalTokens)) {
+    totalTokens = obj.totalTokens as number;
+  } else {
+    totalTokens = checkedAddCount(input.value, output.value).value;
+    malformed = true;
+  }
+  return {
+    tokens: {
+      inputTokens: input.value,
+      outputTokens: output.value,
+      cachedInputTokens: cachedInput.value,
+      cacheCreationInputTokens: cacheCreation.value,
+      totalTokens,
+    },
+    malformed,
+  };
+}
+
+function anyToken(tokens: TokenBreakdown): boolean {
+  return (
+    tokens.inputTokens > 0 ||
+    tokens.outputTokens > 0 ||
+    tokens.cachedInputTokens > 0 ||
+    tokens.cacheCreationInputTokens > 0 ||
+    tokens.totalTokens > 0
+  );
+}
+
 /** Turn a trusted domain observation into a normalized delta (the four
  *  provider outcomes + manual). `attributionLost` is set only by token
  *  malformation/saturation — never by pricing (which uses unknownCostCallCount). */
@@ -252,42 +306,57 @@ export function normalizeIpcUsageDelta(raw: unknown): NormalizedDelta | null {
   let attributionLost = obj.attributionLost === true;
 
   const { cost, priced } = buildCost(obj.cost);
-  const { tokens, malformed } = buildTokens(obj.tokens, "completion", true);
+  const { tokens, malformed } = buildIpcTokens(obj.tokens);
   if (malformed) attributionLost = true;
 
   let unknownCostCallCount = 0;
   if (isSafeCount(obj.unknownCostCallCount)) {
     unknownCostCallCount = obj.unknownCostCallCount;
-  } else if (obj.unknownCostCallCount !== undefined) {
-    attributionLost = true; // present-but-malformed
   } else {
-    attributionLost = true; // missing
+    attributionLost = true; // absent or present-but-malformed
   }
   if (!priced) {
-    unknownCostCallCount = checkedAddCount(unknownCostCallCount, 1).value;
+    const bumped = checkedAddCount(unknownCostCallCount, 1);
+    unknownCostCallCount = bumped.value;
+    if (bumped.saturated) attributionLost = true;
   }
 
-  const entry = recoverIpcEntry(obj.entry);
-  if (entry === "invalid") {
-    attributionLost = true;
+  const recovery = recoverIpcEntry(obj.entry);
+  if (recovery.status === "invalid") {
+    return { cost, tokens, unknownCostCallCount, attributionLost: true };
+  }
+  if (recovery.status === "absent") {
+    // A well-formed provider/manual delta always carries its entry; an entry-less
+    // delta is legitimate ONLY as an all-zero unresolved attempt. Measurable
+    // money/tokens with no entry means attribution was lost in transit.
+    if (cost.totalCost > 0 || anyToken(tokens)) attributionLost = true;
     return { cost, tokens, unknownCostCallCount, attributionLost };
   }
-  return { entry, cost, tokens, unknownCostCallCount, attributionLost };
+  if (recovery.malformed) attributionLost = true;
+  return { entry: recovery.entry, cost, tokens, unknownCostCallCount, attributionLost };
 }
+
+type IpcEntryRecovery =
+  | { status: "absent" }
+  | { status: "invalid" }
+  | { status: "ok"; entry: UsageEntry; malformed: boolean };
 
 /** Recover an untrusted entry: valid iff kind ∈ UsageKind and the model sentinel
  *  invariant holds. Its cost/tokens are normalized independently and NEVER
- *  override the flat totals. Returns "invalid" to omit the entry + degrade. */
-function recoverIpcEntry(raw: unknown): UsageEntry | undefined | "invalid" {
+ *  override the flat totals. `"invalid"` omits the entry and degrades; `"ok"`
+ *  reports whether the entry's OWN components were malformed (an unpriced entry
+ *  cost or a malformed token field), so the caller can degrade while keeping the
+ *  usable entry. */
+function recoverIpcEntry(raw: unknown): IpcEntryRecovery {
   if (raw === undefined || raw === null) {
-    return undefined;
+    return { status: "absent" };
   }
   if (typeof raw !== "object") {
-    return "invalid";
+    return { status: "invalid" };
   }
   const obj = raw as Record<string, unknown>;
   if (!isUsageKind(obj.kind)) {
-    return "invalid";
+    return { status: "invalid" };
   }
   const kind = obj.kind;
   const model = obj.model;
@@ -295,11 +364,11 @@ function recoverIpcEntry(raw: unknown): UsageEntry | undefined | "invalid" {
     ? model === ""
     : typeof model === "string" && model.length > 0;
   if (!modelOk) {
-    return "invalid";
+    return { status: "invalid" };
   }
-  const { cost } = buildCost(obj.cost);
-  const { tokens } = buildTokens(obj.tokens, kind, false);
-  return { kind, model: model as string, cost, tokens };
+  const { cost, priced } = buildCost(obj.cost);
+  const { tokens, malformed } = buildIpcTokens(obj.tokens);
+  return { status: "ok", entry: { kind, model: model as string, cost, tokens }, malformed: !priced || malformed };
 }
 
 /** A fresh, non-serialized accumulator for one invocation/leg. Buckets attribution

--- a/packages/agency-lang/lib/runtime/invocationUsage.ts
+++ b/packages/agency-lang/lib/runtime/invocationUsage.ts
@@ -1,298 +1,402 @@
 // Per-invocation usage accounting for the serve cost seam.
 //
-// A hosted invocation (`/node`, `/function`, `/resume`) must report the
-// authoritative cost it just incurred so a host can attribute spend per
-// project. This file owns the value types and the arithmetic:
-//   - `InvocationUsageMeter` — a fresh, non-serialized accumulator that lives on
-//     each execution context (see state/context.ts). One per invocation/leg.
-//   - the delta helpers that turn a completion / an `addCost` charge / an
-//     untrusted IPC message into a normalized `InvocationUsageDelta`.
-//   - `ServedInvocationOutcome` — how a run core hands a value-or-error plus its
-//     usage snapshot to the serve adapters without ever mutating the user value
-//     or the thrown error.
-//
-// Two independent completeness axes, never conflated:
-//   - `pricingComplete` (on the usage) — did every call have a price? Derived
-//     from `unknownCostCallCount === 0`.
-//   - `usageComplete` (on the snapshot) — was all telemetry delivered? Becomes
-//     permanently false when an abnormal subprocess termination means we cannot
-//     rule out unsent child usage, making `usage` a trusted LOWER BOUND.
+// A hosted invocation must report the complete cost/token breakdown it incurred:
+// an AUTHORITATIVE flat total (`usage.cost`/`usage.tokens`) plus a BEST-EFFORT
+// per-`(kind, model)` attribution (`usage.entries`). Call sites emit one of three
+// domain observations; `normalizeObservation` turns each into a `NormalizedDelta`;
+// `InvocationUsageMeter` accumulates. Untrusted IPC input goes through
+// `normalizeIpcUsageDelta`, which recovers every independently-valid field and
+// degrades `usageComplete` rather than dropping money.
 
+import type { EmbedResult, ImageGenResult, PromptResult } from "smoltalk";
 import type { RuntimeContext } from "./state/context.js";
 import type { StateStack } from "./state/stateStack.js";
 import type { GraphState } from "./types.js";
+import { resolveCompletionModel } from "./modelIdentity.js";
 
-/** Reconciliation tolerance for the per-model breakdown vs. the authoritative
- *  flat total. Relative+absolute because float ulp drift scales with magnitude:
- *  a $10k total accumulated over a million calls drifts more than a $0.01 one.
- *  This is an accounting-precision policy, not a proof that every sub-threshold
- *  omitted charge is detectable — the flat total stays authoritative. A consumer
- *  that validates the breakdown MUST use this same function. */
-export const USAGE_RECONCILE_ABS_USD = 1e-9;
-export const USAGE_RECONCILE_REL = 1e-9;
-export function usageReconcileTolerance(total: number): number {
-  return Math.max(USAGE_RECONCILE_ABS_USD, USAGE_RECONCILE_REL * Math.abs(total));
-}
+type SmoltalkCost = NonNullable<
+  PromptResult["cost"] | EmbedResult["costEstimate"] | ImageGenResult["costEstimate"]
+>;
+type SmoltalkTokens = NonNullable<
+  PromptResult["usage"] | EmbedResult["tokenUsage"] | ImageGenResult["tokenUsage"]
+>;
 
-/** Priced cost + input/output token counts for one model (or the unattributed
- *  bucket). Cost is a single total per model — input-vs-output cost is not split
- *  (the provider gives one `totalCost` through this seam). */
-export type ModelUsageRow = {
-  pricedCost: number;
+export type ProviderUsageKind = "completion" | "embedding" | "image";
+export type UsageKind = ProviderUsageKind | "manual";
+const USAGE_KINDS: readonly UsageKind[] = ["completion", "embedding", "image", "manual"];
+
+export type CostBreakdown = {
+  inputCost: number;
+  outputCost: number;
+  cachedInputCost: number;
+  cacheCreationInputCost: number;
+  hostedToolsCost: number;
+  totalCost: number;
+  currency: "USD";
+};
+export type TokenBreakdown = {
   inputTokens: number;
   outputTokens: number;
+  cachedInputTokens: number;
+  cacheCreationInputTokens: number;
+  totalTokens: number;
 };
-
-/** How a charge is attributed. A discriminated value, not an optional model
- *  scalar, so "deliberately model-less" (addCost) is distinct from "provenance
- *  missing" (a received wire message an older runtime sent, whose delta simply
- *  has no `attribution` at all). */
-export type UsageAttribution =
-  | { kind: "model"; model: string }
-  | { kind: "unattributed" };
-
+export type UsageEntry = {
+  kind: UsageKind;
+  model: string; // "" is the manual sentinel; provider kinds always non-empty
+  cost: CostBreakdown;
+  tokens: TokenBreakdown;
+};
 export type InvocationUsage = {
-  pricedCost: number;
-  inputTokens: number;
-  outputTokens: number;
+  cost: CostBreakdown; // AUTHORITATIVE flat total (billed)
+  tokens: TokenBreakdown; // AUTHORITATIVE flat total
   unknownCostCallCount: number;
-  pricingComplete: boolean;
-  /** Per-model priced cost + input/output tokens. Real models only. The flat
-   *  totals are authoritative; the rows plus `unattributed` are attribution that
-   *  reconciles to them — cost within `usageReconcileTolerance(pricedCost)`, and
-   *  token counts exactly WITHIN THE SAFE-INTEGER RANGE. The meter rejects any
-   *  individual count at or above 2**53, and real token totals are far below it;
-   *  only a subprocess relaying many absurd-but-safe counts whose ACCUMULATION
-   *  crosses the safe range makes token reconciliation best-effort (like cost),
-   *  never the flat total. Null-prototype so a provider model name like
-   *  `__proto__` is a plain own key. Optional for back-compat; the current
-   *  runtime always sets it. */
-  models?: Record<string, ModelUsageRow>;
-  /** Paid spend with no model (addCost: memory, image generation), plus any
-   *  spend whose model was lost in transit. A separate field, not a key in
-   *  `models`, so no sentinel can collide with a real model name. */
-  unattributed?: ModelUsageRow;
-  /** False when priced spend landed in `unattributed` because its model was
-   *  lost (a version-skewed child), NOT because it was genuinely model-less.
-   *  Distinct from `pricingComplete` (price availability) and `usageComplete`
-   *  (telemetry delivery). */
-  modelAttributionComplete?: boolean;
+  pricingComplete: boolean; // === (unknownCostCallCount === 0)
+  entries: UsageEntry[]; // best-effort attribution, one per (kind, model)
 };
-
-export type InvocationUsageDelta = {
-  pricedCost: number;
-  inputTokens: number;
-  outputTokens: number;
-  unknownCostCallCount: number;
-  /** How this charge is attributed. Absent means provenance-unknown — only
-   *  reachable from a received wire message an older runtime sent. Locally-built
-   *  deltas (completion, addCost) always set it. */
-  attribution?: UsageAttribution;
-};
-
 export type InvocationUsageSnapshot = {
   usage: InvocationUsage;
-  /** ⚠️ A SIBLING of `usage`, not nested inside it — easy to miss. When `false`,
-   *  the whole `usage` figure (including `pricedCost`) is a trusted LOWER BOUND:
-   *  an abnormal subprocess termination means unsent child telemetry could not
-   *  be ruled out. A consumer MUST treat the dollar total conservatively
-   *  whenever this (or `usage.pricingComplete`) is false. Distinct axis from
-   *  `pricingComplete`: that is about price availability, this is about
-   *  telemetry delivery. */
+  /** ⚠️ SIBLING of `usage`. When false, the whole figure is a trusted LOWER
+   *  BOUND (abnormal subprocess termination, or recovered-but-degraded IPC).
+   *  Distinct axis from `usage.pricingComplete` (price availability). */
   usageComplete: boolean;
+};
+export type UsageObservation =
+  | {
+      type: "provider";
+      kind: ProviderUsageKind;
+      reportedModel?: string | null;
+      configuredModel?: string | null;
+      cost?: SmoltalkCost | null;
+      tokens?: SmoltalkTokens | null;
+    }
+  | { type: "attempt"; kind: ProviderUsageKind }
+  | { type: "manual"; amount: number };
+export type NormalizedDelta = {
+  entry?: UsageEntry;
+  cost: CostBreakdown;
+  tokens: TokenBreakdown;
+  unknownCostCallCount: number;
+  attributionLost: boolean;
 };
 
 export type ServedInvocationOutcome<T> =
   | ({ status: "returned"; value: T } & InvocationUsageSnapshot)
   | ({ status: "threw"; error: unknown } & InvocationUsageSnapshot);
 
-/** Explicit ownership for an accounting call: which invocation's meter to merge
- *  into and which branch stack to bill. Passed explicitly so out-of-frame
- *  callers (the IPC telemetry handler) never depend on AsyncLocalStorage. */
 export type InvocationAccountingTarget = {
   ctx: RuntimeContext<GraphState>;
   stack: StateStack;
 };
 
-/** A finite, nonnegative number (used for costs — `0` is a valid known price). */
-function isValidCost(value: unknown): value is number {
+/** Reconciliation tolerance for the best-effort attribution vs. the authoritative
+ *  total (relative+absolute; float ulp drift scales with magnitude). Reconciled
+ *  only when telemetry is complete; the flat total is always authoritative. */
+export const USAGE_RECONCILE_ABS_USD = 1e-9;
+export const USAGE_RECONCILE_REL = 1e-9;
+export function usageReconcileTolerance(total: number): number {
+  return Math.max(USAGE_RECONCILE_ABS_USD, USAGE_RECONCILE_REL * Math.abs(total));
+}
+
+const MAX_COUNT = Number.MAX_SAFE_INTEGER;
+
+/** Add two counts without ever performing the unsafe addition first: saturate at
+ *  MAX_COUNT and report it, so the caller can degrade `usageComplete`. */
+function checkedAddCount(left: number, right: number): { value: number; saturated: boolean } {
+  if (right > MAX_COUNT - left) {
+    return { value: MAX_COUNT, saturated: true };
+  }
+  return { value: left + right, saturated: false };
+}
+
+function isFiniteNonNeg(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value) && value >= 0;
 }
-
-/** A nonnegative SAFE integer (used for token/count fields). Values at or above
- *  2**53 are rejected: counts arrive from untrusted IPC, and above the safe
- *  range integer addition loses precision. This bounds each INDIVIDUAL count, so
- *  exact-token reconciliation holds within the safe range; it does not bound the
- *  ACCUMULATED total, so a malicious child relaying many safe counts that sum
- *  past the safe range makes token reconciliation best-effort (scoped on
- *  InvocationUsage.models). No real completion reports counts near this. */
-function isValidCount(value: unknown): value is number {
+function isSafeCount(value: unknown): value is number {
   return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
 }
-
-/** Coerce an untrusted token/count field to a valid count, else 0. */
-function asCount(value: unknown): number {
-  return isValidCount(value) ? value : 0;
+function costComponent(value: unknown): number {
+  return isFiniteNonNeg(value) ? value : 0;
 }
 
-function newRow(): ModelUsageRow {
-  return { pricedCost: 0, inputTokens: 0, outputTokens: 0 };
+function zeroCost(): CostBreakdown {
+  return { inputCost: 0, outputCost: 0, cachedInputCost: 0, cacheCreationInputCost: 0, hostedToolsCost: 0, totalCost: 0, currency: "USD" };
+}
+function zeroTokens(): TokenBreakdown {
+  return { inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, cacheCreationInputTokens: 0, totalTokens: 0 };
+}
+function copyCost(cost: CostBreakdown): CostBreakdown {
+  return { ...cost };
+}
+function copyTokens(tokens: TokenBreakdown): TokenBreakdown {
+  return { ...tokens };
 }
 
-/** A fresh null-prototype map of fresh row objects — the meter never hands out a
- *  reference to its live rows. */
-function copyModels(models: Record<string, ModelUsageRow>): Record<string, ModelUsageRow> {
-  const out: Record<string, ModelUsageRow> = Object.create(null);
-  for (const key of Object.keys(models)) out[key] = { ...models[key] };
-  return out;
+/** Build a cost breakdown from a (trusted or untrusted) estimate-shaped object.
+ *  A price is valid only when `totalCost` is finite-nonnegative AND currency is
+ *  USD; otherwise every field is zero and the call is unpriced (`priced=false`).
+ *  Named components are copied independently (best-effort, no sum-to-total). */
+function buildCost(raw: unknown): { cost: CostBreakdown; priced: boolean } {
+  const obj = raw && typeof raw === "object" ? (raw as Record<string, unknown>) : undefined;
+  const priced = obj !== undefined && isFiniteNonNeg(obj.totalCost) && obj.currency === "USD";
+  if (!priced || obj === undefined) {
+    return { cost: zeroCost(), priced: false };
+  }
+  return {
+    cost: {
+      inputCost: costComponent(obj.inputCost),
+      outputCost: costComponent(obj.outputCost),
+      cachedInputCost: costComponent(obj.cachedInputCost),
+      cacheCreationInputCost: costComponent(obj.cacheCreationInputCost),
+      hostedToolsCost: costComponent(obj.hostedToolsCost),
+      totalCost: obj.totalCost as number,
+      currency: "USD",
+    },
+    priced: true,
+  };
 }
 
-/** True when a delta carries priced cost or tokens (i.e. it will create a row).
- *  Owned here beside the delta type so meter bucketing and the IPC provenance
- *  check share one definition. */
-export function isMeasurableDelta(delta: InvocationUsageDelta): boolean {
-  return delta.pricedCost !== 0 || delta.inputTokens !== 0 || delta.outputTokens !== 0;
+/** One token counter. Absent (undefined/null) is a benign 0; a present malformed
+ *  value is 0 AND flags malformed (for `attributionLost`). `absentDegrades`
+ *  distinguishes trusted providers (absent OK) from untrusted IPC (absent bad). */
+function tokenCounter(value: unknown, absentDegrades: boolean): { value: number; malformed: boolean } {
+  if (value === undefined || value === null) {
+    return { value: 0, malformed: absentDegrades };
+  }
+  if (isSafeCount(value)) {
+    return { value, malformed: false };
+  }
+  return { value: 0, malformed: true };
 }
 
-/** A fresh, non-serialized accumulator for one invocation/leg. */
+/** Kind-specific total-token fallback when the provider omits/malforms it.
+ *  completion normalizes cached vs ordinary input into disjoint buckets (add all);
+ *  embedding/image cached counts may overlap input (add input+output only). */
+function fallbackTotalTokens(kind: UsageKind, t: { inputTokens: number; outputTokens: number; cachedInputTokens: number; cacheCreationInputTokens: number }): { value: number; saturated: boolean } {
+  const parts = kind === "completion"
+    ? [t.inputTokens, t.outputTokens, t.cachedInputTokens, t.cacheCreationInputTokens]
+    : [t.inputTokens, t.outputTokens];
+  let acc = 0;
+  let saturated = false;
+  for (const part of parts) {
+    const next = checkedAddCount(acc, part);
+    acc = next.value;
+    saturated = saturated || next.saturated;
+  }
+  return { value: acc, saturated };
+}
+
+function buildTokens(raw: unknown, kind: UsageKind, absentDegrades: boolean): { tokens: TokenBreakdown; malformed: boolean } {
+  const obj = raw && typeof raw === "object" ? (raw as Record<string, unknown>) : undefined;
+  const input = tokenCounter(obj?.inputTokens, absentDegrades);
+  const output = tokenCounter(obj?.outputTokens, absentDegrades);
+  const cachedInput = tokenCounter(obj?.cachedInputTokens, false); // cache counters absent is normal
+  const cacheCreation = tokenCounter(obj?.cacheCreationInputTokens, false);
+  const partial = {
+    inputTokens: input.value,
+    outputTokens: output.value,
+    cachedInputTokens: cachedInput.value,
+    cacheCreationInputTokens: cacheCreation.value,
+  };
+  let malformed = input.malformed || output.malformed || cachedInput.malformed || cacheCreation.malformed;
+
+  const rawTotal = obj?.totalTokens;
+  let totalTokens: number;
+  if (rawTotal === undefined || rawTotal === null) {
+    const fb = fallbackTotalTokens(kind, partial);
+    totalTokens = fb.value;
+    malformed = malformed || fb.saturated;
+  } else if (isSafeCount(rawTotal)) {
+    totalTokens = rawTotal;
+  } else {
+    const fb = fallbackTotalTokens(kind, partial);
+    totalTokens = fb.value;
+    malformed = true; // present-but-malformed provider total
+  }
+  return { tokens: { ...partial, totalTokens }, malformed };
+}
+
+/** Turn a trusted domain observation into a normalized delta (the four
+ *  provider outcomes + manual). `attributionLost` is set only by token
+ *  malformation/saturation — never by pricing (which uses unknownCostCallCount). */
+export function normalizeObservation(observation: UsageObservation): NormalizedDelta {
+  if (observation.type === "attempt") {
+    return { cost: zeroCost(), tokens: zeroTokens(), unknownCostCallCount: 1, attributionLost: false };
+  }
+  if (observation.type === "manual") {
+    const cost: CostBreakdown = { ...zeroCost(), totalCost: observation.amount };
+    const entry: UsageEntry = { kind: "manual", model: "", cost: copyCost(cost), tokens: zeroTokens() };
+    return { entry, cost, tokens: zeroTokens(), unknownCostCallCount: 0, attributionLost: false };
+  }
+  const model = resolveCompletionModel(observation.reportedModel, observation.configuredModel);
+  const { cost, priced } = buildCost(observation.cost);
+  const { tokens, malformed } = buildTokens(observation.tokens, observation.kind, false);
+  const entry: UsageEntry = { kind: observation.kind, model, cost: copyCost(cost), tokens: copyTokens(tokens) };
+  return { entry, cost, tokens, unknownCostCallCount: priced ? 0 : 1, attributionLost: malformed };
+}
+
+function isUsageKind(value: unknown): value is UsageKind {
+  return typeof value === "string" && (USAGE_KINDS as readonly string[]).includes(value);
+}
+
+/** Recover a normalized delta from UNTRUSTED IPC input. Never drops
+ *  independently-valid money; a message carrying real value it cannot fully
+ *  attribute preserves the authoritative totals, omits the entry, and sets
+ *  `attributionLost` (which degrades `usageComplete`). Returns null only when the
+ *  whole message is unusable (not an object). */
+export function normalizeIpcUsageDelta(raw: unknown): NormalizedDelta | null {
+  if (raw === null || typeof raw !== "object") {
+    return null;
+  }
+  const obj = raw as Record<string, unknown>;
+  let attributionLost = obj.attributionLost === true;
+
+  const { cost, priced } = buildCost(obj.cost);
+  const { tokens, malformed } = buildTokens(obj.tokens, "completion", true);
+  if (malformed) attributionLost = true;
+
+  let unknownCostCallCount = 0;
+  if (isSafeCount(obj.unknownCostCallCount)) {
+    unknownCostCallCount = obj.unknownCostCallCount;
+  } else if (obj.unknownCostCallCount !== undefined) {
+    attributionLost = true; // present-but-malformed
+  } else {
+    attributionLost = true; // missing
+  }
+  if (!priced) {
+    unknownCostCallCount = checkedAddCount(unknownCostCallCount, 1).value;
+  }
+
+  const entry = recoverIpcEntry(obj.entry);
+  if (entry === "invalid") {
+    attributionLost = true;
+    return { cost, tokens, unknownCostCallCount, attributionLost };
+  }
+  return { entry, cost, tokens, unknownCostCallCount, attributionLost };
+}
+
+/** Recover an untrusted entry: valid iff kind ∈ UsageKind and the model sentinel
+ *  invariant holds. Its cost/tokens are normalized independently and NEVER
+ *  override the flat totals. Returns "invalid" to omit the entry + degrade. */
+function recoverIpcEntry(raw: unknown): UsageEntry | undefined | "invalid" {
+  if (raw === undefined || raw === null) {
+    return undefined;
+  }
+  if (typeof raw !== "object") {
+    return "invalid";
+  }
+  const obj = raw as Record<string, unknown>;
+  if (!isUsageKind(obj.kind)) {
+    return "invalid";
+  }
+  const kind = obj.kind;
+  const model = obj.model;
+  const modelOk = kind === "manual"
+    ? model === ""
+    : typeof model === "string" && model.length > 0;
+  if (!modelOk) {
+    return "invalid";
+  }
+  const { cost } = buildCost(obj.cost);
+  const { tokens } = buildTokens(obj.tokens, kind, false);
+  return { kind, model: model as string, cost, tokens };
+}
+
+/** A fresh, non-serialized accumulator for one invocation/leg. Buckets attribution
+ *  by (kind, model) via a nested null-prototype index into `entries` (first-seen
+ *  order); keeps authoritative call-order flat totals with checked-add saturation. */
 export class InvocationUsageMeter {
-  private pricedCost = 0;
-  private inputTokens = 0;
-  private outputTokens = 0;
+  private cost: CostBreakdown = zeroCost();
+  private tokens: TokenBreakdown = zeroTokens();
   private unknownCostCallCount = 0;
   private usageComplete = true;
-  private modelAttributionComplete = true;
-  private models: Record<string, ModelUsageRow> = Object.create(null);
-  private unattributed: ModelUsageRow = newRow();
+  private entries: UsageEntry[] = [];
+  private index: Record<UsageKind, Record<string, number>> = {
+    completion: Object.create(null),
+    embedding: Object.create(null),
+    image: Object.create(null),
+    manual: Object.create(null),
+  };
 
-  merge(delta: InvocationUsageDelta): void {
-    this.pricedCost += delta.pricedCost;
-    this.inputTokens += delta.inputTokens;
-    this.outputTokens += delta.outputTokens;
-    this.unknownCostCallCount += delta.unknownCostCallCount;
+  /** Accumulate one delta. Returns true only when THIS merge newly makes usage
+   *  incomplete (via a count-overflow transition). */
+  merge(delta: NormalizedDelta): boolean {
+    let saturated = false;
+    this.addCostInto(this.cost, delta.cost);
+    saturated = this.addTokensInto(this.tokens, delta.tokens) || saturated;
+    const bumped = checkedAddCount(this.unknownCostCallCount, delta.unknownCostCallCount);
+    this.unknownCostCallCount = bumped.value;
+    saturated = saturated || bumped.saturated;
 
-    // A charge with money or tokens lands in exactly one row — its model, or
-    // the unattributed bucket (kind "unattributed" OR absent). This is what
-    // keeps sum(models) + unattributed reconciled to the flat totals. `merge`
-    // stays pure: the provenance-missing SIGNAL is raised at the IPC boundary,
-    // not here.
-    if (isMeasurableDelta(delta)) {
-      const attribution = delta.attribution;
-      const row = attribution?.kind === "model"
-        ? (this.models[attribution.model] ??= newRow())
-        : this.unattributed;
-      row.pricedCost += delta.pricedCost;
-      row.inputTokens += delta.inputTokens;
-      row.outputTokens += delta.outputTokens;
+    if (delta.entry !== undefined) {
+      const target = this.entryFor(delta.entry);
+      this.addCostInto(target.cost, delta.entry.cost);
+      saturated = this.addTokensInto(target.tokens, delta.entry.tokens) || saturated;
     }
+    return saturated ? this.markIncomplete() : false;
   }
 
-  /** Mark telemetry delivery as no longer guaranteed complete. Idempotent;
-   *  returns true only on the first complete → incomplete transition, so a
-   *  caller can relay a single upward incompleteness marker. */
+  private entryFor(entry: UsageEntry): UsageEntry {
+    const perModel = this.index[entry.kind];
+    const existing = perModel[entry.model];
+    if (existing !== undefined) {
+      return this.entries[existing];
+    }
+    const fresh: UsageEntry = { kind: entry.kind, model: entry.model, cost: zeroCost(), tokens: zeroTokens() };
+    perModel[entry.model] = this.entries.length;
+    this.entries.push(fresh);
+    return fresh;
+  }
+
+  private addCostInto(target: CostBreakdown, add: CostBreakdown): void {
+    target.inputCost += add.inputCost;
+    target.outputCost += add.outputCost;
+    target.cachedInputCost += add.cachedInputCost;
+    target.cacheCreationInputCost += add.cacheCreationInputCost;
+    target.hostedToolsCost += add.hostedToolsCost;
+    target.totalCost += add.totalCost;
+  }
+
+  private addTokensInto(target: TokenBreakdown, add: TokenBreakdown): boolean {
+    let saturated = false;
+    for (const key of ["inputTokens", "outputTokens", "cachedInputTokens", "cacheCreationInputTokens", "totalTokens"] as const) {
+      const next = checkedAddCount(target[key], add[key]);
+      target[key] = next.value;
+      saturated = saturated || next.saturated;
+    }
+    return saturated;
+  }
+
+  /** Mark telemetry delivery no longer guaranteed complete. Idempotent; returns
+   *  true only on the first complete → incomplete transition, so a caller relays
+   *  a single upward marker. */
   markIncomplete(): boolean {
-    if (!this.usageComplete) return false;
+    if (!this.usageComplete) {
+      return false;
+    }
     this.usageComplete = false;
-    return true;
-  }
-
-  /** Mark model attribution as no longer trustworthy (measurable spend arrived
-   *  with a lost model). Idempotent; returns true only on the first transition
-   *  so the caller relays a single upward marker — mirrors markIncomplete(). */
-  markModelAttributionIncomplete(): boolean {
-    if (!this.modelAttributionComplete) return false;
-    this.modelAttributionComplete = false;
     return true;
   }
 
   snapshot(): InvocationUsageSnapshot {
     return {
       usage: {
-        pricedCost: this.pricedCost,
-        inputTokens: this.inputTokens,
-        outputTokens: this.outputTokens,
+        cost: copyCost(this.cost),
+        tokens: copyTokens(this.tokens),
         unknownCostCallCount: this.unknownCostCallCount,
         pricingComplete: this.unknownCostCallCount === 0,
-        models: copyModels(this.models),
-        unattributed: { ...this.unattributed },
-        modelAttributionComplete: this.modelAttributionComplete,
+        entries: this.entries.map((entry) => ({ kind: entry.kind, model: entry.model, cost: copyCost(entry.cost), tokens: copyTokens(entry.tokens) })),
       },
       usageComplete: this.usageComplete,
     };
   }
 }
 
-/** A delta for a trusted LLM completion. A finite `0` cost is a known free price;
- *  an absent/negative/non-finite cost is UNKNOWN (no priced cost, one unknown
- *  call). Missing or invalid token counts contribute zero. The `model` is the
- *  resolved billing key (see resolveCompletionModel) — the charge is attributed
- *  to it even when its price is unknown. */
-export function completionUsageDelta(args: {
-  cost: number | null | undefined;
-  inputTokens: number | null | undefined;
-  outputTokens: number | null | undefined;
-  model: string;
-}): InvocationUsageDelta {
-  const priced = isValidCost(args.cost);
-  return {
-    pricedCost: priced ? (args.cost as number) : 0,
-    inputTokens: asCount(args.inputTokens),
-    outputTokens: asCount(args.outputTokens),
-    unknownCostCallCount: priced ? 0 : 1,
-    attribution: { kind: "model", model: args.model },
-  };
-}
-
-/** A delta for a trusted in-process paid charge (`addCost`). Invalid input
- *  THROWS — an addCost caller must never silently drop a real charge. Deliberately
- *  model-less: attributed `unattributed`, distinct on the wire from provenance-
- *  missing. */
-export function paidCostDelta(amount: number): InvocationUsageDelta {
-  if (!isValidCost(amount)) {
-    throw new Error(`paidCostDelta: amount must be a finite, nonnegative number (got ${amount})`);
-  }
-  return {
-    pricedCost: amount, inputTokens: 0, outputTokens: 0, unknownCostCallCount: 0,
-    attribution: { kind: "unattributed" },
-  };
-}
-
-/** Normalize an UNTRUSTED attribution (from an IPC message). A well-formed
- *  discriminated value survives; anything else becomes `undefined`
- *  (provenance-unknown — the IPC handler flags it). */
-function normalizeAttribution(raw: unknown): UsageAttribution | undefined {
-  if (raw === null || typeof raw !== "object") return undefined;
-  const attribution = raw as Record<string, unknown>;
-  if (attribution.kind === "unattributed") return { kind: "unattributed" };
-  if (attribution.kind === "model" && typeof attribution.model === "string" && attribution.model.length > 0) {
-    return { kind: "model", model: attribution.model };
-  }
-  return undefined;
-}
-
-/** Normalize an UNTRUSTED delta (from an IPC message). Returns null only when the
- *  input is not a usable object. Otherwise each field is validated
- *  independently: an invalid `pricedCost` becomes zero priced cost plus one
- *  unknown-cost call (never a silent known-free zero), invalid token/count
- *  fields become zero, and a malformed/absent `attribution` becomes undefined —
- *  valid metadata is preserved even when cost is bad. */
-export function normalizeUsageDelta(raw: unknown): InvocationUsageDelta | null {
-  if (raw === null || typeof raw !== "object") return null;
-  const obj = raw as Record<string, unknown>;
-  const costValid = isValidCost(obj.pricedCost);
-  const baseUnknown = asCount(obj.unknownCostCallCount);
-  return {
-    pricedCost: costValid ? (obj.pricedCost as number) : 0,
-    inputTokens: asCount(obj.inputTokens),
-    outputTokens: asCount(obj.outputTokens),
-    unknownCostCallCount: costValid ? baseUnknown : baseUnknown + 1,
-    attribution: normalizeAttribution(obj.attribution),
-  };
-}
-
 /** Take a run core's outcome back to a raw value-or-throw, preserving the exact
  *  thrown value's identity (strings, frozen objects, anything). */
 export function unwrapServedInvocationOutcome<T>(outcome: ServedInvocationOutcome<T>): T {
-  if (outcome.status === "returned") return outcome.value;
+  if (outcome.status === "returned") {
+    return outcome.value;
+  }
   throw outcome.error;
 }

--- a/packages/agency-lang/lib/runtime/ipc.test.ts
+++ b/packages/agency-lang/lib/runtime/ipc.test.ts
@@ -7,7 +7,6 @@ import {
   getSubprocessRunInfo,
   resolveDepthCap,
   attachSessionHandlers,
-  handleTelemetryMessage,
   handleInvocationUsageMessage,
   handleInvocationUsageIncompleteMessage,
   handleCallbackMessage,
@@ -286,87 +285,15 @@ describe("wall-clock timer is per execution segment", () => {
   });
 });
 
-describe("handleTelemetryMessage", () => {
-  const makeTelemetrySession = (stack: StateStack) => {
-    const kills: string[] = [];
-    const rejections: any[] = [];
-    const session = makeSession({
-      child: { kill: (sig: string) => { kills.push(sig); return true; }, connected: true },
-      stateStack: stack,
-      rejectPromise: (err: any) => { rejections.push(err); },
-    });
-    return { session, kills, rejections };
-  };
-
-  it("charges localCost and guards; no trip under budget", () => {
-    const stack = new StateStack();
-    const guard = new CostGuard(1.0);
-    stack.guards.push(guard);
-    const { session, kills, rejections } = makeTelemetrySession(stack);
-
-    handleTelemetryMessage(session, { type: "telemetry", costUsd: 0.25 });
-
-    expect(stack.localCost).toBe(0.25);
-    expect(guard.check(stack)).toBeNull();
-    expect(kills).toEqual([]);
-    expect(rejections).toEqual([]);
-    expect(session.settled).toBe(false);
-  });
-
-  it("a trip kills the child and rejects the session with the guard-trip abort", () => {
-    const stack = new StateStack();
-    stack.guards.push(new CostGuard(0.1));
-    const { session, kills, rejections } = makeTelemetrySession(stack);
-
-    handleTelemetryMessage(session, { type: "telemetry", costUsd: 0.2 });
-
-    expect(kills).toEqual(["SIGKILL"]);
-    expect(rejections).toHaveLength(1);
-    expect(session.settled).toBe(true);
-    // The rejection must be the guard-trip abort ITSELF (identity, not a
-    // wrapper or re-thrown copy) so the OWNING boundary's ownedGuardIds
-    // matching converts it (the stdlib run() plain try re-throws).
-    expect(isGuardExceededError(rejections[0])).toBe(true);
-    expect(String(rejections[0])).toMatch(/cost/i);
-  });
-
-  it("post-settle telemetry still charges (the spend was real) but does not enforce", () => {
-    const stack = new StateStack();
-    stack.guards.push(new CostGuard(0.1));
-    const { session, kills, rejections } = makeTelemetrySession(stack);
-    session.settled = true;
-
-    handleTelemetryMessage(session, { type: "telemetry", costUsd: 0.2 });
-
-    expect(stack.localCost).toBe(0.2);
-    expect(kills).toEqual([]);
-    expect(rejections).toEqual([]);
-  });
-
-  it("ignores malformed cost values", () => {
-    const stack = new StateStack();
-    const { session } = makeTelemetrySession(stack);
-    handleTelemetryMessage(session, { type: "telemetry", costUsd: NaN } as any);
-    handleTelemetryMessage(session, { type: "telemetry", costUsd: -5 } as any);
-    handleTelemetryMessage(session, { type: "telemetry" } as any);
-    expect(stack.localCost).toBe(0);
-  });
-
-  it("books legacy cost to unattributed and flags degraded model attribution", () => {
-    const { session } = makeTelemetrySession(new StateStack());
-    handleTelemetryMessage(session, { type: "telemetry", costUsd: 0.05 });
-    const { usage } = session.ctx.invocationUsage.snapshot();
-    expect(usage.unattributed!.pricedCost).toBeCloseTo(0.05);
-    expect(usage.modelAttributionComplete).toBe(false);
-  });
-});
-
-describe("handleInvocationUsageMessage (full delta)", () => {
+describe("handleInvocationUsageMessage (untrusted recovery + relay)", () => {
   const originalSend = process.send;
   afterEach(() => {
     process.send = originalSend;
     vi.unstubAllEnvs();
   });
+
+  const fullCost = { inputCost: 0.3, outputCost: 0.2, cachedInputCost: 0, cacheCreationInputCost: 0, hostedToolsCost: 0, totalCost: 0.5, currency: "USD" };
+  const fullTokens = { inputTokens: 100, outputTokens: 20, cachedInputTokens: 0, cacheCreationInputTokens: 0, totalTokens: 120 };
 
   const makeUsageSession = () => {
     const stack = new StateStack();
@@ -382,121 +309,103 @@ describe("handleInvocationUsageMessage (full delta)", () => {
     return { session, ctx, stack, rejections, kills };
   };
 
-  it("merges the full delta into the parent invocation meter and bills the stack", () => {
+  it("merges a recovered delta into the parent meter, bills the stack, and buckets the entry", () => {
     const { session, ctx, stack } = makeUsageSession();
     handleInvocationUsageMessage(session, {
-      type: "invocationUsage", pricedCost: 0.5, inputTokens: 100, outputTokens: 20, unknownCostCallCount: 0,
+      type: "invocationUsage", cost: fullCost, tokens: fullTokens, unknownCostCallCount: 0,
+      entry: { kind: "completion", model: "opus-4.8", cost: fullCost, tokens: fullTokens },
     });
     expect(stack.localCost).toBeCloseTo(0.5);
-    const s = ctx.invocationUsage.snapshot();
-    expect(s.usage.pricedCost).toBeCloseTo(0.5);
-    expect(s.usage.inputTokens).toBe(100);
-    expect(s.usage.outputTokens).toBe(20);
-  });
-
-  it("buckets a modeled child charge under its model", () => {
-    const { session, ctx } = makeUsageSession();
-    handleInvocationUsageMessage(session, {
-      type: "invocationUsage", pricedCost: 0.1, inputTokens: 100, outputTokens: 20, unknownCostCallCount: 0,
-      attribution: { kind: "model", model: "opus-4.8" },
-    });
     const { usage } = ctx.invocationUsage.snapshot();
-    expect(usage.models!["opus-4.8"]).toEqual({ pricedCost: 0.1, inputTokens: 100, outputTokens: 20 });
-    expect(usage.modelAttributionComplete).toBe(true);
+    expect(usage.cost.totalCost).toBeCloseTo(0.5);
+    expect(usage.tokens.inputTokens).toBe(100);
+    expect(usage.entries.map((e) => `${e.kind}:${e.model}`)).toEqual(["completion:opus-4.8"]);
   });
 
-  it("keeps two concurrent sessions' model rows independent", () => {
+  it("keeps two concurrent sessions' entries independent", () => {
     const first = makeUsageSession();
     const second = makeUsageSession();
     handleInvocationUsageMessage(first.session, {
-      type: "invocationUsage", pricedCost: 0.1, inputTokens: 1, outputTokens: 1, unknownCostCallCount: 0,
-      attribution: { kind: "model", model: "opus" },
+      type: "invocationUsage", cost: { totalCost: 0.1, currency: "USD" }, unknownCostCallCount: 0,
+      entry: { kind: "completion", model: "opus", cost: { totalCost: 0.1, currency: "USD" }, tokens: fullTokens },
     });
     handleInvocationUsageMessage(second.session, {
-      type: "invocationUsage", pricedCost: 0.2, inputTokens: 1, outputTokens: 1, unknownCostCallCount: 0,
-      attribution: { kind: "model", model: "haiku" },
+      type: "invocationUsage", cost: { totalCost: 0.2, currency: "USD" }, unknownCostCallCount: 0,
+      entry: { kind: "completion", model: "haiku", cost: { totalCost: 0.2, currency: "USD" }, tokens: fullTokens },
     });
-    expect(Object.keys(first.ctx.invocationUsage.snapshot().usage.models!)).toEqual(["opus"]);
-    expect(Object.keys(second.ctx.invocationUsage.snapshot().usage.models!)).toEqual(["haiku"]);
+    expect(first.ctx.invocationUsage.snapshot().usage.entries.map((e) => e.model)).toEqual(["opus"]);
+    expect(second.ctx.invocationUsage.snapshot().usage.entries.map((e) => e.model)).toEqual(["haiku"]);
   });
 
-  it("trips attribution incomplete on a #801 child delta with no attribution", () => {
+  it("recovers flat money but omits an unusable entry and degrades usageComplete", () => {
     const { session, ctx } = makeUsageSession();
     handleInvocationUsageMessage(session, {
-      type: "invocationUsage", pricedCost: 0.1, inputTokens: 1, outputTokens: 1, unknownCostCallCount: 0,
+      type: "invocationUsage", cost: fullCost, tokens: fullTokens, unknownCostCallCount: 0,
+      entry: { kind: "nope", model: "x", cost: fullCost, tokens: fullTokens },
     });
-    const { usage } = ctx.invocationUsage.snapshot();
-    expect(usage.unattributed!.pricedCost).toBeCloseTo(0.1);
-    expect(usage.modelAttributionComplete).toBe(false);
+    const s = ctx.invocationUsage.snapshot();
+    expect(s.usage.cost.totalCost).toBeCloseTo(0.5);
+    expect(s.usage.entries).toHaveLength(0);
+    expect(s.usageComplete).toBe(false);
   });
 
-  it("does NOT trip for an explicitly unattributed child charge", () => {
-    const { session, ctx } = makeUsageSession();
-    handleInvocationUsageMessage(session, {
-      type: "invocationUsage", pricedCost: 0.05, inputTokens: 0, outputTokens: 0, unknownCostCallCount: 0,
-      attribution: { kind: "unattributed" },
-    });
-    expect(ctx.invocationUsage.snapshot().usage.modelAttributionComplete).toBe(true);
-  });
-
-  it("propagates a modelAttributionIncomplete marker through the dispatch entry point", async () => {
-    const { session, ctx } = makeUsageSession();
-    // The canonical mock caps ipcPayload at 1 byte; give this control message
-    // room so it dispatches instead of being dropped as oversize.
-    session.limits = { ...session.limits, ipcPayload: 1_000_000 };
-    await handleChildMessage(session, { type: "modelAttributionIncomplete" });
-    expect(ctx.invocationUsage.snapshot().usage.modelAttributionComplete).toBe(false);
+  it("drops a wholly non-object message", () => {
+    const { session, ctx, stack } = makeUsageSession();
+    handleInvocationUsageMessage(session, 42 as any);
+    expect(stack.localCost).toBe(0);
+    expect(ctx.invocationUsage.snapshot().usage.cost.totalCost).toBe(0);
   });
 
   it("accumulates exact totals across multiple child messages (one-child)", () => {
     const { session, ctx } = makeUsageSession();
-    handleInvocationUsageMessage(session, { type: "invocationUsage", pricedCost: 0.1, inputTokens: 5, outputTokens: 1, unknownCostCallCount: 0 });
-    handleInvocationUsageMessage(session, { type: "invocationUsage", pricedCost: 0.2, inputTokens: 7, outputTokens: 2, unknownCostCallCount: 1 });
+    handleInvocationUsageMessage(session, { type: "invocationUsage", cost: { totalCost: 0.1, currency: "USD" }, tokens: { inputTokens: 5, outputTokens: 1, totalTokens: 6 }, unknownCostCallCount: 0 });
+    handleInvocationUsageMessage(session, { type: "invocationUsage", cost: { totalCost: 0.2, currency: "USD" }, tokens: { inputTokens: 7, outputTokens: 2, totalTokens: 9 }, unknownCostCallCount: 1 });
     const s = ctx.invocationUsage.snapshot();
-    expect(s.usage.pricedCost).toBeCloseTo(0.3);
-    expect(s.usage.inputTokens).toBe(12);
-    expect(s.usage.outputTokens).toBe(3);
+    expect(s.usage.cost.totalCost).toBeCloseTo(0.3);
+    expect(s.usage.tokens.inputTokens).toBe(12);
+    expect(s.usage.tokens.outputTokens).toBe(3);
     expect(s.usage.unknownCostCallCount).toBe(1);
     expect(s.usage.pricingComplete).toBe(false);
   });
 
-  it("re-relays the received delta upward once when this process is itself a child (grandchild path)", () => {
+  it("re-relays the recovered delta upward once when this process is itself a child (grandchild path)", () => {
     vi.stubEnv("AGENCY_IPC", "1");
     const send = vi.fn(() => true);
     process.send = send as any;
     const { session } = makeUsageSession();
-    // A current-runtime relay carries attribution, so provenance detection does
-    // not fire and only the usage delta is re-relayed (exactly once).
-    const delta = { pricedCost: 0.15, inputTokens: 3, outputTokens: 1, unknownCostCallCount: 1, attribution: { kind: "model" as const, model: "opus" } };
-    handleInvocationUsageMessage(session, { type: "invocationUsage", ...delta });
-    expect(send).toHaveBeenCalledExactlyOnceWith({ type: "invocationUsage", ...delta });
+    handleInvocationUsageMessage(session, {
+      type: "invocationUsage", cost: { totalCost: 0.15, currency: "USD" }, tokens: { inputTokens: 3, outputTokens: 1, totalTokens: 4 }, unknownCostCallCount: 1,
+      entry: { kind: "completion", model: "opus", cost: { totalCost: 0.15, currency: "USD" }, tokens: { inputTokens: 3, outputTokens: 1, totalTokens: 4 } },
+    });
+    const relayed = (send.mock.calls as any[]).map((c) => c[0].type);
+    expect(relayed).toEqual(["invocationUsage"]);
   });
 
-  it("normalizes an invalid cost to an unknown-cost call without dropping tokens", () => {
+  it("recovers an invalid cost as an unknown-cost call without dropping tokens", () => {
     const { session, ctx, stack } = makeUsageSession();
-    handleInvocationUsageMessage(session, { type: "invocationUsage", pricedCost: -1, inputTokens: 9, outputTokens: 3, unknownCostCallCount: 0 } as any);
+    handleInvocationUsageMessage(session, { type: "invocationUsage", cost: { totalCost: -1, currency: "USD" }, tokens: { inputTokens: 9, outputTokens: 3, totalTokens: 12 }, unknownCostCallCount: 0 });
     expect(stack.localCost).toBe(0);
     const s = ctx.invocationUsage.snapshot();
-    expect(s.usage.inputTokens).toBe(9);
+    expect(s.usage.tokens.inputTokens).toBe(9);
     expect(s.usage.unknownCostCallCount).toBe(1);
   });
 
-  it("a guard trip from a usage message kills+rejects AND marks the invocation incomplete", () => {
-    const { session, ctx, stack, rejections, kills } = makeUsageSession();
+  it("a guard trip from a usage message kills+rejects the session", () => {
+    const { session, stack, rejections, kills } = makeUsageSession();
     stack.guards.push(new CostGuard(0.1));
-    handleInvocationUsageMessage(session, { type: "invocationUsage", pricedCost: 0.2, inputTokens: 1, outputTokens: 1, unknownCostCallCount: 0 });
+    handleInvocationUsageMessage(session, { type: "invocationUsage", cost: { totalCost: 0.2, currency: "USD" }, tokens: fullTokens, unknownCostCallCount: 0 });
     expect(kills).toEqual(["SIGKILL"]);
     expect(rejections).toHaveLength(1);
+    expect(isGuardExceededError(rejections[0])).toBe(true);
     expect(session.settled).toBe(true);
-    expect(ctx.invocationUsage.snapshot().usageComplete).toBe(false);
   });
 
   it("post-settle usage still merges (lower bound) but does not enforce", () => {
     const { session, ctx, stack } = makeUsageSession();
     session.settled = true;
-    handleInvocationUsageMessage(session, { type: "invocationUsage", pricedCost: 0.2, inputTokens: 0, outputTokens: 0, unknownCostCallCount: 0 });
+    handleInvocationUsageMessage(session, { type: "invocationUsage", cost: { totalCost: 0.2, currency: "USD" }, unknownCostCallCount: 0 });
     expect(stack.localCost).toBeCloseTo(0.2);
-    expect(ctx.invocationUsage.snapshot().usage.pricedCost).toBeCloseTo(0.2);
+    expect(ctx.invocationUsage.snapshot().usage.cost.totalCost).toBeCloseTo(0.2);
   });
 });
 

--- a/packages/agency-lang/lib/runtime/ipc.test.ts
+++ b/packages/agency-lang/lib/runtime/ipc.test.ts
@@ -373,10 +373,13 @@ describe("handleInvocationUsageMessage (untrusted recovery + relay)", () => {
     const send = vi.fn(() => true);
     process.send = send as any;
     const { session } = makeUsageSession();
+    const wireTokens = { inputTokens: 3, outputTokens: 1, cachedInputTokens: 0, cacheCreationInputTokens: 0, totalTokens: 4 };
     handleInvocationUsageMessage(session, {
-      type: "invocationUsage", cost: { totalCost: 0.15, currency: "USD" }, tokens: { inputTokens: 3, outputTokens: 1, totalTokens: 4 }, unknownCostCallCount: 1,
-      entry: { kind: "completion", model: "opus", cost: { totalCost: 0.15, currency: "USD" }, tokens: { inputTokens: 3, outputTokens: 1, totalTokens: 4 } },
+      type: "invocationUsage", cost: fullCost, tokens: wireTokens, unknownCostCallCount: 0,
+      entry: { kind: "completion", model: "opus", cost: fullCost, tokens: wireTokens },
     });
+    // A fully well-formed message recovers cleanly, so exactly the usage delta is
+    // re-relayed (no incompleteness marker).
     const relayed = (send.mock.calls as any[]).map((c) => c[0].type);
     expect(relayed).toEqual(["invocationUsage"]);
   });

--- a/packages/agency-lang/lib/runtime/ipc.ts
+++ b/packages/agency-lang/lib/runtime/ipc.ts
@@ -20,12 +20,10 @@ import type { State, StateStack } from "./state/stateStack.js";
 import { getSubprocessRunInfo, setSubprocessRunInfo, isIpcMode, type SubprocessRunInfo } from "./subprocessRunInfo.js";
 import { truncate } from "./truncate.js";
 import {
-  isPayableCost,
-  type IpcTelemetryMessage,
   type IpcInvocationUsageMessage,
 } from "./costTelemetry.js";
-import { recordPaidUsageAt, markInvocationUsageIncompleteAt, markModelAttributionIncompleteAt } from "./recordPaidUsage.js";
-import { normalizeUsageDelta, isMeasurableDelta, type InvocationUsageDelta } from "./invocationUsage.js";
+import { recordNormalizedUsageDelta, markInvocationUsageIncompleteAt } from "./recordPaidUsage.js";
+import { normalizeIpcUsageDelta, type NormalizedDelta } from "./invocationUsage.js";
 import { type IpcCallbackMessage, NON_FORWARDABLE_CALLBACKS } from "./callbackForwarding.js";
 import { invokeCallbacks } from "./hooks.js";
 import { VALID_CALLBACK_NAMES, type CallbackName } from "../types/function.js";
@@ -289,10 +287,8 @@ export type SubprocessToParent =
   | IpcErrorMessage
   | IpcLockAcquireMessage
   | IpcLockReleaseMessage
-  | IpcTelemetryMessage
   | IpcInvocationUsageMessage
   | { type: "invocationUsageIncomplete" }
-  | { type: "modelAttributionIncomplete" }
   | IpcCallbackMessage;
 export type ParentToSubprocess = IpcDecisionMessage | IpcLockGrantedMessage;
 
@@ -954,8 +950,8 @@ function handleErrorMessage(s: RunSession, msg: any): void {
  * if this process is itself a subprocess (grandchild propagation). Billing is
  * unconditional (the spend already happened, even post-settle); enforcement only
  * runs on a live session, and a trip kills the child and rejects the session. */
-function accountChildUsage(s: RunSession, delta: InvocationUsageDelta): void {
-  recordPaidUsageAt({ ctx: s.ctx, stack: s.stateStack }, delta);
+function accountChildUsage(s: RunSession, delta: NormalizedDelta): void {
+  recordNormalizedUsageDelta(s.ctx, s.stateStack, delta);
   if (s.settled) return;
   try {
     s.stateStack.enforceGuards();
@@ -965,34 +961,16 @@ function accountChildUsage(s: RunSession, delta: InvocationUsageDelta): void {
   }
 }
 
-/** Account a child delta AND detect lost model provenance: a measurable delta
- * with no `attribution` came from a child whose runtime predates the model
- * field, so the spend books to `unattributed` and this invocation's
- * `modelAttributionComplete` flips (relayed once). A deliberately-unattributed
- * or modeled charge carries an attribution and never trips it. */
-function accountChildUsageWithProvenance(s: RunSession, delta: InvocationUsageDelta): void {
-  if (isMeasurableDelta(delta) && delta.attribution === undefined) {
-    markSessionModelAttributionIncomplete(s);
-  }
-  accountChildUsage(s, delta);
-}
-
-/** Legacy cost-only telemetry (version-skewed child). Bill only a payable
- *  positive cost, preserving the old contract. The delta has no attribution, so
- *  provenance detection flags degraded model attribution. */
-export function handleTelemetryMessage(s: RunSession, msg: IpcTelemetryMessage): void {
-  if (!isPayableCost(msg.costUsd)) return;
-  accountChildUsageWithProvenance(s, { pricedCost: msg.costUsd, inputTokens: 0, outputTokens: 0, unknownCostCallCount: 0 });
-}
-
-/** Full per-invocation usage delta from a child. Normalized (untrusted input;
- *  an invalid cost becomes an unknown-cost call, valid tokens survive). Routed
- *  through provenance detection so a child that sent no attribution (a #801
- *  runtime) flags degraded model attribution. */
+/** Full per-invocation usage delta from a child. Recovered field-by-field from
+ *  untrusted input by `normalizeIpcUsageDelta`: independently-valid money and
+ *  tokens survive a malformed sibling, an unusable attribution entry is omitted
+ *  and degrades `usageComplete`, and only a wholly non-object message is
+ *  dropped. The recovered delta (including its `attributionLost`) then flows
+ *  through the same accounting sink as an in-process charge. */
 export function handleInvocationUsageMessage(s: RunSession, msg: IpcInvocationUsageMessage): void {
-  const delta = normalizeUsageDelta(msg);
+  const delta = normalizeIpcUsageDelta(msg);
   if (!delta) return;
-  accountChildUsageWithProvenance(s, delta);
+  accountChildUsage(s, delta);
 }
 
 /** A child reported that its (or a descendant's) usage telemetry may be
@@ -1006,12 +984,6 @@ export function handleInvocationUsageIncompleteMessage(s: RunSession): void {
  *  unsent telemetry is never presented as an authoritative total. */
 function markSessionUsageIncomplete(s: RunSession): void {
   if (s.ctx && s.ctx.invocationUsage) markInvocationUsageIncompleteAt(s.ctx);
-}
-
-/** Mark the owning invocation's model attribution as no longer trustworthy,
- *  guarding a minimal test ctx. Mirrors markSessionUsageIncomplete. */
-function markSessionModelAttributionIncomplete(s: RunSession): void {
-  if (s.ctx && s.ctx.invocationUsage) markModelAttributionIncompleteAt(s.ctx);
 }
 
 function isForwardableCallbackName(name: unknown): name is CallbackName {
@@ -1156,14 +1128,10 @@ export async function handleChildMessage(s: RunSession, msg: any): Promise<void>
     settle(s, s.resolvePromise, { type: "result", value: msg.value } satisfies SessionOutcome);
   } else if (msg.type === "interrupted") {
     settle(s, s.resolvePromise, { type: "interrupted", msg } satisfies SessionOutcome);
-  } else if (msg.type === "telemetry") {
-    handleTelemetryMessage(s, msg);
   } else if (msg.type === "invocationUsage") {
     handleInvocationUsageMessage(s, msg);
   } else if (msg.type === "invocationUsageIncomplete") {
     handleInvocationUsageIncompleteMessage(s);
-  } else if (msg.type === "modelAttributionIncomplete") {
-    markSessionModelAttributionIncomplete(s);
   } else if (msg.type === "callback") {
     handleCallbackMessage(s, msg);
   } else if (msg.type === "error") {

--- a/packages/agency-lang/lib/runtime/memory/manager.test.ts
+++ b/packages/agency-lang/lib/runtime/memory/manager.test.ts
@@ -12,6 +12,9 @@ import { agency } from "../agency.js";
 import { RuntimeContext } from "../state/context.js";
 import { StateStack } from "../state/stateStack.js";
 import { ThreadStore } from "../state/threadStore.js";
+import { runInTestContext } from "../asyncContext.js";
+import { CostGuard, isGuardExceededError } from "../guard.js";
+import type { GraphState } from "../types.js";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
@@ -37,6 +40,14 @@ function mockLlmClient() {
       value: { embeddings: [[0.1, 0.2, 0.3]], model: "mock-embed" },
     }),
   };
+}
+
+function makeEmbedCtx() {
+  return new RuntimeContext<GraphState>({
+    statelogConfig: { host: "", apiKey: "", projectId: "", debugMode: false, observability: false },
+    smoltalkDefaults: {},
+    dirname: "/project",
+  });
 }
 
 function wrapTextResult(output: string) {
@@ -71,6 +82,65 @@ describe("MemoryManager", () => {
       llmClient: mockLlmClient(),
     });
     expect(manager.getMemoryId()).toBe("default");
+  });
+
+  it("accounts a priced embedding that returns no vectors, then throws the no-vector error", async () => {
+    const pricedEmpty = {
+      success: true,
+      value: {
+        embeddings: [],
+        model: "mock-embed",
+        costEstimate: { inputCost: 0, outputCost: 0.5, cachedInputCost: 0, cacheCreationInputCost: 0, hostedToolsCost: 0, totalCost: 0.5, currency: "USD" },
+        tokenUsage: { inputTokens: 4, outputTokens: 0, cachedInputTokens: 0, cacheCreationInputTokens: 0, totalTokens: 4 },
+      },
+    };
+    const client = mockLlmClient();
+    (client.embed as any).mockResolvedValue(pricedEmpty);
+    const manager = new MemoryManager({
+      store: new FileMemoryStore(tmpDir),
+      config: { dir: tmpDir, embeddings: { model: "text-embedding-3-small" } },
+      llmClient: client,
+    });
+    const ctx = makeEmbedCtx();
+    // The provider charged us even though it returned no vectors: usage is
+    // accounted (guards + meter), then the structural no-vector error is thrown.
+    await expect(
+      runInTestContext(ctx, ctx.stateStack, new ThreadStore(), async () => (manager as any)._embed("hello")),
+    ).rejects.toThrow(/no vectors/);
+    expect(ctx.stateStack.localCost).toBeCloseTo(0.5);
+    const { usage } = ctx.invocationUsage.snapshot();
+    expect(usage.cost.totalCost).toBeCloseTo(0.5);
+    expect(usage.entries.some((entry) => entry.kind === "embedding")).toBe(true);
+  });
+
+  it("lets a guard trip win over the no-vector error for a priced empty embedding", async () => {
+    const pricedEmpty = {
+      success: true,
+      value: {
+        embeddings: [],
+        model: "mock-embed",
+        costEstimate: { inputCost: 0, outputCost: 0.5, cachedInputCost: 0, cacheCreationInputCost: 0, hostedToolsCost: 0, totalCost: 0.5, currency: "USD" },
+        tokenUsage: { inputTokens: 4, outputTokens: 0, cachedInputTokens: 0, cacheCreationInputTokens: 0, totalTokens: 4 },
+      },
+    };
+    const client = mockLlmClient();
+    (client.embed as any).mockResolvedValue(pricedEmpty);
+    const manager = new MemoryManager({
+      store: new FileMemoryStore(tmpDir),
+      config: { dir: tmpDir, embeddings: { model: "text-embedding-3-small" } },
+      llmClient: client,
+    });
+    const ctx = makeEmbedCtx();
+    ctx.stateStack.guards.push(new CostGuard(0.1));
+    let caught: unknown;
+    await runInTestContext(ctx, ctx.stateStack, new ThreadStore(), async () => {
+      try {
+        await (manager as any)._embed("hello");
+      } catch (err) {
+        caught = err;
+      }
+    });
+    expect(isGuardExceededError(caught)).toBe(true);
   });
 
   it("sets memoryId", () => {

--- a/packages/agency-lang/lib/runtime/memory/manager.ts
+++ b/packages/agency-lang/lib/runtime/memory/manager.ts
@@ -369,30 +369,36 @@ export class MemoryManager {
         throw new Error(`memory embed call failed: ${result.error}`);
       }
       const vector = result.value.embeddings[0];
-      if (!vector) {
+      // A resolved provider response charged us even if it returned no vectors,
+      // so the trace event fires only when a vector exists (its contract needs
+      // `dimensions`) but the usage is accounted either way — the embedding
+      // analogue of the empty-image path. The no-vector error is thrown only
+      // AFTER accounting + guard enforcement, so a guard trip wins over it.
+      if (vector) {
+        try {
+          await this.statelogClient?.embedCompletion({
+            inputPreview: text.slice(0, EMBED_PREVIEW_CHARS),
+            inputCount: 1,
+            model: result.value.model ?? options?.model,
+            dimensions: vector.length,
+            timeTaken,
+            phase,
+          });
+        } catch (err) {
+          this.logger.debug(
+            `[memory] statelog embedCompletion failed: ${(err as Error).message}`,
+          );
+        }
+      } else {
         this.logger.warn(
           `[memory] embed returned no vectors (phase=${phase}, model=${result.value.model ?? "?"})`,
-        );
-        throw new Error("memory embed returned no vectors");
-      }
-      try {
-        await this.statelogClient?.embedCompletion({
-          inputPreview: text.slice(0, EMBED_PREVIEW_CHARS),
-          inputCount: 1,
-          model: result.value.model ?? options?.model,
-          dimensions: vector.length,
-          timeTaken,
-          phase,
-        });
-      } catch (err) {
-        this.logger.debug(
-          `[memory] statelog embedCompletion failed: ${(err as Error).message}`,
         );
       }
       // Same rationale as `_text` above — embed calls contribute to the
       // surrounding branch's cost/token totals too. `EmbedResult.costEstimate`
       // and `tokenUsage` (smoltalk's names) are optional; an absent estimate is
-      // recorded as an unpriced embedding rather than dropped.
+      // recorded as an unpriced embedding rather than dropped. Recorded (and
+      // guards enforced) BEFORE the no-vector throw below, so a guard trip wins.
       recordMemoryUsageIfInFrame({
         type: "provider",
         kind: "embedding",
@@ -401,6 +407,9 @@ export class MemoryManager {
         cost: result.value.costEstimate,
         tokens: result.value.tokenUsage,
       });
+      if (!vector) {
+        throw new Error("memory embed returned no vectors");
+      }
       return vector;
     } finally {
       this.statelogClient?.endSpan(spanId);

--- a/packages/agency-lang/lib/runtime/memory/manager.ts
+++ b/packages/agency-lang/lib/runtime/memory/manager.ts
@@ -25,23 +25,31 @@ import type { StatelogClient } from "../../statelogClient.js";
 import forgetTemplate from "../../templates/prompts/memory/forget.js";
 import retrievalTemplate from "../../templates/prompts/memory/retrieval.js";
 import type { LLMClient } from "../llmClient.js";
-import { agency } from "../agency.js";
-import { agencyStore } from "../asyncContext.js";
+import { agencyStore, getRuntimeContext } from "../asyncContext.js";
+import { recordUsage } from "../recordPaidUsage.js";
+import type { UsageObservation } from "../invocationUsage.js";
 import { isGuardExceededError } from "../guard.js";
 
 /**
- * Charge `amount` against the active branch's `withCostGuard` budget
- * if (and only if) we're inside an Agency execution frame. Memory's
- * text + embed calls run from inside `runPrompt`'s post-completion
- * hook or from stdlib agency calls — both reach this code with an
- * `agencyStore` frame already installed, so production paths always
- * charge correctly. The frame check is for direct-construction unit
- * tests that exercise `MemoryManager` without going through the
- * runner.
+ * Record one memory provider outcome (a text completion or an embedding)
+ * against the active branch — accounting its cost/tokens into the invocation
+ * usage meter and the branch's `withCostGuard` budget — if (and only if) we're
+ * inside an Agency execution frame. Memory's text + embed calls run from inside
+ * `runPrompt`'s post-completion hook or from stdlib agency calls — both reach
+ * this code with an `agencyStore` frame already installed, so production paths
+ * always account correctly. The frame check is for direct-construction unit
+ * tests that exercise `MemoryManager` without going through the runner.
+ *
+ * `recordUsage` bills the guards but does not throw; this enforces the active
+ * stack once afterwards, so an over-budget memory charge trips its surrounding
+ * `withCostGuard` — the trip is a `GuardExceededError` that `rethrowIfGuard`
+ * re-raises out of memory's best-effort catches.
  */
-function chargeCostIfInFrame(amount: number): void {
+function recordMemoryUsageIfInFrame(observation: UsageObservation): void {
   if (!agencyStore.getStore()) return;
-  agency.addCost(amount);
+  const { ctx, stack } = getRuntimeContext();
+  recordUsage(ctx, stack, observation);
+  stack.enforceGuards();
 }
 
 /**
@@ -284,12 +292,18 @@ export class MemoryManager {
           `[memory] statelog promptCompletion failed: ${(err as Error).message}`,
         );
       }
-      // Charge this call's spend against the surrounding branch's
-      // cost budget. Mirrors the post-completion charge that
-      // `prompt.ts` performs for agency-side `llm()` calls, so a
-      // `withCostGuard($X)` wrapping the agent now sees memory's
-      // extraction / compaction / tier-3 spend too.
-      chargeCostIfInFrame(result.value.cost?.totalCost ?? 0);
+      // Account this call's full cost/tokens against the surrounding branch.
+      // Mirrors the post-completion accounting that `prompt.ts` performs for
+      // agency-side `llm()` calls, so a `withCostGuard($X)` wrapping the agent
+      // now sees memory's extraction / compaction / tier-3 spend too.
+      recordMemoryUsageIfInFrame({
+        type: "provider",
+        kind: "completion",
+        reportedModel: result.value.model,
+        configuredModel: model,
+        cost: result.value.cost,
+        tokens: result.value.usage,
+      });
       return result.value.output ?? "";
     } finally {
       this.statelogClient?.endSpan(spanId);
@@ -363,11 +377,18 @@ export class MemoryManager {
           `[memory] statelog embedCompletion failed: ${(err as Error).message}`,
         );
       }
-      // Same rationale as `_text` above — embed calls contribute to
-      // the surrounding branch's cost budget too. `EmbedResult.costEstimate`
-      // (smoltalk's name) is optional; absent / zero means "free or
-      // unknown" and the charge is skipped.
-      chargeCostIfInFrame(result.value.costEstimate?.totalCost ?? 0);
+      // Same rationale as `_text` above — embed calls contribute to the
+      // surrounding branch's cost/token totals too. `EmbedResult.costEstimate`
+      // and `tokenUsage` (smoltalk's names) are optional; an absent estimate is
+      // recorded as an unpriced embedding rather than dropped.
+      recordMemoryUsageIfInFrame({
+        type: "provider",
+        kind: "embedding",
+        reportedModel: result.value.model,
+        configuredModel: options?.model,
+        cost: result.value.costEstimate,
+        tokens: result.value.tokenUsage,
+      });
       return vector;
     } finally {
       this.statelogClient?.endSpan(spanId);

--- a/packages/agency-lang/lib/runtime/memory/manager.ts
+++ b/packages/agency-lang/lib/runtime/memory/manager.ts
@@ -26,8 +26,8 @@ import forgetTemplate from "../../templates/prompts/memory/forget.js";
 import retrievalTemplate from "../../templates/prompts/memory/retrieval.js";
 import type { LLMClient } from "../llmClient.js";
 import { agencyStore, getRuntimeContext } from "../asyncContext.js";
-import { recordUsage } from "../recordPaidUsage.js";
-import type { UsageObservation } from "../invocationUsage.js";
+import { recordUsage, meteredDispatch } from "../recordPaidUsage.js";
+import type { ProviderUsageKind, UsageObservation } from "../invocationUsage.js";
 import { isGuardExceededError } from "../guard.js";
 
 /**
@@ -50,6 +50,18 @@ function recordMemoryUsageIfInFrame(observation: UsageObservation): void {
   const { ctx, stack } = getRuntimeContext();
   recordUsage(ctx, stack, observation);
   stack.enforceGuards();
+}
+
+/** Run a memory provider dispatch as a metered attempt WHEN in an execution
+ *  frame: a rejected dispatch records one unresolved attempt (so
+ *  `pricingComplete` cannot stay true after a post-dispatch throw), mirroring the
+ *  prompt path. Outside a frame (direct-construction unit tests) it just runs
+ *  the dispatch — there is no meter to record into. A resolved `Result.failure`
+ *  is NOT metered here (deferred to agency-lang #809). */
+function meteredMemoryDispatch<T>(kind: ProviderUsageKind, dispatch: () => Promise<T>): Promise<T> {
+  if (!agencyStore.getStore()) return dispatch();
+  const { ctx, stack } = getRuntimeContext();
+  return meteredDispatch(ctx, stack, kind, dispatch);
 }
 
 /**
@@ -244,14 +256,14 @@ export class MemoryManager {
     const spanId = this.statelogClient?.startSpan("llmCall");
     const startTime = performance.now();
     try {
-      const result = await this.llmClient.text({
+      const result = await meteredMemoryDispatch("completion", () => this.llmClient.text({
         ...this.smoltalkDefaults,
         messages: [smoltalk.userMessage(prompt)],
         model,
         ...(options?.responseFormat
           ? { responseFormat: options.responseFormat }
           : {}),
-      } as any);
+      } as any));
       const timeTaken = performance.now() - startTime;
       if (!result.success) {
         this.logger.warn(
@@ -325,7 +337,7 @@ export class MemoryManager {
     const spanId = this.statelogClient?.startSpan("embedding");
     const startTime = performance.now();
     try {
-      const result = await this.llmClient.embed(text, {
+      const result = await meteredMemoryDispatch("embedding", () => this.llmClient.embed(text, {
         model: options?.model,
         // Pass the provider explicitly so smoltalk routes to the right embed
         // endpoint even when the model name doesn't imply it (e.g. ollama).
@@ -335,7 +347,7 @@ export class MemoryManager {
           google: (this.smoltalkDefaults as any).apiKey?.google,
         },
         baseUrl: { ollama: (this.smoltalkDefaults as any).baseUrl?.ollama },
-      } as any);
+      } as any));
       const timeTaken = performance.now() - startTime;
       if (!result.success) {
         this.logger.warn(

--- a/packages/agency-lang/lib/runtime/prompt.test.ts
+++ b/packages/agency-lang/lib/runtime/prompt.test.ts
@@ -480,7 +480,7 @@ describe("meteredDispatch — provider-attempt unknown-cost accounting", () => {
 
   it("a resolved dispatch records no unknown-cost attempt", async () => {
     const ctx = makeCtx();
-    const out = await meteredDispatch(ctx, ctx.stateStack, async () => "ok");
+    const out = await meteredDispatch(ctx, ctx.stateStack, "completion", async () => "ok");
     expect(out).toBe("ok");
     expect(ctx.invocationUsage.snapshot().usage.unknownCostCallCount).toBe(0);
     expect(ctx.invocationUsage.snapshot().usage.pricingComplete).toBe(true);
@@ -490,11 +490,11 @@ describe("meteredDispatch — provider-attempt unknown-cost accounting", () => {
     const ctx = makeCtx();
     const err = new Error("provider 500 after dispatch");
     await expect(
-      meteredDispatch(ctx, ctx.stateStack, async () => { throw err; }),
+      meteredDispatch(ctx, ctx.stateStack, "completion", async () => { throw err; }),
     ).rejects.toBe(err);
     const s = ctx.invocationUsage.snapshot();
     expect(s.usage.unknownCostCallCount).toBe(1);
-    expect(s.usage.pricedCost).toBe(0);
+    expect(s.usage.cost.totalCost).toBe(0);
     expect(s.usage.pricingComplete).toBe(false);
   });
 
@@ -502,9 +502,9 @@ describe("meteredDispatch — provider-attempt unknown-cost accounting", () => {
     const ctx = makeCtx();
     // First attempt throws (e.g. a timeout), second resolves.
     await expect(
-      meteredDispatch(ctx, ctx.stateStack, async () => { throw new Error("timeout"); }),
+      meteredDispatch(ctx, ctx.stateStack, "completion", async () => { throw new Error("timeout"); }),
     ).rejects.toThrow();
-    await meteredDispatch(ctx, ctx.stateStack, async () => "recovered");
+    await meteredDispatch(ctx, ctx.stateStack, "completion", async () => "recovered");
     expect(ctx.invocationUsage.snapshot().usage.unknownCostCallCount).toBe(1);
   });
 });

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -21,7 +21,7 @@ import {
   type BoundaryContext,
 } from "./turnBoundary.js";
 import { AgencyCancelledError, isAbortError, makeAbortCause, readCause } from "./errors.js";
-import { accountCompletionUsage, meteredDispatch } from "./recordPaidUsage.js";
+import { recordCompletionUsage, meteredDispatch } from "./recordPaidUsage.js";
 import { resolveCompletionModel } from "./modelIdentity.js";
 import { abortableSleep } from "../stdlib/abortable.js";
 import { decideRetry, decideValidationRetry, enrichSchemaLimitationError, resolveRetryPolicy } from "./llmRetry.js";
@@ -495,7 +495,7 @@ async function dispatchWithRetry(args: {
   const targetStack = stateStack ?? ctx.stateStack;
   return runWithRetry(
     (signal) =>
-      meteredDispatch(ctx, targetStack, () =>
+      meteredDispatch(ctx, targetStack, "completion", () =>
         dispatchLLMRequest({
           ctx,
           promptConfig: { ...promptConfig, abortSignal: signal } as PromptConfig,
@@ -771,7 +771,7 @@ async function _runPrompt({
   // descendants' spend in real time; mid-fork trips fire on the next
   // enforceGuards() call. See docs/superpowers/specs/2026-05-20-thread-
   // builtins-and-stdlib-design.md.
-  accountCompletionUsage(ctx, targetStack, completion, modelName);
+  recordCompletionUsage(ctx, targetStack, completion, clientConfig.model);
   // NOTE: no post-charge enforceGuards here anymore. A trip caused by
   // THIS charge is raised resumably at the caller's next guard gate
   // (round.N.guardGate / guardGate.final in runPrompt) — the paid work

--- a/packages/agency-lang/lib/runtime/recordPaidUsage.test.ts
+++ b/packages/agency-lang/lib/runtime/recordPaidUsage.test.ts
@@ -1,12 +1,11 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import {
-  recordPaidUsageAt,
-  recordPaidUsage,
-  recordUnknownCostAttempt,
+  recordUsage,
+  recordUnresolvedAttempt,
+  recordNormalizedUsageDelta,
+  meteredDispatch,
   markInvocationUsageIncompleteAt,
-  accountCompletionUsage,
 } from "./recordPaidUsage.js";
-import { completionUsageDelta, paidCostDelta } from "./invocationUsage.js";
 import { addCost } from "./cost.js";
 import { RuntimeContext } from "./state/context.js";
 import { StateStack } from "./state/stateStack.js";
@@ -14,6 +13,9 @@ import { ThreadStore } from "./state/threadStore.js";
 import { CostGuard } from "./guard.js";
 import { runInTestContext } from "./asyncContext.js";
 import type { GraphState } from "./types.js";
+import type { CostBreakdown, NormalizedDelta, TokenBreakdown } from "./invocationUsage.js";
+
+const MAX = Number.MAX_SAFE_INTEGER;
 
 function makeCtx() {
   return new RuntimeContext<GraphState>({
@@ -23,6 +25,19 @@ function makeCtx() {
   });
 }
 
+function zeroCost(): CostBreakdown {
+  return { inputCost: 0, outputCost: 0, cachedInputCost: 0, cacheCreationInputCost: 0, hostedToolsCost: 0, totalCost: 0, currency: "USD" };
+}
+function zeroTokens(): TokenBreakdown {
+  return { inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, cacheCreationInputTokens: 0, totalTokens: 0 };
+}
+function delta(over: Partial<NormalizedDelta>): NormalizedDelta {
+  return { cost: zeroCost(), tokens: zeroTokens(), unknownCostCallCount: 0, attributionLost: false, ...over };
+}
+function sentTypes(send: ReturnType<typeof vi.fn>): string[] {
+  return send.mock.calls.map((c) => (c[0] as { type: string }).type);
+}
+
 const originalSend = process.send;
 afterEach(() => {
   process.send = originalSend;
@@ -30,55 +45,144 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe("recordPaidUsageAt (explicit target)", () => {
-  it("bills the given branch's cost + guards once and merges the meter once", () => {
+describe("recordUsage (provider + manual observations)", () => {
+  it("records a priced completion: bills the target branch and merges the meter once", () => {
     const ctx = makeCtx();
     const branch = new StateStack();
-    const guard = new CostGuard(1);
-    branch.guards.push(guard);
-    recordPaidUsageAt({ ctx, stack: branch }, { pricedCost: 0.25, inputTokens: 100, outputTokens: 20, unknownCostCallCount: 0 });
-
+    branch.guards.push(new CostGuard(1));
+    recordUsage(ctx, branch, {
+      type: "provider",
+      kind: "completion",
+      reportedModel: "opus",
+      cost: { totalCost: 0.25, currency: "USD" } as any,
+      tokens: { inputTokens: 100, outputTokens: 20, totalTokens: 120 } as any,
+    });
     expect(branch.localCost).toBeCloseTo(0.25);
-    // The invocation meter, not ctx.stateStack, saw the spend.
-    expect(ctx.invocationUsage.snapshot().usage.pricedCost).toBeCloseTo(0.25);
-    expect(ctx.invocationUsage.snapshot().usage.inputTokens).toBe(100);
+    const { usage } = ctx.invocationUsage.snapshot();
+    expect(usage.cost.totalCost).toBeCloseTo(0.25);
+    expect(usage.tokens.inputTokens).toBe(100);
+    expect(usage.entries.map((e) => `${e.kind}:${e.model}`)).toEqual(["completion:opus"]);
+    // Billed the given branch, not ctx.stateStack.
     expect(ctx.stateStack.localCost).toBe(0);
   });
 
-  it("relays the full delta once when in IPC mode", () => {
-    vi.stubEnv("AGENCY_IPC", "1");
-    const send = vi.fn(() => true);
-    process.send = send as any;
-    recordPaidUsageAt({ ctx: makeCtx(), stack: new StateStack() }, { pricedCost: 0.5, inputTokens: 1, outputTokens: 1, unknownCostCallCount: 0 });
-    expect(send).toHaveBeenCalledExactlyOnceWith({
-      type: "invocationUsage", pricedCost: 0.5, inputTokens: 1, outputTokens: 1, unknownCostCallCount: 0,
-    });
-  });
-
-  it("an unpriced completion records tokens/unknown without charging guards", () => {
+  it("records a manual charge as a manual entry (model '') and bills it", () => {
     const ctx = makeCtx();
     const branch = new StateStack();
-    recordPaidUsageAt({ ctx, stack: branch }, completionUsageDelta({ cost: undefined, inputTokens: 5, outputTokens: 2, model: "m" }));
-    expect(branch.localCost).toBe(0);
-    const s = ctx.invocationUsage.snapshot();
-    expect(s.usage.pricedCost).toBe(0);
-    expect(s.usage.inputTokens).toBe(5);
-    expect(s.usage.unknownCostCallCount).toBe(1);
-    expect(s.usage.pricingComplete).toBe(false);
+    recordUsage(ctx, branch, { type: "manual", amount: 0.03 });
+    expect(branch.localCost).toBeCloseTo(0.03);
+    const { usage } = ctx.invocationUsage.snapshot();
+    expect(usage.cost.totalCost).toBeCloseTo(0.03);
+    expect(usage.entries).toHaveLength(1);
+    expect(usage.entries[0]).toMatchObject({ kind: "manual", model: "" });
+    expect(usage.entries[0].cost.totalCost).toBeCloseTo(0.03);
+  });
+
+  it("keeps a separate entry per model", () => {
+    const ctx = makeCtx();
+    const b = new StateStack();
+    recordUsage(ctx, b, { type: "provider", kind: "completion", reportedModel: "opus", cost: { totalCost: 0.1, currency: "USD" } as any });
+    recordUsage(ctx, b, { type: "provider", kind: "completion", reportedModel: "sonnet", cost: { totalCost: 0.2, currency: "USD" } as any });
+    expect(ctx.invocationUsage.snapshot().usage.entries.map((e) => e.model)).toEqual(["opus", "sonnet"]);
   });
 });
 
-describe("recordPaidUsage / addCost (ambient target)", () => {
-  it("addCost records cost against the invocation meter and enforces guards", async () => {
+describe("recordUnresolvedAttempt", () => {
+  it("adds one unknown-cost call, no cost, and flips pricingComplete false", () => {
     const ctx = makeCtx();
-    await runInTestContext(ctx, ctx.stateStack, new ThreadStore(), async () => {
-      addCost(0.25);
-    });
-    expect(ctx.invocationUsage.snapshot().usage.pricedCost).toBeCloseTo(0.25);
+    recordUnresolvedAttempt(ctx, ctx.stateStack, "completion");
+    const { usage } = ctx.invocationUsage.snapshot();
+    expect(usage.unknownCostCallCount).toBe(1);
+    expect(usage.pricingComplete).toBe(false);
+    expect(usage.cost.totalCost).toBe(0);
+    expect(ctx.stateStack.localCost).toBe(0);
+  });
+});
+
+describe("recordUsageDelta sink: order, suppression, and degrade-once", () => {
+  it("relays the delta, then ONE incompleteness marker after it, on attribution loss", () => {
+    vi.stubEnv("AGENCY_IPC", "1");
+    const send = vi.fn(() => true);
+    process.send = send as any;
+    const ctx = makeCtx();
+    recordNormalizedUsageDelta(ctx, new StateStack(), delta({
+      cost: { ...zeroCost(), totalCost: 0.5 },
+      tokens: { ...zeroTokens(), inputTokens: 1, totalTokens: 1 },
+      attributionLost: true,
+    }));
+    // FIFO preserves the recovered money before degrading the ancestor.
+    expect(sentTypes(send)).toEqual(["invocationUsage", "invocationUsageIncomplete"]);
+    expect(ctx.invocationUsage.snapshot().usageComplete).toBe(false);
+  });
+
+  it("a no-op (all-zero) delta emits no IPC message", () => {
+    vi.stubEnv("AGENCY_IPC", "1");
+    const send = vi.fn(() => true);
+    process.send = send as any;
+    recordNormalizedUsageDelta(makeCtx(), new StateStack(), delta({}));
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("outside IPC mode nothing is emitted even for a real delta", () => {
+    const send = vi.fn(() => true);
+    process.send = send as any;
+    recordNormalizedUsageDelta(makeCtx(), new StateStack(), delta({ cost: { ...zeroCost(), totalCost: 1 } }));
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("a count overflow degrades once: marker only on the first transition, always after the delta", () => {
+    vi.stubEnv("AGENCY_IPC", "1");
+    const send = vi.fn(() => true);
+    process.send = send as any;
+    const ctx = makeCtx();
+    const branch = new StateStack();
+    recordNormalizedUsageDelta(ctx, branch, delta({ tokens: { ...zeroTokens(), inputTokens: MAX, totalTokens: MAX } }));
+    send.mockClear();
+    recordNormalizedUsageDelta(ctx, branch, delta({ tokens: { ...zeroTokens(), inputTokens: 1, totalTokens: 1 } }));
+    expect(sentTypes(send)).toEqual(["invocationUsage", "invocationUsageIncomplete"]);
+    send.mockClear();
+    recordNormalizedUsageDelta(ctx, branch, delta({ tokens: { ...zeroTokens(), inputTokens: 1, totalTokens: 1 } }));
+    expect(sentTypes(send)).toEqual(["invocationUsage"]);
+    const s = ctx.invocationUsage.snapshot();
+    expect(s.usage.tokens.inputTokens).toBe(MAX);
+    expect(s.usageComplete).toBe(false);
+  });
+});
+
+describe("meteredDispatch", () => {
+  it("a resolved dispatch records nothing", async () => {
+    const ctx = makeCtx();
+    await meteredDispatch(ctx, ctx.stateStack, "completion", async () => "ok");
+    expect(ctx.invocationUsage.snapshot().usage.unknownCostCallCount).toBe(0);
+  });
+
+  it("a rejected dispatch records exactly one unresolved attempt", async () => {
+    const ctx = makeCtx();
+    await expect(
+      meteredDispatch(ctx, ctx.stateStack, "completion", async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+    await Promise.resolve();
+    expect(ctx.invocationUsage.snapshot().usage.unknownCostCallCount).toBe(1);
+  });
+
+  it("returns the dispatch promise unchanged (no extra microtask tick)", () => {
+    const ctx = makeCtx();
+    const p = Promise.resolve(7);
+    expect(meteredDispatch(ctx, ctx.stateStack, "completion", () => p)).toBe(p);
+  });
+});
+
+describe("addCost (ambient target)", () => {
+  it("records a manual charge against the active frame and enforces guards", async () => {
+    const ctx = makeCtx();
+    await runInTestContext(ctx, ctx.stateStack, new ThreadStore(), async () => addCost(0.25));
+    expect(ctx.invocationUsage.snapshot().usage.cost.totalCost).toBeCloseTo(0.25);
     expect(ctx.stateStack.localCost).toBeCloseTo(0.25);
   });
 
-  it("addCost with an over-budget charge trips the guard (enforcement preserved)", async () => {
+  it("an over-budget charge trips the guard (enforcement preserved)", async () => {
     const ctx = makeCtx();
     ctx.stateStack.guards.push(new CostGuard(0.1));
     await expect(
@@ -86,45 +190,16 @@ describe("recordPaidUsage / addCost (ambient target)", () => {
     ).rejects.toBeTruthy();
   });
 
-  it("invalid addCost throws before any mutation (never a silent dropped charge)", async () => {
+  it("rejects a negative or non-finite amount before any mutation", async () => {
     const ctx = makeCtx();
+    const msg = "addCost: amount must be a finite, non-negative number";
     await runInTestContext(ctx, ctx.stateStack, new ThreadStore(), async () => {
-      expect(() => addCost(-1)).toThrow();
-      expect(() => addCost(NaN)).toThrow();
+      expect(() => addCost(-1)).toThrow(msg);
+      expect(() => addCost(Number.NaN)).toThrow(msg);
+      expect(() => addCost(Number.POSITIVE_INFINITY)).toThrow(msg);
     });
     expect(ctx.stateStack.localCost).toBe(0);
-    expect(ctx.invocationUsage.snapshot().usage.pricedCost).toBe(0);
-  });
-
-  it("recordPaidUsage delegates to the active frame", async () => {
-    const ctx = makeCtx();
-    await runInTestContext(ctx, ctx.stateStack, new ThreadStore(), async () => {
-      recordPaidUsage(paidCostDelta(0.4));
-    });
-    expect(ctx.invocationUsage.snapshot().usage.pricedCost).toBeCloseTo(0.4);
-  });
-});
-
-describe("recordUnknownCostAttempt", () => {
-  it("adds one unknown-cost call, no cost, and flips pricingComplete false", () => {
-    const ctx = makeCtx();
-    recordUnknownCostAttempt(ctx, ctx.stateStack);
-    const s = ctx.invocationUsage.snapshot();
-    expect(s.usage.unknownCostCallCount).toBe(1);
-    expect(s.usage.pricedCost).toBe(0);
-    expect(s.usage.pricingComplete).toBe(false);
-    expect(ctx.stateStack.localCost).toBe(0);
-  });
-
-  it("relays the unknown-cost delta upward in IPC mode", () => {
-    vi.stubEnv("AGENCY_IPC", "1");
-    const send = vi.fn(() => true);
-    process.send = send as any;
-    const ctx = makeCtx();
-    recordUnknownCostAttempt(ctx, ctx.stateStack);
-    expect(send).toHaveBeenCalledExactlyOnceWith({
-      type: "invocationUsage", pricedCost: 0, inputTokens: 0, outputTokens: 0, unknownCostCallCount: 1,
-    });
+    expect(ctx.invocationUsage.snapshot().usage.cost.totalCost).toBe(0);
   });
 });
 
@@ -138,21 +213,5 @@ describe("markInvocationUsageIncompleteAt", () => {
     markInvocationUsageIncompleteAt(ctx);
     expect(send).toHaveBeenCalledExactlyOnceWith({ type: "invocationUsageIncomplete" });
     expect(ctx.invocationUsage.snapshot().usageComplete).toBe(false);
-  });
-});
-
-describe("accountCompletionUsage", () => {
-  it("attributes the completion to the provided model", () => {
-    const ctx = makeCtx();
-    const stack = new StateStack();
-    accountCompletionUsage(
-      ctx,
-      stack,
-      { cost: { totalCost: 0.1 }, usage: { inputTokens: 5, outputTokens: 2, totalTokens: 7 } },
-      "opus-4.8",
-    );
-    const { usage } = ctx.invocationUsage.snapshot();
-    expect(usage.models!["opus-4.8"]).toEqual({ pricedCost: 0.1, inputTokens: 5, outputTokens: 2 });
-    expect(stack.localTokens).toBe(7);
   });
 });

--- a/packages/agency-lang/lib/runtime/recordPaidUsage.ts
+++ b/packages/agency-lang/lib/runtime/recordPaidUsage.ts
@@ -1,106 +1,129 @@
 // The single accounting boundary for the serve cost seam.
 //
-// Every paid unit of work — an LLM completion (prompt.ts), an `addCost` charge
-// (cost.ts; memory and image generation pay through it), and a subprocess's
-// relayed usage (ipc.ts) — submits one `InvocationUsageDelta` here. This is the
-// ONE place that (1) bills the branch's cost guards via `StateStack.billCharge`,
-// (2) merges the invocation's usage meter, and (3) relays the full delta upward
-// exactly once when this process is itself a subprocess. Because all three
-// happen together, "authoritative cost" never depends on execution topology: the
-// same charge counts identically in-process and in a child.
+// Every paid unit of work — an LLM completion/embedding/image (prompt.ts,
+// memory/manager.ts, stdlib/image.ts), an `addCost` charge (cost.ts), and a
+// subprocess's relayed usage (ipc.ts) — becomes one domain observation or one
+// already-recovered IPC delta that flows through this ONE synchronous sink. The
+// sink (1) bills the branch's cost guards via `StateStack.billCharge`, (2)
+// merges the invocation's usage meter, (3) degrades `usageComplete` when this
+// delta lost attribution, and (4) relays the delta upward — then, after it, one
+// incompleteness marker on the first meter transition — when this process is
+// itself a subprocess. Because all four happen together, "authoritative cost"
+// never depends on execution topology: the same charge counts identically
+// in-process and in a child.
 
-import { getRuntimeContext } from "./asyncContext.js";
+import type { PromptResult } from "smoltalk";
 import type { RuntimeContext } from "./state/context.js";
 import type { StateStack } from "./state/stateStack.js";
 import type { GraphState } from "./types.js";
 import {
-  completionUsageDelta,
-  type InvocationAccountingTarget,
-  type InvocationUsageDelta,
+  normalizeObservation,
+  type NormalizedDelta,
+  type ProviderUsageKind,
+  type UsageObservation,
 } from "./invocationUsage.js";
 import {
   sendInvocationUsageToParent,
   sendInvocationUsageIncompleteToParent,
-  sendModelAttributionIncompleteToParent,
 } from "./costTelemetry.js";
 
-/** Account one paid delta against an EXPLICIT target (out-of-frame callers such
- *  as the IPC telemetry handler pass `RunSession.ctx/stateStack`, never relying
- *  on AsyncLocalStorage). Bills guards, merges the meter, relays once. */
-export function recordPaidUsageAt(
-  target: InvocationAccountingTarget,
-  delta: InvocationUsageDelta,
-): void {
-  target.stack.billCharge(delta.pricedCost);
-  target.ctx.invocationUsage.merge(delta);
+type AccountingTarget = {
+  ctx: RuntimeContext<GraphState>;
+  stack: StateStack;
+};
+
+/** THE accounting sink — private to this module. Bills the branch, merges the
+ *  meter once, and degrades `usageComplete` when the delta lost attribution. It
+ *  then relays the normalized delta upward and, only when a meter transition
+ *  actually happened (a first count-overflow inside `merge`, or the
+ *  attribution-loss `markIncomplete`), relays ONE incompleteness marker AFTER
+ *  the delta. FIFO therefore preserves the recovered money before degrading the
+ *  ancestor, and the marker is never sent twice for the same transition. */
+function recordUsageDelta(target: AccountingTarget, delta: NormalizedDelta): void {
+  target.stack.billCharge(delta.cost.totalCost);
+  const overflowTransition = target.ctx.invocationUsage.merge(delta);
+  const attributionTransition = delta.attributionLost
+    ? target.ctx.invocationUsage.markIncomplete()
+    : false;
   sendInvocationUsageToParent(delta);
+  if (overflowTransition || attributionTransition) {
+    sendInvocationUsageIncompleteToParent();
+  }
 }
 
-/** Ambient convenience for in-frame TS helpers (only `addCost`): reads the
- *  active `{ ctx, stack }` from the execution frame and delegates. */
-export function recordPaidUsage(delta: InvocationUsageDelta): void {
-  const { ctx, stack } = getRuntimeContext();
-  recordPaidUsageAt({ ctx, stack }, delta);
-}
-
-/** Account one LLM completion through the paid-usage boundary (guards + meter +
- *  subprocess relay) and update the per-branch total-token accumulator that
- *  std::thread's getTokens() reports. Called from the prompt completion site. */
-export function accountCompletionUsage(
+/** Record one domain observation (a provider outcome or a manual charge) against
+ *  an explicit branch target. Normalizes exactly once, then submits to the sink. */
+export function recordUsage(
   ctx: RuntimeContext<GraphState>,
-  targetStack: StateStack,
-  completion: {
-    cost?: { totalCost?: number } | null;
-    usage?: { inputTokens?: number; outputTokens?: number; totalTokens?: number } | null;
-  },
-  model: string,
+  stack: StateStack,
+  observation: UsageObservation,
 ): void {
-  recordPaidUsageAt(
-    { ctx, stack: targetStack },
-    completionUsageDelta({
-      cost: completion.cost?.totalCost,
-      inputTokens: completion.usage?.inputTokens,
-      outputTokens: completion.usage?.outputTokens,
-      model,
-    }),
-  );
-  targetStack.localTokens += completion.usage?.totalTokens ?? 0;
+  recordUsageDelta({ ctx, stack }, normalizeObservation(observation));
 }
 
-/** Record one UNKNOWN-cost provider attempt: a request that was dispatched to
- *  the provider but did not resolve to a priced completion (timeout / cancel /
- *  provider error after dispatch — possible spend, no price metadata). Adds one
- *  to unknownCostCallCount (no cost, no tokens) so pricingComplete goes false;
- *  relays upward once if this is a subprocess. A failure PROVEN before dispatch
- *  never calls this. */
-export function recordUnknownCostAttempt(
+/** Account one LLM completion (the prompt completion site) as a provider
+ *  observation AND update the per-branch total-token accumulator that
+ *  std::thread's getTokens() reports. The branch-local update is a compatibility
+ *  side effect kept deliberately out of the general sink. */
+export function recordCompletionUsage(
   ctx: RuntimeContext<GraphState>,
-  targetStack: StateStack,
+  stack: StateStack,
+  completion: Pick<PromptResult, "model" | "cost" | "usage">,
+  configuredModel: string | null | undefined,
 ): void {
-  recordPaidUsageAt(
-    { ctx, stack: targetStack },
-    { pricedCost: 0, inputTokens: 0, outputTokens: 0, unknownCostCallCount: 1 },
-  );
+  recordUsage(ctx, stack, {
+    type: "provider",
+    kind: "completion",
+    reportedModel: completion.model,
+    configuredModel,
+    cost: completion.cost,
+    tokens: completion.usage,
+  });
+  stack.localTokens += completion.usage?.totalTokens ?? 0;
+}
+
+/** Record one UNRESOLVED provider attempt: a request that was dispatched to the
+ *  provider but never resolved to a priced result (timeout / cancel / a
+ *  post-dispatch provider error — possible spend, no price metadata). Adds one
+ *  to `unknownCostCallCount` (no cost, no tokens) so `pricingComplete` goes
+ *  false. A failure PROVEN before dispatch never calls this. */
+export function recordUnresolvedAttempt(
+  ctx: RuntimeContext<GraphState>,
+  stack: StateStack,
+  kind: ProviderUsageKind,
+): void {
+  recordUsage(ctx, stack, { type: "attempt", kind });
+}
+
+/** The narrow IPC entry point into the sink. The delta was ALREADY recovered by
+ *  `normalizeIpcUsageDelta`, so this must not normalize again and must not
+ *  enforce guards (the IPC handler enforces live-session guards afterward). */
+export function recordNormalizedUsageDelta(
+  ctx: RuntimeContext<GraphState>,
+  stack: StateStack,
+  delta: NormalizedDelta,
+): void {
+  recordUsageDelta({ ctx, stack }, delta);
 }
 
 /** Run one provider dispatch as a metered attempt (serve cost seam; each retry
- *  is a fresh attempt). A resolved dispatch is priced later at the completion
- *  site; a dispatched-but-UNRESOLVED attempt (timeout/cancel/provider error
- *  after dispatch — possible spend, no price) records one unknown-cost attempt
- *  so pricingComplete goes false. A pre-dispatch failure never enters here.
+ *  is a fresh attempt). A resolved dispatch is priced later at its completion
+ *  site; a dispatched-but-UNRESOLVED attempt records one unresolved attempt so
+ *  `pricingComplete` goes false. A pre-dispatch failure never enters here.
  *
  *  Returns the dispatch promise UNCHANGED (not wrapped in await/then): the
- *  unknown-cost record is a fire-and-forget side effect on rejection, so this
- *  adds no microtask tick to the caller's timing. That matters — race()
- *  determinism (which loser calls complete before the abort fires) is timing-
- *  sensitive, and wrapping the dispatch would shift it. */
+ *  attempt record is a fire-and-forget side effect on rejection, so this adds no
+ *  microtask tick to the caller's timing. That matters — race() determinism
+ *  (which loser calls complete before the abort fires) is timing-sensitive, and
+ *  wrapping the dispatch would shift it. */
 export function meteredDispatch<T>(
   ctx: RuntimeContext<GraphState>,
-  targetStack: StateStack,
+  stack: StateStack,
+  kind: ProviderUsageKind,
   dispatch: () => Promise<T>,
 ): Promise<T> {
   const pending = dispatch();
-  void pending.catch(() => recordUnknownCostAttempt(ctx, targetStack));
+  void pending.catch(() => recordUnresolvedAttempt(ctx, stack, kind));
   return pending;
 }
 
@@ -111,16 +134,5 @@ export function meteredDispatch<T>(
 export function markInvocationUsageIncompleteAt(ctx: RuntimeContext<GraphState>): void {
   if (ctx.invocationUsage.markIncomplete()) {
     sendInvocationUsageIncompleteToParent();
-  }
-}
-
-/** Mark this invocation's model attribution as no longer trustworthy (a
- *  measurable child charge arrived with no attribution — a version-skewed
- *  child). Relays the marker upward once, only on the first transition, so a
- *  mid-tier process forwards a descendant's degraded attribution without
- *  spamming. */
-export function markModelAttributionIncompleteAt(ctx: RuntimeContext<GraphState>): void {
-  if (ctx.invocationUsage.markModelAttributionIncomplete()) {
-    sendModelAttributionIncompleteToParent();
   }
 }

--- a/packages/agency-lang/lib/runtime/state/context.invocationUsage.test.ts
+++ b/packages/agency-lang/lib/runtime/state/context.invocationUsage.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { RuntimeContext } from "./context.js";
 import type { Checkpoint } from "./checkpointStore.js";
+import type { NormalizedDelta } from "../invocationUsage.js";
 
 // The invocation meter is per-execCtx and must NOT survive a checkpoint restore
 // (a resume leg starts fresh), nor appear in any serialization.
@@ -12,6 +13,16 @@ function makeContext() {
   });
 }
 
+function delta(totalCost: number, over: Partial<NormalizedDelta> = {}): NormalizedDelta {
+  return {
+    cost: { inputCost: 0, outputCost: 0, cachedInputCost: 0, cacheCreationInputCost: 0, hostedToolsCost: 0, totalCost, currency: "USD" },
+    tokens: { inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, cacheCreationInputTokens: 0, totalTokens: 0 },
+    unknownCostCallCount: 0,
+    attributionLost: false,
+    ...over,
+  };
+}
+
 describe("execution-context invocation meter", () => {
   it("each createExecutionContext gets an independent, complete, zeroed meter", async () => {
     const parent = makeContext();
@@ -20,22 +31,24 @@ describe("execution-context invocation meter", () => {
 
     expect(a.invocationUsage.snapshot()).toEqual({
       usage: {
-        pricedCost: 0, inputTokens: 0, outputTokens: 0, unknownCostCallCount: 0, pricingComplete: true,
-        models: {}, unattributed: { pricedCost: 0, inputTokens: 0, outputTokens: 0 },
-        modelAttributionComplete: true,
+        cost: { inputCost: 0, outputCost: 0, cachedInputCost: 0, cacheCreationInputCost: 0, hostedToolsCost: 0, totalCost: 0, currency: "USD" },
+        tokens: { inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, cacheCreationInputTokens: 0, totalTokens: 0 },
+        unknownCostCallCount: 0,
+        pricingComplete: true,
+        entries: [],
       },
       usageComplete: true,
     });
 
-    a.invocationUsage.merge({ pricedCost: 1, inputTokens: 10, outputTokens: 2, unknownCostCallCount: 1 });
+    a.invocationUsage.merge(delta(1, { unknownCostCallCount: 1 }));
     // b is untouched by a's spend (concurrent-invocation isolation).
-    expect(b.invocationUsage.snapshot().usage.pricedCost).toBe(0);
+    expect(b.invocationUsage.snapshot().usage.cost.totalCost).toBe(0);
     expect(b.invocationUsage.snapshot().usage.pricingComplete).toBe(true);
   });
 
   it("restoreState neither resets nor hydrates the meter (resume-leg isolation is structural)", async () => {
     const execCtx = await makeContext().createExecutionContext("run-1");
-    execCtx.invocationUsage.merge({ pricedCost: 0.5, inputTokens: 7, outputTokens: 3, unknownCostCallCount: 0 });
+    execCtx.invocationUsage.merge(delta(0.5));
 
     const checkpoint = execCtx.stateToJSON() as unknown as Checkpoint;
     execCtx.restoreState(checkpoint);
@@ -43,12 +56,12 @@ describe("execution-context invocation meter", () => {
     // The meter is exactly what it was — restore did not touch it. (In real
     // resume the FRESH execCtx is what gives per-leg isolation; here we prove
     // restore itself carries no meter state.)
-    expect(execCtx.invocationUsage.snapshot().usage.pricedCost).toBeCloseTo(0.5);
+    expect(execCtx.invocationUsage.snapshot().usage.cost.totalCost).toBeCloseTo(0.5);
   });
 
   it("no serialization includes the meter", async () => {
     const execCtx = await makeContext().createExecutionContext("run-2");
-    execCtx.invocationUsage.merge({ pricedCost: 9.99, inputTokens: 1, outputTokens: 1, unknownCostCallCount: 0 });
+    execCtx.invocationUsage.merge(delta(9.99));
     expect(JSON.stringify(execCtx.toJSON())).not.toContain("invocationUsage");
     expect(JSON.stringify(execCtx.stateToJSON())).not.toContain("9.99");
   });

--- a/packages/agency-lang/lib/serve/http/adapter.test.ts
+++ b/packages/agency-lang/lib/serve/http/adapter.test.ts
@@ -253,9 +253,10 @@ describe("HTTP adapter", () => {
     // interrupt execution, so a real meter is unnecessary here (that path is
     // covered by serveCostSeam.integration.test.ts).
     const breakdownUsage = {
-      pricedCost: 0.03, inputTokens: 0, outputTokens: 0, unknownCostCallCount: 0, pricingComplete: true,
-      models: {}, unattributed: { pricedCost: 0.03, inputTokens: 0, outputTokens: 0 },
-      modelAttributionComplete: true,
+      cost: { inputCost: 0, outputCost: 0, cachedInputCost: 0, cacheCreationInputCost: 0, hostedToolsCost: 0, totalCost: 0.03, currency: "USD" as const },
+      tokens: { inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, cacheCreationInputTokens: 0, totalTokens: 0 },
+      unknownCostCallCount: 0, pricingComplete: true,
+      entries: [{ kind: "manual" as const, model: "", cost: { inputCost: 0, outputCost: 0, cachedInputCost: 0, cacheCreationInputCost: 0, hostedToolsCost: 0, totalCost: 0.03, currency: "USD" as const }, tokens: { inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, cacheCreationInputTokens: 0, totalTokens: 0 } }],
     };
     const pausedValue = { paused: true };
     const { exports } = makeExports();

--- a/packages/agency-lang/lib/serve/http/serveCostSeam.integration.test.ts
+++ b/packages/agency-lang/lib/serve/http/serveCostSeam.integration.test.ts
@@ -64,21 +64,20 @@ describe("serve cost seam — end to end", () => {
     const result = await handlerFor(makeCtx(), () => { addCost(0.03); return "done"; })("POST", "/function/run", {});
     expect(result.status).toBe(200);
     expect(result.body).toEqual({ success: true, value: "done" });
-    expect(result.usage?.pricedCost).toBeCloseTo(0.03);
+    expect(result.usage?.cost.totalCost).toBeCloseTo(0.03);
     expect(result.usage?.pricingComplete).toBe(true);
     expect(result.usageComplete).toBe(true);
   });
 
-  it("success carries a reconciled unattributed breakdown (addCost has no model)", async () => {
+  it("success carries a reconciled manual breakdown (addCost has model '')", async () => {
     setup();
     const result = await handlerFor(makeCtx(), () => { addCost(0.03); return "done"; })("POST", "/function/run", {});
-    // addCost is model-less, so it lands in the unattributed row, not models.
-    expect(result.usage?.models).toEqual({});
-    expect(result.usage?.unattributed?.pricedCost).toBeCloseTo(0.03);
-    expect(result.usage?.modelAttributionComplete).toBe(true);
-    const modelCost = Object.values(result.usage!.models ?? {}).reduce((total, row) => total + row.pricedCost, 0);
-    const attributed = modelCost + (result.usage!.unattributed?.pricedCost ?? 0);
-    expect(Math.abs(attributed - result.usage!.pricedCost)).toBeLessThanOrEqual(usageReconcileTolerance(result.usage!.pricedCost));
+    // addCost is a manual charge, so it lands in a single manual entry (model "").
+    expect(result.usage?.entries).toHaveLength(1);
+    expect(result.usage?.entries[0]).toMatchObject({ kind: "manual", model: "" });
+    expect(result.usage?.entries[0].cost.totalCost).toBeCloseTo(0.03);
+    const attributed = result.usage!.entries.reduce((total, entry) => total + entry.cost.totalCost, 0);
+    expect(Math.abs(attributed - result.usage!.cost.totalCost)).toBeLessThanOrEqual(usageReconcileTolerance(result.usage!.cost.totalCost));
   });
 
   it("two concurrent invocations report independent usage (own execCtx each)", async () => {
@@ -86,8 +85,8 @@ describe("serve cost seam — end to end", () => {
     const cheap = handlerFor(makeCtx(), () => { addCost(0.01); return "a"; })("POST", "/function/run", {});
     const dear = handlerFor(makeCtx(), () => { addCost(0.5); return "b"; })("POST", "/function/run", {});
     const [a, b] = await Promise.all([cheap, dear]);
-    expect(a.usage?.pricedCost).toBeCloseTo(0.01);
-    expect(b.usage?.pricedCost).toBeCloseTo(0.5);
+    expect(a.usage?.cost.totalCost).toBeCloseTo(0.01);
+    expect(b.usage?.cost.totalCost).toBeCloseTo(0.5);
   });
 
   it("a function that spends then throws still reports the pre-throw cost", async () => {
@@ -98,10 +97,10 @@ describe("serve cost seam — end to end", () => {
     })("POST", "/function/run", {});
     expect(result.status).toBe(200);
     expect(result.body).toEqual({ success: false, error: "Tool execution failed" });
-    expect(result.usage?.pricedCost).toBeCloseTo(0.02);
+    expect(result.usage?.cost.totalCost).toBeCloseTo(0.02);
     // The breakdown is not dropped on the error path.
-    expect(result.usage?.unattributed?.pricedCost).toBeCloseTo(0.02);
-    expect(result.usage?.modelAttributionComplete).toBe(true);
+    expect(result.usage?.entries[0]?.cost.totalCost).toBeCloseTo(0.02);
+    expect(result.usageComplete).toBe(true);
   });
 
   it("a baked budget trip returns 402 carrying the cost up to the trip", async () => {
@@ -109,7 +108,7 @@ describe("serve cost seam — end to end", () => {
     const result = await handlerFor(makeCtx({ maxCost: 0 }), () => { addCost(1); return "x"; })("POST", "/function/run", {});
     expect(result.status).toBe(402);
     expect(result.body).toMatchObject({ code: "budgetExceeded", dimension: "cost", limit: 0 });
-    expect(result.usage?.pricedCost).toBeCloseTo(1);
+    expect(result.usage?.cost.totalCost).toBeCloseTo(1);
   });
 
   it("/list carries no usage (no invocation started)", async () => {

--- a/packages/agency-lang/lib/serve/testOutcome.ts
+++ b/packages/agency-lang/lib/serve/testOutcome.ts
@@ -1,11 +1,17 @@
 // Test-only builders for ServedInvocationOutcome, so adapter/discovery unit
 // tests can supply plain-JS invokers without spinning up a real runtime.
-import type { ServedInvocationOutcome } from "../runtime/invocationUsage.js";
+import type { InvocationUsageSnapshot, ServedInvocationOutcome } from "../runtime/invocationUsage.js";
 
-const ZERO_SNAPSHOT = {
-  usage: { pricedCost: 0, inputTokens: 0, outputTokens: 0, unknownCostCallCount: 0, pricingComplete: true },
+const ZERO_SNAPSHOT: InvocationUsageSnapshot = {
+  usage: {
+    cost: { inputCost: 0, outputCost: 0, cachedInputCost: 0, cacheCreationInputCost: 0, hostedToolsCost: 0, totalCost: 0, currency: "USD" },
+    tokens: { inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, cacheCreationInputTokens: 0, totalTokens: 0 },
+    unknownCostCallCount: 0,
+    pricingComplete: true,
+    entries: [],
+  },
   usageComplete: true,
-} as const;
+};
 
 /** A returned outcome carrying a fixed usage snapshot (override `usage` when a
  *  test asserts specific figures). */

--- a/packages/agency-lang/lib/stdlib/image.test.ts
+++ b/packages/agency-lang/lib/stdlib/image.test.ts
@@ -30,8 +30,8 @@ async function withClient(
   const stack = makeStack();
   const imageGeneration = vi.fn().mockResolvedValue(undefined);
   const store = {
-    // A real meter: image generation pays via addCost → recordPaidUsage, which
-    // merges ctx.invocationUsage (the serve cost seam's accounting boundary).
+    // A real meter: image generation accounts via recordUsage, which merges
+    // ctx.invocationUsage (the serve cost seam's accounting boundary).
     ctx: { llmClient: { image: imageImpl }, statelogClient: { imageGeneration }, invocationUsage: new InvocationUsageMeter() },
     stack,
     threads: {},
@@ -46,7 +46,7 @@ const okResult = (overrides: any = {}) => ({
   value: {
     images: [{ data: new Uint8Array([1, 2, 3]), mimeType: "image/png" }],
     model: "m",
-    costEstimate: { totalCost: 0.04 },
+    costEstimate: { totalCost: 0.04, currency: "USD" },
     tokenUsage: { totalTokens: 10 },
     ...overrides,
   },
@@ -79,7 +79,7 @@ describe("_generateImage", () => {
   });
 
   it("propagates a guard trip, but still traces the spend + tokens first", async () => {
-    await withClient(async () => okResult({ costEstimate: { totalCost: 5.0 } }), async ({ stack, imageGeneration }) => {
+    await withClient(async () => okResult({ costEstimate: { totalCost: 5.0, currency: "USD" } }), async ({ stack, imageGeneration }) => {
       stack.enforceGuards.mockImplementation(() => {
         throw new Error("budget exceeded");
       });
@@ -90,6 +90,21 @@ describe("_generateImage", () => {
       // before the trip propagates (same ordering as llm()).
       expect(stack.localTokens).toBe(10);
       expect(imageGeneration).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("a successful result with no image accounts usage + tokens, skips the event, and fails", async () => {
+    await withClient(async () => okResult({ images: [] }), async ({ stack, imageGeneration }) => {
+      const r = await _generateImage("x", "", "", "", "", [], "", "");
+      expect(r.success).toBe(false);
+      if (!r.success) expect(r.error).toMatch(/returned no images/);
+      // The provider still charged us: full usage + tokens are accounted and the
+      // guard gate runs, even though there is no image to return.
+      expect(stack.localCost).toBeCloseTo(0.04);
+      expect(stack.localTokens).toBe(10);
+      expect(stack.enforceGuards).toHaveBeenCalled();
+      // No image → no imageGeneration event (its contract requires an image).
+      expect(imageGeneration).not.toHaveBeenCalled();
     });
   });
 
@@ -118,7 +133,7 @@ describe("_generateImage", () => {
     let captured: any;
     const impl: ImageImpl = async (input) => {
       captured = input;
-      return okResult({ costEstimate: { totalCost: 0 } });
+      return okResult({ costEstimate: { totalCost: 0, currency: "USD" } });
     };
     await withClient(impl, async () => {
       await _generateImage("edit", "", "", "", "", ["./a.png", "https://x/b.png"], "", "");

--- a/packages/agency-lang/lib/stdlib/image.test.ts
+++ b/packages/agency-lang/lib/stdlib/image.test.ts
@@ -25,20 +25,21 @@ function makeStack() {
  *  statelog. Returns the frame's stack + statelog spy for assertions. */
 async function withClient(
   imageImpl: ImageImpl | undefined,
-  fn: (helpers: { stack: ReturnType<typeof makeStack>; imageGeneration: ReturnType<typeof vi.fn> }) => Promise<void>,
+  fn: (helpers: { stack: ReturnType<typeof makeStack>; imageGeneration: ReturnType<typeof vi.fn>; meter: InvocationUsageMeter }) => Promise<void>,
 ) {
   const stack = makeStack();
   const imageGeneration = vi.fn().mockResolvedValue(undefined);
+  const meter = new InvocationUsageMeter();
   const store = {
     // A real meter: image generation accounts via recordUsage, which merges
     // ctx.invocationUsage (the serve cost seam's accounting boundary).
-    ctx: { llmClient: { image: imageImpl }, statelogClient: { imageGeneration }, invocationUsage: new InvocationUsageMeter() },
+    ctx: { llmClient: { image: imageImpl }, statelogClient: { imageGeneration }, invocationUsage: meter },
     stack,
     threads: {},
     globals: {},
     callsite: { moduleId: "test", scopeName: "main", stepPath: "" },
   } as any;
-  await agencyStore.run(store, () => fn({ stack, imageGeneration }));
+  await agencyStore.run(store, () => fn({ stack, imageGeneration, meter }));
 }
 
 const okResult = (overrides: any = {}) => ({
@@ -119,6 +120,16 @@ describe("_generateImage", () => {
         expect(imageGeneration).not.toHaveBeenCalled();
       },
     );
+  });
+
+  it("a rejected image dispatch records one unresolved attempt (pricingComplete goes false)", async () => {
+    await withClient(async () => { throw new Error("provider 500 after dispatch"); }, async ({ meter }) => {
+      await expect(_generateImage("x", "", "", "", "", [], "", "")).rejects.toThrow(/provider 500/);
+      await Promise.resolve();
+      const { usage } = meter.snapshot();
+      expect(usage.unknownCostCallCount).toBe(1);
+      expect(usage.pricingComplete).toBe(false);
+    });
   });
 
   it("returns a descriptive failure when the client has no image() support", async () => {

--- a/packages/agency-lang/lib/stdlib/image.ts
+++ b/packages/agency-lang/lib/stdlib/image.ts
@@ -1,7 +1,8 @@
 import { performance } from "node:perf_hooks";
 import { getRuntimeContext } from "../runtime/asyncContext.js";
 import { success, failure, type ResultValue } from "../runtime/result.js";
-import { addCost, addTokens } from "../runtime/cost.js";
+import { addTokens } from "../runtime/cost.js";
+import { recordUsage } from "../runtime/recordPaidUsage.js";
 import { classifySource } from "./thread.js";
 // One image type surface — imported from llmClient.ts, not smoltalk directly.
 import type { ImageConfig, ImageInput, ImageRef } from "../runtime/llmClient.js";
@@ -40,7 +41,7 @@ export async function _generateImage(
   apiKey: string,
   baseUrl: string,
 ): Promise<ResultValue> {
-  const { ctx } = getRuntimeContext();
+  const { ctx, stack } = getRuntimeContext();
   if (!ctx.llmClient.image) {
     return failure(
       "The active LLM client does not support image generation. Use the default client or register one with image() support.",
@@ -72,29 +73,41 @@ export async function _generateImage(
   }
   const gen = result.value;
   const first = gen.images[0];
+
+  // The provider dispatch resolved and cost real money whether or not it handed
+  // back an image, so account its full usage in BOTH cases. Record usage and
+  // tokens, trace the event (only when there is an image — the statelog contract
+  // requires one), and enforce guards LAST — same ordering as the llm() path
+  // (lib/runtime/prompt.ts). `recordUsage` bills the guards but does not throw;
+  // the explicit `enforceGuards()` is the guard gate, so a trip still leaves the
+  // spend accounted and (for a returned image) traced before it propagates, and
+  // a trip wins over either return below.
+  recordUsage(ctx, stack, {
+    type: "provider",
+    kind: "image",
+    reportedModel: gen.model,
+    configuredModel: model,
+    cost: gen.costEstimate,
+    tokens: gen.tokenUsage,
+  });
+  addTokens(gen.tokenUsage?.totalTokens ?? 0);
+  if (first) {
+    ctx.statelogClient.imageGeneration({
+      promptPreview: prompt.slice(0, PROMPT_PREVIEW_MAX),
+      model: gen.model,
+      timeTaken,
+      usage: gen.tokenUsage,
+      cost:
+        gen.costEstimate === undefined
+          ? undefined
+          : { totalCost: gen.costEstimate.totalCost },
+    });
+  }
+  stack.enforceGuards();
+
   if (!first) {
     return failure("Image generation returned no images.");
   }
-
-  // The generation already happened (and cost real money), so record tokens and
-  // trace the event BEFORE enforcing guards — same ordering as the llm() path
-  // (lib/runtime/prompt.ts). This way a guard trip inside addCost still leaves
-  // the spend traced and token accounting consistent; the trip then propagates.
-  addTokens(gen.tokenUsage?.totalTokens ?? 0);
-  ctx.statelogClient.imageGeneration({
-    promptPreview: prompt.slice(0, PROMPT_PREVIEW_MAX),
-    model: gen.model,
-    timeTaken,
-    usage: gen.tokenUsage,
-    cost:
-      gen.costEstimate === undefined
-        ? undefined
-        : { totalCost: gen.costEstimate.totalCost },
-  });
-  // addCost accrues localCost, bills guards, and enforces limits (may throw a
-  // guard trip, which must propagate — must be last).
-  addCost(gen.costEstimate?.totalCost ?? 0);
-
   return success({
     base64: Buffer.from(first.data).toString("base64"),
     mimeType: first.mimeType,

--- a/packages/agency-lang/lib/stdlib/image.ts
+++ b/packages/agency-lang/lib/stdlib/image.ts
@@ -2,7 +2,7 @@ import { performance } from "node:perf_hooks";
 import { getRuntimeContext } from "../runtime/asyncContext.js";
 import { success, failure, type ResultValue } from "../runtime/result.js";
 import { addTokens } from "../runtime/cost.js";
-import { recordUsage } from "../runtime/recordPaidUsage.js";
+import { recordUsage, meteredDispatch } from "../runtime/recordPaidUsage.js";
 import { classifySource } from "./thread.js";
 // One image type surface — imported from llmClient.ts, not smoltalk directly.
 import type { ImageConfig, ImageInput, ImageRef } from "../runtime/llmClient.js";
@@ -63,7 +63,13 @@ export async function _generateImage(
   });
 
   const start = performance.now();
-  const result = await ctx.llmClient.image(buildInput(prompt, images), config);
+  // Metered dispatch: a rejected image() promise records one unresolved attempt
+  // (so pricingComplete cannot stay true after a post-dispatch throw), mirroring
+  // the prompt path. A resolved failure Result is handled below (not metered
+  // here — deferred to #809).
+  const result = await meteredDispatch(ctx, stack, "image", () =>
+    ctx.llmClient.image!(buildInput(prompt, images), config),
+  );
   const timeTaken = performance.now() - start;
 
   // Cost/statelog happen ONLY on success — a failed generation must not charge

--- a/packages/agency-lang/scripts/agency.test.ts
+++ b/packages/agency-lang/scripts/agency.test.ts
@@ -171,13 +171,13 @@ describe("agency CLI command tree", () => {
     remoteRecipeMocks.runSpend.mockClear();
     const program = createProgram();
     await program.parseAsync(
-      ["remote", "spend", "my-project", "--since", "7d", "--json", "--host", "https://h", "--api-key-env", "SPEND_KEY"],
+      ["remote", "spend", "my-project", "--since", "7d", "--json", "--by-model", "--by-kind", "--host", "https://h", "--api-key-env", "SPEND_KEY"],
       { from: "user" },
     );
     expect(remoteRecipeMocks.runSpend).toHaveBeenCalledTimes(1);
     const [project, options] = remoteRecipeMocks.runSpend.mock.calls[0];
     expect(project).toBe("my-project");
-    expect(options).toMatchObject({ since: "7d", json: true, host: "https://h", apiKeyEnv: "SPEND_KEY" });
+    expect(options).toMatchObject({ since: "7d", json: true, byModel: true, byKind: true, host: "https://h", apiKeyEnv: "SPEND_KEY" });
   });
 
   it("forwards bare `remote spend` with an undefined project", async () => {

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -579,6 +579,8 @@ export function createProgram(deps: CliDependencies = {}): Command {
     .option("--from <when>", "window start — ISO-8601 (UTC/offset) or epoch-ms")
     .option("--to <when>", "window end — ISO-8601 (UTC/offset) or epoch-ms")
     .option("--json", "emit JSON for machine use")
+    .option("--by-model", "group the breakdown by model")
+    .option("--by-kind", "group the breakdown by operation kind")
     .option(HOST_OPTION, HOST_DESC)
     .option(API_KEY_ENV_OPTION, API_KEY_ENV_DESC)
     .action((project: string | undefined, opts: SpendOptions) => runSpend(project, opts, getConfigContext()));


### PR DESCRIPTION
## What

Replaces the flat per-model cost figure with a complete **cost and token breakdown** for every hosted invocation, keeps recoverable accounting across the subprocess IPC boundary, and surfaces it through `agency remote spend`. This is the agency-lang half of the full-cost-token-breakdown design; it pairs with a companion statelog schema and must ship as a pinned pair.

There are no users of the old shape yet, so this is a clean breaking change.

## The two figures

Each invocation now carries, and must not confuse:

- **Authoritative flat total** — `usage.cost` (full `CostBreakdown`) and `usage.tokens` (full `TokenBreakdown`). This is what gets billed.
- **Best-effort attribution** — `usage.entries`, one per `(kind, model)`. Reconciled against the flat total only when telemetry is complete; the total is never derived from summing entries.

`kind` is the API verb (`completion | embedding | image | manual`). A manual `addCost()` charge uses the model sentinel `""` (never null). Two independent completeness axes ride alongside: `pricingComplete` (did every call have a usable USD price?) and `usageComplete` (did all telemetry arrive?) — the latter a **sibling** of `usage`, flipping it to a trusted lower bound.

## Key rules (easy to get wrong)

- A price is valid only when `totalCost` is finite-nonnegative **and** `currency === "USD"`; otherwise the call is unpriced (all cost zero, `unknownCostCallCount` bumps). `totalCost: 0` is known-free.
- Cost components are best-effort and never reconciled to the total.
- `totalTokens` is authoritative when present; the fallback is kind-specific — embedding/image add only input+output because their cache counters may overlap input.
- All counts checked-add with saturation at `MAX_SAFE_INTEGER`; a saturation degrades `usageComplete`.
- Untrusted IPC input is recovered field-by-field and **never** drops money — an unusable entry is omitted while the flat total survives and `usageComplete` degrades.

## Layout

- `lib/runtime/invocationUsage.ts` — pure value layer + meter + IPC recovery.
- `lib/runtime/recordPaidUsage.ts` / `cost.ts` — one private `recordUsageDelta` sink; `addCost` validates finite-nonnegative first.
- `lib/runtime/prompt.ts`, `memory/manager.ts`, `stdlib/image.ts` — each provider outcome emits one observation (image accounts an empty result too — the provider still charged).
- `lib/runtime/costTelemetry.ts` / `ipc.ts` — new untrusted `invocationUsage` wire shape, recover-and-relay; legacy `costUsd` / `modelAttributionIncomplete` removed.
- `lib/cli/statelog/spendTypes.ts` + clients/renderers — new `ProjectSpend` shape and `agency remote spend --by-model` / `--by-kind`.
- `docs/dev/invocation-usage-accounting.md` — the architecture note (+ CLAUDE.md pointer).

## #809 boundary

Only a **rejected** provider promise counts as an unresolved attempt. A resolved `Result.failure` records nothing, because smoltalk can't yet distinguish a pre-dispatch failure (no spend) from a post-dispatch one (real spend). Closing that is deferred to agency-lang #809.

## Testing

- `pnpm run typecheck`, `pnpm run lint:structure`, and `make` all green.
- All affected unit/integration test files updated and passing (value layer, sink, sources, IPC recovery, serve adapter/integration, spend schema/clients/renderers/command).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
