### PR TITLE
test(integration): per-PR artifact-command tests (pack standalone, trace/bundle, coverage)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -191,6 +191,7 @@ jobs:
         node tests/integration/bundlers/test-vite.mjs ./agency-lang-*.tgz
         node tests/integration/cli/test.mjs ./agency-lang-*.tgz
         node tests/integration/cli-lang/test.mjs ./agency-lang-*.tgz
+        node tests/integration/cli-tier2/test.mjs ./agency-lang-*.tgz
         node tests/integration/serve/test.mjs ./agency-lang-*.tgz
         rm -f agency-lang-*.tgz
     - name: Main-only CLI command integration tests

--- a/packages/agency-lang/tests/integration/cli-main/test.mjs
+++ b/packages/agency-lang/tests/integration/cli-main/test.mjs
@@ -6,7 +6,6 @@ import {
   cpSync,
   existsSync,
   mkdirSync,
-  readFileSync,
   realpathSync,
   statSync,
   unlinkSync,
@@ -17,12 +16,17 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   assert,
+  assertFile,
+  assertFileEquals,
   assertIncludes,
   cleanup,
   createTempProject,
   getTarballPath,
   initProject,
   installTarball,
+  normalizeOptionalFinalNewline,
+  readJsonLines,
+  readText,
   runInstalledAgency,
 } from "../helpers.mjs";
 
@@ -37,38 +41,6 @@ mkdirSync(logsDir, { recursive: true });
 
 function stripAnsi(text) {
   return text.replace(/\x1b\[[0-9;]*m/g, "");
-}
-
-function normalizeNewline(text) {
-  return text.replace(/\r\n/g, "\n");
-}
-
-function readText(path) {
-  return normalizeNewline(readFileSync(path, "utf8"));
-}
-
-function assertFile(path, message) {
-  assert(existsSync(path), message || `Expected file to exist: ${path}`);
-}
-
-function normalizeOptionalFinalNewline(text) {
-  return normalizeNewline(text).replace(/\n*$/, "\n");
-}
-
-// Compares two files for equality. By default the comparison is strict
-// (line-for-line, preserving trailing newlines). Pass
-// `{ normalizeTrailingNewline: true }` to collapse trailing newline
-// differences before comparing.
-function assertFileEquals(actualPath, expectedPath, opts = {}) {
-  const normalize = opts.normalizeTrailingNewline
-    ? normalizeOptionalFinalNewline
-    : normalizeNewline;
-  const actual = normalize(readFileSync(actualPath, "utf8"));
-  const expected = normalize(readFileSync(expectedPath, "utf8"));
-  assert(
-    actual === expected,
-    `Expected ${actualPath} to match ${expectedPath}\n--- actual ---\n${actual}\n--- expected ---\n${expected}`,
-  );
 }
 
 function commandToString(file, args) {
@@ -157,13 +129,6 @@ function copyProjectFixtures() {
 
 // trace helpers
 
-function readJsonLines(path) {
-  return readText(path)
-    .trim()
-    .split("\n")
-    .filter((line) => line.length > 0)
-    .map((line) => JSON.parse(line));
-}
 
 function collectHashStrings(value, out = []) {
   if (typeof value === "string") {

--- a/packages/agency-lang/tests/integration/cli-tier2/test.mjs
+++ b/packages/agency-lang/tests/integration/cli-tier2/test.mjs
@@ -11,6 +11,7 @@ import {
   mkdtempSync,
   readdirSync,
   renameSync,
+  rmSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -49,6 +50,15 @@ function subdir(name) {
   return full;
 }
 
+// runInstalledAgency plus a clean-success check: the command must leave stderr
+// blank. `pack` is the documented exception (it logs compile progress to
+// stderr) and uses runInstalledAgency directly.
+function runCleanAgency(cwd, args, label) {
+  const result = runInstalledAgency(cwd, args);
+  assertBlank(result.stderr, `[${label}] stderr`);
+  return result;
+}
+
 // --- pack: the standalone-isolation contract --------------------------------
 // pack already has per-PR coverage that runs the output beside the project's
 // node_modules (cli/test.mjs). The missing contract is that the packed file is
@@ -77,34 +87,42 @@ function checkPackStandalone() {
   assertFile(join(packDir, "packed.mjs"), "pack should write packed.mjs");
 
   // Copy only the packed file to a fresh root with no node_modules ancestor.
+  // The root lives outside `dir`, so clean it up ourselves in finally.
   const standaloneRoot = mkdtempSync(join(tmpdir(), "agency-tier2-standalone-"));
-  for (let cur = standaloneRoot; ; cur = dirname(cur)) {
-    assert(
-      !existsSync(join(cur, "node_modules")),
-      `standalone root ancestor unexpectedly has node_modules: ${cur}`,
-    );
-    if (dirname(cur) === cur) break;
-  }
-  cpSync(join(packDir, "packed.mjs"), join(standaloneRoot, "packed.mjs"));
-
-  // Rename the installed project's node_modules while running the copy, so an
-  // absolute reference back to the install fails just as a bare import would.
-  const nodeModules = join(dir, "node_modules");
-  const stashed = join(dir, "node_modules.stashed");
-  renameSync(nodeModules, stashed);
   try {
-    // Invoke it the way a user would — `node packed.mjs` from its own directory.
-    // (A packed program only auto-runs `main` when launched by a relative path.)
-    const result = runProcess(process.execPath, ["packed.mjs"], {
-      cwd: standaloneRoot,
-    });
-    assert(
-      result.stdout.replace(/\r\n/g, "\n") === PACK_EXPECTED,
-      `standalone packed output was:\n${result.stdout}`,
-    );
-    assertBlank(result.stderr, "[pack standalone] stderr");
+    for (let cur = standaloneRoot; ; cur = dirname(cur)) {
+      assert(
+        !existsSync(join(cur, "node_modules")),
+        `standalone root ancestor unexpectedly has node_modules: ${cur}`,
+      );
+      if (dirname(cur) === cur) break;
+    }
+    cpSync(join(packDir, "packed.mjs"), join(standaloneRoot, "packed.mjs"));
+
+    // Remove the source dir so an artifact embedding an absolute source path
+    // fails, and rename the install's node_modules so bare/absolute install
+    // references fail too. Together these prove the copy is self-contained.
+    rmSync(packDir, { recursive: true, force: true });
+    const nodeModules = join(dir, "node_modules");
+    const stashed = join(dir, "node_modules.stashed");
+    renameSync(nodeModules, stashed);
+    try {
+      // Invoke it the way a user would — `node packed.mjs` from its own
+      // directory. (A packed program only auto-runs `main` when launched by a
+      // relative path.)
+      const result = runProcess(process.execPath, ["packed.mjs"], {
+        cwd: standaloneRoot,
+      });
+      assert(
+        result.stdout.replace(/\r\n/g, "\n") === PACK_EXPECTED,
+        `standalone packed output was:\n${result.stdout}`,
+      );
+      assertBlank(result.stderr, "[pack standalone] stderr");
+    } finally {
+      renameSync(stashed, nodeModules);
+    }
   } finally {
-    renameSync(stashed, nodeModules);
+    cleanup(standaloneRoot);
   }
   console.log("[cli-tier2] pack standalone ✓");
 }
@@ -120,7 +138,7 @@ function checkTraceBundleRoundTrip() {
     `node main() {\n  print(tier2TraceHelper())\n}\n`;
   writeFile(traceDir, "probe.agency", source);
 
-  runInstalledAgency(traceDir, ["trace", "run", "probe.agency", "-o", "probe.trace"]);
+  runCleanAgency(traceDir, ["trace", "run", "probe.agency", "-o", "probe.trace"], "trace run");
   const traceLines = readJsonLines(join(traceDir, "probe.trace"));
   const headers = traceLines.filter((l) => l.type === "header");
   const footers = traceLines.filter((l) => l.type === "footer");
@@ -132,28 +150,34 @@ function checkTraceBundleRoundTrip() {
   assert(manifests.length > 0, "expected at least one trace manifest (checkpoint)");
   assert(headers[0].program === "probe.agency", `trace program was ${headers[0].program}`);
 
-  runInstalledAgency(traceDir, ["trace", "log", "probe.trace", "-o", "events.json"]);
+  runCleanAgency(traceDir, ["trace", "log", "probe.trace", "-o", "events.json"], "trace log");
   const baselineEvents = JSON.parse(readText(join(traceDir, "events.json")));
   assert(Array.isArray(baselineEvents) && baselineEvents.length > 0, "trace log must yield a non-empty array");
+  // Assert the distinctive semantic event for THIS program, not just any
+  // node-enter (which every trace gets from `main`).
   assert(
-    baselineEvents.some((e) => e.type === "node-enter"),
-    "trace log must contain a node-enter event",
+    baselineEvents.some((e) => e.type === "function-enter" && e.functionName === "tier2TraceHelper"),
+    "trace log must contain a function-enter for tier2TraceHelper",
   );
 
-  // Bundle the source + trace, then delete both originals so unbundle cannot
-  // copy external inputs.
-  runInstalledAgency(traceDir, ["bundle", "probe.agency", "probe.trace", "-o", "probe.bundle"]);
+  // Save the original source, then bundle and DELETE both originals so unbundle
+  // cannot fall back to reading on-disk inputs.
   const savedSource = readText(join(traceDir, "probe.agency"));
   const originalSourcePath = join(traceDir, "probe.agency.original");
   writeFile(traceDir, "probe.agency.original", savedSource);
-  runInstalledAgency(traceDir, ["unbundle", "probe.bundle", "-o", "unpacked"]);
+  runCleanAgency(traceDir, ["bundle", "probe.agency", "probe.trace", "-o", "probe.bundle"], "bundle");
+  rmSync(join(traceDir, "probe.agency"));
+  rmSync(join(traceDir, "probe.trace"));
+  assert(!existsSync(join(traceDir, "probe.agency")), "original source must be gone before unbundle");
+  assert(!existsSync(join(traceDir, "probe.trace")), "original trace must be gone before unbundle");
+  runCleanAgency(traceDir, ["unbundle", "probe.bundle", "-o", "unpacked"], "unbundle");
 
   assertFileEquals(join(traceDir, "unpacked", "probe.agency"), originalSourcePath, {
     normalizeTrailingNewline: true,
   });
 
   // The unbundled trace must still be consumable and semantically identical.
-  runInstalledAgency(traceDir, ["trace", "log", join("unpacked", "probe.trace"), "-o", join("unpacked", "events.json")]);
+  runCleanAgency(traceDir, ["trace", "log", join("unpacked", "probe.trace"), "-o", join("unpacked", "events.json")], "trace log (unbundled)");
   const restoredEvents = JSON.parse(readText(join(traceDir, "unpacked", "events.json")));
   assert(
     JSON.stringify(restoredEvents) === JSON.stringify(baselineEvents),
@@ -201,20 +225,24 @@ function checkCoverageLifecycle() {
   );
   assert(!existsSync(join(covDir, ".coverage")), "coverage dir must not exist before the run");
 
-  const testOut = runInstalledAgency(covDir, ["test", "probe.agency", "--coverage"]);
+  const testOut = runCleanAgency(covDir, ["test", "probe.agency", "--coverage"], "test --coverage");
   assertIncludes(stripAnsi(testOut.stdout), "1/1 tests passed");
   const covFiles = readdirSync(join(covDir, ".coverage")).filter(
     (f) => f.startsWith("cov-") && f.endsWith(".json"),
   );
   assert(covFiles.length > 0, "coverage run should write a .coverage/cov-*.json file");
 
-  const report = runInstalledAgency(covDir, ["coverage", "report", "probe.agency", "--detail", "--threshold", "100"]);
+  const report = runCleanAgency(
+    covDir,
+    ["coverage", "report", "probe.agency", "--detail", "--threshold", "100"],
+    "coverage report",
+  );
   const { percentage, covered, total } = parseCoverageTotal(report.stdout);
   assert(total > 0, "coverage total steps must be non-zero");
   assert(covered === total, `expected covered === total, got ${covered}/${total}`);
   assert(percentage === 100, `expected 100% coverage, got ${percentage}%`);
 
-  runInstalledAgency(covDir, ["coverage", "clean"]);
+  runCleanAgency(covDir, ["coverage", "clean"], "coverage clean");
   assert(!existsSync(join(covDir, ".coverage")), "coverage clean should remove .coverage");
   console.log("[cli-tier2] coverage lifecycle ✓");
 }

--- a/packages/agency-lang/tests/integration/cli-tier2/test.mjs
+++ b/packages/agency-lang/tests/integration/cli-tier2/test.mjs
@@ -1,0 +1,238 @@
+// Per-PR integration tests for the Tier 2 artifact CLI commands: pack, trace,
+// bundle/unbundle, and coverage. Installs the npm tarball once, then runs each
+// stateful workflow in its own project subdirectory so they share no mutable
+// state. Deep format matrices stay in cli-main; these are per-PR
+// packaging-and-consumability smoke checks.
+
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  renameSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import {
+  assert,
+  assertFile,
+  assertFileEquals,
+  assertIncludes,
+  cleanup,
+  createTempProject,
+  getTarballPath,
+  initProject,
+  installTarball,
+  readJsonLines,
+  readText,
+  runInstalledAgency,
+  runProcess,
+  writeFile,
+} from "../helpers.mjs";
+
+const tarball = resolve(getTarballPath());
+const dir = createTempProject("cli-tier2");
+
+function stripAnsi(text) {
+  // eslint-disable-next-line no-control-regex
+  return text.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+function assertBlank(text, label) {
+  assert(stripAnsi(text).trim() === "", `${label} should be empty, got:\n${text}`);
+}
+
+function subdir(name) {
+  const full = join(dir, name);
+  mkdirSync(full, { recursive: true });
+  return full;
+}
+
+// --- pack: the standalone-isolation contract --------------------------------
+// pack already has per-PR coverage that runs the output beside the project's
+// node_modules (cli/test.mjs). The missing contract is that the packed file is
+// genuinely self-contained: it must run where no node_modules is reachable and
+// where the original sources and install are gone.
+
+const PACK_EXPECTED = "TIER2_PACK_SENTINEL_2\n";
+
+function checkPackStandalone() {
+  const packDir = subdir("pack");
+  // An import-bearing entry: a local module contributes part of the output and
+  // a stdlib function contributes the rest, so local, stdlib, and runtime
+  // bundling are all exercised.
+  writeFile(packDir, "helper.agency", `export def part(): string {\n  return "TIER2_PACK_SENTINEL"\n}\n`);
+  writeFile(
+    packDir,
+    "probe.agency",
+    `import { part } from "./helper.agency"\n` +
+      `import { add } from "std::math"\n\n` +
+      `node main() {\n  print(part() + "_" + add(1, 1))\n}\n`,
+  );
+
+  // pack emits compile progress, so do not assert empty stderr on the command
+  // itself; the empty-stderr contract is asserted on the standalone run below.
+  runInstalledAgency(packDir, ["pack", "probe.agency", "-o", "packed.mjs"]);
+  assertFile(join(packDir, "packed.mjs"), "pack should write packed.mjs");
+
+  // Copy only the packed file to a fresh root with no node_modules ancestor.
+  const standaloneRoot = mkdtempSync(join(tmpdir(), "agency-tier2-standalone-"));
+  for (let cur = standaloneRoot; ; cur = dirname(cur)) {
+    assert(
+      !existsSync(join(cur, "node_modules")),
+      `standalone root ancestor unexpectedly has node_modules: ${cur}`,
+    );
+    if (dirname(cur) === cur) break;
+  }
+  cpSync(join(packDir, "packed.mjs"), join(standaloneRoot, "packed.mjs"));
+
+  // Rename the installed project's node_modules while running the copy, so an
+  // absolute reference back to the install fails just as a bare import would.
+  const nodeModules = join(dir, "node_modules");
+  const stashed = join(dir, "node_modules.stashed");
+  renameSync(nodeModules, stashed);
+  try {
+    // Invoke it the way a user would — `node packed.mjs` from its own directory.
+    // (A packed program only auto-runs `main` when launched by a relative path.)
+    const result = runProcess(process.execPath, ["packed.mjs"], {
+      cwd: standaloneRoot,
+    });
+    assert(
+      result.stdout.replace(/\r\n/g, "\n") === PACK_EXPECTED,
+      `standalone packed output was:\n${result.stdout}`,
+    );
+    assertBlank(result.stderr, "[pack standalone] stderr");
+  } finally {
+    renameSync(stashed, nodeModules);
+  }
+  console.log("[cli-tier2] pack standalone ✓");
+}
+
+// --- trace + bundle/unbundle round-trip -------------------------------------
+
+function checkTraceBundleRoundTrip() {
+  const traceDir = subdir("trace");
+  // trace runs the `main` node; a uniquely named helper gives the event log a
+  // distinctive function to look for.
+  const source =
+    `def tier2TraceHelper(): string {\n  return "traced"\n}\n\n` +
+    `node main() {\n  print(tier2TraceHelper())\n}\n`;
+  writeFile(traceDir, "probe.agency", source);
+
+  runInstalledAgency(traceDir, ["trace", "run", "probe.agency", "-o", "probe.trace"]);
+  const traceLines = readJsonLines(join(traceDir, "probe.trace"));
+  const headers = traceLines.filter((l) => l.type === "header");
+  const footers = traceLines.filter((l) => l.type === "footer");
+  const manifests = traceLines.filter((l) => l.type === "manifest");
+  assert(headers.length === 1, `expected one trace header, got ${headers.length}`);
+  assert(footers.length === 1, `expected one trace footer, got ${footers.length}`);
+  assert(traceLines[0].type === "header", "trace header must be first");
+  assert(traceLines[traceLines.length - 1].type === "footer", "trace footer must be last");
+  assert(manifests.length > 0, "expected at least one trace manifest (checkpoint)");
+  assert(headers[0].program === "probe.agency", `trace program was ${headers[0].program}`);
+
+  runInstalledAgency(traceDir, ["trace", "log", "probe.trace", "-o", "events.json"]);
+  const baselineEvents = JSON.parse(readText(join(traceDir, "events.json")));
+  assert(Array.isArray(baselineEvents) && baselineEvents.length > 0, "trace log must yield a non-empty array");
+  assert(
+    baselineEvents.some((e) => e.type === "node-enter"),
+    "trace log must contain a node-enter event",
+  );
+
+  // Bundle the source + trace, then delete both originals so unbundle cannot
+  // copy external inputs.
+  runInstalledAgency(traceDir, ["bundle", "probe.agency", "probe.trace", "-o", "probe.bundle"]);
+  const savedSource = readText(join(traceDir, "probe.agency"));
+  const originalSourcePath = join(traceDir, "probe.agency.original");
+  writeFile(traceDir, "probe.agency.original", savedSource);
+  runInstalledAgency(traceDir, ["unbundle", "probe.bundle", "-o", "unpacked"]);
+
+  assertFileEquals(join(traceDir, "unpacked", "probe.agency"), originalSourcePath, {
+    normalizeTrailingNewline: true,
+  });
+
+  // The unbundled trace must still be consumable and semantically identical.
+  runInstalledAgency(traceDir, ["trace", "log", join("unpacked", "probe.trace"), "-o", join("unpacked", "events.json")]);
+  const restoredEvents = JSON.parse(readText(join(traceDir, "unpacked", "events.json")));
+  assert(
+    JSON.stringify(restoredEvents) === JSON.stringify(baselineEvents),
+    "unbundled trace produced a different event log than the original",
+  );
+  console.log("[cli-tier2] trace/bundle round-trip ✓");
+}
+
+// --- coverage lifecycle -----------------------------------------------------
+
+function parseCoverageTotal(output) {
+  const clean = stripAnsi(output);
+  const match =
+    clean.match(/Total\s+([0-9.]+)%\s+\((\d+)\/(\d+) steps\)/) ||
+    clean.match(/\.agency\s+([0-9.]+)%\s+\((\d+)\/(\d+)\)/);
+  assert(match, `expected a coverage total line, got:\n${clean}`);
+  return { percentage: Number(match[1]), covered: Number(match[2]), total: Number(match[3]) };
+}
+
+function checkCoverageLifecycle() {
+  const covDir = subdir("coverage");
+  writeFile(
+    covDir,
+    "probe.agency",
+    `node covered(): string {\n  const label = "tier2-covered"\n  return label\n}\n`,
+  );
+  writeFile(
+    covDir,
+    "probe.test.json",
+    JSON.stringify(
+      {
+        sourceFile: "probe.agency",
+        tests: [
+          {
+            nodeName: "covered",
+            input: "",
+            expectedOutput: '"tier2-covered"',
+            evaluationCriteria: [{ type: "exact" }],
+          },
+        ],
+      },
+      null,
+      2,
+    ) + "\n",
+  );
+  assert(!existsSync(join(covDir, ".coverage")), "coverage dir must not exist before the run");
+
+  const testOut = runInstalledAgency(covDir, ["test", "probe.agency", "--coverage"]);
+  assertIncludes(stripAnsi(testOut.stdout), "1/1 tests passed");
+  const covFiles = readdirSync(join(covDir, ".coverage")).filter(
+    (f) => f.startsWith("cov-") && f.endsWith(".json"),
+  );
+  assert(covFiles.length > 0, "coverage run should write a .coverage/cov-*.json file");
+
+  const report = runInstalledAgency(covDir, ["coverage", "report", "probe.agency", "--detail", "--threshold", "100"]);
+  const { percentage, covered, total } = parseCoverageTotal(report.stdout);
+  assert(total > 0, "coverage total steps must be non-zero");
+  assert(covered === total, `expected covered === total, got ${covered}/${total}`);
+  assert(percentage === 100, `expected 100% coverage, got ${percentage}%`);
+
+  runInstalledAgency(covDir, ["coverage", "clean"]);
+  assert(!existsSync(join(covDir, ".coverage")), "coverage clean should remove .coverage");
+  console.log("[cli-tier2] coverage lifecycle ✓");
+}
+
+// --- Run everything ---------------------------------------------------------
+
+try {
+  initProject(dir);
+  installTarball(dir, tarball);
+
+  checkPackStandalone();
+  checkTraceBundleRoundTrip();
+  checkCoverageLifecycle();
+
+  console.log("=== cli-tier2 test passed ===");
+  cleanup(dir);
+} catch (err) {
+  console.error("cli-tier2 test failed:", err);
+  console.error("Temp directory preserved at:", dir);
+  process.exit(1);
+}

--- a/packages/agency-lang/tests/integration/helpers.mjs
+++ b/packages/agency-lang/tests/integration/helpers.mjs
@@ -2,26 +2,26 @@
 // Each integration test creates a fresh project in a temp directory,
 // installs Agency from a tarball, and verifies user-facing workflows.
 
-import { mkdtempSync, readFileSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, writeFileSync, mkdirSync, rmSync, existsSync } from "node:fs";
 import { execSync, spawnSync } from "node:child_process";
 import { join, dirname, resolve } from "node:path";
 import { tmpdir } from "node:os";
 
 const DEFAULT_COMMAND_TIMEOUT_MS = 120_000;
 
-// The single process boundary for running the installed `agency` CLI. It is the
-// only layer that knows about spawnSync, `npx --no-install` (which forbids an
-// npm registry fallback, so a missing local bin is a real failure), the default
-// timeout, environment merging, spawn errors, and status enforcement. Callers
-// declare the exact expected exit status rather than bypassing the helper for
-// failure cases, and always get stdout and stderr back separately.
-export function runInstalledAgency(
-  dir,
+// The single process boundary for the integration tests. It is the only layer
+// that knows about spawnSync, the default timeout, environment merging, spawn
+// errors, and exact-status enforcement. Callers declare the expected status
+// rather than bypassing the helper for failure cases, and always get stdout and
+// stderr back separately. On a spawn error or wrong status it throws with the
+// captured streams and status attached, so callers can log on failure.
+export function runProcess(
+  executable,
   args,
-  { expectedStatus = 0, input, env, timeout = DEFAULT_COMMAND_TIMEOUT_MS } = {},
+  { expectedStatus = 0, cwd, input, env, timeout = DEFAULT_COMMAND_TIMEOUT_MS } = {},
 ) {
-  const result = spawnSync("npx", ["--no-install", "agency", ...args], {
-    cwd: dir,
+  const result = spawnSync(executable, args, {
+    cwd,
     encoding: "utf8",
     timeout,
     input,
@@ -30,10 +30,8 @@ export function runInstalledAgency(
   });
   const stdout = result.stdout || "";
   const stderr = result.stderr || "";
-  const command = ["npx", "--no-install", "agency", ...args].join(" ");
+  const command = [executable, ...args].join(" ");
 
-  // Both throw paths attach the captured streams and status so callers can log
-  // per-command output on failure (that is exactly when the log matters).
   if (result.error) {
     const error = new Error(
       `Command failed to start: ${command}\n${result.error.message}\n${stdout}${stderr}`,
@@ -57,6 +55,55 @@ export function runInstalledAgency(
   }
 
   return { status: result.status, stdout, stderr, signal: result.signal };
+}
+
+// Run the installed `agency` CLI in `dir`. `--no-install` forbids an npm
+// registry fallback, so a missing local bin is a real failure rather than a
+// silent download. Thin wrapper over the generic runProcess boundary.
+export function runInstalledAgency(dir, args, opts = {}) {
+  return runProcess("npx", ["--no-install", "agency", ...args], { ...opts, cwd: dir });
+}
+
+// --- Shared file / JSONL helpers (used by cli-main and cli-tier2) ---
+
+export function normalizeNewline(text) {
+  return text.replace(/\r\n/g, "\n");
+}
+
+export function normalizeOptionalFinalNewline(text) {
+  return normalizeNewline(text).replace(/\n*$/, "\n");
+}
+
+export function readText(path) {
+  return normalizeNewline(readFileSync(path, "utf8"));
+}
+
+export function assertFile(path, message) {
+  assert(existsSync(path), message || `Expected file to exist: ${path}`);
+}
+
+// Read a `.jsonl` file into an array of parsed objects, one per non-empty line.
+export function readJsonLines(path) {
+  return readText(path)
+    .trim()
+    .split("\n")
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line));
+}
+
+// Compare two files. By default strict (line-for-line, trailing newlines kept);
+// pass `{ normalizeTrailingNewline: true }` to collapse trailing-newline
+// differences before comparing.
+export function assertFileEquals(actualPath, expectedPath, opts = {}) {
+  const normalize = opts.normalizeTrailingNewline
+    ? normalizeOptionalFinalNewline
+    : normalizeNewline;
+  const actual = normalize(readFileSync(actualPath, "utf8"));
+  const expected = normalize(readFileSync(expectedPath, "utf8"));
+  assert(
+    actual === expected,
+    `Expected ${actualPath} to match ${expectedPath}\n--- actual ---\n${actual}\n--- expected ---\n${expected}`,
+  );
 }
 
 export function createTempProject(name) {

--- a/packages/agency-lang/tests/integration/helpers.mjs
+++ b/packages/agency-lang/tests/integration/helpers.mjs
@@ -9,9 +9,10 @@ import { tmpdir } from "node:os";
 
 const DEFAULT_COMMAND_TIMEOUT_MS = 120_000;
 
-// The single process boundary for the integration tests. It is the only layer
-// that knows about spawnSync, the default timeout, environment merging, spawn
-// errors, and exact-status enforcement. Callers declare the expected status
+// The single spawnSync boundary for the integration tests (setup/install still
+// use execSync via `run` below). It is the only layer that knows about
+// spawnSync, the default timeout, environment merging, spawn errors, and
+// exact-status enforcement. Callers declare the expected status
 // rather than bypassing the helper for failure cases, and always get stdout and
 // stderr back separately. On a spawn error or wrong status it throws with the
 // captured streams and status attached, so callers can log on failure.


### PR DESCRIPTION
## What

Tier 2 CLI integration tests, **PR 1 of 3** (artifact workflows). Adds `tests/integration/cli-tier2/test.mjs`, a per-PR tarball runner for the artifact commands, and does the shared-helper groundwork the later PRs build on.

## Why

`pack`, `trace`, `bundle`/`unbundle`, and `coverage` are only integration-tested on push to `main` (`cli-main`), so a packaging regression in any of them is invisible until after merge. (`pack` has a per-PR test, but it runs the output beside the project's `node_modules`, so it can't catch a non-self-contained bundle.)

## What it checks

- **`pack` — standalone isolation.** Packs an import-bearing program (local module + a `std::math` call + runtime), copies **only** the packed file to a root with no `node_modules` ancestor, renames the installed `node_modules`, and runs it there — asserting the exact output. This is the contract the existing per-PR pack test can't reach.
- **`trace` + `bundle`/`unbundle` round-trip.** `trace run` yields well-formed JSONL (one header first, one footer last, ≥1 manifest, correct `header.program`); `trace log` yields a non-empty event array containing a `node-enter`; `bundle` → delete originals → `unbundle` restores the source byte-for-byte, and the unbundled trace re-logs to an **identical** event array.
- **`coverage` lifecycle.** `test --coverage` writes `cov-*.json` and reports `1/1` passing; `coverage report --threshold 100` shows a **non-zero** total with `covered === total` at 100%; `coverage clean` removes `.coverage`. (The non-zero check matters — `coverage report` exits 0 with "No coverage data found" on empty data.)

## Shared-helper work (used by cli-main and cli-tier2)

- `helpers.mjs`: new generic `runProcess(executable, args, opts)` boundary; `runInstalledAgency` is now a thin wrapper over it. `runProcess` also runs the packed file with `node`.
- Promoted `readJsonLines` and the normalized file-equality helpers to `helpers.mjs`; `cli-main` now imports them instead of keeping private copies.
- Wired `cli-tier2` into the existing integration job (runs on PRs and pushes) — no new job, secret, or matrix.

## Validation

Against a fresh tarball: `cli-tier2`, `cli-main`, and `cli-lang` all pass; `typecheck` and `lint:structure` clean. Proved the runner can fail: a partial-coverage mutant drops coverage to 66.7% and the coverage oracle fails as intended.

## Note worth a look

A packed program only auto-runs `main` when launched by a **relative** path (`node packed.mjs`). Absolute-path invocation (`node /abs/packed.mjs`) exits 0 but prints nothing. The standalone check invokes it the way a user (and the existing `cli/test.mjs`) does — relative, from its directory. Flagging in case that absolute-path behavior is itself worth a follow-up.

## Follow-ups (per the spec)

- PR 2: `definition`, `models list`, isolated `local`.
- PR 3: `label ingest` with a persistence oracle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
