### PR TITLE
test(integration): per-PR tarball tests for the deterministic language CLI commands

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,6 +152,7 @@ jobs:
         node tests/integration/bundlers/test-esbuild.mjs ./agency-lang-*.tgz
         node tests/integration/bundlers/test-vite.mjs ./agency-lang-*.tgz
         node tests/integration/cli/test.mjs ./agency-lang-*.tgz
+        node tests/integration/cli-lang/test.mjs ./agency-lang-*.tgz
         node tests/integration/serve/test.mjs ./agency-lang-*.tgz
         rm -f agency-lang-*.tgz
     - name: Main-only CLI command integration tests

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -65,7 +65,7 @@ import {
   redactConfigSecrets,
 } from "@/config.js";
 import * as path from "path";
-import { _parseAgency } from "@/parser.js";
+import { parseAgency } from "@/parser.js";
 import { TypescriptPreprocessor } from "@/preprocessors/typescriptPreprocessor.js";
 import { buildCompilationUnit } from "@/compilationUnit.js";
 import { expandSplices } from "@/preprocessors/expandSplices.js";
@@ -75,7 +75,6 @@ import { formatErrors, formatDiagnosticsHint, typeCheck } from "@/typeChecker/in
 import { Command, InvalidArgumentError } from "commander";
 import * as fs from "fs";
 import { color } from "@/utils/termcolors.js";
-import { TarsecError } from "tarsec";
 import process from "process";
 import { agent } from "@/cli/agent.js";
 import { mcpAdd, mcpRemove, mcpList, type McpAddOptions } from "@/cli/mcp.js";
@@ -1181,15 +1180,16 @@ export function createProgram(deps: CliDependencies = {}): Command {
     .description("Run diagnostics for VSCode")
     .argument("[inputs...]", "Paths to .agency input files")
     .action(async (inputs: string[]) => {
+      // Route through parseAgency so the payload is the normalized
+      // ParseAgencyErrorData (zero-indexed user-source coordinates), covering
+      // both committed and recoverable parse failures. applyTemplate:false keeps
+      // coordinates in the exact source the editor supplied; lower:false keeps
+      // this to syntax diagnostics.
+      const config = getConfig();
       await forEachSource(inputs, (contents) => {
-        try {
-          _parseAgency(contents);
-        } catch (error) {
-          if (error instanceof TarsecError) {
-            console.log(JSON.stringify(error.data, null, 2));
-          } else {
-            throw error;
-          }
+        const result = parseAgency(contents, config, false, false);
+        if (!result.success && result.errorData) {
+          console.log(JSON.stringify(result.errorData, null, 2));
         }
       });
     });

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -1191,14 +1191,16 @@ export function createProgram(deps: CliDependencies = {}): Command {
         const result = parseAgency(contents, {}, false, false);
         if (result.success) return;
         // Always emit a payload for a failure. A rare failure path returns no
-        // errorData; fall back to a minimal one built from the message so the
-        // editor still gets JSON.
+        // errorData; fall back to a minimal one. `result.message` is optional,
+        // so normalize it to a non-empty string for both required message
+        // fields of ParseAgencyErrorData.
+        const message = result.message ?? "Parse error";
         const errorData = result.errorData ?? {
           line: 0,
           column: 0,
           length: 1,
-          message: result.message,
-          prettyMessage: result.message,
+          message,
+          prettyMessage: message,
         };
         console.log(JSON.stringify(errorData, null, 2));
       });

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -1182,15 +1182,25 @@ export function createProgram(deps: CliDependencies = {}): Command {
     .action(async (inputs: string[]) => {
       // Route through parseAgency so the payload is the normalized
       // ParseAgencyErrorData (zero-indexed user-source coordinates), covering
-      // both committed and recoverable parse failures. applyTemplate:false keeps
+      // both committed and recoverable parse failures. Parsing does not depend
+      // on config, so pass {} rather than getConfig(): a broken agency.json
+      // must not take editor diagnostics down with it. applyTemplate:false keeps
       // coordinates in the exact source the editor supplied; lower:false keeps
       // this to syntax diagnostics.
-      const config = getConfig();
       await forEachSource(inputs, (contents) => {
-        const result = parseAgency(contents, config, false, false);
-        if (!result.success && result.errorData) {
-          console.log(JSON.stringify(result.errorData, null, 2));
-        }
+        const result = parseAgency(contents, {}, false, false);
+        if (result.success) return;
+        // Always emit a payload for a failure. A rare failure path returns no
+        // errorData; fall back to a minimal one built from the message so the
+        // editor still gets JSON.
+        const errorData = result.errorData ?? {
+          line: 0,
+          column: 0,
+          length: 1,
+          message: result.message,
+          prettyMessage: result.message,
+        };
+        console.log(JSON.stringify(errorData, null, 2));
       });
     });
 

--- a/packages/agency-lang/tests/integration/cli-lang/test.mjs
+++ b/packages/agency-lang/tests/integration/cli-lang/test.mjs
@@ -91,9 +91,13 @@ node preprocessProbe(): string {
 }
 `;
 
+// The body carries a unique sentinel found nowhere in the signature or
+// docstring. `doc` documents the public API, not the body, so the sentinel must
+// be absent from the generated Markdown — a check that survives any body
+// reformatting a broken generator might apply.
 const docProbe = `export def greet(name: string): string {
   """Greet a person by name."""
-  return "Hello, " + name
+  return "Hello, " + name + " DOC_BODY_SENTINEL"
 }
 `;
 
@@ -103,6 +107,14 @@ const diagnosticsBad = `def brokenParams(first: string; second: string) {}
 const diagnosticsGood = `def joinStrings(first: string, second: string): string {
   return first + second
 }
+`;
+
+// A RECOVERABLE parse failure (not a thrown TarsecError). The old diagnostics
+// path emitted nothing for these; the whole point of this PR's change is that
+// they now produce JSON. The bad token is on the second line, so this also
+// proves line mapping rather than only column mapping on line 0.
+const diagnosticsRecoverable = `const x = 5
+!!!
 `;
 
 // outDir + log.projectId are echoed by `config show`. verbose is deliberately
@@ -250,7 +262,7 @@ function checkDoc() {
   assertIncludes(doc, "### greet");
   assertIncludes(doc, "```ts\ngreet(name: string): string\n```");
   assertIncludes(doc, "Greet a person by name.");
-  assert(!doc.includes('return "Hello, " + name'), "[doc] must not copy the function body into the docs");
+  assert(!doc.includes("DOC_BODY_SENTINEL"), "[doc] must not copy the function body into the docs");
   console.log("[cli-lang] doc behavior ✓");
 }
 
@@ -294,6 +306,25 @@ function checkDiagnostics() {
   const goodResult = runInstalledAgency(dir, ["diagnostics", "diagnostics-good.agency"]);
   assertBlank(goodResult.stdout, "[diagnostics valid] stdout");
   assertBlank(goodResult.stderr, "[diagnostics valid] stderr");
+
+  // Recoverable failure: proves the non-committed branch emits JSON and that
+  // line mapping works (the bad token is on the second line).
+  const recoverableLine = diagnosticsRecoverable.slice(0, diagnosticsRecoverable.indexOf("!!!")).split("\n").length - 1;
+  const recResult = runInstalledAgency(dir, ["diagnostics", "diagnostics-recoverable.agency"]);
+  assertBlank(recResult.stderr, "[diagnostics recoverable] stderr");
+  const recDiagnostic = JSON.parse(recResult.stdout);
+  assert(
+    recDiagnostic.line === recoverableLine,
+    `[diagnostics recoverable] line was ${recDiagnostic.line}, expected ${recoverableLine}`,
+  );
+  assert(recDiagnostic.length === 1, `[diagnostics recoverable] length was ${recDiagnostic.length}`);
+  assert(
+    typeof recDiagnostic.message === "string" && recDiagnostic.message.length > 0,
+    "[diagnostics recoverable] message must be a non-empty string",
+  );
+  // prettyMessage carries a 1-indexed "Line N" prefix, so this confirms the
+  // reported line rather than only the column.
+  assertIncludes(recDiagnostic.prettyMessage, `Line ${recoverableLine + 1}`);
   console.log("[cli-lang] diagnostics behavior ✓");
 }
 
@@ -311,6 +342,7 @@ try {
   writeFile(dir, "doc-probe.agency", docProbe);
   writeFile(dir, "diagnostics-bad.agency", diagnosticsBad);
   writeFile(dir, "diagnostics-good.agency", diagnosticsGood);
+  writeFile(dir, "diagnostics-recoverable.agency", diagnosticsRecoverable);
   writeFile(dir, "config-probe.json", configProbe);
 
   for (const testCase of commandCases) runCommandCase(testCase);

--- a/packages/agency-lang/tests/integration/cli-lang/test.mjs
+++ b/packages/agency-lang/tests/integration/cli-lang/test.mjs
@@ -350,6 +350,13 @@ try {
   checkAstPreprocess();
   checkDoc();
   checkConfig();
+
+  // Guard the config-independence of `diagnostics`. With a malformed agency.json
+  // present, any config-loading command (e.g. `config show`) exits non-zero, so
+  // if `diagnostics` ever reverted to getConfig() its expected-status-0 checks
+  // below would fail. Because it parses with {}, it ignores project config and
+  // stays green. Written here, after every config-sensitive check above.
+  writeFile(dir, "agency.json", "{ this is not valid json ");
   checkDiagnostics();
 
   console.log("=== cli-lang test passed ===");

--- a/packages/agency-lang/tests/integration/cli-lang/test.mjs
+++ b/packages/agency-lang/tests/integration/cli-lang/test.mjs
@@ -1,0 +1,329 @@
+// Per-PR integration tests for the deterministic language CLI commands.
+// Runs from a fresh temp project with agency-lang installed from an npm pack
+// tarball. Every command is offline and deterministic: no model or network
+// calls, no secrets, no server, no interactive prompt. This is a fast per-PR
+// packaging gate; deep behavior lives in unit tests and the main-only
+// cli-main runner.
+
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import {
+  assert,
+  assertIncludes,
+  cleanup,
+  createTempProject,
+  getTarballPath,
+  initProject,
+  installTarball,
+  runInstalledAgency,
+  writeFile,
+} from "../helpers.mjs";
+
+const tarball = resolve(getTarballPath());
+const dir = createTempProject("cli-lang");
+
+// The CLI emits ANSI color even when stdout is piped, so strip it before any
+// substring assertion. JSON-producing commands emit plain output, so stripping
+// is a no-op there.
+function stripAnsi(text) {
+  // eslint-disable-next-line no-control-regex
+  return text.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+function assertBlank(text, label) {
+  assert(stripAnsi(text).trim() === "", `${label} should be empty, got:\n${text}`);
+}
+
+function normalizeTrailingNewlines(text) {
+  return text.replace(/\r\n/g, "\n").replace(/\n*$/, "\n");
+}
+
+function walkNodes(value, visit) {
+  if (Array.isArray(value)) {
+    for (const item of value) walkNodes(item, visit);
+    return;
+  }
+  if (value && typeof value === "object") {
+    visit(value);
+    for (const key of Object.keys(value)) walkNodes(value[key], visit);
+  }
+}
+
+// --- Fixtures -------------------------------------------------------------
+
+const typecheckGood = `node typecheckGood(): number {
+  return 42
+}
+`;
+
+const typecheckBad = `def takesNumber(value: number): number {
+  return value
+}
+
+node typecheckBad(): number {
+  return takesNumber("oops")
+}
+`;
+
+const formatMessy = `node formatProbe(){const answer=40+2
+return answer}
+`;
+
+const formatExpected = `node formatProbe() {
+  const answer = 40 + 2
+  return answer
+}
+`;
+
+const lintProbe = `import { map } from "std::array"
+
+node lintProbe(): number {
+  return 1
+}
+`;
+
+const astPreprocessProbe = `def identity(value: string): string {
+  return value
+}
+
+node preprocessProbe(): string {
+  return identity("ok")
+}
+`;
+
+const docProbe = `export def greet(name: string): string {
+  """Greet a person by name."""
+  return "Hello, " + name
+}
+`;
+
+const diagnosticsBad = `def brokenParams(first: string; second: string) {}
+`;
+
+const diagnosticsGood = `def joinStrings(first: string, second: string): string {
+  return first + second
+}
+`;
+
+// outDir + log.projectId are echoed by `config show`. verbose is deliberately
+// omitted: it writes a config-loading notice to stderr, which would break the
+// quiet-stderr assertion below.
+const configProbe = `${JSON.stringify(
+  { outDir: "plan-probe-dist", log: { projectId: "plan-probe" } },
+  null,
+  2,
+)}
+`;
+
+// --- Declarative simple command contracts ---------------------------------
+
+const commandCases = [
+  {
+    name: "typecheck accepts valid input",
+    args: ["typecheck", "typecheck-good.agency"],
+    expectedStatus: 0,
+    stdoutIncludes: ["No type errors found."],
+    stderrIncludes: [],
+    stdoutEmpty: false,
+    stderrEmpty: true,
+  },
+  {
+    name: "typecheck rejects a wrong argument type",
+    args: ["typecheck", "typecheck-bad.agency"],
+    expectedStatus: 1,
+    stdoutIncludes: [],
+    stderrIncludes: ["AG6019", "takesNumber", "oops", "number"],
+    stdoutEmpty: true,
+    stderrEmpty: false,
+  },
+  {
+    name: "lint reports an unused import without failing",
+    args: ["lint", "lint-probe.agency"],
+    expectedStatus: 0,
+    stdoutIncludes: ["lint-probe.agency", "AL0001", "map", "never used"],
+    stderrIncludes: [],
+    stdoutEmpty: false,
+    stderrEmpty: true,
+  },
+  {
+    name: "explain renders AG2005",
+    args: ["explain", "AG2005"],
+    expectedStatus: 0,
+    stdoutIncludes: ["AG2005", "typeNotAssignable", "severity:", "not assignable"],
+    stderrIncludes: [],
+    stdoutEmpty: false,
+    stderrEmpty: true,
+  },
+];
+
+function runCommandCase(testCase) {
+  const { stdout, stderr } = runInstalledAgency(dir, testCase.args, {
+    expectedStatus: testCase.expectedStatus,
+  });
+  const out = stripAnsi(stdout);
+  const err = stripAnsi(stderr);
+  for (const needle of testCase.stdoutIncludes) {
+    assertIncludes(out, needle, `[${testCase.name}] stdout missing "${needle}"\n${out}`);
+  }
+  for (const needle of testCase.stderrIncludes) {
+    assertIncludes(err, needle, `[${testCase.name}] stderr missing "${needle}"\n${err}`);
+  }
+  if (testCase.stdoutEmpty) assertBlank(stdout, `[${testCase.name}] stdout`);
+  if (testCase.stderrEmpty) assertBlank(stderr, `[${testCase.name}] stderr`);
+  console.log(`[cli-lang] ${testCase.name} ✓`);
+}
+
+// --- Behavioral checks with independent oracles ---------------------------
+
+function checkFormat() {
+  const original = readFileSync(join(dir, "format-probe.agency"), "utf8");
+
+  const stdoutResult = runInstalledAgency(dir, ["format", "format-probe.agency"]);
+  assertBlank(stdoutResult.stderr, "[format stdout mode] stderr");
+  assert(
+    normalizeTrailingNewlines(stdoutResult.stdout) === normalizeTrailingNewlines(formatExpected),
+    `[format stdout mode] output did not match the expected canonical source:\n${stdoutResult.stdout}`,
+  );
+  assert(
+    readFileSync(join(dir, "format-probe.agency"), "utf8") === original,
+    "[format stdout mode] must not modify the file",
+  );
+
+  const inPlace = runInstalledAgency(dir, ["format", "-i", "format-probe.agency"]);
+  assertIncludes(stripAnsi(inPlace.stdout), "Formatted: format-probe.agency", "[format -i] message");
+  assertBlank(inPlace.stderr, "[format -i] stderr");
+  const afterFirst = readFileSync(join(dir, "format-probe.agency"), "utf8");
+  assert(afterFirst !== original, "[format -i] must rewrite the file");
+  assert(
+    normalizeTrailingNewlines(afterFirst) === normalizeTrailingNewlines(formatExpected),
+    "[format -i] file content did not match the expected canonical source",
+  );
+
+  runInstalledAgency(dir, ["format", "-i", "format-probe.agency"]);
+  assert(
+    readFileSync(join(dir, "format-probe.agency"), "utf8") === afterFirst,
+    "[format -i] second run must be idempotent",
+  );
+  console.log("[cli-lang] format behavior ✓");
+}
+
+function checkAstPreprocess() {
+  const astResult = runInstalledAgency(dir, ["ast", "ast-preprocess-probe.agency"]);
+  assertBlank(astResult.stderr, "[ast] stderr");
+  const ast = JSON.parse(astResult.stdout);
+  assert(ast.type === "agencyProgram", "ast must emit an agencyProgram");
+  assert(
+    ast.nodes.some((node) => node.type === "graphNode" && node.nodeName === "preprocessProbe"),
+    "ast must contain the preprocessProbe graph node",
+  );
+  let astHasScope = false;
+  walkNodes(ast, (node) => {
+    if (Object.prototype.hasOwnProperty.call(node, "scope")) astHasScope = true;
+  });
+  assert(!astHasScope, "raw ast must not carry preprocessor scope annotations");
+
+  const preResult = runInstalledAgency(dir, ["preprocess", "ast-preprocess-probe.agency"]);
+  assertBlank(preResult.stderr, "[preprocess] stderr");
+  const pre = JSON.parse(preResult.stdout);
+  assert(pre.type === "agencyProgram", "preprocess must emit an agencyProgram");
+  let preHasArgsScope = false;
+  walkNodes(pre, (node) => {
+    if (node.scope === "args") preHasArgsScope = true;
+  });
+  assert(
+    preHasArgsScope,
+    "preprocess must annotate a parameter reference with args scope (proves it is not the raw parser)",
+  );
+  console.log("[cli-lang] ast/preprocess behavior ✓");
+}
+
+function checkDoc() {
+  const result = runInstalledAgency(dir, ["doc", "doc-probe.agency", "-o", "generated-docs"]);
+  assertBlank(result.stdout, "[doc] stdout");
+  assertBlank(result.stderr, "[doc] stderr");
+  const docPath = join(dir, "generated-docs", "doc-probe.md");
+  assert(existsSync(docPath), `[doc] expected generated file at ${docPath}`);
+  const doc = readFileSync(docPath, "utf8");
+  assertIncludes(doc, 'name: "doc-probe"');
+  assertIncludes(doc, "# doc-probe");
+  assertIncludes(doc, "## Functions");
+  assertIncludes(doc, "### greet");
+  assertIncludes(doc, "```ts\ngreet(name: string): string\n```");
+  assertIncludes(doc, "Greet a person by name.");
+  assert(!doc.includes('return "Hello, " + name'), "[doc] must not copy the function body into the docs");
+  console.log("[cli-lang] doc behavior ✓");
+}
+
+function checkConfig() {
+  const result = runInstalledAgency(dir, ["-c", "config-probe.json", "config", "show"]);
+  assertBlank(result.stderr, "[config show] stderr");
+  const config = JSON.parse(result.stdout);
+  assert(config.outDir === "plan-probe-dist", `[config show] outDir was ${config.outDir}`);
+  assert(config.log?.projectId === "plan-probe", `[config show] projectId was ${config.log?.projectId}`);
+  console.log("[cli-lang] config show behavior ✓");
+}
+
+function checkDiagnostics() {
+  // The expected location is derived from the fixture rather than hard-coded.
+  const markerOffset = diagnosticsBad.indexOf(";");
+  const beforeMarker = diagnosticsBad.slice(0, markerOffset);
+  const expectedLine = beforeMarker.split("\n").length - 1;
+  const previousNewline = beforeMarker.lastIndexOf("\n");
+  const expectedColumn =
+    previousNewline === -1 ? beforeMarker.length : beforeMarker.length - previousNewline - 1;
+
+  const badResult = runInstalledAgency(dir, ["diagnostics", "diagnostics-bad.agency"]);
+  assertBlank(badResult.stderr, "[diagnostics error] stderr");
+  const diagnostic = JSON.parse(badResult.stdout);
+  assert(diagnostic.line === expectedLine, `[diagnostics] line was ${diagnostic.line}, expected ${expectedLine}`);
+  assert(
+    diagnostic.column === expectedColumn,
+    `[diagnostics] column was ${diagnostic.column}, expected ${expectedColumn}`,
+  );
+  assert(diagnostic.length === 1, `[diagnostics] length was ${diagnostic.length}`);
+  assert(
+    typeof diagnostic.message === "string" && diagnostic.message.length > 0,
+    "[diagnostics] message must be a non-empty string",
+  );
+  assert(
+    typeof diagnostic.prettyMessage === "string" && diagnostic.prettyMessage.length > 0,
+    "[diagnostics] prettyMessage must be a non-empty string",
+  );
+  assertIncludes(diagnostic.message, "expected `,` between parameters");
+
+  const goodResult = runInstalledAgency(dir, ["diagnostics", "diagnostics-good.agency"]);
+  assertBlank(goodResult.stdout, "[diagnostics valid] stdout");
+  assertBlank(goodResult.stderr, "[diagnostics valid] stderr");
+  console.log("[cli-lang] diagnostics behavior ✓");
+}
+
+// --- Run everything -------------------------------------------------------
+
+try {
+  initProject(dir);
+  installTarball(dir, tarball);
+
+  writeFile(dir, "typecheck-good.agency", typecheckGood);
+  writeFile(dir, "typecheck-bad.agency", typecheckBad);
+  writeFile(dir, "format-probe.agency", formatMessy);
+  writeFile(dir, "lint-probe.agency", lintProbe);
+  writeFile(dir, "ast-preprocess-probe.agency", astPreprocessProbe);
+  writeFile(dir, "doc-probe.agency", docProbe);
+  writeFile(dir, "diagnostics-bad.agency", diagnosticsBad);
+  writeFile(dir, "diagnostics-good.agency", diagnosticsGood);
+  writeFile(dir, "config-probe.json", configProbe);
+
+  for (const testCase of commandCases) runCommandCase(testCase);
+  checkFormat();
+  checkAstPreprocess();
+  checkDoc();
+  checkConfig();
+  checkDiagnostics();
+
+  console.log("=== cli-lang test passed ===");
+  cleanup(dir);
+} catch (err) {
+  console.error("cli-lang test failed:", err);
+  console.error("Temp directory preserved at:", dir);
+  process.exit(1);
+}

--- a/packages/agency-lang/tests/integration/cli-main/test.mjs
+++ b/packages/agency-lang/tests/integration/cli-main/test.mjs
@@ -116,14 +116,24 @@ function runLogged(label, file, args = [], opts = {}) {
 // expected status via `opts.expectedStatus` (default 0) instead of the old
 // boolean `expectFail`.
 function runAgency(label, args, opts = {}) {
-  const result = runInstalledAgency(dir, args, {
-    expectedStatus: opts.expectedStatus ?? 0,
-    input: opts.input,
-    env: opts.env,
-    timeout: opts.timeout,
-  });
+  const logPath = join(logsDir, `${label}.txt`);
+  let result;
+  try {
+    result = runInstalledAgency(dir, args, {
+      expectedStatus: opts.expectedStatus ?? 0,
+      input: opts.input,
+      env: opts.env,
+      timeout: opts.timeout,
+    });
+  } catch (err) {
+    // runInstalledAgency throws on an unexpected status, timeout, or spawn
+    // error. Preserve the per-command log before rethrowing — that is when it
+    // is most useful. The helper attaches the captured streams to the error.
+    writeFileSync(logPath, `${err.stdout ?? ""}${err.stderr ?? ""}`);
+    throw err;
+  }
   const output = `${result.stdout}${result.stderr}`;
-  writeFileSync(join(logsDir, `${label}.txt`), output);
+  writeFileSync(logPath, output);
   return opts.combined ? output : result.stdout;
 }
 

--- a/packages/agency-lang/tests/integration/cli-main/test.mjs
+++ b/packages/agency-lang/tests/integration/cli-main/test.mjs
@@ -23,6 +23,7 @@ import {
   getTarballPath,
   initProject,
   installTarball,
+  runInstalledAgency,
 } from "../helpers.mjs";
 
 const tarball = resolve(getTarballPath());
@@ -109,8 +110,21 @@ function runLogged(label, file, args = [], opts = {}) {
   return opts.combined ? output : stdout;
 }
 
+// The installed-CLI path now goes through the shared `runInstalledAgency`
+// boundary in helpers.mjs. This wrapper keeps the label/log-file behavior and
+// the stdout-vs-combined return contract. Failure cases declare their exact
+// expected status via `opts.expectedStatus` (default 0) instead of the old
+// boolean `expectFail`.
 function runAgency(label, args, opts = {}) {
-  return runLogged(label, "npx", ["--no-install", "agency", ...args], opts);
+  const result = runInstalledAgency(dir, args, {
+    expectedStatus: opts.expectedStatus ?? 0,
+    input: opts.input,
+    env: opts.env,
+    timeout: opts.timeout,
+  });
+  const output = `${result.stdout}${result.stderr}`;
+  writeFileSync(join(logsDir, `${label}.txt`), output);
+  return opts.combined ? output : result.stdout;
 }
 
 function runNode(label, args, opts = {}) {
@@ -355,7 +369,7 @@ try {
   const invalidPackTarget = runAgency(
     "10-pack-invalid-target",
     ["pack", "src/pack-target.agency", "--target", "browser"],
-    { expectFail: true },
+    { expectedStatus: 1, combined: true },
   );
   assertIncludes(invalidPackTarget, "Unsupported pack target: browser");
 
@@ -526,7 +540,7 @@ try {
   const thresholdFailure = stripAnsi(runAgency(
     "23-coverage-threshold-failure",
     ["coverage", "report", "src/coverage-partial.agency", "--threshold", "100"],
-    { expectFail: true },
+    { expectedStatus: 1, combined: true },
   ));
   assertIncludes(thresholdFailure, "below threshold 100%");
   runAgency("24-coverage-clean-partial", ["coverage", "clean"]);
@@ -542,7 +556,7 @@ try {
   const tcError = stripAnsi(runAgency(
     "26-tc-error",
     ["tc", "src/type-error.agency"],
-    { expectFail: true },
+    { expectedStatus: 1, combined: true },
   ));
   assertIncludes(tcError, "Type '\"oops\"' is not assignable to type 'number'");
   assertIncludes(tcError, "return in 'bad'");
@@ -558,7 +572,7 @@ try {
   const strictError = stripAnsi(runAgency(
     "28-tc-strict",
     ["tc", "src/type-strict.agency", "--strict"],
-    { expectFail: true },
+    { expectedStatus: 1, combined: true },
   ));
   assertIncludes(strictError, "no type annotation");
   assertIncludes(strictError, "strict mode");
@@ -636,7 +650,7 @@ node beeMain(): string {
 `,
   );
   const tcImportOut = stripAnsi(
-    runAgency("28a2-tc-dir-imports", ["tc", "tc-imports"], { expectFail: true }),
+    runAgency("28a2-tc-dir-imports", ["tc", "tc-imports"], { expectedStatus: 1, combined: true }),
   );
   assertIncludes(tcImportOut, "in call to 'xFromCee'");
   assertIncludes(tcImportOut, "in call to 'yFromDee'");
@@ -685,7 +699,7 @@ node u(): string {
 `,
   );
   const tcBadImportOut = stripAnsi(
-    runAgency("28e-tc-missing-import", ["tc", "tc-bad-import"], { expectFail: true }),
+    runAgency("28e-tc-missing-import", ["tc", "tc-bad-import"], { expectedStatus: 1, combined: true }),
   );
   assertIncludes(tcBadImportOut, "AG4008");
   assertIncludes(tcBadImportOut, "missingFn");
@@ -746,7 +760,7 @@ node u(): string {
   const removeOutput = stripAnsi(runAgency(
     "35-schedule-remove-missing",
     ["schedule", "remove", "nightly"],
-    { env: scheduleEnv, expectFail: true },
+    { env: scheduleEnv, expectedStatus: 1, combined: true },
   ));
   assertIncludes(removeOutput, "No schedule named \"nightly\"");
 
@@ -767,14 +781,14 @@ node u(): string {
   const existingSchedule = stripAnsi(runAgency(
     "38-schedule-existing-failure",
     ["schedule", "add", "agents/nightly.agency", "--backend", "github", "--every", "hourly", "--name", "nightly", "--no-pin"],
-    { env: scheduleEnv, expectFail: true },
+    { env: scheduleEnv, expectedStatus: 1, combined: true },
   ));
   assertIncludes(existingSchedule, "File already exists");
 
   const invalidBackend = stripAnsi(runAgency(
     "39-schedule-invalid-backend",
     ["schedule", "add", "agents/nightly.agency", "--backend", "local", "--every", "hourly", "--name", "bad"],
-    { env: scheduleEnv, expectFail: true },
+    { env: scheduleEnv, expectedStatus: 1, combined: true },
   ));
   assertIncludes(invalidBackend, "Unknown --backend value");
 

--- a/packages/agency-lang/tests/integration/helpers.mjs
+++ b/packages/agency-lang/tests/integration/helpers.mjs
@@ -32,15 +32,28 @@ export function runInstalledAgency(
   const stderr = result.stderr || "";
   const command = ["npx", "--no-install", "agency", ...args].join(" ");
 
+  // Both throw paths attach the captured streams and status so callers can log
+  // per-command output on failure (that is exactly when the log matters).
   if (result.error) {
-    throw new Error(
+    const error = new Error(
       `Command failed to start: ${command}\n${result.error.message}\n${stdout}${stderr}`,
     );
+    error.cause = result.error;
+    error.stdout = stdout;
+    error.stderr = stderr;
+    error.status = result.status;
+    error.signal = result.signal;
+    throw error;
   }
   if (result.status !== expectedStatus) {
-    throw new Error(
+    const error = new Error(
       `Expected exit ${expectedStatus}, got ${result.status}: ${command}\n${stdout}${stderr}`,
     );
+    error.stdout = stdout;
+    error.stderr = stderr;
+    error.status = result.status;
+    error.signal = result.signal;
+    throw error;
   }
 
   return { status: result.status, stdout, stderr, signal: result.signal };

--- a/packages/agency-lang/tests/integration/helpers.mjs
+++ b/packages/agency-lang/tests/integration/helpers.mjs
@@ -3,9 +3,48 @@
 // installs Agency from a tarball, and verifies user-facing workflows.
 
 import { mkdtempSync, readFileSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
-import { execSync } from "node:child_process";
+import { execSync, spawnSync } from "node:child_process";
 import { join, dirname, resolve } from "node:path";
 import { tmpdir } from "node:os";
+
+const DEFAULT_COMMAND_TIMEOUT_MS = 120_000;
+
+// The single process boundary for running the installed `agency` CLI. It is the
+// only layer that knows about spawnSync, `npx --no-install` (which forbids an
+// npm registry fallback, so a missing local bin is a real failure), the default
+// timeout, environment merging, spawn errors, and status enforcement. Callers
+// declare the exact expected exit status rather than bypassing the helper for
+// failure cases, and always get stdout and stderr back separately.
+export function runInstalledAgency(
+  dir,
+  args,
+  { expectedStatus = 0, input, env, timeout = DEFAULT_COMMAND_TIMEOUT_MS } = {},
+) {
+  const result = spawnSync("npx", ["--no-install", "agency", ...args], {
+    cwd: dir,
+    encoding: "utf8",
+    timeout,
+    input,
+    stdio: ["pipe", "pipe", "pipe"],
+    env: env ? { ...process.env, ...env } : process.env,
+  });
+  const stdout = result.stdout || "";
+  const stderr = result.stderr || "";
+  const command = ["npx", "--no-install", "agency", ...args].join(" ");
+
+  if (result.error) {
+    throw new Error(
+      `Command failed to start: ${command}\n${result.error.message}\n${stdout}${stderr}`,
+    );
+  }
+  if (result.status !== expectedStatus) {
+    throw new Error(
+      `Expected exit ${expectedStatus}, got ${result.status}: ${command}\n${stdout}${stderr}`,
+    );
+  }
+
+  return { status: result.status, stdout, stderr, signal: result.signal };
+}
 
 export function createTempProject(name) {
   const dir = mkdtempSync(join(tmpdir(), `agency-integration-${name}-`));


### PR DESCRIPTION
## What

Adds a fast, offline, per-PR integration runner for the deterministic language CLI commands, and normalizes the `diagnostics` command's output so its result can be asserted.

## Why

The deep CLI integration suite (`cli-main/test.mjs`) only runs on push to `main`, so a packaging regression in the everyday language commands (`fmt`, `typecheck`, `ast`/`parse`, `doc`) was invisible until after merge. And `lint`, `explain`, `config show`, `preprocess`, and `diagnostics` had no tarball coverage anywhere.

An integration test here catches what the many `lib/cli/*.test.ts` unit tests cannot: a missing `dist/` file, a broken bin entry, output sent to the wrong stream, or a wrong exit code — i.e. "works in-process, broken once published."

## What the new runner checks

`tests/integration/cli-lang/test.mjs` installs the npm tarball and runs the canonical commands: `typecheck`, `format`, `lint`, `explain`, `ast`, `preprocess`, `doc`, `config show`, `diagnostics`. Every check asserts the exact exit status and keeps stdout/stderr separate, and each uses an independent oracle so a stable-but-wrong implementation cannot pass:

- `format` compares against an independent expected value, and separates stdout mode from `-i` mode, so a no-op or a formatter that corrupts source both fail.
- `preprocess` asserts a `scope: "args"` annotation that the raw parser never emits, so `preprocess` cannot be silently wired to `ast`.
- `doc` asserts the generated markers **and** that the function body was not copied in.
- `diagnostics` derives the expected error position from the fixture rather than hard-coding it.

It complements `cli-main` (which owns deep syntax matrices, stdin/directory inputs, and strict mode) rather than duplicating it, and uses canonical command names where `cli-main` mostly uses aliases.

## Supporting changes

- **`helpers.mjs`**: one shared `runInstalledAgency` boundary — the only layer that knows about `spawnSync`, `npx --no-install` (no registry fallback), exact-status enforcement, and separate streams.
- **`cli-main/test.mjs`**: routed through the shared boundary; the boolean `expectFail` became an exact `expectedStatus` (all failing cases are exit 1, verified).
- **`scripts/agency.ts`**: `diagnostics` now routes through `parseAgency().errorData`, giving normalized, zero-indexed error data for both committed and recoverable parse failures instead of raw `TarsecError.data`.
- **`test.yml`**: the new runner runs in the existing integration job (already on PRs and pushes) — no new job, secret, or matrix.

## Validation (local, fresh tarball)

- New runner: all 9 checks pass.
- Migrated `cli-main`: passes.
- Deliberately corrupting an expectation makes the runner fail (proves the checks can fail).
- `pnpm run typecheck` and `pnpm run lint:structure`: clean.

## Note

Two intentional deviations from the literal plan: the runner strips ANSI before substring assertions (the CLI emits color even when piped), and the `preprocess` scope check uses a tree walk rather than index-based navigation (robust to AST shape changes). Same intent, same coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
