### PR TITLE
Deploy diff rendering + agency remote files list (CLI side of bundle replacement)

### DIFF
--- a/packages/agency-lang/docs/dev/statelog-clients.md
+++ b/packages/agency-lang/docs/dev/statelog-clients.md
@@ -23,6 +23,25 @@ it, and on failure reports:
   HTML with HTTP 200),
 - how the **body starts** (whitespace-collapsed, truncated).
 
+## Bundle-replacement fields on the upload response
+
+statelog's bundle-replacement change (spec:
+`statelog/docs/superpowers/specs/2026-08-09-bundle-replacement-design.md`)
+adds `removedFiles` and `orphanedSchedules` to the upload response.
+`uploadClient` reads them **tolerantly**: hosts that predate the feature send
+neither, and malformed values are dropped, because they are presentation data
+about a deploy that already landed — a deploy must never fail over its
+warning payload. `renderOutcome` prints them as a "Replaced previous bundle"
+section with a warning per orphaned schedule.
+
+`projectClient.listFiles()` reads the API-key-accessible file listing
+(`GET /api/projects/:slug/agency_files`) behind the same route-tolerance
+mechanism as the spend API: on a host that predates the route, an unknown 404
+becomes "this statelog host does not support the file listing API". It backs
+`agency remote files list`, the CLI's only file verb besides deploy —
+deliberately read-only, since files are mutated through whole-bundle deploys
+and per-file deletion stays a web-app action.
+
 Two rules for future changes:
 
 - New statelog client code must go through `readJsonBody`, not

--- a/packages/agency-lang/lib/cli/deploy/deploy.ts
+++ b/packages/agency-lang/lib/cli/deploy/deploy.ts
@@ -8,6 +8,7 @@ import type { DeployTarget, TargetProvenance } from "./target.js";
 import { collectAgencyBundle, validateBundleCompiles } from "./bundle.js";
 import type { AgencyBundle } from "./bundle.js";
 import { uploadBundle } from "../statelog/uploadClient.js";
+import type { OrphanedSchedule } from "../statelog/uploadClient.js";
 import type { ServeManifest } from "../statelog/serveClient.js";
 
 export type DeployOptions = {
@@ -27,7 +28,14 @@ export type DeployPlan = {
 export type DeployOutcome =
   | { kind: "error"; error: string }
   | { kind: "preview"; plan: DeployPlan }
-  | { kind: "deployed"; plan: DeployPlan; endpointUrls: string[]; manifest?: ServeManifest };
+  | {
+      kind: "deployed";
+      plan: DeployPlan;
+      endpointUrls: string[];
+      manifest?: ServeManifest;
+      removedFiles: string[];
+      orphanedSchedules: OrphanedSchedule[];
+    };
 
 export async function deploy(
   entrypointPath: string,
@@ -69,5 +77,7 @@ export async function deploy(
     plan,
     endpointUrls: uploaded.endpointUrls,
     manifest: uploaded.manifest,
+    removedFiles: uploaded.removedFiles,
+    orphanedSchedules: uploaded.orphanedSchedules,
   };
 }

--- a/packages/agency-lang/lib/cli/deploy/render.test.ts
+++ b/packages/agency-lang/lib/cli/deploy/render.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderOutcome } from "./render.js";
+import type { DeployOutcome, DeployPlan } from "./deploy.js";
+
+const plan: DeployPlan = {
+  target: { host: "https://h", projectId: "proj", apiKey: "secret-key" },
+  provenance: { host: "--host", projectId: "--project", apiKey: "$STATELOG_API_KEY" },
+  bundle: {
+    entrypoint: "daily.agency",
+    files: [{ name: "daily.agency", contents: "x", absPath: "/tmp/daily.agency" }],
+  },
+};
+
+function deployed(overrides: Partial<Extract<DeployOutcome, { kind: "deployed" }>>): DeployOutcome {
+  return {
+    kind: "deployed",
+    plan,
+    endpointUrls: ["https://h/serve/u/proj/daily/list"],
+    manifest: undefined,
+    removedFiles: [],
+    orphanedSchedules: [],
+    ...overrides,
+  };
+}
+
+let logSpy: ReturnType<typeof vi.spyOn>;
+
+function output(): string {
+  return logSpy.mock.calls.map((call: unknown[]) => call.join(" ")).join("\n");
+}
+
+beforeEach(() => {
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("renderOutcome bundle replacement", () => {
+  it("prints removed files and orphaned-schedule warnings", () => {
+    renderOutcome(
+      deployed({
+        removedFiles: ["helpers.agency"],
+        orphanedSchedules: [
+          { id: "s1", name: "mine", fileName: "helpers", targetKind: "node", targetName: "refresh" },
+        ],
+      }),
+    );
+    expect(output()).toContain("Replaced previous bundle");
+    expect(output()).toContain("helpers.agency");
+    expect(output()).toContain("schedule s1 (mine)");
+    expect(output()).toContain("node refresh");
+  });
+
+  it("prints no replacement section when nothing was removed", () => {
+    renderOutcome(deployed({}));
+    expect(output()).not.toContain("Replaced previous bundle");
+  });
+
+  it("never prints the API key", () => {
+    renderOutcome(deployed({ removedFiles: ["helpers.agency"], orphanedSchedules: [] }));
+    expect(output()).not.toContain("secret-key");
+  });
+});

--- a/packages/agency-lang/lib/cli/deploy/render.ts
+++ b/packages/agency-lang/lib/cli/deploy/render.ts
@@ -8,6 +8,7 @@ import { color } from "@/utils/termcolors.js";
 import renderDeployReport from "@/templates/cli/deployReport.js";
 import type { DeployOutcome, DeployPlan } from "./deploy.js";
 import { serveBaseUrl } from "../statelog/uploadClient.js";
+import type { OrphanedSchedule } from "../statelog/uploadClient.js";
 import type { ServeManifest } from "../statelog/serveClient.js";
 import { curlExamples } from "./curlExamples.js";
 
@@ -25,9 +26,33 @@ export function renderOutcome(outcome: DeployOutcome): void {
       dryRun: outcome.kind === "preview",
       dryRunNote: `\n\n${color.yellow("dry run")} — nothing uploaded. Re-run without ${color.bold("--dry-run")} to deploy.`,
       deployed,
-      deployedBody: deployed ? deployedBody(outcome.endpointUrls, outcome.manifest) : "",
+      deployedBody:
+        outcome.kind === "deployed"
+          ? deployedBody(outcome.endpointUrls, outcome.manifest) +
+            replacementSection(outcome.removedFiles, outcome.orphanedSchedules)
+          : "",
     }),
   );
+}
+
+/** What this deploy removed from the project (bundle replacement), and any
+ *  schedules now pointing at a removed file. Empty on hosts that predate
+ *  bundle replacement, and on deploys that removed nothing. */
+function replacementSection(
+  removedFiles: string[],
+  orphanedSchedules: OrphanedSchedule[],
+): string {
+  if (removedFiles.length === 0) {
+    return "";
+  }
+  const rows = removedFiles.map((name) => `  ${color.dim("removed")} ${name}`);
+  for (const schedule of orphanedSchedules) {
+    const label = schedule.name === null ? schedule.id : `${schedule.id} (${schedule.name})`;
+    rows.push(
+      `  ${color.yellow("warning")} schedule ${label} targets ${schedule.targetKind} ${schedule.targetName} in removed file ${schedule.fileName} — its runs will fail until it is removed or the file returns`,
+    );
+  }
+  return section(color.bold("Replaced previous bundle"), rows);
 }
 
 function targetBlock(plan: DeployPlan): string {

--- a/packages/agency-lang/lib/cli/remote/commands/files.test.ts
+++ b/packages/agency-lang/lib/cli/remote/commands/files.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { runFilesList, formatFilesTable } from "./files.js";
+import type { ProjectFile } from "../../statelog/projectClient.js";
+import type { RemoteCommandContext } from "./util.js";
+
+const listFilesMock = vi.fn();
+vi.mock("../../statelog/projectClient.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../statelog/projectClient.js")>();
+  return {
+    ...original,
+    createProjectClient: (...clientArgs: unknown[]) => {
+      clientFactoryMock(...clientArgs);
+      return { listFiles: (...a: unknown[]) => listFilesMock(...a) };
+    },
+  };
+});
+const clientFactoryMock = vi.fn();
+
+const KEY_ENV = "FILES_LIST_TEST_KEY";
+
+const context: RemoteCommandContext = {
+  config: { log: { host: "https://h" } },
+  configPath: "/nonexistent-files-list-test/agency.json",
+} as RemoteCommandContext;
+
+const options = { project: "proj", apiKeyEnv: KEY_ENV };
+
+const daily: ProjectFile = {
+  id: "f1",
+  fileName: "daily",
+  nodeNames: ["main", "refresh"],
+  hasSource: true,
+  bundleEntrypoints: ["daily"],
+  updatedAt: "2026-08-09T12:34:56.000Z",
+};
+
+const legacy: ProjectFile = {
+  id: "f2",
+  fileName: "old-probe",
+  nodeNames: [],
+  hasSource: false,
+  bundleEntrypoints: [],
+  updatedAt: "2026-05-01T00:00:00.000Z",
+};
+
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  process.env[KEY_ENV] = "secret-key";
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  vi.spyOn(process, "exit").mockImplementation((code?: number | string | null) => {
+    throw new Error(`exit:${code}`);
+  });
+});
+
+afterEach(() => {
+  delete process.env[KEY_ENV];
+  vi.restoreAllMocks();
+  listFilesMock.mockReset();
+  clientFactoryMock.mockClear();
+});
+
+describe("formatFilesTable", () => {
+  it("renders the exact table, marking untracked bundles and missing source", () => {
+    const expected = [
+      "Name".padEnd(11) + "Nodes".padEnd(15) + "Bundles".padEnd(13) + "Source".padEnd(9) +
+        "Updated",
+      "daily".padEnd(11) + "main, refresh".padEnd(15) + "daily".padEnd(13) + "yes".padEnd(9) +
+        "2026-08-09",
+      "old-probe".padEnd(11) + "-".padEnd(15) + "(untracked)".padEnd(13) + "MISSING".padEnd(9) +
+        "2026-05-01",
+    ].join("\n");
+    expect(formatFilesTable([daily, legacy])).toBe(expected);
+  });
+
+  it("renders the friendly empty state", () => {
+    expect(formatFilesTable([])).toBe("No files deployed to this project.");
+  });
+});
+
+describe("runFilesList", () => {
+  it("lists via the resolved target and prints the table", async () => {
+    listFilesMock.mockResolvedValue([daily]);
+    await runFilesList(options, context);
+    expect(clientFactoryMock).toHaveBeenCalledWith("https://h", "proj", "secret-key");
+    expect(listFilesMock).toHaveBeenCalledTimes(1);
+    expect(logSpy).toHaveBeenCalledWith(formatFilesTable([daily]));
+  });
+
+  it("exits with the client's message on failure, printing no table", async () => {
+    listFilesMock.mockRejectedValue(new Error("this statelog host does not support the file listing API (upgrade the host)"));
+    await expect(runFilesList(options, context)).rejects.toThrow("exit:1");
+    expect(logSpy).not.toHaveBeenCalled();
+    const errors = errorSpy.mock.calls.map((call: unknown[]) => call.join(" ")).join("\n");
+    expect(errors).toContain("does not support the file listing API");
+    expect(errors).not.toContain("secret-key");
+  });
+
+  it("exits on target-resolution failure before creating a client", async () => {
+    await expect(
+      runFilesList(
+        { project: undefined, apiKeyEnv: KEY_ENV },
+        { config: {}, configPath: "/nonexistent-files-list-test/agency.json" } as RemoteCommandContext,
+      ),
+    ).rejects.toThrow("exit:1");
+    expect(clientFactoryMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agency-lang/lib/cli/remote/commands/files.ts
+++ b/packages/agency-lang/lib/cli/remote/commands/files.ts
@@ -1,0 +1,58 @@
+// `agency remote files list` — the read-only inventory of a project's deployed
+// files. Deliberately the ONLY file verb in the CLI besides deploy: files are
+// mutated through whole-bundle deploys, never individually (per-file deletion
+// is a web-app action). The listing exists to make server-side state visible —
+// which bundles a file belongs to, and which legacy rows have no stored source
+// (those are what break `/source` and `agency remote pull`).
+
+import { createProjectClient } from "../../statelog/projectClient.js";
+import type { ProjectFile } from "../../statelog/projectClient.js";
+import { resolveProjectTarget, failProjectCommand } from "./util.js";
+import type { ProjectCommandOptions, RemoteCommandContext } from "./util.js";
+
+export async function runFilesList(
+  options: ProjectCommandOptions,
+  context: RemoteCommandContext,
+): Promise<void> {
+  const target = resolveProjectTarget(context, options);
+  try {
+    const files = await createProjectClient(
+      target.origin,
+      target.projectSlug,
+      target.apiKey,
+    ).listFiles();
+    console.log(formatFilesTable(files));
+  } catch (error) {
+    failProjectCommand(error);
+  }
+}
+
+export function formatFilesTable(files: ProjectFile[]): string {
+  if (files.length === 0) {
+    return "No files deployed to this project.";
+  }
+  const rows = files.map((file) => ({
+    name: file.fileName,
+    nodes: file.nodeNames.join(", ") || "-",
+    bundles: file.bundleEntrypoints.join(", ") || "(untracked)",
+    source: file.hasSource ? "yes" : "MISSING",
+    updated: file.updatedAt.slice(0, 10),
+  }));
+  const headers = {
+    name: "Name",
+    nodes: "Nodes",
+    bundles: "Bundles",
+    source: "Source",
+    updated: "Updated",
+  };
+  const columns = ["name", "nodes", "bundles", "source", "updated"] as const;
+  const width = (column: (typeof columns)[number]) =>
+    Math.max(headers[column].length, ...rows.map((row) => row[column].length)) + 2;
+  const render = (row: Record<(typeof columns)[number], string>) =>
+    columns
+      .map((column, index) =>
+        index === columns.length - 1 ? row[column] : row[column].padEnd(width(column)),
+      )
+      .join("");
+  return [render(headers), ...rows.map(render)].join("\n");
+}

--- a/packages/agency-lang/lib/cli/statelog/projectClient.test.ts
+++ b/packages/agency-lang/lib/cli/statelog/projectClient.test.ts
@@ -154,6 +154,46 @@ describe.each<[string, unknown, "pullSource" | "listTraces" | "traceLogs"]>([
   });
 });
 
+describe("projectClient.listFiles", () => {
+  const wireFile = {
+    id: "f1",
+    fileName: "daily",
+    nodeNames: ["main"],
+    hasSource: true,
+    bundleEntrypoints: ["daily"],
+    updatedAt: "2026-08-09T00:00:00.000Z",
+  };
+
+  it("GETs the agency_files listing and returns validated rows", async () => {
+    fetchMock.mockResolvedValue(response(200, { success: true, value: [wireFile] }));
+    await expect(client().listFiles()).resolves.toEqual([wireFile]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://h/api/projects/proj/agency_files",
+      expect.any(Object),
+    );
+  });
+
+  it("preserves untracked/missing-source rows as data", async () => {
+    const legacy = { ...wireFile, id: "f2", hasSource: false, bundleEntrypoints: [] };
+    fetchMock.mockResolvedValue(response(200, { success: true, value: [legacy] }));
+    await expect(client().listFiles()).resolves.toEqual([legacy]);
+  });
+
+  it("rejects a malformed row", async () => {
+    fetchMock.mockResolvedValue(
+      response(200, { success: true, value: [{ ...wireFile, hasSource: "yes" }] }),
+    );
+    await expect(client().listFiles()).rejects.toBeInstanceOf(ProjectRequestError);
+  });
+
+  it("maps an unknown 404 to the unsupported-host message", async () => {
+    fetchMock.mockResolvedValue(response(404, { error: "Not found" }));
+    await expect(client().listFiles()).rejects.toThrow(
+      /does not support the file listing API/,
+    );
+  });
+});
+
 describe("projectClient envelope/transport edge cases", () => {
   it("a 2xx non-JSON body → non-JSON error naming the request and body", async () => {
     fetchMock.mockResolvedValue(nonJsonResponse(200));

--- a/packages/agency-lang/lib/cli/statelog/projectClient.ts
+++ b/packages/agency-lang/lib/cli/statelog/projectClient.ts
@@ -15,6 +15,18 @@ import { readJsonBody } from "./jsonBody.js";
 
 export type SourceFile = { name: string; contents: string };
 
+/** One deployed file's metadata, from the API-key-readable listing. `hasSource`
+ *  false marks the legacy rows that break the `/source` route; an empty
+ *  `bundleEntrypoints` marks a row untracked by bundle replacement. */
+export type ProjectFile = {
+  id: string;
+  fileName: string;
+  nodeNames: string[];
+  hasSource: boolean;
+  bundleEntrypoints: string[];
+  updatedAt: string;
+};
+
 export type TraceSummary = { id: string; createdAt: string };
 
 /** A statelog log row, narrowed to what the viewer bridge needs. `data` stays
@@ -55,8 +67,18 @@ const traceLogSchema = z
     data: row.data as { type: string } & Record<string, unknown>,
   }));
 
+const projectFileSchema: z.ZodType<ProjectFile> = z.object({
+  id: z.string().min(1),
+  fileName: z.string(),
+  nodeNames: z.array(z.string()),
+  hasSource: z.boolean(),
+  bundleEntrypoints: z.array(z.string()),
+  updatedAt: z.string(),
+});
+
 export type ProjectClient = {
   pullSource(): Promise<SourceFile[]>;
+  listFiles(): Promise<ProjectFile[]>;
   listTraces(): Promise<TraceSummary[]>;
   traceLogs(traceId: string): Promise<TraceLog[]>;
   getSpend(window: SpendWindow): Promise<ProjectSpend>;
@@ -148,6 +170,16 @@ export function createProjectClient(
   return {
     async pullSource() {
       return parseWire(sourceBundleSchema, await request({ segments: ["source"] })).files;
+    },
+    async listFiles() {
+      return parseWire(
+        z.array(projectFileSchema),
+        await request({
+          segments: ["agency_files"],
+          unsupportedRouteMessage:
+            "this statelog host does not support the file listing API (upgrade the host)",
+        }),
+      );
     },
     async listTraces() {
       return parseWire(z.array(traceSummarySchema), await request({ segments: ["traces"] }));

--- a/packages/agency-lang/lib/cli/statelog/uploadClient.test.ts
+++ b/packages/agency-lang/lib/cli/statelog/uploadClient.test.ts
@@ -42,7 +42,60 @@ describe("uploadBundle", () => {
         "https://statelog.example/serve/u/proj/greeter/node/main",
       ],
       manifest,
+      // A host that predates bundle replacement sends neither field.
+      removedFiles: [],
+      orphanedSchedules: [],
     });
+  });
+
+  it("carries the bundle-replacement fields when the host sends them", async () => {
+    const orphan = {
+      id: "s1",
+      name: "mine",
+      fileName: "helpers",
+      targetKind: "node",
+      targetName: "refresh",
+    };
+    mockFetch(() => ({
+      success: true,
+      value: {
+        endpointUrls: ["/serve/u/proj/greeter/list"],
+        removedFiles: ["helpers.agency"],
+        orphanedSchedules: [orphan],
+      },
+    }));
+    const result = await uploadBundle(target, bundle);
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.removedFiles).toEqual(["helpers.agency"]);
+    expect(result.orphanedSchedules).toEqual([orphan]);
+  });
+
+  it("drops malformed replacement values instead of failing a landed deploy", async () => {
+    mockFetch(() => ({
+      success: true,
+      value: {
+        endpointUrls: ["/serve/u/proj/greeter/list"],
+        removedFiles: ["ok.agency", 42, null],
+        orphanedSchedules: [
+          { id: "s1", name: null, fileName: "f", targetKind: "node", targetName: "n" },
+          { id: 7, fileName: "f", targetKind: "node", targetName: "n" },
+          { id: "s2", name: null, fileName: "f", targetKind: "job", targetName: "n" },
+          "not an object",
+        ],
+      },
+    }));
+    const result = await uploadBundle(target, bundle);
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.removedFiles).toEqual(["ok.agency"]);
+    expect(result.orphanedSchedules).toEqual([
+      { id: "s1", name: null, fileName: "f", targetKind: "node", targetName: "n" },
+    ]);
   });
 
   it("surfaces a rejection envelope as an error", async () => {

--- a/packages/agency-lang/lib/cli/statelog/uploadClient.ts
+++ b/packages/agency-lang/lib/cli/statelog/uploadClient.ts
@@ -11,8 +11,26 @@ import { createServeClient, ServeRequestError } from "./serveClient.js";
 import type { ServeManifest } from "./serveClient.js";
 import { readJsonBody } from "./jsonBody.js";
 
+/** A schedule left pointing at a file this deploy removed (statelog's
+ *  bundle-replacement warning). */
+export type OrphanedSchedule = {
+  id: string;
+  name: string | null;
+  fileName: string;
+  targetKind: "node" | "function";
+  targetName: string;
+};
+
 export type UploadResult =
-  | { ok: true; endpointUrls: string[]; manifest?: ServeManifest }
+  | {
+      ok: true;
+      endpointUrls: string[];
+      manifest?: ServeManifest;
+      /** Files soft-deleted because they fell out of this entrypoint's bundle.
+       *  Empty on hosts that predate bundle replacement. */
+      removedFiles: string[];
+      orphanedSchedules: OrphanedSchedule[];
+    }
   | { ok: false; error: string };
 
 /**
@@ -72,7 +90,55 @@ export async function uploadBundle(
     return { ok: false, error: error instanceof Error ? error.message : String(error) };
   }
   const manifest = await enrichManifest(absoluteUrls, target.apiKey);
-  return { ok: true, endpointUrls: absoluteUrls, manifest };
+  return {
+    ok: true,
+    endpointUrls: absoluteUrls,
+    manifest,
+    removedFiles: readRemovedFiles(envelope),
+    orphanedSchedules: readOrphanedSchedules(envelope),
+  };
+}
+
+// The replacement fields are best-effort presentation data on a deploy that
+// already landed, and older hosts don't send them at all — so absent or
+// malformed values become empty, never an error.
+function readRemovedFiles(envelope: unknown): string[] {
+  const value = (envelope as { value?: { removedFiles?: unknown } }).value?.removedFiles;
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((name): name is string => typeof name === "string");
+}
+
+function readOrphanedSchedules(envelope: unknown): OrphanedSchedule[] {
+  const value = (envelope as { value?: { orphanedSchedules?: unknown } }).value
+    ?.orphanedSchedules;
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const schedules: OrphanedSchedule[] = [];
+  for (const row of value) {
+    if (row === null || typeof row !== "object") {
+      continue;
+    }
+    const { id, name, fileName, targetKind, targetName } = row as Record<string, unknown>;
+    if (
+      typeof id !== "string" ||
+      typeof fileName !== "string" ||
+      typeof targetName !== "string" ||
+      (targetKind !== "node" && targetKind !== "function")
+    ) {
+      continue;
+    }
+    schedules.push({
+      id,
+      name: typeof name === "string" ? name : null,
+      fileName,
+      targetKind,
+      targetName,
+    });
+  }
+  return schedules;
 }
 
 /** Endpoint URLs from a `{ success: true, value: { endpointUrls } }` envelope,

--- a/packages/agency-lang/scripts/agency.test.ts
+++ b/packages/agency-lang/scripts/agency.test.ts
@@ -17,6 +17,7 @@ const remoteRecipeMocks = vi.hoisted(() => ({
   runKeysCreate: vi.fn(),
   runSpend: vi.fn(),
   runPull: vi.fn(),
+  runFilesList: vi.fn(),
   runLogs: vi.fn(),
 }));
 vi.mock("@/cli/remote/commands/whoami.js", () => ({
@@ -36,6 +37,9 @@ vi.mock("@/cli/remote/commands/spend.js", () => ({
 // pull/logs recipes are mocked; logsMode and util stay REAL so the
 // registration's mode/TTY preflight and clean-exit are exercised.
 vi.mock("@/cli/remote/commands/pull.js", () => ({ runPull: remoteRecipeMocks.runPull }));
+vi.mock("@/cli/remote/commands/files.js", () => ({
+  runFilesList: remoteRecipeMocks.runFilesList,
+}));
 vi.mock("@/cli/remote/commands/logs.js", () => ({ runLogs: remoteRecipeMocks.runLogs }));
 
 // Remote schedule recipes are mocked so dispatch/normalization can be tested
@@ -184,6 +188,7 @@ describe("agency CLI command tree", () => {
     expect(remote?.commands.map((command) => command.name()).sort()).toEqual([
       "call",
       "deploy",
+      "files",
       "keys",
       "link",
       "logs",
@@ -445,6 +450,21 @@ describe("remote management command registration", () => {
       { out: "/o", force: true, project: "p" },
       CONTEXT,
     );
+  });
+
+  it("remote files list forwards target options and context", async () => {
+    await createProgram().parseAsync([
+      "node", "agency", "remote", "files", "list", "--project", "p", "--host", "https://h",
+    ]);
+    expect(remoteRecipeMocks.runFilesList).toHaveBeenCalledWith(
+      { project: "p", host: "https://h" },
+      CONTEXT,
+    );
+  });
+
+  it("remote files ls is an alias for list", async () => {
+    await createProgram().parseAsync(["node", "agency", "remote", "files", "ls", "--project", "p"]);
+    expect(remoteRecipeMocks.runFilesList).toHaveBeenCalledTimes(1);
   });
 
   it("remote logs --json forwards a fetch/json mode", async () => {

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -32,6 +32,7 @@ import type { CreateKeyOptions } from "@/cli/remote/commands/keys.js";
 import { runSpend } from "@/cli/remote/commands/spend.js";
 import type { SpendOptions } from "@/cli/remote/commands/spend.js";
 import { runPull } from "@/cli/remote/commands/pull.js";
+import { runFilesList } from "@/cli/remote/commands/files.js";
 import type { PullOptions } from "@/cli/remote/commands/pull.js";
 import { runLogs } from "@/cli/remote/commands/logs.js";
 import {
@@ -621,6 +622,19 @@ export function createProgram(deps: CliDependencies = {}): Command {
     .option(HOST_OPTION, HOST_DESC)
     .option(API_KEY_ENV_OPTION, API_KEY_ENV_DESC)
     .action((opts: PullOptions) => runPull(opts, getConfigContext()));
+
+  const filesCmd = remoteCmd
+    .command("files")
+    .description("Inspect the files deployed to a project");
+
+  filesCmd
+    .command("list")
+    .alias("ls")
+    .description("List deployed files: their bundles and source availability")
+    .option(PROJECT_OPTION, PROJECT_DESC)
+    .option(HOST_OPTION, HOST_DESC)
+    .option(API_KEY_ENV_OPTION, API_KEY_ENV_DESC)
+    .action((opts: ProjectCommandOptions) => runFilesList(opts, getConfigContext()));
 
   remoteCmd
     .command("logs")


### PR DESCRIPTION
The agency-lang half of bundle replacement (statelog spec: `docs/superpowers/specs/2026-08-09-bundle-replacement-design.md` in the statelog repo). **Hold until the statelog side merges**, per owner — though everything here degrades gracefully against old hosts, so merge order is safety, not correctness.

## Deploy output shows what a deploy replaced

The upload response's new `removedFiles` / `orphanedSchedules` fields are parsed **tolerantly** in `uploadClient`: hosts that predate bundle replacement send neither, and malformed values are dropped rather than failing a deploy that already landed. `renderOutcome` prints a `Replaced previous bundle` section listing removed files, with a yellow warning per schedule left pointing at a removed file:

```
Replaced previous bundle
  removed helpers.agency
  warning schedule s1 (mine) targets node refresh in removed file helpers — its runs will fail until it is removed or the file returns
```

## `agency remote files list`

New read-only command backed by `projectClient.listFiles()` against the new `GET /api/projects/:slug/agency_files` route. Columns: name, nodes, bundle membership (`(untracked)` marks legacy pre-feature rows), source availability (`MISSING` marks the rows that break `/source` and `remote pull`), updated date. On a host without the route, the unknown-404 becomes "this statelog host does not support the file listing API" via the same mechanism the spend API uses.

Per the agreed boundary, this is the CLI's only file verb besides deploy — deliberately read-only. No per-file mutation is added; that stays a session-authenticated web-app action.

## Verification

Touched suites all green: uploadClient 12 (incl. absent/malformed replacement fields), projectClient 40 (listFiles transport/tolerance), render 3, files command 6, CLI dispatch 60. Lint + typecheck clean. `docs/dev/statelog-clients.md` updated with the tolerance contract and the read-only rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
