### PR TITLE
Local LLMs: reject aborted text() calls, drop stray buffered Enter in input()

### DIFF
--- a/packages/agency-lang/lib/runtime/llmClient.textAbort.test.ts
+++ b/packages/agency-lang/lib/runtime/llmClient.textAbort.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { AgencyCancelledError } from "./errors.js";
+
+// Mock only smoltalk's text entry point; keep every other real export
+// (SmolError classes etc.) so the rest of SmoltalkClient is unaffected.
+vi.mock("smoltalk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("smoltalk")>();
+  return { ...actual, text: vi.fn() };
+});
+
+import * as smoltalk from "smoltalk";
+import { SmoltalkClient } from "./llmClient.js";
+
+const client = new SmoltalkClient();
+
+function configWith(signal: AbortSignal) {
+  return { messages: [{ role: "user", content: "hi" }], abortSignal: signal } as any;
+}
+
+beforeEach(() => {
+  vi.mocked(smoltalk.text).mockReset();
+});
+
+describe("SmoltalkClient.text — cancellation rejects", () => {
+  it("converts an aborted failure Result into a rejection carrying signal.reason", async () => {
+    const controller = new AbortController();
+    const reason = new AgencyCancelledError("call timeout");
+    // smoltalk resolves its distinguishable abort failure (never throws).
+    vi.mocked(smoltalk.text).mockImplementation((async () => {
+      controller.abort(reason);
+      return { success: false, error: "Request was aborted" };
+    }) as any);
+    await expect(client.text(configWith(controller.signal))).rejects.toBe(reason);
+  });
+
+  it("converts an aborted EMPTY success into a rejection (local stopOnAbortSignal shape)", async () => {
+    // smoltalk-llama-cpp sets stopOnAbortSignal, so an aborted generation
+    // RESOLVES as success with output null (everything was in an unterminated
+    // think segment) — that must surface as a cancellation, not a success.
+    const controller = new AbortController();
+    const reason = new AgencyCancelledError("call timeout");
+    vi.mocked(smoltalk.text).mockImplementation((async () => {
+      controller.abort(reason);
+      return {
+        success: true,
+        value: { output: null, toolCalls: [], usage: { totalTokens: 169301 } },
+      };
+    }) as any);
+    await expect(client.text(configWith(controller.signal))).rejects.toBe(reason);
+  });
+
+  it("keeps a success WITH content that raced ahead of a late abort", async () => {
+    const controller = new AbortController();
+    vi.mocked(smoltalk.text).mockImplementation((async () => {
+      const result = { success: true, value: { output: "done", toolCalls: [] } };
+      controller.abort(new AgencyCancelledError("late"));
+      return result;
+    }) as any);
+    const r = await client.text(configWith(controller.signal));
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.value.output).toBe("done");
+  });
+
+  it("keeps an aborted success that carries tool calls (content, not an empty shell)", async () => {
+    const controller = new AbortController();
+    vi.mocked(smoltalk.text).mockImplementation((async () => {
+      const result = {
+        success: true,
+        value: {
+          output: null,
+          toolCalls: [{ id: "1", name: "getWeather", arguments: "{}" }],
+        },
+      };
+      controller.abort(new AgencyCancelledError("late"));
+      return result;
+    }) as any);
+    const r = await client.text(configWith(controller.signal));
+    expect(r.success).toBe(true);
+  });
+
+  it("passes a NON-abort failure Result through unchanged (does not throw)", async () => {
+    vi.mocked(smoltalk.text).mockResolvedValue({
+      success: false,
+      error: "no api key",
+    } as any);
+    const r = await client.text(configWith(new AbortController().signal));
+    expect(r.success).toBe(false);
+    if (!r.success) expect(r.error).toBe("no api key");
+  });
+
+  it("rejects with a NON-Error abort reason unchanged (identity preserved)", async () => {
+    const controller = new AbortController();
+    const reason = { kind: "sentinel-object-reason" };
+    vi.mocked(smoltalk.text).mockImplementation((async () => {
+      controller.abort(reason);
+      return { success: false, error: "Request was aborted" };
+    }) as any);
+    await expect(client.text(configWith(controller.signal))).rejects.toBe(reason);
+  });
+});
+
+describe("SmoltalkClient.textStream — cancellation rejects", () => {
+  async function drain(gen: AsyncGenerator<any>) {
+    const chunks: any[] = [];
+    for await (const chunk of gen) chunks.push(chunk);
+    return chunks;
+  }
+
+  it("throws signal.reason instead of yielding an aborted empty done chunk", async () => {
+    const controller = new AbortController();
+    const reason = new AgencyCancelledError("call timeout");
+    vi.mocked(smoltalk.text).mockImplementation((function* () {
+      controller.abort(reason);
+      yield { type: "done", result: { output: null, toolCalls: [] } };
+    }) as any);
+    await expect(drain(client.textStream(configWith(controller.signal)))).rejects.toBe(
+      reason,
+    );
+  });
+
+  it("throws signal.reason instead of yielding an aborted error chunk", async () => {
+    const controller = new AbortController();
+    const reason = new AgencyCancelledError("call timeout");
+    vi.mocked(smoltalk.text).mockImplementation((function* () {
+      controller.abort(reason);
+      yield { type: "error", error: "Request was aborted" };
+    }) as any);
+    await expect(drain(client.textStream(configWith(controller.signal)))).rejects.toBe(
+      reason,
+    );
+  });
+
+  it("passes a normal stream through unchanged", async () => {
+    vi.mocked(smoltalk.text).mockImplementation((function* () {
+      yield { type: "text", text: "hel" };
+      yield { type: "text", text: "lo" };
+      yield { type: "done", result: { output: "hello", toolCalls: [] } };
+    }) as any);
+    const chunks = await drain(client.textStream(configWith(new AbortController().signal)));
+    expect(chunks.map((c) => c.type)).toEqual(["text", "text", "done"]);
+  });
+
+  it("keeps an aborted done chunk that carries real output (late abort race)", async () => {
+    const controller = new AbortController();
+    vi.mocked(smoltalk.text).mockImplementation((function* () {
+      controller.abort(new AgencyCancelledError("late"));
+      yield { type: "text", text: "partial" };
+      yield { type: "done", result: { output: "partial", toolCalls: [] } };
+    }) as any);
+    const chunks = await drain(client.textStream(configWith(controller.signal)));
+    expect(chunks.at(-1).type).toBe("done");
+    expect(chunks.at(-1).result.output).toBe("partial");
+  });
+});

--- a/packages/agency-lang/lib/runtime/llmClient.textAbort.test.ts
+++ b/packages/agency-lang/lib/runtime/llmClient.textAbort.test.ts
@@ -78,6 +78,27 @@ describe("SmoltalkClient.text — cancellation rejects", () => {
     expect(r.success).toBe(true);
   });
 
+  it("keeps an aborted success that carries only hosted tool results", async () => {
+    // Hosted tools (e.g. web_search) run provider-side; their results can be
+    // the only content on an otherwise output-less completion. That is real,
+    // paid-for content — not an empty shell to discard as a cancellation.
+    const controller = new AbortController();
+    vi.mocked(smoltalk.text).mockImplementation((async () => {
+      const result = {
+        success: true,
+        value: {
+          output: null,
+          toolCalls: [],
+          hostedToolResults: [{ type: "web_search", queries: ["q"] }],
+        },
+      };
+      controller.abort(new AgencyCancelledError("late"));
+      return result;
+    }) as any);
+    const r = await client.text(configWith(controller.signal));
+    expect(r.success).toBe(true);
+  });
+
   it("passes a NON-abort failure Result through unchanged (does not throw)", async () => {
     vi.mocked(smoltalk.text).mockResolvedValue({
       success: false,

--- a/packages/agency-lang/lib/runtime/llmClient.ts
+++ b/packages/agency-lang/lib/runtime/llmClient.ts
@@ -193,12 +193,44 @@ export type LLMClient = {
 };
 
 export class SmoltalkClient implements LLMClient {
+  // Cancellation on the text paths follows the same contract as transcribe/
+  // speak below: an aborted call REJECTS with the branch reason, so the retry
+  // classifier sees the runtime's abort cause (e.g. callTimeout → retryable)
+  // instead of a resolved failure/success it would record as a completion.
+  //
+  // Two aborted shapes must convert, detected by our OWN signal:
+  //  - a resolved failure (smoltalk's `failure("Request was aborted")`);
+  //  - a resolved success carrying NO content — smoltalk-llama-cpp sets
+  //    `stopOnAbortSignal`, so node-llama-cpp resolves an aborted generation
+  //    with the partial response, and a response that never left its thinking
+  //    segment drains to `output: null`. Recording that as a success writes a
+  //    null assistant turn into thread history and defeats the timeout retry.
+  // A success that carries real output or tool calls keeps its success + cost
+  // even when the signal aborted a tick later (the late-abort race).
   async text(config: PromptConfig): Promise<Result<PromptResult>> {
-    return smoltalk.text({ ...toSmolConfig(config), stream: false });
+    const result = await smoltalk.text({ ...toSmolConfig(config), stream: false });
+    if (!result.success || isEmptyPromptResult(result.value)) {
+      rejectIfAborted(config.abortSignal);
+    }
+    return result;
   }
 
   async *textStream(config: PromptConfig): AsyncGenerator<StreamChunk> {
-    yield* smoltalk.text({ ...toSmolConfig(config), stream: true });
+    for await (const chunk of smoltalk.text({
+      ...toSmolConfig(config),
+      stream: true,
+    })) {
+      // Same policy as text(): an error chunk or an empty final result on an
+      // aborted call surfaces as the cancellation, not as a normal chunk.
+      if (
+        chunk.type === "error" ||
+        chunk.type === "timeout" ||
+        (chunk.type === "done" && isEmptyPromptResult(chunk.result))
+      ) {
+        rejectIfAborted(config.abortSignal);
+      }
+      yield chunk;
+    }
   }
 
   async embed(
@@ -301,14 +333,21 @@ export class SmoltalkClient implements LLMClient {
 
 }
 
+/** True when an LLM result carries nothing a caller could use — no visible
+ *  output and no tool calls. Only consulted when deciding whether an aborted
+ *  call's resolved "success" is really a cancellation (see text/textStream). */
+function isEmptyPromptResult(result: PromptResult): boolean {
+  return !result.output && (result.toolCalls?.length ?? 0) === 0;
+}
+
 /** If the branch signal has aborted, throw its reason UNCHANGED so cancellation
  *  surfaces as the runtime's abort cause rather than smoltalk's resolved
  *  `failure("Request was aborted")`. Identity is preserved — `abort()` accepts
  *  strings/objects/null and that can matter to race/cancellation handling — and
  *  a reason is synthesized ONLY when genuinely `undefined` (an explicit `null`
  *  is a valid reason and is preserved). See the adapters. */
-function rejectIfAborted(signal: AbortSignal): void {
-  if (signal.aborted) {
+function rejectIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) {
     if (signal.reason !== undefined) {
       throw signal.reason;
     }

--- a/packages/agency-lang/lib/runtime/llmClient.ts
+++ b/packages/agency-lang/lib/runtime/llmClient.ts
@@ -334,10 +334,15 @@ export class SmoltalkClient implements LLMClient {
 }
 
 /** True when an LLM result carries nothing a caller could use — no visible
- *  output and no tool calls. Only consulted when deciding whether an aborted
- *  call's resolved "success" is really a cancellation (see text/textStream). */
+ *  output, no tool calls, and no hosted-tool results. Only consulted when
+ *  deciding whether an aborted call's resolved "success" is really a
+ *  cancellation (see text/textStream). */
 function isEmptyPromptResult(result: PromptResult): boolean {
-  return !result.output && (result.toolCalls?.length ?? 0) === 0;
+  return (
+    !result.output &&
+    (result.toolCalls?.length ?? 0) === 0 &&
+    (result.hostedToolResults?.length ?? 0) === 0
+  );
 }
 
 /** If the branch signal has aborted, throw its reason UNCHANGED so cancellation

--- a/packages/agency-lang/lib/stdlib/builtins.input.test.ts
+++ b/packages/agency-lang/lib/stdlib/builtins.input.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { PassThrough } from "node:stream";
+import { __internal_input } from "./builtins.js";
+
+// inputImpl reads process.stdin/stdout at call time, so tests swap in a
+// PassThrough pair for the duration of each test. `isTTY` is set per-test:
+// the buffered-blank-line filter must only ever run on interactive stdin.
+type FakeStream = PassThrough & { isTTY?: boolean };
+
+let fakeStdin: FakeStream;
+let fakeStdout: FakeStream;
+const realStdin = Object.getOwnPropertyDescriptor(process, "stdin");
+const realStdout = Object.getOwnPropertyDescriptor(process, "stdout");
+
+function swapStd(name: "stdin" | "stdout", stream: FakeStream) {
+  Object.defineProperty(process, name, { value: stream, configurable: true });
+}
+
+function restoreStd() {
+  if (realStdin) Object.defineProperty(process, "stdin", realStdin);
+  if (realStdout) Object.defineProperty(process, "stdout", realStdout);
+}
+
+/** Minimal ctx/stack: no guards, no override, a never-aborting signal. */
+function makeCtxStack() {
+  const controller = new AbortController();
+  const ctx = {
+    inputOverride: undefined,
+    getAbortSignal: () => controller.signal,
+  } as any;
+  const stack = { guards: [] } as any;
+  return { ctx, stack };
+}
+
+function callInput(prompt = "> "): Promise<string> {
+  const { ctx, stack } = makeCtxStack();
+  return __internal_input(ctx, stack, undefined as any, prompt);
+}
+
+beforeEach(() => {
+  fakeStdin = new PassThrough();
+  fakeStdout = new PassThrough();
+  fakeStdout.resume(); // discard prompt echoes so the sink never backpressures
+  swapStd("stdin", fakeStdin);
+  swapStd("stdout", fakeStdout);
+});
+
+afterEach(() => {
+  restoreStd();
+});
+
+describe("input() and buffered lines", () => {
+  it("skips a blank line buffered before the prompt and returns the next real line (TTY)", async () => {
+    fakeStdin.isTTY = true;
+    // Both lines were typed while the program was busy (e.g. during a slow
+    // LLM call): a liveness Enter, then the real message.
+    fakeStdin.write("\nhello\n");
+    await expect(callInput()).resolves.toBe("hello");
+  });
+
+  it("skips several buffered blank lines in a row (TTY)", async () => {
+    fakeStdin.isTTY = true;
+    fakeStdin.write("\n\n\nhello\n");
+    await expect(callInput()).resolves.toBe("hello");
+  });
+
+  it("accepts a deliberate blank line typed after the prompt is visible (TTY)", async () => {
+    fakeStdin.isTTY = true;
+    const pending = callInput();
+    // A human pressing Enter at a visible prompt: arrives well after the
+    // prompt attached, so it is a real (empty) answer, not buffered residue.
+    setTimeout(() => fakeStdin.write("\n"), 80);
+    await expect(pending).resolves.toBe("");
+  });
+
+  it("keeps a blank line from piped, non-TTY stdin (scripts are never filtered)", async () => {
+    fakeStdin.write("\n");
+    await expect(callInput()).resolves.toBe("");
+  });
+
+  it("keeps a buffered non-empty line (type-ahead is preserved) (TTY)", async () => {
+    fakeStdin.isTTY = true;
+    fakeStdin.write("typed ahead\n");
+    await expect(callInput()).resolves.toBe("typed ahead");
+  });
+});

--- a/packages/agency-lang/lib/stdlib/builtins.ts
+++ b/packages/agency-lang/lib/stdlib/builtins.ts
@@ -105,13 +105,39 @@ function inputImpl(
       reject(new AgencyCancelledError("input cancelled"));
     };
     signal.addEventListener("abort", onAbort, { once: true });
-    rl.question(prompt, (answer: string) => {
-      signal.removeEventListener("abort", onAbort);
-      rl.close();
-      resolve(answer);
-    });
+    const ask = () => {
+      const askedAt = Date.now();
+      rl.question(prompt, (answer: string) => {
+        // A blank line that lands faster than a human could react to the
+        // prompt was buffered while the program was busy — an Enter pressed
+        // to check on a slow run, not an answer — and would otherwise become
+        // an accidental (empty) submission. Discard it and re-ask; the next
+        // buffered line (real type-ahead) is delivered normally. Deliberate
+        // blank answers arrive after human-scale delay and are kept. Only
+        // interactive stdin is filtered: piped input legitimately arrives
+        // instantly. Real wall clock on purpose — this measures I/O latency,
+        // and fake-clock tests use inputOverride, never this path.
+        if (
+          answer === "" &&
+          process.stdin.isTTY &&
+          Date.now() - askedAt < BUFFERED_BLANK_LINE_MS
+        ) {
+          ask();
+          return;
+        }
+        signal.removeEventListener("abort", onAbort);
+        rl.close();
+        resolve(answer);
+      });
+    };
+    ask();
   }).finally(resumeGuards);
 }
+
+/** A blank line answered within this window of the prompt attaching cannot be
+ *  a human reacting to the prompt (buffered lines arrive in ~1ms; human
+ *  reaction to a newly-visible prompt is 150ms+). */
+const BUFFERED_BLANK_LINE_MS = 25;
 
 /** Deprecated context-injected wrapper kept in place during the ALS
  *  migration so the registry/codegen path keeps working until the


### PR DESCRIPTION
## The incident

A two-turn conversation with a local Qwen3.5-4B model took 100 minutes to answer its second message, then "succeeded" with nothing. The logs told the real story:

| Call | Sent | Output tokens | Time | Result |
|---|---|---|---|---|
| 1 | story request | 6,636 (~6,500 hidden thinking) | 166 s | story |
| 2 | **an empty user message** | 169,119 | 6,000 s (the per-call timeout) | `output: null`, recorded as success |
| 3 | the user's real second message | 1,380 | 29 s | fine |

Two runtime bugs chained together:

1. **The empty message came from `input()`.** An Enter pressed during the silent 166-second first call sat in the terminal's line buffer and was consumed instantly as the next answer (call 2 started 8 ms after call 1 finished). The empty user turn sent the thinking model into an unbounded `<think>` spiral — reproduced directly: it rambles about the "ambiguous prompt structure" and never closes the block — until the 100-minute per-attempt timeout fired.

2. **The timeout was then swallowed.** smoltalk-llama-cpp sets `stopOnAbortSignal`, so node-llama-cpp *resolves* an aborted generation with the partial response. Everything was inside an unterminated think segment, so it drained to `success(output: null)`. The retry classifier never saw an error: no retry (despite `callTimeout` being classified retryable), no Failure, and a literal `assistant: null` written into thread history.

## The fixes

**`SmoltalkClient.text()` / `textStream()` now reject on abort** (`lib/runtime/llmClient.ts`), following the same cancellation contract `transcribe()`/`speak()` already document: when the branch signal has aborted, a resolved failure — or a resolved success carrying no output and no tool calls (exactly the `stopOnAbortSignal` shape) — throws the signal's reason. A timed-out call now enters the retry loop as the retryable timeout it was always meant to be, and surfaces as a real Failure when retries exhaust. A success with real content still survives a late abort race, matching the audio adapters.

**`input()` discards stray buffered blank lines** (`lib/stdlib/builtins.ts`). A blank line arriving within 25 ms of the prompt attaching cannot be a human reacting to the prompt — it's a buffered Enter pressed while the program was busy. It is discarded and the prompt re-asks. Deliberately narrow: non-empty type-ahead is preserved, a deliberate Enter at a visible prompt still returns `""`, and piped/non-TTY stdin is never filtered.

## Testing

Both fixes were written test-first: 10 new tests in `llmClient.textAbort.test.ts` (abort→reject shapes, late-abort races, non-abort pass-through, identity preservation of abort reasons) and 5 in `builtins.input.test.ts` (buffered blanks skipped, deliberate blanks kept, type-ahead kept, non-TTY untouched), each watched failing before implementation. `pnpm typecheck`, `pnpm lint:structure`, `make`, and the full `lib/runtime` + `lib/stdlib` unit sweep (3,465 tests) are green.

## Follow-ups (separate package)

The provider-side hardening lives in smoltalk-llama-cpp and is not part of this PR: return a failure (not success) on abort, a default `maxTokens` cap, a context-size cap, and not force-opening `<think>` when a JSON grammar is attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
