### PR TITLE
feat(remote): breakdownTruncated + otherSpend on ProjectSpend

### DIFF
--- a/packages/agency-lang/lib/cli/remote/commands/spend.test.ts
+++ b/packages/agency-lang/lib/cli/remote/commands/spend.test.ts
@@ -41,7 +41,7 @@ class ProcessExit extends Error {
 
 const usd = { inputCost: 0.3, outputCost: 0.2, cachedInputCost: 0, cacheCreationInputCost: 0, hostedToolsCost: 0, totalCost: 0.5, currency: "USD" };
 const tok = { inputTokens: 10, outputTokens: 2, cachedInputTokens: 0, cacheCreationInputTokens: 0, totalTokens: 12 };
-const spend = { cost: usd, tokens: tok, invocationCount: 3, unpricedCallCount: 0, pricingComplete: true, usageComplete: true, breakdown: [] };
+const spend = { cost: usd, tokens: tok, invocationCount: 3, unpricedCallCount: 0, pricingComplete: true, usageComplete: true, breakdown: [], breakdownTruncated: false, otherSpend: { cost: { inputCost: 0, outputCost: 0, cachedInputCost: 0, cacheCreationInputCost: 0, hostedToolsCost: 0, totalCost: 0, currency: "USD" }, tokens: { inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, cacheCreationInputTokens: 0, totalTokens: 0 } } };
 const accountRows = [{ projectSlug: "p", deletedAt: null, spend }];
 
 let dir: string;

--- a/packages/agency-lang/lib/cli/remote/render.test.ts
+++ b/packages/agency-lang/lib/cli/remote/render.test.ts
@@ -186,7 +186,7 @@ function toks(input: number, output: number) {
 const NONE_GROUP = { byModel: false, byKind: false };
 
 const spend = (overrides: Partial<ProjectSpend> = {}): ProjectSpend => ({
-  cost: usd(0.4212), tokens: toks(12400, 3010), invocationCount: 87, unpricedCallCount: 0, pricingComplete: true, usageComplete: true, breakdown: [], ...overrides,
+  cost: usd(0.4212), tokens: toks(12400, 3010), invocationCount: 87, unpricedCallCount: 0, pricingComplete: true, usageComplete: true, breakdown: [], breakdownTruncated: false, otherSpend: { cost: { inputCost: 0, outputCost: 0, cachedInputCost: 0, cacheCreationInputCost: 0, hostedToolsCost: 0, totalCost: 0, currency: "USD" }, tokens: { inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, cacheCreationInputTokens: 0, totalTokens: 0 } }, ...overrides,
 });
 
 describe("renderProjectSpend", () => {
@@ -271,6 +271,17 @@ describe("renderProjectSpend", () => {
     expect(out).toContain("embedding");
     expect(out).toContain("completion");
     expect(out).not.toContain("MODEL");
+  });
+  it("notes the omitted tail when the breakdown is truncated", () => {
+    const breakdown = [{ model: "opus", kind: "completion" as const, cost: usd(1), tokens: toks(10, 2) }];
+    const out = strip(renderProjectSpend("a", spend({ breakdown, breakdownTruncated: true, otherSpend: { cost: usd(3), tokens: toks(5, 5) } }), "all time", { byModel: true, byKind: false }));
+    expect(out).toContain("more across other groups");
+    expect(out).toContain("$3.0000");
+  });
+  it("shows no truncation note when the breakdown is complete", () => {
+    const breakdown = [{ model: "opus", kind: "completion" as const, cost: usd(1), tokens: toks(10, 2) }];
+    const out = strip(renderProjectSpend("a", spend({ breakdown }), "all time", { byModel: true, byKind: false }));
+    expect(out).not.toContain("more across other groups");
   });
 });
 

--- a/packages/agency-lang/lib/cli/remote/render.ts
+++ b/packages/agency-lang/lib/cli/remote/render.ts
@@ -278,6 +278,11 @@ export function renderProjectSpend(
   ];
   if (grouping.byModel || grouping.byKind) {
     lines.push("", renderGroupTable(groupBreakdown(spend.breakdown, grouping), grouping));
+    if (spend.breakdownTruncated) {
+      // The host caps the breakdown to its top spenders; the rest is summed into
+      // `otherSpend` (the grouped rows above therefore omit it).
+      lines.push(color.dim(`  top ${formatCount(spend.breakdown.length)} (model, kind) shown; ${formatUsd(spend.otherSpend.cost.totalCost)} more across other groups`));
+    }
   }
   lines.push(...trustNotes(spend, "  "));
   return lines.join("\n");

--- a/packages/agency-lang/lib/cli/statelog/accountClient.test.ts
+++ b/packages/agency-lang/lib/cli/statelog/accountClient.test.ts
@@ -303,7 +303,7 @@ describe("accountClient id-map safety", () => {
 describe("accountClient.getAccountSpend", () => {
   const usd = { inputCost: 0.3, outputCost: 0.2, cachedInputCost: 0, cacheCreationInputCost: 0, hostedToolsCost: 0, totalCost: 0.5, currency: "USD" };
   const tok = { inputTokens: 10, outputTokens: 2, cachedInputTokens: 0, cacheCreationInputTokens: 0, totalTokens: 12 };
-  const validSpend = { cost: usd, tokens: tok, invocationCount: 3, unpricedCallCount: 0, pricingComplete: true, usageComplete: true, breakdown: [] };
+  const validSpend = { cost: usd, tokens: tok, invocationCount: 3, unpricedCallCount: 0, pricingComplete: true, usageComplete: true, breakdown: [], breakdownTruncated: false, otherSpend: { cost: { inputCost: 0, outputCost: 0, cachedInputCost: 0, cacheCreationInputCost: 0, hostedToolsCost: 0, totalCost: 0, currency: "USD" }, tokens: { inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, cacheCreationInputTokens: 0, totalTokens: 0 } } };
   const okRows = { success: true, value: [{ projectSlug: "p", deletedAt: null, spend: validSpend }] };
 
   it("GETs /api/spend with both bounds, omitting null ones", async () => {

--- a/packages/agency-lang/lib/cli/statelog/projectClient.test.ts
+++ b/packages/agency-lang/lib/cli/statelog/projectClient.test.ts
@@ -174,7 +174,7 @@ describe("projectClient.getSpend", () => {
   const tok = { inputTokens: 10, outputTokens: 2, cachedInputTokens: 0, cacheCreationInputTokens: 0, totalTokens: 12 };
   const okSpend = {
     success: true,
-    value: { cost: usd, tokens: tok, invocationCount: 3, unpricedCallCount: 0, pricingComplete: true, usageComplete: true, breakdown: [] },
+    value: { cost: usd, tokens: tok, invocationCount: 3, unpricedCallCount: 0, pricingComplete: true, usageComplete: true, breakdown: [], breakdownTruncated: false, otherSpend: { cost: { inputCost: 0, outputCost: 0, cachedInputCost: 0, cacheCreationInputCost: 0, hostedToolsCost: 0, totalCost: 0, currency: "USD" }, tokens: { inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, cacheCreationInputTokens: 0, totalTokens: 0 } } },
   };
 
   it("GETs the spend route with both bounds as query params", async () => {

--- a/packages/agency-lang/lib/cli/statelog/spendTypes.test.ts
+++ b/packages/agency-lang/lib/cli/statelog/spendTypes.test.ts
@@ -3,6 +3,8 @@ import { projectSpendSchema, accountSpendRowSchema, toSpendQuery } from "./spend
 
 const usd = { inputCost: 0.3, outputCost: 0.2, cachedInputCost: 0, cacheCreationInputCost: 0, hostedToolsCost: 0, totalCost: 0.5, currency: "USD" as const };
 const tok = { inputTokens: 10, outputTokens: 2, cachedInputTokens: 0, cacheCreationInputTokens: 0, totalTokens: 12 };
+const zeroUsd = { inputCost: 0, outputCost: 0, cachedInputCost: 0, cacheCreationInputCost: 0, hostedToolsCost: 0, totalCost: 0, currency: "USD" as const };
+const zeroTok = { inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, cacheCreationInputTokens: 0, totalTokens: 0 };
 const valid = {
   cost: usd,
   tokens: tok,
@@ -11,15 +13,19 @@ const valid = {
   pricingComplete: true,
   usageComplete: true,
   breakdown: [{ model: "opus", kind: "completion" as const, cost: usd, tokens: tok }],
+  breakdownTruncated: false,
+  otherSpend: { cost: zeroUsd, tokens: zeroTok },
 };
 const empty = {
-  cost: { inputCost: 0, outputCost: 0, cachedInputCost: 0, cacheCreationInputCost: 0, hostedToolsCost: 0, totalCost: 0, currency: "USD" as const },
-  tokens: { inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, cacheCreationInputTokens: 0, totalTokens: 0 },
+  cost: zeroUsd,
+  tokens: zeroTok,
   invocationCount: 0,
   unpricedCallCount: 0,
   pricingComplete: true,
   usageComplete: true,
   breakdown: [],
+  breakdownTruncated: false,
+  otherSpend: { cost: zeroUsd, tokens: zeroTok },
 };
 
 describe("projectSpendSchema", () => {
@@ -42,6 +48,16 @@ describe("projectSpendSchema", () => {
     expect(() => projectSpendSchema.parse({ ...valid, unpricedCallCount: 1, pricingComplete: true })).toThrow();
     expect(() => projectSpendSchema.parse({ ...valid, unpricedCallCount: 0, pricingComplete: false })).toThrow();
     expect(projectSpendSchema.parse({ ...valid, unpricedCallCount: 1, pricingComplete: false }).pricingComplete).toBe(false);
+  });
+
+  it("requires breakdownTruncated and otherSpend, and parses a truncated spend", () => {
+    const { breakdownTruncated: _bt, ...noTruncated } = valid;
+    expect(() => projectSpendSchema.parse(noTruncated)).toThrow();
+    const { otherSpend: _os, ...noOther } = valid;
+    expect(() => projectSpendSchema.parse(noOther)).toThrow();
+    const parsed = projectSpendSchema.parse({ ...valid, breakdownTruncated: true, otherSpend: { cost: usd, tokens: tok } });
+    expect(parsed.breakdownTruncated).toBe(true);
+    expect(parsed.otherSpend.cost.totalCost).toBe(0.5);
   });
 
   it("rejects extra fields and a mismatched model sentinel", () => {

--- a/packages/agency-lang/lib/cli/statelog/spendTypes.test.ts
+++ b/packages/agency-lang/lib/cli/statelog/spendTypes.test.ts
@@ -60,6 +60,15 @@ describe("projectSpendSchema", () => {
     expect(parsed.otherSpend.cost.totalCost).toBe(0.5);
   });
 
+  it("requires otherSpend to be zero when breakdownTruncated is false", () => {
+    // non-zero tail without truncation → rejected
+    expect(() => projectSpendSchema.parse({ ...valid, breakdownTruncated: false, otherSpend: { cost: usd, tokens: tok } })).toThrow();
+    // zero tail without truncation → accepted (the valid fixture already is this)
+    expect(projectSpendSchema.parse(valid).breakdownTruncated).toBe(false);
+    // a truncated response may carry a zero tail too (omitted groups were free)
+    expect(projectSpendSchema.parse({ ...valid, breakdownTruncated: true }).breakdownTruncated).toBe(true);
+  });
+
   it("rejects extra fields and a mismatched model sentinel", () => {
     expect(() => projectSpendSchema.parse({ ...valid, surprise: 1 })).toThrow();
     // manual rows must use model "" and provider rows a non-empty model.

--- a/packages/agency-lang/lib/cli/statelog/spendTypes.ts
+++ b/packages/agency-lang/lib/cli/statelog/spendTypes.ts
@@ -70,7 +70,15 @@ export const projectSpendSchema = z
     unpricedCallCount: nonNegativeSafeInt,
     pricingComplete: z.boolean(),
     usageComplete: z.boolean(),
+    // The top spenders by cost; `breakdown` is at most the host's top-N.
     breakdown: z.array(modelKindSpendSchema),
+    // True when more distinct (model, kind) groups existed than `breakdown`
+    // returns; the omitted tail is summed into `otherSpend`. Authoritative
+    // `cost`/`tokens` totals are unaffected.
+    breakdownTruncated: z.boolean(),
+    otherSpend: z
+      .object({ cost: costBreakdownSchema, tokens: tokenBreakdownSchema })
+      .strict(),
   })
   .strict()
   .refine(

--- a/packages/agency-lang/lib/cli/statelog/spendTypes.ts
+++ b/packages/agency-lang/lib/cli/statelog/spendTypes.ts
@@ -84,7 +84,29 @@ export const projectSpendSchema = z
   .refine(
     (spend) => spend.pricingComplete === (spend.unpricedCallCount === 0),
     "pricingComplete must equal (unpricedCallCount === 0)",
-  );
+  )
+  .refine((spend) => {
+    // A complete breakdown has no omitted tail, so otherSpend must be the zero
+    // identity — otherwise a non-truncated response carries hidden spend that the
+    // renderer would silently ignore.
+    if (spend.breakdownTruncated) {
+      return true;
+    }
+    const { cost, tokens } = spend.otherSpend;
+    return (
+      cost.inputCost === 0 &&
+      cost.outputCost === 0 &&
+      cost.cachedInputCost === 0 &&
+      cost.cacheCreationInputCost === 0 &&
+      cost.hostedToolsCost === 0 &&
+      cost.totalCost === 0 &&
+      tokens.inputTokens === 0 &&
+      tokens.outputTokens === 0 &&
+      tokens.cachedInputTokens === 0 &&
+      tokens.cacheCreationInputTokens === 0 &&
+      tokens.totalTokens === 0
+    );
+  }, "otherSpend must be the zero identity when breakdownTruncated is false");
 export type ProjectSpend = z.infer<typeof projectSpendSchema>;
 
 export const accountSpendRowSchema = z


### PR DESCRIPTION
## What

Extends the pinned `ProjectSpend` contract with **`breakdownTruncated`** and **`otherSpend`**, so the statelog spend host can bound the per-`(model, kind)` breakdown to its top spenders without silently dropping the tail. This is the agency-lang half of a pinned pair with **statelog #24**.

## Why

`breakdown` is an array with one entry per distinct `(model, kind)`. `model` is producer-supplied free text, so an authenticated caller can accumulate unbounded distinct models over time and force an ever-growing scan/memory/JSON response on the spend endpoints (a DoS). statelog #24 caps the breakdown to the top-N=100 by cost; this PR is the contract + rendering half so the truncation is **explicit**:

- `breakdownTruncated: boolean` — more distinct groups existed than `breakdown` returns.
- `otherSpend: { cost, tokens }` — the summed spend of the omitted (non-top-N) groups.

The authoritative `cost`/`tokens` totals come from the parent invocation rows and are **unaffected** by truncation.

## Changes

- `lib/cli/statelog/spendTypes.ts`: add the two fields to `projectSpendSchema` (strict; `otherSpend` is a strict cost+tokens object).
- `lib/cli/remote/render.ts`: under a grouped breakdown table, render `top N (model, kind) shown; $X more across other groups` when truncated. `--json` emits the raw fields automatically.

## Testing

`pnpm run typecheck`, `pnpm run lint:structure` clean; the 5 spend test files pass (106 tests), including new schema-requires-fields and render-truncation-note tests.

## Rollout

Ship pinned with statelog #24 (both extend `ProjectSpend` identically). Part of the full-cost-token-breakdown pinned pair (agency #811 + statelog #24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
