### PR TITLE
test(integration): per-PR successful label ingest with a persistence oracle

### DIFF
--- a/packages/agency-lang/tests/integration/cli-tier2/test.mjs
+++ b/packages/agency-lang/tests/integration/cli-tier2/test.mjs
@@ -403,6 +403,69 @@ function checkLocalIsolated() {
   console.log("[cli-tier2] local isolated ✓");
 }
 
+// --- label ingest (store mutation + persistence oracle) ---------------------
+
+function checkLabelIngest() {
+  const labelDir = subdir("label");
+  const fixture = ["tier2 first output", "tier2 second output", "tier2 third output"];
+  const n = fixture.length;
+  // A top-level JSON array of strings is the only shape the JSON loader accepts.
+  writeFile(labelDir, "data.json", JSON.stringify(fixture) + "\n");
+
+  const first = runInstalledAgency(labelDir, ["label", "ingest", "data.json", "--store", "labels", "--source", "batch"]);
+  assertBlank(first.stderr, "[label ingest] stderr");
+  const firstOut = stripAnsi(first.stdout);
+  assertIncludes(firstOut, `${n} new records, 0 already stored`);
+  assertIncludes(firstOut, `${n} new occurrences, 0 already recorded`);
+
+  // outputs.jsonl: exactly one record per fixture string (order-independent).
+  const outputs = readJsonLines(join(labelDir, "labels", "outputs.jsonl"));
+  assert(outputs.length === n, `expected ${n} output records, got ${outputs.length}`);
+  const outputIdByString = {};
+  for (const record of outputs) {
+    const value = record.fields.output;
+    assert(fixture.includes(value), `unexpected output record: "${value}"`);
+    outputIdByString[value] = record.outputId;
+  }
+  for (const value of fixture) {
+    assert(value in outputIdByString, `outputs.jsonl is missing a record for "${value}"`);
+  }
+
+  // occurrences.jsonl: one per fixture item, each referencing the right output.
+  const occurrences = readJsonLines(join(labelDir, "labels", "occurrences.jsonl"));
+  assert(occurrences.length === n, `expected ${n} occurrences, got ${occurrences.length}`);
+  const seenIndexes = [];
+  for (const occ of occurrences) {
+    assert(occ.source === "batch", `occurrence source was "${occ.source}"`);
+    assert(occ.origin.kind === "json", `occurrence origin.kind was "${occ.origin.kind}"`);
+    assert(occ.origin.itemKey === "data.json", `occurrence origin.itemKey was "${occ.origin.itemKey}"`);
+    const idx = occ.origin.itemIndex;
+    assert(!seenIndexes.includes(idx), `duplicate itemIndex ${idx}`);
+    seenIndexes.push(idx);
+    assert(
+      occ.outputId === outputIdByString[fixture[idx]],
+      `occurrence ${idx} outputId does not reference the output for "${fixture[idx]}"`,
+    );
+  }
+  seenIndexes.sort((a, b) => a - b);
+  assert(
+    JSON.stringify(seenIndexes) === JSON.stringify([...Array(n).keys()]),
+    `expected itemIndexes 0..${n - 1}, got ${seenIndexes}`,
+  );
+
+  // Re-ingesting the same data is idempotent: nothing new, both files unchanged.
+  const outputsBefore = readText(join(labelDir, "labels", "outputs.jsonl"));
+  const occurrencesBefore = readText(join(labelDir, "labels", "occurrences.jsonl"));
+  const second = runInstalledAgency(labelDir, ["label", "ingest", "data.json", "--store", "labels", "--source", "batch"]);
+  assertBlank(second.stderr, "[label ingest re-run] stderr");
+  const secondOut = stripAnsi(second.stdout);
+  assertIncludes(secondOut, `0 new records, ${n} already stored`);
+  assertIncludes(secondOut, `0 new occurrences, ${n} already recorded`);
+  assert(readText(join(labelDir, "labels", "outputs.jsonl")) === outputsBefore, "outputs.jsonl changed on re-ingest");
+  assert(readText(join(labelDir, "labels", "occurrences.jsonl")) === occurrencesBefore, "occurrences.jsonl changed on re-ingest");
+  console.log("[cli-tier2] label ingest ✓");
+}
+
 // --- Run everything ---------------------------------------------------------
 
 try {
@@ -415,6 +478,7 @@ try {
   checkDefinition();
   checkModelsList();
   checkLocalIsolated();
+  checkLabelIngest();
 
   console.log("=== cli-tier2 test passed ===");
   cleanup(dir);

--- a/packages/agency-lang/tests/integration/cli-tier2/test.mjs
+++ b/packages/agency-lang/tests/integration/cli-tier2/test.mjs
@@ -10,6 +10,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readdirSync,
+  readFileSync,
   renameSync,
   rmSync,
 } from "node:fs";
@@ -421,14 +422,16 @@ function checkLabelIngest() {
   // outputs.jsonl: exactly one record per fixture string (order-independent).
   const outputs = readJsonLines(join(labelDir, "labels", "outputs.jsonl"));
   assert(outputs.length === n, `expected ${n} output records, got ${outputs.length}`);
-  const outputIdByString = {};
+  // Null-prototype object + Object.hasOwn, so a fixture string like "__proto__"
+  // cannot collide with prototype keys.
+  const outputIdByString = Object.create(null);
   for (const record of outputs) {
     const value = record.fields.output;
     assert(fixture.includes(value), `unexpected output record: "${value}"`);
     outputIdByString[value] = record.outputId;
   }
   for (const value of fixture) {
-    assert(value in outputIdByString, `outputs.jsonl is missing a record for "${value}"`);
+    assert(Object.hasOwn(outputIdByString, value), `outputs.jsonl is missing a record for "${value}"`);
   }
 
   // occurrences.jsonl: one per fixture item, each referencing the right output.
@@ -454,15 +457,19 @@ function checkLabelIngest() {
   );
 
   // Re-ingesting the same data is idempotent: nothing new, both files unchanged.
-  const outputsBefore = readText(join(labelDir, "labels", "outputs.jsonl"));
-  const occurrencesBefore = readText(join(labelDir, "labels", "occurrences.jsonl"));
+  // Snapshot raw bytes (not readText, which normalizes CRLF) so a re-ingest that
+  // rewrote LF as CRLF would still fail the byte-identical check.
+  const outputsPath = join(labelDir, "labels", "outputs.jsonl");
+  const occurrencesPath = join(labelDir, "labels", "occurrences.jsonl");
+  const outputsBefore = readFileSync(outputsPath);
+  const occurrencesBefore = readFileSync(occurrencesPath);
   const second = runInstalledAgency(labelDir, ["label", "ingest", "data.json", "--store", "labels", "--source", "batch"]);
   assertBlank(second.stderr, "[label ingest re-run] stderr");
   const secondOut = stripAnsi(second.stdout);
   assertIncludes(secondOut, `0 new records, ${n} already stored`);
   assertIncludes(secondOut, `0 new occurrences, ${n} already recorded`);
-  assert(readText(join(labelDir, "labels", "outputs.jsonl")) === outputsBefore, "outputs.jsonl changed on re-ingest");
-  assert(readText(join(labelDir, "labels", "occurrences.jsonl")) === occurrencesBefore, "occurrences.jsonl changed on re-ingest");
+  assert(readFileSync(outputsPath).equals(outputsBefore), "outputs.jsonl bytes changed on re-ingest");
+  assert(readFileSync(occurrencesPath).equals(occurrencesBefore), "occurrences.jsonl bytes changed on re-ingest");
   console.log("[cli-tier2] label ingest ✓");
 }
 


### PR DESCRIPTION
## What

Tier 2 CLI integration tests, **PR 3 of 3** (the last). Adds a `label ingest` check to the `cli-tier2` runner.

## Why

`label ingest` had *partial* per-PR coverage — `cli/test.mjs` checks that the parent `--store` option reaches the subcommand, but with a deliberately missing input, so it never tests a real ingest. This is the first **successful ingest + persistence** check.

## What it checks (`checkLabelIngest`)

- Writes a top-level JSON array of N distinct strings (the only shape the JSON loader accepts) and runs `label ingest data.json --store labels --source batch`.
- Asserts the summary counts exactly: **N new records, 0 already stored, N new occurrences, 0 already recorded** (blank stderr; the "new field" note is on stdout).
- Parses `outputs.jsonl`: one record per fixture string (order-independent), building an outputId-by-string map.
- Parses `occurrences.jsonl`: one per item, `source: "batch"`, `origin.kind: "json"`, `origin.itemKey: "data.json"`, each `itemIndex` exactly once, and each `outputId` referencing the output whose `fields.output` equals `fixture[itemIndex]`.
- Re-ingests and requires **0 new / N already**, with both JSONL files **byte-identical** — proving the store reopens and replays without reimplementing store validation in the test.

Deep matrices (hashing, locking, corruption, migration) stay in the label unit tests.

## Validation

Against a fresh tarball: all seven `cli-tier2` workflows pass; `typecheck` and `lint:structure` clean. Proved the runner can fail: a duplicate fixture string exercises content-identity dedup and the oracle fails as intended (`2 new records, 1 already stored`).

## Tier 2 complete

With this, the Tier 2 set is done: `pack` (standalone), `trace`/`bundle`, `coverage` (PR 1); `definition`, `models list`, `local` (PR 2); `label ingest` (this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
