### PR TITLE
Local models: refresh the catalog, add `local list -l`, fix the config schema that rejected refreshed aliases

### DIFF
--- a/packages/agency-lang/data/model-catalog.json
+++ b/packages/agency-lang/data/model-catalog.json
@@ -41,6 +41,16 @@
       "description": "Strong multilingual small general workhorse from Alibaba.",
       "sha256": "00fe7986ff5f6b463e62455821146049db6f9313603938a70800d1fb69ef11a4"
     },
+    "gemma-4-e2b": {
+      "uri": "hf:unsloth/gemma-4-E2B-it-GGUF:Q4_K_M",
+      "params": "2B (E2B)",
+      "sizeBytes": 3110000000,
+      "category": "general",
+      "contextWindow": 131072,
+      "license": "apache-2.0",
+      "description": "Smallest Gemma 4; ~3 GB multimodal model for phones and thin laptops.",
+      "sha256": "740185b21d22ceb83a11c3aa62ad5842ef32c70f6096d756bbee85a1e4ec34b8"
+    },
     "gemma-4-e4b": {
       "uri": "hf:unsloth/gemma-4-E4B-it-GGUF:Q4_K_M",
       "params": "4B (E4B)",
@@ -49,7 +59,17 @@
       "contextWindow": 131072,
       "license": "apache-2.0",
       "description": "Google's compact Gemma 4 (4.5B effective); ~5 GB, laptop-friendly multimodal model.",
-      "sha256": "519b9793ed6ce0ff530f1b7c96e848e08e49e7af4d57bb97f76215963a54146d"
+      "sha256": "85a896a047553e842f25297ee5b031d64ff30147d9c4af17b1e4b394cd1fab87"
+    },
+    "granite-4.1-8b": {
+      "uri": "hf:unsloth/granite-4.1-8b-GGUF:Q4_K_M",
+      "params": "8B",
+      "sizeBytes": 5350000000,
+      "category": "general",
+      "contextWindow": 131072,
+      "license": "apache-2.0",
+      "description": "IBM's enterprise-tuned 8B; built for retrieval, tool use, and long documents.",
+      "sha256": "0f45c1af986e9900bb3b6ba46a25937e1bb80426935bc242d88c9ca90e9f5c88"
     },
     "qwen3.5-9b": {
       "uri": "hf:unsloth/Qwen3.5-9B-GGUF:Q4_K_M",
@@ -69,7 +89,7 @@
       "contextWindow": 262144,
       "license": "apache-2.0",
       "description": "Google's mid-size Gemma 4 dense model; strong multilingual multimodal use, 256K context.",
-      "sha256": "43fec98c5102b1c446b4ddd0a9439f1db3a2e1f2e0b8cd143ce1ea619a9403d6"
+      "sha256": "0a270ec9fe6b34f4a0d33992b6135117b484ebc4766ab76b51d4ae8c457e4c42"
     },
     "gpt-oss-20b": {
       "uri": "hf:unsloth/gpt-oss-20b-GGUF:Q4_K_M",
@@ -91,6 +111,26 @@
       "description": "Mistral's general 24B base model (also Devstral's foundation); broad utility.",
       "sha256": "6d670773c3908584349d41a5048d1472226b593c881fd394e8ac196c802e81e2"
     },
+    "mistral-small-3.2": {
+      "uri": "hf:unsloth/Mistral-Small-3.2-24B-Instruct-2506-GGUF:Q4_K_M",
+      "params": "24B",
+      "sizeBytes": 14333000000,
+      "category": "general",
+      "contextWindow": 131072,
+      "license": "apache-2.0",
+      "description": "Drop-in upgrade over 3.1: better instruction following, far fewer runaway generations.",
+      "sha256": "a3cc56310807ed0d145eaf9f018ccda9ae7ad8edb41ec870aa2454b0d4700b3c"
+    },
+    "dolphin-3.0-mistral-24b": {
+      "uri": "hf:bartowski/cognitivecomputations_Dolphin3.0-Mistral-24B-GGUF:Q4_K_M",
+      "params": "24B",
+      "sizeBytes": 14333000000,
+      "category": "general",
+      "contextWindow": 32768,
+      "license": "apache-2.0",
+      "description": "Steerable Mistral-24B fine-tune with no built-in refusals; you own the system prompt.",
+      "sha256": "6f193bbf98628140194df257c7466e2c6f80a7ef70a6ebae26c53b2f2ef21994"
+    },
     "qwen3.5-27b": {
       "uri": "hf:unsloth/Qwen3.5-27B-GGUF:Q4_K_M",
       "params": "27B",
@@ -109,7 +149,7 @@
       "contextWindow": 262144,
       "license": "apache-2.0",
       "description": "Google's Gemma 4 MoE (3.8B active); fast yet capable multimodal model, 256K context.",
-      "sha256": "34c746b1d50ab813e29cd46c4796e3f43c741901a582f93a67b55b9fc9687b35"
+      "sha256": "f2c28b3dc4776931ac6f879e11f203dec637ea0f14267a86ec8f6165f63f293f"
     },
     "gemma-4-31b": {
       "uri": "hf:unsloth/gemma-4-31B-it-GGUF:Q4_K_M",
@@ -119,7 +159,17 @@
       "contextWindow": 262144,
       "license": "apache-2.0",
       "description": "Largest dense Gemma 4; top Gemma quality for high-RAM workstations, 256K context.",
-      "sha256": "9fdf3dc8b0384830b4402d151388c140bd8eb2abf8d60588d8224231198254a1"
+      "sha256": "38bd64c852c4b460434cc7162fa9bdcf242faf86502581a754cb72956bb17f84"
+    },
+    "qwen3.5-35b-a3b": {
+      "uri": "hf:unsloth/Qwen3.5-35B-A3B-GGUF:Q4_K_M",
+      "params": "35B (A3B)",
+      "sizeBytes": 22016000000,
+      "category": "general",
+      "contextWindow": 262144,
+      "license": "apache-2.0",
+      "description": "Qwen's general MoE (3B active); 27B-class quality at 9B speed, needs ~32 GB RAM.",
+      "sha256": "3b46d1066bc91cc2d613e3bc22ce691dd77e6f0d33c9060690d24ce6de494375"
     },
     "deepseek-r1-distill-llama-8b": {
       "uri": "hf:unsloth/DeepSeek-R1-Distill-Llama-8B-GGUF:Q4_K_M",
@@ -131,6 +181,16 @@
       "description": "Chain-of-thought distill into Llama-8B; best small reasoning model.",
       "sha256": "0addb1339a82385bcd973186cd80d18dcc71885d45eabd899781a118d03827d9"
     },
+    "deepseek-r1-0528-qwen3-8b": {
+      "uri": "hf:unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF:Q4_K_M",
+      "params": "8B",
+      "sizeBytes": 5030000000,
+      "category": "reasoning",
+      "contextWindow": 131072,
+      "license": "mit",
+      "description": "DeepSeek's newer R1 distill onto Qwen3-8B; supersedes the Llama-8B distill.",
+      "sha256": "a86349a4180c4e6bb43f874c29c404fa2be3f90b15509bd6d86f697dba724ec1"
+    },
     "phi-4-reasoning": {
       "uri": "hf:unsloth/Phi-4-reasoning-GGUF:Q4_K_M",
       "params": "14B",
@@ -141,6 +201,16 @@
       "description": "Microsoft's reasoning-tuned 14B; competitive with much larger models on math/logic.",
       "sha256": "960d3870b218f91116c55bf81dc313e6cdbce31b1047bb2bc8bc7ea47899b032"
     },
+    "magistral-small-2509": {
+      "uri": "hf:unsloth/Magistral-Small-2509-GGUF:Q4_K_M",
+      "params": "24B",
+      "sizeBytes": 14333000000,
+      "category": "reasoning",
+      "contextWindow": 131072,
+      "license": "apache-2.0",
+      "description": "Mistral's reasoning model; the strongest chain-of-thought that still fits ~16 GB.",
+      "sha256": "6d3e5f2a83ed9d64bd3382fb03be2f6e0bc7596a9de16e107bf22f959891945b"
+    },
     "devstral-small-2507": {
       "uri": "hf:mistralai/Devstral-Small-2507_gguf:Q4_K_M",
       "params": "24B",
@@ -150,6 +220,16 @@
       "license": "apache-2.0",
       "description": "Mistral's official coding-agent GGUF; #1 open-source on SWE-Bench at release.",
       "sha256": "1bcc2b1b7b7ea3168ba2dbe782432c464f2240598bd193930122c41b117c1796"
+    },
+    "devstral-small-2-24b": {
+      "uri": "hf:unsloth/Devstral-Small-2-24B-Instruct-2512-GGUF:Q4_K_M",
+      "params": "24B",
+      "sizeBytes": 14334000000,
+      "category": "coding",
+      "contextWindow": 393216,
+      "license": "apache-2.0",
+      "description": "Mistral's current coding agent; supersedes 2507 and reads 384K tokens at once.",
+      "sha256": "d14ba9edee1bb4c4996a726deb81e49ae81800a3216f0774634238c380aee496"
     },
     "qwen3-coder-30b-a3b": {
       "uri": "hf:unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF:Q4_K_M",

--- a/packages/agency-lang/data/model-catalog.json
+++ b/packages/agency-lang/data/model-catalog.json
@@ -8,7 +8,7 @@
       "category": "general",
       "contextWindow": 8192,
       "license": "apache-2.0",
-      "description": "Smallest practical chat model; used by our integration tests, runs anywhere.",
+      "description": "Smallest practical chat model. Used by the Agency integration tests, runs anywhere.",
       "sha256": "ed5fa30c487b282ec156c29062f1222e5c20875a944ac98289dbd242e947f747"
     },
     "qwen3.5-0.8b": {
@@ -18,7 +18,7 @@
       "category": "general",
       "contextWindow": 131072,
       "license": "apache-2.0",
-      "description": "Tiny model from Alibaba's current generation; good edge-device default.",
+      "description": "Tiny model from Alibaba's current generation. Good edge-device default.",
       "sha256": "bd258782e35f7f458f8aced1adc053e6e92e89bc735ba3be89d38a06121dc517"
     },
     "qwen3.5-2b": {
@@ -28,7 +28,7 @@
       "category": "general",
       "contextWindow": 131072,
       "license": "apache-2.0",
-      "description": "Most popular modern small general model; runs on CPU comfortably.",
+      "description": "Most popular modern small general model. Runs on CPU comfortably.",
       "sha256": "aaf42c8b7c3cab2bf3d69c355048d4a0ee9973d48f16c731c0520ee914699223"
     },
     "qwen3.5-4b": {
@@ -48,7 +48,7 @@
       "category": "general",
       "contextWindow": 131072,
       "license": "apache-2.0",
-      "description": "Smallest Gemma 4; ~3 GB multimodal model for phones and thin laptops.",
+      "description": "Smallest Gemma 4 for phones and thin laptops.",
       "sha256": "740185b21d22ceb83a11c3aa62ad5842ef32c70f6096d756bbee85a1e4ec34b8"
     },
     "gemma-4-e4b": {
@@ -58,7 +58,7 @@
       "category": "general",
       "contextWindow": 131072,
       "license": "apache-2.0",
-      "description": "Google's compact Gemma 4 (4.5B effective); ~5 GB, laptop-friendly multimodal model.",
+      "description": "Google's compact Gemma 4 (4.5B effective). ~5 GB, laptop-friendly multimodal model.",
       "sha256": "85a896a047553e842f25297ee5b031d64ff30147d9c4af17b1e4b394cd1fab87"
     },
     "granite-4.1-8b": {
@@ -68,7 +68,7 @@
       "category": "general",
       "contextWindow": 131072,
       "license": "apache-2.0",
-      "description": "IBM's enterprise-tuned 8B; built for retrieval, tool use, and long documents.",
+      "description": "IBM's enterprise-tuned 8B. Built for retrieval, tool use, and long documents.",
       "sha256": "0f45c1af986e9900bb3b6ba46a25937e1bb80426935bc242d88c9ca90e9f5c88"
     },
     "qwen3.5-9b": {
@@ -78,7 +78,7 @@
       "category": "general",
       "contextWindow": 131072,
       "license": "apache-2.0",
-      "description": "Modern medium general model with strong tool use; 128K context.",
+      "description": "Modern medium general model with strong tool use.",
       "sha256": "03b74727a860a56338e042c4420bb3f04b2fec5734175f4cb9fa853daf52b7e8"
     },
     "gemma-4-12b": {
@@ -88,7 +88,7 @@
       "category": "general",
       "contextWindow": 262144,
       "license": "apache-2.0",
-      "description": "Google's mid-size Gemma 4 dense model; strong multilingual multimodal use, 256K context.",
+      "description": "Google's mid-size Gemma 4 dense model. Strong multilingual multimodal use.",
       "sha256": "0a270ec9fe6b34f4a0d33992b6135117b484ebc4766ab76b51d4ae8c457e4c42"
     },
     "gpt-oss-20b": {
@@ -98,7 +98,7 @@
       "category": "general",
       "contextWindow": 131072,
       "license": "apache-2.0",
-      "description": "OpenAI's open-weights release; balanced general model for ~16 GB machines.",
+      "description": "OpenAI's open-weights release. Balanced general model for ~16 GB machines.",
       "sha256": "c27536640e410032865dc68781d80a08b98f8db5e93575919af8ccc0568aeb4f"
     },
     "mistral-small-3.1": {
@@ -108,7 +108,7 @@
       "category": "general",
       "contextWindow": 131072,
       "license": "apache-2.0",
-      "description": "Mistral's general 24B base model (also Devstral's foundation); broad utility.",
+      "description": "Mistral's general 24B base model (also Devstral's foundation). Broad utility.",
       "sha256": "6d670773c3908584349d41a5048d1472226b593c881fd394e8ac196c802e81e2"
     },
     "mistral-small-3.2": {
@@ -118,7 +118,7 @@
       "category": "general",
       "contextWindow": 131072,
       "license": "apache-2.0",
-      "description": "Drop-in upgrade over 3.1: better instruction following, far fewer runaway generations.",
+      "description": "Drop-in upgrade over 3.1. Better instruction following, far fewer runaway generations.",
       "sha256": "a3cc56310807ed0d145eaf9f018ccda9ae7ad8edb41ec870aa2454b0d4700b3c"
     },
     "qwen3.5-27b": {
@@ -128,7 +128,7 @@
       "category": "general",
       "contextWindow": 131072,
       "license": "apache-2.0",
-      "description": "Modern dense general 27B; the practical ceiling for most workstations.",
+      "description": "Modern dense general 27B. The practical ceiling for most workstations.",
       "sha256": "84b5f7f112156d63836a01a69dc3f11a6ba63b10a23b8ca7a7efaf52d5a2d806"
     },
     "gemma-4-26b-a4b": {
@@ -138,7 +138,7 @@
       "category": "general",
       "contextWindow": 262144,
       "license": "apache-2.0",
-      "description": "Google's Gemma 4 MoE (3.8B active); fast yet capable multimodal model, 256K context.",
+      "description": "Google's Gemma 4 MoE (3.8B active). Fast yet capable multimodal model.",
       "sha256": "f2c28b3dc4776931ac6f879e11f203dec637ea0f14267a86ec8f6165f63f293f"
     },
     "gemma-4-31b": {
@@ -148,7 +148,7 @@
       "category": "general",
       "contextWindow": 262144,
       "license": "apache-2.0",
-      "description": "Largest dense Gemma 4; top Gemma quality for high-RAM workstations, 256K context.",
+      "description": "Largest dense Gemma 4. Top Gemma quality for high-RAM workstations.",
       "sha256": "38bd64c852c4b460434cc7162fa9bdcf242faf86502581a754cb72956bb17f84"
     },
     "qwen3.5-35b-a3b": {
@@ -158,7 +158,7 @@
       "category": "general",
       "contextWindow": 262144,
       "license": "apache-2.0",
-      "description": "Qwen's general MoE (3B active); 27B-class quality at 9B speed, needs ~32 GB RAM.",
+      "description": "Qwen's general MoE (3B active). 27B-class quality at 9B speed, needs ~32 GB RAM.",
       "sha256": "3b46d1066bc91cc2d613e3bc22ce691dd77e6f0d33c9060690d24ce6de494375"
     },
     "deepseek-r1-distill-llama-8b": {
@@ -168,7 +168,7 @@
       "category": "reasoning",
       "contextWindow": 131072,
       "license": "mit",
-      "description": "Chain-of-thought distill into Llama-8B; best small reasoning model.",
+      "description": "Chain-of-thought distill into Llama-8B. Best small reasoning model.",
       "sha256": "0addb1339a82385bcd973186cd80d18dcc71885d45eabd899781a118d03827d9"
     },
     "deepseek-r1-0528-qwen3-8b": {
@@ -178,7 +178,7 @@
       "category": "reasoning",
       "contextWindow": 131072,
       "license": "mit",
-      "description": "DeepSeek's newer R1 distill onto Qwen3-8B; supersedes the Llama-8B distill.",
+      "description": "DeepSeek's newer R1 distill onto Qwen3-8B. Supersedes the Llama-8B distill.",
       "sha256": "a86349a4180c4e6bb43f874c29c404fa2be3f90b15509bd6d86f697dba724ec1"
     },
     "phi-4-reasoning": {
@@ -188,7 +188,7 @@
       "category": "reasoning",
       "contextWindow": 32768,
       "license": "mit",
-      "description": "Microsoft's reasoning-tuned 14B; competitive with much larger models on math/logic.",
+      "description": "Microsoft's reasoning-tuned 14B. Competitive with much larger models on math/logic.",
       "sha256": "960d3870b218f91116c55bf81dc313e6cdbce31b1047bb2bc8bc7ea47899b032"
     },
     "magistral-small-2509": {
@@ -198,7 +198,7 @@
       "category": "reasoning",
       "contextWindow": 131072,
       "license": "apache-2.0",
-      "description": "Mistral's reasoning model; the strongest chain-of-thought that still fits ~16 GB.",
+      "description": "Mistral's reasoning model. The strongest chain-of-thought that still fits ~16 GB.",
       "sha256": "6d3e5f2a83ed9d64bd3382fb03be2f6e0bc7596a9de16e107bf22f959891945b"
     },
     "devstral-small-2507": {
@@ -208,7 +208,7 @@
       "category": "coding",
       "contextWindow": 131072,
       "license": "apache-2.0",
-      "description": "Mistral's official coding-agent GGUF; #1 open-source on SWE-Bench at release.",
+      "description": "Mistral's official coding-agent GGUF.",
       "sha256": "1bcc2b1b7b7ea3168ba2dbe782432c464f2240598bd193930122c41b117c1796"
     },
     "devstral-small-2-24b": {
@@ -218,7 +218,7 @@
       "category": "coding",
       "contextWindow": 393216,
       "license": "apache-2.0",
-      "description": "Mistral's current coding agent; supersedes 2507 and reads 384K tokens at once.",
+      "description": "Mistral's current coding agent. Supersedes 2507 and reads 384K tokens at once.",
       "sha256": "d14ba9edee1bb4c4996a726deb81e49ae81800a3216f0774634238c380aee496"
     },
     "qwen3-coder-30b-a3b": {
@@ -228,7 +228,7 @@
       "category": "coding",
       "contextWindow": 262144,
       "license": "apache-2.0",
-      "description": "Qwen's MoE coder (3.3B active); strong agentic coding + 256K context.",
+      "description": "Qwen's MoE coder (3.3B active). Strong agentic coding model.",
       "sha256": "fadc3e5f8d42bf7e894a785b05082e47daee4df26680389817e2093056f088ad"
     },
     "nomic-embed-text": {
@@ -238,7 +238,7 @@
       "category": "embedding",
       "contextWindow": 8192,
       "license": "apache-2.0",
-      "description": "Returns 768-dim embeddings; pair with a chat model for RAG.",
+      "description": "Returns 768-dim embeddings. Pair with a chat model for RAG.",
       "sha256": "d4e388894e09cf3816e8b0896d81d265b55e7a9fff9ab03fe8bf4ef5e11295ac"
     }
   }

--- a/packages/agency-lang/data/model-catalog.json
+++ b/packages/agency-lang/data/model-catalog.json
@@ -121,16 +121,6 @@
       "description": "Drop-in upgrade over 3.1: better instruction following, far fewer runaway generations.",
       "sha256": "a3cc56310807ed0d145eaf9f018ccda9ae7ad8edb41ec870aa2454b0d4700b3c"
     },
-    "dolphin-3.0-mistral-24b": {
-      "uri": "hf:bartowski/cognitivecomputations_Dolphin3.0-Mistral-24B-GGUF:Q4_K_M",
-      "params": "24B",
-      "sizeBytes": 14333000000,
-      "category": "general",
-      "contextWindow": 32768,
-      "license": "apache-2.0",
-      "description": "Steerable Mistral-24B fine-tune with no built-in refusals; you own the system prompt.",
-      "sha256": "6f193bbf98628140194df257c7466e2c6f80a7ef70a6ebae26c53b2f2ef21994"
-    },
     "qwen3.5-27b": {
       "uri": "hf:unsloth/Qwen3.5-27B-GGUF:Q4_K_M",
       "params": "27B",

--- a/packages/agency-lang/docs/dev/local-models.md
+++ b/packages/agency-lang/docs/dev/local-models.md
@@ -98,6 +98,15 @@ whole-file (last writer wins) — accepted for display metadata.
 2. An alias in `client.modelAliases` (nearest `agency.json`) wins next — a
    value is either a bare URI string or an object
    `{ uri, …metadata, source?, sha256? }`.
+
+   **Both forms must validate against `ModelAliasSchema` in `lib/config.ts`.**
+   That schema is a separate copy of the same contract as `AliasObject` here,
+   and the two have drifted before: the object form was added for
+   `agency local refresh` while `config.ts` still required a plain string, so a
+   refresh wrote a config that the next `agency run` refused to load. If you add
+   a field to `AliasObject`, add it there too —
+   `lib/config.modelAliases.test.ts` round-trips a fully-populated entry to
+   catch exactly this.
 3. Otherwise a curated short name in `CURATED_LOCAL_MODELS`.
 
 `_listModelNames` merges curated + aliases (alias wins on a name clash) for the

--- a/packages/agency-lang/docs/site/cli/local.md
+++ b/packages/agency-lang/docs/site/cli/local.md
@@ -11,6 +11,7 @@ Use this to manage and run local models. Backed by `smoltalk-llama-cpp` + `node-
 agency local download                     # pick a model from the catalog interactively
 agency local download qwen3.5-2b          # curated name, alias, hf: URI, or .gguf path
 agency local list                         # the catalog, with downloaded models marked
+agency local list -l                      # ...and each model's description
 agency local remove my-model.gguf         # delete a downloaded file by its name in the cache
 agency local resolve my7b                 # show what a name/alias maps to
 
@@ -32,7 +33,7 @@ The agent's `--local` runs the local model as both the fast and slow model, so t
 
 | command | purpose |
 |---|---|
-| `agency local list` | Show the full catalog with a checkmark and on-disk size for downloaded models. The first line names the models directory. Files that match no catalog entry appear under `OTHER FILES`. Works without `smoltalk-llama-cpp` installed. |
+| `agency local list` | Show the full catalog with a checkmark and on-disk size for downloaded models. The first line names the models directory. Files that match no catalog entry appear under `OTHER FILES`. Add `-l` / `--long` to print each model's description on its own line below its row. Works without `smoltalk-llama-cpp` installed. |
 | `agency local download [value]` | Download a model if not already cached; prints the source it resolved to and the local path. `<value>` may be a curated short name, an alias, an `hf:` URI, or an existing `.gguf` path. With no value, opens an interactive picker (in scripts it prints the catalog and exits 1 instead). |
 | `agency local remove <file>` | Delete a downloaded `.gguf` from the cache, by its file name as shown in `OTHER FILES` or the models directory. |
 | `agency local resolve <value>` | Show what a name/alias maps to, without downloading. |

--- a/packages/agency-lang/lib/cli/local.ts
+++ b/packages/agency-lang/lib/cli/local.ts
@@ -56,7 +56,7 @@ export function aliasRemove(name: string, file?: string): string {
 /** Deliberately ungated: browsing the catalog needs no provider package
  *  (only download/remove do), and the pre-install experience — see what is
  *  available, then get told what to install — is the point. */
-export function runList(): void {
+export function runList(long: boolean = false): void {
   const dir = _modelsCacheDir();
   console.log(
     formatLocalList({
@@ -64,6 +64,7 @@ export function runList(): void {
       entries: _listModelNames(),
       manifest: readDownloadManifest(dir),
       files: _listDownloadedModels(),
+      long,
     }),
   );
 }

--- a/packages/agency-lang/lib/config.modelAliases.test.ts
+++ b/packages/agency-lang/lib/config.modelAliases.test.ts
@@ -6,7 +6,39 @@ describe("config client.modelAliases", () => {
     const parsed = AgencyConfigSchema.parse({ client: { modelAliases: { my7b: "hf:org/repo:Q4_K_M" } } });
     expect(parsed.client?.modelAliases).toEqual({ my7b: "hf:org/repo:Q4_K_M" });
   });
-  it("rejects a non-string value", () => {
+  it("accepts the rich object form written by `agency local refresh`", () => {
+    // Every field `_refreshCatalog` writes, so the schema can't drift from
+    // what the refresh actually puts on disk (this is what broke: refresh
+    // wrote objects that the config loader then rejected on the next run).
+    const entry = {
+      uri: "hf:unsloth/Qwen3.5-2B-GGUF:Q4_K_M",
+      source: "remote",
+      params: "2B",
+      sizeBytes: 1_280_000_000,
+      category: "general",
+      contextWindow: 131072,
+      license: "apache-2.0",
+      description: "Most popular modern small general model.",
+      sha256: "aaf42c8b7c3cab2bf3d69c355048d4a0ee9973d48f16c731c0520ee914699223",
+    };
+    const parsed = AgencyConfigSchema.parse({ client: { modelAliases: { "qwen3.5-2b": entry } } });
+    expect(parsed.client?.modelAliases).toEqual({ "qwen3.5-2b": entry });
+  });
+  it("accepts string and object aliases side by side", () => {
+    const parsed = AgencyConfigSchema.parse({
+      client: { modelAliases: { my7b: "hf:org/repo:Q4_K_M", managed: { uri: "hf:o/m:Q4" } } },
+    });
+    expect(parsed.client?.modelAliases).toEqual({
+      my7b: "hf:org/repo:Q4_K_M",
+      managed: { uri: "hf:o/m:Q4" },
+    });
+  });
+  it("rejects a value that is neither a string nor an object", () => {
     expect(() => AgencyConfigSchema.parse({ client: { modelAliases: { x: 5 } } })).toThrow();
+  });
+  it("rejects an object alias with no uri", () => {
+    expect(() =>
+      AgencyConfigSchema.parse({ client: { modelAliases: { x: { params: "2B" } } } }),
+    ).toThrow();
   });
 });

--- a/packages/agency-lang/lib/config.ts
+++ b/packages/agency-lang/lib/config.ts
@@ -180,11 +180,13 @@ export interface AgencyConfig {
      * the `AGENCY_PROVIDER_MODULES` env var at runtime.
      */
     providerModules: string[];
-    /** Short name → Hugging Face URI aliases for local models, used by
-     *  `std::agency/local` and the `agency local` CLI. Read and written at
-     *  runtime (not compile-time baked) so `agency local alias` edits take
-     *  effect on the next run. */
-    modelAliases: Record<string, string>;
+    /** Short name → local-model alias, used by `std::agency/local` and the
+     *  `agency local` CLI. A value is either a bare Hugging Face URI or an
+     *  object carrying that URI plus display metadata (what `agency local
+     *  refresh` writes) — see `ModelAliasSchema`. Read and written at runtime
+     *  (not compile-time baked) so `agency local alias` edits take effect on
+     *  the next run. */
+    modelAliases: Record<string, ModelAlias>;
     /** Directory downloaded local models are cached in. Overridden by the
      *  `AGENCY_MODELS_DIR` env var; defaults to `~/.agency-agent/models`. Read
      *  at runtime by `std::agency/local` and the `agency local` CLI. */
@@ -408,6 +410,39 @@ export interface AgencyConfig {
 
 // --- Zod schema for runtime validation of agency.json ---
 
+/** One `client.modelAliases` value. Two forms are on disk:
+ *
+ *  - a bare URI string, the shape `agency local alias add` writes; and
+ *  - an object carrying the URI plus display metadata, the shape
+ *    `agency local refresh` writes for catalog-managed entries (tagged
+ *    `source: "remote"` so a refresh can tell its own entries from yours).
+ *
+ *  Both must validate here or a refresh leaves agency.json unloadable. The
+ *  object mirrors `AliasObject` in `lib/stdlib/localModels.ts`, which is the
+ *  type side of the same contract; `lib/config.modelAliases.test.ts` round-trips
+ *  a fully-populated entry so the two cannot drift apart. Unknown metadata keys
+ *  are allowed through so an older agency can load a config written by a newer
+ *  one (forward compatibility) rather than erroring on a field it lacks. */
+export const ModelAliasSchema = z.union([
+  z.string(),
+  z
+    .object({
+      uri: z.string(),
+      source: z.literal("remote").optional(),
+      params: z.string().optional(),
+      sizeBytes: z.number().optional(),
+      category: z.string().optional(),
+      contextWindow: z.number().optional(),
+      license: z.string().optional(),
+      description: z.string().optional(),
+      sha256: z.string().optional(),
+    })
+    .passthrough(),
+]);
+
+/** A `client.modelAliases` value: a bare URI or the rich object form. */
+export type ModelAlias = z.infer<typeof ModelAliasSchema>;
+
 export const AgencyConfigSchema = z
   .object({
     verbose: z.boolean(),
@@ -492,7 +527,7 @@ export const AgencyConfigSchema = z
         maxToolResultChars: z.number(),
         maxToolSchemaChars: z.number(),
         providerModules: z.array(z.string()),
-        modelAliases: z.record(z.string(), z.string()),
+        modelAliases: z.record(z.string(), ModelAliasSchema),
         modelsDir: z.string(),
         statelog: z
           .object({

--- a/packages/agency-lang/lib/config.ts
+++ b/packages/agency-lang/lib/config.ts
@@ -108,8 +108,8 @@ export interface AgencyConfig {
   eval?: {
     runsDir?: string;
     optimizeRunsDir?: string;
-    graders?: string;                              // path to a TS grading module
-    sourceCacheRoot?: string;                      // git-source clone cache override
+    graders?: string; // path to a TS grading module
+    sourceCacheRoot?: string; // git-source clone cache override
 
     /** Where the human-label dataset lives. Outside runsDir on purpose: runs
      *  are disposable and the labels must outlive them. A relative path
@@ -119,14 +119,14 @@ export interface AgencyConfig {
     /** Per-run resource limits for the agent subprocess. Unset fields keep the
      *  built-in defaults (lib/eval/run/subprocess.ts). */
     limits?: {
-      wallClockSec?: number;                       // max seconds per agent run (default 60)
-      maxCostUsd?: number;                         // max LLM spend per agent run (default 50)
+      wallClockSec?: number; // max seconds per agent run (default 60)
+      maxCostUsd?: number; // max LLM spend per agent run (default 50)
     };
 
     optimize?: {
       goal?: string;
-      graders?: string;                              // path to a TS grading module
-      optimizer?: string;                            // built-in name or path to a TS/JS optimizer module
+      graders?: string; // path to a TS grading module
+      optimizer?: string; // built-in name or path to a TS/JS optimizer module
       validation?: { inputs?: string; split?: number };
     };
   };
@@ -437,7 +437,7 @@ export const ModelAliasSchema = z.union([
       description: z.string().optional(),
       sha256: z.string().optional(),
     })
-    .passthrough(),
+    .loose(),
 ]);
 
 /** A `client.modelAliases` value: a bare URI or the rich object form. */
@@ -484,16 +484,24 @@ export const AgencyConfigSchema = z
         // Positive int only: the value feeds setTimeout (×1000), where 0 and
         // negatives don't mean "no limit" — they fire immediately and fail
         // every run with a wall_clock limit error.
-        limits: z.object({
-          wallClockSec: z.number().int().positive(),
-          maxCostUsd: z.number().positive(),
-        }).partial().optional(),
+        limits: z
+          .object({
+            wallClockSec: z.number().int().positive(),
+            maxCostUsd: z.number().positive(),
+          })
+          .partial()
+          .optional(),
         optimize: z
           .object({
             goal: z.string().optional(),
             graders: z.string().optional(),
             optimizer: z.string().optional(),
-            validation: z.object({ inputs: z.string().optional(), split: z.number().optional() }).optional(),
+            validation: z
+              .object({
+                inputs: z.string().optional(),
+                split: z.number().optional(),
+              })
+              .optional(),
           })
           .partial()
           .optional(),
@@ -567,7 +575,10 @@ export const AgencyConfigSchema = z
       .object({
         maxCost: z
           .number()
-          .refine((n) => Number.isFinite(n), "budget.maxCost must be a finite number"),
+          .refine(
+            (n) => Number.isFinite(n),
+            "budget.maxCost must be a finite number",
+          ),
         maxTime: z.string(),
       })
       .partial(),
@@ -602,22 +613,18 @@ export const AgencyConfigSchema = z
     memory: z.object({
       dir: z.string(),
       model: z.string().optional(),
-      autoExtract: z
-        .object({ interval: z.number().optional() })
-        .optional(),
+      autoExtract: z.object({ interval: z.number().optional() }).optional(),
       compaction: z
         .object({
           trigger: z.enum(["token", "messages"]).optional(),
           threshold: z.number().optional(),
         })
         .optional(),
-      embeddings: z
-        .object({ model: z.string().optional() })
-        .optional(),
+      embeddings: z.object({ model: z.string().optional() }).optional(),
     }),
   })
   .partial()
-  .passthrough();
+  .loose();
 
 /**
  * Load agency.json at the given path without calling process.exit.
@@ -801,7 +808,10 @@ export function applyCliFlags(
     next.maxToolCallRounds = flags.maxToolCallRounds;
   }
   if (flags.maxToolResultChars !== undefined) {
-    next.client = { ...next.client, maxToolResultChars: flags.maxToolResultChars };
+    next.client = {
+      ...next.client,
+      maxToolResultChars: flags.maxToolResultChars,
+    };
   }
   if (flags.model !== undefined) {
     // A bare model drops an inherited provider so smoltalk can infer one from
@@ -903,7 +913,10 @@ export function redactConfigSecrets(config: AgencyConfig): AgencyConfig {
     clone.log.apiKey = mask(clone.log.apiKey);
   }
   redactKeyMap(clone.client?.apiKey as Record<string, unknown> | undefined);
-  if (clone.client?.statelog && typeof clone.client.statelog.apiKey === "string") {
+  if (
+    clone.client?.statelog &&
+    typeof clone.client.statelog.apiKey === "string"
+  ) {
     clone.client.statelog.apiKey = mask(clone.client.statelog.apiKey);
   }
   return clone;

--- a/packages/agency-lang/lib/stdlib/localModels.test.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.test.ts
@@ -282,6 +282,7 @@ describe("formatLocalList", () => {
       sizeBytes: 1_200_000_000,
       contextWindow: 131072,
       license: "apache-2.0",
+      description: "A middling model.",
     },
   ];
 
@@ -324,6 +325,39 @@ describe("formatLocalList", () => {
     });
     expect(out).toContain("OTHER FILES");
     expect(out).toContain("raw.gguf");
+  });
+
+  it("omits descriptions by default", () => {
+    const out = formatLocalList({ dir: "/d", entries, manifest: {}, files: [] });
+    expect(out).not.toContain("A middling model.");
+  });
+
+  it("long mode puts the description on its own line below its model", () => {
+    const out = formatLocalList({ dir: "/d", entries, manifest: {}, files: [], long: true });
+    const lines = out.split("\n");
+    const midAt = lines.findIndex((l) => l.includes("mid"));
+    expect(lines[midAt + 1]).toContain("A middling model.");
+    // The description gets a line to itself, not a table column.
+    expect(lines[midAt]).not.toContain("A middling model.");
+    // Blank line BETWEEN models: "tiny" has no description, so the blank
+    // before "mid" is the separator, not a leftover from a description line.
+    expect(lines[midAt - 1]).toBe("");
+  });
+
+  it("long mode does not double-space the section that follows the table", () => {
+    const out = formatLocalList({
+      dir: "/d",
+      entries,
+      manifest: {},
+      files: [{ name: "raw.gguf", path: "/d/raw.gguf", sizeBytes: 500_000_000 }],
+      long: true,
+    });
+    const lines = out.split("\n");
+    const othersAt = lines.indexOf("OTHER FILES");
+    expect(othersAt).toBeGreaterThan(0);
+    // Exactly one blank line separates the last model from OTHER FILES.
+    expect(lines[othersAt - 1]).toBe("");
+    expect(lines[othersAt - 2]).not.toBe("");
   });
 });
 

--- a/packages/agency-lang/lib/stdlib/localModels.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.ts
@@ -1212,6 +1212,7 @@ export function formatLocalList(args: {
             : "",
       ctx: e.contextWindow !== undefined ? formatCtx(e.contextWindow) : "",
       license: e.license ?? "",
+      category: e.category ?? "",
       description: e.description ?? "",
     };
   });
@@ -1222,7 +1223,15 @@ export function formatLocalList(args: {
     .map((e) => args.manifest[e.target])
     .filter((f): f is string => f !== undefined);
   const others = args.files.filter((f) => !claimedFiles.includes(f.name));
-  const headers = ["", "NAME", "PARAMS", "SIZE", "CONTEXT", "LICENSE"];
+  const headers = [
+    "",
+    "NAME",
+    "PARAMS",
+    "SIZE",
+    "CONTEXT",
+    "CATEGORY",
+    "LICENSE",
+  ];
   const cols = [
     colWidth(
       headers[0],
@@ -1246,6 +1255,10 @@ export function formatLocalList(args: {
     ),
     colWidth(
       headers[5],
+      rows.map((r) => r.category),
+    ),
+    colWidth(
+      headers[6],
       rows.map((r) => r.license),
     ),
   ];
@@ -1262,7 +1275,9 @@ export function formatLocalList(args: {
     // Blank line *between* models, not after the last one, so the sections
     // below (which push their own leading "") aren't double-spaced.
     if (args.long === true && i > 0) lines.push("");
-    lines.push(render([r.mark, r.name, r.params, r.size, r.ctx, r.license]));
+    lines.push(
+      render([r.mark, r.name, r.params, r.size, r.ctx, r.category, r.license]),
+    );
     if (args.long === true && r.description !== "") {
       lines.push(ttyColor.dim(`${descIndent}${r.description}`));
     }

--- a/packages/agency-lang/lib/stdlib/localModels.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.ts
@@ -18,10 +18,10 @@ import { ttyColor } from "../utils/termcolors.js";
  *  by `params` / `sizeBytes`). Lets the CLI group + filter without parsing the
  *  description. */
 export type ModelCategory =
-  | "general"     // general-purpose chat / instruct
-  | "coding"      // SWE-tuned specialists
-  | "reasoning"   // chain-of-thought / R1-style distills
-  | "embedding";  // returns vectors, not text
+  | "general" // general-purpose chat / instruct
+  | "coding" // SWE-tuned specialists
+  | "reasoning" // chain-of-thought / R1-style distills
+  | "embedding"; // returns vectors, not text
 
 export type ModelInfo = {
   /** Hugging Face URI passed to `node-llama-cpp`'s `resolveModelFile`. */
@@ -59,179 +59,261 @@ export const CURATED_LOCAL_MODELS: Record<string, ModelInfo> = {
   // ── General ─────────────────────────────────────────────────────────────
   "smollm2-135m": {
     uri: "hf:unsloth/SmolLM2-135M-Instruct-GGUF:Q4_K_M",
+    params: "135M",
+    sizeBytes: 105000000,
+    category: "general",
+    contextWindow: 8192,
+    license: "apache-2.0",
+    description:
+      "Smallest practical chat model. Used by the Agency integration tests, runs anywhere.",
     sha256: "ed5fa30c487b282ec156c29062f1222e5c20875a944ac98289dbd242e947f747",
-    params: "135M", sizeBytes: 105_000_000, category: "general",
-    contextWindow: 8192, license: "apache-2.0",
-    description: "Smallest practical chat model; used by our integration tests, runs anywhere.",
   },
   "qwen3.5-0.8b": {
     uri: "hf:unsloth/Qwen3.5-0.8B-GGUF:Q4_K_M",
+    params: "0.8B",
+    sizeBytes: 500000000,
+    category: "general",
+    contextWindow: 131072,
+    license: "apache-2.0",
+    description:
+      "Tiny model from Alibaba's current generation. Good edge-device default.",
     sha256: "bd258782e35f7f458f8aced1adc053e6e92e89bc735ba3be89d38a06121dc517",
-    params: "0.8B", sizeBytes: 500_000_000, category: "general",
-    contextWindow: 131072, license: "apache-2.0",
-    description: "Tiny model from Alibaba's current generation; good edge-device default.",
   },
   "qwen3.5-2b": {
     uri: "hf:unsloth/Qwen3.5-2B-GGUF:Q4_K_M",
+    params: "2B",
+    sizeBytes: 1280000000,
+    category: "general",
+    contextWindow: 131072,
+    license: "apache-2.0",
+    description:
+      "Most popular modern small general model. Runs on CPU comfortably.",
     sha256: "aaf42c8b7c3cab2bf3d69c355048d4a0ee9973d48f16c731c0520ee914699223",
-    params: "2B", sizeBytes: 1_280_000_000, category: "general",
-    contextWindow: 131072, license: "apache-2.0",
-    description: "Most popular modern small general model; runs on CPU comfortably.",
   },
   "qwen3.5-4b": {
     uri: "hf:unsloth/Qwen3.5-4B-GGUF:Q4_K_M",
-    sha256: "00fe7986ff5f6b463e62455821146049db6f9313603938a70800d1fb69ef11a4",
-    params: "4B", sizeBytes: 2_400_000_000, category: "general",
-    contextWindow: 131072, license: "apache-2.0",
+    params: "4B",
+    sizeBytes: 2400000000,
+    category: "general",
+    contextWindow: 131072,
+    license: "apache-2.0",
     description: "Strong multilingual small general workhorse from Alibaba.",
+    sha256: "00fe7986ff5f6b463e62455821146049db6f9313603938a70800d1fb69ef11a4",
   },
   "gemma-4-e2b": {
     uri: "hf:unsloth/gemma-4-E2B-it-GGUF:Q4_K_M",
+    params: "2B (E2B)",
+    sizeBytes: 3110000000,
+    category: "general",
+    contextWindow: 131072,
+    license: "apache-2.0",
+    description: "Smallest Gemma 4 for phones and thin laptops.",
     sha256: "740185b21d22ceb83a11c3aa62ad5842ef32c70f6096d756bbee85a1e4ec34b8",
-    params: "2B (E2B)", sizeBytes: 3_110_000_000, category: "general",
-    contextWindow: 131072, license: "apache-2.0",
-    description: "Smallest Gemma 4; ~3 GB multimodal model for phones and thin laptops.",
   },
   "gemma-4-e4b": {
     uri: "hf:unsloth/gemma-4-E4B-it-GGUF:Q4_K_M",
+    params: "4B (E4B)",
+    sizeBytes: 4980000000,
+    category: "general",
+    contextWindow: 131072,
+    license: "apache-2.0",
+    description:
+      "Google's compact Gemma 4 (4.5B effective). ~5 GB, laptop-friendly multimodal model.",
     sha256: "85a896a047553e842f25297ee5b031d64ff30147d9c4af17b1e4b394cd1fab87",
-    params: "4B (E4B)", sizeBytes: 4_980_000_000, category: "general",
-    contextWindow: 131072, license: "apache-2.0",
-    description: "Google's compact Gemma 4 (4.5B effective); ~5 GB, laptop-friendly multimodal model.",
   },
   "granite-4.1-8b": {
     uri: "hf:unsloth/granite-4.1-8b-GGUF:Q4_K_M",
+    params: "8B",
+    sizeBytes: 5350000000,
+    category: "general",
+    contextWindow: 131072,
+    license: "apache-2.0",
+    description:
+      "IBM's enterprise-tuned 8B. Built for retrieval, tool use, and long documents.",
     sha256: "0f45c1af986e9900bb3b6ba46a25937e1bb80426935bc242d88c9ca90e9f5c88",
-    params: "8B", sizeBytes: 5_350_000_000, category: "general",
-    contextWindow: 131072, license: "apache-2.0",
-    description: "IBM's enterprise-tuned 8B; built for retrieval, tool use, and long documents.",
   },
   "qwen3.5-9b": {
     uri: "hf:unsloth/Qwen3.5-9B-GGUF:Q4_K_M",
+    params: "9B",
+    sizeBytes: 5500000000,
+    category: "general",
+    contextWindow: 131072,
+    license: "apache-2.0",
+    description: "Modern medium general model with strong tool use.",
     sha256: "03b74727a860a56338e042c4420bb3f04b2fec5734175f4cb9fa853daf52b7e8",
-    params: "9B", sizeBytes: 5_500_000_000, category: "general",
-    contextWindow: 131072, license: "apache-2.0",
-    description: "Modern medium general model with strong tool use; 128K context.",
   },
   "gemma-4-12b": {
     uri: "hf:unsloth/gemma-4-12b-it-GGUF:Q4_K_M",
+    params: "12B",
+    sizeBytes: 7120000000,
+    category: "general",
+    contextWindow: 262144,
+    license: "apache-2.0",
+    description:
+      "Google's mid-size Gemma 4 dense model. Strong multilingual multimodal use.",
     sha256: "0a270ec9fe6b34f4a0d33992b6135117b484ebc4766ab76b51d4ae8c457e4c42",
-    params: "12B", sizeBytes: 7_120_000_000, category: "general",
-    contextWindow: 262144, license: "apache-2.0",
-    description: "Google's mid-size Gemma 4 dense model; strong multilingual multimodal use, 256K context.",
   },
   "gpt-oss-20b": {
     uri: "hf:unsloth/gpt-oss-20b-GGUF:Q4_K_M",
+    params: "20B",
+    sizeBytes: 12000000000,
+    category: "general",
+    contextWindow: 131072,
+    license: "apache-2.0",
+    description:
+      "OpenAI's open-weights release. Balanced general model for ~16 GB machines.",
     sha256: "c27536640e410032865dc68781d80a08b98f8db5e93575919af8ccc0568aeb4f",
-    params: "20B", sizeBytes: 12_000_000_000, category: "general",
-    contextWindow: 131072, license: "apache-2.0",
-    description: "OpenAI's open-weights release; balanced general model for ~16 GB machines.",
   },
   "mistral-small-3.1": {
     uri: "hf:unsloth/Mistral-Small-3.1-24B-Instruct-2503-GGUF:Q4_K_M",
+    params: "24B",
+    sizeBytes: 14000000000,
+    category: "general",
+    contextWindow: 131072,
+    license: "apache-2.0",
+    description:
+      "Mistral's general 24B base model (also Devstral's foundation). Broad utility.",
     sha256: "6d670773c3908584349d41a5048d1472226b593c881fd394e8ac196c802e81e2",
-    params: "24B", sizeBytes: 14_000_000_000, category: "general",
-    contextWindow: 131072, license: "apache-2.0",
-    description: "Mistral's general 24B base model (also Devstral's foundation); broad utility.",
   },
   "mistral-small-3.2": {
     uri: "hf:unsloth/Mistral-Small-3.2-24B-Instruct-2506-GGUF:Q4_K_M",
+    params: "24B",
+    sizeBytes: 14333000000,
+    category: "general",
+    contextWindow: 131072,
+    license: "apache-2.0",
+    description:
+      "Drop-in upgrade over 3.1. Better instruction following, far fewer runaway generations.",
     sha256: "a3cc56310807ed0d145eaf9f018ccda9ae7ad8edb41ec870aa2454b0d4700b3c",
-    params: "24B", sizeBytes: 14_333_000_000, category: "general",
-    contextWindow: 131072, license: "apache-2.0",
-    description: "Drop-in upgrade over 3.1: better instruction following, far fewer runaway generations.",
   },
   "qwen3.5-27b": {
     uri: "hf:unsloth/Qwen3.5-27B-GGUF:Q4_K_M",
+    params: "27B",
+    sizeBytes: 16000000000,
+    category: "general",
+    contextWindow: 131072,
+    license: "apache-2.0",
+    description:
+      "Modern dense general 27B. The practical ceiling for most workstations.",
     sha256: "84b5f7f112156d63836a01a69dc3f11a6ba63b10a23b8ca7a7efaf52d5a2d806",
-    params: "27B", sizeBytes: 16_000_000_000, category: "general",
-    contextWindow: 131072, license: "apache-2.0",
-    description: "Modern dense general 27B; the practical ceiling for most workstations.",
   },
   "gemma-4-26b-a4b": {
     uri: "hf:unsloth/gemma-4-26B-A4B-it-GGUF:Q4_K_M",
+    params: "26B (A4B)",
+    sizeBytes: 16900000000,
+    category: "general",
+    contextWindow: 262144,
+    license: "apache-2.0",
+    description:
+      "Google's Gemma 4 MoE (3.8B active). Fast yet capable multimodal model.",
     sha256: "f2c28b3dc4776931ac6f879e11f203dec637ea0f14267a86ec8f6165f63f293f",
-    params: "26B (A4B)", sizeBytes: 16_900_000_000, category: "general",
-    contextWindow: 262144, license: "apache-2.0",
-    description: "Google's Gemma 4 MoE (3.8B active); fast yet capable multimodal model, 256K context.",
   },
   "gemma-4-31b": {
     uri: "hf:unsloth/gemma-4-31B-it-GGUF:Q4_K_M",
+    params: "31B",
+    sizeBytes: 18300000000,
+    category: "general",
+    contextWindow: 262144,
+    license: "apache-2.0",
+    description:
+      "Largest dense Gemma 4. Top Gemma quality for high-RAM workstations.",
     sha256: "38bd64c852c4b460434cc7162fa9bdcf242faf86502581a754cb72956bb17f84",
-    params: "31B", sizeBytes: 18_300_000_000, category: "general",
-    contextWindow: 262144, license: "apache-2.0",
-    description: "Largest dense Gemma 4; top Gemma quality for high-RAM workstations, 256K context.",
   },
-
   "qwen3.5-35b-a3b": {
     uri: "hf:unsloth/Qwen3.5-35B-A3B-GGUF:Q4_K_M",
+    params: "35B (A3B)",
+    sizeBytes: 22016000000,
+    category: "general",
+    contextWindow: 262144,
+    license: "apache-2.0",
+    description:
+      "Qwen's general MoE (3B active). 27B-class quality at 9B speed, needs ~32 GB RAM.",
     sha256: "3b46d1066bc91cc2d613e3bc22ce691dd77e6f0d33c9060690d24ce6de494375",
-    params: "35B (A3B)", sizeBytes: 22_016_000_000, category: "general",
-    contextWindow: 262144, license: "apache-2.0",
-    description: "Qwen's general MoE (3B active); 27B-class quality at 9B speed, needs ~32 GB RAM.",
   },
-
-  // ── Reasoning ───────────────────────────────────────────────────────────
   "deepseek-r1-distill-llama-8b": {
     uri: "hf:unsloth/DeepSeek-R1-Distill-Llama-8B-GGUF:Q4_K_M",
+    params: "8B",
+    sizeBytes: 4920000000,
+    category: "reasoning",
+    contextWindow: 131072,
+    license: "mit",
+    description:
+      "Chain-of-thought distill into Llama-8B. Best small reasoning model.",
     sha256: "0addb1339a82385bcd973186cd80d18dcc71885d45eabd899781a118d03827d9",
-    params: "8B", sizeBytes: 4_920_000_000, category: "reasoning",
-    contextWindow: 131072, license: "mit",
-    description: "Chain-of-thought distill into Llama-8B; best small reasoning model.",
   },
   "deepseek-r1-0528-qwen3-8b": {
     uri: "hf:unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF:Q4_K_M",
+    params: "8B",
+    sizeBytes: 5030000000,
+    category: "reasoning",
+    contextWindow: 131072,
+    license: "mit",
+    description:
+      "DeepSeek's newer R1 distill onto Qwen3-8B. Supersedes the Llama-8B distill.",
     sha256: "a86349a4180c4e6bb43f874c29c404fa2be3f90b15509bd6d86f697dba724ec1",
-    params: "8B", sizeBytes: 5_030_000_000, category: "reasoning",
-    contextWindow: 131072, license: "mit",
-    description: "DeepSeek's newer R1 distill onto Qwen3-8B; supersedes the Llama-8B distill.",
   },
   "phi-4-reasoning": {
     uri: "hf:unsloth/Phi-4-reasoning-GGUF:Q4_K_M",
+    params: "14B",
+    sizeBytes: 9050000000,
+    category: "reasoning",
+    contextWindow: 32768,
+    license: "mit",
+    description:
+      "Microsoft's reasoning-tuned 14B. Competitive with much larger models on math/logic.",
     sha256: "960d3870b218f91116c55bf81dc313e6cdbce31b1047bb2bc8bc7ea47899b032",
-    params: "14B", sizeBytes: 9_050_000_000, category: "reasoning",
-    contextWindow: 32768, license: "mit",
-    description: "Microsoft's reasoning-tuned 14B; competitive with much larger models on math/logic.",
   },
-
   "magistral-small-2509": {
     uri: "hf:unsloth/Magistral-Small-2509-GGUF:Q4_K_M",
+    params: "24B",
+    sizeBytes: 14333000000,
+    category: "reasoning",
+    contextWindow: 131072,
+    license: "apache-2.0",
+    description:
+      "Mistral's reasoning model. The strongest chain-of-thought that still fits ~16 GB.",
     sha256: "6d3e5f2a83ed9d64bd3382fb03be2f6e0bc7596a9de16e107bf22f959891945b",
-    params: "24B", sizeBytes: 14_333_000_000, category: "reasoning",
-    contextWindow: 131072, license: "apache-2.0",
-    description: "Mistral's reasoning model; the strongest chain-of-thought that still fits ~16 GB.",
   },
-
-  // ── Coding ──────────────────────────────────────────────────────────────
   "devstral-small-2507": {
     uri: "hf:mistralai/Devstral-Small-2507_gguf:Q4_K_M",
+    params: "24B",
+    sizeBytes: 14300000000,
+    category: "coding",
+    contextWindow: 131072,
+    license: "apache-2.0",
+    description: "Mistral's official coding-agent GGUF.",
     sha256: "1bcc2b1b7b7ea3168ba2dbe782432c464f2240598bd193930122c41b117c1796",
-    params: "24B", sizeBytes: 14_300_000_000, category: "coding",
-    contextWindow: 131072, license: "apache-2.0",
-    description: "Mistral's official coding-agent GGUF; #1 open-source on SWE-Bench at release.",
   },
   "devstral-small-2-24b": {
     uri: "hf:unsloth/Devstral-Small-2-24B-Instruct-2512-GGUF:Q4_K_M",
+    params: "24B",
+    sizeBytes: 14334000000,
+    category: "coding",
+    contextWindow: 393216,
+    license: "apache-2.0",
+    description:
+      "Mistral's current coding agent. Supersedes 2507 and reads 384K tokens at once.",
     sha256: "d14ba9edee1bb4c4996a726deb81e49ae81800a3216f0774634238c380aee496",
-    params: "24B", sizeBytes: 14_334_000_000, category: "coding",
-    contextWindow: 393216, license: "apache-2.0",
-    description: "Mistral's current coding agent; supersedes 2507 and reads 384K tokens at once.",
   },
   "qwen3-coder-30b-a3b": {
     uri: "hf:unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF:Q4_K_M",
+    params: "30B (A3B)",
+    sizeBytes: 19000000000,
+    category: "coding",
+    contextWindow: 262144,
+    license: "apache-2.0",
+    description: "Qwen's MoE coder (3.3B active). Strong agentic coding model.",
     sha256: "fadc3e5f8d42bf7e894a785b05082e47daee4df26680389817e2093056f088ad",
-    params: "30B (A3B)", sizeBytes: 19_000_000_000, category: "coding",
-    contextWindow: 262144, license: "apache-2.0",
-    description: "Qwen's MoE coder (3.3B active); strong agentic coding + 256K context.",
   },
-
-  // ── Embedding ───────────────────────────────────────────────────────────
   "nomic-embed-text": {
     uri: "hf:nomic-ai/nomic-embed-text-v1.5-GGUF:Q4_K_M",
+    params: "137M",
+    sizeBytes: 89000000,
+    category: "embedding",
+    contextWindow: 8192,
+    license: "apache-2.0",
+    description: "Returns 768-dim embeddings. Pair with a chat model for RAG.",
     sha256: "d4e388894e09cf3816e8b0896d81d265b55e7a9fff9ab03fe8bf4ef5e11295ac",
-    params: "137M", sizeBytes: 89_000_000, category: "embedding",
-    contextWindow: 8192, license: "apache-2.0",
-    description: "Returns 768-dim embeddings; pair with a chat model for RAG.",
   },
 };
 
@@ -288,8 +370,13 @@ function isCatalogUri(v: string): boolean {
 /** The agency.json that owns aliases: nearest `agency.json` walking up from
  *  `startDir` (cwd by default); falls back to `~/agency.json` when none is
  *  found. Exported so the CLI can echo it on every write. */
-export function resolveAliasConfigPath(startDir: string = process.cwd()): string {
-  return findFileUp(startDir, "agency.json") ?? path.join(os.homedir(), "agency.json");
+export function resolveAliasConfigPath(
+  startDir: string = process.cwd(),
+): string {
+  return (
+    findFileUp(startDir, "agency.json") ??
+    path.join(os.homedir(), "agency.json")
+  );
 }
 
 /** Treat empty string as "caller wants resolveAliasConfigPath()". */
@@ -355,7 +442,9 @@ export function aliasUri(value: AliasValue): string {
   return typeof value === "string" ? value : value.uri;
 }
 
-export function readModelAliases(file: string = ""): Record<string, AliasValue> {
+export function readModelAliases(
+  file: string = "",
+): Record<string, AliasValue> {
   const cfg = readJson(resolveAliasFile(file));
   return (cfg.client?.modelAliases ?? {}) as Record<string, AliasValue>;
 }
@@ -384,7 +473,10 @@ export function _resolveModelName(value: string, file: string = ""): string {
   const curated = CURATED_LOCAL_MODELS[value];
   const mapped = aliasTarget ?? curated?.uri;
   if (!mapped) {
-    const names = [...Object.keys(CURATED_LOCAL_MODELS), ...Object.keys(aliases)].join(", ");
+    const names = [
+      ...Object.keys(CURATED_LOCAL_MODELS),
+      ...Object.keys(aliases),
+    ].join(", ");
     throw new Error(
       `Unknown local model "${value}". Known names: ${names || "(none)"}; ` +
         `or pass a .gguf path or an "hf:" URI.`,
@@ -395,7 +487,13 @@ export function _resolveModelName(value: string, file: string = ""): string {
 
 type EntryMeta = Pick<
   ModelNameEntry,
-  "params" | "sizeBytes" | "category" | "description" | "contextWindow" | "license" | "sha256"
+  | "params"
+  | "sizeBytes"
+  | "category"
+  | "description"
+  | "contextWindow"
+  | "license"
+  | "sha256"
 >;
 
 /** Project the optional display-metadata fields off any source shape
@@ -417,26 +515,37 @@ function metaFrom(src: string | Partial<EntryMeta>): EntryMeta {
 }
 
 export function _listModelNames(file: string = ""): ModelNameEntry[] {
-  const curatedEntries: ModelNameEntry[] = Object.entries(CURATED_LOCAL_MODELS).map(
-    ([name, info]) => ({ name, target: info.uri, source: "curated", ...metaFrom(info) }),
-  );
-  const aliasEntries: ModelNameEntry[] = Object.entries(readModelAliases(file)).map(
-    ([name, value]) => ({
-      name,
-      target: aliasUri(value),
-      source: "alias",
-      ...metaFrom(value),
-    }),
-  );
+  const curatedEntries: ModelNameEntry[] = Object.entries(
+    CURATED_LOCAL_MODELS,
+  ).map(([name, info]) => ({
+    name,
+    target: info.uri,
+    source: "curated",
+    ...metaFrom(info),
+  }));
+  const aliasEntries: ModelNameEntry[] = Object.entries(
+    readModelAliases(file),
+  ).map(([name, value]) => ({
+    name,
+    target: aliasUri(value),
+    source: "alias",
+    ...metaFrom(value),
+  }));
   // Alias wins on name collision: the alias entry overwrites the curated one
   // in the object literal because it comes later. `Object.values` then yields
   // exactly one entry per name.
   return Object.values(
-    Object.fromEntries([...curatedEntries, ...aliasEntries].map((e) => [e.name, e])),
+    Object.fromEntries(
+      [...curatedEntries, ...aliasEntries].map((e) => [e.name, e]),
+    ),
   );
 }
 
-export function _aliasModel(name: string, uri: string, file: string = ""): string {
+export function _aliasModel(
+  name: string,
+  uri: string,
+  file: string = "",
+): string {
   const resolved = resolveAliasFile(file);
   writeJson(resolved, withAlias(readJson(resolved), name, uri));
   return resolved;
@@ -510,15 +619,25 @@ export type CatalogModel = {
 };
 
 /** Resolve the catalog URL: explicit arg → env → config → built-in default. */
-export function resolveCatalogUrl(explicit: string = "", file: string = ""): string {
+export function resolveCatalogUrl(
+  explicit: string = "",
+  file: string = "",
+): string {
   if (explicit !== "") return explicit;
-  if (process.env.AGENCY_MODEL_CATALOG_URL) return process.env.AGENCY_MODEL_CATALOG_URL;
+  if (process.env.AGENCY_MODEL_CATALOG_URL)
+    return process.env.AGENCY_MODEL_CATALOG_URL;
   const configured = readJson(resolveAliasFile(file)).client?.modelCatalogUrl;
-  if (typeof configured === "string" && configured.length > 0) return configured;
+  if (typeof configured === "string" && configured.length > 0)
+    return configured;
   return DEFAULT_CATALOG_URL;
 }
 
-const CATALOG_CATEGORIES = ["general", "coding", "reasoning", "embedding"] as const;
+const CATALOG_CATEGORIES = [
+  "general",
+  "coding",
+  "reasoning",
+  "embedding",
+] as const;
 
 /** Bound on how long the default fetcher will wait for the remote catalog
  *  before aborting. Long enough to tolerate slow CI mirrors; short enough
@@ -535,7 +654,9 @@ const CATALOG_MAX_BYTES = 5_000_000;
 // is dropped rather than failing the whole entry (lenient metadata); a
 // missing/insecure `uri` fails the entry (it's then skipped + warned).
 const CatalogModelSchema = z.object({
-  uri: z.string().refine(isCatalogUri, "uri must be an hf:/https: URI or a .gguf path"),
+  uri: z
+    .string()
+    .refine(isCatalogUri, "uri must be an hf:/https: URI or a .gguf path"),
   params: z.string().optional().catch(undefined),
   sizeBytes: z.number().optional().catch(undefined),
   category: z.enum(CATALOG_CATEGORIES).optional().catch(undefined),
@@ -562,7 +683,9 @@ const CatalogTopSchema = z.object({
 /** Strip keys whose value is `undefined` so the resulting object is JSON-clean
  *  (no `"params": undefined` after `JSON.stringify`) and in canonical order. */
 function compact<T extends Record<string, unknown>>(o: T): Partial<T> {
-  return Object.fromEntries(Object.entries(o).filter(([, v]) => v !== undefined)) as Partial<T>;
+  return Object.fromEntries(
+    Object.entries(o).filter(([, v]) => v !== undefined),
+  ) as Partial<T>;
 }
 
 /** Parse + validate the catalog JSON. Throws on blob-level problems (bad JSON,
@@ -594,32 +717,34 @@ export function parseCatalog(text: string): Record<string, CatalogModel> {
   }
   // Validate each entry independently; a bad entry is skipped + warned, not
   // fatal. Rebuild a canonical-order `CatalogModel` from the validated data.
-  const entries: ([string, CatalogModel] | null)[] = Object.entries(top.data.models).map(
-    ([name, entry]) => {
-      const parsed = CatalogModelSchema.safeParse(entry);
-      if (!parsed.success) {
-        console.warn(
-          `[catalog] skipping "${name}": ${parsed.error.issues[0]?.message ?? "invalid entry"}`,
-        );
-        return null;
-      }
-      const d = parsed.data;
-      const model: CatalogModel = {
-        uri: d.uri,
-        ...compact({
-          params: d.params,
-          sizeBytes: d.sizeBytes,
-          category: d.category,
-          contextWindow: d.contextWindow,
-          license: d.license,
-          description: d.description,
-          sha256: d.sha256,
-        }),
-      };
-      return [name, model];
-    },
+  const entries: ([string, CatalogModel] | null)[] = Object.entries(
+    top.data.models,
+  ).map(([name, entry]) => {
+    const parsed = CatalogModelSchema.safeParse(entry);
+    if (!parsed.success) {
+      console.warn(
+        `[catalog] skipping "${name}": ${parsed.error.issues[0]?.message ?? "invalid entry"}`,
+      );
+      return null;
+    }
+    const d = parsed.data;
+    const model: CatalogModel = {
+      uri: d.uri,
+      ...compact({
+        params: d.params,
+        sizeBytes: d.sizeBytes,
+        category: d.category,
+        contextWindow: d.contextWindow,
+        license: d.license,
+        description: d.description,
+        sha256: d.sha256,
+      }),
+    };
+    return [name, model];
+  });
+  return Object.fromEntries(
+    entries.filter((e): e is [string, CatalogModel] => e !== null),
   );
-  return Object.fromEntries(entries.filter((e): e is [string, CatalogModel] => e !== null));
 }
 
 /** If `url` names a local file (a `file://` URL or a plain filesystem path —
@@ -628,7 +753,8 @@ export function parseCatalog(text: string): Record<string, CatalogModel> {
  *  makes the merge logic integration-testable without a network round-trip. */
 function catalogLocalPath(url: string): string | null {
   if (url.startsWith("file://")) return fileURLToPath(url);
-  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(url) || url.startsWith("hf:")) return null;
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(url) || url.startsWith("hf:"))
+    return null;
   return url;
 }
 
@@ -636,7 +762,9 @@ function catalogLocalPath(url: string): string | null {
 function readCatalogFile(path: string): string {
   const size = fs.statSync(path).size;
   if (size > CATALOG_MAX_BYTES) {
-    throw new Error(`catalog file too large (${size} bytes; cap ${CATALOG_MAX_BYTES} bytes)`);
+    throw new Error(
+      `catalog file too large (${size} bytes; cap ${CATALOG_MAX_BYTES} bytes)`,
+    );
   }
   return fs.readFileSync(path, "utf-8");
 }
@@ -645,7 +773,11 @@ function readCatalogFile(path: string): string {
  *  large/malicious body can't be fully buffered first. Mirrors the capped
  *  reader in `lib/stdlib/http.ts`; counts raw bytes (`byteLength`), not
  *  UTF-16 code units. */
-async function readBodyCapped(res: Response, url: string, maxBytes: number): Promise<string> {
+async function readBodyCapped(
+  res: Response,
+  url: string,
+  maxBytes: number,
+): Promise<string> {
   if (!res.body) return "";
   const reader = res.body.getReader();
   const decoder = new TextDecoder("utf-8");
@@ -749,12 +881,17 @@ function classifyEntry(
   // model named like a prototype member (`toString`, `__proto__`, …) must not
   // be treated as a collision with — or a previous value from — an inherited
   // property the user never set.
-  const has = (o: object, k: string): boolean => Object.prototype.hasOwnProperty.call(o, k);
+  const has = (o: object, k: string): boolean =>
+    Object.prototype.hasOwnProperty.call(o, k);
   if (has(userAliases, name)) {
     return {
       kind: "skipped",
       name,
-      entry: { name, keptUri: aliasUri(userAliases[name]), remoteUri: model.uri },
+      entry: {
+        name,
+        keptUri: aliasUri(userAliases[name]),
+        remoteUri: model.uri,
+      },
     };
   }
   const value: AliasObject = { ...model, source: "remote" };
@@ -770,7 +907,8 @@ function classifyEntry(
 
 /** Predicate factory for declarative filtering by `Classification.kind`. */
 function isKind<K extends Classification["kind"]>(k: K) {
-  return (c: Classification): c is Extract<Classification, { kind: K }> => c.kind === k;
+  return (c: Classification): c is Extract<Classification, { kind: K }> =>
+    c.kind === k;
 }
 
 /** Fetch + validate the catalog, then rewrite the `source:"remote"` aliases in
@@ -778,7 +916,11 @@ function isKind<K extends Classification["kind"]>(k: K) {
  *  collisions (the remote entry is skipped). Throws (leaving the file
  *  untouched) on fetch/parse/validation failure. */
 export async function _refreshCatalog(
-  opts: { url?: string; fetcher?: (url: string) => Promise<string>; file?: string } = {},
+  opts: {
+    url?: string;
+    fetcher?: (url: string) => Promise<string>;
+    file?: string;
+  } = {},
 ): Promise<RefreshResult> {
   const file = resolveAliasFile(opts.file ?? "");
   const url = resolveCatalogUrl(opts.url ?? "", file);
@@ -797,18 +939,21 @@ export async function _refreshCatalog(
 
   // Partition existing aliases by who manages them.
   const userAliases: Record<string, AliasValue> = Object.fromEntries(
-    Object.entries(existing).filter(([, v]) => !(typeof v === "object" && v.source === "remote")),
+    Object.entries(existing).filter(
+      ([, v]) => !(typeof v === "object" && v.source === "remote"),
+    ),
   );
   const oldManaged: Record<string, AliasObject> = Object.fromEntries(
     Object.entries(existing).filter(
-      (e): e is [string, AliasObject] => typeof e[1] === "object" && e[1].source === "remote",
+      (e): e is [string, AliasObject] =>
+        typeof e[1] === "object" && e[1].source === "remote",
     ),
   );
 
   // The entire merge policy: classify each catalog entry once. Everything
   // downstream is a filter/project on this array.
-  const classifications: Classification[] = Object.entries(models).map(([name, model]) =>
-    classifyEntry(name, model, userAliases, oldManaged),
+  const classifications: Classification[] = Object.entries(models).map(
+    ([name, model]) => classifyEntry(name, model, userAliases, oldManaged),
   );
 
   const namesIn = <K extends Classification["kind"]>(k: K): string[] =>
@@ -822,9 +967,14 @@ export async function _refreshCatalog(
   // What ends up in `client.modelAliases`: user aliases (untouched) plus
   // every non-skipped classification's value.
   const writtenManaged: Record<string, AliasValue> = Object.fromEntries(
-    classifications.filter((c) => c.kind !== "skipped").map((c) => [c.name, (c as { value: AliasObject }).value]),
+    classifications
+      .filter((c) => c.kind !== "skipped")
+      .map((c) => [c.name, (c as { value: AliasObject }).value]),
   );
-  const next: Record<string, AliasValue> = { ...userAliases, ...writtenManaged };
+  const next: Record<string, AliasValue> = {
+    ...userAliases,
+    ...writtenManaged,
+  };
 
   const surviving = [...added, ...updated, ...unchanged];
   const removed = Object.keys(oldManaged).filter((n) => !surviving.includes(n));
@@ -869,7 +1019,9 @@ function requireSupport(): void {
     return;
   }
   if (!_localModelsSupported()) {
-    throw new Error("Local models need smoltalk-llama-cpp — run: npm i -g smoltalk-llama-cpp");
+    throw new Error(
+      "Local models need smoltalk-llama-cpp — run: npm i -g smoltalk-llama-cpp",
+    );
   }
 }
 
@@ -927,7 +1079,10 @@ export async function verifyModelFile(
     fs.renameSync(filePath, quarantine);
   } catch (err) {
     moved = false;
-    console.warn(`Could not move "${filePath}" to "${quarantine}" after SHA-256 mismatch:`, err);
+    console.warn(
+      `Could not move "${filePath}" to "${quarantine}" after SHA-256 mismatch:`,
+      err,
+    );
   }
   throw new Error(
     `SHA-256 verification failed for "${name}": expected ${expected}, got ${actual}. ` +
@@ -942,7 +1097,10 @@ export async function verifyModelFile(
  *  model). An alias entry governs the name entirely — a user alias shadowing a
  *  curated name must NOT borrow the curated hash, but a user MAY opt in by
  *  setting their own `sha256` on the alias object. */
-export function pinnedSha256(value: string, file: string = ""): string | undefined {
+export function pinnedSha256(
+  value: string,
+  file: string = "",
+): string | undefined {
   if (isGgufPath(value) || isModelUri(value)) return undefined;
   const aliases = readModelAliases(file);
   if (Object.hasOwn(aliases, value)) {
@@ -967,7 +1125,10 @@ export function snapshotFreshness(dir: string): FreshnessProbe {
 }
 
 /** Resolve a name/uri/path to a local .gguf path, downloading if needed. */
-export async function _downloadModel(value: string, cacheDir: string = ""): Promise<string> {
+export async function _downloadModel(
+  value: string,
+  cacheDir: string = "",
+): Promise<string> {
   requireSupport();
   const target = _resolveModelName(value);
   const dir = resolveCacheDir(cacheDir);
@@ -988,7 +1149,10 @@ export async function _downloadModel(value: string, cacheDir: string = ""): Prom
 }
 
 /** Convenience: register the provider + ensure the model is downloaded. */
-export async function _registerLocalModel(value: string, cacheDir: string = ""): Promise<string> {
+export async function _registerLocalModel(
+  value: string,
+  cacheDir: string = "",
+): Promise<string> {
   await _registerLocalProvider();
   return await _downloadModel(value, cacheDir);
 }
@@ -1060,15 +1224,36 @@ export function formatLocalList(args: {
   const others = args.files.filter((f) => !claimedFiles.includes(f.name));
   const headers = ["", "NAME", "PARAMS", "SIZE", "CONTEXT", "LICENSE"];
   const cols = [
-    colWidth(headers[0], rows.map((r) => r.mark)),
-    colWidth(headers[1], rows.map((r) => r.name)),
-    colWidth(headers[2], rows.map((r) => r.params)),
-    colWidth(headers[3], rows.map((r) => r.size)),
-    colWidth(headers[4], rows.map((r) => r.ctx)),
-    colWidth(headers[5], rows.map((r) => r.license)),
+    colWidth(
+      headers[0],
+      rows.map((r) => r.mark),
+    ),
+    colWidth(
+      headers[1],
+      rows.map((r) => r.name),
+    ),
+    colWidth(
+      headers[2],
+      rows.map((r) => r.params),
+    ),
+    colWidth(
+      headers[3],
+      rows.map((r) => r.size),
+    ),
+    colWidth(
+      headers[4],
+      rows.map((r) => r.ctx),
+    ),
+    colWidth(
+      headers[5],
+      rows.map((r) => r.license),
+    ),
   ];
   const render = (cells: string[]) =>
-    cells.map((c, i) => c.padEnd(cols[i])).join("  ").trimEnd();
+    cells
+      .map((c, i) => c.padEnd(cols[i]))
+      .join("  ")
+      .trimEnd();
   // Indent descriptions two past where NAME starts (mark column + its
   // separator), so they read as nested under the model they describe.
   const descIndent = " ".repeat(cols[0] + 2 + 2);
@@ -1123,11 +1308,26 @@ export function formatModelCatalog(): string {
     // Computed widths so columns fit the actual data (names range from ~10
     // to ~28 chars). SIZE and CTX are numeric, so they right-align.
     const w = {
-      name: colWidth("NAME", rows.map((r) => r.name)),
-      params: colWidth("PARAMS", rows.map((r) => r.params)),
-      category: colWidth("CATEGORY", rows.map((r) => r.category)),
-      size: colWidth("SIZE", rows.map((r) => r.size)),
-      ctx: colWidth("CTX", rows.map((r) => r.ctx)),
+      name: colWidth(
+        "NAME",
+        rows.map((r) => r.name),
+      ),
+      params: colWidth(
+        "PARAMS",
+        rows.map((r) => r.params),
+      ),
+      category: colWidth(
+        "CATEGORY",
+        rows.map((r) => r.category),
+      ),
+      size: colWidth(
+        "SIZE",
+        rows.map((r) => r.size),
+      ),
+      ctx: colWidth(
+        "CTX",
+        rows.map((r) => r.ctx),
+      ),
     };
     const row = (
       name: string,
@@ -1142,7 +1342,11 @@ export function formatModelCatalog(): string {
       )}  ${size.padStart(w.size)}  ${ctx.padStart(w.ctx)}  ${license}`;
 
     // LICENSE is the last column, so it needs no trailing pad.
-    lines.push(ttyColor.bold(row("NAME", "PARAMS", "CATEGORY", "SIZE", "CTX", "LICENSE")));
+    lines.push(
+      ttyColor.bold(
+        row("NAME", "PARAMS", "CATEGORY", "SIZE", "CTX", "LICENSE"),
+      ),
+    );
     rows.forEach((r, i) => {
       // Blank line *between* models, not after the last one, so the joined
       // string has no trailing newline (console.log adds exactly one).

--- a/packages/agency-lang/lib/stdlib/localModels.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.ts
@@ -78,12 +78,26 @@ export const CURATED_LOCAL_MODELS: Record<string, ModelInfo> = {
     contextWindow: 131072, license: "apache-2.0",
     description: "Strong multilingual small general workhorse from Alibaba.",
   },
+  "gemma-4-e2b": {
+    uri: "hf:unsloth/gemma-4-E2B-it-GGUF:Q4_K_M",
+    sha256: "740185b21d22ceb83a11c3aa62ad5842ef32c70f6096d756bbee85a1e4ec34b8",
+    params: "2B (E2B)", sizeBytes: 3_110_000_000, category: "general",
+    contextWindow: 131072, license: "apache-2.0",
+    description: "Smallest Gemma 4; ~3 GB multimodal model for phones and thin laptops.",
+  },
   "gemma-4-e4b": {
     uri: "hf:unsloth/gemma-4-E4B-it-GGUF:Q4_K_M",
-    sha256: "519b9793ed6ce0ff530f1b7c96e848e08e49e7af4d57bb97f76215963a54146d",
+    sha256: "85a896a047553e842f25297ee5b031d64ff30147d9c4af17b1e4b394cd1fab87",
     params: "4B (E4B)", sizeBytes: 4_980_000_000, category: "general",
     contextWindow: 131072, license: "apache-2.0",
     description: "Google's compact Gemma 4 (4.5B effective); ~5 GB, laptop-friendly multimodal model.",
+  },
+  "granite-4.1-8b": {
+    uri: "hf:unsloth/granite-4.1-8b-GGUF:Q4_K_M",
+    sha256: "0f45c1af986e9900bb3b6ba46a25937e1bb80426935bc242d88c9ca90e9f5c88",
+    params: "8B", sizeBytes: 5_350_000_000, category: "general",
+    contextWindow: 131072, license: "apache-2.0",
+    description: "IBM's enterprise-tuned 8B; built for retrieval, tool use, and long documents.",
   },
   "qwen3.5-9b": {
     uri: "hf:unsloth/Qwen3.5-9B-GGUF:Q4_K_M",
@@ -94,7 +108,7 @@ export const CURATED_LOCAL_MODELS: Record<string, ModelInfo> = {
   },
   "gemma-4-12b": {
     uri: "hf:unsloth/gemma-4-12b-it-GGUF:Q4_K_M",
-    sha256: "43fec98c5102b1c446b4ddd0a9439f1db3a2e1f2e0b8cd143ce1ea619a9403d6",
+    sha256: "0a270ec9fe6b34f4a0d33992b6135117b484ebc4766ab76b51d4ae8c457e4c42",
     params: "12B", sizeBytes: 7_120_000_000, category: "general",
     contextWindow: 262144, license: "apache-2.0",
     description: "Google's mid-size Gemma 4 dense model; strong multilingual multimodal use, 256K context.",
@@ -113,6 +127,20 @@ export const CURATED_LOCAL_MODELS: Record<string, ModelInfo> = {
     contextWindow: 131072, license: "apache-2.0",
     description: "Mistral's general 24B base model (also Devstral's foundation); broad utility.",
   },
+  "mistral-small-3.2": {
+    uri: "hf:unsloth/Mistral-Small-3.2-24B-Instruct-2506-GGUF:Q4_K_M",
+    sha256: "a3cc56310807ed0d145eaf9f018ccda9ae7ad8edb41ec870aa2454b0d4700b3c",
+    params: "24B", sizeBytes: 14_333_000_000, category: "general",
+    contextWindow: 131072, license: "apache-2.0",
+    description: "Drop-in upgrade over 3.1: better instruction following, far fewer runaway generations.",
+  },
+  "dolphin-3.0-mistral-24b": {
+    uri: "hf:bartowski/cognitivecomputations_Dolphin3.0-Mistral-24B-GGUF:Q4_K_M",
+    sha256: "6f193bbf98628140194df257c7466e2c6f80a7ef70a6ebae26c53b2f2ef21994",
+    params: "24B", sizeBytes: 14_333_000_000, category: "general",
+    contextWindow: 32768, license: "apache-2.0",
+    description: "Steerable Mistral-24B fine-tune with no built-in refusals; you own the system prompt.",
+  },
   "qwen3.5-27b": {
     uri: "hf:unsloth/Qwen3.5-27B-GGUF:Q4_K_M",
     sha256: "84b5f7f112156d63836a01a69dc3f11a6ba63b10a23b8ca7a7efaf52d5a2d806",
@@ -122,17 +150,25 @@ export const CURATED_LOCAL_MODELS: Record<string, ModelInfo> = {
   },
   "gemma-4-26b-a4b": {
     uri: "hf:unsloth/gemma-4-26B-A4B-it-GGUF:Q4_K_M",
-    sha256: "34c746b1d50ab813e29cd46c4796e3f43c741901a582f93a67b55b9fc9687b35",
+    sha256: "f2c28b3dc4776931ac6f879e11f203dec637ea0f14267a86ec8f6165f63f293f",
     params: "26B (A4B)", sizeBytes: 16_900_000_000, category: "general",
     contextWindow: 262144, license: "apache-2.0",
     description: "Google's Gemma 4 MoE (3.8B active); fast yet capable multimodal model, 256K context.",
   },
   "gemma-4-31b": {
     uri: "hf:unsloth/gemma-4-31B-it-GGUF:Q4_K_M",
-    sha256: "9fdf3dc8b0384830b4402d151388c140bd8eb2abf8d60588d8224231198254a1",
+    sha256: "38bd64c852c4b460434cc7162fa9bdcf242faf86502581a754cb72956bb17f84",
     params: "31B", sizeBytes: 18_300_000_000, category: "general",
     contextWindow: 262144, license: "apache-2.0",
     description: "Largest dense Gemma 4; top Gemma quality for high-RAM workstations, 256K context.",
+  },
+
+  "qwen3.5-35b-a3b": {
+    uri: "hf:unsloth/Qwen3.5-35B-A3B-GGUF:Q4_K_M",
+    sha256: "3b46d1066bc91cc2d613e3bc22ce691dd77e6f0d33c9060690d24ce6de494375",
+    params: "35B (A3B)", sizeBytes: 22_016_000_000, category: "general",
+    contextWindow: 262144, license: "apache-2.0",
+    description: "Qwen's general MoE (3B active); 27B-class quality at 9B speed, needs ~32 GB RAM.",
   },
 
   // ── Reasoning ───────────────────────────────────────────────────────────
@@ -143,12 +179,27 @@ export const CURATED_LOCAL_MODELS: Record<string, ModelInfo> = {
     contextWindow: 131072, license: "mit",
     description: "Chain-of-thought distill into Llama-8B; best small reasoning model.",
   },
+  "deepseek-r1-0528-qwen3-8b": {
+    uri: "hf:unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF:Q4_K_M",
+    sha256: "a86349a4180c4e6bb43f874c29c404fa2be3f90b15509bd6d86f697dba724ec1",
+    params: "8B", sizeBytes: 5_030_000_000, category: "reasoning",
+    contextWindow: 131072, license: "mit",
+    description: "DeepSeek's newer R1 distill onto Qwen3-8B; supersedes the Llama-8B distill.",
+  },
   "phi-4-reasoning": {
     uri: "hf:unsloth/Phi-4-reasoning-GGUF:Q4_K_M",
     sha256: "960d3870b218f91116c55bf81dc313e6cdbce31b1047bb2bc8bc7ea47899b032",
     params: "14B", sizeBytes: 9_050_000_000, category: "reasoning",
     contextWindow: 32768, license: "mit",
     description: "Microsoft's reasoning-tuned 14B; competitive with much larger models on math/logic.",
+  },
+
+  "magistral-small-2509": {
+    uri: "hf:unsloth/Magistral-Small-2509-GGUF:Q4_K_M",
+    sha256: "6d3e5f2a83ed9d64bd3382fb03be2f6e0bc7596a9de16e107bf22f959891945b",
+    params: "24B", sizeBytes: 14_333_000_000, category: "reasoning",
+    contextWindow: 131072, license: "apache-2.0",
+    description: "Mistral's reasoning model; the strongest chain-of-thought that still fits ~16 GB.",
   },
 
   // ── Coding ──────────────────────────────────────────────────────────────
@@ -158,6 +209,13 @@ export const CURATED_LOCAL_MODELS: Record<string, ModelInfo> = {
     params: "24B", sizeBytes: 14_300_000_000, category: "coding",
     contextWindow: 131072, license: "apache-2.0",
     description: "Mistral's official coding-agent GGUF; #1 open-source on SWE-Bench at release.",
+  },
+  "devstral-small-2-24b": {
+    uri: "hf:unsloth/Devstral-Small-2-24B-Instruct-2512-GGUF:Q4_K_M",
+    sha256: "d14ba9edee1bb4c4996a726deb81e49ae81800a3216f0774634238c380aee496",
+    params: "24B", sizeBytes: 14_334_000_000, category: "coding",
+    contextWindow: 393216, license: "apache-2.0",
+    description: "Mistral's current coding agent; supersedes 2507 and reads 384K tokens at once.",
   },
   "qwen3-coder-30b-a3b": {
     uri: "hf:unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF:Q4_K_M",
@@ -962,14 +1020,17 @@ function colWidth(header: string, values: string[]): number {
  *  a downloaded marker, then cache-dir files no catalog entry claims. A row
  *  is "downloaded" when the manifest maps its target URI to a file that still
  *  exists in the cache dir; its SIZE column then shows the on-disk size
- *  rather than the catalog estimate. Compact and operational — `alias list`
- *  keeps the verbose per-model catalog with descriptions. Returns the block
- *  with no trailing newline (the caller's `console.log` adds exactly one). */
+ *  rather than the catalog estimate. Compact and operational by default;
+ *  `long` (the `-l` flag) adds each model's description on its own dimmed
+ *  line, with a blank line between models so the descriptions stay readable.
+ *  Returns the block with no trailing newline (the caller's `console.log`
+ *  adds exactly one). */
 export function formatLocalList(args: {
   dir: string;
   entries: ModelNameEntry[];
   manifest: Record<string, string>;
   files: { name: string; path: string; sizeBytes: number }[];
+  long?: boolean;
 }): string {
   const byName = Object.fromEntries(args.files.map((f) => [f.name, f]));
   const rows = args.entries.map((e) => {
@@ -987,6 +1048,7 @@ export function formatLocalList(args: {
             : "",
       ctx: e.contextWindow !== undefined ? formatCtx(e.contextWindow) : "",
       license: e.license ?? "",
+      description: e.description ?? "",
     };
   });
   // Only files claimed by a CATALOG row are excluded from OTHER FILES. The
@@ -1007,12 +1069,19 @@ export function formatLocalList(args: {
   ];
   const render = (cells: string[]) =>
     cells.map((c, i) => c.padEnd(cols[i])).join("  ").trimEnd();
-  const lines = [
-    `Models directory: ${args.dir}`,
-    "",
-    render(headers),
-    ...rows.map((r) => render([r.mark, r.name, r.params, r.size, r.ctx, r.license])),
-  ];
+  // Indent descriptions two past where NAME starts (mark column + its
+  // separator), so they read as nested under the model they describe.
+  const descIndent = " ".repeat(cols[0] + 2 + 2);
+  const lines = [`Models directory: ${args.dir}`, "", render(headers)];
+  rows.forEach((r, i) => {
+    // Blank line *between* models, not after the last one, so the sections
+    // below (which push their own leading "") aren't double-spaced.
+    if (args.long === true && i > 0) lines.push("");
+    lines.push(render([r.mark, r.name, r.params, r.size, r.ctx, r.license]));
+    if (args.long === true && r.description !== "") {
+      lines.push(ttyColor.dim(`${descIndent}${r.description}`));
+    }
+  });
   if (others.length > 0) {
     lines.push("", "OTHER FILES");
     for (const f of others) lines.push(`  ${f.name}  ${formatGB(f.sizeBytes)}`);

--- a/packages/agency-lang/lib/stdlib/localModels.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.ts
@@ -39,7 +39,14 @@ export type ModelInfo = {
   /** License identifier (SPDX-ish). Curated entries are permissive only
    *  (apache-2.0 / mit); restrictively-licensed models (older Gemma's custom
    *  terms, llama) are intentionally excluded. Gemma 4 ships under apache-2.0,
-   *  so it qualifies; Gemma 1–3 did not. */
+   *  so it qualifies; Gemma 1–3 did not.
+   *
+   *  This must be the license the model itself DECLARES, never one inferred
+   *  from its base model. Apache-2.0 is permissive, not copyleft — its §4 lets
+   *  a derivative work carry different terms — so a fine-tune of an
+   *  apache-2.0 base is not thereby apache-2.0. A model whose card declares no
+   *  license (the Dolphin 3.0 Mistral fine-tunes, for one) does not belong
+   *  here at all; add it locally with `agency local alias add` instead. */
   license: string;
   /** Pinned content SHA-256 (hex) of the resolved single-file GGUF, used to
    *  verify the download. Absent for sharded models (see issue #348). */
@@ -133,13 +140,6 @@ export const CURATED_LOCAL_MODELS: Record<string, ModelInfo> = {
     params: "24B", sizeBytes: 14_333_000_000, category: "general",
     contextWindow: 131072, license: "apache-2.0",
     description: "Drop-in upgrade over 3.1: better instruction following, far fewer runaway generations.",
-  },
-  "dolphin-3.0-mistral-24b": {
-    uri: "hf:bartowski/cognitivecomputations_Dolphin3.0-Mistral-24B-GGUF:Q4_K_M",
-    sha256: "6f193bbf98628140194df257c7466e2c6f80a7ef70a6ebae26c53b2f2ef21994",
-    params: "24B", sizeBytes: 14_333_000_000, category: "general",
-    contextWindow: 32768, license: "apache-2.0",
-    description: "Steerable Mistral-24B fine-tune with no built-in refusals; you own the system prompt.",
   },
   "qwen3.5-27b": {
     uri: "hf:unsloth/Qwen3.5-27B-GGUF:Q4_K_M",

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -1589,7 +1589,9 @@ export function createProgram(deps: CliDependencies = {}): Command {
     );
 
   const localCmd = program.command("local").description("Manage and run local models");
-  localCmd.command("list").description("List local models: the full catalog, with downloaded models marked").action(localList);
+  localCmd.command("list").description("List local models: the full catalog, with downloaded models marked")
+    .option("-l, --long", "Show each model's description on its own line")
+    .action((opts: { long?: boolean }) => localList(opts.long === true));
   localCmd.command("download").description("Download a model (curated name, alias, or hf: URI); no argument opens a picker")
     .argument("[value]").action(localDownload);
   localCmd.command("remove").description("Delete a downloaded model").argument("<name>")


### PR DESCRIPTION
Three related changes to local-model support. The bug fix is the one that matters most — a successful `agency local refresh` currently leaves your `agency.json` unloadable.

## Fix: a refresh wrote a config that would not load

`agency local refresh` writes rich alias objects into `client.modelAliases`, but `lib/config.ts` still declared that field as `Record<string, string>`. So the refresh succeeded, and then the next run of any file died with a wall of errors — one line per model:

```
Invalid agency.json config:
  - client.modelAliases.smollm2-135m: Invalid input: expected string, received object
  - client.modelAliases.qwen3.5-0.8b: Invalid input: expected string, received object
  ... (15 more)
```

`ModelAliasSchema` now accepts both forms an alias can take on disk: the bare URI string that `agency local alias add` writes, and the object form that `refresh` writes. It is `.passthrough()` so an older agency can load a config written by a newer one rather than erroring on a metadata field it does not know about.

The root cause is that this shape is declared twice — `AliasObject` in `localModels.ts` is the type side, `ModelAliasSchema` in `config.ts` is the validation side, and nothing tied them together. The object form was added for `refresh` and `config.ts` was never updated to match. Rather than couple the two modules, `config.modelAliases.test.ts` now round-trips a fully-populated entry through the schema, and `docs/dev/local-models.md` records the contract so the next person adding a field knows to update both.

Note that the old test suite actively pinned the bug in place with a case asserting that a non-string value is rejected. That case is kept, narrowed to values that are neither a string nor an object.

## New catalog entries (7)

The curated list had drifted behind upstream. All single-file Q4_K_M, pins minted by `scripts/genModelHashes.ts`:

| Category | Name | Params | Size | Context |
|---|---|---|---|---|
| general | `gemma-4-e2b` | 2B (E2B) | 3.11 GB | 128K |
| general | `granite-4.1-8b` | 8B | 5.35 GB | 128K |
| general | `mistral-small-3.2` | 24B | 14.33 GB | 128K |
| general | `qwen3.5-35b-a3b` | 35B (A3B) | 22.02 GB | 256K |
| reasoning | `deepseek-r1-0528-qwen3-8b` | 8B | 5.03 GB | 128K |
| reasoning | `magistral-small-2509` | 24B | 14.33 GB | 128K |
| coding | `devstral-small-2-24b` | 24B | 14.33 GB | 384K |

Everything stays laptop-scale. Mistral Small 4 was deliberately left out: despite the name it is a 119B MoE needing ~74 GB resident even though only 24B activate per token, which is a different hardware tier from every other entry here.

**On licensing:** an earlier revision of this branch also added `dolphin-3.0-mistral-24b`, an uncensored fine-tune, recorded as `apache-2.0` inherited from its Mistral base. That was wrong and it has been removed. Apache-2.0 is permissive, not copyleft — §4 lets a derivative carry different terms — so a fine-tune of an apache-2.0 base is not thereby apache-2.0. The Dolphin authors do tag licenses when they mean to (`Dolphin3.0-Llama3.1-8B` declares `llama3.1`, `Dolphin3.0-Qwen2.5-3b` declares `other`); for the Mistral-24B model they declared nothing, and there is no LICENSE file in the repo. The `license` field doc now states the rule explicitly: declared, never inherited.

Running the mint script also picked up four unrelated upstream re-uploads — all four `gemma-4` repos have re-uploaded their GGUFs since the pins were last minted, so those hashes moved too. Worth knowing that this is drift the script found, not something this PR caused.

## New: `agency local list -l` / `--long`

Prints each model's description on its own dimmed line below its row.

```
   NAME                          PARAMS     SIZE      CONTEXT  LICENSE
   smollm2-135m                  135M       0.10 GB   8K       apache-2.0
     Smallest practical chat model; used by our integration tests, runs anywhere.

   qwen3.5-0.8b                  0.8B       0.50 GB   128K     apache-2.0
     Tiny model from Alibaba's current generation; good edge-device default.
```

The blank line goes *before* each model rather than after. That is what keeps the `OTHER FILES` and `Total downloaded:` sections — which already push their own leading blank — from ending up double-spaced. There is a test pinning it. Default output is byte-for-byte unchanged.

## Testing

- Reproduced the config bug as a failing unit test first, then fixed it.
- Verified end-to-end: `agency bar.agency` against the real refreshed `agency.json` (17 object-form aliases) now compiles and runs; before the fix it failed with the error above.
- Ran the built CLI for `list`, `list -l`, `list --long`, and `list --help`.
- Full `lib/` unit suite: 12277 passed. Five failures in `lib/optimize/mutator.test.ts` and `lib/stdlib/mcpBridge.contract.test.ts` are pre-existing and environmental — confirmed identical on a clean tree with these changes stashed.
- `tsc --noEmit` and `pnpm run lint:structure` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
