### PR TITLE
agency run --local, a download picker, and a catalog list view

### DIFF
--- a/packages/agency-lang/docs/dev/local-models.md
+++ b/packages/agency-lang/docs/dev/local-models.md
@@ -44,6 +44,52 @@ global) — from the bootstrap hook on the run path, and from
 `_registerLocalProvider` via `__ctx()` on the agent path (the plain CLI has
 no runtime frame, so it emits nothing).
 
+## `agency run --local`
+
+`--local <model>` on `agency run` (and the `agency <file>` shorthand) pins the
+whole run to a local model. The value's domain is `_resolveModelName`'s:
+curated name, alias, `hf:` URI, or `.gguf` path. `--local` with `--model` is
+an error (exit 2), checked before any other work. The value is required — an
+optional-valued flag would swallow the input filename, the same commander
+behavior that split `--trace` in two.
+
+Flow: `runWithOptions` calls `resolveLocalRunFlag` (`lib/cli/localFlag.ts`)
+in the PARENT CLI, so download progress and SHA-256 verification happen in
+the terminal before the program starts. The result —
+`{ model: <absolute .gguf path>, explicitProvider: "llama-cpp" }` — is folded
+into the ordinary `CliFlags.model` slot, so `applyCliFlags` stays the single
+owner of flag→config meaning. The path is absolutized because `LlamaCPP`
+rejects a bare separator-less filename (ambiguous with a model name), which
+is what `--local model.gguf` would otherwise arrive as. The child process
+picks the provider up from baked config via the bootstrap hook above.
+End-to-end coverage: `lib/cli/runLocal.spawn.test.ts` (fake plugin, no
+network).
+
+## The downloads manifest
+
+`downloads.json` in the models cache dir maps a resolved model URI to the
+`.gguf` basename node-llama-cpp stored it under
+(`lib/stdlib/localModelManifest.ts`). `_downloadModel` records after
+verification succeeds (an invalid-hash file is never recorded); writes go
+through temp-file + rename so an interrupted write keeps the previous valid
+manifest. It is display metadata only: resolution, downloading, and
+verification never read it, so a corrupt or deleted manifest can mislabel
+the `agency local list` view and nothing else. Concurrent downloaders race
+whole-file (last writer wins) — accepted for display metadata.
+
+## The `agency local` CLI surface
+
+- `list` (`runList` → `formatLocalList`) is UNGATED — browsing needs no
+  provider package. First line names the resolved models directory; catalog
+  rows get a `✓` + on-disk size when the manifest maps their target URI to a
+  file that still exists; files no catalog row claims (raw-URI downloads,
+  pre-manifest downloads) appear under `OTHER FILES`.
+- `download` with no argument opens a `prompts` picker over
+  `downloadChoices(_listModelNames())`, with a trailing custom choice for an
+  `hf:` URI / `.gguf` path. Non-TTY prints the catalog plus a
+  `Pass a model:` hint and exits 1. Cancel exits 0. `download`/`remove` keep
+  the install gate.
+
 ## Name resolution
 
 `_resolveModelName(value)` maps a value to a model URI/path:

--- a/packages/agency-lang/lib/cli/local.test.ts
+++ b/packages/agency-lang/lib/cli/local.test.ts
@@ -76,13 +76,17 @@ describe("downloadChoices", () => {
   });
 });
 
-describe("runDownload without a value, non-TTY", () => {
-  it("prints the catalog and the hint, exits 1", async () => {
+describe("runDownload without a value, non-interactive", () => {
+  /** Run runDownload(undefined) with the given TTY shape; expect the
+   *  non-interactive path: catalog + hint + exit 1. */
+  async function expectNonInteractive(stdinTTY: boolean, stdoutTTY: boolean) {
     // Any non-empty override satisfies the gate; nothing is imported before
     // the TTY check, so the file need not exist.
     process.env.AGENCY_LLAMA_PROVIDER_MODULE = "/nonexistent/fake.mjs";
-    const savedIsTTY = process.stdout.isTTY;
-    Object.defineProperty(process.stdout, "isTTY", { value: false, configurable: true });
+    const savedIn = process.stdin.isTTY;
+    const savedOut = process.stdout.isTTY;
+    Object.defineProperty(process.stdin, "isTTY", { value: stdinTTY, configurable: true });
+    Object.defineProperty(process.stdout, "isTTY", { value: stdoutTTY, configurable: true });
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
       throw new Error(`exit:${code}`);
     }) as never);
@@ -95,12 +99,21 @@ describe("runDownload without a value, non-TTY", () => {
         errSpy.mock.calls.some((c) => String(c[0]).includes("agency local download <name>")),
       ).toBe(true);
     } finally {
-      Object.defineProperty(process.stdout, "isTTY", { value: savedIsTTY, configurable: true });
+      Object.defineProperty(process.stdin, "isTTY", { value: savedIn, configurable: true });
+      Object.defineProperty(process.stdout, "isTTY", { value: savedOut, configurable: true });
       exitSpy.mockRestore();
       logSpy.mockRestore();
       errSpy.mockRestore();
       delete process.env.AGENCY_LLAMA_PROVIDER_MODULE;
     }
+  }
+
+  it("non-TTY stdout: prints the catalog and the hint, exits 1", async () => {
+    await expectNonInteractive(false, false);
+  });
+
+  it("TTY stdout but piped stdin (download < /dev/null from a terminal): same non-interactive path", async () => {
+    await expectNonInteractive(false, true);
   });
 });
 

--- a/packages/agency-lang/lib/cli/local.test.ts
+++ b/packages/agency-lang/lib/cli/local.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import { aliasAdd, aliasList, aliasRemove, formatRefreshOutput } from "./local.js";
+import { aliasAdd, aliasList, aliasRemove, formatRefreshOutput, runList } from "./local.js";
 
 let dir: string;
 let aliasFile: string;
@@ -29,6 +29,28 @@ describe("agency local CLI helpers", () => {
         .toBeUndefined();
     } finally {
       log.mockRestore();
+    }
+  });
+});
+
+describe("runList", () => {
+  it("is ungated: prints the catalog view with no local-model support", () => {
+    // The old runList exited 1 without the provider package; this pins the
+    // spec's "browsing needs no package". Deterministic in CI (plugin never
+    // installed) and still green on dev machines: the new code never
+    // consults support at all.
+    delete process.env.AGENCY_LLAMA_PROVIDER_MODULE;
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("exit called");
+    }) as never);
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      runList();
+      expect(exitSpy).not.toHaveBeenCalled();
+      expect(String(logSpy.mock.calls[0][0])).toMatch(/^Models directory: /);
+    } finally {
+      exitSpy.mockRestore();
+      logSpy.mockRestore();
     }
   });
 });

--- a/packages/agency-lang/lib/cli/local.test.ts
+++ b/packages/agency-lang/lib/cli/local.test.ts
@@ -2,7 +2,16 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import { aliasAdd, aliasList, aliasRemove, formatRefreshOutput, runList } from "./local.js";
+import {
+  aliasAdd,
+  aliasList,
+  aliasRemove,
+  formatRefreshOutput,
+  runList,
+  runDownload,
+  downloadChoices,
+  CUSTOM_CHOICE,
+} from "./local.js";
 
 let dir: string;
 let aliasFile: string;
@@ -51,6 +60,46 @@ describe("runList", () => {
     } finally {
       exitSpy.mockRestore();
       logSpy.mockRestore();
+    }
+  });
+});
+
+describe("downloadChoices", () => {
+  it("labels entries with params and size and appends the custom option", () => {
+    const choices = downloadChoices([
+      { name: "tiny", target: "hf:o/t:Q4", source: "curated", params: "135M", sizeBytes: 100_000_000 },
+      { name: "plain-alias", target: "hf:x/y:Q4", source: "alias" },
+    ]);
+    expect(choices[0]).toEqual({ title: "tiny  (135M, 0.10 GB)", value: "tiny" });
+    expect(choices[1]).toEqual({ title: "plain-alias", value: "plain-alias" });
+    expect(choices[choices.length - 1].value).toBe(CUSTOM_CHOICE);
+  });
+});
+
+describe("runDownload without a value, non-TTY", () => {
+  it("prints the catalog and the hint, exits 1", async () => {
+    // Any non-empty override satisfies the gate; nothing is imported before
+    // the TTY check, so the file need not exist.
+    process.env.AGENCY_LLAMA_PROVIDER_MODULE = "/nonexistent/fake.mjs";
+    const savedIsTTY = process.stdout.isTTY;
+    Object.defineProperty(process.stdout, "isTTY", { value: false, configurable: true });
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`exit:${code}`);
+    }) as never);
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      await expect(runDownload(undefined)).rejects.toThrow("exit:1");
+      expect(logSpy).toHaveBeenCalled(); // the catalog table
+      expect(
+        errSpy.mock.calls.some((c) => String(c[0]).includes("agency local download <name>")),
+      ).toBe(true);
+    } finally {
+      Object.defineProperty(process.stdout, "isTTY", { value: savedIsTTY, configurable: true });
+      exitSpy.mockRestore();
+      logSpy.mockRestore();
+      errSpy.mockRestore();
+      delete process.env.AGENCY_LLAMA_PROVIDER_MODULE;
     }
   });
 });

--- a/packages/agency-lang/lib/cli/local.ts
+++ b/packages/agency-lang/lib/cli/local.ts
@@ -90,7 +90,10 @@ export async function runDownload(value?: string): Promise<void> {
   gate();
   let picked = value;
   if (picked === undefined) {
-    if (!process.stdout.isTTY) {
+    // Prompting needs BOTH ends of the terminal: a TTY stdout to draw on and
+    // a TTY stdin to read from (`agency local download < /dev/null` from a
+    // terminal has a TTY stdout but nothing to read).
+    if (process.stdin.isTTY !== true || process.stdout.isTTY !== true) {
       // A script that reaches this point asked for a download and did not
       // get one — print what is available and fail.
       console.log(formatModelCatalog());
@@ -103,7 +106,9 @@ export async function runDownload(value?: string): Promise<void> {
       message: "Which model do you want to download?",
       choices: downloadChoices(_listModelNames()),
     });
-    if (answer.model === undefined) return; // cancelled — exit 0, nothing downloaded
+    // Cancellation can surface as a missing key or as null — treat both as
+    // "exit 0, nothing downloaded".
+    if (answer.model == null) return;
     picked = answer.model as string;
     if (picked === CUSTOM_CHOICE) {
       const custom = await prompts({
@@ -111,7 +116,7 @@ export async function runDownload(value?: string): Promise<void> {
         name: "value",
         message: "hf: URI or .gguf path:",
       });
-      if (custom.value === undefined || custom.value === "") return;
+      if (custom.value == null || custom.value === "") return;
       picked = custom.value as string;
     }
   }

--- a/packages/agency-lang/lib/cli/local.ts
+++ b/packages/agency-lang/lib/cli/local.ts
@@ -1,3 +1,4 @@
+import prompts from "prompts";
 import {
   _resolveModelName,
   _downloadModel,
@@ -8,9 +9,11 @@ import {
   _unaliasModel,
   _removeModel,
   hasLocalModelSupport,
+  formatGB,
   formatModelCatalog,
   formatLocalList,
   _refreshCatalog,
+  type ModelNameEntry,
   type RefreshResult,
 } from "../stdlib/localModels.js";
 import { readDownloadManifest } from "../stdlib/localModelManifest.js";
@@ -65,13 +68,58 @@ export function runList(): void {
   );
 }
 
-export async function runDownload(value: string): Promise<void> {
+export const CUSTOM_CHOICE = "__custom__";
+
+/** Picker rows for the no-argument `agency local download`. Metadata-less
+ *  aliases get a bare name; the trailing choice lets the user type an hf: URI
+ *  or .gguf path. */
+export function downloadChoices(
+  entries: ModelNameEntry[],
+): { title: string; value: string }[] {
+  const rows = entries.map((e) => ({
+    title:
+      e.params !== undefined && e.sizeBytes !== undefined
+        ? `${e.name}  (${e.params}, ${formatGB(e.sizeBytes)})`
+        : e.name,
+    value: e.name,
+  }));
+  return [...rows, { title: "custom (hf: URI or .gguf path)…", value: CUSTOM_CHOICE }];
+}
+
+export async function runDownload(value?: string): Promise<void> {
   gate();
+  let picked = value;
+  if (picked === undefined) {
+    if (!process.stdout.isTTY) {
+      // A script that reaches this point asked for a download and did not
+      // get one — print what is available and fail.
+      console.log(formatModelCatalog());
+      console.error("Pass a model: agency local download <name>");
+      process.exit(1);
+    }
+    const answer = await prompts({
+      type: "select",
+      name: "model",
+      message: "Which model do you want to download?",
+      choices: downloadChoices(_listModelNames()),
+    });
+    if (answer.model === undefined) return; // cancelled — exit 0, nothing downloaded
+    picked = answer.model as string;
+    if (picked === CUSTOM_CHOICE) {
+      const custom = await prompts({
+        type: "text",
+        name: "value",
+        message: "hf: URI or .gguf path:",
+      });
+      if (custom.value === undefined || custom.value === "") return;
+      picked = custom.value as string;
+    }
+  }
   // Show the source it resolved to (the hf: URI for a name/alias) and the
   // local path it landed at. For a .gguf-path input the two are the same, so
   // the source line is skipped.
-  const source = _resolveModelName(value);
-  const modelPath = await _downloadModel(value);
+  const source = _resolveModelName(picked);
+  const modelPath = await _downloadModel(picked);
   if (source !== modelPath) {
     console.log(`source: ${source}`);
   }

--- a/packages/agency-lang/lib/cli/local.ts
+++ b/packages/agency-lang/lib/cli/local.ts
@@ -3,15 +3,17 @@ import {
   _downloadModel,
   _listDownloadedModels,
   _listModelNames,
+  _modelsCacheDir,
   _aliasModel,
   _unaliasModel,
   _removeModel,
   hasLocalModelSupport,
-  formatGB,
   formatModelCatalog,
+  formatLocalList,
   _refreshCatalog,
   type RefreshResult,
 } from "../stdlib/localModels.js";
+import { readDownloadManifest } from "../stdlib/localModelManifest.js";
 import { ttyColor } from "../utils/termcolors.js";
 
 /** Install-gate for I/O commands. Honors the AGENCY_LLAMA_PROVIDER_MODULE
@@ -48,18 +50,19 @@ export function aliasRemove(name: string, file?: string): string {
   return inspected;
 }
 
+/** Deliberately ungated: browsing the catalog needs no provider package
+ *  (only download/remove do), and the pre-install experience — see what is
+ *  available, then get told what to install — is the point. */
 export function runList(): void {
-  gate();
-  const models = _listDownloadedModels();
-  if (models.length === 0) {
-    console.log("No models downloaded.");
-    return;
-  }
-  for (const m of models) {
-    console.log(`${m.name}\t${formatGB(m.sizeBytes)}`);
-  }
-  const total = models.reduce((sum, m) => sum + m.sizeBytes, 0);
-  console.log(`Total: ${formatGB(total)}`);
+  const dir = _modelsCacheDir();
+  console.log(
+    formatLocalList({
+      dir,
+      entries: _listModelNames(),
+      manifest: readDownloadManifest(dir),
+      files: _listDownloadedModels(),
+    }),
+  );
 }
 
 export async function runDownload(value: string): Promise<void> {

--- a/packages/agency-lang/lib/cli/localFlag.test.ts
+++ b/packages/agency-lang/lib/cli/localFlag.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import { fileURLToPath } from "url";
+import * as smoltalkPkg from "smoltalk";
+import { resolveLocalRunFlag } from "./localFlag.js";
+import { hasLocalModelSupport } from "../stdlib/localModels.js";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+// ONE fake for the whole file: smoltalk's loadLlamaCpp caches the loaded
+// module per process (first load wins), so per-test fakes with different
+// behavior would silently all resolve to whichever loaded first. The echo
+// shape (resolveModel returns its input) serves every case here.
+const fakePlugin = path.join(here, `__tmp_fake_flag_${process.pid}.mjs`);
+
+function writeFakePlugin(): string {
+  fs.writeFileSync(
+    fakePlugin,
+    `import { BaseClient } from "smoltalk";
+export class LlamaCPP extends BaseClient {}
+export async function resolveModel(target, dir) { return target; }
+`,
+  );
+  return fakePlugin;
+}
+
+afterEach(() => {
+  delete process.env.AGENCY_LLAMA_PROVIDER_MODULE;
+  smoltalkPkg.unregisterProvider("llama-cpp");
+  try {
+    fs.unlinkSync(fakePlugin);
+  } catch {
+    /* ignore */
+  }
+});
+
+describe("resolveLocalRunFlag", () => {
+  it("resolves through the plugin and pins the llama-cpp provider", async () => {
+    process.env.AGENCY_LLAMA_PROVIDER_MODULE = writeFakePlugin();
+    const flag = await resolveLocalRunFlag("./some-model.gguf");
+    expect(flag).toEqual({
+      model: path.resolve(process.cwd(), "./some-model.gguf"),
+      explicitProvider: "llama-cpp",
+    });
+    expect(smoltalkPkg.hasProvider("llama-cpp")).toBe(true);
+  });
+
+  it("absolutizes the resolved path (LlamaCPP rejects bare filenames)", async () => {
+    process.env.AGENCY_LLAMA_PROVIDER_MODULE = writeFakePlugin();
+    // A bare separator-less filename is what `--local model.gguf` arrives as.
+    const flag = await resolveLocalRunFlag("model.gguf");
+    expect(flag.model).toBe(path.resolve(process.cwd(), "model.gguf"));
+    expect(path.isAbsolute(flag.model)).toBe(true);
+    expect(flag.explicitProvider).toBe("llama-cpp");
+  });
+
+  it("propagates the install-hint error when support is missing", async () => {
+    // No override; rely on smoltalk-llama-cpp not being installed in CI.
+    // Skip on dev machines that have it resolvable.
+    if (hasLocalModelSupport()) return;
+    await expect(resolveLocalRunFlag("qwen3.5-0.8b")).rejects.toThrow(
+      /smoltalk-llama-cpp/,
+    );
+  });
+});

--- a/packages/agency-lang/lib/cli/localFlag.ts
+++ b/packages/agency-lang/lib/cli/localFlag.ts
@@ -1,0 +1,18 @@
+import * as path from "node:path";
+import type { ResolvedModelFlag } from "@/config.js";
+import { _registerLocalModel } from "@/stdlib/localModels.js";
+
+/** Turn `agency run --local <value>` into the shared model-flag shape:
+ *  resolve the name (curated / alias / hf: URI / .gguf path), download and
+ *  verify if needed (progress prints here, in the parent, before the program
+ *  starts), and pin the llama-cpp provider. Errors (package missing, unknown
+ *  name, failed download) carry user-ready messages from localModels.
+ *
+ *  The path is absolutized before it is baked into config: LlamaCPP rejects a
+ *  bare separator-less filename (ambiguous with a model name), which is what
+ *  a user-supplied `--local model.gguf` would otherwise arrive as, and an
+ *  absolute path also keeps the child process independent of cwd drift. */
+export async function resolveLocalRunFlag(value: string): Promise<ResolvedModelFlag> {
+  const modelPath = await _registerLocalModel(value);
+  return { model: path.resolve(modelPath), explicitProvider: "llama-cpp" };
+}

--- a/packages/agency-lang/lib/cli/runLocal.spawn.test.ts
+++ b/packages/agency-lang/lib/cli/runLocal.spawn.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import { execFile } from "child_process";
+import { promisify } from "util";
+import * as fs from "fs";
+import * as path from "path";
+import { existsSync, mkdtempSync, rmSync, realpathSync } from "fs";
+
+const execFileAsync = promisify(execFile);
+const CLI = path.resolve("dist/scripts/agency.js");
+
+// The temp dir must live INSIDE the package: the fake plugin does
+// `import { BaseClient } from "smoltalk"`, and Node resolves that bare
+// specifier by walking up from the plugin file — from the OS tmpdir there is
+// no node_modules with smoltalk. Same pattern as runPolicy.spawn.test.ts.
+function makeLocalDir(): string {
+  return mkdtempSync(path.join(process.cwd(), ".run-local-"));
+}
+
+// Only ever remove a direct `.run-local-*` child of the package dir.
+function rmLocal(dir: string): void {
+  const root = realpathSync(process.cwd());
+  const resolved = realpathSync(dir);
+  if (
+    path.dirname(resolved) === root &&
+    path.basename(resolved).startsWith(".run-local-")
+  ) {
+    rmSync(resolved, { recursive: true, force: true });
+  }
+}
+
+const FAKE = `import { BaseClient } from "smoltalk";
+export class LlamaCPP extends BaseClient {
+  async textSync() { return { success: true, value: { output: "local-model-reply", toolCalls: [] } }; }
+}
+export async function resolveModel(target, dir) { return target; }
+`;
+
+const PROGRAM = `node main(): string {
+  const reply: string = llm("say something")
+  print(reply)
+  return reply
+}
+`;
+
+// Requires the built CLI (`dist/scripts/agency.js`). `pnpm test:run` alone does
+// not build `dist`, so skip in a clean checkout rather than hard-fail; CI
+// builds (`make`) before running tests, so this suite runs there.
+describe.skipIf(!existsSync(CLI))("agency run --local (end-to-end)", () => {
+  it("routes the programs llm() call to the local provider", async () => {
+    // The chain this pins: the parent resolves ./model.gguf through the fake
+    // plugin's resolveModel, folds { model, explicitProvider: "llama-cpp" }
+    // into baked config, the child's bootstrap hook loads the fake from the
+    // inherited env var, and the program's llm() call lands on it. No
+    // network, no real model.
+    const dir = makeLocalDir();
+    try {
+      fs.writeFileSync(path.join(dir, "fake-plugin.mjs"), FAKE);
+      fs.writeFileSync(path.join(dir, "model.gguf"), "not a real model");
+      fs.writeFileSync(path.join(dir, "prog.agency"), PROGRAM);
+      const { stdout } = await execFileAsync(
+        process.execPath,
+        [CLI, "run", "--local", "./model.gguf", "prog.agency"],
+        {
+          cwd: dir,
+          timeout: 120_000,
+          env: {
+            ...process.env,
+            AGENCY_LLAMA_PROVIDER_MODULE: path.join(dir, "fake-plugin.mjs"),
+          },
+        },
+      );
+      expect(stdout).toContain("local-model-reply");
+    } finally {
+      rmLocal(dir);
+    }
+  }, 150_000);
+
+  it("rejects --local together with --model before doing any work (exit 2)", async () => {
+    const dir = makeLocalDir();
+    try {
+      fs.writeFileSync(path.join(dir, "prog.agency"), PROGRAM);
+      // No env override on purpose: the exclusion check must fire before the
+      // gate, the download, and compilation.
+      const r = await execFileAsync(
+        process.execPath,
+        [CLI, "run", "--local", "x.gguf", "--model", "gpt-4o-mini", "prog.agency"],
+        { cwd: dir, timeout: 60_000 },
+      ).then(
+        () => ({ code: 0, stderr: "" }),
+        (e: { code?: number; stderr?: string }) => ({
+          code: e.code ?? 1,
+          stderr: String(e.stderr ?? ""),
+        }),
+      );
+      expect(r.code).toBe(2);
+      expect(r.stderr).toContain("not both");
+    } finally {
+      rmLocal(dir);
+    }
+  }, 60_000);
+});

--- a/packages/agency-lang/lib/stdlib/localModelManifest.test.ts
+++ b/packages/agency-lang/lib/stdlib/localModelManifest.test.ts
@@ -59,4 +59,35 @@ describe("download manifest", () => {
       expect(fs.readdirSync(nested)).toEqual([MANIFEST_FILE]);
     });
   });
+
+  it("recordDownload never throws: a failed write warns instead of failing the download", () => {
+    withDir((dir) => {
+      // Make the "dir" a plain file so mkdirSync/writeFileSync fail.
+      const blocked = path.join(dir, "not-a-dir");
+      fs.writeFileSync(blocked, "occupied");
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        expect(() => recordDownload(blocked, "hf:a/b:Q", "b.gguf")).not.toThrow();
+        expect(warnSpy).toHaveBeenCalled();
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+  });
+
+  it("keys named like Object.prototype members are plain data (null-proto read)", () => {
+    withDir((dir) => {
+      // Raw string: in an object LITERAL `__proto__:` is prototype-setter
+      // syntax and would never reach the JSON.
+      fs.writeFileSync(
+        path.join(dir, MANIFEST_FILE),
+        '{"__proto__":"evil.gguf","toString":"t.gguf","normal":"n.gguf"}',
+      );
+      const manifest = readDownloadManifest(dir);
+      expect(manifest["toString"]).toBe("t.gguf");
+      expect(manifest["normal"]).toBe("n.gguf");
+      expect(manifest["__proto__"]).toBe("evil.gguf"); // own key, plain data
+      expect(({} as Record<string, unknown>)["__proto__"]).not.toBe("evil.gguf");
+    });
+  });
 });

--- a/packages/agency-lang/lib/stdlib/localModelManifest.test.ts
+++ b/packages/agency-lang/lib/stdlib/localModelManifest.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import {
+  readDownloadManifest,
+  recordDownload,
+  MANIFEST_FILE,
+} from "./localModelManifest.js";
+
+function withDir(fn: (dir: string) => void) {
+  const dir = mkdtempSync(path.join(tmpdir(), "manifest-"));
+  try {
+    fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe("download manifest", () => {
+  it("round-trips and upserts", () => {
+    withDir((dir) => {
+      expect(readDownloadManifest(dir)).toEqual({});
+      recordDownload(dir, "hf:org/repo:Q4_K_M", "repo.Q4_K_M.gguf");
+      recordDownload(dir, "hf:org/other:Q4_K_M", "other.Q4_K_M.gguf");
+      recordDownload(dir, "hf:org/repo:Q4_K_M", "repo2.gguf"); // upsert wins
+      expect(readDownloadManifest(dir)).toEqual({
+        "hf:org/repo:Q4_K_M": "repo2.gguf",
+        "hf:org/other:Q4_K_M": "other.Q4_K_M.gguf",
+      });
+    });
+  });
+
+  it("tolerates a corrupt manifest (display metadata only, never throws)", () => {
+    withDir((dir) => {
+      fs.writeFileSync(path.join(dir, MANIFEST_FILE), "{nope");
+      expect(readDownloadManifest(dir)).toEqual({});
+      recordDownload(dir, "hf:a/b:Q", "b.gguf"); // overwrites the corrupt file
+      expect(readDownloadManifest(dir)).toEqual({ "hf:a/b:Q": "b.gguf" });
+    });
+  });
+
+  it("drops non-string values instead of throwing", () => {
+    withDir((dir) => {
+      fs.writeFileSync(
+        path.join(dir, MANIFEST_FILE),
+        JSON.stringify({ good: "a.gguf", bad: 42, worse: { nested: true } }),
+      );
+      expect(readDownloadManifest(dir)).toEqual({ good: "a.gguf" });
+    });
+  });
+
+  it("recordDownload creates the dir if missing and leaves no temp file", () => {
+    withDir((dir) => {
+      const nested = path.join(dir, "models");
+      recordDownload(nested, "hf:a/b:Q", "b.gguf");
+      expect(readDownloadManifest(nested)).toEqual({ "hf:a/b:Q": "b.gguf" });
+      expect(fs.readdirSync(nested)).toEqual([MANIFEST_FILE]);
+    });
+  });
+});

--- a/packages/agency-lang/lib/stdlib/localModelManifest.ts
+++ b/packages/agency-lang/lib/stdlib/localModelManifest.ts
@@ -1,14 +1,18 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
+import * as crypto from "node:crypto";
 
 /** downloads.json in the models cache dir: resolved model URI → the .gguf
  *  basename node-llama-cpp stored it under. Written on successful (verified)
  *  download; read only by the `agency local list` view. Display metadata:
  *  resolution, downloading, and verification never consult it, so a missing
- *  or corrupt manifest can mislabel the list and nothing else. Writes go
- *  through a sibling temp file + rename so an interrupted write keeps the
- *  previous valid manifest; two agency processes downloading concurrently
- *  still race whole-file (last writer wins) — accepted for display metadata. */
+ *  or corrupt manifest can mislabel the list and nothing else — and for the
+ *  same reason `recordDownload` NEVER throws (a bookkeeping failure must not
+ *  turn a successful download into a failed command). Writes go through a
+ *  uniquely-named sibling temp file + rename: an interrupted write keeps the
+ *  previous valid manifest, and two concurrent downloaders cannot collide on
+ *  the temp file — they race whole-file on the rename (last writer wins),
+ *  accepted for display metadata. */
 export const MANIFEST_FILE = "downloads.json";
 
 export function readDownloadManifest(dir: string): Record<string, string> {
@@ -19,7 +23,10 @@ export function readDownloadManifest(dir: string): Record<string, string> {
     if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
       return {};
     }
-    const out: Record<string, string> = {};
+    // Null-prototype: on-disk JSON is untrusted, and keys like "__proto__" /
+    // "toString" must behave as plain data (same convention as smoltalk's
+    // provider registry).
+    const out: Record<string, string> = Object.create(null);
     for (const [k, v] of Object.entries(parsed)) {
       if (typeof v === "string") out[k] = v;
     }
@@ -30,10 +37,27 @@ export function readDownloadManifest(dir: string): Record<string, string> {
 }
 
 export function recordDownload(dir: string, uri: string, file: string): void {
-  fs.mkdirSync(dir, { recursive: true });
-  const next = { ...readDownloadManifest(dir), [uri]: file };
-  const target = path.join(dir, MANIFEST_FILE);
-  const tmp = `${target}.tmp`;
-  fs.writeFileSync(tmp, JSON.stringify(next, null, 2) + "\n");
-  fs.renameSync(tmp, target);
+  // Unique per writer: a fixed name would make two concurrent downloads race
+  // on the SAME temp file — the loser's rename throws ENOENT after its model
+  // downloaded fine.
+  const tmp = path.join(
+    dir,
+    `${MANIFEST_FILE}.${process.pid}-${crypto.randomBytes(4).toString("hex")}.tmp`,
+  );
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+    const next = { ...readDownloadManifest(dir), [uri]: file };
+    fs.writeFileSync(tmp, JSON.stringify(next, null, 2) + "\n");
+    fs.renameSync(tmp, path.join(dir, MANIFEST_FILE));
+  } catch (err) {
+    try {
+      fs.unlinkSync(tmp);
+    } catch {
+      /* never written, or already renamed */
+    }
+    console.warn(
+      `Could not record the download in ${MANIFEST_FILE} (the list view may not mark this model):`,
+      (err as Error).message,
+    );
+  }
 }

--- a/packages/agency-lang/lib/stdlib/localModelManifest.ts
+++ b/packages/agency-lang/lib/stdlib/localModelManifest.ts
@@ -1,0 +1,39 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+/** downloads.json in the models cache dir: resolved model URI → the .gguf
+ *  basename node-llama-cpp stored it under. Written on successful (verified)
+ *  download; read only by the `agency local list` view. Display metadata:
+ *  resolution, downloading, and verification never consult it, so a missing
+ *  or corrupt manifest can mislabel the list and nothing else. Writes go
+ *  through a sibling temp file + rename so an interrupted write keeps the
+ *  previous valid manifest; two agency processes downloading concurrently
+ *  still race whole-file (last writer wins) — accepted for display metadata. */
+export const MANIFEST_FILE = "downloads.json";
+
+export function readDownloadManifest(dir: string): Record<string, string> {
+  try {
+    const parsed: unknown = JSON.parse(
+      fs.readFileSync(path.join(dir, MANIFEST_FILE), "utf-8"),
+    );
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(parsed)) {
+      if (typeof v === "string") out[k] = v;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+export function recordDownload(dir: string, uri: string, file: string): void {
+  fs.mkdirSync(dir, { recursive: true });
+  const next = { ...readDownloadManifest(dir), [uri]: file };
+  const target = path.join(dir, MANIFEST_FILE);
+  const tmp = `${target}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify(next, null, 2) + "\n");
+  fs.renameSync(tmp, target);
+}

--- a/packages/agency-lang/lib/stdlib/localModels.test.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.test.ts
@@ -163,6 +163,7 @@ describe("support check", () => {
 // with the probe functions themselves.
 
 import { _registerLocalProvider, _downloadModel, _registerLocalModel } from "./localModels.js";
+import { readDownloadManifest } from "./localModelManifest.js";
 import * as smoltalkPkg from "smoltalk";
 
 describe("provider register + download (fake plugin module)", () => {
@@ -198,11 +199,12 @@ describe("provider register + download (fake plugin module)", () => {
     await _registerLocalProvider();
     expect(smoltalkPkg.getClient({ model: "m", provider: "llama-cpp" }).constructor.name).toBe("LlamaCPP");
   });
-  it("downloads (resolves) a uri to a real path", async () => {
+  it("downloads (resolves) a uri to a real path and records it in the manifest", async () => {
     process.env.AGENCY_LLAMA_PROVIDER_MODULE = fakeModule();
     const out = await _downloadModel("hf:org/repo:Q4", dir); // raw uri → no pin
     expect(out).toBe(path.join(dir, "model.gguf"));
     expect(fs.existsSync(out)).toBe(true);
+    expect(readDownloadManifest(dir)).toEqual({ "hf:org/repo:Q4": "model.gguf" });
   });
   it("registerLocalModel registers and returns the resolved path", async () => {
     process.env.AGENCY_LLAMA_PROVIDER_MODULE = fakeModule();

--- a/packages/agency-lang/lib/stdlib/localModels.test.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.test.ts
@@ -14,6 +14,8 @@ import {
   _localModelsSupported,
   resolveAliasConfigPath,
   formatModelCatalog,
+  formatLocalList,
+  type ModelNameEntry,
   resolveCatalogUrl,
   parseCatalog,
   _refreshCatalog,
@@ -258,6 +260,70 @@ describe("provider register + download (fake plugin module)", () => {
     } finally {
       process.chdir(cwd);
     }
+  });
+});
+
+describe("formatLocalList", () => {
+  const entries: ModelNameEntry[] = [
+    {
+      name: "tiny",
+      target: "hf:o/tiny:Q4",
+      source: "curated",
+      params: "135M",
+      sizeBytes: 100_000_000,
+      contextWindow: 8192,
+      license: "apache-2.0",
+    },
+    {
+      name: "mid",
+      target: "hf:o/mid:Q4",
+      source: "curated",
+      params: "2B",
+      sizeBytes: 1_200_000_000,
+      contextWindow: 131072,
+      license: "apache-2.0",
+    },
+  ];
+
+  it("marks manifest-and-file-backed entries as downloaded; first line names the dir", () => {
+    const out = formatLocalList({
+      dir: "/home/u/.agency-agent/models",
+      entries,
+      manifest: { "hf:o/tiny:Q4": "tiny.Q4.gguf" },
+      files: [{ name: "tiny.Q4.gguf", path: "/x/tiny.Q4.gguf", sizeBytes: 99_000_000 }],
+    });
+    const lines = out.split("\n");
+    expect(lines[0]).toBe("Models directory: /home/u/.agency-agent/models");
+    const tinyLine = lines.find((l) => l.includes("tiny"));
+    const midLine = lines.find((l) => l.includes("mid"));
+    expect(tinyLine).toContain("✓");
+    expect(midLine).not.toContain("✓");
+    expect(out).toContain("Total downloaded: 0.10 GB");
+    expect(out).not.toContain("OTHER FILES");
+  });
+
+  it("stale manifest entry (file gone) is not marked; unmatched files land in OTHER FILES", () => {
+    const out = formatLocalList({
+      dir: "/d",
+      entries,
+      manifest: { "hf:o/tiny:Q4": "gone.gguf" },
+      files: [{ name: "mystery.gguf", path: "/d/mystery.gguf", sizeBytes: 2_100_000_000 }],
+    });
+    expect(out.split("\n").find((l) => l.includes("tiny"))).not.toContain("✓");
+    expect(out).toContain("OTHER FILES");
+    expect(out).toContain("mystery.gguf");
+    expect(out).toContain("2.10 GB");
+  });
+
+  it("raw-URI downloads (in the manifest but not the catalog) stay visible in OTHER FILES", () => {
+    const out = formatLocalList({
+      dir: "/d",
+      entries,
+      manifest: { "hf:raw/repo:Q4": "raw.gguf" },
+      files: [{ name: "raw.gguf", path: "/d/raw.gguf", sizeBytes: 500_000_000 }],
+    });
+    expect(out).toContain("OTHER FILES");
+    expect(out).toContain("raw.gguf");
   });
 });
 

--- a/packages/agency-lang/lib/stdlib/localModels.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.ts
@@ -11,6 +11,7 @@ import {
   resolveSmoltalkLlamaCppEntry,
 } from "../runtime/localProvider.js";
 import { __ctx } from "../runtime/asyncContext.js";
+import { recordDownload } from "./localModelManifest.js";
 import { ttyColor } from "../utils/termcolors.js";
 
 /** What a model is FOR — a single axis, orthogonal to size (size is conveyed
@@ -197,6 +198,13 @@ export function defaultCacheDir(): string {
 /** Treat empty string as "caller wants the default cache dir". */
 function resolveCacheDir(cacheDir: string): string {
   return cacheDir === "" ? defaultCacheDir() : cacheDir;
+}
+
+/** The resolved models cache dir (AGENCY_MODELS_DIR env → agency.json
+ *  client.modelsDir → ~/.agency-agent/models). Exported so `agency local
+ *  list` can name where downloads land. */
+export function _modelsCacheDir(cacheDir: string = ""): string {
+  return resolveCacheDir(cacheDir);
 }
 
 function isGgufPath(v: string): boolean {
@@ -915,6 +923,9 @@ export async function _downloadModel(value: string, cacheDir: string = ""): Prom
   if (expected !== undefined && wasFresh(resolved)) {
     await verifyModelFile(resolved, expected, value);
   }
+  // Record-after-verify: an invalid-hash file throws above and is never
+  // written into the manifest.
+  recordDownload(dir, target, path.basename(resolved));
   return resolved;
 }
 

--- a/packages/agency-lang/lib/stdlib/localModels.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.ts
@@ -958,6 +958,70 @@ function colWidth(header: string, values: string[]): number {
   return Math.max(header.length, ...values.map((v) => v.length));
 }
 
+/** The `agency local list` view: every usable model (curated + aliases) with
+ *  a downloaded marker, then cache-dir files no catalog entry claims. A row
+ *  is "downloaded" when the manifest maps its target URI to a file that still
+ *  exists in the cache dir; its SIZE column then shows the on-disk size
+ *  rather than the catalog estimate. Compact and operational — `alias list`
+ *  keeps the verbose per-model catalog with descriptions. Returns the block
+ *  with no trailing newline (the caller's `console.log` adds exactly one). */
+export function formatLocalList(args: {
+  dir: string;
+  entries: ModelNameEntry[];
+  manifest: Record<string, string>;
+  files: { name: string; path: string; sizeBytes: number }[];
+}): string {
+  const byName = Object.fromEntries(args.files.map((f) => [f.name, f]));
+  const rows = args.entries.map((e) => {
+    const manifestFile = args.manifest[e.target];
+    const file = manifestFile === undefined ? undefined : byName[manifestFile];
+    return {
+      mark: file !== undefined ? "✓" : "",
+      name: e.name,
+      params: e.params ?? "",
+      size:
+        file !== undefined
+          ? formatGB(file.sizeBytes)
+          : e.sizeBytes !== undefined
+            ? formatGB(e.sizeBytes)
+            : "",
+      ctx: e.contextWindow !== undefined ? formatCtx(e.contextWindow) : "",
+      license: e.license ?? "",
+    };
+  });
+  // Only files claimed by a CATALOG row are excluded from OTHER FILES. The
+  // manifest also records raw-URI downloads, which have no row here — their
+  // files must stay visible.
+  const claimedFiles: string[] = args.entries
+    .map((e) => args.manifest[e.target])
+    .filter((f): f is string => f !== undefined);
+  const others = args.files.filter((f) => !claimedFiles.includes(f.name));
+  const headers = ["", "NAME", "PARAMS", "SIZE", "CONTEXT", "LICENSE"];
+  const cols = [
+    colWidth(headers[0], rows.map((r) => r.mark)),
+    colWidth(headers[1], rows.map((r) => r.name)),
+    colWidth(headers[2], rows.map((r) => r.params)),
+    colWidth(headers[3], rows.map((r) => r.size)),
+    colWidth(headers[4], rows.map((r) => r.ctx)),
+    colWidth(headers[5], rows.map((r) => r.license)),
+  ];
+  const render = (cells: string[]) =>
+    cells.map((c, i) => c.padEnd(cols[i])).join("  ").trimEnd();
+  const lines = [
+    `Models directory: ${args.dir}`,
+    "",
+    render(headers),
+    ...rows.map((r) => render([r.mark, r.name, r.params, r.size, r.ctx, r.license])),
+  ];
+  if (others.length > 0) {
+    lines.push("", "OTHER FILES");
+    for (const f of others) lines.push(`  ${f.name}  ${formatGB(f.sizeBytes)}`);
+  }
+  const total = args.files.reduce((sum, f) => sum + f.sizeBytes, 0);
+  lines.push("", `Total downloaded: ${formatGB(total)}`);
+  return lines.join("\n");
+}
+
 /** Render the usable-model list as an aligned table: a header row plus one
  *  fact row per curated model (params, category, size, context window,
  *  license), the description on a dimmed line below, a blank line between

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -1590,8 +1590,8 @@ export function createProgram(deps: CliDependencies = {}): Command {
 
   const localCmd = program.command("local").description("Manage and run local models");
   localCmd.command("list").description("List local models: the full catalog, with downloaded models marked").action(localList);
-  localCmd.command("download").description("Download a model (curated name, alias, or hf: URI)")
-    .argument("<value>").action(localDownload);
+  localCmd.command("download").description("Download a model (curated name, alias, or hf: URI); no argument opens a picker")
+    .argument("[value]").action(localDownload);
   localCmd.command("remove").description("Delete a downloaded model").argument("<name>")
     .action(localRemove);
   localCmd.command("resolve").description("Show what a name/alias resolves to").argument("<value>")

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -1589,7 +1589,7 @@ export function createProgram(deps: CliDependencies = {}): Command {
     );
 
   const localCmd = program.command("local").description("Manage and run local models");
-  localCmd.command("list").description("List downloaded models").action(localList);
+  localCmd.command("list").description("List local models: the full catalog, with downloaded models marked").action(localList);
   localCmd.command("download").description("Download a model (curated name, alias, or hf: URI)")
     .argument("<value>").action(localDownload);
   localCmd.command("remove").description("Delete a downloaded model").argument("<name>")

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -18,6 +18,7 @@ import {
 } from "@/cli/installLocation.js";
 import { pack } from "@/cli/pack.js";
 import { resolveModelFlag } from "@/cli/modelFlag.js";
+import { resolveLocalRunFlag } from "@/cli/localFlag.js";
 import { warnMisplacedAgencyFlags } from "@/cli/commandLine.js";
 import { runLink } from "@/cli/remote/commands/link.js";
 import { runDeploy } from "@/cli/remote/commands/deploy.js";
@@ -145,6 +146,7 @@ type RunOptions = Omit<CliFlags, "trace"> & {
   interactive?: boolean;
   maxCost?: string;
   maxTime?: string;
+  local?: string;
 };
 
 // commander option parsers. Match the WHOLE string against digits so
@@ -239,7 +241,24 @@ export function createProgram(deps: CliDependencies = {}): Command {
     return { config: getConfig(), configPath };
   }
 
-  function runWithOptions(input: string, options: RunOptions, nodeArgs: string[] = []) {
+  async function runWithOptions(input: string, options: RunOptions, nodeArgs: string[] = []) {
+    if (options.local !== undefined && options.model !== undefined) {
+      console.error(
+        "Error: Pass either --model (hosted) or --local (local), not both.",
+      );
+      process.exit(2);
+    }
+    if (options.local !== undefined) {
+      // Resolve + download in the parent, before compiling, so progress and
+      // SHA-256 verification happen in the terminal; the result rides the
+      // ordinary --model pathway (applyCliFlags) into baked config.
+      try {
+        options = { ...options, model: await resolveLocalRunFlag(options.local) };
+      } catch (e) {
+        console.error(`Error: ${(e as Error).message}`);
+        process.exit(1);
+      }
+    }
     // applyCliFlags takes one field: a path, or `true` for the default path.
     // The CLI splits that across two flags so neither swallows the filename.
     const config = applyCliFlags(
@@ -395,6 +414,10 @@ export function createProgram(deps: CliDependencies = {}): Command {
         (value: string) => resolveModelFlag(value),
       )
       .option(
+        "--local <model>",
+        "Run every LLM call on a local model: a curated name, an alias, an hf: URI, or a .gguf path (see: agency local list)",
+      )
+      .option(
         "--policy <name|path>",
         "Interrupt policy: a built-in (recommended|minimal|with-writes|approve-all) or a policy JSON file",
       )
@@ -434,7 +457,7 @@ export function createProgram(deps: CliDependencies = {}): Command {
         "Arguments after the filename go to the program; read them with std::args",
       ),
   ).action(
-    (input: string, nodeArgs: string[], options: RunOptions, command: Command) => {
+    async (input: string, nodeArgs: string[], options: RunOptions, command: Command) => {
       const warning = warnMisplacedAgencyFlags(command, input);
       if (warning !== undefined) console.warn(warning);
       if (
@@ -446,7 +469,7 @@ export function createProgram(deps: CliDependencies = {}): Command {
         // be; the diagnostic suggests near-miss command names.
         command.unknownFallbackOperand(input);
       }
-      runWithOptions(input, options, nodeArgs);
+      await runWithOptions(input, options, nodeArgs);
     },
   );
 
@@ -734,9 +757,9 @@ export function createProgram(deps: CliDependencies = {}): Command {
       "Output trace file path (default: <input>.trace)",
     )
     .option("--resume <statefile>", "Resume execution from a saved state file")
-    .action((input: string, options: { output?: string; resume?: string }) => {
+    .action(async (input: string, options: { output?: string; resume?: string }) => {
       const traceFile = options.output || input.replace(/\.agency$/, ".trace");
-      runWithOptions(input, { traceFile, resume: options.resume });
+      await runWithOptions(input, { traceFile, resume: options.resume });
     });
 
   traceCmd


### PR DESCRIPTION
## What this does

PR 2 of 2 from `packages/agency-lang/2026-08-11-run-local-flag-spec.md`, on top of the smoltalk loader seam (#841). Three user-facing pieces:

**`agency run --local <model>`** — pin a whole run to a local llama-cpp model. The value is a curated name, an alias, an `hf:` URI, or a `.gguf` path (the same domain as `agency local download`). `--local` with `--model` errors with exit 2 before any other work. The value is required, not optional: an optional-valued flag would swallow the input filename (`agency run --local foo.agency` would parse `foo.agency` as the model), the same commander behavior that split `--trace` in two. Resolution and download run in the parent CLI — progress and SHA-256 verification appear in the terminal before the program starts — and the result rides the existing `CliFlags.model` pathway (`{ model: <absolute path>, explicitProvider: "llama-cpp" }`), so `applyCliFlags` remains the single owner of flag→config meaning. The path is absolutized because the plugin rejects bare separator-less filenames. The child process gets the provider from baked config via the #841 bootstrap hook. Combines naturally with `--max-cost 0` (no paid spend, local only).

**`agency local download` with no argument opens a picker** — a `prompts` select over the catalog (name, params, size), with a trailing "custom" choice for an `hf:` URI or `.gguf` path. Non-TTY prints the catalog plus a `Pass a model:` hint and exits 1; cancel exits 0 without downloading.

**`agency local list` becomes the catalog view** — first line names the resolved models directory (env → `agency.json` → default), every catalog entry shows with a `✓` marker and on-disk size when downloaded, and files no catalog row claims (raw-URI or pre-manifest downloads) stay visible under `OTHER FILES` with the total. The command is now **ungated**: browsing what is available requires no provider package (`download`/`remove` keep their gates).

## The downloads manifest

Catalog names map to `hf:org/repo:quant` URIs, but node-llama-cpp picks the final `.gguf` filename, so "is this entry downloaded" is not derivable after the fact. `_downloadModel` now records `{ resolved URI → basename }` in a `downloads.json` in the models cache dir, after verification succeeds (an invalid-hash file is never recorded), via temp-file + rename so an interrupted write keeps the previous valid manifest. It is display metadata only — resolution, downloading, and verification never read it, so a corrupt/deleted manifest can mislabel the list view and nothing else. Models downloaded before the manifest existed show under `OTHER FILES` until re-downloaded (cosmetic only).

## Testing

- `lib/cli/runLocal.spawn.test.ts` (new): end-to-end `agency run --local` through the built CLI with a fake plugin — parent resolves + absolutizes, config bakes, child bootstrap loads the fake from the inherited env override, and the program's `llm()` call lands on it; plus the `--local`+`--model` exit-2 contract. No network, no real model.
- `lib/cli/localFlag.test.ts` (new): resolution + absolutization + the install-hint propagation.
- `lib/stdlib/localModelManifest.test.ts` (new): round-trip/upsert, corrupt-manifest tolerance, non-string dropping, dir creation, no leftover temp file.
- `lib/stdlib/localModels.test.ts`: `formatLocalList` (markers, stale-manifest entries, raw-URI visibility in OTHER FILES) and manifest recording in the download flow.
- `lib/cli/local.test.ts`: ungated `runList` regression (the old code exited 1 without the package), `downloadChoices` labels, and the non-TTY download contract (catalog + hint + exit 1).
- Verified live on this machine: the new `list` shows the models directory, the full catalog, and three pre-manifest `.gguf` files under `OTHER FILES`; non-TTY `download` exits 1.
- `tsc --noEmit`, `lib/sourceIsText.test.ts`, and `pnpm run lint:structure` all clean; full `make` build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
