### PR TITLE
Fix two red CI jobs: stale action fixture and an unpublished package pin

### DIFF
--- a/.github/workflows/local-model.yml
+++ b/.github/workflows/local-model.yml
@@ -35,7 +35,7 @@ jobs:
     env:
       # Bump this in lockstep with smoltalk-llama-cpp upstream releases.
       # node-llama-cpp's version is pinned transitively via smoltalk-llama-cpp's lockfile.
-      SMOLTALK_LLAMA_CPP_VERSION: "0.5.2"
+      SMOLTALK_LLAMA_CPP_VERSION: "0.4.0"
 
     steps:
       - name: Checkout repository

--- a/packages/agency-lang/docs/dev/local-model-integration.md
+++ b/packages/agency-lang/docs/dev/local-model-integration.md
@@ -39,10 +39,14 @@ cache and finish in seconds.
 If you change the curated `smollm2-135m` URI in `lib/stdlib/localModels.ts`,
 update **two** values:
 
-1. `EXPECTED_SHA256` in `tests/integration/local-model/smoltest.test.ts` —
-   currently `null` (format-only check). The first green integration run
-   prints the actual hash; paste it in to enable strict tamper-canary
-   matching on subsequent runs.
+1. `EXPECTED_SHA256` in `tests/integration/local-model/smoltest.test.ts`. It
+   holds the hash of the file the curated URI points at, and the test compares
+   the download against it byte for byte, so a stale value fails the run.
+   Recapture it from Hugging Face's LFS metadata for the new file (the git-LFS
+   oid is the sha256 of the content), or take it from the log line the test
+   prints. Setting it back to `null` drops the check to format-only (64 hex
+   chars) and logs the observed hash, which is a way to recapture a hash you
+   do not have — not a resting state to leave it in.
 2. The cache key in `.github/workflows/local-model.yml` (bump the `v1` suffix
    or change the model identifier in the key).
 

--- a/packages/agency-lang/docs/dev/local-model-integration.md
+++ b/packages/agency-lang/docs/dev/local-model-integration.md
@@ -23,7 +23,9 @@ won't write to your real `~/.agency-agent/models` or `~/agency.json`.
 ```bash
 # In packages/agency-lang/. Install the optional provider (one-time; not in
 # package.json, so this doesn't affect normal `pnpm install`).
-pnpm add --save=false smoltalk-llama-cpp@0.5.2
+# Keep the version in step with SMOLTALK_LLAMA_CPP_VERSION in
+# .github/workflows/local-model.yml, which is the source of truth.
+pnpm add --save=false smoltalk-llama-cpp@0.4.0
 
 # Run the suite (dedicated config — the default vitest run excludes tests/).
 AGENCY_LLM_INTEGRATION=1 pnpm test:integration

--- a/packages/agency-lang/docs/dev/updating-pinned-actions.md
+++ b/packages/agency-lang/docs/dev/updating-pinned-actions.md
@@ -83,6 +83,19 @@ pnpm test:run lib/cli/schedule/backends/github.snapshot.test.ts
 
 Inspect the diff to confirm only the SHA and tag changed.
 
+### 5.25. Update the CLI integration fixtures
+
+A second set of fixtures bakes in the tag: the expected workflow YAML that
+`tests/integration/cli-main/test.mjs` compares against.
+
+```bash
+grep -rln "run-agency-action@" tests/integration/cli-main/fixtures/expected/
+```
+
+Edit the `uses:` line in each. These only run in CI (the `integration`
+workflow), so a stale fixture here passes every local check and fails
+after the merge.
+
 ### 5.5. Re-pin the live workflow files
 
 `pinnedActions.ts` controls workflows generated in *future*. The workflows that
@@ -107,13 +120,16 @@ All schedule tests should pass.
 
 ### 7. Commit
 
-A version bump is a single commit touching three files:
+A version bump is a single commit touching four sets of files:
 
 ```
 lib/cli/schedule/backends/pinnedActions.ts
 makefile
 lib/cli/schedule/backends/__snapshots__/*.yml
+tests/integration/cli-main/fixtures/expected/*.yml
 ```
+
+Plus the live workflows from step 5.5 if any pin the action.
 
 Open a PR with a title like `chore(schedule): bump
 egonSchiele/run-agency-action to v1.0.3`.

--- a/packages/agency-lang/tests/integration/cli-main/fixtures/expected/nightly-cron.expected.yml
+++ b/packages/agency-lang/tests/integration/cli-main/fixtures/expected/nightly-cron.expected.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4.1.7
-      - uses: egonSchiele/run-agency-action@v1.0.2
+      - uses: egonSchiele/run-agency-action@v1.0.3
         with:
           file: 'agents/nightly.agency'
         env:

--- a/packages/agency-lang/tests/integration/cli-main/fixtures/expected/nightly-write.expected.yml
+++ b/packages/agency-lang/tests/integration/cli-main/fixtures/expected/nightly-write.expected.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4.1.7
-      - uses: egonSchiele/run-agency-action@v1.0.2
+      - uses: egonSchiele/run-agency-action@v1.0.3
         with:
           file: 'agents/nightly.agency'
         env:

--- a/packages/agency-lang/tests/integration/cli-main/fixtures/expected/nightly.expected.yml
+++ b/packages/agency-lang/tests/integration/cli-main/fixtures/expected/nightly.expected.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4.1.7
-      - uses: egonSchiele/run-agency-action@v1.0.2
+      - uses: egonSchiele/run-agency-action@v1.0.3
         with:
           file: 'agents/nightly.agency'
         env:


### PR DESCRIPTION
Two CI jobs have been red on main for reasons unrelated to any recent change. This fixes both, and adds the missing step to each doc that would have caught the drift.

## The `integration` job: a fixture nobody updated

The job generates a workflow file with `agency schedule add --backend github` and compares it to a checked-in fixture. One line differed:

```
actual:   - uses: egonSchiele/run-agency-action@v1.0.3
expected: - uses: egonSchiele/run-agency-action@v1.0.2
```

Commit 077e18328 bumped the action to v1.0.3 and updated the generator snapshots under `lib/cli/schedule/backends/__snapshots__/`, but left the three fixtures under `tests/integration/cli-main/fixtures/expected/` on v1.0.2. Everything else was bumped correctly: `pinnedActions.ts`, the makefile tag list, the unit snapshots, and the three live scheduled workflows.

## The `local-model-tests` job: a version that was never published

The job pins `SMOLTALK_LLAMA_CPP_VERSION: "0.5.2"` and fails at install:

```
[ERR_PNPM_NO_MATCHING_VERSION] No matching version found for smoltalk-llama-cpp@0.5.2
The latest release of smoltalk-llama-cpp is "0.4.0".
```

`npm view smoltalk-llama-cpp versions` returns `0.1.0, 0.1.1, 0.2.0, 0.3.0, 0.4.0` — 0.5.2 was never published, so this pin has been unresolvable since it was added in d9df2e51e back in June. Moved to 0.4.0.

## The docs

Both drifts were possible because the written procedure did not mention the file that went stale.

`updating-pinned-actions.md` walks through regenerating the generator snapshots but never mentions the integration fixtures, and its verify step (`pnpm test:run lib/cli/schedule`) does not touch them. Those fixtures only run in the `integration` workflow, so a stale one passes every local check and fails after the merge. Added a step for them, and listed them in the commit file list.

`local-model-integration.md` calls the workflow env var the single source of truth for the smoltalk version, then hardcoded 0.5.2 in its own local-setup instructions. Fixed the version and pointed the reader at the workflow.

## Verification

- The fixtures now match the generator's own checked-in snapshot exactly. `diff` of the `uses:` lines in `nightly-write.expected.yml` against `__snapshots__/all-tag.yml` is empty, on both `actions/checkout@v4.1.7` and `run-agency-action@v1.0.3`. That snapshot is regenerated from `pinnedActions.ts`, so fixture and generator now agree.
- npm confirms 0.4.0 is the latest published version.

Two limits worth stating. I did not run the full integration suite locally — it packs and installs the package, which is the slow CI path. And if anything in `tests/integration/local-model/` depends on a smoltalk API added after 0.4.0, that job will now get past `pnpm add` and fail later instead; this PR's own CI run is the check for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
