### PR TITLE
Fix committed-failure parse errors reporting a line shifted by the prelude offset (#716)

### DIFF
--- a/packages/agency-lang/docs/dev/locations.md
+++ b/packages/agency-lang/docs/dev/locations.md
@@ -96,6 +96,12 @@ Net result:
 
 Both modes produce the same `loc.line`. Same for `errorData.line`. There is **one** convention; consumers don't compensate.
 
+### The `"Line X, col Y: "` message prefix is offset-corrected too
+
+A *committed failure* (tarsec `committed`, e.g. a node/def declared inside a body, or a malformed code literal) produces its message via `getErrorMessage()`, which prepends a `"Line X, col Y: "` prefix computed in **wrapped-input coordinates**. That prefix does not flow through `withLoc`, so with the template applied it named a line `AGENCY_TEMPLATE_OFFSET` below the real one — the CLI prints `parseResult.message`, so a user saw the wrong line even though `errorData.line` was already correct (`buildErrorData` subtracts `offset`).
+
+`correctCommittedFailureLine(message, offset)` rewrites the number in that prefix back into user-source coordinates. It runs at both committed-failure exits in `parseAgency` (the recoverable-failure branch and the `TarsecError` catch), so `message`, `errorData.message`, and `errorData.prettyMessage` all agree with `errorData.line`. It is a no-op when the wrapper wasn't applied (offset 0) or the message has no such prefix. The `parseAgency structured errors` tests parse one committed-failure source in both modes and assert the reported line agrees — the bug existed precisely because nothing compared the two modes.
+
 ## About `start` / `end`
 
 `loc.start` and `loc.end` are byte offsets into the input the parser saw. In `applyTemplate=true` mode, they're offsets into the templated string (which includes the prelude bytes); in `applyTemplate=false` mode, they're offsets into the user source directly.

--- a/packages/agency-lang/lib/parser.test.ts
+++ b/packages/agency-lang/lib/parser.test.ts
@@ -231,6 +231,37 @@ describe("parseAgency structured errors", () => {
     expect(result.errorData!.column).toBe(3);
   });
 
+  // A committed failure's "Line X, col Y: " prefix used to be computed in
+  // wrapped-input coordinates, so the CLI (which prints `message`) reported
+  // a line AGENCY_TEMPLATE_OFFSET below the real one whenever the template
+  // wrapper was applied — even though `errorData.line` was already correct.
+  // Parse the same source in both modes and assert the reported line agrees;
+  // any future committed-failure diagnostic would inherit the shift silently
+  // without a cross-mode comparison like this.
+  it("reports the same committed-failure line with and without the template wrapper", () => {
+    // `node inner()` inside a node body is a committed failure: node/def are
+    // only legal at the top level. The declaration is on user-source line 2.
+    const source = "node main() {\n  node inner() {\n    print(1)\n  }\n}\n";
+
+    const plain = parseAgency(source, {}, false);
+    const templated = parseAgency(source, {}, true);
+    expect(plain.success).toBe(false);
+    expect(templated.success).toBe(false);
+    if (plain.success || templated.success) return;
+
+    const lineOf = (message: string | undefined): string | undefined =>
+      message?.match(/^Line (\d+),/)?.[1];
+
+    // Both modes name line 2 (1-indexed), not line 4 in templated mode.
+    expect(lineOf(plain.message)).toBe("2");
+    expect(lineOf(templated.message)).toBe("2");
+    // errorData.message embeds the same prefix, so it must agree too.
+    expect(lineOf(plain.errorData?.message)).toBe("2");
+    expect(lineOf(templated.errorData?.message)).toBe("2");
+    // The structured line was already correct; keep it pinned to that.
+    expect(plain.errorData!.line).toBe(templated.errorData!.line);
+  });
+
   // Pins the targeted message produced by the `parseError` wrapper
   // around `def`'s parameter-list close-paren. Before this, the same
   // input dumped the full top-level alternatives list ("expected

--- a/packages/agency-lang/lib/parser.ts
+++ b/packages/agency-lang/lib/parser.ts
@@ -244,6 +244,26 @@ export type ParseAgencyResult =
  * is applied. Used by both the recoverable-failure branch and the
  * `TarsecError` branch in `parseAgency`.
  */
+/**
+ * A committed-failure message from tarsec carries a "Line X, col Y: "
+ * prefix that tarsec computes in wrapped-input coordinates. When the
+ * template wrapper was applied, X is too high by the prelude length
+ * (`AGENCY_TEMPLATE_OFFSET`), so it names a line `offset` below the real
+ * one. Rewrite the line number back into the user's source coordinates.
+ *
+ * `buildErrorData` already corrects the structured `errorData.line`; this
+ * keeps the message text — which the CLI prints and `errorData` embeds —
+ * consistent with it. No-op when the wrapper wasn't applied (offset 0) or
+ * the message has no such prefix.
+ */
+function correctCommittedFailureLine(message: string, offset: number): string {
+  if (offset === 0) return message;
+  return message.replace(
+    /^Line (\d+)(, col \d+: )/,
+    (_full, line: string, rest: string) => `Line ${Number(line) - offset}${rest}`,
+  );
+}
+
 function buildErrorData(
   input: string,
   rightmostPos: number | null,
@@ -311,14 +331,17 @@ export function parseAgency(
       "rightmostPos" in result && typeof result.rightmostPos === "number"
         ? result.rightmostPos
         : null;
+    // The "Line X, col Y: " prefix is in wrapped coordinates; pull it back
+    // to the user's source line before it reaches the message or errorData.
+    const correctedMessage = correctCommittedFailureLine(result.message, offset);
     if (rightmostPos != null) {
       // Strip the "Line X, col Y: " prefix that getErrorMessage prepends
       // so the LSP / CLI can render the location separately without
       // duplicating it inside the message body.
-      const cleanMessage = result.message.replace(/^Line \d+, col \d+: /, "");
+      const cleanMessage = correctedMessage.replace(/^Line \d+, col \d+: /, "");
       return {
         success: false,
-        message: result.message,
+        message: correctedMessage,
         rest: input,
         errorData: buildErrorData(
           input,
@@ -326,11 +349,11 @@ export function parseAgency(
           offset,
           { line: 0, column: 0, length: 1 },
           cleanMessage,
-          result.message,
+          correctedMessage,
         ),
       };
     }
-    return { success: false, message: result.message, rest: result.rest };
+    return { success: false, message: correctedMessage, rest: result.rest };
   } catch (error) {
     if (error instanceof TarsecError) {
       // A committed failure (tarsec `committed`, e.g. a malformed code
@@ -343,20 +366,23 @@ export function parseAgency(
       if (committedCaught !== null) {
         const committedMessage = getErrorMessage();
         if (committedMessage !== null) {
+          // The "Line X, col Y: " prefix is in wrapped coordinates; pull it
+          // back to the user's source line so message and errorData agree.
+          const correctedMessage = correctCommittedFailureLine(committedMessage, offset);
           // Position from the COMMITTED failure, not the rightmost
           // record — the record is the misleading one here, and the LSP
           // squiggle must land where the message points (review finding).
           return {
             success: false,
-            message: committedMessage,
+            message: correctedMessage,
             rest: input,
             errorData: buildErrorData(
               input,
               getInputStr().length - committedCaught.rest.length,
               offset,
               { line: 0, column: 0, length: 1 },
-              committedMessage,
-              committedMessage,
+              correctedMessage,
+              correctedMessage,
             ),
           };
         }


### PR DESCRIPTION
Fixes #716.

## The bug

Parse errors from a *committed failure* reported a line number two higher than the real one whenever the template wrapper was applied (which is what the CLI does). Two is exactly `AGENCY_TEMPLATE_OFFSET`, the prelude length.

```
$ agency compile decl.agency
Failed to parse .../decl.agency: Line 4, col 14: `node`, `def` and `function`
declarations are only legal at the top level of a file.
```

The declaration is on line 2.

## What I found

Reproducing in both parse modes showed the shift is **only** in the message string. The structured `errorData.line`/`column` were already correct in both modes — `buildErrorData` subtracts `offset`. The problem: a committed failure's `"Line X, col Y: "` prefix comes from `getErrorMessage()` in wrapped-input coordinates and never passes through `withLoc`. The CLI prints `parseResult.message` (`lib/analysis/closure.ts:40`), and `errorData.message`/`prettyMessage` embed the same wrong string — so the human-readable text pointed two lines below the real error while the squiggle position was fine.

## The fix

`correctCommittedFailureLine(message, offset)` rewrites the number in the `"Line X, col Y: "` prefix back into user-source coordinates. It runs at both committed-failure exits in `parseAgency` (the recoverable-failure branch and the `TarsecError` catch), so `message`, `errorData.message`, and `errorData.prettyMessage` all agree with `errorData.line`. No-op when the wrapper wasn't applied (offset 0) or the message has no such prefix.

## Verification

- All three known committed-failure diagnostics now report the same line with and without the wrapper (node/def-in-body, unclosed code literal, nested code literals).
- CLI repro now prints `Line 2`.
- New test parses a committed-failure source in both modes and asserts the reported line agrees (it would report `4` and fail without the fix). Full `lib/parser.test.ts` green (39 tests); structural lint clean.
- Dev note added to `docs/dev/locations.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
