### PR TITLE
agency run --model: pick a run's default model on the command line

### DIFF
--- a/packages/agency-lang/docs/dev/config.md
+++ b/packages/agency-lang/docs/dev/config.md
@@ -26,6 +26,47 @@ Where applied: sources 1⊕2 at the CLI (baked into the generated program);
 source 3 at runtime, in the `RuntimeContext` constructor. Inspect the resolved
 result with `agency config show` (secrets masked; `--show-secrets` to reveal).
 
+## What `--model` means
+
+`agency run --model` and the `agency <file>` shorthand set the run's default
+model. The value is parsed by `resolveModelFlag` in `lib/cli/modelFlag.ts` and
+mapped by `applyCliFlags`:
+
+| you write | `client.defaultModel` | `client.defaultProvider` |
+| --- | --- | --- |
+| `gpt-4o-mini` | `gpt-4o-mini` | **deleted** |
+| `anthropic/claude-opus-4-8` | `claude-opus-4-8` | `anthropic` |
+| `openrouter/anthropic/claude-sonnet-4` | `anthropic/claude-sonnet-4` | `openrouter` |
+
+The split is on the **first** slash only, which is what lets an OpenRouter model
+identifier survive as the model name.
+
+Three things about this are easy to get wrong later.
+
+**A bare model deletes the provider rather than leaving it.** The code generator
+emits a provider only when one is configured, so deleting it is how smoltalk is
+allowed to infer the provider from the model name. If your `agency.json` sets
+`defaultProvider` to route through a proxy, a bare `--model` bypasses that
+proxy; name it (`--model litellm/gpt-4o-mini`) to keep it. The mapping deletes
+the key, rather than setting it to `undefined`, because the generator checks for
+presence.
+
+**A stated provider is sticky.** The layers merge field by field
+(`lib/runtime/state/context.ts` `getSmoltalkConfig`), so a provider set by the
+flag survives a later `setModel("other")` in Agency code — the pair becomes that
+provider plus the new model. Code that wants to move provider too must say
+`setLlmOptions({ model, provider })`, or pass both per call. The precedence
+cases in `lib/runtime/agencyLlm.test.ts` pin all four combinations.
+
+**Only a bare name is validated.** It is checked against the hosted **text**
+models from `_listHostedModels()` — not smoltalk's `getAllModels()`, which also
+returns image, embedding and speech models. A prefixed name is never checked,
+because `client.providerModules` can register a provider under any name at
+startup, so at flag-parse time a custom provider and a typo are the same thing.
+The escape for a model missing from the baked catalog is the prefix form; note
+that `agency models refresh` prints JSON to stdout and persists nothing, so it
+cannot affect a later process's validation.
+
 ## All options
 
 ### Basic

--- a/packages/agency-lang/docs/dev/config.md
+++ b/packages/agency-lang/docs/dev/config.md
@@ -43,13 +43,16 @@ identifier survive as the model name.
 
 Three things about this are easy to get wrong later.
 
-**A bare model deletes the provider rather than leaving it.** The code generator
-emits a provider only when one is configured, so deleting it is how smoltalk is
-allowed to infer the provider from the model name. If your `agency.json` sets
-`defaultProvider` to route through a proxy, a bare `--model` bypasses that
-proxy; name it (`--model litellm/gpt-4o-mini`) to keep it. The mapping deletes
-the key, rather than setting it to `undefined`, because the generator checks for
-presence.
+**A bare model drops the provider rather than leaving it.** The code generator
+emits a provider only when `client.defaultProvider` is truthy, so clearing it is
+how smoltalk is allowed to infer the provider from the model name. If your
+`agency.json` sets `defaultProvider` to route through a proxy, a bare `--model`
+bypasses that proxy; name it (`--model litellm/gpt-4o-mini`) to keep it.
+
+The mapping removes the key rather than setting it to `undefined`. Either would
+satisfy the generator; removing it keeps the resolved config free of dangling
+fields, which is what `agency config show` and any other consumer sees. The test
+asserts the key is absent, so that contract cannot drift unnoticed.
 
 **A stated provider is sticky.** The layers merge field by field
 (`lib/runtime/state/context.ts` `getSmoltalkConfig`), so a provider set by the

--- a/packages/agency-lang/docs/superpowers/plans/2026-08-05-run-model-flag-REVIEW-2.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-08-05-run-model-flag-REVIEW-2.md
@@ -1,0 +1,133 @@
+# Re-review: `agency run --model` implementation plan, revision 2
+
+## Recommendation
+
+**One substantive change required.** The revision resolves nearly all findings
+from the first review: it uses only supported commands, fixes Commander's argv
+mode, removes duplicate test files and provider assertions, tests the final
+client configuration, adds the positional-boundary case, and makes the resolver
+catalog fixture deterministic.
+
+Task 6 still substitutes a branch-level provider override for the spec's
+per-call provider override. Those pass through different merge layers, so the
+substitution leaves one documented behavior untested.
+
+## 1. Required: the fourth precedence case must set the provider per call
+
+The spec requires this case:
+
+| baked flag value | Agency call | expected pair |
+| --- | --- | --- |
+| `p/A` | `llm({ model: "B", provider: "q" })` | provider `q`, model B |
+
+Task 6 instead does this:
+
+```ts
+_setLlmOptions({ model: "branch-model", provider: "anthropic" });
+return agency.llm("hi");
+```
+
+That proves a **branch default** replaces the baked provider. It does not prove
+that a **per-call option** replaces a provider from either lower layer. The two
+values enter `runPrompt` through different objects:
+
+```ts
+const clientConfig = ctx.getSmoltalkConfig({
+  ...stackSmolDefaults,
+  ...restClientConfig,
+});
+```
+
+The proposed test would still pass if `restClientConfig.provider` stopped
+overriding `stackSmolDefaults.provider`, which is exactly the regression the
+fourth spec case is meant to detect.
+
+The plan correctly notes that the TypeScript `agency.llm` facade does not expose
+a per-call provider. The answer is not to replace the case with a branch
+override; test the generated-code seam directly through the existing exported
+`runPrompt` function.
+
+**Correction:** import `runPrompt` from `./prompt.js` and make the fourth case:
+
+```ts
+const pair = await effectivePair(
+  { model: "baked-model", provider: "openrouter" },
+  () =>
+    runPrompt({
+      prompt: "hi",
+      messages: agency.thread.current(),
+      clientConfig: {
+        model: "call-model",
+        provider: "anthropic",
+      },
+    }),
+);
+expect(pair).toEqual({
+  model: "call-model",
+  provider: "anthropic",
+});
+```
+
+`effectivePair` already invokes the callback inside `agency.withTestContext`, so
+`agency.thread.current()` resolves the same active test thread. This reaches
+the real per-call `restClientConfig` merge and the existing `RecordingClient`
+observes its final result. Do not expand the `agency.llm` TypeScript API merely
+for this test.
+
+Update the Task 6 background and self-review language as well: after this
+change, the fourth case genuinely tests per-call `{ model, provider }` rather
+than only the `setLlmOptions({ model, provider })` escape.
+
+## 2. Medium: Commander wiring tests should not depend on current catalog names
+
+Task 3 correctly removes catalog-snapshot coupling from the resolver unit tests,
+but Task 4 reintroduces it by requiring `gpt-4o-mini` and
+`claude-opus-4-8` to remain in the real catalog. Its instruction to replace the
+names when retired confirms the test has a maintenance failure mode unrelated
+to what it owns.
+
+The Commander suite is responsible for:
+
+- option registration;
+- turning parser output into `opts.model`;
+- the one-argument adapter;
+- last-value-wins behavior when the flag repeats.
+
+Catalog membership belongs to the resolver and real-binary integration tests.
+
+**Correction:** mock `_listHostedModels()` for `scripts/agency.test.ts` with two
+stable text names and use those bare names in the wiring cases. Keep the
+repeated values bare: the second bare resolution is what makes the adapter test
+load-bearing. If mocking the stdlib module globally would interfere with other
+tests in this large suite, export a narrowly scoped program dependency for the
+model parser or use the real adapter's first two returned names dynamically;
+do not hard-code monthly catalog entries.
+
+This is not a blocker because the current names make the tests function today,
+but deterministic ownership would make the plan internally consistent.
+
+## Resolved from the first review
+
+- Task 7 now drives only `run` and the shorthand; it no longer invents
+  `compile --model` support.
+- The integration cases inspect output from the actual supported commands and
+  test successful execution at the same time.
+- Task 4 now passes user argv correctly with `parseAsync(words, { from:
+  "user" })`.
+- Config, Commander, and runtime tests now extend their existing owning suites
+  rather than creating three unnecessary files.
+- Task 5 adds only the missing model assertion and leaves the two existing
+  provider codegen tests alone.
+- Task 6 observes the final `PromptConfig` through the existing
+  `RecordingClient` rather than testing `getSmoltalkConfig` in isolation.
+- Task 7 proves an invalid bare value fails before compilation.
+- Task 7 covers `--model` after the filename and proves it is forwarded rather
+  than validated by Agency.
+- Resolver default-catalog tests use a stable `_listHostedModels` mock rather
+  than current external catalog membership.
+- The production design remains a clean declarative resolver and config
+  mapping over existing imperative compilation/runtime machinery.
+
+After replacing Task 6's fourth case, the plan covers the promised precedence
+semantics and is ready to implement. Finding 2 can be fixed at the same time
+with a small test-fixture adjustment.

--- a/packages/agency-lang/docs/superpowers/plans/2026-08-05-run-model-flag-REVIEW.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-08-05-run-model-flag-REVIEW.md
@@ -1,0 +1,240 @@
+# Review: `agency run --model` implementation plan
+
+## Recommendation
+
+**Changes requested.** The production architecture is good: a pure resolver
+produces a declarative `ResolvedModelFlag`, `applyCliFlags` remains the single
+configuration mapping boundary, and existing compilation/runtime machinery does
+the imperative work. The plan does not scatter model/provider precedence logic
+through the CLI.
+
+The test plan is not ready, however. Task 7 invokes the flag on a command that
+does not receive it, Task 6 tests only one shallow spread rather than the
+documented precedence path, and Task 4 constructs Commander's argv incorrectly.
+Several proposed test files and codegen cases also duplicate existing suites.
+
+## 1. Blocker: Task 7 uses `agency compile --model`, but the plan adds the flag only to `run`
+
+Task 4 adds `--model` through `addRunOptions`, which is shared by `run` and the
+hidden shorthand command. The standalone `compile` command has its own option
+list and its action forwards only its existing flags to `applyCliFlags`.
+
+These Task 7 commands will therefore fail with “unknown option”:
+
+```bash
+agency compile --model claude-opus-4-8 greet.agency
+agency compile --model openrouter/anthropic/claude-sonnet-4 greet.agency
+```
+
+Adding the flag to `compile` would expand the feature beyond the goal and the
+spec. Do not do that merely to make the tests pass.
+
+**Correction:** exercise the two supported surfaces and inspect the files they
+compile:
+
+1. Run `agency run --model claude-opus-4-8 greet.agency`, then read `greet.js`
+   and assert the new model is present and no literal provider is emitted.
+2. Run the shorthand with the prefixed value,
+   `agency --model openrouter/anthropic/claude-sonnet-4 greet.agency`, then read
+   `greet.js` and assert both model and provider.
+
+These two calls replace the two unsupported compile calls and the two later
+execution-only calls. They prove supported command wiring, successful
+execution, and generated configuration without adding four redundant runs.
+
+## 2. Blocker: Task 6 does not test the precedence behavior promised by the spec
+
+Task 6 calls `RuntimeContext.getSmoltalkConfig()` directly. That proves only
+this existing spread:
+
+```ts
+{ ...this.smoltalkDefaults, ...config }
+```
+
+It does **not** exercise:
+
+- branch defaults written by `setModel` / `_setLlmOptions`;
+- the `stackSmolDefaults` plus per-call merge in `runPrompt`;
+- per-call model/provider precedence;
+- the final configuration delivered to an LLM client.
+
+The plan's self-review acknowledges this reduction but gives the wrong reason.
+`RecordingClient` in `lib/runtime/agencyLlm.test.ts` already records every final
+`PromptConfig`, including both `model` and `provider`. That suite already uses
+the client to verify provider flow. There is no need to settle for testing an
+internal spread.
+
+**Correction:** replace Task 6 with final-client precedence tests in the
+existing `lib/runtime/agencyLlm.test.ts`. Let `makeCtx` accept baked smoltalk
+defaults, install `RecordingClient`, apply branch defaults through
+`_setLlmOptions`, make the prompt call, and assert the recorded pair. Cover all
+four rules from the spec:
+
+| baked defaults | branch defaults | per-call options | final result |
+| --- | --- | --- | --- |
+| `{ model: A }` | `{ model: B }` | none | model B, no provider |
+| `{ model: A, provider: p }` | `{ model: B }` | none | model B, provider p |
+| `{ model: A, provider: p }` | none | `{ model: B }` | model B, provider p |
+| `{ model: A, provider: p }` | none | `{ model: B, provider: q }` | model B, provider q |
+
+Use the runtime prompt path that accepts provider-shaped per-call config. The TS
+`agency.llm` convenience facade does not expose every generated Agency option,
+but `runPrompt` does and is the merge being specified.
+
+This change also removes the proposed `lib/runtime/modelPrecedence.test.ts`.
+
+## 3. High: Task 4 gives Commander the wrong argv shape
+
+The helper proposes:
+
+```ts
+program.parse(["node", "agency", ...words], { from: "user" });
+```
+
+These are two different parsing modes mixed together. With `from: "user"`,
+Commander treats **every** array element as a user argument; it does not remove
+the executable and script entries. Existing tests correctly use either:
+
+```ts
+program.parseAsync(["run", ...], { from: "user" });
+```
+
+or a full `['node', 'agency', ...]` array with the default Node argv mode.
+The proposed form may send `node` through the hidden default command instead of
+testing `run` at all.
+
+**Correction:** make `runOptionsFor` async and use:
+
+```ts
+await program.parseAsync(words, { from: "user" });
+```
+
+Update callers to await it, and use `await expect(...).rejects` for invalid
+model parsing. Keep the repeated-flag case; it correctly proves that the
+one-argument adapter is load-bearing.
+
+## 4. High: Task 5 claims to test `applyCliFlags`, but bypasses it and duplicates existing tests
+
+The codegen helper takes a ready-made `AgencyConfig` and passes it directly to
+`TypeScriptBuilder`. It never invokes `applyCliFlags`, so Task 5 does not
+“consume the `applyCliFlags` mapping” or prove the flag reaches generated code.
+Task 2 tests mapping, and the corrected Task 7 should test the cross-boundary
+path.
+
+Two of Task 5's three cases already exist in
+`smoltalkDefaults.codegen.test.ts`:
+
+- `omits provider when defaultProvider is unset`
+- `bakes provider when defaultProvider is set`
+
+The proposed `not.toContain("provider:")` is also less precise than the
+existing anchored regex because generated output contains unrelated provider
+tokens.
+
+**Correction:** add only the missing assertion that `client.defaultModel` is
+baked. Leave the existing provider cases unchanged and correct Task 5's stated
+interface: it pins existing codegen behavior; it does not test CLI mapping.
+
+## 5. Medium: put tests in the existing behavior-owning suites
+
+The plan creates several narrowly named test files beside suites that already
+own the exact behavior and helpers:
+
+- Append the `applyCliFlags` cases to `lib/config.test.ts`, in its existing
+  `describe("applyCliFlags")` block. Do not create
+  `lib/config.modelFlag.test.ts`.
+- Append the Commander wiring cases to `scripts/agency.test.ts`, which already
+  owns `createProgram` and CLI parsing. Do not create
+  `scripts/agency.modelFlag.test.ts`.
+- Put final-client precedence cases in `lib/runtime/agencyLlm.test.ts`. Do not
+  create `lib/runtime/modelPrecedence.test.ts`.
+
+The new `lib/cli/modelFlag.test.ts` is justified because `modelFlag.ts` is a new
+pure module. A test beside the newly shared `levenshtein.ts` is also reasonable.
+
+While moving the config cases, remove the unnecessary casts in the proposed
+fixtures:
+
+```ts
+return { client: { ... } } as unknown as AgencyConfig;
+applyCliFlags({} as AgencyConfig, ...);
+```
+
+Those objects already satisfy `AgencyConfig`. Casting through `unknown` can
+hide a bad fixture instead of asking TypeScript to verify it.
+
+## 6. Medium: add the new flag's positional-boundary regression test
+
+The design explicitly promises that a `--model` appearing after the filename
+belongs to the Agency program and is not parsed or validated by the CLI:
+
+```bash
+agency run greet.agency --model gpt-4o-mini
+```
+
+Task 4 bypasses `runCli` and its `splitCommandLine` preprocessing. Task 7 uses
+`--model` only before the filename. Existing generic tests use `--max-cost`, but
+they do not prove that the newly registered option is included in the derived
+run-option metadata.
+
+**Correction:** add one real-binary case to Task 7 with `--model` after the
+filename. Assert that:
+
+- output contains `Warning: --model went to your program`;
+- the program's argument parser receives and rejects the unknown flag;
+- Agency does not emit an “Unknown model” validation error.
+
+One explicit `run` case is enough because existing boundary tests already pin
+generic shorthand parity.
+
+## 7. Medium: make the default-catalog resolver test deterministic
+
+Task 3 says injected catalogs keep unit tests independent of whichever models
+ship this month, then adds two tests tied to the current smoltalk snapshot:
+`gpt-image-1` must exist as non-text and `gpt-4o-mini` must exist as text.
+Filtering itself belongs to `_listHostedModels` and is already tested with a
+mock catalog in `lib/stdlib/llm.test.ts`; `modelFlag.ts` consumes its normalized
+result.
+
+**Correction:** mock `_listHostedModels()` in the resolver suite with stable
+hosted text names and use that to prove the resolver's default path calls the
+adapter. Keep one separate, name-agnostic catalog integration test only if the
+existing hosted-catalog integration test does not already cover the wiring. Do
+not make this feature's unit tests depend on external catalog membership.
+
+## Anti-pattern assessment
+
+The planned **production code** avoids the important anti-patterns:
+
+- `ResolvedModelFlag` and `resolveModelFlag` form a small declarative interface
+  over slash parsing, catalog validation, and error construction.
+- `applyCliFlags` remains the sole declarative flag-to-config mapping instead of
+  creating a second imperative merge path in `runWithOptions`.
+- The existing Levenshtein implementation is moved and reused rather than
+  copied.
+- The type lives at the configuration boundary, avoiding a config-to-CLI
+  dependency and runtime cycle.
+
+The **test plan** does contain unnecessary duplication and leaky seam tests:
+Task 5 repeats existing provider assertions, Task 6 tests an internal spread
+instead of the user-visible final client configuration, and three new test
+files split behavior away from existing owning suites. The corrections above
+remove those problems without changing the production design.
+
+## Smallest corrected task structure
+
+1. Share Levenshtein and retain its focused tests.
+2. Add the declarative config type/mapping; extend `config.test.ts`.
+3. Add the pure resolver and its focused, deterministic tests.
+4. Wire the one-argument Commander adapter; extend `agency.test.ts` with the
+   correct argv mode and repeated-value case.
+5. Add only the missing default-model codegen assertion.
+6. Extend `agencyLlm.test.ts` with the four final-client precedence cases.
+7. Test supported `run` and shorthand surfaces end to end, inspect generated
+   output, verify failure-before-compilation, and verify the post-filename
+   boundary.
+8. Add the developer documentation.
+
+After these changes, the plan will test the behavior it claims while keeping
+the declarative production boundary intact and avoiding unnecessary files and
+duplicate assertions.

--- a/packages/agency-lang/docs/superpowers/plans/2026-08-05-run-model-flag.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-08-05-run-model-flag.md
@@ -1,0 +1,1189 @@
+# `agency run --model` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `--model` flag to `agency run` and the bare `agency <file>` shorthand that sets the default model for that run, accepting either a bare model name or `provider/model`.
+
+**Architecture:** A pure resolver turns the flag's text into `{ model, explicitProvider? }`, validating a bare name against the hosted **text** model catalog. Commander runs the resolver as its option parser, so the CLI action receives an already-resolved value, and `applyCliFlags` — the one place that defines what a flag means in configuration terms — maps it onto `client.defaultModel` and `client.defaultProvider`. Everything downstream is existing machinery.
+
+**Tech Stack:** TypeScript, Commander 14, vitest, smoltalk.
+
+**Spec:** `docs/superpowers/specs/2026-08-05-run-model-flag-design.md` (revision 3). Read it before starting — especially "Model and provider are two separate settings", which is the reason this design is shaped the way it is.
+
+## Global Constraints
+
+- **Do not edit `CHANGELOG.md`.** The owner maintains it.
+- **Do not edit anything under `docs/site/**`.** User-facing documentation is out of scope for this change. `docs/dev/**` is in scope and Task 7 updates it.
+- Never commit to `main`. Work happens on the branch this worktree is on (`adit/run-model-flag`).
+- Never force-push or amend commits.
+- Write commit messages to a file and pass it with `git commit -F <file>` — apostrophes and backticks break inline `-m`.
+- Stage named paths, never `git add -A`. This worktree may hold other work.
+- Save every test run's output to a file so a failure does not need a re-run to diagnose. This repo's tests are slow.
+- Do not run the whole test suite. Run only the tests named in each task; CI runs the rest.
+- Run `make` only where a task says to. It is slow, and only the two tasks that need a rebuilt CLI ask for it.
+- Types, not interfaces. Objects, not Maps. Arrays, not Sets. No dynamic imports.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `lib/levenshtein.ts` | **Create.** Edit distance between two strings. Moved out of `builtinGraders.ts` so both callers share one copy. |
+| `lib/levenshtein.test.ts` | **Create.** Tests for the above. |
+| `lib/eval/grading/graders/builtinGraders.ts` | **Modify.** Delete its private `levenshtein` and import the shared one. |
+| `lib/config.ts` | **Modify.** Declare `ResolvedModelFlag`, add `model?: ResolvedModelFlag` to `CliFlags`, and map it in `applyCliFlags`. |
+| `lib/config.modelFlag.test.ts` | **Create.** Tests for the `applyCliFlags` mapping. |
+| `lib/cli/modelFlag.ts` | **Create.** `resolveModelFlag` — parse `provider/model`, validate structure, validate a bare name against the text catalog, build the error message. |
+| `lib/cli/modelFlag.test.ts` | **Create.** Tests for the resolver. |
+| `scripts/agency.ts` | **Modify.** Add the option to `addRunOptions`, behind a one-line adapter. |
+| `scripts/agency.modelFlag.test.ts` | **Create.** Commander wiring test — proves a repeated `--model` takes the last value. |
+| `lib/backends/smoltalkDefaults.codegen.test.ts` | **Modify.** Add cases proving the configuration reaches the generated client block. |
+| `lib/runtime/modelPrecedence.test.ts` | **Create.** Proves a stated provider survives a later model-only override. |
+| `tests/integration/cli/test.mjs` | **Modify.** End-to-end through the real binary, both commands, and the failure-before-compilation case. |
+| `docs/dev/config.md` | **Modify.** Document what `--model` means in configuration terms, beside the other flags. |
+
+Why the resolver and the configuration mapping are separate files: the resolver knows about catalogs, slashes and Commander errors; `applyCliFlags` knows about configuration shape. `lib/config.ts` imports nothing from `lib/cli/`, and this change must not be the first thing to do so — which is why `ResolvedModelFlag` is declared in `config.ts` and the CLI imports it with `import type`.
+
+---
+
+## Task 1: Share the edit-distance function
+
+**Files:**
+- Create: `packages/agency-lang/lib/levenshtein.ts`
+- Create: `packages/agency-lang/lib/levenshtein.test.ts`
+- Modify: `packages/agency-lang/lib/eval/grading/graders/builtinGraders.ts:104-118`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `export function levenshtein(a: string, b: string): number`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/agency-lang/lib/levenshtein.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { levenshtein } from "./levenshtein.js";
+
+describe("levenshtein", () => {
+  it("is zero for identical strings", () => {
+    expect(levenshtein("gpt-4o-mini", "gpt-4o-mini")).toBe(0);
+  });
+
+  it("counts a single inserted character", () => {
+    expect(levenshtein("gpt-4o-mini", "gpt-4o-minii")).toBe(1);
+  });
+
+  it("counts a substitution", () => {
+    expect(levenshtein("cat", "cot")).toBe(1);
+  });
+
+  it("handles an empty string on either side", () => {
+    expect(levenshtein("", "abc")).toBe(3);
+    expect(levenshtein("abc", "")).toBe(3);
+    expect(levenshtein("", "")).toBe(0);
+  });
+
+  it("is symmetric", () => {
+    expect(levenshtein("kitten", "sitting")).toBe(
+      levenshtein("sitting", "kitten"),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and watch it fail**
+
+```bash
+cd packages/agency-lang
+npx vitest run lib/levenshtein.test.ts > /tmp/agency-t1.log 2>&1; tail -20 /tmp/agency-t1.log
+```
+
+Expected: FAIL — cannot resolve `./levenshtein.js`.
+
+- [ ] **Step 3: Create the shared module**
+
+Create `packages/agency-lang/lib/levenshtein.ts` with the body moved verbatim from `builtinGraders.ts`:
+
+```ts
+/** Classic Levenshtein edit distance (deterministic, dependency-free). */
+export function levenshtein(a: string, b: string): number {
+  const cols = b.length + 1;
+  let prev = Array.from({ length: cols }, (_unused, j) => j);
+  for (let i = 1; i <= a.length; i += 1) {
+    const curr = [i];
+    for (let j = 1; j < cols; j += 1) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      curr[j] = Math.min(prev[j] + 1, curr[j - 1] + 1, prev[j - 1] + cost);
+    }
+    prev = curr;
+  }
+  return prev[cols - 1];
+}
+```
+
+- [ ] **Step 4: Delete the private copy and import the shared one**
+
+In `packages/agency-lang/lib/eval/grading/graders/builtinGraders.ts`, delete the whole `function levenshtein(...) { ... }` block (including its doc comment, currently lines 104–118) and add to the imports at the top of the file:
+
+```ts
+import { levenshtein } from "@/levenshtein.js";
+```
+
+Leave every call site unchanged — the name and signature are identical.
+
+- [ ] **Step 5: Run both test files**
+
+```bash
+cd packages/agency-lang
+npx vitest run lib/levenshtein.test.ts lib/eval/grading/graders/ \
+  > /tmp/agency-t1b.log 2>&1; grep -E "Test Files|Tests |FAIL" /tmp/agency-t1b.log
+```
+
+Expected: all PASS. The grader tests exercise the moved function through the `levenshtein` grader, so they are the proof the move did not change behaviour.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/adityabhargava/agency-lang/worktree-model-flag
+mkdir -p .tmp && cat > .tmp/msg.txt <<'EOF'
+refactor: share the levenshtein helper
+
+The --model flag needs edit distance for its "did you mean" suggestion.
+Rather than a second copy, the existing implementation moves out of
+builtinGraders.ts into lib/levenshtein.ts and both callers import it.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+EOF
+git add packages/agency-lang/lib/levenshtein.ts \
+  packages/agency-lang/lib/levenshtein.test.ts \
+  packages/agency-lang/lib/eval/grading/graders/builtinGraders.ts
+git commit -F .tmp/msg.txt && rm -rf .tmp
+```
+
+---
+
+## Task 2: The configuration contract and mapping
+
+**Files:**
+- Modify: `packages/agency-lang/lib/config.ts` (type near `CliFlags` at line 681; mapping inside `applyCliFlags`, which ends with `return next;` at line 755)
+- Create: `packages/agency-lang/lib/config.modelFlag.test.ts`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces:
+  - `export type ResolvedModelFlag = { model: string; explicitProvider?: string }`
+  - `CliFlags` gains `model?: ResolvedModelFlag`
+  - `applyCliFlags(config, flags, input?)` honours `flags.model`
+
+**Background the implementer needs.** `applyCliFlags` folds per-invocation flags onto a **copy** of the configuration and never mutates its input. The established shape for a nested client field is one line, e.g.:
+
+```ts
+if (flags.maxToolResultChars !== undefined) {
+  next.client = { ...next.client, maxToolResultChars: flags.maxToolResultChars };
+}
+```
+
+The model mapping is unusual in one way: a bare model must **remove** `client.defaultProvider` rather than set it. That is deliberate — see the spec's "Provider semantics". With no provider configured, the code generator emits none, and smoltalk infers the provider from the model name.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/agency-lang/lib/config.modelFlag.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { applyCliFlags, type AgencyConfig } from "./config.js";
+
+/** A config with a provider already set, as agency.json might. */
+function configWithProvider(): AgencyConfig {
+  return {
+    client: {
+      defaultModel: "gpt-4o-mini",
+      defaultProvider: "openrouter",
+      providerModules: ["./my-provider.mjs"],
+    },
+  } as unknown as AgencyConfig;
+}
+
+describe("applyCliFlags: --model", () => {
+  it("does nothing when the flag is absent", () => {
+    const before = configWithProvider();
+    const after = applyCliFlags(before, {});
+    expect(after.client?.defaultModel).toBe("gpt-4o-mini");
+    expect(after.client?.defaultProvider).toBe("openrouter");
+  });
+
+  it("a bare model sets the model and clears an inherited provider", () => {
+    const after = applyCliFlags(configWithProvider(), {
+      model: { model: "claude-opus-4-8" },
+    });
+    expect(after.client?.defaultModel).toBe("claude-opus-4-8");
+    expect(after.client?.defaultProvider).toBeUndefined();
+  });
+
+  it("a prefixed model sets both fields", () => {
+    const after = applyCliFlags(configWithProvider(), {
+      model: { model: "my-tune", explicitProvider: "my-company" },
+    });
+    expect(after.client?.defaultModel).toBe("my-tune");
+    expect(after.client?.defaultProvider).toBe("my-company");
+  });
+
+  it("leaves neighbouring client fields alone", () => {
+    const after = applyCliFlags(configWithProvider(), {
+      model: { model: "claude-opus-4-8" },
+    });
+    expect(after.client?.providerModules).toEqual(["./my-provider.mjs"]);
+  });
+
+  it("does not mutate the config it was given", () => {
+    const before = configWithProvider();
+    applyCliFlags(before, { model: { model: "claude-opus-4-8" } });
+    expect(before.client?.defaultModel).toBe("gpt-4o-mini");
+    expect(before.client?.defaultProvider).toBe("openrouter");
+  });
+
+  it("works when the config has no client block at all", () => {
+    const after = applyCliFlags({} as AgencyConfig, {
+      model: { model: "claude-opus-4-8" },
+    });
+    expect(after.client?.defaultModel).toBe("claude-opus-4-8");
+    expect(after.client?.defaultProvider).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests and watch them fail**
+
+```bash
+cd packages/agency-lang
+npx vitest run lib/config.modelFlag.test.ts > /tmp/agency-t2.log 2>&1; tail -25 /tmp/agency-t2.log
+```
+
+Expected: FAIL — TypeScript rejects `model` as a `CliFlags` property, and the assertions do not hold.
+
+- [ ] **Step 3: Declare the type and extend `CliFlags`**
+
+In `packages/agency-lang/lib/config.ts`, immediately **above** `export type CliFlags` (line 681):
+
+```ts
+/**
+ * A `--model` value after parsing. `explicitProvider` is set only when the
+ * user wrote `provider/model`; a bare model leaves it undefined so smoltalk
+ * infers the provider from the model name.
+ *
+ * Declared here rather than in the CLI so `CliFlags` stays self-contained:
+ * `lib/config.ts` must not depend on `lib/cli/`, which would pull the CLI and
+ * the runtime graph behind it into every consumer of the config module.
+ */
+export type ResolvedModelFlag = {
+  model: string;
+  explicitProvider?: string;
+};
+```
+
+Then add the field to `CliFlags`:
+
+```ts
+export type CliFlags = {
+  trace?: string | true;
+  logFile?: string;
+  logStdout?: boolean;
+  observability?: boolean;
+  strict?: boolean;
+  maxToolCallRounds?: number;
+  maxToolResultChars?: number;
+  model?: ResolvedModelFlag;
+};
+```
+
+- [ ] **Step 4: Map it in `applyCliFlags`**
+
+In `packages/agency-lang/lib/config.ts`, immediately before the closing `return next;` of `applyCliFlags` (line 755):
+
+```ts
+  if (flags.model !== undefined) {
+    // A bare model DELETES an inherited provider so smoltalk can infer one
+    // from the model name; a stated provider replaces it. Destructuring is
+    // how the deletion happens without mutating `next.client`.
+    const { defaultProvider: _dropped, ...client } = next.client ?? {};
+    next.client =
+      flags.model.explicitProvider === undefined
+        ? { ...client, defaultModel: flags.model.model }
+        : {
+            ...client,
+            defaultModel: flags.model.model,
+            defaultProvider: flags.model.explicitProvider,
+          };
+  }
+```
+
+Also extend the doc comment above `applyCliFlags` (the list starting `--trace <file>   → ...` at line 694) with two lines:
+
+```
+ *   --model <m>      → client.defaultModel=<m> and client.defaultProvider
+ *                      DELETED, so smoltalk infers the provider
+ *   --model <p>/<m>  → client.defaultModel=<m> + client.defaultProvider=<p>
+```
+
+- [ ] **Step 5: Run the tests and watch them pass**
+
+```bash
+cd packages/agency-lang
+npx vitest run lib/config.modelFlag.test.ts lib/config.test.ts \
+  > /tmp/agency-t2b.log 2>&1; grep -E "Test Files|Tests |FAIL" /tmp/agency-t2b.log
+```
+
+Expected: all PASS. `lib/config.test.ts` is included to prove the existing `applyCliFlags` behaviour is untouched.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/adityabhargava/agency-lang/worktree-model-flag
+mkdir -p .tmp && cat > .tmp/msg.txt <<'EOF'
+feat(config): map a resolved --model onto the client defaults
+
+A bare model sets client.defaultModel and deletes any inherited
+client.defaultProvider, so smoltalk infers the provider from the name.
+A provider/model value sets both.
+
+The deletion matters because the layers merge field by field: a provider
+left in place would survive and route the request somewhere the model
+does not belong.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+EOF
+git add packages/agency-lang/lib/config.ts packages/agency-lang/lib/config.modelFlag.test.ts
+git commit -F .tmp/msg.txt && rm -rf .tmp
+```
+
+---
+
+## Task 3: The resolver
+
+**Files:**
+- Create: `packages/agency-lang/lib/cli/modelFlag.ts`
+- Create: `packages/agency-lang/lib/cli/modelFlag.test.ts`
+
+**Interfaces:**
+- Consumes: `levenshtein` from Task 1; `ResolvedModelFlag` from Task 2.
+- Produces: `export function resolveModelFlag(value: string, catalogNames?: string[]): ResolvedModelFlag`
+
+**Background the implementer needs.**
+
+`InvalidArgumentError` comes from Commander and is the error type Commander recognises: throwing it from an option parser makes Commander print `error: option '--model <name>' argument '<value>' is invalid. <your message>` and exit non-zero. `scripts/agency.ts` already throws it from `parseBoundedInt`.
+
+The catalog is the **hosted text models**. `_listHostedModels()` in `lib/stdlib/llm.ts:104` returns `HostedModelInfo[]` already filtered to `model.type === "text"`. Do not call smoltalk's `getAllModels()` directly: it returns 68 entries of which only 56 are text, and the rest are image, embedding and speech models that would be accepted as chat models and then fail at the first call.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/agency-lang/lib/cli/modelFlag.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { resolveModelFlag } from "./modelFlag.js";
+
+const CATALOG = ["gpt-4o-mini", "gpt-4o", "claude-opus-4-8", "gemini-2.5-pro"];
+
+const resolve = (value: string) => resolveModelFlag(value, CATALOG);
+
+describe("resolveModelFlag: bare names", () => {
+  it("accepts a known model and states no provider", () => {
+    expect(resolve("gpt-4o-mini")).toEqual({ model: "gpt-4o-mini" });
+  });
+
+  it("rejects an unknown name and suggests the closest catalog entry", () => {
+    expect(() => resolve("gpt-4o-minii")).toThrow(/Unknown model "gpt-4o-minii"/);
+    expect(() => resolve("gpt-4o-minii")).toThrow(/Did you mean "gpt-4o-mini"/);
+  });
+
+  it("rejects an unknown name with no near match, and suggests nothing", () => {
+    expect(() => resolve("zzzzzzzzzzzz")).toThrow(/Unknown model/);
+    expect(() => resolve("zzzzzzzzzzzz")).not.toThrow(/Did you mean/);
+  });
+
+  it("names the prefix escape in the error", () => {
+    expect(() => resolve("gpt-4o-minii")).toThrow(/provider\/model/);
+  });
+});
+
+describe("resolveModelFlag: provider prefixes", () => {
+  it("splits on the first slash", () => {
+    expect(resolve("anthropic/claude-opus-4-8")).toEqual({
+      model: "claude-opus-4-8",
+      explicitProvider: "anthropic",
+    });
+  });
+
+  it("keeps every later slash in the model name", () => {
+    expect(resolve("openrouter/anthropic/claude-sonnet-4")).toEqual({
+      model: "anthropic/claude-sonnet-4",
+      explicitProvider: "openrouter",
+    });
+  });
+
+  it("accepts an unknown provider, because provider modules register at runtime", () => {
+    expect(resolve("my-company/my-tune")).toEqual({
+      model: "my-tune",
+      explicitProvider: "my-company",
+    });
+  });
+
+  it("never checks a prefixed model against the catalog", () => {
+    expect(() => resolve("openai/not-a-real-model-at-all")).not.toThrow();
+  });
+});
+
+describe("resolveModelFlag: structurally invalid values", () => {
+  it.each([
+    ["", "empty value"],
+    ["/claude-opus-4-8", "empty provider"],
+    ["anthropic/", "empty model"],
+    ["/", "both empty"],
+  ])("rejects %s (%s)", (value) => {
+    expect(() => resolve(value)).toThrow();
+  });
+});
+
+describe("resolveModelFlag: the default catalog", () => {
+  it("excludes non-text models", () => {
+    // gpt-image-1 is in smoltalk's catalog, but as an image model. Accepting
+    // it here would fail at the first llm() call instead.
+    expect(() => resolveModelFlag("gpt-image-1")).toThrow(/Unknown model/);
+  });
+
+  it("accepts a real text model from the default catalog", () => {
+    expect(resolveModelFlag("gpt-4o-mini")).toEqual({ model: "gpt-4o-mini" });
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests and watch them fail**
+
+```bash
+cd packages/agency-lang
+npx vitest run lib/cli/modelFlag.test.ts > /tmp/agency-t3.log 2>&1; tail -20 /tmp/agency-t3.log
+```
+
+Expected: FAIL — cannot resolve `./modelFlag.js`.
+
+- [ ] **Step 3: Write the resolver**
+
+Create `packages/agency-lang/lib/cli/modelFlag.ts`:
+
+```ts
+import { InvalidArgumentError } from "commander";
+import type { ResolvedModelFlag } from "@/config.js";
+import { levenshtein } from "@/levenshtein.js";
+import { _listHostedModels } from "@/stdlib/llm.js";
+
+/** Suggest a catalog name only when it is this close to what was typed. */
+const SUGGESTION_DISTANCE = 3;
+
+function hostedTextModelNames(): string[] {
+  return _listHostedModels().map((model) => model.name);
+}
+
+/**
+ * Turn a `--model` value into a model and, when the user said one, a provider.
+ *
+ * A slash means a provider was named: everything before the FIRST slash is the
+ * provider, everything after is the model. Splitting on the first slash only is
+ * what lets `openrouter/anthropic/claude-sonnet-4` work — OpenRouter model
+ * identifiers contain a slash of their own.
+ *
+ * A bare name is validated against the hosted text catalog, because that is the
+ * only case where agency has to work the provider out for itself. A prefixed
+ * name is never validated: `client.providerModules` can register a provider
+ * under any name at startup, so at flag-parse time a custom provider and a typo
+ * look identical, and guessing would reject working setups.
+ */
+export function resolveModelFlag(
+  value: string,
+  catalogNames: string[] = hostedTextModelNames(),
+): ResolvedModelFlag {
+  if (value === "") {
+    throw new InvalidArgumentError("No model named.");
+  }
+
+  const slash = value.indexOf("/");
+  if (slash !== -1) {
+    const provider = value.slice(0, slash);
+    const model = value.slice(slash + 1);
+    if (provider === "" || model === "") {
+      throw new InvalidArgumentError(
+        `"${value}" is not a model. Write provider/model, e.g. openrouter/anthropic/claude-sonnet-4.`,
+      );
+    }
+    return { model, explicitProvider: provider };
+  }
+
+  if (catalogNames.includes(value)) {
+    return { model: value };
+  }
+  throw new InvalidArgumentError(unknownModelMessage(value, catalogNames));
+}
+
+function unknownModelMessage(value: string, catalogNames: string[]): string {
+  const lines = [`Unknown model "${value}".`];
+  const suggestion = closestName(value, catalogNames);
+  if (suggestion !== undefined) {
+    lines.push(`Did you mean "${suggestion}"?`);
+  }
+  lines.push(
+    `For a model from another provider, write provider/model — e.g. openrouter/${value}.`,
+    "Run `agency models list` to see the catalog.",
+  );
+  return lines.join("\n  ");
+}
+
+function closestName(
+  value: string,
+  catalogNames: string[],
+): string | undefined {
+  let best: string | undefined;
+  let bestDistance = SUGGESTION_DISTANCE + 1;
+  for (const name of catalogNames) {
+    const distance = levenshtein(value, name);
+    if (distance < bestDistance) {
+      best = name;
+      bestDistance = distance;
+    }
+  }
+  return bestDistance <= SUGGESTION_DISTANCE ? best : undefined;
+}
+```
+
+- [ ] **Step 4: Run the tests and watch them pass**
+
+```bash
+cd packages/agency-lang
+npx vitest run lib/cli/modelFlag.test.ts > /tmp/agency-t3b.log 2>&1; grep -E "Test Files|Tests |FAIL" /tmp/agency-t3b.log
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Typecheck**
+
+```bash
+cd packages/agency-lang
+npx tsc --noEmit -p tsconfig.json 2>&1 | head -10
+```
+
+Expected: no output. If `@/stdlib/llm.js` does not resolve, check the path alias against a neighbouring file's imports rather than switching to a relative path.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/adityabhargava/agency-lang/worktree-model-flag
+mkdir -p .tmp && cat > .tmp/msg.txt <<'EOF'
+feat(cli): resolve a --model value into a model and provider
+
+Splits on the first slash only, so an OpenRouter identifier survives as
+the model name. A bare name is checked against the hosted TEXT catalog;
+a prefixed one never is, because a provider module can register any name
+at startup and a custom provider is indistinguishable from a typo here.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+EOF
+git add packages/agency-lang/lib/cli/modelFlag.ts packages/agency-lang/lib/cli/modelFlag.test.ts
+git commit -F .tmp/msg.txt && rm -rf .tmp
+```
+
+---
+
+## Task 4: Wire the flag into the CLI
+
+**Files:**
+- Modify: `packages/agency-lang/scripts/agency.ts` — the `addRunOptions` function, and the `RunOptions` type at line 132
+- Create: `packages/agency-lang/scripts/agency.modelFlag.test.ts`
+
+**Interfaces:**
+- Consumes: `resolveModelFlag` from Task 3, `ResolvedModelFlag` from Task 2.
+- Produces: `agency run --model <name>` and `agency --model <name> <file>`.
+
+**Background the implementer needs — read this before writing the option.**
+
+Commander calls an option parser with **two** arguments: `(value, previous)`, where `previous` is whatever the parser returned last time the flag appeared. So passing `resolveModelFlag` straight in means that on
+
+```bash
+agency run --model gpt-4o-mini --model claude-opus-4-8 greet.agency
+```
+
+the second call receives the first `ResolvedModelFlag` as its `catalogNames` argument, and the resolver validates against nonsense. The existing parsers dodge this by accident — `parsePositiveInt(value: string)` declares one parameter, so the extra argument is dropped. A resolver with a meaningful second parameter cannot rely on that.
+
+**Wrap it in a one-line adapter.** This is not decoration; Step 1's test fails without it.
+
+`addRunOptions` is shared by `run` and the hidden `default` command (the `agency <file>` shorthand), so one declaration serves both.
+
+- [ ] **Step 1: Write the failing wiring test**
+
+Create `packages/agency-lang/scripts/agency.modelFlag.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { createProgram } from "./agency.js";
+
+/** Parse an argv and hand back the RunOptions the `run` action would see. */
+function runOptionsFor(words: string[]): Record<string, unknown> {
+  const program = createProgram({});
+  const run = program.commands.find((cmd) => cmd.name() === "run");
+  if (run === undefined) throw new Error("no run command");
+  let captured: Record<string, unknown> = {};
+  run.action(() => {
+    captured = run.opts();
+  });
+  program.exitOverride();
+  run.exitOverride();
+  program.parse(["node", "agency", ...words], { from: "user" });
+  return captured;
+}
+
+describe("--model wiring", () => {
+  it("resolves a bare model", () => {
+    const opts = runOptionsFor(["run", "--model", "gpt-4o-mini", "f.agency"]);
+    expect(opts.model).toEqual({ model: "gpt-4o-mini" });
+  });
+
+  it("resolves a prefixed model", () => {
+    const opts = runOptionsFor([
+      "run", "--model", "openrouter/anthropic/claude-sonnet-4", "f.agency",
+    ]);
+    expect(opts.model).toEqual({
+      model: "anthropic/claude-sonnet-4",
+      explicitProvider: "openrouter",
+    });
+  });
+
+  it("takes the last value when the flag is repeated", () => {
+    // Commander passes the PREVIOUS parsed value as the parser's second
+    // argument. Without an adapter, that object lands in `catalogNames`.
+    const opts = runOptionsFor([
+      "run", "--model", "gpt-4o-mini", "--model", "claude-opus-4-8", "f.agency",
+    ]);
+    expect(opts.model).toEqual({ model: "claude-opus-4-8" });
+  });
+
+  it("rejects an unknown bare model", () => {
+    expect(() =>
+      runOptionsFor(["run", "--model", "gpt-4o-minii", "f.agency"]),
+    ).toThrow();
+  });
+});
+```
+
+If `createProgram` is not exported from `scripts/agency.ts`, export it — it is already used this way by `scripts/agency.test.ts`, so check there first.
+
+- [ ] **Step 2: Run the test and watch it fail**
+
+```bash
+cd packages/agency-lang
+npx vitest run scripts/agency.modelFlag.test.ts > /tmp/agency-t4.log 2>&1; tail -20 /tmp/agency-t4.log
+```
+
+Expected: FAIL — `opts.model` is `undefined`, because the option does not exist yet.
+
+- [ ] **Step 3: Add the option**
+
+In `packages/agency-lang/scripts/agency.ts`, add the import beside the other `@/cli/...` imports:
+
+```ts
+import { resolveModelFlag } from "@/cli/modelFlag.js";
+```
+
+Add `model` to the `RunOptions` type (line 132):
+
+```ts
+type RunOptions = Omit<CliFlags, "trace"> & {
+  trace?: boolean;
+  traceFile?: string;
+  resume?: string;
+  policy?: string;
+  approve?: string;
+  reject?: string;
+  interactive?: boolean;
+  maxCost?: string;
+  maxTime?: string;
+};
+```
+
+`CliFlags` already carries `model?: ResolvedModelFlag` from Task 2, so `RunOptions` inherits it and no new field is needed here. Confirm that by reading the type — if `RunOptions` does not spread `CliFlags`, add `model?: ResolvedModelFlag` explicitly and import the type.
+
+Then, inside `addRunOptions`, add the option to the chain:
+
+```ts
+      .option(
+        "--model <name>",
+        "Model for this run's LLM calls, as `model` or `provider/model` (e.g. gpt-4o-mini, openrouter/anthropic/claude-sonnet-4)",
+        // Adapter, not decoration: commander calls a parser with
+        // (value, previous), and `previous` would land in the resolver's
+        // catalogNames parameter when --model is repeated.
+        (value: string) => resolveModelFlag(value),
+      )
+```
+
+- [ ] **Step 4: Run the test and watch it pass**
+
+```bash
+cd packages/agency-lang
+npx vitest run scripts/agency.modelFlag.test.ts scripts/agency.test.ts \
+  > /tmp/agency-t4b.log 2>&1; grep -E "Test Files|Tests |FAIL" /tmp/agency-t4b.log
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Prove the adapter is load-bearing**
+
+Temporarily change the option's parser from `(value: string) => resolveModelFlag(value)` to `resolveModelFlag`, re-run only the repeated-flag test, and confirm it FAILS. Then put the adapter back and confirm it passes again.
+
+```bash
+cd packages/agency-lang
+npx vitest run scripts/agency.modelFlag.test.ts -t "repeated" \
+  > /tmp/agency-t4c.log 2>&1; grep -E "Tests |FAIL" /tmp/agency-t4c.log
+```
+
+A test that passes either way is not a test. Do not skip this step.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/adityabhargava/agency-lang/worktree-model-flag
+mkdir -p .tmp && cat > .tmp/msg.txt <<'EOF'
+feat(cli): agency run --model, and the shorthand too
+
+The option goes on addRunOptions, which `run` and the bare
+`agency <file>` shorthand already share, so one declaration serves both.
+
+The parser is wrapped in an adapter because commander calls a parser
+with (value, previous): passing the resolver directly would hand the
+previously parsed object to its catalogNames parameter whenever --model
+appears twice.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+EOF
+git add packages/agency-lang/scripts/agency.ts packages/agency-lang/scripts/agency.modelFlag.test.ts
+git commit -F .tmp/msg.txt && rm -rf .tmp
+```
+
+---
+
+## Task 5: Prove the configuration reaches the generated program
+
+**Files:**
+- Modify: `packages/agency-lang/lib/backends/smoltalkDefaults.codegen.test.ts`
+
+**Interfaces:**
+- Consumes: the `applyCliFlags` mapping from Task 2.
+- Produces: nothing for later tasks.
+
+**Background the implementer needs.** The compiler writes the smoltalk client configuration into the generated JavaScript. `lib/backends/typescriptBuilder.ts:4413` emits `model: <string>` always, and emits `provider: <string>` **only when `client.defaultProvider` is set** — the comment there says it leaves it unset otherwise so smoltalk's model-to-provider lookup still applies. That conditional is exactly what the bare-model rule depends on, so it is worth pinning.
+
+This file already has a `generate(source, config)` helper that runs the parser, preprocessor and builder and returns the printed TypeScript.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to the `describe("smoltalkDefaults codegen", ...)` block in `packages/agency-lang/lib/backends/smoltalkDefaults.codegen.test.ts`:
+
+```ts
+  it("bakes client.defaultModel into the generated client config", () => {
+    const out = generate(PROGRAM, { client: { defaultModel: "claude-opus-4-8" } });
+    expect(out).toContain('model: "claude-opus-4-8"');
+  });
+
+  it("emits no provider when none is configured, so smoltalk infers one", () => {
+    const out = generate(PROGRAM, { client: { defaultModel: "claude-opus-4-8" } });
+    expect(out).not.toContain("provider:");
+  });
+
+  it("bakes both when a provider is configured", () => {
+    const out = generate(PROGRAM, {
+      client: {
+        defaultModel: "anthropic/claude-sonnet-4",
+        defaultProvider: "openrouter",
+      },
+    });
+    expect(out).toContain('model: "anthropic/claude-sonnet-4"');
+    expect(out).toContain('provider: "openrouter"');
+  });
+```
+
+- [ ] **Step 2: Run the tests**
+
+```bash
+cd packages/agency-lang
+npx vitest run lib/backends/smoltalkDefaults.codegen.test.ts \
+  > /tmp/agency-t5.log 2>&1; grep -E "Test Files|Tests |FAIL" /tmp/agency-t5.log
+```
+
+Expected: all PASS immediately — this is existing behaviour being pinned, not new behaviour. If the second case fails because `provider:` appears for an unrelated reason, tighten the assertion to `expect(out).not.toContain('provider: "')` and note why in a comment.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/adityabhargava/agency-lang/worktree-model-flag
+mkdir -p .tmp && cat > .tmp/msg.txt <<'EOF'
+test(codegen): pin the model and provider baked into the client config
+
+The bare-model rule depends on the code generator emitting no provider
+when none is configured, so smoltalk infers one from the model name.
+That conditional had no test.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+EOF
+git add packages/agency-lang/lib/backends/smoltalkDefaults.codegen.test.ts
+git commit -F .tmp/msg.txt && rm -rf .tmp
+```
+
+---
+
+## Task 6: Prove a stated provider is sticky
+
+**Files:**
+- Create: `packages/agency-lang/lib/runtime/modelPrecedence.test.ts`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks — this pins existing runtime behaviour the design depends on.
+- Produces: nothing for later tasks.
+
+**Background the implementer needs.** The spec's central claim is that model and provider merge **independently**, so a provider set by a lower layer survives a higher layer that changes only the model. Two places do that merging:
+
+- `lib/runtime/state/context.ts:763` — `getSmoltalkConfig(config)` returns `{ ...this.smoltalkDefaults, ...config }`
+- `lib/runtime/prompt.ts:1026` — `ctx.getSmoltalkConfig({ ...stackSmolDefaults, ...restClientConfig })`
+
+If someone later "fixes" either into a merge that clears the provider when the model changes, the sticky-provider rule this feature documents silently stops holding. Nothing in the suite would notice. That is what this test is for.
+
+Note this test does **not** make an LLM call. The deterministic mock client reports `model: "deterministic"` in its result and does not expose the incoming model, so an end-to-end assertion is not available; the merge functions are the real mechanism and are tested directly.
+
+`lib/runtime/configOverrides.test.ts:159` shows how to construct a `RuntimeContext` in a test — copy its construction shape rather than inventing one.
+
+- [ ] **Step 1: Write the test**
+
+Create `packages/agency-lang/lib/runtime/modelPrecedence.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { RuntimeContext } from "./state/context.js";
+
+/**
+ * A context whose baked defaults are what `--model openrouter/foo` would
+ * produce: both a model and a provider.
+ */
+function contextWithBakedPair() {
+  return new RuntimeContext({
+    smoltalkDefaults: { model: "foo", provider: "openrouter" },
+  } as never);
+}
+
+describe("model and provider merge independently", () => {
+  it("keeps a baked provider when only the model is overridden", () => {
+    const ctx = contextWithBakedPair();
+    // What `setModel("claude-opus-4-8")` contributes: the model alone.
+    const merged = ctx.getSmoltalkConfig({ model: "claude-opus-4-8" });
+    expect(merged.model).toBe("claude-opus-4-8");
+    expect(merged.provider).toBe("openrouter");
+  });
+
+  it("replaces the provider when the caller supplies one", () => {
+    const ctx = contextWithBakedPair();
+    const merged = ctx.getSmoltalkConfig({
+      model: "claude-opus-4-8",
+      provider: "anthropic",
+    });
+    expect(merged.model).toBe("claude-opus-4-8");
+    expect(merged.provider).toBe("anthropic");
+  });
+
+  it("leaves the provider unset when nothing baked one", () => {
+    const ctx = new RuntimeContext({
+      smoltalkDefaults: { model: "gpt-4o-mini" },
+    } as never);
+    const merged = ctx.getSmoltalkConfig({ model: "claude-opus-4-8" });
+    expect(merged.provider).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test**
+
+```bash
+cd packages/agency-lang
+npx vitest run lib/runtime/modelPrecedence.test.ts \
+  > /tmp/agency-t6.log 2>&1; grep -E "Test Files|Tests |FAIL" /tmp/agency-t6.log
+```
+
+Expected: all PASS — this pins behaviour that already exists. If the `RuntimeContext` constructor rejects that argument shape, open `lib/runtime/configOverrides.test.ts` around line 159 and copy the fields it passes, keeping `smoltalkDefaults` as above.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/adityabhargava/agency-lang/worktree-model-flag
+mkdir -p .tmp && cat > .tmp/msg.txt <<'EOF'
+test(runtime): pin that model and provider merge independently
+
+The --model design depends on a stated provider surviving a later
+model-only override, which follows from getSmoltalkConfig being a
+shallow spread. Nothing tested that, so a later merge change would break
+the documented rule in silence.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+EOF
+git add packages/agency-lang/lib/runtime/modelPrecedence.test.ts
+git commit -F .tmp/msg.txt && rm -rf .tmp
+```
+
+---
+
+## Task 7: End-to-end through the real binary
+
+**Files:**
+- Modify: `packages/agency-lang/tests/integration/cli/test.mjs`
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: nothing for later tasks.
+
+**Background the implementer needs.** This suite installs a packed tarball into a temporary project and drives the installed `agency` binary. It makes **no LLM calls**, so the assertions are on compiled output and exit status, not on a completed request.
+
+Use `./node_modules/.bin/agency`, never `npx agency` — npx consumes `--`, and this suite already documents that. The `run(dir, cmd, { expectFail: true })` helper returns combined output for a command expected to exit non-zero.
+
+`make` must be run before packing, or the tarball ships a stale CLI.
+
+- [ ] **Step 1: Add the test cases**
+
+In `packages/agency-lang/tests/integration/cli/test.mjs`, immediately before the line `console.log("Test 8 passed");`, insert:
+
+```js
+  // --- --model reaches the compiled program ---
+  // An agency.json with a provider already set, so the bare-model case has
+  // something to clear. Without this the "no provider" assertion could pass
+  // for the wrong reason.
+  writeFile(dir, "agency.json", JSON.stringify({
+    client: { defaultModel: "gpt-4o-mini", defaultProvider: "openrouter" },
+  }, null, 2));
+
+  // A bare model replaces the model AND drops the inherited provider, so
+  // smoltalk infers one from the name.
+  run(dir, "./node_modules/.bin/agency compile --model claude-opus-4-8 greet.agency");
+  const bareOut = readFileSync(join(dir, "greet.js"), "utf-8");
+  assertIncludes(bareOut, 'model: "claude-opus-4-8"');
+  if (bareOut.includes('provider: "')) {
+    throw new Error("a bare --model left a provider in the generated config");
+  }
+
+  // A prefixed model sets both.
+  run(dir, "./node_modules/.bin/agency compile --model openrouter/anthropic/claude-sonnet-4 greet.agency");
+  const prefixedOut = readFileSync(join(dir, "greet.js"), "utf-8");
+  assertIncludes(prefixedOut, 'model: "anthropic/claude-sonnet-4"');
+  assertIncludes(prefixedOut, 'provider: "openrouter"');
+
+  // The flag works on `run` and on the shorthand, which share addRunOptions.
+  const modelRun = run(dir, "./node_modules/.bin/agency run --model claude-opus-4-8 greet.agency --name alice");
+  assertIncludes(modelRun, "Hello, alice!");
+  const modelShorthand = run(dir, "./node_modules/.bin/agency --model claude-opus-4-8 greet.agency --name alice");
+  assertIncludes(modelShorthand, "Hello, alice!");
+
+  // An unknown bare model fails BEFORE compiling. Deleting the output first
+  // and asserting it was never recreated is what proves the ordering — a test
+  // that only checked the message would pass even if validation ran last.
+  rmSync(join(dir, "greet.js"), { force: true });
+  const badModel = run(
+    dir,
+    "./node_modules/.bin/agency run --model gpt-4o-minii greet.agency 2>&1",
+    { expectFail: true },
+  );
+  assertIncludes(badModel, 'Unknown model "gpt-4o-minii"');
+  assertIncludes(badModel, 'Did you mean "gpt-4o-mini"');
+  if (badModel.includes("    at ")) {
+    throw new Error(`an unknown model printed a stack trace: ${badModel}`);
+  }
+  if (existsSync(join(dir, "greet.js"))) {
+    throw new Error("compilation happened despite an invalid --model");
+  }
+
+  // Leave no agency.json behind for the later cases in this file.
+  rmSync(join(dir, "agency.json"), { force: true });
+```
+
+Extend the `node:fs` import at the top of the file to cover the helpers used above:
+
+```js
+import { readFileSync, existsSync, rmSync } from "node:fs";
+```
+
+- [ ] **Step 2: Build and run the suite**
+
+```bash
+cd packages/agency-lang
+make > /tmp/agency-t7-make.log 2>&1; echo "make=$?"
+npm pack > /tmp/agency-t7-pack.log 2>&1
+node tests/integration/cli/test.mjs ./agency-lang-*.tgz > /tmp/agency-t7.log 2>&1; echo "cli=$?"
+rm -f agency-lang-*.tgz
+tail -30 /tmp/agency-t7.log
+```
+
+Expected: `make=0`, `cli=0`, and the suite ends with `=== All CLI tests passed ===`.
+
+If the bare-model case fails because `greet.js` already existed from an earlier case in the file, add `rmSync(join(dir, "greet.js"), { force: true });` before the first compile as well.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/adityabhargava/agency-lang/worktree-model-flag
+mkdir -p .tmp && cat > .tmp/msg.txt <<'EOF'
+test(cli): --model end to end, on run and the shorthand
+
+Starts from an agency.json that already names a provider, so the
+bare-model case has something to clear and cannot pass for the wrong
+reason. The invalid-model case deletes the output first and asserts it
+was never written, which is what proves validation runs before
+compilation rather than after it.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+EOF
+git add packages/agency-lang/tests/integration/cli/test.mjs
+git commit -F .tmp/msg.txt && rm -rf .tmp
+```
+
+---
+
+## Task 8: Developer documentation
+
+**Files:**
+- Modify: `packages/agency-lang/docs/dev/config.md`
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: nothing.
+
+**Background the implementer needs.** `docs/dev/config.md` documents `AgencyConfig` and has a "Config resolution (single source of truth)" section at line 9 listing sources in increasing precedence. That is where a reader goes to find out what a flag means in configuration terms, so that is where this belongs. Do not touch `docs/site/**`.
+
+- [ ] **Step 1: Add the section**
+
+In `packages/agency-lang/docs/dev/config.md`, after the "Config resolution (single source of truth)" section, add:
+
+```markdown
+## What `--model` means
+
+`agency run --model` and the `agency <file>` shorthand set the run's default
+model. The value is parsed by `resolveModelFlag` in `lib/cli/modelFlag.ts` and
+mapped by `applyCliFlags`:
+
+| you write | `client.defaultModel` | `client.defaultProvider` |
+| --- | --- | --- |
+| `gpt-4o-mini` | `gpt-4o-mini` | **deleted** |
+| `anthropic/claude-opus-4-8` | `claude-opus-4-8` | `anthropic` |
+| `openrouter/anthropic/claude-sonnet-4` | `anthropic/claude-sonnet-4` | `openrouter` |
+
+Three things about this are easy to get wrong later.
+
+**A bare model deletes the provider rather than leaving it.** The code generator
+emits a provider only when one is configured, so deleting it is how smoltalk is
+allowed to infer the provider from the model name. If your `agency.json` sets
+`defaultProvider` to route through a proxy, a bare `--model` bypasses that
+proxy; name it (`--model litellm/gpt-4o-mini`) to keep it.
+
+**A stated provider is sticky.** The layers merge field by field
+(`lib/runtime/state/context.ts:763`), so a provider set by the flag survives a
+later `setModel("other")` in Agency code — the pair becomes that provider plus
+the new model. Code that wants to move provider too must say
+`setLlmOptions({ model, provider })`. `lib/runtime/modelPrecedence.test.ts` pins
+this.
+
+**Only a bare name is validated.** It is checked against the hosted **text**
+models from `_listHostedModels()` — not smoltalk's `getAllModels()`, which also
+returns image, embedding and speech models. A prefixed name is never checked,
+because `client.providerModules` can register a provider under any name at
+startup, so at flag-parse time a custom provider and a typo are the same thing.
+```
+
+- [ ] **Step 2: Check the surrounding document still reads in order**
+
+```bash
+cd packages/agency-lang
+grep -n "^#" docs/dev/config.md
+```
+
+Expected: the new `## What --model means` heading sits after "Config resolution" and before "All options".
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/adityabhargava/agency-lang/worktree-model-flag
+mkdir -p .tmp && cat > .tmp/msg.txt <<'EOF'
+docs(dev): what --model means in config terms
+
+Records the three things a later change is most likely to get wrong: a
+bare model deletes the provider, a stated provider is sticky under a
+model-only override, and only bare names are validated.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+EOF
+git add packages/agency-lang/docs/dev/config.md
+git commit -F .tmp/msg.txt && rm -rf .tmp
+```
+
+---
+
+## Finishing up
+
+- [ ] **Run every test this change touches, in one go**
+
+```bash
+cd packages/agency-lang
+npx vitest run \
+  lib/levenshtein.test.ts \
+  lib/config.modelFlag.test.ts \
+  lib/config.test.ts \
+  lib/cli/modelFlag.test.ts \
+  lib/eval/grading/graders/ \
+  scripts/agency.modelFlag.test.ts \
+  scripts/agency.test.ts \
+  lib/backends/smoltalkDefaults.codegen.test.ts \
+  lib/runtime/modelPrecedence.test.ts \
+  > /tmp/agency-final.log 2>&1
+grep -E "Test Files|Tests |FAIL" /tmp/agency-final.log
+```
+
+Expected: all PASS. If anything fails, read `/tmp/agency-final.log` rather than re-running.
+
+- [ ] **Run the structural linter**
+
+```bash
+cd packages/agency-lang
+pnpm run lint:structure > /tmp/agency-lint.log 2>&1; echo "lint=$?"; tail -20 /tmp/agency-lint.log
+```
+
+- [ ] **Audit the diff against the anti-patterns list**
+
+Read `docs/dev/anti-patterns.md`, then read your own diff:
+
+```bash
+cd /Users/adityabhargava/agency-lang/worktree-model-flag
+git diff $(git merge-base HEAD origin/main) --stat
+git diff $(git merge-base HEAD origin/main)
+```
+
+Use `git merge-base`, not `origin/main` directly — main moves.
+
+- [ ] **Push and open a PR**
+
+```bash
+cd /Users/adityabhargava/agency-lang/worktree-model-flag
+git push -u origin adit/run-model-flag
+```
+
+Write the PR body to a file and pass it with `gh pr create --body-file`. Cover: what the flag does with an example of each form; that a bare model clears an inherited provider and why; that a stated provider is sticky; that only bare names are validated and the prefix is the escape; and the `--trace`-style note that `agency models refresh` is not an escape because it persists nothing.
+
+**Open the PR and stop.** The owner squash-merges every PR; do not run `gh pr merge`.
+
+---
+
+## Self-review notes
+
+Checked against the spec, revision 3:
+
+- **Every spec section has a task.** Reading the value → Task 3. Provider semantics → Tasks 2 and 6. Validation, both structural and catalog → Task 3. Suggestions → Tasks 1 and 3. Dataflow and the Commander adapter → Task 4. The `ResolvedModelFlag` location → Task 2. The codegen effect → Task 5. Integration coverage → Task 7. Documentation → Task 8.
+- **The spec's test list is covered**, with one deliberate substitution: the spec asked for an Agency execution test observing `{ model, provider }` for four flag-and-code combinations. The deterministic mock client reports `model: "deterministic"` and does not expose the incoming model, so that observation is not available end to end. Task 6 tests the merge functions directly instead, and Task 7 covers the flag-to-codegen half. The seam left untested is "generated JavaScript values become `smoltalkDefaults`", which is pre-existing behaviour this change does not touch. **This is a real reduction in coverage from what the spec asked for and should be raised in the PR description** rather than passed off as equivalent.
+- **Names are consistent across tasks**: `ResolvedModelFlag` (Task 2, used in 3 and 4), `resolveModelFlag` (Task 3, used in 4), `levenshtein` (Task 1, used in 3), `explicitProvider` throughout.
+- **Two steps ask the implementer to watch a test fail on purpose** — Task 4 Step 5 in particular, which temporarily removes the adapter. That step exists because the repeated-flag test is the only thing standing between this design and a bug that unit tests structurally cannot see.

--- a/packages/agency-lang/docs/superpowers/plans/2026-08-05-run-model-flag.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-08-05-run-model-flag.md
@@ -33,15 +33,19 @@
 | `lib/levenshtein.test.ts` | **Create.** Tests for the above. |
 | `lib/eval/grading/graders/builtinGraders.ts` | **Modify.** Delete its private `levenshtein` and import the shared one. |
 | `lib/config.ts` | **Modify.** Declare `ResolvedModelFlag`, add `model?: ResolvedModelFlag` to `CliFlags`, and map it in `applyCliFlags`. |
-| `lib/config.modelFlag.test.ts` | **Create.** Tests for the `applyCliFlags` mapping. |
+| `lib/config.test.ts` | **Modify.** Add cases to its existing `describe("applyCliFlags")` block at line 184. |
 | `lib/cli/modelFlag.ts` | **Create.** `resolveModelFlag` — parse `provider/model`, validate structure, validate a bare name against the text catalog, build the error message. |
 | `lib/cli/modelFlag.test.ts` | **Create.** Tests for the resolver. |
 | `scripts/agency.ts` | **Modify.** Add the option to `addRunOptions`, behind a one-line adapter. |
-| `scripts/agency.modelFlag.test.ts` | **Create.** Commander wiring test — proves a repeated `--model` takes the last value. |
+| `scripts/agency.test.ts` | **Modify.** Add Commander wiring cases; it already owns `createProgram` and CLI parsing. |
 | `lib/backends/smoltalkDefaults.codegen.test.ts` | **Modify.** Add cases proving the configuration reaches the generated client block. |
-| `lib/runtime/modelPrecedence.test.ts` | **Create.** Proves a stated provider survives a later model-only override. |
+| `lib/runtime/agencyLlm.test.ts` | **Modify.** Add four precedence cases observing the final client config via the existing `RecordingClient`. |
 | `tests/integration/cli/test.mjs` | **Modify.** End-to-end through the real binary, both commands, and the failure-before-compilation case. |
 | `docs/dev/config.md` | **Modify.** Document what `--model` means in configuration terms, beside the other flags. |
+
+Tests live in the suites that already own the behaviour rather than in new
+narrowly named files. Only `lib/cli/modelFlag.test.ts` and
+`lib/levenshtein.test.ts` are new, because their modules are new.
 
 Why the resolver and the configuration mapping are separate files: the resolver knows about catalogs, slashes and Commander errors; `applyCliFlags` knows about configuration shape. `lib/config.ts` imports nothing from `lib/cli/`, and this change must not be the first thing to do so — which is why `ResolvedModelFlag` is declared in `config.ts` and the CLI imports it with `import type`.
 
@@ -168,7 +172,7 @@ git commit -F .tmp/msg.txt && rm -rf .tmp
 
 **Files:**
 - Modify: `packages/agency-lang/lib/config.ts` (type near `CliFlags` at line 681; mapping inside `applyCliFlags`, which ends with `return next;` at line 755)
-- Create: `packages/agency-lang/lib/config.modelFlag.test.ts`
+- Modify: `packages/agency-lang/lib/config.test.ts` — the existing `describe("applyCliFlags")` block at line 184
 
 **Interfaces:**
 - Consumes: nothing from earlier tasks.
@@ -189,76 +193,79 @@ The model mapping is unusual in one way: a bare model must **remove** `client.de
 
 - [ ] **Step 1: Write the failing tests**
 
-Create `packages/agency-lang/lib/config.modelFlag.test.ts`:
+Append these to the existing `describe("applyCliFlags", ...)` block in
+`packages/agency-lang/lib/config.test.ts` (line 184). Do not create a new file —
+that block already owns this behaviour and its helpers.
+
+Note the fixtures need no casts: these objects already satisfy `AgencyConfig`,
+and casting through `unknown` would hide a bad fixture instead of asking
+TypeScript to check it.
 
 ```ts
-import { describe, expect, it } from "vitest";
-import { applyCliFlags, type AgencyConfig } from "./config.js";
+  describe("--model", () => {
+    /** A config with a provider already set, as agency.json might. */
+    function configWithProvider(): AgencyConfig {
+      return {
+        client: {
+          defaultModel: "gpt-4o-mini",
+          defaultProvider: "openrouter",
+          providerModules: ["./my-provider.mjs"],
+        },
+      };
+    }
 
-/** A config with a provider already set, as agency.json might. */
-function configWithProvider(): AgencyConfig {
-  return {
-    client: {
-      defaultModel: "gpt-4o-mini",
-      defaultProvider: "openrouter",
-      providerModules: ["./my-provider.mjs"],
-    },
-  } as unknown as AgencyConfig;
-}
-
-describe("applyCliFlags: --model", () => {
-  it("does nothing when the flag is absent", () => {
-    const before = configWithProvider();
-    const after = applyCliFlags(before, {});
-    expect(after.client?.defaultModel).toBe("gpt-4o-mini");
-    expect(after.client?.defaultProvider).toBe("openrouter");
-  });
-
-  it("a bare model sets the model and clears an inherited provider", () => {
-    const after = applyCliFlags(configWithProvider(), {
-      model: { model: "claude-opus-4-8" },
+    it("does nothing when the flag is absent", () => {
+      const after = applyCliFlags(configWithProvider(), {});
+      expect(after.client?.defaultModel).toBe("gpt-4o-mini");
+      expect(after.client?.defaultProvider).toBe("openrouter");
     });
-    expect(after.client?.defaultModel).toBe("claude-opus-4-8");
-    expect(after.client?.defaultProvider).toBeUndefined();
-  });
 
-  it("a prefixed model sets both fields", () => {
-    const after = applyCliFlags(configWithProvider(), {
-      model: { model: "my-tune", explicitProvider: "my-company" },
+    it("a bare model sets the model and clears an inherited provider", () => {
+      const after = applyCliFlags(configWithProvider(), {
+        model: { model: "claude-opus-4-8" },
+      });
+      expect(after.client?.defaultModel).toBe("claude-opus-4-8");
+      expect(after.client?.defaultProvider).toBeUndefined();
     });
-    expect(after.client?.defaultModel).toBe("my-tune");
-    expect(after.client?.defaultProvider).toBe("my-company");
-  });
 
-  it("leaves neighbouring client fields alone", () => {
-    const after = applyCliFlags(configWithProvider(), {
-      model: { model: "claude-opus-4-8" },
+    it("a prefixed model sets both fields", () => {
+      const after = applyCliFlags(configWithProvider(), {
+        model: { model: "my-tune", explicitProvider: "my-company" },
+      });
+      expect(after.client?.defaultModel).toBe("my-tune");
+      expect(after.client?.defaultProvider).toBe("my-company");
     });
-    expect(after.client?.providerModules).toEqual(["./my-provider.mjs"]);
-  });
 
-  it("does not mutate the config it was given", () => {
-    const before = configWithProvider();
-    applyCliFlags(before, { model: { model: "claude-opus-4-8" } });
-    expect(before.client?.defaultModel).toBe("gpt-4o-mini");
-    expect(before.client?.defaultProvider).toBe("openrouter");
-  });
-
-  it("works when the config has no client block at all", () => {
-    const after = applyCliFlags({} as AgencyConfig, {
-      model: { model: "claude-opus-4-8" },
+    it("leaves neighbouring client fields alone", () => {
+      const after = applyCliFlags(configWithProvider(), {
+        model: { model: "claude-opus-4-8" },
+      });
+      expect(after.client?.providerModules).toEqual(["./my-provider.mjs"]);
     });
-    expect(after.client?.defaultModel).toBe("claude-opus-4-8");
-    expect(after.client?.defaultProvider).toBeUndefined();
+
+    it("does not mutate the config it was given", () => {
+      const before = configWithProvider();
+      applyCliFlags(before, { model: { model: "claude-opus-4-8" } });
+      expect(before.client?.defaultModel).toBe("gpt-4o-mini");
+      expect(before.client?.defaultProvider).toBe("openrouter");
+    });
+
+    it("works when the config has no client block at all", () => {
+      const after = applyCliFlags({}, { model: { model: "claude-opus-4-8" } });
+      expect(after.client?.defaultModel).toBe("claude-opus-4-8");
+      expect(after.client?.defaultProvider).toBeUndefined();
+    });
   });
-});
 ```
+
+If `AgencyConfig` requires fields these fixtures omit, add only what the
+compiler demands — do not reach for a cast.
 
 - [ ] **Step 2: Run the tests and watch them fail**
 
 ```bash
 cd packages/agency-lang
-npx vitest run lib/config.modelFlag.test.ts > /tmp/agency-t2.log 2>&1; tail -25 /tmp/agency-t2.log
+npx vitest run lib/config.test.ts > /tmp/agency-t2.log 2>&1; tail -25 /tmp/agency-t2.log
 ```
 
 Expected: FAIL — TypeScript rejects `model` as a `CliFlags` property, and the assertions do not hold.
@@ -331,11 +338,10 @@ Also extend the doc comment above `applyCliFlags` (the list starting `--trace <f
 
 ```bash
 cd packages/agency-lang
-npx vitest run lib/config.modelFlag.test.ts lib/config.test.ts \
-  > /tmp/agency-t2b.log 2>&1; grep -E "Test Files|Tests |FAIL" /tmp/agency-t2b.log
+npx vitest run lib/config.test.ts > /tmp/agency-t2b.log 2>&1; grep -E "Test Files|Tests |FAIL" /tmp/agency-t2b.log
 ```
 
-Expected: all PASS. `lib/config.test.ts` is included to prove the existing `applyCliFlags` behaviour is untouched.
+Expected: all PASS — the new cases and every pre-existing `applyCliFlags` case, which together prove the mapping was added without disturbing the others.
 
 - [ ] **Step 6: Commit**
 
@@ -354,7 +360,7 @@ does not belong.
 
 Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
 EOF
-git add packages/agency-lang/lib/config.ts packages/agency-lang/lib/config.modelFlag.test.ts
+git add packages/agency-lang/lib/config.ts packages/agency-lang/lib/config.test.ts
 git commit -F .tmp/msg.txt && rm -rf .tmp
 ```
 
@@ -381,7 +387,7 @@ The catalog is the **hosted text models**. `_listHostedModels()` in `lib/stdlib/
 Create `packages/agency-lang/lib/cli/modelFlag.test.ts`:
 
 ```ts
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { resolveModelFlag } from "./modelFlag.js";
 
 const CATALOG = ["gpt-4o-mini", "gpt-4o", "claude-opus-4-8", "gemini-2.5-pro"];
@@ -446,15 +452,29 @@ describe("resolveModelFlag: structurally invalid values", () => {
   });
 });
 
+// The default catalog comes from `_listHostedModels()`. Mock it rather than
+// asserting on real model names: which models ship changes month to month, and
+// a test that breaks when a catalog is refreshed is a test nobody trusts. The
+// text-only filtering belongs to `_listHostedModels` and is already covered in
+// `lib/stdlib/llm.test.ts`; what matters here is that the resolver asks it.
+vi.mock("@/stdlib/llm.js", () => ({
+  _listHostedModels: () => [
+    { name: "catalog-model-one", provider: "openai" },
+    { name: "catalog-model-two", provider: "anthropic" },
+  ],
+}));
+
 describe("resolveModelFlag: the default catalog", () => {
-  it("excludes non-text models", () => {
-    // gpt-image-1 is in smoltalk's catalog, but as an image model. Accepting
-    // it here would fail at the first llm() call instead.
-    expect(() => resolveModelFlag("gpt-image-1")).toThrow(/Unknown model/);
+  it("accepts a name the adapter returns", () => {
+    expect(resolveModelFlag("catalog-model-one")).toEqual({
+      model: "catalog-model-one",
+    });
   });
 
-  it("accepts a real text model from the default catalog", () => {
-    expect(resolveModelFlag("gpt-4o-mini")).toEqual({ model: "gpt-4o-mini" });
+  it("rejects a name the adapter does not return", () => {
+    expect(() => resolveModelFlag("catalog-model-three")).toThrow(
+      /Unknown model/,
+    );
   });
 });
 ```
@@ -597,7 +617,7 @@ git commit -F .tmp/msg.txt && rm -rf .tmp
 
 **Files:**
 - Modify: `packages/agency-lang/scripts/agency.ts` — the `addRunOptions` function, and the `RunOptions` type at line 132
-- Create: `packages/agency-lang/scripts/agency.modelFlag.test.ts`
+- Modify: `packages/agency-lang/scripts/agency.test.ts` — it already owns `createProgram` and CLI parsing
 
 **Interfaces:**
 - Consumes: `resolveModelFlag` from Task 3, `ResolvedModelFlag` from Task 2.
@@ -619,35 +639,35 @@ the second call receives the first `ResolvedModelFlag` as its `catalogNames` arg
 
 - [ ] **Step 1: Write the failing wiring test**
 
-Create `packages/agency-lang/scripts/agency.modelFlag.test.ts`:
+Append to `packages/agency-lang/scripts/agency.test.ts`:
 
 ```ts
-import { describe, expect, it } from "vitest";
-import { createProgram } from "./agency.js";
-
-/** Parse an argv and hand back the RunOptions the `run` action would see. */
-function runOptionsFor(words: string[]): Record<string, unknown> {
-  const program = createProgram({});
-  const run = program.commands.find((cmd) => cmd.name() === "run");
-  if (run === undefined) throw new Error("no run command");
-  let captured: Record<string, unknown> = {};
-  run.action(() => {
-    captured = run.opts();
-  });
-  program.exitOverride();
-  run.exitOverride();
-  program.parse(["node", "agency", ...words], { from: "user" });
-  return captured;
-}
-
 describe("--model wiring", () => {
-  it("resolves a bare model", () => {
-    const opts = runOptionsFor(["run", "--model", "gpt-4o-mini", "f.agency"]);
+  /** Parse an argv and hand back the RunOptions the `run` action would see. */
+  async function runOptionsFor(words: string[]): Promise<Record<string, unknown>> {
+    const program = createProgram({});
+    const run = program.commands.find((cmd) => cmd.name() === "run");
+    if (run === undefined) throw new Error("no run command");
+    let captured: Record<string, unknown> = {};
+    run.action(() => {
+      captured = run.opts();
+    });
+    program.exitOverride();
+    run.exitOverride();
+    // `from: "user"` means every element is a user argument — commander does
+    // NOT strip a leading node/script pair in this mode. Passing them would
+    // send "node" through the hidden default command instead of testing `run`.
+    await program.parseAsync(words, { from: "user" });
+    return captured;
+  }
+
+  it("resolves a bare model", async () => {
+    const opts = await runOptionsFor(["run", "--model", "gpt-4o-mini", "f.agency"]);
     expect(opts.model).toEqual({ model: "gpt-4o-mini" });
   });
 
-  it("resolves a prefixed model", () => {
-    const opts = runOptionsFor([
+  it("resolves a prefixed model", async () => {
+    const opts = await runOptionsFor([
       "run", "--model", "openrouter/anthropic/claude-sonnet-4", "f.agency",
     ]);
     expect(opts.model).toEqual({
@@ -656,22 +676,28 @@ describe("--model wiring", () => {
     });
   });
 
-  it("takes the last value when the flag is repeated", () => {
+  it("takes the last value when the flag is repeated", async () => {
     // Commander passes the PREVIOUS parsed value as the parser's second
-    // argument. Without an adapter, that object lands in `catalogNames`.
-    const opts = runOptionsFor([
+    // argument. Without the adapter, that object lands in `catalogNames`.
+    const opts = await runOptionsFor([
       "run", "--model", "gpt-4o-mini", "--model", "claude-opus-4-8", "f.agency",
     ]);
     expect(opts.model).toEqual({ model: "claude-opus-4-8" });
   });
 
-  it("rejects an unknown bare model", () => {
-    expect(() =>
+  it("rejects an unknown bare model", async () => {
+    await expect(
       runOptionsFor(["run", "--model", "gpt-4o-minii", "f.agency"]),
-    ).toThrow();
+    ).rejects.toThrow();
   });
 });
 ```
+
+The model names above must exist in the real catalog, because this test drives
+the real resolver through the real program. `gpt-4o-mini` and `claude-opus-4-8`
+are both in it today; if either has been retired, substitute a current name from
+`agency models list` rather than mocking here — the point of this suite is the
+wiring, end to end.
 
 If `createProgram` is not exported from `scripts/agency.ts`, export it — it is already used this way by `scripts/agency.test.ts`, so check there first.
 
@@ -679,7 +705,7 @@ If `createProgram` is not exported from `scripts/agency.ts`, export it — it is
 
 ```bash
 cd packages/agency-lang
-npx vitest run scripts/agency.modelFlag.test.ts > /tmp/agency-t4.log 2>&1; tail -20 /tmp/agency-t4.log
+npx vitest run scripts/agency.test.ts > /tmp/agency-t4.log 2>&1; tail -20 /tmp/agency-t4.log
 ```
 
 Expected: FAIL — `opts.model` is `undefined`, because the option does not exist yet.
@@ -727,7 +753,7 @@ Then, inside `addRunOptions`, add the option to the chain:
 
 ```bash
 cd packages/agency-lang
-npx vitest run scripts/agency.modelFlag.test.ts scripts/agency.test.ts \
+npx vitest run scripts/agency.test.ts \
   > /tmp/agency-t4b.log 2>&1; grep -E "Test Files|Tests |FAIL" /tmp/agency-t4b.log
 ```
 
@@ -739,7 +765,7 @@ Temporarily change the option's parser from `(value: string) => resolveModelFlag
 
 ```bash
 cd packages/agency-lang
-npx vitest run scripts/agency.modelFlag.test.ts -t "repeated" \
+npx vitest run scripts/agency.test.ts -t "repeated" \
   > /tmp/agency-t4c.log 2>&1; grep -E "Tests |FAIL" /tmp/agency-t4c.log
 ```
 
@@ -762,7 +788,7 @@ appears twice.
 
 Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
 EOF
-git add packages/agency-lang/scripts/agency.ts packages/agency-lang/scripts/agency.modelFlag.test.ts
+git add packages/agency-lang/scripts/agency.ts packages/agency-lang/scripts/agency.test.ts
 git commit -F .tmp/msg.txt && rm -rf .tmp
 ```
 
@@ -774,39 +800,39 @@ git commit -F .tmp/msg.txt && rm -rf .tmp
 - Modify: `packages/agency-lang/lib/backends/smoltalkDefaults.codegen.test.ts`
 
 **Interfaces:**
-- Consumes: the `applyCliFlags` mapping from Task 2.
+- Consumes: nothing. This task pins existing code-generation behaviour; it does
+  **not** exercise `applyCliFlags`, because the `generate` helper hands a
+  ready-made `AgencyConfig` straight to `TypeScriptBuilder`. Task 2 covers the
+  mapping and Task 7 covers the two joined together.
 - Produces: nothing for later tasks.
 
-**Background the implementer needs.** The compiler writes the smoltalk client configuration into the generated JavaScript. `lib/backends/typescriptBuilder.ts:4413` emits `model: <string>` always, and emits `provider: <string>` **only when `client.defaultProvider` is set** — the comment there says it leaves it unset otherwise so smoltalk's model-to-provider lookup still applies. That conditional is exactly what the bare-model rule depends on, so it is worth pinning.
+**Background the implementer needs.** The compiler writes the smoltalk client
+configuration into the generated JavaScript. `lib/backends/typescriptBuilder.ts:4413`
+emits `model: <string>` always, and emits `provider: <string>` **only when
+`client.defaultProvider` is set**.
 
-This file already has a `generate(source, config)` helper that runs the parser, preprocessor and builder and returns the printed TypeScript.
+**Most of this is already tested.** `smoltalkDefaults.codegen.test.ts` has
+`omits provider when defaultProvider is unset` (line 64) and `bakes provider when
+defaultProvider is set` (line 71). Leave both alone. Note the existing test
+anchors on `/provider:\s*"/` rather than the bare token, with a comment
+explaining that `provider` appears elsewhere in generated output — do not add a
+looser assertion beside it.
+
+Only one assertion is missing: that `client.defaultModel` is baked at all.
 
 - [ ] **Step 1: Write the failing tests**
 
-Append to the `describe("smoltalkDefaults codegen", ...)` block in `packages/agency-lang/lib/backends/smoltalkDefaults.codegen.test.ts`:
+Append one case to the `describe("smoltalkDefaults codegen", ...)` block in
+`packages/agency-lang/lib/backends/smoltalkDefaults.codegen.test.ts`:
 
 ```ts
   it("bakes client.defaultModel into the generated client config", () => {
     const out = generate(PROGRAM, { client: { defaultModel: "claude-opus-4-8" } });
-    expect(out).toContain('model: "claude-opus-4-8"');
-  });
-
-  it("emits no provider when none is configured, so smoltalk infers one", () => {
-    const out = generate(PROGRAM, { client: { defaultModel: "claude-opus-4-8" } });
-    expect(out).not.toContain("provider:");
-  });
-
-  it("bakes both when a provider is configured", () => {
-    const out = generate(PROGRAM, {
-      client: {
-        defaultModel: "anthropic/claude-sonnet-4",
-        defaultProvider: "openrouter",
-      },
-    });
-    expect(out).toContain('model: "anthropic/claude-sonnet-4"');
-    expect(out).toContain('provider: "openrouter"');
+    expect(out).toMatch(/model:\s*"claude-opus-4-8"/);
   });
 ```
+
+Do not add provider cases; lines 64 and 71 already cover both directions.
 
 - [ ] **Step 2: Run the tests**
 
@@ -816,18 +842,17 @@ npx vitest run lib/backends/smoltalkDefaults.codegen.test.ts \
   > /tmp/agency-t5.log 2>&1; grep -E "Test Files|Tests |FAIL" /tmp/agency-t5.log
 ```
 
-Expected: all PASS immediately — this is existing behaviour being pinned, not new behaviour. If the second case fails because `provider:` appears for an unrelated reason, tighten the assertion to `expect(out).not.toContain('provider: "')` and note why in a comment.
+Expected: all PASS immediately — this is existing behaviour being pinned, not new behaviour.
 
 - [ ] **Step 3: Commit**
 
 ```bash
 cd /Users/adityabhargava/agency-lang/worktree-model-flag
 mkdir -p .tmp && cat > .tmp/msg.txt <<'EOF'
-test(codegen): pin the model and provider baked into the client config
+test(codegen): pin the model baked into the client config
 
-The bare-model rule depends on the code generator emitting no provider
-when none is configured, so smoltalk infers one from the model name.
-That conditional had no test.
+The provider cases were already covered; only the model itself had no
+assertion.
 
 Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
 EOF
@@ -837,98 +862,151 @@ git commit -F .tmp/msg.txt && rm -rf .tmp
 
 ---
 
-## Task 6: Prove a stated provider is sticky
+## Task 6: Prove precedence at the final client config
 
 **Files:**
-- Create: `packages/agency-lang/lib/runtime/modelPrecedence.test.ts`
+- Modify: `packages/agency-lang/lib/runtime/agencyLlm.test.ts`
 
 **Interfaces:**
 - Consumes: nothing from earlier tasks — this pins existing runtime behaviour the design depends on.
 - Produces: nothing for later tasks.
 
-**Background the implementer needs.** The spec's central claim is that model and provider merge **independently**, so a provider set by a lower layer survives a higher layer that changes only the model. Two places do that merging:
+**Background the implementer needs.** The spec's central claim is that model and
+provider merge **independently**, so a provider set by a lower layer survives a
+higher layer that changes only the model. If someone later "fixes" that into a
+merge that clears the provider whenever the model changes, the sticky-provider
+rule silently stops holding and nothing in the suite notices.
 
-- `lib/runtime/state/context.ts:763` — `getSmoltalkConfig(config)` returns `{ ...this.smoltalkDefaults, ...config }`
-- `lib/runtime/prompt.ts:1026` — `ctx.getSmoltalkConfig({ ...stackSmolDefaults, ...restClientConfig })`
+This is observable end to end. `lib/runtime/agencyLlm.test.ts` already has a
+`RecordingClient` (line 35) that stores every `PromptConfig` it is handed in
+`configs[]`, and an existing test at line 103 asserts on
+`client.configs[0].provider` after `_setLlmOptions({ provider, model })`. Assert
+on the recorded pair rather than on any internal merge function.
 
-If someone later "fixes" either into a merge that clears the provider when the model changes, the sticky-provider rule this feature documents silently stops holding. Nothing in the suite would notice. That is what this test is for.
+Two facts that shape the cases:
 
-Note this test does **not** make an LLM call. The deterministic mock client reports `model: "deterministic"` in its result and does not expose the incoming model, so an end-to-end assertion is not available; the merge functions are the real mechanism and are tested directly.
+- `makeCtx()` (line 11) hard-codes `smoltalkDefaults: { model: "default-model" }`.
+  It needs a parameter so a test can bake a provider too. Give the parameter the
+  current value as its default so every existing caller is unaffected.
+- The TypeScript `agency.llm` facade forwards only `model` and `maxTokens` to
+  `clientConfig` (`lib/runtime/agencyLlm.ts:96`) — **not** `provider`. Generated
+  Agency code does forward it, but this facade does not, so the per-call
+  provider case uses `_setLlmOptions({ model, provider })`, which the spec names
+  as the supported way to move both.
 
-`lib/runtime/configOverrides.test.ts:159` shows how to construct a `RuntimeContext` in a test — copy its construction shape rather than inventing one.
+- [ ] **Step 1: Give `makeCtx` a defaults parameter**
 
-- [ ] **Step 1: Write the test**
-
-Create `packages/agency-lang/lib/runtime/modelPrecedence.test.ts`:
+In `packages/agency-lang/lib/runtime/agencyLlm.test.ts`, change `makeCtx` (line 11):
 
 ```ts
-import { describe, expect, it } from "vitest";
-import { RuntimeContext } from "./state/context.js";
-
-/**
- * A context whose baked defaults are what `--model openrouter/foo` would
- * produce: both a model and a provider.
- */
-function contextWithBakedPair() {
+function makeCtx(
+  smoltalkDefaults: Record<string, unknown> = { model: "default-model" },
+): RuntimeContext<any> {
   return new RuntimeContext({
-    smoltalkDefaults: { model: "foo", provider: "openrouter" },
-  } as never);
+    statelogConfig: {
+      host: "https://example.com",
+      apiKey: "test-api-key",
+      projectId: "test-project",
+      debugMode: false,
+    },
+    smoltalkDefaults,
+    dirname: "/tmp",
+  });
 }
+```
 
-describe("model and provider merge independently", () => {
-  it("keeps a baked provider when only the model is overridden", () => {
-    const ctx = contextWithBakedPair();
-    // What `setModel("claude-opus-4-8")` contributes: the model alone.
-    const merged = ctx.getSmoltalkConfig({ model: "claude-opus-4-8" });
-    expect(merged.model).toBe("claude-opus-4-8");
-    expect(merged.provider).toBe("openrouter");
-  });
+The default keeps every existing caller identical.
 
-  it("replaces the provider when the caller supplies one", () => {
-    const ctx = contextWithBakedPair();
-    const merged = ctx.getSmoltalkConfig({
-      model: "claude-opus-4-8",
-      provider: "anthropic",
+- [ ] **Step 2: Write the precedence cases**
+
+Append to `packages/agency-lang/lib/runtime/agencyLlm.test.ts`:
+
+```ts
+describe("model and provider precedence", () => {
+  /** The pair the client was actually asked for. */
+  async function effectivePair(
+    baked: Record<string, unknown>,
+    call: () => Promise<unknown>,
+  ): Promise<{ model?: string; provider?: string }> {
+    const ctx = makeCtx(baked);
+    const client = new RecordingClient(["ok"]);
+    ctx.setLLMClient(client);
+    const threads = ThreadStore.withDefaultActive(ctx.statelogClient);
+    await inFrame(ctx, threads, call);
+    const config = client.configs[0] as any;
+    return { model: config.model, provider: config.provider };
+  }
+
+  it("a branch model override leaves no provider when none was baked", async () => {
+    const pair = await effectivePair({ model: "baked-model" }, async () => {
+      _setLlmOptions({ model: "branch-model" });
+      return agency.llm("hi");
     });
-    expect(merged.model).toBe("claude-opus-4-8");
-    expect(merged.provider).toBe("anthropic");
+    expect(pair).toEqual({ model: "branch-model", provider: undefined });
   });
 
-  it("leaves the provider unset when nothing baked one", () => {
-    const ctx = new RuntimeContext({
-      smoltalkDefaults: { model: "gpt-4o-mini" },
-    } as never);
-    const merged = ctx.getSmoltalkConfig({ model: "claude-opus-4-8" });
-    expect(merged.provider).toBeUndefined();
+  it("a baked provider survives a branch model-only override", async () => {
+    const pair = await effectivePair(
+      { model: "baked-model", provider: "openrouter" },
+      async () => {
+        _setLlmOptions({ model: "branch-model" });
+        return agency.llm("hi");
+      },
+    );
+    expect(pair).toEqual({ model: "branch-model", provider: "openrouter" });
+  });
+
+  it("a baked provider survives a per-call model-only override", async () => {
+    const pair = await effectivePair(
+      { model: "baked-model", provider: "openrouter" },
+      () => agency.llm("hi", { model: "call-model" }),
+    );
+    expect(pair).toEqual({ model: "call-model", provider: "openrouter" });
+  });
+
+  it("supplying both replaces the baked provider", async () => {
+    const pair = await effectivePair(
+      { model: "baked-model", provider: "openrouter" },
+      async () => {
+        _setLlmOptions({ model: "branch-model", provider: "anthropic" });
+        return agency.llm("hi");
+      },
+    );
+    expect(pair).toEqual({ model: "branch-model", provider: "anthropic" });
   });
 });
 ```
 
-- [ ] **Step 2: Run the test**
+The first three cases are the sticky-provider rule the spec promises. The fourth
+is the escape it names.
+
+- [ ] **Step 3: Run the suite**
 
 ```bash
 cd packages/agency-lang
-npx vitest run lib/runtime/modelPrecedence.test.ts \
+npx vitest run lib/runtime/agencyLlm.test.ts \
   > /tmp/agency-t6.log 2>&1; grep -E "Test Files|Tests |FAIL" /tmp/agency-t6.log
 ```
 
-Expected: all PASS — this pins behaviour that already exists. If the `RuntimeContext` constructor rejects that argument shape, open `lib/runtime/configOverrides.test.ts` around line 159 and copy the fields it passes, keeping `smoltalkDefaults` as above.
+Expected: all PASS, new and pre-existing. These pin behaviour that already
+exists; if one fails, the merge does not work the way the spec claims and the
+spec is wrong — stop and say so rather than adjusting the assertion to match.
 
-- [ ] **Step 3: Commit**
+- [ ] **Step 4: Commit**
 
 ```bash
 cd /Users/adityabhargava/agency-lang/worktree-model-flag
 mkdir -p .tmp && cat > .tmp/msg.txt <<'EOF'
-test(runtime): pin that model and provider merge independently
+test(runtime): pin model and provider precedence at the client
 
 The --model design depends on a stated provider surviving a later
-model-only override, which follows from getSmoltalkConfig being a
-shallow spread. Nothing tested that, so a later merge change would break
-the documented rule in silence.
+model-only override. Asserted on the config the client is actually
+handed, via the RecordingClient this suite already has, rather than on
+an internal merge function.
 
 Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
 EOF
-git add packages/agency-lang/lib/runtime/modelPrecedence.test.ts
+git add packages/agency-lang/lib/runtime/agencyLlm.test.ts
 git commit -F .tmp/msg.txt && rm -rf .tmp
 ```
 
@@ -951,37 +1029,41 @@ Use `./node_modules/.bin/agency`, never `npx agency` — npx consumes `--`, and 
 
 - [ ] **Step 1: Add the test cases**
 
-In `packages/agency-lang/tests/integration/cli/test.mjs`, immediately before the line `console.log("Test 8 passed");`, insert:
+In `packages/agency-lang/tests/integration/cli/test.mjs`, immediately before the
+line `console.log("Test 8 passed");`, insert:
 
 ```js
   // --- --model reaches the compiled program ---
-  // An agency.json with a provider already set, so the bare-model case has
-  // something to clear. Without this the "no provider" assertion could pass
-  // for the wrong reason.
+  // `--model` lives on addRunOptions, which `run` and the shorthand share.
+  // `agency compile` has its own option list and does NOT take it, so these
+  // cases drive the two supported surfaces and read what they compiled.
+  //
+  // Start from an agency.json that already names a provider, so the bare-model
+  // case has something to clear and cannot pass for the wrong reason.
   writeFile(dir, "agency.json", JSON.stringify({
     client: { defaultModel: "gpt-4o-mini", defaultProvider: "openrouter" },
   }, null, 2));
 
   // A bare model replaces the model AND drops the inherited provider, so
   // smoltalk infers one from the name.
-  run(dir, "./node_modules/.bin/agency compile --model claude-opus-4-8 greet.agency");
+  const bareRun = run(dir, "./node_modules/.bin/agency run --model claude-opus-4-8 greet.agency --name alice");
+  assertIncludes(bareRun, "Hello, alice!");
   const bareOut = readFileSync(join(dir, "greet.js"), "utf-8");
   assertIncludes(bareOut, 'model: "claude-opus-4-8"');
-  if (bareOut.includes('provider: "')) {
+  // Anchored on a baked literal: the bare token `provider` also appears in
+  // unrelated generated output.
+  if (/provider:\s*"/.test(bareOut)) {
     throw new Error("a bare --model left a provider in the generated config");
   }
 
-  // A prefixed model sets both.
-  run(dir, "./node_modules/.bin/agency compile --model openrouter/anthropic/claude-sonnet-4 greet.agency");
+  // The shorthand takes the flag too, and a prefixed value sets both fields.
+  const prefixedRun = run(dir, "./node_modules/.bin/agency --model openrouter/anthropic/claude-sonnet-4 greet.agency --name alice");
+  assertIncludes(prefixedRun, "Hello, alice!");
   const prefixedOut = readFileSync(join(dir, "greet.js"), "utf-8");
   assertIncludes(prefixedOut, 'model: "anthropic/claude-sonnet-4"');
-  assertIncludes(prefixedOut, 'provider: "openrouter"');
-
-  // The flag works on `run` and on the shorthand, which share addRunOptions.
-  const modelRun = run(dir, "./node_modules/.bin/agency run --model claude-opus-4-8 greet.agency --name alice");
-  assertIncludes(modelRun, "Hello, alice!");
-  const modelShorthand = run(dir, "./node_modules/.bin/agency --model claude-opus-4-8 greet.agency --name alice");
-  assertIncludes(modelShorthand, "Hello, alice!");
+  if (!/provider:\s*"openrouter"/.test(prefixedOut)) {
+    throw new Error("a prefixed --model did not bake its provider");
+  }
 
   // An unknown bare model fails BEFORE compiling. Deleting the output first
   // and asserting it was never recreated is what proves the ordering — a test
@@ -1001,11 +1083,27 @@ In `packages/agency-lang/tests/integration/cli/test.mjs`, immediately before the
     throw new Error("compilation happened despite an invalid --model");
   }
 
+  // The position rule applies to the new flag like any other: after the
+  // filename it belongs to the program, is NOT validated by agency, and draws
+  // the standard warning. greet does not declare --model, so its own parser
+  // rejects it — which is also the proof the flag was forwarded.
+  const modelAfterFile = run(
+    dir,
+    "./node_modules/.bin/agency run greet.agency --model gpt-4o-mini 2>&1",
+    { expectFail: true },
+  );
+  assertIncludes(modelAfterFile, "Warning: --model went to your program");
+  assertIncludes(modelAfterFile, "unknown flag --model");
+  if (modelAfterFile.includes("Unknown model")) {
+    throw new Error("agency validated a --model that belonged to the program");
+  }
+
   // Leave no agency.json behind for the later cases in this file.
   rmSync(join(dir, "agency.json"), { force: true });
 ```
 
-Extend the `node:fs` import at the top of the file to cover the helpers used above:
+Extend the `node:fs` import at the top of the file to cover the helpers used
+above:
 
 ```js
 import { readFileSync, existsSync, rmSync } from "node:fs";
@@ -1024,7 +1122,9 @@ tail -30 /tmp/agency-t7.log
 
 Expected: `make=0`, `cli=0`, and the suite ends with `=== All CLI tests passed ===`.
 
-If the bare-model case fails because `greet.js` already existed from an earlier case in the file, add `rmSync(join(dir, "greet.js"), { force: true });` before the first compile as well.
+If the bare-model case reads a stale `greet.js` from an earlier case in this
+file, add `rmSync(join(dir, "greet.js"), { force: true });` before the first run
+as well.
 
 - [ ] **Step 3: Commit**
 
@@ -1036,8 +1136,9 @@ test(cli): --model end to end, on run and the shorthand
 Starts from an agency.json that already names a provider, so the
 bare-model case has something to clear and cannot pass for the wrong
 reason. The invalid-model case deletes the output first and asserts it
-was never written, which is what proves validation runs before
-compilation rather than after it.
+was never written, which proves validation runs before compilation. A
+last case puts --model after the filename and asserts agency forwards it
+without validating, so the new option obeys the position rule.
 
 Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
 EOF
@@ -1087,8 +1188,8 @@ proxy; name it (`--model litellm/gpt-4o-mini`) to keep it.
 (`lib/runtime/state/context.ts:763`), so a provider set by the flag survives a
 later `setModel("other")` in Agency code — the pair becomes that provider plus
 the new model. Code that wants to move provider too must say
-`setLlmOptions({ model, provider })`. `lib/runtime/modelPrecedence.test.ts` pins
-this.
+`setLlmOptions({ model, provider })`. The precedence cases in
+`lib/runtime/agencyLlm.test.ts` pin this.
 
 **Only a bare name is validated.** It is checked against the hosted **text**
 models from `_listHostedModels()` — not smoltalk's `getAllModels()`, which also
@@ -1133,14 +1234,12 @@ git commit -F .tmp/msg.txt && rm -rf .tmp
 cd packages/agency-lang
 npx vitest run \
   lib/levenshtein.test.ts \
-  lib/config.modelFlag.test.ts \
   lib/config.test.ts \
   lib/cli/modelFlag.test.ts \
   lib/eval/grading/graders/ \
-  scripts/agency.modelFlag.test.ts \
   scripts/agency.test.ts \
   lib/backends/smoltalkDefaults.codegen.test.ts \
-  lib/runtime/modelPrecedence.test.ts \
+  lib/runtime/agencyLlm.test.ts \
   > /tmp/agency-final.log 2>&1
 grep -E "Test Files|Tests |FAIL" /tmp/agency-final.log
 ```
@@ -1181,9 +1280,38 @@ Write the PR body to a file and pass it with `gh pr create --body-file`. Cover: 
 
 ## Self-review notes
 
-Checked against the spec, revision 3:
+Checked against the spec, revision 3, and revised after review.
 
-- **Every spec section has a task.** Reading the value → Task 3. Provider semantics → Tasks 2 and 6. Validation, both structural and catalog → Task 3. Suggestions → Tasks 1 and 3. Dataflow and the Commander adapter → Task 4. The `ResolvedModelFlag` location → Task 2. The codegen effect → Task 5. Integration coverage → Task 7. Documentation → Task 8.
-- **The spec's test list is covered**, with one deliberate substitution: the spec asked for an Agency execution test observing `{ model, provider }` for four flag-and-code combinations. The deterministic mock client reports `model: "deterministic"` and does not expose the incoming model, so that observation is not available end to end. Task 6 tests the merge functions directly instead, and Task 7 covers the flag-to-codegen half. The seam left untested is "generated JavaScript values become `smoltalkDefaults`", which is pre-existing behaviour this change does not touch. **This is a real reduction in coverage from what the spec asked for and should be raised in the PR description** rather than passed off as equivalent.
-- **Names are consistent across tasks**: `ResolvedModelFlag` (Task 2, used in 3 and 4), `resolveModelFlag` (Task 3, used in 4), `levenshtein` (Task 1, used in 3), `explicitProvider` throughout.
-- **Two steps ask the implementer to watch a test fail on purpose** — Task 4 Step 5 in particular, which temporarily removes the adapter. That step exists because the repeated-flag test is the only thing standing between this design and a bug that unit tests structurally cannot see.
+- **Every spec section has a task.** Reading the value → Task 3. Provider
+  semantics → Tasks 2 and 6. Validation, both structural and catalog → Task 3.
+  Suggestions → Tasks 1 and 3. Dataflow and the Commander adapter → Task 4. The
+  `ResolvedModelFlag` location → Task 2. The codegen effect → Task 5.
+  Integration coverage → Task 7. Documentation → Task 8.
+- **The spec's four-way precedence test is now delivered in full.** An earlier
+  revision of this plan claimed the observation was unavailable and substituted
+  a test of an internal merge function. That was wrong: `RecordingClient` in
+  `lib/runtime/agencyLlm.test.ts` records every `PromptConfig` handed to the
+  client, including both `model` and `provider`, and an existing test already
+  asserts on it. The claim came from checking the deterministic mock client and
+  stopping there. Task 6 now asserts on the configuration the client actually
+  receives.
+- **Tests live in the suites that own the behaviour.** `applyCliFlags` cases go
+  in `lib/config.test.ts`, Commander wiring in `scripts/agency.test.ts`,
+  precedence in `lib/runtime/agencyLlm.test.ts`. Only `lib/cli/modelFlag.test.ts`
+  and `lib/levenshtein.test.ts` are new files, because their modules are new.
+- **Task 5 adds one assertion, not three.** The two provider cases already exist
+  at lines 64 and 71 of `smoltalkDefaults.codegen.test.ts`, with an anchored
+  regex and a comment explaining why the bare `provider:` token is the wrong
+  thing to match. Only the model assertion was missing.
+- **Task 7 drives only the two surfaces that have the flag.** `--model` is on
+  `addRunOptions`, which `compile` does not use, so the integration cases use
+  `run` and the shorthand and read the files those runs compiled.
+- **Names are consistent across tasks**: `ResolvedModelFlag` (Task 2, used in 3
+  and 4), `resolveModelFlag` (Task 3, used in 4), `levenshtein` (Task 1, used in
+  3), `explicitProvider` throughout.
+- **Three steps ask the implementer to watch something fail on purpose.** Task 4
+  Step 5 temporarily removes the Commander adapter, because the repeated-flag
+  test is the only thing standing between this design and a bug that unit tests
+  structurally cannot see. Task 6 Step 3 says to stop and report if a precedence
+  case fails, rather than adjust the assertion to match — those cases encode the
+  spec's central claim, so a failure means the spec is wrong.

--- a/packages/agency-lang/docs/superpowers/plans/2026-08-05-run-model-flag.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-08-05-run-model-flag.md
@@ -13,14 +13,14 @@
 ## Global Constraints
 
 - **Do not edit `CHANGELOG.md`.** The owner maintains it.
-- **Do not edit anything under `docs/site/**`.** User-facing documentation is out of scope for this change. `docs/dev/**` is in scope and Task 7 updates it.
+- **Do not edit anything under `docs/site/**`.** User-facing documentation is out of scope for this change. `docs/dev/**` is in scope and Task 8 updates it.
 - Never commit to `main`. Work happens on the branch this worktree is on (`adit/run-model-flag`).
 - Never force-push or amend commits.
 - Write commit messages to a file and pass it with `git commit -F <file>` — apostrophes and backticks break inline `-m`.
 - Stage named paths, never `git add -A`. This worktree may hold other work.
 - Save every test run's output to a file so a failure does not need a re-run to diagnose. This repo's tests are slow.
 - Do not run the whole test suite. Run only the tests named in each task; CI runs the rest.
-- Run `make` only where a task says to. It is slow, and only the two tasks that need a rebuilt CLI ask for it.
+- Run `make` only where a task says to. It is slow, and only Task 7 needs a rebuilt CLI.
 - Types, not interfaces. Objects, not Maps. Arrays, not Sets. No dynamic imports.
 
 ---
@@ -38,7 +38,7 @@
 | `lib/cli/modelFlag.test.ts` | **Create.** Tests for the resolver. |
 | `scripts/agency.ts` | **Modify.** Add the option to `addRunOptions`, behind a one-line adapter. |
 | `scripts/agency.test.ts` | **Modify.** Add Commander wiring cases; it already owns `createProgram` and CLI parsing. |
-| `lib/backends/smoltalkDefaults.codegen.test.ts` | **Modify.** Add cases proving the configuration reaches the generated client block. |
+| `lib/backends/smoltalkDefaults.codegen.test.ts` | **Modify.** Add the missing model case proving the configuration reaches the generated client block. |
 | `lib/runtime/agencyLlm.test.ts` | **Modify.** Add four precedence cases observing the final client config via the existing `RecordingClient`. |
 | `tests/integration/cli/test.mjs` | **Modify.** End-to-end through the real binary, both commands, and the failure-before-compilation case. |
 | `docs/dev/config.md` | **Modify.** Document what `--model` means in configuration terms, beside the other flags. |
@@ -60,7 +60,7 @@ Why the resolver and the configuration mapping are separate files: the resolver 
 
 **Interfaces:**
 - Consumes: nothing.
-- Produces: `export function levenshtein(a: string, b: string): number`
+- Produces: `export function levenshtein(left: string, right: string): number`
 
 - [ ] **Step 1: Write the failing test**
 
@@ -108,22 +108,31 @@ Expected: FAIL — cannot resolve `./levenshtein.js`.
 
 - [ ] **Step 3: Create the shared module**
 
-Create `packages/agency-lang/lib/levenshtein.ts` with the body moved verbatim from `builtinGraders.ts`:
+Create `packages/agency-lang/lib/levenshtein.ts` with the existing algorithm
+moved from `builtinGraders.ts`. Give its inputs and indices descriptive names
+rather than carrying the old single-character locals into the new shared API:
 
 ```ts
 /** Classic Levenshtein edit distance (deterministic, dependency-free). */
-export function levenshtein(a: string, b: string): number {
-  const cols = b.length + 1;
-  let prev = Array.from({ length: cols }, (_unused, j) => j);
-  for (let i = 1; i <= a.length; i += 1) {
-    const curr = [i];
-    for (let j = 1; j < cols; j += 1) {
-      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
-      curr[j] = Math.min(prev[j] + 1, curr[j - 1] + 1, prev[j - 1] + cost);
+export function levenshtein(left: string, right: string): number {
+  const columnCount = right.length + 1;
+  let previousRow = Array.from(
+    { length: columnCount },
+    (_unused, columnIndex) => columnIndex,
+  );
+  for (let rowIndex = 1; rowIndex <= left.length; rowIndex += 1) {
+    const currentRow = [rowIndex];
+    for (let columnIndex = 1; columnIndex < columnCount; columnIndex += 1) {
+      const cost = left[rowIndex - 1] === right[columnIndex - 1] ? 0 : 1;
+      currentRow[columnIndex] = Math.min(
+        previousRow[columnIndex] + 1,
+        currentRow[columnIndex - 1] + 1,
+        previousRow[columnIndex - 1] + cost,
+      );
     }
-    prev = curr;
+    previousRow = currentRow;
   }
-  return prev[cols - 1];
+  return previousRow[columnCount - 1];
 }
 ```
 
@@ -226,6 +235,7 @@ TypeScript to check it.
       });
       expect(after.client?.defaultModel).toBe("claude-opus-4-8");
       expect(after.client?.defaultProvider).toBeUndefined();
+      expect(after.client).not.toHaveProperty("defaultProvider");
     });
 
     it("a prefixed model sets both fields", () => {
@@ -245,9 +255,9 @@ TypeScript to check it.
 
     it("does not mutate the config it was given", () => {
       const before = configWithProvider();
+      const snapshot = structuredClone(before);
       applyCliFlags(before, { model: { model: "claude-opus-4-8" } });
-      expect(before.client?.defaultModel).toBe("gpt-4o-mini");
-      expect(before.client?.defaultProvider).toBe("openrouter");
+      expect(before).toEqual(snapshot);
     });
 
     it("works when the config has no client block at all", () => {
@@ -388,6 +398,7 @@ Create `packages/agency-lang/lib/cli/modelFlag.test.ts`:
 
 ```ts
 import { describe, expect, it, vi } from "vitest";
+import { InvalidArgumentError } from "commander";
 import { resolveModelFlag } from "./modelFlag.js";
 
 const CATALOG = ["gpt-4o-mini", "gpt-4o", "claude-opus-4-8", "gemini-2.5-pro"];
@@ -400,6 +411,7 @@ describe("resolveModelFlag: bare names", () => {
   });
 
   it("rejects an unknown name and suggests the closest catalog entry", () => {
+    expect(() => resolve("gpt-4o-minii")).toThrow(InvalidArgumentError);
     expect(() => resolve("gpt-4o-minii")).toThrow(/Unknown model "gpt-4o-minii"/);
     expect(() => resolve("gpt-4o-minii")).toThrow(/Did you mean "gpt-4o-mini"/);
   });
@@ -448,7 +460,7 @@ describe("resolveModelFlag: structurally invalid values", () => {
     ["anthropic/", "empty model"],
     ["/", "both empty"],
   ])("rejects %s (%s)", (value) => {
-    expect(() => resolve(value)).toThrow();
+    expect(() => resolve(value)).toThrow(InvalidArgumentError);
   });
 });
 
@@ -639,15 +651,34 @@ the second call receives the first `ResolvedModelFlag` as its `catalogNames` arg
 
 - [ ] **Step 1: Write the failing wiring test**
 
-Append to `packages/agency-lang/scripts/agency.test.ts`:
+Add this import to `packages/agency-lang/scripts/agency.test.ts` beside its other
+CLI/runtime imports:
+
+```ts
+import { _listHostedModels } from "@/stdlib/llm.js";
+```
+
+Append to the same file. Derive two names from the installed catalog rather
+than hard-coding models that can later be retired. This suite owns Commander
+wiring, not monthly catalog membership; the resolver suite owns catalog
+behavior.
 
 ```ts
 describe("--model wiring", () => {
+  const [firstCatalogModel, secondCatalogModel] = _listHostedModels().map(
+    (model) => model.name,
+  );
+  if (firstCatalogModel === undefined || secondCatalogModel === undefined) {
+    throw new Error("the hosted text catalog needs at least two models");
+  }
+
   /** Parse an argv and hand back the RunOptions the `run` action would see. */
   async function runOptionsFor(words: string[]): Promise<Record<string, unknown>> {
     const program = createProgram({});
     const run = program.commands.find((cmd) => cmd.name() === "run");
-    if (run === undefined) throw new Error("no run command");
+    if (run === undefined) {
+      throw new Error("no run command");
+    }
     let captured: Record<string, unknown> = {};
     run.action(() => {
       captured = run.opts();
@@ -662,8 +693,10 @@ describe("--model wiring", () => {
   }
 
   it("resolves a bare model", async () => {
-    const opts = await runOptionsFor(["run", "--model", "gpt-4o-mini", "f.agency"]);
-    expect(opts.model).toEqual({ model: "gpt-4o-mini" });
+    const opts = await runOptionsFor([
+      "run", "--model", firstCatalogModel, "f.agency",
+    ]);
+    expect(opts.model).toEqual({ model: firstCatalogModel });
   });
 
   it("resolves a prefixed model", async () => {
@@ -680,24 +713,26 @@ describe("--model wiring", () => {
     // Commander passes the PREVIOUS parsed value as the parser's second
     // argument. Without the adapter, that object lands in `catalogNames`.
     const opts = await runOptionsFor([
-      "run", "--model", "gpt-4o-mini", "--model", "claude-opus-4-8", "f.agency",
+      "run", "--model", firstCatalogModel,
+      "--model", secondCatalogModel, "f.agency",
     ]);
-    expect(opts.model).toEqual({ model: "claude-opus-4-8" });
+    expect(opts.model).toEqual({ model: secondCatalogModel });
   });
 
   it("rejects an unknown bare model", async () => {
     await expect(
-      runOptionsFor(["run", "--model", "gpt-4o-minii", "f.agency"]),
+      runOptionsFor([
+        "run", "--model", "definitely-not-a-hosted-model", "f.agency",
+      ]),
     ).rejects.toThrow();
   });
 });
 ```
 
-The model names above must exist in the real catalog, because this test drives
-the real resolver through the real program. `gpt-4o-mini` and `claude-opus-4-8`
-are both in it today; if either has been retired, substitute a current name from
-`agency models list` rather than mocking here — the point of this suite is the
-wiring, end to end.
+The test still drives the real resolver through the real program, but it does
+not fail merely because one particular model was retired. Keep both repeated
+values bare: a prefixed second value returns before consulting `catalogNames`
+and would no longer prove that the one-argument adapter is necessary.
 
 If `createProgram` is not exported from `scripts/agency.ts`, export it — it is already used this way by `scripts/agency.test.ts`, so check there first.
 
@@ -890,17 +925,25 @@ Two facts that shape the cases:
   current value as its default so every existing caller is unaffected.
 - The TypeScript `agency.llm` facade forwards only `model` and `maxTokens` to
   `clientConfig` (`lib/runtime/agencyLlm.ts:96`) — **not** `provider`. Generated
-  Agency code does forward it, but this facade does not, so the per-call
-  provider case uses `_setLlmOptions({ model, provider })`, which the spec names
-  as the supported way to move both.
+  Agency code does forward it. The per-call provider case therefore invokes the
+  exported `runPrompt` seam directly rather than substituting a branch-level
+  `_setLlmOptions` update or expanding the TypeScript facade for a test.
 
 - [ ] **Step 1: Give `makeCtx` a defaults parameter**
 
-In `packages/agency-lang/lib/runtime/agencyLlm.test.ts`, change `makeCtx` (line 11):
+In `packages/agency-lang/lib/runtime/agencyLlm.test.ts`, add `SmolConfig` to the
+existing type import from `smoltalk`, and import `runPrompt`:
+
+```ts
+import type { Result, PromptResult, SmolConfig, StreamChunk } from "smoltalk";
+import { runPrompt } from "./prompt.js";
+```
+
+Then change `makeCtx` (line 11):
 
 ```ts
 function makeCtx(
-  smoltalkDefaults: Record<string, unknown> = { model: "default-model" },
+  smoltalkDefaults: Partial<SmolConfig> = { model: "default-model" },
 ): RuntimeContext<any> {
   return new RuntimeContext({
     statelogConfig: {
@@ -925,7 +968,7 @@ Append to `packages/agency-lang/lib/runtime/agencyLlm.test.ts`:
 describe("model and provider precedence", () => {
   /** The pair the client was actually asked for. */
   async function effectivePair(
-    baked: Record<string, unknown>,
+    baked: Partial<SmolConfig>,
     call: () => Promise<unknown>,
   ): Promise<{ model?: string; provider?: string }> {
     const ctx = makeCtx(baked);
@@ -933,7 +976,10 @@ describe("model and provider precedence", () => {
     ctx.setLLMClient(client);
     const threads = ThreadStore.withDefaultActive(ctx.statelogClient);
     await inFrame(ctx, threads, call);
-    const config = client.configs[0] as any;
+    const config = client.configs[0];
+    if (config === undefined) {
+      throw new Error("the prompt never reached the recording client");
+    }
     return { model: config.model, provider: config.provider };
   }
 
@@ -964,21 +1010,27 @@ describe("model and provider precedence", () => {
     expect(pair).toEqual({ model: "call-model", provider: "openrouter" });
   });
 
-  it("supplying both replaces the baked provider", async () => {
+  it("per-call model and provider replace the baked pair", async () => {
     const pair = await effectivePair(
       { model: "baked-model", provider: "openrouter" },
-      async () => {
-        _setLlmOptions({ model: "branch-model", provider: "anthropic" });
-        return agency.llm("hi");
-      },
+      () =>
+        runPrompt({
+          prompt: "hi",
+          messages: agency.thread.current(),
+          clientConfig: {
+            model: "call-model",
+            provider: "anthropic",
+          },
+        }),
     );
-    expect(pair).toEqual({ model: "branch-model", provider: "anthropic" });
+    expect(pair).toEqual({ model: "call-model", provider: "anthropic" });
   });
 });
 ```
 
-The first three cases are the sticky-provider rule the spec promises. The fourth
-is the escape it names.
+The first three cases are the sticky-provider rule the spec promises. The
+fourth reaches the per-call `restClientConfig` spread and proves that supplying
+both fields there replaces the lower-precedence pair.
 
 - [ ] **Step 3: Run the suite**
 
@@ -1065,13 +1117,16 @@ line `console.log("Test 8 passed");`, insert:
     throw new Error("a prefixed --model did not bake its provider");
   }
 
-  // An unknown bare model fails BEFORE compiling. Deleting the output first
-  // and asserting it was never recreated is what proves the ordering — a test
-  // that only checked the message would pass even if validation ran last.
-  rmSync(join(dir, "greet.js"), { force: true });
+  // An unknown bare model fails BEFORE compiling. Give it a fresh source name
+  // whose output cannot exist from an earlier case; asserting that output was
+  // never created proves the ordering without deleting a test artifact first.
+  writeFile(dir, "invalid-model.agency", `node main() {
+  print("must not execute")
+}
+`);
   const badModel = run(
     dir,
-    "./node_modules/.bin/agency run --model gpt-4o-minii greet.agency 2>&1",
+    "./node_modules/.bin/agency run --model gpt-4o-minii invalid-model.agency 2>&1",
     { expectFail: true },
   );
   assertIncludes(badModel, 'Unknown model "gpt-4o-minii"');
@@ -1079,17 +1134,20 @@ line `console.log("Test 8 passed");`, insert:
   if (badModel.includes("    at ")) {
     throw new Error(`an unknown model printed a stack trace: ${badModel}`);
   }
-  if (existsSync(join(dir, "greet.js"))) {
+  if (existsSync(join(dir, "invalid-model.js"))) {
     throw new Error("compilation happened despite an invalid --model");
   }
 
   // The position rule applies to the new flag like any other: after the
   // filename it belongs to the program, is NOT validated by agency, and draws
   // the standard warning. greet does not declare --model, so its own parser
-  // rejects it — which is also the proof the flag was forwarded.
+  // rejects it — which is also the proof the flag was forwarded. Use an
+  // unknown attached value: that distinguishes "not validated" from a valid
+  // value that agency might have validated successfully, and covers
+  // `--model=value` in the boundary scanner at the same time.
   const modelAfterFile = run(
     dir,
-    "./node_modules/.bin/agency run greet.agency --model gpt-4o-mini 2>&1",
+    "./node_modules/.bin/agency run greet.agency --model=definitely-not-a-real-model 2>&1",
     { expectFail: true },
   );
   assertIncludes(modelAfterFile, "Warning: --model went to your program");
@@ -1098,16 +1156,13 @@ line `console.log("Test 8 passed");`, insert:
     throw new Error("agency validated a --model that belonged to the program");
   }
 
-  // Leave no agency.json behind for the later cases in this file.
-  rmSync(join(dir, "agency.json"), { force: true });
+  // Restore neutral configuration for the later cases in this file. Writing
+  // the fixture is safer and clearer than deleting a path during a test.
+  writeFile(dir, "agency.json", "{}\n");
 ```
 
-Extend the `node:fs` import at the top of the file to cover the helpers used
-above:
-
-```js
-import { readFileSync, existsSync, rmSync } from "node:fs";
-```
+The file already imports `readFileSync` and `existsSync` from `node:fs`; no new
+filesystem import is needed.
 
 - [ ] **Step 2: Build and run the suite**
 
@@ -1122,10 +1177,6 @@ tail -30 /tmp/agency-t7.log
 
 Expected: `make=0`, `cli=0`, and the suite ends with `=== All CLI tests passed ===`.
 
-If the bare-model case reads a stale `greet.js` from an earlier case in this
-file, add `rmSync(join(dir, "greet.js"), { force: true });` before the first run
-as well.
-
 - [ ] **Step 3: Commit**
 
 ```bash
@@ -1135,10 +1186,11 @@ test(cli): --model end to end, on run and the shorthand
 
 Starts from an agency.json that already names a provider, so the
 bare-model case has something to clear and cannot pass for the wrong
-reason. The invalid-model case deletes the output first and asserts it
+reason. The invalid-model case uses a fresh output path and asserts it
 was never written, which proves validation runs before compilation. A
-last case puts --model after the filename and asserts agency forwards it
-without validating, so the new option obeys the position rule.
+last case puts an unknown attached --model after the filename and
+asserts agency forwards it without validating, so the new option obeys
+the position rule.
 
 Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
 EOF
@@ -1294,7 +1346,9 @@ Checked against the spec, revision 3, and revised after review.
   client, including both `model` and `provider`, and an existing test already
   asserts on it. The claim came from checking the deterministic mock client and
   stopping there. Task 6 now asserts on the configuration the client actually
-  receives.
+  receives; its fourth case calls `runPrompt` directly so the per-call
+  `{ model, provider }` spread is covered rather than replaced with a branch
+  default.
 - **Tests live in the suites that own the behaviour.** `applyCliFlags` cases go
   in `lib/config.test.ts`, Commander wiring in `scripts/agency.test.ts`,
   precedence in `lib/runtime/agencyLlm.test.ts`. Only `lib/cli/modelFlag.test.ts`
@@ -1306,6 +1360,11 @@ Checked against the spec, revision 3, and revised after review.
 - **Task 7 drives only the two surfaces that have the flag.** `--model` is on
   `addRunOptions`, which `compile` does not use, so the integration cases use
   `run` and the shorthand and read the files those runs compiled.
+- **Tests cannot pass for the wrong absence.** Task 2 asserts that a bare model
+  removes the `defaultProvider` property rather than merely reading as
+  `undefined`. Task 7 gives invalid input a fresh source/output name, and its
+  post-filename case uses an unknown attached value so successful Agency
+  validation cannot masquerade as no validation.
 - **Names are consistent across tasks**: `ResolvedModelFlag` (Task 2, used in 3
   and 4), `resolveModelFlag` (Task 3, used in 4), `levenshtein` (Task 1, used in
   3), `explicitProvider` throughout.

--- a/packages/agency-lang/docs/superpowers/specs/2026-08-05-run-model-flag-design-REVIEW-2.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-08-05-run-model-flag-design-REVIEW-2.md
@@ -1,0 +1,111 @@
+# Re-review: `agency run --model` design, revision 2
+
+## Recommendation
+
+**One change required.** Revision 2 resolves the substantive findings from the
+first review: provider precedence is now accurate, bare and prefixed values have
+clear semantics, the resolver result reaches `applyCliFlags` through one typed
+path, validation uses text models, refresh is no longer presented as persistent,
+and the tests observe configuration effects rather than only parsing.
+
+The remaining issue is in the proposed Commander parser signature. As written,
+repeating `--model` can pass a resolved object where the resolver expects a
+catalog array.
+
+## 1. Required: do not pass the injectable resolver directly to Commander
+
+The spec proposes this testable signature:
+
+```ts
+resolveModelFlag(value: string, catalogNames?: string[]): ResolvedModelFlag
+```
+
+and then installs it directly as Commander's option parser:
+
+```ts
+.option("--model <name>", description, resolveModelFlag)
+```
+
+Commander calls an option parser with `(value, previous)`. On the second
+occurrence in a command such as:
+
+```bash
+agency run --model gpt-4o-mini --model claude-opus-4-8 greet.agency
+```
+
+the second argument is the first `ResolvedModelFlag`, not `string[]`. The
+resolver will therefore treat a resolved object as its catalog. Depending on
+its implementation, that either throws an unrelated runtime error or validates
+against nonsense rather than preserving Commander's normal last-value-wins
+behavior.
+
+Keep the pure injectable resolver, but prevent Commander's accumulator argument
+from entering that interface:
+
+```ts
+.option(
+  "--model <name>",
+  "Model for this run's LLM calls, as `model` or `provider/model`",
+  (value: string) => resolveModelFlag(value),
+)
+```
+
+Alternatively, make the catalog an explicit first-class dependency through a
+factory:
+
+```ts
+export function modelFlagParser(catalogNames: string[] = hostedTextModelNames()) {
+  return (value: string): ResolvedModelFlag =>
+    resolveModelFlag(value, catalogNames);
+}
+```
+
+The one-line adapter is the smaller choice unless production code needs to
+construct parsers against different catalogs.
+
+Add a CLI parser test with `--model` repeated and assert that the last value
+wins. This test is important because direct unit tests of `resolveModelFlag`
+cannot expose the mismatch between its second parameter and Commander's parser
+contract.
+
+## 2. Minor: put the shared data type at the configuration boundary
+
+The spec declares `ResolvedModelFlag` in `lib/cli/modelFlag.ts`, then requires
+`lib/config.ts` to import that CLI-owned type for `CliFlags`. This points the
+general configuration module back toward a CLI implementation module. It also
+creates a potential runtime cycle if the import is not type-only:
+
+```text
+config.ts -> cli/modelFlag.ts -> stdlib/llm.ts -> runtime modules
+```
+
+The declarative value is part of the `CliFlags` contract, so the cleaner
+ownership is to declare it beside `CliFlags` in `lib/config.ts` and have
+`modelFlag.ts` import it with `import type`. Then dependencies point from the
+CLI adapter toward the configuration contract, and `config.ts` remains unaware
+of catalog lookup and Commander.
+
+If the type remains in `modelFlag.ts`, the plan should at minimum require
+`config.ts` to use an explicit `import type` so no runtime dependency or cycle
+is introduced.
+
+## Resolved from the first review
+
+- A bare model clears an inherited provider; a prefixed provider is explicitly
+  documented as sticky under later model-only overrides.
+- The resolver's `string[]` input is now consistent with its output because a
+  bare value no longer claims to derive a provider.
+- `RunOptions.model`, `CliFlags.model`, and `applyCliFlags` form one declarative
+  path rather than a second imperative configuration merge.
+- Unknown prefixed values are allowed for custom providers while empty
+  provider/model components are rejected structurally.
+- Validation uses `_listHostedModels()` and therefore excludes image,
+  embedding, and speech models.
+- The stale-catalog escape is accurately documented as `provider/model`; the
+  existing non-persistent refresh command is not misrepresented.
+- Tests cover immutable config mapping, preservation of neighboring client
+  fields, command and shorthand wiring, failure before compilation, and both
+  model and provider precedence.
+
+With finding 1 corrected, the design is ready to turn into an implementation
+plan.

--- a/packages/agency-lang/docs/superpowers/specs/2026-08-05-run-model-flag-design-REVIEW.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-08-05-run-model-flag-design-REVIEW.md
@@ -1,0 +1,206 @@
+# Review: `agency run --model` design
+
+## Recommendation
+
+**Changes requested.** The flag and the `provider/model` spelling are useful,
+and the proposed pure resolver is the right general boundary. The spec is not
+implementation-ready yet, however. It needs explicit provider-precedence
+semantics, a typed path from the resolver into `applyCliFlags`, and a correction
+to the claim that `agency models refresh` updates the catalog used by later CLI
+runs.
+
+## 1. Blocker: model precedence does not imply provider precedence
+
+The spec treats `{ model, provider }` as one selection and concludes that
+`setModel()` and per-call `model` options automatically win over the CLI flag.
+The runtime does not merge them atomically; it merges fields independently:
+
+- `setModel(name)` writes only `{ model: name }`.
+- `_setLlmOptions` preserves every key the caller omits.
+- `runPrompt` shallow-spreads branch defaults and per-call options over the
+  baked smoltalk defaults.
+- `getSmoltalkConfig` is another shallow spread.
+
+Therefore a lower-precedence provider survives a higher-precedence model-only
+override. Two cases need a defined result:
+
+1. `agency.json` says `defaultProvider: "openrouter"`, then the user runs
+   `--model gpt-4o-mini`. If the flag changes only `defaultModel`, the request
+   still goes through OpenRouter rather than allowing smoltalk to infer OpenAI.
+2. The user runs `--model openrouter/foo`, then Agency code calls
+   `setModel("claude-opus-4-8")`. The effective pair is still
+   `openrouter + claude-opus-4-8`; the model does not independently select the
+   Anthropic provider.
+
+Revise the spec to distinguish an inferred provider from an explicit one:
+
+```ts
+export type ResolvedModelFlag = {
+  model: string;
+  explicitProvider?: string;
+};
+```
+
+Recommended semantics:
+
+- A bare model sets `client.defaultModel` and **removes an inherited
+  `client.defaultProvider`**, allowing smoltalk to infer the provider.
+- `provider/model` sets both fields.
+- An explicit CLI provider remains sticky under a later model-only override.
+  Agency code that wants to switch providers must use
+  `setLlmOptions({ model, provider })`, and a per-call override must likewise
+  pass both fields.
+
+That is the smallest change consistent with the existing rule that
+`setLlmOptions` changes only fields the caller supplies. If the desired rule is
+instead that every higher-precedence model-only value clears a lower provider,
+the feature also requires a runtime merge change in `runPrompt`; it is not a
+compile-time CLI-only change.
+
+The precedence test must record and assert both the model and provider. A test
+that observes only the model will pass while requests are routed through the
+wrong provider.
+
+## 2. Blocker: the resolver interface cannot produce its declared result
+
+The proposed function accepts only model names:
+
+```ts
+resolveModelFlag(value: string, catalogNames?: string[]): ResolvedModel
+```
+
+but `ResolvedModel` may contain a provider, and the resolution table says a bare
+model derives that provider from the catalog. A `string[]` contains no provider
+information, so this contract cannot implement the table.
+
+More importantly, the dataflow into configuration is unspecified and currently
+contradictory:
+
+- `CliFlags` is said to gain `model?: string`.
+- `resolveModelFlag` returns an object.
+- resolution happens in the CLI action.
+- `applyCliFlags` is said to map the resolved value.
+- today `runWithOptions` passes Commander's raw `RunOptions` directly to
+  `applyCliFlags`.
+
+Choose one complete typed flow. A clean option is to use Commander's option
+parser:
+
+```ts
+export type CliFlags = {
+  // existing fields
+  model?: ResolvedModelFlag;
+};
+
+cmd.option(
+  "--model <model>",
+  "...",
+  resolveModelFlag,
+);
+```
+
+Then both `run` and the shorthand naturally pass the resolved value through the
+shared `runWithOptions` path to `applyCliFlags`. Resolver failures should become
+`InvalidArgumentError`s so Commander owns formatting and exit status.
+
+With the recommended provider semantics above, the resolver only needs to
+validate a bare name and can return no provider for it. If the design still
+wants to return the catalog-derived provider, replace `catalogNames` with
+entries such as `{ name, provider }[]`.
+
+## 3. Blocker: `agency models refresh` is not an escape for a new bare model
+
+The spec says users can refresh the catalog and then use a newly released model
+as a bare name. That is not how the current command works:
+
+- `modelsRefresh` fetches data and prints JSON to stdout.
+- It does not register or persist the result.
+- A saved file is loaded only when explicitly supplied to `agency models list`,
+  and only for that process.
+- `std::llm.loadModelData()` runs inside an Agency program, after this CLI
+  validation would already have rejected the flag.
+
+Use the small-scope behavior: remove refresh as an escape and say that a model
+missing from the baked catalog must be written as `provider/model`.
+
+If refreshed bare names are a requirement, this becomes a larger feature. The
+spec must define where refresh persists model data, how every later CLI process
+loads it before parsing `--model`, schema/version handling, precedence over the
+baked catalog, and a cross-process test.
+
+## 4. High: validate only text models and validate prefix structure
+
+The default catalog must not be raw `getAllModels()`. Smoltalk's union also
+contains non-text models. Agency already owns the correct hosted-text adapter in
+`lib/stdlib/llm.ts`: `_listHostedModels()` filters `model.type === "text"` and
+normalizes the fields. Reuse that source rather than duplicating its filtering
+and naming rules in `modelFlag.ts`.
+
+Also distinguish structural validation from catalog validation. Unknown
+prefixed values should be accepted for custom providers, but malformed values
+should still fail before compilation:
+
+- `/model` — empty provider
+- `provider/` — empty model
+- `/` — both empty
+
+“A prefixed name is never validated” should mean its provider and model are not
+checked against the catalog, not that empty components are valid.
+
+## 5. High: strengthen the tests around configuration effects
+
+The proposed integration assertion that generated JavaScript contains a model
+string does not prove provider behavior, preservation of neighboring config, or
+failure before compilation.
+
+Add focused `applyCliFlags` tests:
+
+- A bare model replaces the old model and removes an inherited
+  `defaultProvider`.
+- A prefixed model replaces both model and provider.
+- Other `client` fields, especially `providerModules`, survive.
+- The input configuration is not mutated.
+
+Add resolver tests:
+
+- A bare known model resolves without an explicit provider.
+- Prefix parsing preserves everything after the first slash.
+- Unknown custom providers are accepted.
+- Empty provider/model components fail.
+- The default validation source excludes non-text models.
+
+Strengthen CLI integration coverage:
+
+- Start with an `agency.json` containing a conflicting `defaultProvider`, then
+  prove a bare model clears it.
+- For a prefixed model, assert both generated model and provider.
+- Exercise both `run` and the shorthand.
+- For an unknown bare model, assert non-zero status, the intended stderr text,
+  no Node stack trace, and no generated output file. The last assertion proves
+  validation happened before compilation.
+
+Finally, make the runtime precedence fixture observe `{ model, provider }` for:
+
+- bare CLI model plus `setModel`
+- prefixed CLI model plus `setModel`
+- per-call model only
+- per-call `{ model, provider }`
+
+## 6. Clarify the memory statement
+
+The statement that the flag changes memory extraction is correct for the model:
+`memory.model` falls back to the top-level smoltalk default. Provider behavior
+must follow the decision in finding 1, however. Update this section after that
+decision so it does not imply that changing a model necessarily changes or
+re-derives the provider.
+
+## What is already strong
+
+- One shared `addRunOptions` declaration correctly gives the flag to `run` and
+  the shorthand without duplicate command wiring.
+- First-slash splitting correctly preserves OpenRouter model identifiers.
+- Accepting unknown, structurally valid prefixed values is necessary for custom
+  provider modules.
+- Moving the existing Levenshtein implementation avoids duplicating it.
+- Keeping configuration mapping in `applyCliFlags` is the correct declarative
+  boundary, once the resolved flag type and provider semantics are explicit.

--- a/packages/agency-lang/docs/superpowers/specs/2026-08-05-run-model-flag-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-08-05-run-model-flag-design.md
@@ -3,6 +3,8 @@
 Adds a `--model` flag to `agency run` and to the bare `agency <file>` shorthand,
 which sets the default model for that run.
 
+Revision 2. Changes from revision 1 are listed at the end.
+
 ## Background
 
 ### What you can do today, and what you cannot
@@ -17,49 +19,76 @@ model, your only options are to edit `agency.json`, or to change the Agency
 source and recompile. Neither is convenient when you are comparing two models
 against the same program, which is the main thing people want this for.
 
+### Model and provider are two separate settings
+
+This is the fact the whole design turns on, so it comes first.
+
+A request to a language model needs two pieces of information: which model, and
+which provider to reach it through. In agency these live in two configuration
+fields, `client.defaultModel` and `client.defaultProvider`, and they are carried
+separately all the way down to the request.
+
+They are also **merged separately**. Every layer that can override a model does
+so with a shallow object spread, meaning it replaces only the keys it actually
+sets:
+
+- `lib/runtime/state/context.ts:763` — `{ ...this.smoltalkDefaults, ...config }`
+- `lib/runtime/prompt.ts:1026` — `{ ...stackSmolDefaults, ...restClientConfig }`
+
+And `setModel(name)` in `stdlib/llm.agency` writes only `{ model: name }`.
+
+Put together: **a provider set by a lower layer survives a higher layer that
+changes only the model.** If `agency.json` says the provider is `openrouter` and
+Agency code then calls `setModel("claude-opus-4-8")`, the request still goes to
+OpenRouter, now asking it for a model named `claude-opus-4-8`.
+
+That is not a bug — it is what "set only what I named" means — but it means this
+design cannot treat model-and-provider as a single value that higher layers
+replace wholesale. Section "Provider semantics" below defines what the flag does
+about it.
+
 ### How a model gets chosen today
 
-There are three places a model can come from, and they layer. The layering is
-documented in `lib/runtime/prompt.ts:1010` and is worth stating exactly, because
-the whole design depends on it:
+Three layers, documented at `lib/runtime/prompt.ts:1010`:
 
 ```
 baked agency.json  <  setModel() / setLlmOptions()  <  llm({ model: ... })
 ```
 
-Reading that from the left:
+Reading from the left:
 
 1. **The baked default.** When agency compiles your program it writes a smoltalk
-   client configuration straight into the generated JavaScript
+   client configuration into the generated JavaScript
    (`lib/backends/typescriptBuilder.ts:4413`), including
-   `model: cfg.client?.defaultModel || "gpt-4o-mini"`. This is the fallback that
-   applies when nothing else says otherwise.
-2. **Run-wide defaults set from Agency code.** `setModel("claude-opus-4-8")`
-   from `std::llm` stores a value on the active branch's `llmDefaults`, which
-   applies to every later `llm()` call in that branch.
+   `model: cfg.client?.defaultModel || "gpt-4o-mini"`. A provider is written
+   **only if one is configured** — the codegen comment says it leaves it unset
+   otherwise "so smoltalk's normal model→provider registry lookup still
+   applies".
+2. **Run-wide defaults from Agency code.** `setModel("claude-opus-4-8")` stores
+   a value on the active branch's `llmDefaults`, applying to every later `llm()`
+   call in that branch.
 3. **Per-call options.** `llm(prompt, { model: "gpt-4o-mini" })` wins over
    everything.
 
-Because the CLI flag will feed layer 1 — the lowest one — the requirement that
-"a model set explicitly in Agency code still wins" needs no new code. It already
-holds.
+Because the CLI flag feeds layer 1 — the lowest — the requirement that "a model
+set explicitly in Agency code still wins" needs no new code for the *model*. The
+provider needs the rule in "Provider semantics".
 
 ### How a CLI flag becomes configuration
 
-`lib/config.ts:655` documents three configuration sources and where each is
-applied:
+`lib/config.ts:655` documents three configuration sources and where each applies:
 
 1. `agency.json`, found by walking up from the current directory.
-2. **CLI flags**, mapped onto the configuration by `applyCliFlags`. That comment
+2. **CLI flags**, mapped onto configuration by `applyCliFlags`. That comment
    says this is "the ONLY place that defines what each flag means in config
    terms". The result is baked into the generated program at compile time.
-3. `AGENCY_CONFIG_OVERRIDES`, a JSON blob in the environment, applied at runtime.
-   Its stated job is to push configuration into a process whose configuration
-   was already baked and cannot be re-derived from source — precompiled agents
-   and `agency pack` bundles.
+3. `AGENCY_CONFIG_OVERRIDES`, a JSON blob in the environment, applied at
+   runtime. Its stated job is to reach a process whose configuration was already
+   baked and cannot be re-derived from source — precompiled agents and
+   `agency pack` bundles.
 
-`--model` belongs in source 2. Source 3 exists for programs that have already
-been compiled, which is not the case here.
+`--model` belongs in source 2. Source 3 exists for already-compiled programs,
+which is not this case.
 
 ### Why baking at compile time costs nothing
 
@@ -69,37 +98,44 @@ a full rebuild.
 
 Neither happens. `agency run` passes an import strategy to `compile()`, and
 `resolveFreshness` in `lib/compiler/buildSession.ts:104` returns `"always"`
-whenever an import strategy is supplied. That means `agency run` never consults
+whenever an import strategy is supplied. `agency run` therefore never consults
 the build manifest and recompiles every time, with or without this flag. I
 confirmed this by measuring: running the same two-file program twice rewrites
 the imported module's `.js` both times.
 
 For `agency compile`, which does use the manifest, the cache key is
 `deriveConfigKey(config)` — `JSON.stringify` of the whole configuration
-(`lib/compiler/buildManifest.ts:131`). A changed model therefore changes the key
-and correctly invalidates. Nothing needs adding for either path.
+(`lib/compiler/buildManifest.ts:131`). A changed model changes the key and
+correctly invalidates. Nothing needs adding for either path.
 
 ### What names models actually have
 
-The built-in catalog, reachable through smoltalk's `getAllModels()`, holds 68
-hosted text models across four providers: `openai` (28), `google` (23),
-`anthropic` (12), and `openai-responses` (5). Two facts about it shape the
-design, both measured rather than assumed:
+Smoltalk's `getAllModels()` returns 68 entries, but **only 56 are text models**.
+The rest are 7 image models, 4 embedding models, and 1 speech-to-text model.
+Validating a chat model against the unfiltered list would accept `gpt-image-1`,
+which then fails at the first call.
 
-- **No catalog model name contains a slash.** So a slash in the flag value is
-  free to mean something.
-- **No model name appears under more than one provider.** So looking a bare name
-  up in the catalog gives exactly one provider, with no ambiguity to resolve.
+Agency already owns the right adapter: `_listHostedModels()` in
+`lib/stdlib/llm.ts:104` filters `model.type === "text"` and normalizes the
+fields. That is the source this design uses.
+
+Two facts about those 56 text models shape the design, both measured:
+
+- **No text model name contains a slash.** So a slash in the flag value is free
+  to mean something.
+- **No text model name appears under more than one provider.** The breakdown is
+  `openai` 24, `google` 15, `anthropic` 12, `openai-responses` 5. So looking a
+  bare name up gives exactly one provider, with no ambiguity.
 
 Beyond the catalog, smoltalk ships clients for `openrouter`, `deepinfra`,
-`litellm`, `openai-compat`, `ollama`, `replicate`, and `modal`, none of which
-have catalog entries. And users can register **entirely new providers** of their
-own: `client.providerModules` lists JavaScript files loaded at startup, each
-exporting `register({ registerProvider })` (`lib/config.ts:174`). Those names are
-created by imperative code at runtime, so the CLI cannot know them when it parses
-the flag.
+`litellm`, `openai-compat`, `ollama`, `replicate`, and `modal`, none with
+catalog entries. And users can register **entirely new providers**:
+`client.providerModules` (`lib/config.ts:174`) lists JavaScript files loaded at
+startup, each exporting `register({ registerProvider })`. Those names are
+created by imperative code at runtime, so the CLI cannot know them when it
+parses the flag.
 
-That last point decides the validation rule below.
+That last point decides the validation rule.
 
 ## The flag
 
@@ -107,17 +143,17 @@ That last point decides the validation rule below.
 --model <name>    Model for this run's LLM calls, as `model` or `provider/model`
 ```
 
-It is added to `addRunOptions`, the helper that `run` and the hidden default
-command already share, so the shorthand gets it from the same line:
+It is added to `addRunOptions`, the helper `run` and the hidden default command
+already share, so the shorthand gets it from the same line:
 
 ```bash
 agency run --model claude-opus-4-8 greet.agency
 agency --model claude-opus-4-8 greet.agency
 ```
 
-Both forms follow the position rule shipped in #805 and #808: agency's flags go
-before the filename, and everything after the filename belongs to the program.
-Writing `agency run greet.agency --model x` sends `--model x` to the program and
+Both follow the position rule shipped in #805 and #808: agency's flags go before
+the filename, everything after belongs to the program. Writing
+`agency run greet.agency --model x` forwards `--model x` to the program and
 prints the standard warning. That behaviour is inherited, not added here.
 
 ## Reading the value
@@ -127,7 +163,7 @@ the provider and everything after it is the model name.
 
 | you write | provider | model name |
 | --- | --- | --- |
-| `gpt-4o-mini` | looked up in the catalog → `openai` | `gpt-4o-mini` |
+| `gpt-4o-mini` | none set; smoltalk infers `openai` | `gpt-4o-mini` |
 | `anthropic/claude-opus-4-8` | `anthropic` | `claude-opus-4-8` |
 | `openrouter/anthropic/claude-sonnet-4` | `openrouter` | `anthropic/claude-sonnet-4` |
 | `my-company/my-tune` | `my-company` | `my-tune` |
@@ -137,144 +173,275 @@ model identifiers contain a slash natively — `anthropic/claude-sonnet-4` is th
 whole model name as far as OpenRouter is concerned — so the prefix form is how
 you say which layer you mean.
 
-The fourth row is the case that custom providers force. There is no list of
-"real" provider names to check against, because a provider module can register
-any name it likes at startup. So a slash means a provider was given, and agency
-takes the user at their word.
+The fourth row is what custom providers force. There is no list of "real"
+provider names to check against, because a provider module can register any name
+at startup. A slash means a provider was given, and agency takes the user at
+their word.
 
 **The one thing this cannot express** is a bare OpenRouter-style name. Typing
 `--model anthropic/claude-sonnet-4` when you meant OpenRouter's model of that
-name gives you provider `anthropic` instead. Writing
+name gives you provider `anthropic`. Writing
 `openrouter/anthropic/claude-sonnet-4` says it unambiguously. This is a
 deliberate trade: the alternative was a second `--provider` flag, and one flag
-that reads left to right beats two flags with a precedence rule.
+that reads left to right beats two flags with a precedence rule between them.
+
+## Provider semantics
+
+The resolved flag distinguishes a provider the user *stated* from one that is
+merely *inferred*:
+
+```ts
+export type ResolvedModelFlag = {
+  model: string;
+  /** Set only when the user wrote `provider/model`. */
+  explicitProvider?: string;
+};
+```
+
+Three rules follow.
+
+**A bare model sets the model and clears any inherited provider.**
+`applyCliFlags` sets `client.defaultModel` and **deletes**
+`client.defaultProvider`. With no provider configured, the codegen emits none,
+and smoltalk infers the provider from the model name. This is what "derive the
+provider if we can" means in practice.
+
+*Consequence worth knowing.* If your `agency.json` sets
+`defaultProvider: "litellm"` to route everything through a proxy, then
+`--model gpt-4o-mini` will **not** use that proxy — it clears the provider and
+goes to OpenAI directly. To keep the proxy, name it: `--model litellm/gpt-4o-mini`.
+This is the intended reading of "just the model name, derive the provider", but
+it is a real behaviour change for anyone relying on a configured provider, so it
+is called out here rather than left to be discovered.
+
+**`provider/model` sets both fields.** `client.defaultProvider` and
+`client.defaultModel` are both written.
+
+**An explicit provider is sticky.** Because layers merge field by field, a
+provider set by the flag survives a later `setModel("other")` in Agency code.
+The pair becomes `that provider + the new model`. Agency code that wants to
+change provider too must say so: `setLlmOptions({ model, provider })`, or a
+per-call `llm(prompt, { model, provider })`.
+
+This is the smallest rule consistent with how `setLlmOptions` already behaves —
+it changes only the fields the caller supplies. Making a model-only override
+clear a lower-layer provider would require changing the runtime merge in
+`runPrompt`, which is a larger change than a CLI flag and is not proposed here.
 
 ## Validation
 
-**A bare name — no slash — must be in the catalog.** A bare name is the only
-case where agency has to derive the provider itself, and the catalog is the only
-thing it can derive it from. If the name is not there, agency cannot proceed
-sensibly, so it stops before doing any work:
+Two kinds, and they are different.
+
+**Structural validation applies to every value.** These fail regardless of
+provider, because they cannot mean anything:
+
+| value | why it fails |
+| --- | --- |
+| `` (empty) | no model named |
+| `/model` | empty provider |
+| `provider/` | empty model |
+| `/` | both empty |
+
+**Catalog validation applies only to a bare name.** A bare name is the only case
+where agency must derive the provider itself, and the text catalog is the only
+thing it can derive from. If the name is not there, agency stops before doing
+any work:
 
 ```
 $ agency run --model gpt-4o-minii greet.agency
-Error: unknown model "gpt-4o-minii".
-  Did you mean "gpt-4o-mini"?
+error: option '--model <name>' argument 'gpt-4o-minii' is invalid.
+  Unknown model "gpt-4o-minii". Did you mean "gpt-4o-mini"?
   For a model from another provider, write provider/model —
   e.g. openrouter/gpt-4o-minii
   Run `agency models list` to see the catalog.
 ```
 
-**A prefixed name is never validated.** Agency sets the provider and model
-verbatim and lets the LLM call be the judge. A custom provider registered by a
-provider module is indistinguishable, at flag-parse time, from a typo — so
-guessing would reject legitimate configurations.
+**A prefixed name is never checked against the catalog.** Agency sets provider
+and model verbatim and lets the LLM call be the judge. A custom provider
+registered by a provider module is indistinguishable, at flag-parse time, from a
+typo, so guessing would reject legitimate configurations.
 
-The failure this prevents is a real one: without validation, a typo starts the
-run, compiles the program, executes everything up to the first `llm()` call, and
-only then fails. For an agent that can be minutes of work and real spend.
+The failure this prevents is real: without validation a typo starts the run,
+compiles the program, executes everything up to the first `llm()` call, and only
+then fails. For an agent that can be minutes of work and real spend.
 
 The cost is that a hosted model released after the catalog snapshot is rejected
-when typed bare. There are two escapes and the error names both: write
-`openai/the-new-model`, or refresh the catalog with `agency models refresh`.
+when typed bare. **The escape is the prefix form**, `openai/the-new-model`, and
+the error names it. Note that `agency models refresh` is *not* an escape: it
+prints JSON to stdout and persists nothing (`lib/cli/hostedModels.ts:71`), so it
+cannot affect a later CLI process's validation. Making refreshed data visible to
+CLI validation would need a persistence location, a load step before flag
+parsing, schema versioning, and precedence against the baked catalog — a
+separate feature, not this one.
 
 ### Suggestions
 
-The "did you mean" line uses Levenshtein edit distance against the catalog
+The "did you mean" line uses Levenshtein edit distance against the text catalog
 names, suggesting the closest match when its distance is at most 3 and omitting
 the line otherwise. `lib/eval/grading/graders/builtinGraders.ts:106` already
-contains a dependency-free implementation; it moves to `lib/levenshtein.ts` and
+holds a dependency-free implementation; it moves to `lib/levenshtein.ts` and
 both callers import it, rather than a second copy being written.
 
 ## What this changes and what it does not
 
-**Changes.** `client.defaultModel`, and `client.defaultProvider` when a prefix
-was given. That is the whole configuration footprint.
+**Changes.** `client.defaultModel` always; `client.defaultProvider` set when a
+prefix was given, deleted when it was not. That is the whole configuration
+footprint.
 
-**Does not change.** `setModel()` and `llm({ model })` keep winning, per the
-layering above. No `--fastmodel`, `--slowmodel`, or `--provider` flag is added;
-those remain specific to `agency agent`, which needs several model slots because
-it runs several kinds of work. `agency run` runs one program.
+**Does not change.** `setModel()` and `llm({ model })` keep winning for the
+model. No `--fastmodel`, `--slowmodel`, or `--provider` flag is added; those stay
+specific to `agency agent`, which needs several model slots because it runs
+several kinds of work. `agency run` runs one program.
 
-**A knock-on effect worth stating.** Memory extraction resolves its model as
-`memory.model` first and falls back to the top-level default
+**A knock-on effect.** Memory extraction resolves its model as `memory.model`
+first, falling back to the top-level default
 (`lib/runtime/memory/manager.ts:560`). So `--model` also changes the model used
-for memory extraction and compaction. This is intended: the flag sets the run's
-default model, and memory extraction is part of the run.
+for memory extraction and compaction. Memory has no provider field of its own,
+so it reaches the provider through the same client configuration as everything
+else — which means a bare `--model` also moves memory extraction onto the
+inferred provider, and a prefixed one onto the named provider. This is intended:
+the flag sets the run's default model, and memory extraction is part of the run.
 
 ## Structure
 
 Three pieces, each with one job.
 
-**`lib/cli/modelFlag.ts`** — the parse-and-validate step, as a pure function:
+**`lib/cli/modelFlag.ts`** — parsing and validation, as a pure function:
 
 ```ts
-export type ResolvedModel = { model: string; provider?: string };
+export type ResolvedModelFlag = {
+  model: string;
+  explicitProvider?: string;
+};
 
-/** Throws with a user-facing message when a bare name is not in the catalog.
- *  `catalogNames` defaults to smoltalk's `getAllModels()`. */
+/** Commander option parser. Throws InvalidArgumentError with a user-facing
+ *  message for a structurally invalid value, or a bare name that is not a
+ *  known text model. `catalogNames` defaults to the names from
+ *  `_listHostedModels()`. */
 export function resolveModelFlag(
   value: string,
   catalogNames?: string[],
-): ResolvedModel;
+): ResolvedModelFlag;
 ```
 
-Pure and catalog-driven, so it is testable without a CLI or a network call. The
-catalog arrives as a defaulted parameter so tests supply their own list instead
-of depending on which models happen to ship this month.
+`catalogNames` is a plain `string[]` because a bare name no longer needs to
+produce a provider — it clears the provider and lets smoltalk infer. The
+parameter is defaulted so tests supply their own list instead of depending on
+which models happen to ship this month.
 
 **`lib/levenshtein.ts`** — the edit-distance function moved out of
 `builtinGraders.ts`, unchanged.
 
-**`applyCliFlags` in `lib/config.ts`** — maps the resolved value onto
-`client.defaultModel` and `client.defaultProvider`. This keeps the promise the
-file already makes: one place defines what a flag means in configuration terms.
+**`applyCliFlags` in `lib/config.ts`** — maps `ResolvedModelFlag` onto
+`client.defaultModel` and `client.defaultProvider`, per the three rules above.
+This keeps the promise the file already makes: one place defines what a flag
+means in configuration terms.
 
-`CliFlags` gains `model?: string`, and `addRunOptions` in `scripts/agency.ts`
-gains the option. Both `run` and the shorthand pick it up from there.
+### Dataflow
 
-## Errors
+The resolver is wired as Commander's own option parser, the way
+`parsePositiveInt` already is for `--max-tool-call-rounds`:
 
-One error, raised before any compilation: an unknown bare model name, shown
-above. It exits non-zero with the message on stderr, matching how the CLI
-reports every other bad flag value.
+```ts
+.option(
+  "--model <name>",
+  "Model for this run's LLM calls, as `model` or `provider/model`",
+  resolveModelFlag,
+)
+```
 
-`applyCliFlags` is not the place to raise it — that function is a pure mapping
-and is called on paths that should not exit. The check runs in
-`resolveModelFlag`, called from the CLI action, and the CLI turns the thrown
-message into the stderr output and exit code.
+So by the time the action runs, `RunOptions.model` is already a
+`ResolvedModelFlag`, and `runWithOptions` passes it to `applyCliFlags` through
+the path it already uses for every other flag. `CliFlags` gains
+`model?: ResolvedModelFlag`.
+
+Nothing new is needed in the action, and both `run` and the shorthand inherit
+the flag from `addRunOptions`.
+
+### Errors
+
+Failures are `InvalidArgumentError`s thrown by the parser, so Commander owns the
+formatting, the `error:` prefix, and the exit status — the same treatment every
+other bad flag value gets today. `applyCliFlags` raises nothing: it stays a pure
+mapping, and is called on paths that must not exit.
 
 ## Testing
 
-**`lib/cli/modelFlag.test.ts`** — one case per row of the resolution table, plus:
+**`lib/cli/modelFlag.test.ts`**
 
-- a bare unknown name throws, and the message names the closest catalog entry
-- a bare unknown name with no near match still throws, without a "did you mean"
-  line
-- a prefixed unknown name does **not** throw, which is the custom-provider
-  guarantee and the one most likely to be broken by a later "improvement"
+- one case per row of the resolution table
 - `openrouter/anthropic/claude-sonnet-4` keeps the second slash in the model name
+- a bare known name resolves with no `explicitProvider`
+- a bare unknown name throws, and the message names the closest catalog entry
+- a bare unknown name with no near match throws without a "did you mean" line
+- a prefixed unknown name and unknown provider do **not** throw — the
+  custom-provider guarantee, and the case most likely to be broken by a later
+  "improvement"
+- every structural case fails: ``, `/model`, `provider/`, `/`
+- the default catalog excludes non-text models: `gpt-image-1` is rejected as a
+  bare name
 
-**`tests/integration/cli/test.mjs`** — the flag reaching a real run. The existing
-suite makes no LLM calls, so the assertion is on the compiled output rather than
-on a completed call: compile with `--model` and check the generated JavaScript
-carries that model in its smoltalk client configuration. A second case asserts
-that an unknown bare name exits non-zero with the error, and a third runs the
-same thing through the shorthand to prove both commands share the flag.
+**`lib/config.test.ts`** (or the existing `applyCliFlags` tests)
 
-**`lib/runtime/` precedence test** — an Agency execution test calling
-`setModel()` and asserting the model actually used is the one from the code, not
-the one from the flag. This is the guarantee users are relying on when they set a
-model in source, and nothing else in the suite would notice if the layering
-changed.
+- a bare model replaces `defaultModel` and **deletes** an inherited
+  `defaultProvider`
+- a prefixed model sets both fields
+- other `client` fields survive, `providerModules` especially
+- the input configuration object is not mutated
+
+**`tests/integration/cli/test.mjs`** — the flag reaching a real run. The suite
+makes no LLM calls, so assertions are on the compiled output:
+
+- with an `agency.json` containing a conflicting `defaultProvider`, a bare
+  `--model` produces generated JavaScript with the new model and **no** provider
+- a prefixed `--model` produces both the model and the provider
+- the same through the shorthand, proving both commands share the flag
+- an unknown bare name exits non-zero, prints the intended stderr text, shows no
+  Node stack trace, and **writes no output file** — that last assertion is what
+  proves validation happened before compilation rather than after
+
+**An Agency execution test for precedence** — the guarantee users rely on when
+they set a model in source, which nothing else in the suite would notice
+breaking. It must observe **both** model and provider, since a test watching
+only the model would pass while requests went to the wrong provider. Four cases:
+
+| flag | code | expected pair |
+| --- | --- | --- |
+| bare `--model A` | `setModel("B")` | provider inferred from B, model B |
+| `p/A` | `setModel("B")` | provider `p`, model B (sticky) |
+| `p/A` | `llm({ model: "B" })` | provider `p`, model B |
+| `p/A` | `llm({ model: "B", provider: "q" })` | provider `q`, model B |
 
 ## Out of scope
 
 - `--fastmodel` / `--slowmodel` / `--provider` for `agency run`.
-- Local models. `--local` and `--local-model` remain agent-only. A local model
+- Local models. `--local` and `--local-model` stay agent-only. A local model
   reached through a provider module works today via the prefix form.
+- Persisting `agency models refresh` output so refreshed names pass validation.
 - `agency test`, `agency eval`, and `agency serve`.
-- The two `agency agent` command-line gaps found while investigating this: a
+- The two `agency agent` command-line gaps found while investigating: a
   misplaced `--max-cost` is forwarded to the agent, and root flags such as `-c`
   cannot reach agency at all. Both currently produce a clear error rather than
-  failing silently. They are noted here only so they are not lost.
+  failing silently. Noted here only so they are not lost.
+
+## Changes from revision 1
+
+1. **Provider precedence is now specified.** Revision 1 assumed model and
+   provider moved together; they merge field by field, so a lower-layer provider
+   survives a model-only override. Added `ResolvedModelFlag` with
+   `explicitProvider`, the clear-on-bare rule, and the sticky-provider rule.
+2. **The resolver's contract is now coherent.** Revision 1 returned a provider
+   but took only `string[]`, which cannot supply one. Bare names no longer
+   return a provider, so `string[]` is right.
+3. **The dataflow is specified**: the resolver is a Commander option parser, so
+   `RunOptions.model` is already resolved and reaches `applyCliFlags` unchanged.
+4. **`agency models refresh` removed as an escape.** It prints to stdout and
+   persists nothing, so it cannot affect later validation. The prefix form is
+   the only escape.
+5. **Validation source corrected** from `getAllModels()` (68 entries, 12 of them
+   not text) to `_listHostedModels()` (56 text models). Revision 1's "68 hosted
+   text models" was wrong.
+6. **Structural validation added** for empty provider or model components.
+7. **Tests strengthened**: `applyCliFlags` cases, provider assertions in the
+   integration and precedence tests, and the no-output-file assertion that
+   proves validation precedes compilation.

--- a/packages/agency-lang/docs/superpowers/specs/2026-08-05-run-model-flag-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-08-05-run-model-flag-design.md
@@ -3,7 +3,7 @@
 Adds a `--model` flag to `agency run` and to the bare `agency <file>` shorthand,
 which sets the default model for that run.
 
-Revision 2. Changes from revision 1 are listed at the end.
+Revision 3. Changes from earlier revisions are listed at the end.
 
 ## Background
 
@@ -188,7 +188,8 @@ that reads left to right beats two flags with a precedence rule between them.
 ## Provider semantics
 
 The resolved flag distinguishes a provider the user *stated* from one that is
-merely *inferred*:
+merely *inferred*. The type is declared in `lib/config.ts` beside `CliFlags`,
+because it is part of that contract:
 
 ```ts
 export type ResolvedModelFlag = {
@@ -197,6 +198,12 @@ export type ResolvedModelFlag = {
   explicitProvider?: string;
 };
 ```
+
+Declaring it there keeps dependencies pointing one way. `lib/config.ts` imports
+only `types`, `logger`, `zod`, `fs` and `path` today; if it reached into
+`lib/cli/modelFlag.ts` for this type it would gain a path toward the CLI, and
+through it toward `lib/stdlib/llm.ts` and the runtime. `modelFlag.ts` takes the
+type the other way with `import type`, so nothing new exists at runtime.
 
 Three rules follow.
 
@@ -309,15 +316,11 @@ Three pieces, each with one job.
 **`lib/cli/modelFlag.ts`** — parsing and validation, as a pure function:
 
 ```ts
-export type ResolvedModelFlag = {
-  model: string;
-  explicitProvider?: string;
-};
+import type { ResolvedModelFlag } from "@/config.js";
 
-/** Commander option parser. Throws InvalidArgumentError with a user-facing
- *  message for a structurally invalid value, or a bare name that is not a
- *  known text model. `catalogNames` defaults to the names from
- *  `_listHostedModels()`. */
+/** Throws InvalidArgumentError with a user-facing message for a structurally
+ *  invalid value, or a bare name that is not a known text model.
+ *  `catalogNames` defaults to the names from `_listHostedModels()`. */
 export function resolveModelFlag(
   value: string,
   catalogNames?: string[],
@@ -340,15 +343,34 @@ means in configuration terms.
 ### Dataflow
 
 The resolver is wired as Commander's own option parser, the way
-`parsePositiveInt` already is for `--max-tool-call-rounds`:
+`parsePositiveInt` already is for `--max-tool-call-rounds` — but behind a
+one-line adapter:
 
 ```ts
 .option(
   "--model <name>",
   "Model for this run's LLM calls, as `model` or `provider/model`",
-  resolveModelFlag,
+  (value: string) => resolveModelFlag(value),
 )
 ```
+
+**The adapter is not decoration.** Commander calls an option parser with
+`(value, previous)`, where `previous` is whatever the parser returned last time.
+Repeating the flag —
+
+```bash
+agency run --model gpt-4o-mini --model claude-opus-4-8 greet.agency
+```
+
+— calls the parser a second time with the first `ResolvedModelFlag` as its
+second argument. Passing `resolveModelFlag` in directly would hand that object
+to `catalogNames`, which expects `string[]`: the resolver would then validate
+against nonsense or throw something unrelated, instead of Commander's normal
+last-value-wins behaviour. I verified Commander does this.
+
+The existing parsers avoid the problem by accident: `parsePositiveInt(value:
+string)` declares one parameter, so the extra argument is ignored. A resolver
+with a meaningful second parameter cannot rely on that.
 
 So by the time the action runs, `RunOptions.model` is already a
 `ResolvedModelFlag`, and `runWithOptions` passes it to `applyCliFlags` through
@@ -380,6 +402,12 @@ mapping, and is called on paths that must not exit.
 - every structural case fails: ``, `/model`, `provider/`, `/`
 - the default catalog excludes non-text models: `gpt-image-1` is rejected as a
   bare name
+
+**A Commander wiring test** — build the program, parse
+`--model gpt-4o-mini --model claude-opus-4-8`, and assert the last value wins
+with a correctly resolved object. Unit tests of `resolveModelFlag` cannot catch
+this: the mismatch is between its second parameter and Commander's parser
+contract, which only appears once the two are wired together.
 
 **`lib/config.test.ts`** (or the existing `applyCliFlags` tests)
 
@@ -423,6 +451,16 @@ only the model would pass while requests went to the wrong provider. Four cases:
   misplaced `--max-cost` is forwarded to the agent, and root flags such as `-c`
   cannot reach agency at all. Both currently produce a clear error rather than
   failing silently. Noted here only so they are not lost.
+
+## Changes from revision 2
+
+1. **The Commander parser is wrapped in a one-line adapter.** Passing
+   `resolveModelFlag` directly would let Commander's `previous` argument arrive
+   as `catalogNames` when the flag is repeated. Added a wiring test for the
+   repeated flag.
+2. **`ResolvedModelFlag` moves to `lib/config.ts`**, beside `CliFlags`, with
+   `modelFlag.ts` importing it via `import type`. Keeps `config.ts` from
+   depending on a CLI module and the runtime graph behind it.
 
 ## Changes from revision 1
 

--- a/packages/agency-lang/docs/superpowers/specs/2026-08-05-run-model-flag-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-08-05-run-model-flag-design.md
@@ -1,0 +1,280 @@
+# `agency run --model` — design
+
+Adds a `--model` flag to `agency run` and to the bare `agency <file>` shorthand,
+which sets the default model for that run.
+
+## Background
+
+### What you can do today, and what you cannot
+
+`agency agent` already lets you pick a model on the command line. It has four
+flags for it — `--model`, `--fastmodel`, `--slowmodel`, and `--provider` —
+because the agent runs several kinds of work and wants a different model for
+each: ordinary turns use one, deep-reasoning subagents use another.
+
+`agency run` has none of this. If you want your program to use a different
+model, your only options are to edit `agency.json`, or to change the Agency
+source and recompile. Neither is convenient when you are comparing two models
+against the same program, which is the main thing people want this for.
+
+### How a model gets chosen today
+
+There are three places a model can come from, and they layer. The layering is
+documented in `lib/runtime/prompt.ts:1010` and is worth stating exactly, because
+the whole design depends on it:
+
+```
+baked agency.json  <  setModel() / setLlmOptions()  <  llm({ model: ... })
+```
+
+Reading that from the left:
+
+1. **The baked default.** When agency compiles your program it writes a smoltalk
+   client configuration straight into the generated JavaScript
+   (`lib/backends/typescriptBuilder.ts:4413`), including
+   `model: cfg.client?.defaultModel || "gpt-4o-mini"`. This is the fallback that
+   applies when nothing else says otherwise.
+2. **Run-wide defaults set from Agency code.** `setModel("claude-opus-4-8")`
+   from `std::llm` stores a value on the active branch's `llmDefaults`, which
+   applies to every later `llm()` call in that branch.
+3. **Per-call options.** `llm(prompt, { model: "gpt-4o-mini" })` wins over
+   everything.
+
+Because the CLI flag will feed layer 1 — the lowest one — the requirement that
+"a model set explicitly in Agency code still wins" needs no new code. It already
+holds.
+
+### How a CLI flag becomes configuration
+
+`lib/config.ts:655` documents three configuration sources and where each is
+applied:
+
+1. `agency.json`, found by walking up from the current directory.
+2. **CLI flags**, mapped onto the configuration by `applyCliFlags`. That comment
+   says this is "the ONLY place that defines what each flag means in config
+   terms". The result is baked into the generated program at compile time.
+3. `AGENCY_CONFIG_OVERRIDES`, a JSON blob in the environment, applied at runtime.
+   Its stated job is to push configuration into a process whose configuration
+   was already baked and cannot be re-derived from source — precompiled agents
+   and `agency pack` bundles.
+
+`--model` belongs in source 2. Source 3 exists for programs that have already
+been compiled, which is not the case here.
+
+### Why baking at compile time costs nothing
+
+Baking configuration into generated code raises an obvious worry: if the
+compiler caches its output, changing `--model` would either be ignored or force
+a full rebuild.
+
+Neither happens. `agency run` passes an import strategy to `compile()`, and
+`resolveFreshness` in `lib/compiler/buildSession.ts:104` returns `"always"`
+whenever an import strategy is supplied. That means `agency run` never consults
+the build manifest and recompiles every time, with or without this flag. I
+confirmed this by measuring: running the same two-file program twice rewrites
+the imported module's `.js` both times.
+
+For `agency compile`, which does use the manifest, the cache key is
+`deriveConfigKey(config)` — `JSON.stringify` of the whole configuration
+(`lib/compiler/buildManifest.ts:131`). A changed model therefore changes the key
+and correctly invalidates. Nothing needs adding for either path.
+
+### What names models actually have
+
+The built-in catalog, reachable through smoltalk's `getAllModels()`, holds 68
+hosted text models across four providers: `openai` (28), `google` (23),
+`anthropic` (12), and `openai-responses` (5). Two facts about it shape the
+design, both measured rather than assumed:
+
+- **No catalog model name contains a slash.** So a slash in the flag value is
+  free to mean something.
+- **No model name appears under more than one provider.** So looking a bare name
+  up in the catalog gives exactly one provider, with no ambiguity to resolve.
+
+Beyond the catalog, smoltalk ships clients for `openrouter`, `deepinfra`,
+`litellm`, `openai-compat`, `ollama`, `replicate`, and `modal`, none of which
+have catalog entries. And users can register **entirely new providers** of their
+own: `client.providerModules` lists JavaScript files loaded at startup, each
+exporting `register({ registerProvider })` (`lib/config.ts:174`). Those names are
+created by imperative code at runtime, so the CLI cannot know them when it parses
+the flag.
+
+That last point decides the validation rule below.
+
+## The flag
+
+```
+--model <name>    Model for this run's LLM calls, as `model` or `provider/model`
+```
+
+It is added to `addRunOptions`, the helper that `run` and the hidden default
+command already share, so the shorthand gets it from the same line:
+
+```bash
+agency run --model claude-opus-4-8 greet.agency
+agency --model claude-opus-4-8 greet.agency
+```
+
+Both forms follow the position rule shipped in #805 and #808: agency's flags go
+before the filename, and everything after the filename belongs to the program.
+Writing `agency run greet.agency --model x` sends `--model x` to the program and
+prints the standard warning. That behaviour is inherited, not added here.
+
+## Reading the value
+
+Split on the **first** slash only. If there is a slash, everything before it is
+the provider and everything after it is the model name.
+
+| you write | provider | model name |
+| --- | --- | --- |
+| `gpt-4o-mini` | looked up in the catalog → `openai` | `gpt-4o-mini` |
+| `anthropic/claude-opus-4-8` | `anthropic` | `claude-opus-4-8` |
+| `openrouter/anthropic/claude-sonnet-4` | `openrouter` | `anthropic/claude-sonnet-4` |
+| `my-company/my-tune` | `my-company` | `my-tune` |
+
+Splitting on the first slash only is what makes the third row work. OpenRouter's
+model identifiers contain a slash natively — `anthropic/claude-sonnet-4` is the
+whole model name as far as OpenRouter is concerned — so the prefix form is how
+you say which layer you mean.
+
+The fourth row is the case that custom providers force. There is no list of
+"real" provider names to check against, because a provider module can register
+any name it likes at startup. So a slash means a provider was given, and agency
+takes the user at their word.
+
+**The one thing this cannot express** is a bare OpenRouter-style name. Typing
+`--model anthropic/claude-sonnet-4` when you meant OpenRouter's model of that
+name gives you provider `anthropic` instead. Writing
+`openrouter/anthropic/claude-sonnet-4` says it unambiguously. This is a
+deliberate trade: the alternative was a second `--provider` flag, and one flag
+that reads left to right beats two flags with a precedence rule.
+
+## Validation
+
+**A bare name — no slash — must be in the catalog.** A bare name is the only
+case where agency has to derive the provider itself, and the catalog is the only
+thing it can derive it from. If the name is not there, agency cannot proceed
+sensibly, so it stops before doing any work:
+
+```
+$ agency run --model gpt-4o-minii greet.agency
+Error: unknown model "gpt-4o-minii".
+  Did you mean "gpt-4o-mini"?
+  For a model from another provider, write provider/model —
+  e.g. openrouter/gpt-4o-minii
+  Run `agency models list` to see the catalog.
+```
+
+**A prefixed name is never validated.** Agency sets the provider and model
+verbatim and lets the LLM call be the judge. A custom provider registered by a
+provider module is indistinguishable, at flag-parse time, from a typo — so
+guessing would reject legitimate configurations.
+
+The failure this prevents is a real one: without validation, a typo starts the
+run, compiles the program, executes everything up to the first `llm()` call, and
+only then fails. For an agent that can be minutes of work and real spend.
+
+The cost is that a hosted model released after the catalog snapshot is rejected
+when typed bare. There are two escapes and the error names both: write
+`openai/the-new-model`, or refresh the catalog with `agency models refresh`.
+
+### Suggestions
+
+The "did you mean" line uses Levenshtein edit distance against the catalog
+names, suggesting the closest match when its distance is at most 3 and omitting
+the line otherwise. `lib/eval/grading/graders/builtinGraders.ts:106` already
+contains a dependency-free implementation; it moves to `lib/levenshtein.ts` and
+both callers import it, rather than a second copy being written.
+
+## What this changes and what it does not
+
+**Changes.** `client.defaultModel`, and `client.defaultProvider` when a prefix
+was given. That is the whole configuration footprint.
+
+**Does not change.** `setModel()` and `llm({ model })` keep winning, per the
+layering above. No `--fastmodel`, `--slowmodel`, or `--provider` flag is added;
+those remain specific to `agency agent`, which needs several model slots because
+it runs several kinds of work. `agency run` runs one program.
+
+**A knock-on effect worth stating.** Memory extraction resolves its model as
+`memory.model` first and falls back to the top-level default
+(`lib/runtime/memory/manager.ts:560`). So `--model` also changes the model used
+for memory extraction and compaction. This is intended: the flag sets the run's
+default model, and memory extraction is part of the run.
+
+## Structure
+
+Three pieces, each with one job.
+
+**`lib/cli/modelFlag.ts`** — the parse-and-validate step, as a pure function:
+
+```ts
+export type ResolvedModel = { model: string; provider?: string };
+
+/** Throws with a user-facing message when a bare name is not in the catalog.
+ *  `catalogNames` defaults to smoltalk's `getAllModels()`. */
+export function resolveModelFlag(
+  value: string,
+  catalogNames?: string[],
+): ResolvedModel;
+```
+
+Pure and catalog-driven, so it is testable without a CLI or a network call. The
+catalog arrives as a defaulted parameter so tests supply their own list instead
+of depending on which models happen to ship this month.
+
+**`lib/levenshtein.ts`** — the edit-distance function moved out of
+`builtinGraders.ts`, unchanged.
+
+**`applyCliFlags` in `lib/config.ts`** — maps the resolved value onto
+`client.defaultModel` and `client.defaultProvider`. This keeps the promise the
+file already makes: one place defines what a flag means in configuration terms.
+
+`CliFlags` gains `model?: string`, and `addRunOptions` in `scripts/agency.ts`
+gains the option. Both `run` and the shorthand pick it up from there.
+
+## Errors
+
+One error, raised before any compilation: an unknown bare model name, shown
+above. It exits non-zero with the message on stderr, matching how the CLI
+reports every other bad flag value.
+
+`applyCliFlags` is not the place to raise it — that function is a pure mapping
+and is called on paths that should not exit. The check runs in
+`resolveModelFlag`, called from the CLI action, and the CLI turns the thrown
+message into the stderr output and exit code.
+
+## Testing
+
+**`lib/cli/modelFlag.test.ts`** — one case per row of the resolution table, plus:
+
+- a bare unknown name throws, and the message names the closest catalog entry
+- a bare unknown name with no near match still throws, without a "did you mean"
+  line
+- a prefixed unknown name does **not** throw, which is the custom-provider
+  guarantee and the one most likely to be broken by a later "improvement"
+- `openrouter/anthropic/claude-sonnet-4` keeps the second slash in the model name
+
+**`tests/integration/cli/test.mjs`** — the flag reaching a real run. The existing
+suite makes no LLM calls, so the assertion is on the compiled output rather than
+on a completed call: compile with `--model` and check the generated JavaScript
+carries that model in its smoltalk client configuration. A second case asserts
+that an unknown bare name exits non-zero with the error, and a third runs the
+same thing through the shorthand to prove both commands share the flag.
+
+**`lib/runtime/` precedence test** — an Agency execution test calling
+`setModel()` and asserting the model actually used is the one from the code, not
+the one from the flag. This is the guarantee users are relying on when they set a
+model in source, and nothing else in the suite would notice if the layering
+changed.
+
+## Out of scope
+
+- `--fastmodel` / `--slowmodel` / `--provider` for `agency run`.
+- Local models. `--local` and `--local-model` remain agent-only. A local model
+  reached through a provider module works today via the prefix form.
+- `agency test`, `agency eval`, and `agency serve`.
+- The two `agency agent` command-line gaps found while investigating this: a
+  misplaced `--max-cost` is forwarded to the agent, and root flags such as `-c`
+  cannot reach agency at all. Both currently produce a clear error rather than
+  failing silently. They are noted here only so they are not lost.

--- a/packages/agency-lang/lib/backends/smoltalkDefaults.codegen.test.ts
+++ b/packages/agency-lang/lib/backends/smoltalkDefaults.codegen.test.ts
@@ -72,4 +72,9 @@ describe("smoltalkDefaults codegen", () => {
     const out = generate(PROGRAM, { client: { defaultProvider: "openrouter" } });
     expect(out).toMatch(/provider:\s*"openrouter"/);
   });
+
+  it("bakes client.defaultModel into the generated client config", () => {
+    const out = generate(PROGRAM, { client: { defaultModel: "claude-opus-4-8" } });
+    expect(out).toMatch(/model:\s*"claude-opus-4-8"/);
+  });
 });

--- a/packages/agency-lang/lib/cli/modelFlag.test.ts
+++ b/packages/agency-lang/lib/cli/modelFlag.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+import { InvalidArgumentError } from "commander";
+import { resolveModelFlag } from "./modelFlag.js";
+
+// The default catalog comes from `_listHostedModels()`. Mock it rather than
+// asserting on real model names: which models ship changes month to month, and
+// a test that breaks when a catalog is refreshed is a test nobody trusts. The
+// text-only filtering belongs to `_listHostedModels` and is already covered in
+// `lib/stdlib/llm.test.ts`; what matters here is that the resolver asks it.
+vi.mock("@/stdlib/llm.js", () => ({
+  _listHostedModels: () => [
+    { name: "catalog-model-one", provider: "openai" },
+    { name: "catalog-model-two", provider: "anthropic" },
+  ],
+}));
+
+const CATALOG = ["gpt-4o-mini", "gpt-4o", "claude-opus-4-8", "gemini-2.5-pro"];
+
+const resolve = (value: string) => resolveModelFlag(value, CATALOG);
+
+describe("resolveModelFlag: bare names", () => {
+  it("accepts a known model and states no provider", () => {
+    expect(resolve("gpt-4o-mini")).toEqual({ model: "gpt-4o-mini" });
+  });
+
+  it("rejects an unknown name and suggests the closest catalog entry", () => {
+    expect(() => resolve("gpt-4o-minii")).toThrow(InvalidArgumentError);
+    expect(() => resolve("gpt-4o-minii")).toThrow(/Unknown model "gpt-4o-minii"/);
+    expect(() => resolve("gpt-4o-minii")).toThrow(/Did you mean "gpt-4o-mini"/);
+  });
+
+  it("rejects an unknown name with no near match, and suggests nothing", () => {
+    expect(() => resolve("zzzzzzzzzzzz")).toThrow(/Unknown model/);
+    expect(() => resolve("zzzzzzzzzzzz")).not.toThrow(/Did you mean/);
+  });
+
+  it("names the prefix escape in the error", () => {
+    expect(() => resolve("gpt-4o-minii")).toThrow(/provider\/model/);
+  });
+});
+
+describe("resolveModelFlag: provider prefixes", () => {
+  it("splits on the first slash", () => {
+    expect(resolve("anthropic/claude-opus-4-8")).toEqual({
+      model: "claude-opus-4-8",
+      explicitProvider: "anthropic",
+    });
+  });
+
+  it("keeps every later slash in the model name", () => {
+    expect(resolve("openrouter/anthropic/claude-sonnet-4")).toEqual({
+      model: "anthropic/claude-sonnet-4",
+      explicitProvider: "openrouter",
+    });
+  });
+
+  it("accepts an unknown provider, because provider modules register at runtime", () => {
+    expect(resolve("my-company/my-tune")).toEqual({
+      model: "my-tune",
+      explicitProvider: "my-company",
+    });
+  });
+
+  it("never checks a prefixed model against the catalog", () => {
+    expect(() => resolve("openai/not-a-real-model-at-all")).not.toThrow();
+  });
+});
+
+describe("resolveModelFlag: structurally invalid values", () => {
+  it.each([
+    ["", "empty value"],
+    ["/claude-opus-4-8", "empty provider"],
+    ["anthropic/", "empty model"],
+    ["/", "both empty"],
+  ])("rejects %s (%s)", (value) => {
+    expect(() => resolve(value)).toThrow(InvalidArgumentError);
+  });
+});
+
+describe("resolveModelFlag: the default catalog", () => {
+  it("accepts a name the adapter returns", () => {
+    expect(resolveModelFlag("catalog-model-one")).toEqual({
+      model: "catalog-model-one",
+    });
+  });
+
+  it("rejects a name the adapter does not return", () => {
+    expect(() => resolveModelFlag("catalog-model-three")).toThrow(
+      /Unknown model/,
+    );
+  });
+});

--- a/packages/agency-lang/lib/cli/modelFlag.ts
+++ b/packages/agency-lang/lib/cli/modelFlag.ts
@@ -1,0 +1,80 @@
+import { InvalidArgumentError } from "commander";
+import type { ResolvedModelFlag } from "@/config.js";
+import { levenshtein } from "@/levenshtein.js";
+import { _listHostedModels } from "@/stdlib/llm.js";
+
+/** Suggest a catalog name only when it is this close to what was typed. */
+const SUGGESTION_DISTANCE = 3;
+
+function hostedTextModelNames(): string[] {
+  return _listHostedModels().map((model) => model.name);
+}
+
+/**
+ * Turn a `--model` value into a model and, when the user said one, a provider.
+ *
+ * A slash means a provider was named: everything before the FIRST slash is the
+ * provider, everything after is the model. Splitting on the first slash only is
+ * what lets `openrouter/anthropic/claude-sonnet-4` work — OpenRouter model
+ * identifiers contain a slash of their own.
+ *
+ * A bare name is validated against the hosted text catalog, because that is the
+ * only case where agency has to work the provider out for itself. A prefixed
+ * name is never validated: `client.providerModules` can register a provider
+ * under any name at startup, so at flag-parse time a custom provider and a typo
+ * look identical, and guessing would reject working setups.
+ */
+export function resolveModelFlag(
+  value: string,
+  catalogNames: string[] = hostedTextModelNames(),
+): ResolvedModelFlag {
+  if (value === "") {
+    throw new InvalidArgumentError("No model named.");
+  }
+
+  const slash = value.indexOf("/");
+  if (slash !== -1) {
+    const provider = value.slice(0, slash);
+    const model = value.slice(slash + 1);
+    if (provider === "" || model === "") {
+      throw new InvalidArgumentError(
+        `"${value}" is not a model. Write provider/model, e.g. openrouter/anthropic/claude-sonnet-4.`,
+      );
+    }
+    return { model, explicitProvider: provider };
+  }
+
+  if (catalogNames.includes(value)) {
+    return { model: value };
+  }
+  throw new InvalidArgumentError(unknownModelMessage(value, catalogNames));
+}
+
+function unknownModelMessage(value: string, catalogNames: string[]): string {
+  const lines = [`Unknown model "${value}".`];
+  const suggestion = closestName(value, catalogNames);
+  if (suggestion !== undefined) {
+    lines.push(`Did you mean "${suggestion}"?`);
+  }
+  lines.push(
+    `For a model from another provider, write provider/model — e.g. openrouter/${value}.`,
+    "Run `agency models list` to see the catalog.",
+  );
+  return lines.join("\n  ");
+}
+
+function closestName(
+  value: string,
+  catalogNames: string[],
+): string | undefined {
+  let best: string | undefined;
+  let bestDistance = SUGGESTION_DISTANCE + 1;
+  for (const name of catalogNames) {
+    const distance = levenshtein(value, name);
+    if (distance < bestDistance) {
+      best = name;
+      bestDistance = distance;
+    }
+  }
+  return bestDistance <= SUGGESTION_DISTANCE ? best : undefined;
+}

--- a/packages/agency-lang/lib/config.test.ts
+++ b/packages/agency-lang/lib/config.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
+import type { AgencyConfig } from "./config.js";
 import {
   AgencyConfigSchema,
   applyCliFlags,
@@ -238,6 +239,64 @@ describe("applyCliFlags", () => {
     const input = {};
     applyCliFlags(input, { strict: true, logFile: "x", trace: "t", maxToolCallRounds: 5 });
     expect(input).toEqual({});
+  });
+
+  describe("--model", () => {
+    /** A config with a provider already set, as agency.json might. */
+    function configWithProvider(): AgencyConfig {
+      return {
+        client: {
+          defaultModel: "gpt-4o-mini",
+          defaultProvider: "openrouter",
+          providerModules: ["./my-provider.mjs"],
+        },
+      };
+    }
+
+    it("does nothing when the flag is absent", () => {
+      const after = applyCliFlags(configWithProvider(), {});
+      expect(after.client?.defaultModel).toBe("gpt-4o-mini");
+      expect(after.client?.defaultProvider).toBe("openrouter");
+    });
+
+    it("a bare model sets the model and clears an inherited provider", () => {
+      const after = applyCliFlags(configWithProvider(), {
+        model: { model: "claude-opus-4-8" },
+      });
+      expect(after.client?.defaultModel).toBe("claude-opus-4-8");
+      expect(after.client?.defaultProvider).toBeUndefined();
+      // Stronger than toBeUndefined: the key must be GONE, because the code
+      // generator emits a provider whenever the key is present.
+      expect(after.client).not.toHaveProperty("defaultProvider");
+    });
+
+    it("a prefixed model sets both fields", () => {
+      const after = applyCliFlags(configWithProvider(), {
+        model: { model: "my-tune", explicitProvider: "my-company" },
+      });
+      expect(after.client?.defaultModel).toBe("my-tune");
+      expect(after.client?.defaultProvider).toBe("my-company");
+    });
+
+    it("leaves neighbouring client fields alone", () => {
+      const after = applyCliFlags(configWithProvider(), {
+        model: { model: "claude-opus-4-8" },
+      });
+      expect(after.client?.providerModules).toEqual(["./my-provider.mjs"]);
+    });
+
+    it("does not mutate the config it was given", () => {
+      const before = configWithProvider();
+      const snapshot = structuredClone(before);
+      applyCliFlags(before, { model: { model: "claude-opus-4-8" } });
+      expect(before).toEqual(snapshot);
+    });
+
+    it("works when the config has no client block at all", () => {
+      const after = applyCliFlags({}, { model: { model: "claude-opus-4-8" } });
+      expect(after.client?.defaultModel).toBe("claude-opus-4-8");
+      expect(after.client?.defaultProvider).toBeUndefined();
+    });
   });
 });
 

--- a/packages/agency-lang/lib/config.test.ts
+++ b/packages/agency-lang/lib/config.test.ts
@@ -265,8 +265,11 @@ describe("applyCliFlags", () => {
       });
       expect(after.client?.defaultModel).toBe("claude-opus-4-8");
       expect(after.client?.defaultProvider).toBeUndefined();
-      // Stronger than toBeUndefined: the key must be GONE, because the code
-      // generator emits a provider whenever the key is present.
+      // Stronger than toBeUndefined, and deliberate: the mapping removes the
+      // key rather than setting it to undefined, so the resulting config
+      // carries no dangling field. (The code generator tests truthiness, so an
+      // explicit undefined would also omit the provider — this pins the
+      // contract, not a codegen requirement.)
       expect(after.client).not.toHaveProperty("defaultProvider");
     });
 

--- a/packages/agency-lang/lib/config.ts
+++ b/packages/agency-lang/lib/config.ts
@@ -678,6 +678,20 @@ export function findProjectRoot(startPath: string): string | null {
 /** Per-invocation flags accepted by `agency run`/`compile` and forwarded to the
  *  bundled agents. Mapped onto AgencyConfig by applyCliFlags. `trace` is
  *  `string` for `--trace <file>`, `true` for a bare `--trace`. */
+/**
+ * A `--model` value after parsing. `explicitProvider` is set only when the
+ * user wrote `provider/model`; a bare model leaves it undefined so smoltalk
+ * infers the provider from the model name.
+ *
+ * Declared here rather than in the CLI so `CliFlags` stays self-contained:
+ * `lib/config.ts` must not depend on `lib/cli/`, which would pull the CLI and
+ * the runtime graph behind it into every consumer of the config module.
+ */
+export type ResolvedModelFlag = {
+  model: string;
+  explicitProvider?: string;
+};
+
 export type CliFlags = {
   trace?: string | true;
   logFile?: string;
@@ -686,6 +700,7 @@ export type CliFlags = {
   strict?: boolean;
   maxToolCallRounds?: number;
   maxToolResultChars?: number;
+  model?: ResolvedModelFlag;
 };
 
 /**
@@ -701,6 +716,9 @@ export type CliFlags = {
  *   --observability  → observability=true
  *   --strict         → typechecker.strict + strictTypes (the compile-path gate
  *                      never runs the checker on strictTypes alone)
+ *   --model <m>      → client.defaultModel=<m> and client.defaultProvider
+ *                      DELETED, so smoltalk infers the provider
+ *   --model <p>/<m>  → client.defaultModel=<m> + client.defaultProvider=<p>
  *   --max-tool-call-rounds <n> → maxToolCallRounds=<n> (baked into runPrompt at
  *                      compile time; overrides agency.json for this run)
  *   --max-tool-result-chars <n> → client.maxToolResultChars=<n> (0 disables the
@@ -751,6 +769,20 @@ export function applyCliFlags(
   }
   if (flags.maxToolResultChars !== undefined) {
     next.client = { ...next.client, maxToolResultChars: flags.maxToolResultChars };
+  }
+  if (flags.model !== undefined) {
+    // A bare model DELETES an inherited provider so smoltalk can infer one
+    // from the model name; a stated provider replaces it. Destructuring is
+    // how the deletion happens without mutating `next.client`.
+    const { defaultProvider: _dropped, ...client } = next.client ?? {};
+    next.client =
+      flags.model.explicitProvider === undefined
+        ? { ...client, defaultModel: flags.model.model }
+        : {
+            ...client,
+            defaultModel: flags.model.model,
+            defaultProvider: flags.model.explicitProvider,
+          };
   }
   return next;
 }

--- a/packages/agency-lang/lib/config.ts
+++ b/packages/agency-lang/lib/config.ts
@@ -675,23 +675,21 @@ export function findProjectRoot(startPath: string): string | null {
 //     that has already been compiled.
 // ════════════════════════════════════════════════════════════════════════
 
-/** Per-invocation flags accepted by `agency run`/`compile` and forwarded to the
- *  bundled agents. Mapped onto AgencyConfig by applyCliFlags. `trace` is
- *  `string` for `--trace <file>`, `true` for a bare `--trace`. */
-/**
- * A `--model` value after parsing. `explicitProvider` is set only when the
- * user wrote `provider/model`; a bare model leaves it undefined so smoltalk
- * infers the provider from the model name.
+/** A `--model` value after parsing. `explicitProvider` is set only when the
+ *  user wrote `provider/model`; a bare model leaves it undefined so smoltalk
+ *  infers the provider from the model name.
  *
- * Declared here rather than in the CLI so `CliFlags` stays self-contained:
- * `lib/config.ts` must not depend on `lib/cli/`, which would pull the CLI and
- * the runtime graph behind it into every consumer of the config module.
- */
+ *  Declared here rather than in the CLI so `CliFlags` stays self-contained:
+ *  `lib/config.ts` must not depend on `lib/cli/`, which would pull the CLI and
+ *  the runtime graph behind it into every consumer of the config module. */
 export type ResolvedModelFlag = {
   model: string;
   explicitProvider?: string;
 };
 
+/** Per-invocation flags accepted by `agency run`/`compile` and forwarded to the
+ *  bundled agents. Mapped onto AgencyConfig by applyCliFlags. `trace` is
+ *  `string` for `--trace <file>`, `true` for a bare `--trace`. */
 export type CliFlags = {
   trace?: string | true;
   logFile?: string;
@@ -771,9 +769,10 @@ export function applyCliFlags(
     next.client = { ...next.client, maxToolResultChars: flags.maxToolResultChars };
   }
   if (flags.model !== undefined) {
-    // A bare model DELETES an inherited provider so smoltalk can infer one
-    // from the model name; a stated provider replaces it. Destructuring is
-    // how the deletion happens without mutating `next.client`.
+    // A bare model drops an inherited provider so smoltalk can infer one from
+    // the model name; a stated provider replaces it. The key is removed rather
+    // than set to undefined so the resulting config carries no dangling field.
+    // Destructuring is how that happens without mutating `next.client`.
     const { defaultProvider: _dropped, ...client } = next.client ?? {};
     next.client =
       flags.model.explicitProvider === undefined

--- a/packages/agency-lang/lib/eval/grading/graders/builtinGraders.ts
+++ b/packages/agency-lang/lib/eval/grading/graders/builtinGraders.ts
@@ -1,6 +1,7 @@
 import { BaseGrader } from "../baseGrader.js";
 import { getPath } from "../getPath.js";
 import type { Grade, GraderInput, GraderOptions, Input, JSONPath } from "../types.js";
+import { levenshtein } from "@/levenshtein.js";
 
 /** Graders that compare the agent output against a value read from the input.
  *  `matchOn` defaults to the first-class `expected` field. */
@@ -102,17 +103,3 @@ function deepEqual(a: unknown, b: unknown): boolean {
   return aKeys.every((k) => Object.hasOwn(bObj, k) && deepEqual(aObj[k], bObj[k]));
 }
 
-/** Classic Levenshtein edit distance (deterministic, dependency-free). */
-function levenshtein(a: string, b: string): number {
-  const cols = b.length + 1;
-  let prev = Array.from({ length: cols }, (_unused, j) => j);
-  for (let i = 1; i <= a.length; i += 1) {
-    const curr = [i];
-    for (let j = 1; j < cols; j += 1) {
-      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
-      curr[j] = Math.min(prev[j] + 1, curr[j - 1] + 1, prev[j - 1] + cost);
-    }
-    prev = curr;
-  }
-  return prev[cols - 1];
-}

--- a/packages/agency-lang/lib/levenshtein.test.ts
+++ b/packages/agency-lang/lib/levenshtein.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { levenshtein } from "./levenshtein.js";
+
+describe("levenshtein", () => {
+  it("is zero for identical strings", () => {
+    expect(levenshtein("gpt-4o-mini", "gpt-4o-mini")).toBe(0);
+  });
+
+  it("counts a single inserted character", () => {
+    expect(levenshtein("gpt-4o-mini", "gpt-4o-minii")).toBe(1);
+  });
+
+  it("counts a substitution", () => {
+    expect(levenshtein("cat", "cot")).toBe(1);
+  });
+
+  it("handles an empty string on either side", () => {
+    expect(levenshtein("", "abc")).toBe(3);
+    expect(levenshtein("abc", "")).toBe(3);
+    expect(levenshtein("", "")).toBe(0);
+  });
+
+  it("is symmetric", () => {
+    expect(levenshtein("kitten", "sitting")).toBe(
+      levenshtein("sitting", "kitten"),
+    );
+  });
+});

--- a/packages/agency-lang/lib/levenshtein.ts
+++ b/packages/agency-lang/lib/levenshtein.ts
@@ -1,0 +1,21 @@
+/** Classic Levenshtein edit distance (deterministic, dependency-free). */
+export function levenshtein(left: string, right: string): number {
+  const columnCount = right.length + 1;
+  let previousRow = Array.from(
+    { length: columnCount },
+    (_unused, columnIndex) => columnIndex,
+  );
+  for (let rowIndex = 1; rowIndex <= left.length; rowIndex += 1) {
+    const currentRow = [rowIndex];
+    for (let columnIndex = 1; columnIndex < columnCount; columnIndex += 1) {
+      const cost = left[rowIndex - 1] === right[columnIndex - 1] ? 0 : 1;
+      currentRow[columnIndex] = Math.min(
+        previousRow[columnIndex] + 1,
+        currentRow[columnIndex - 1] + 1,
+        previousRow[columnIndex - 1] + cost,
+      );
+    }
+    previousRow = currentRow;
+  }
+  return previousRow[columnCount - 1];
+}

--- a/packages/agency-lang/lib/runtime/agencyLlm.test.ts
+++ b/packages/agency-lang/lib/runtime/agencyLlm.test.ts
@@ -1,14 +1,17 @@
 import { describe, it, expect } from "vitest";
 import { z } from "zod";
-import type { Result, PromptResult, StreamChunk } from "smoltalk";
+import type { Result, PromptResult, SmolConfig, StreamChunk } from "smoltalk";
 import { agency } from "./agency.js";
 import { DeterministicClient } from "./deterministicClient.js";
 import type { EmbedConfig, EmbedResult, LLMClient, PromptConfig } from "./llmClient.js";
 import { RuntimeContext } from "./state/context.js";
 import { ThreadStore } from "./state/threadStore.js";
 import { _setLlmOptions } from "../stdlib/llm.js";
+import { runPrompt } from "./prompt.js";
 
-function makeCtx(): RuntimeContext<any> {
+function makeCtx(
+  smoltalkDefaults: Partial<SmolConfig> = { model: "default-model" },
+): RuntimeContext<any> {
   return new RuntimeContext({
     statelogConfig: {
       host: "https://example.com",
@@ -16,7 +19,7 @@ function makeCtx(): RuntimeContext<any> {
       projectId: "test-project",
       debugMode: false,
     },
-    smoltalkDefaults: { model: "default-model" },
+    smoltalkDefaults,
     dirname: "/tmp",
   });
 }
@@ -251,5 +254,74 @@ describe("agency.llm — frame requirement", () => {
     await expect(agency.llm("hi")).rejects.toThrow(
       /outside an Agency execution frame/,
     );
+  });
+});
+
+describe("model and provider precedence", () => {
+  /** The pair the client was actually asked for. */
+  async function effectivePair(
+    baked: Partial<SmolConfig>,
+    call: (threads: ThreadStore) => Promise<unknown>,
+  ): Promise<{ model?: string; provider?: string }> {
+    const ctx = makeCtx(baked);
+    const client = new RecordingClient(["ok"]);
+    ctx.setLLMClient(client);
+    const threads = ThreadStore.withDefaultActive(ctx.statelogClient);
+    await inFrame(ctx, threads, () => call(threads));
+    const config = client.configs[0];
+    if (config === undefined) {
+      throw new Error("the prompt never reached the recording client");
+    }
+    return {
+      model: (config as any).model,
+      provider: (config as any).provider,
+    };
+  }
+
+  it("a branch model override leaves no provider when none was baked", async () => {
+    const pair = await effectivePair({ model: "baked-model" }, async () => {
+      _setLlmOptions({ model: "branch-model" });
+      return agency.llm("hi");
+    });
+    expect(pair).toEqual({ model: "branch-model", provider: undefined });
+  });
+
+  it("a baked provider survives a branch model-only override", async () => {
+    const pair = await effectivePair(
+      { model: "baked-model", provider: "openrouter" },
+      async () => {
+        _setLlmOptions({ model: "branch-model" });
+        return agency.llm("hi");
+      },
+    );
+    expect(pair).toEqual({ model: "branch-model", provider: "openrouter" });
+  });
+
+  it("a baked provider survives a per-call model-only override", async () => {
+    const pair = await effectivePair(
+      { model: "baked-model", provider: "openrouter" },
+      () => agency.llm("hi", { model: "call-model" }),
+    );
+    expect(pair).toEqual({ model: "call-model", provider: "openrouter" });
+  });
+
+  it("per-call model and provider replace the baked pair", async () => {
+    // The TypeScript `agency.llm` facade forwards only model and maxTokens,
+    // not provider. Generated Agency code passes its options object through
+    // verbatim, so this calls the runPrompt seam directly to exercise the
+    // per-call spread the way compiled code does.
+    const pair = await effectivePair(
+      { model: "baked-model", provider: "openrouter" },
+      (threads) =>
+        runPrompt({
+          prompt: "hi",
+          messages: threads.getOrCreateActive(),
+          clientConfig: {
+            model: "call-model",
+            provider: "anthropic",
+          },
+        }),
+    );
+    expect(pair).toEqual({ model: "call-model", provider: "anthropic" });
   });
 });

--- a/packages/agency-lang/lib/runtime/agencyLlm.test.ts
+++ b/packages/agency-lang/lib/runtime/agencyLlm.test.ts
@@ -272,10 +272,7 @@ describe("model and provider precedence", () => {
     if (config === undefined) {
       throw new Error("the prompt never reached the recording client");
     }
-    return {
-      model: (config as any).model,
-      provider: (config as any).provider,
-    };
+    return { model: config.model, provider: config.provider };
   }
 
   it("a branch model override leaves no provider when none was baked", async () => {

--- a/packages/agency-lang/scripts/agency.test.ts
+++ b/packages/agency-lang/scripts/agency.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { splitCommandLine } from "@/cli/commandLine.js";
+import { _listHostedModels } from "@/stdlib/llm.js";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
@@ -500,5 +501,71 @@ describe("remote management command registration", () => {
     expect(messages.join("\n")).toContain("--json");
     exit.mockRestore();
     err.mockRestore();
+  });
+});
+
+describe("--model wiring", () => {
+  const [firstCatalogModel, secondCatalogModel] = _listHostedModels().map(
+    (model) => model.name,
+  );
+  if (firstCatalogModel === undefined || secondCatalogModel === undefined) {
+    throw new Error("the hosted text catalog needs at least two models");
+  }
+
+  /** Parse an argv and hand back the RunOptions the `run` action would see. */
+  async function runOptionsFor(words: string[]): Promise<Record<string, unknown>> {
+    const program = createProgram({});
+    const run = program.commands.find((cmd) => cmd.name() === "run");
+    if (run === undefined) {
+      throw new Error("no run command");
+    }
+    let captured: Record<string, unknown> = {};
+    run.action(() => {
+      captured = run.opts();
+    });
+    program.exitOverride();
+    run.exitOverride();
+    // `from: "user"` means every element is a user argument — commander does
+    // NOT strip a leading node/script pair in this mode. Passing them would
+    // send "node" through the hidden default command instead of testing `run`.
+    await program.parseAsync(words, { from: "user" });
+    return captured;
+  }
+
+  it("resolves a bare model", async () => {
+    const opts = await runOptionsFor([
+      "run", "--model", firstCatalogModel, "f.agency",
+    ]);
+    expect(opts.model).toEqual({ model: firstCatalogModel });
+  });
+
+  it("resolves a prefixed model", async () => {
+    const opts = await runOptionsFor([
+      "run", "--model", "openrouter/anthropic/claude-sonnet-4", "f.agency",
+    ]);
+    expect(opts.model).toEqual({
+      model: "anthropic/claude-sonnet-4",
+      explicitProvider: "openrouter",
+    });
+  });
+
+  it("takes the last value when the flag is repeated", async () => {
+    // Commander passes the PREVIOUS parsed value as the parser's second
+    // argument. Without the adapter, that object lands in `catalogNames`.
+    // Both values stay bare on purpose: a prefixed second value returns
+    // before consulting the catalog and would prove nothing.
+    const opts = await runOptionsFor([
+      "run", "--model", firstCatalogModel,
+      "--model", secondCatalogModel, "f.agency",
+    ]);
+    expect(opts.model).toEqual({ model: secondCatalogModel });
+  });
+
+  it("rejects an unknown bare model", async () => {
+    await expect(
+      runOptionsFor([
+        "run", "--model", "definitely-not-a-hosted-model", "f.agency",
+      ]),
+    ).rejects.toThrow();
   });
 });

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -17,6 +17,7 @@ import {
   installDirFromUrl,
 } from "@/cli/installLocation.js";
 import { pack } from "@/cli/pack.js";
+import { resolveModelFlag } from "@/cli/modelFlag.js";
 import {
   splitCommandLine,
   type Arity,
@@ -380,6 +381,14 @@ export function createProgram(deps: CliDependencies = {}): Command {
         "--max-tool-result-chars <n>",
         "Max chars of a single tool result fed back to the model (0 disables; default 100000; overrides agency.json)",
         parseNonNegativeInt,
+      )
+      .option(
+        "--model <name>",
+        "Model for this run's LLM calls, as `model` or `provider/model` (e.g. gpt-4o-mini, openrouter/anthropic/claude-sonnet-4)",
+        // Adapter, not decoration: commander calls a parser with
+        // (value, previous), and `previous` would land in the resolver's
+        // catalogNames parameter when --model is repeated.
+        (value: string) => resolveModelFlag(value),
       )
       .option(
         "--policy <name|path>",

--- a/packages/agency-lang/tests/integration/cli/test.mjs
+++ b/packages/agency-lang/tests/integration/cli/test.mjs
@@ -397,6 +397,81 @@ node main() {
     throw new Error(`a hidden command was treated as a file: ${remoteHelp}`);
   }
 
+  // --- --model reaches the compiled program ---
+  // `--model` lives on addRunOptions, which `run` and the shorthand share.
+  // `agency compile` has its own option list and does NOT take it, so these
+  // cases drive the two supported surfaces and read what they compiled.
+  //
+  // Start from an agency.json that already names a provider, so the bare-model
+  // case has something to clear and cannot pass for the wrong reason.
+  writeFile(dir, "agency.json", JSON.stringify({
+    client: { defaultModel: "gpt-4o-mini", defaultProvider: "openrouter" },
+  }, null, 2));
+
+  // A bare model replaces the model AND drops the inherited provider, so
+  // smoltalk infers one from the name.
+  const bareRun = run(dir, "./node_modules/.bin/agency run --model claude-opus-4-8 greet.agency --name alice");
+  assertIncludes(bareRun, "Hello, alice!");
+  const bareOut = readFileSync(join(dir, "greet.js"), "utf-8");
+  assertIncludes(bareOut, 'model: "claude-opus-4-8"');
+  // Anchored on a baked literal: the bare token `provider` also appears in
+  // unrelated generated output.
+  if (/provider:\s*"/.test(bareOut)) {
+    throw new Error("a bare --model left a provider in the generated config");
+  }
+
+  // The shorthand takes the flag too, and a prefixed value sets both fields.
+  const prefixedRun = run(dir, "./node_modules/.bin/agency --model openrouter/anthropic/claude-sonnet-4 greet.agency --name alice");
+  assertIncludes(prefixedRun, "Hello, alice!");
+  const prefixedOut = readFileSync(join(dir, "greet.js"), "utf-8");
+  assertIncludes(prefixedOut, 'model: "anthropic/claude-sonnet-4"');
+  if (!/provider:\s*"openrouter"/.test(prefixedOut)) {
+    throw new Error("a prefixed --model did not bake its provider");
+  }
+
+  // An unknown bare model fails BEFORE compiling. Give it a fresh source name
+  // whose output cannot exist from an earlier case; asserting that output was
+  // never created proves the ordering without deleting a test artifact first.
+  writeFile(dir, "invalid-model.agency", `node main() {
+  print("must not execute")
+}
+`);
+  const badModel = run(
+    dir,
+    "./node_modules/.bin/agency run --model gpt-4o-minii invalid-model.agency 2>&1",
+    { expectFail: true },
+  );
+  assertIncludes(badModel, 'Unknown model "gpt-4o-minii"');
+  assertIncludes(badModel, 'Did you mean "gpt-4o-mini"');
+  if (badModel.includes("    at ")) {
+    throw new Error(`an unknown model printed a stack trace: ${badModel}`);
+  }
+  if (existsSync(join(dir, "invalid-model.js"))) {
+    throw new Error("compilation happened despite an invalid --model");
+  }
+
+  // The position rule applies to the new flag like any other: after the
+  // filename it belongs to the program, is NOT validated by agency, and draws
+  // the standard warning. greet does not declare --model, so its own parser
+  // rejects it — which is also the proof the flag was forwarded. Use an
+  // unknown attached value: that distinguishes "not validated" from a valid
+  // value that agency might have validated successfully, and covers
+  // `--model=value` in the boundary scanner at the same time.
+  const modelAfterFile = run(
+    dir,
+    "./node_modules/.bin/agency run greet.agency --model=definitely-not-a-real-model 2>&1",
+    { expectFail: true },
+  );
+  assertIncludes(modelAfterFile, "Warning: --model went to your program");
+  assertIncludes(modelAfterFile, "unknown flag --model");
+  if (modelAfterFile.includes("Unknown model")) {
+    throw new Error("agency validated a --model that belonged to the program");
+  }
+
+  // Restore neutral configuration for the later cases in this file. Writing
+  // the fixture is safer and clearer than deleting a path during a test.
+  writeFile(dir, "agency.json", "{}\n");
+
   console.log("Test 8 passed");
 
   // --- Test 8b: a node parameter default applies on the direct-run path ---


### PR DESCRIPTION
## What this does

`agency run --model` and the `agency <file>` shorthand set the default model for a run:

```bash
agency run --model claude-opus-4-8 greet.agency
agency --model openrouter/anthropic/claude-sonnet-4 greet.agency
```

A model set explicitly in Agency code still wins — the flag feeds the lowest layer of an existing precedence chain, so `setModel()` and `llm({ model })` override it with no new logic.

## Reading the value

Split on the **first** slash only. Anything before it is the provider.

| you write | provider | model |
| --- | --- | --- |
| `gpt-4o-mini` | none set; smoltalk infers `openai` | `gpt-4o-mini` |
| `anthropic/claude-opus-4-8` | `anthropic` | `claude-opus-4-8` |
| `openrouter/anthropic/claude-sonnet-4` | `openrouter` | `anthropic/claude-sonnet-4` |
| `my-company/my-tune` | `my-company` | `my-tune` |

First-slash-only is what makes row 3 work: an OpenRouter identifier contains a slash of its own. Row 4 is why there is no known-provider list — `client.providerModules` can register a provider under any name at startup, so at flag-parse time a custom provider and a typo are indistinguishable.

## Model and provider are two settings, not one

This is the part worth reviewing carefully. They merge **field by field** — `getSmoltalkConfig` and the `runPrompt` merge are both shallow spreads, and `setModel()` writes only `{ model }`. So a provider from a lower layer survives a higher layer that changes only the model.

Three rules follow:

- **A bare model drops any inherited `defaultProvider`**, letting smoltalk infer one from the name. The key is removed rather than set to `undefined` — either satisfies the code generator, which tests truthiness, but removing it keeps the resolved config free of dangling fields.
- **`provider/model` sets both.**
- **A stated provider is sticky** under a later `setModel("other")`. Code that wants to move provider too must pass both.

**Behaviour change worth knowing:** if your `agency.json` sets `defaultProvider` to route through a proxy, a bare `--model` bypasses it. Name the provider (`--model litellm/gpt-4o-mini`) to keep it.

## Validation

A bare name must be in the hosted **text** catalog — `_listHostedModels()`, not smoltalk's `getAllModels()`, which also returns image, embedding and speech models and would accept `gpt-image-1` as a chat model.

```
$ agency run --model gpt-4o-minii greet.agency
error: option '--model <name>' argument 'gpt-4o-minii' is invalid.
  Unknown model "gpt-4o-minii".
  Did you mean "gpt-4o-mini"?
  For a model from another provider, write provider/model — e.g. openrouter/gpt-4o-minii.
  Run `agency models list` to see the catalog.
```

This runs before any compilation, so a typo costs nothing. A prefixed name is never checked. The escape for a model missing from the baked catalog is the prefix form — note `agency models refresh` prints to stdout and persists nothing, so it cannot affect a later process's validation.

## Testing

155 tests across 9 files, plus the full CLI integration suite against a packed tarball.

Three are worth calling out because they were written to fail for the right reason:

- **The Commander adapter.** `.option(..., (value) => resolveModelFlag(value))` looks like decoration. It isn't: Commander calls a parser with `(value, previous)`, so passing the resolver directly hands the previously parsed object to its `catalogNames` parameter when `--model` repeats. I removed the adapter, watched the repeated-flag test fail, and restored it.
- **Precedence.** Four cases assert on the config the client actually receives, via the `RecordingClient` this suite already had. The fourth calls `runPrompt` directly, because the TypeScript `agency.llm` facade forwards only `model` and `maxTokens` — a branch-level override would pass even if the per-call spread stopped working.
- **Ordering.** The invalid-model case compiles a fresh source name and asserts its output was never written, which is what proves validation precedes compilation rather than following it.

Also covered: `--model` after the filename is forwarded to the program and **not** validated, using an attached `--model=…` value so a successful validation cannot masquerade as no validation.

## Not included

`docs/site/**` is untouched per the standing rule, so `docs/site/cli/run.md` does not list `--model` yet. Developer documentation is in `docs/dev/config.md`.

No `--fastmodel`, `--slowmodel` or `--provider`; those stay specific to `agency agent`, which needs several model slots. `agency test`, `agency eval` and `agency serve` are unchanged.

The spec, plan and their reviews are in `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

