### PR TITLE
agency schedule: singular --every aliases + error-driven deploy-if-missing

### DIFF
--- a/packages/agency-lang/docs/dev/schedule-remote-backend.md
+++ b/packages/agency-lang/docs/dev/schedule-remote-backend.md
@@ -58,10 +58,17 @@ report success on a failed request.
 `add` wants the agent on the server before scheduling it. The policy is
 resolved as a `DeployMode`:
 
-- default (`if-missing`): list the project's sources via
-  `projectClient.pullSource()` and deploy only when `<fileName>.agency` is
-  absent (exact basename match);
-- `--redeploy` (`always`): deploy without checking;
+- default (`if-missing`) is **error-driven**: try the create, and only when
+  the server answers exactly `Agent '<fileName>' not found` deploy and retry
+  the create once. There is deliberately NO presence pre-check via the source
+  route — that was the first implementation and it broke in practice: the
+  route fails the whole project when ANY file (even an unrelated legacy row
+  with no stored source) is unavailable, and it downloads every file's
+  contents just to test one name. The exact-message match matters: a broader
+  match would deploy in response to unrelated failures, and an
+  `Unknown node "x" in <file>` answer (file present, target missing) must
+  surface as-is, not trigger an upload;
+- `--redeploy` (`always`): deploy before the first create attempt;
 - `--no-deploy` (`never`): never deploy; the server's
   `Agent '<file>' not found` failure is surfaced with a deploy hint.
   Commander delivers this flag as `deploy: false` (defaulting to `true`), so

--- a/packages/agency-lang/lib/cli/schedule/cron.test.ts
+++ b/packages/agency-lang/lib/cli/schedule/cron.test.ts
@@ -18,6 +18,28 @@ describe("presetToCron", () => {
   it("throws on unknown preset", () => {
     expect(() => presetToCron("biweekly")).toThrow("Unknown preset");
   });
+
+  it.each([
+    ["hour", "hourly"],
+    ["day", "daily"],
+    ["weekday", "weekdays"],
+    ["weekend", "weekends"],
+    ["week", "weekly"],
+    ["month", "monthly"],
+  ])("accepts the singular form %s as %s", (alias, canonical) => {
+    expect(presetToCron(alias)).toBe(presetToCron(canonical));
+  });
+});
+
+describe("resolveCron preset aliases", () => {
+  it("normalizes a singular alias to the canonical preset name", () => {
+    expect(resolveCron({ every: "hour" })).toEqual({ cron: "0 * * * *", preset: "hourly" });
+    expect(resolveCron({ every: "weekend" })).toEqual({ cron: "0 9 * * 0,6", preset: "weekends" });
+  });
+
+  it("still rejects a word that is neither preset nor alias", () => {
+    expect(() => resolveCron({ every: "fortnight" })).toThrow("Unknown preset");
+  });
 });
 
 describe("validateCron", () => {

--- a/packages/agency-lang/lib/cli/schedule/cron.ts
+++ b/packages/agency-lang/lib/cli/schedule/cron.ts
@@ -10,8 +10,24 @@ export const PRESETS: Record<string, string> = {
   monthly: "0 9 1 * *",
 };
 
+// `--every hour` reads better than `--every hourly`, so each preset also
+// accepts its singular noun. Aliases normalize to the canonical name before
+// lookup, storage, and display.
+const PRESET_ALIASES: Record<string, string> = {
+  hour: "hourly",
+  day: "daily",
+  weekday: "weekdays",
+  weekend: "weekends",
+  week: "weekly",
+  month: "monthly",
+};
+
+export function canonicalPreset(preset: string): string {
+  return PRESET_ALIASES[preset] ?? preset;
+}
+
 export function presetToCron(preset: string): string {
-  const cron = PRESETS[preset];
+  const cron = PRESETS[canonicalPreset(preset)];
   if (!cron) {
     throw new Error(
       `Unknown preset "${preset}". Valid presets: ${Object.keys(PRESETS).join(", ")}`,
@@ -58,7 +74,8 @@ export function resolveCron(opts: {
   cron?: string;
 }): { cron: string; preset: string } {
   if (opts.every) {
-    return { cron: presetToCron(opts.every), preset: opts.every };
+    const preset = canonicalPreset(opts.every);
+    return { cron: presetToCron(preset), preset };
   }
   if (opts.cron) {
     if (!validateCron(opts.cron)) {

--- a/packages/agency-lang/lib/cli/schedule/remote.test.ts
+++ b/packages/agency-lang/lib/cli/schedule/remote.test.ts
@@ -8,7 +8,6 @@ import {
   editRemote,
 } from "./remote.js";
 import { ScheduleRequestError } from "../statelog/schedulesClient.js";
-import { ProjectRequestError } from "../statelog/projectClient.js";
 import type { RemoteSchedule } from "../statelog/schedulesClient.js";
 import type { RemoteCommandContext } from "../remote/commands/util.js";
 import { color } from "@/utils/termcolors.js";
@@ -46,15 +45,6 @@ const runDeployMock = vi.fn();
 vi.mock("../remote/commands/deploy.js", () => ({
   runDeploy: (...deployArgs: unknown[]) => runDeployMock(...deployArgs),
 }));
-
-const pullSourceMock = vi.fn();
-vi.mock("../statelog/projectClient.js", async (importOriginal) => {
-  const original = await importOriginal<typeof import("../statelog/projectClient.js")>();
-  return {
-    ...original,
-    createProjectClient: () => ({ pullSource: (...a: unknown[]) => pullSourceMock(...a) }),
-  };
-});
 
 const KEY_ENV = "SCHEDULE_REMOTE_TEST_KEY";
 
@@ -117,10 +107,7 @@ afterEach(() => {
   deleteMock.mockReset();
   clientFactoryMock.mockClear();
   runDeployMock.mockReset();
-  pullSourceMock.mockReset();
 });
-
-const sources = (names: string[]) => names.map((name) => ({ name, contents: "" }));
 
 describe("resolveScheduleAdd", () => {
   it("resolves a node target with a preset cadence", () => {
@@ -327,41 +314,32 @@ describe("addRemote", () => {
 });
 
 describe("addRemote deployment policy", () => {
-  it("skips deployment when the agent's source is already on the server", async () => {
-    pullSourceMock.mockResolvedValue(sources(["other.agency", "daily.agency"]));
+  const agentNotFound = () => new ScheduleRequestError("Agent 'daily' not found", 200);
+
+  it("creates directly, with no deploy, when the agent is on the server", async () => {
     createMock.mockResolvedValue(returnedSchedule);
     await addRemote("agents/daily.agency", baseOptions, context);
     expect(runDeployMock).not.toHaveBeenCalled();
     expect(createMock).toHaveBeenCalledTimes(1);
   });
 
-  it("matches server sources by exact basename only", async () => {
-    pullSourceMock.mockResolvedValue(
-      sources(["dailyx.agency", "notdaily.agency", "daily.agency.bak"]),
-    );
+  it("deploys and retries once, in order, when the server says the agent is missing", async () => {
+    createMock.mockRejectedValueOnce(agentNotFound()).mockResolvedValueOnce(returnedSchedule);
     runDeployMock.mockResolvedValue("deployed");
-    createMock.mockResolvedValue(returnedSchedule);
     await addRemote("agents/daily.agency", baseOptions, context);
+    expect(createMock).toHaveBeenCalledTimes(2);
     expect(runDeployMock).toHaveBeenCalledTimes(1);
-    expect(createMock).toHaveBeenCalledTimes(1);
-  });
-
-  it("deploys then creates, in that order, when the source is missing", async () => {
-    pullSourceMock.mockResolvedValue(sources([]));
-    runDeployMock.mockResolvedValue("deployed");
-    createMock.mockResolvedValue(returnedSchedule);
-    await addRemote("agents/daily.agency", baseOptions, context);
-    const pullOrder = pullSourceMock.mock.invocationCallOrder[0]!;
+    const firstCreate = createMock.mock.invocationCallOrder[0]!;
     const deployOrder = runDeployMock.mock.invocationCallOrder[0]!;
-    const createOrder = createMock.mock.invocationCallOrder[0]!;
-    expect(pullOrder).toBeLessThan(deployOrder);
-    expect(deployOrder).toBeLessThan(createOrder);
+    const retryCreate = createMock.mock.invocationCallOrder[1]!;
+    expect(firstCreate).toBeLessThan(deployOrder);
+    expect(deployOrder).toBeLessThan(retryCreate);
+    expect(logSpy).toHaveBeenCalledTimes(1);
   });
 
   it("passes the resolved target and the same context to runDeploy", async () => {
-    pullSourceMock.mockResolvedValue(sources([]));
+    createMock.mockRejectedValueOnce(agentNotFound()).mockResolvedValueOnce(returnedSchedule);
     runDeployMock.mockResolvedValue("deployed");
-    createMock.mockResolvedValue(returnedSchedule);
     await addRemote("agents/daily.agency", baseOptions, context);
     expect(runDeployMock).toHaveBeenCalledWith(
       "agents/daily.agency",
@@ -370,66 +348,80 @@ describe("addRemote deployment policy", () => {
     );
   });
 
-  it("redeploy always deploys without checking server sources", async () => {
+  it("redeploy deploys before the first create attempt", async () => {
     runDeployMock.mockResolvedValue("deployed");
     createMock.mockResolvedValue(returnedSchedule);
     await addRemote("agents/daily.agency", { ...baseOptions, redeploy: true }, context);
-    expect(pullSourceMock).not.toHaveBeenCalled();
     expect(runDeployMock).toHaveBeenCalledTimes(1);
     expect(createMock).toHaveBeenCalledTimes(1);
+    expect(runDeployMock.mock.invocationCallOrder[0]!).toBeLessThan(
+      createMock.mock.invocationCallOrder[0]!,
+    );
   });
 
-  it("no-deploy neither pulls source nor deploys", async () => {
-    createMock.mockResolvedValue(returnedSchedule);
-    await addRemote("agents/daily.agency", { ...baseOptions, deploy: false }, context);
-    expect(pullSourceMock).not.toHaveBeenCalled();
+  it("no-deploy never deploys, even when the agent is missing", async () => {
+    createMock.mockRejectedValue(agentNotFound());
+    await expect(
+      addRemote("agents/daily.agency", { ...baseOptions, deploy: false }, context),
+    ).rejects.toThrow("exit:1");
     expect(runDeployMock).not.toHaveBeenCalled();
-    expect(createMock).toHaveBeenCalledTimes(1);
+    expect(errorOutput()).toContain("without --no-deploy");
   });
 
   it.each([["aborted"], ["preview"]])(
-    "a %s deploy outcome creates no schedule",
+    "a %s deploy outcome does not retry the create",
     async (outcome) => {
-      pullSourceMock.mockResolvedValue(sources([]));
+      createMock.mockRejectedValue(agentNotFound());
       runDeployMock.mockResolvedValue(outcome);
       await expect(addRemote("agents/daily.agency", baseOptions, context)).rejects.toThrow(
         "exit:1",
       );
       expect(errorOutput()).toContain("Deploy did not complete");
-      expect(createMock).not.toHaveBeenCalled();
+      expect(createMock).toHaveBeenCalledTimes(1);
       expect(logSpy).not.toHaveBeenCalled();
     },
   );
 
-  it("a deploy that exits creates no schedule", async () => {
-    pullSourceMock.mockResolvedValue(sources([]));
+  it("a deploy that exits does not retry the create", async () => {
+    createMock.mockRejectedValue(agentNotFound());
     runDeployMock.mockRejectedValue(new Error("exit:1"));
     await expect(addRemote("agents/daily.agency", baseOptions, context)).rejects.toThrow(
       "exit:1",
     );
-    expect(createMock).not.toHaveBeenCalled();
-  });
-
-  it("a source-listing failure deploys nothing and creates nothing", async () => {
-    pullSourceMock.mockRejectedValue(new ProjectRequestError("project 'proj' not found"));
-    await expect(addRemote("agents/daily.agency", baseOptions, context)).rejects.toThrow(
-      "exit:1",
-    );
-    expect(errorOutput()).toContain("project 'proj' not found");
-    expect(runDeployMock).not.toHaveBeenCalled();
-    expect(createMock).not.toHaveBeenCalled();
-  });
-
-  it("a create failure after a deploy surfaces once and is not retried", async () => {
-    pullSourceMock.mockResolvedValue(sources([]));
-    runDeployMock.mockResolvedValue("deployed");
-    createMock.mockRejectedValue(new ScheduleRequestError("cap reached", 200));
-    await expect(addRemote("agents/daily.agency", baseOptions, context)).rejects.toThrow(
-      "exit:1",
-    );
     expect(createMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("an unknown-target failure deploys nothing (the file exists; the node does not)", async () => {
+    createMock.mockRejectedValue(
+      new ScheduleRequestError('Unknown node "refresh" in daily', 200),
+    );
+    await expect(addRemote("agents/daily.agency", baseOptions, context)).rejects.toThrow(
+      "exit:1",
+    );
+    expect(runDeployMock).not.toHaveBeenCalled();
+    expect(errorOutput()).toContain('Unknown node "refresh" in daily');
+  });
+
+  it("a not-found message for a DIFFERENT agent does not trigger a deploy", async () => {
+    createMock.mockRejectedValue(new ScheduleRequestError("Agent 'other' not found", 200));
+    await expect(addRemote("agents/daily.agency", baseOptions, context)).rejects.toThrow(
+      "exit:1",
+    );
+    expect(runDeployMock).not.toHaveBeenCalled();
+  });
+
+  it("a retry failure after a deploy surfaces once with no further retry", async () => {
+    createMock
+      .mockRejectedValueOnce(agentNotFound())
+      .mockRejectedValueOnce(new ScheduleRequestError("cap reached", 200));
+    runDeployMock.mockResolvedValue("deployed");
+    await expect(addRemote("agents/daily.agency", baseOptions, context)).rejects.toThrow(
+      "exit:1",
+    );
+    expect(createMock).toHaveBeenCalledTimes(2);
     expect(runDeployMock).toHaveBeenCalledTimes(1);
     expect(errorOutput()).toContain("cap reached");
+    expect(logSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/agency-lang/lib/cli/schedule/remote.ts
+++ b/packages/agency-lang/lib/cli/schedule/remote.ts
@@ -23,7 +23,6 @@ import type {
   RemoteSchedule,
   ScheduleTarget,
 } from "../statelog/schedulesClient.js";
-import { createProjectClient, ProjectRequestError } from "../statelog/projectClient.js";
 
 export type DeployMode = "if-missing" | "always" | "never";
 
@@ -113,21 +112,40 @@ export async function addRemote(
     fail(errorMessage(error));
   }
   const target = resolveProjectTarget(context, options);
-  await ensureDeployed(file, resolved.input.fileName, resolved.deployMode, target, context);
   const client = createSchedulesClient(target.origin, target.projectSlug, target.apiKey);
+  if (resolved.deployMode === "always") {
+    await deployForSchedule(file, target, context);
+  }
 
+  // "if-missing" is error-driven: try the create, and only the server's own
+  // "this agent is not deployed" answer triggers a deploy and ONE retry. A
+  // presence pre-check via the source route was tried first and reverted — it
+  // fails the whole project when ANY file (even an unrelated legacy one) has
+  // no stored source, and costs an extra request that downloads every file.
   let schedule;
   try {
     schedule = await client.create(resolved.input);
   } catch (error) {
-    // Point back at THIS command, not `agency remote deploy` — the standalone
-    // deploy resolves its target differently (no binding, no --host/--project
-    // carry-over) and could upload somewhere other than where this schedule
-    // request was aimed.
-    failScheduleRequest(error, {
-      missingAgent:
-        "Rerun this command without --no-deploy to deploy it first (or pass --redeploy).",
-    });
+    if (
+      resolved.deployMode === "if-missing" &&
+      isAgentNotFound(error, resolved.input.fileName)
+    ) {
+      await deployForSchedule(file, target, context);
+      try {
+        schedule = await client.create(resolved.input);
+      } catch (retryError) {
+        failScheduleRequest(retryError);
+      }
+    } else {
+      // Point back at THIS command, not `agency remote deploy` — the standalone
+      // deploy resolves its target differently (no binding, no --host/--project
+      // carry-over) and could upload somewhere other than where this schedule
+      // request was aimed.
+      failScheduleRequest(error, {
+        missingAgent:
+          "Rerun this command without --no-deploy to deploy it first (or pass --redeploy).",
+      });
+    }
   }
   const { input } = resolved;
   console.log(
@@ -135,24 +153,22 @@ export async function addRemote(
   );
 }
 
-/** Enforce the deploy policy before creating a schedule. Returns only when the
- *  agent is on the server or the policy says to trust the server's own
- *  validation ("never"). The deploy runs against the SAME resolved target as
- *  the schedule request — never re-derived from config — so the schedule can't
- *  point at a different project than the upload. */
-async function ensureDeployed(
+/** Exactly the schedules route's missing-file answer for THIS agent — a
+ *  broader match could deploy in response to an unrelated failure. */
+function isAgentNotFound(error: unknown, fileName: string): boolean {
+  return (
+    error instanceof ScheduleRequestError && error.message === `Agent '${fileName}' not found`
+  );
+}
+
+/** Deploy against the SAME resolved target as the schedule request — never
+ *  re-derived from config — so the schedule can't point at a different project
+ *  than the upload. Only a real upload lets scheduling continue. */
+async function deployForSchedule(
   file: string,
-  fileName: string,
-  mode: DeployMode,
   target: ProjectTarget,
   context: RemoteCommandContext,
 ): Promise<void> {
-  if (mode === "never") {
-    return;
-  }
-  if (mode === "if-missing" && (await sourceExists(target, fileName))) {
-    return;
-  }
   const outcome = await runDeploy(
     file,
     { host: target.origin, project: target.projectSlug, apiKeyEnv: target.apiKeyEnvName },
@@ -161,20 +177,6 @@ async function ensureDeployed(
   if (outcome !== "deployed") {
     fail("Deploy did not complete, so the schedule was not created.");
   }
-}
-
-async function sourceExists(target: ProjectTarget, fileName: string): Promise<boolean> {
-  const client = createProjectClient(target.origin, target.projectSlug, target.apiKey);
-  let files;
-  try {
-    files = await client.pullSource();
-  } catch (error) {
-    if (error instanceof ProjectRequestError) {
-      fail(error.message);
-    }
-    throw error;
-  }
-  return files.some((source) => source.name === `${fileName}.agency`);
 }
 
 /** Exit with the server's message, adding guidance for the two failures a user

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -1639,7 +1639,7 @@ export function createProgram(deps: CliDependencies = {}): Command {
     .argument("<file>", "Path to .agency file")
     .option(
       "--every <preset>",
-      "Schedule preset: minute, hourly, daily, weekdays, weekends, weekly, monthly",
+      "Schedule preset: minute, hourly, daily, weekdays, weekends (Sat+Sun), weekly, monthly — singular forms (hour, day, weekday, weekend, week, month) also accepted",
     )
     .option("--cron <expression>", "Cron expression (5 fields)")
     .option(
@@ -1828,7 +1828,7 @@ export function createProgram(deps: CliDependencies = {}): Command {
     .argument("<name>", "Name of the schedule to edit (remote backend: the schedule id)")
     .option(
       "--every <preset>",
-      "Schedule preset: minute, hourly, daily, weekdays, weekends, weekly, monthly",
+      "Schedule preset: minute, hourly, daily, weekdays, weekends (Sat+Sun), weekly, monthly — singular forms (hour, day, weekday, weekend, week, month) also accepted",
     )
     .option("--cron <expression>", "Cron expression (5 fields)")
     .option("--env-file <path>", "Path to .env file")


### PR DESCRIPTION
Two small `agency schedule` fixes.

## Singular `--every` aliases

`--every hour` reads better than `--every hourly`, so each preset now also accepts its singular noun: hour, day, weekday, weekend, week, month. Aliases normalize to the canonical preset name before storage and display, so `schedule list` and registry entries stay consistent. Help text names the aliases and clarifies that `weekends` fires on both Saturday and Sunday (9am each, `0 9 * * 0,6`).

## Fix: schedule add failing with `Deployed source is unavailable` right after a deploy

Root cause: deploy-if-missing pre-checked file presence via `pullSource()` (the `/source` route). That route deliberately fails the WHOLE bundle when any `agency_files` row has `source = NULL` — and projects deployed before source storage have such legacy rows — so a freshly deployed agent could not be scheduled because an unrelated old file poisoned the check. It also downloaded every file just to test one name.

The policy is now error-driven: try the create first, and only when the server answers exactly `Agent '<file>' not found` (validation it performs anyway) deploy and retry the create once. The exact-message match keeps `Unknown node …` (file present, target missing) and every other failure surfacing as-is. `--redeploy` still deploys before the first attempt; `--no-deploy` still never deploys; the aborted-deploy → no-schedule gate is unchanged. Net effect: one request in the common case and immunity to other files' missing sources.

## Verification

Schedule suites: 180 passed (cron 33 incl. new alias cases, remote policy matrix rewritten for the error-driven flow incl. exact-match and no-retry-loop guards). CLI suite 58 passed. Lint + typecheck clean. `docs/dev/schedule-remote-backend.md` updated with why the presence pre-check was reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
