### PR TITLE
Polish the label-a-trace flow: full-screen task prompt + shortened trace ids

### DIFF
--- a/packages/agency-lang/lib/eval/label/load/statelog.test.ts
+++ b/packages/agency-lang/lib/eval/label/load/statelog.test.ts
@@ -207,6 +207,46 @@ describe("loadStatelog", () => {
 
   it("errors naming available traces for an unknown id", () => {
     expect(() => load(["ZZ"])).toThrow(IngestSourceError);
-    expect(() => load(["ZZ"])).toThrow(/"ZZ" is not in/);
+    expect(() => load(["ZZ"])).toThrow(/No trace in .* matches "ZZ"/);
+  });
+
+  describe("prefix trace ids", () => {
+    let pdir: string;
+    let pfile: string;
+    beforeEach(() => {
+      pdir = fs.mkdtempSync(path.join(os.tmpdir(), "loadstatelog-prefix-"));
+      const events = [
+        ev("evalOutputRecorded", { value: "answer" }, "abc123"),
+        ev("agentEnd", {}, "abc123"),
+        ev("evalOutputRecorded", { value: "answer2" }, "abc999"),
+        ev("agentEnd", {}, "abc999"),
+      ];
+      pfile = path.join(pdir, "log.jsonl");
+      fs.writeFileSync(pfile, events.map((e) => JSON.stringify(e)).join("\n") + "\n");
+    });
+    afterEach(() => {
+      fs.rmSync(pdir, { recursive: true, force: true });
+    });
+    const loadFrom = (traceIds: string[]) =>
+      loadStatelog({
+        path: pfile,
+        traceIds,
+        source: "s",
+        constantFields: {},
+        includeTaskField: true,
+        maxBytes: 1_048_576,
+      });
+
+    it("resolves a unique prefix to the full id and records the full id", () => {
+      const batch = loadFrom(["abc1"]);
+      expect(batch.occurrences).toHaveLength(1);
+      expect(batch.occurrences[0].origin).toMatchObject({ kind: "statelog", traceId: "abc123" });
+    });
+
+    it("rejects a prefix shared by more than one trace, listing the candidates", () => {
+      expect(() => loadFrom(["abc"])).toThrow(/ambiguous/);
+      expect(() => loadFrom(["abc"])).toThrow(/abc123/);
+      expect(() => loadFrom(["abc"])).toThrow(/abc999/);
+    });
   });
 });

--- a/packages/agency-lang/lib/eval/label/load/statelog.ts
+++ b/packages/agency-lang/lib/eval/label/load/statelog.ts
@@ -8,7 +8,7 @@ import { JsonValueSchema, OccurrenceOriginSchema, type Fields } from "../types.j
 
 import { projectOccurrenceFields, skipReasonFor } from "./occurrence.js";
 import { selectLabelingFinalOutput } from "./run.js";
-import { describeAvailableTraces, scanStatelog } from "./statelogScan.js";
+import { describeAvailableTraces, matchTraceId, scanStatelog } from "./statelogScan.js";
 import {
   IngestSourceError,
   type IngestSkip,
@@ -173,12 +173,24 @@ export function loadStatelog(args: {
       `A statelog source needs at least one --trace <id>.\n${describeAvailableTraces(scan)}`,
     );
   }
-  for (const traceId of args.traceIds) {
-    if (!(traceId in scan.eventsByTrace)) {
+  // A user copies the shortened trace id shown in the log viewer, so resolve
+  // each requested value (which may be a prefix) to its full id before use.
+  const resolvedIds: string[] = [];
+  for (const requested of args.traceIds) {
+    const match = matchTraceId(scan, requested);
+    if (match.kind === "none") {
       throw new IngestSourceError(
-        `Trace "${traceId}" is not in ${args.path}.\n${describeAvailableTraces(scan)}`,
+        `No trace in ${args.path} matches "${requested}".\n${describeAvailableTraces(scan)}`,
       );
     }
+    if (match.kind === "ambiguous") {
+      throw new IngestSourceError(
+        `Trace id "${requested}" is ambiguous — it matches ${match.matches.length} traces:\n` +
+          match.matches.map((id) => `  ${id}`).join("\n") +
+          "\nUse more characters to pick one.",
+      );
+    }
+    resolvedIds.push(match.traceId);
   }
 
   const occurrences: LoadedOccurrence[] = [];
@@ -187,7 +199,7 @@ export function loadStatelog(args: {
     ? { kind: "keep-default" }
     : { kind: "omit" };
 
-  for (const traceId of args.traceIds) {
+  for (const traceId of resolvedIds) {
     const resolution = resolveTrace(scan.eventsByTrace[traceId], args.path);
     if (resolution.kind === "rejected") {
       skips.push({ item: traceId, reason: resolution.reason });

--- a/packages/agency-lang/lib/eval/label/load/statelogScan.test.ts
+++ b/packages/agency-lang/lib/eval/label/load/statelogScan.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { EventEnvelope } from "@/statelog/wireTypes.js";
 
-import { describeAvailableTraces, scanStatelog } from "./statelogScan.js";
+import { describeAvailableTraces, matchTraceId, scanStatelog } from "./statelogScan.js";
 import { IngestSourceError } from "./types.js";
 
 let ts = 0;
@@ -71,7 +71,7 @@ describe("scanStatelog", () => {
 });
 
 describe("describeAvailableTraces", () => {
-  it("lists each trace with its label and cost", () => {
+  it("prints headers and one row per trace, naming an agent-less trace", () => {
     const text = jsonl([
       ev("A", "agentName", { name: "coder" }),
       ev("A", "promptCompletion", {
@@ -81,9 +81,41 @@ describe("describeAvailableTraces", () => {
       ev("B", "agentStart"),
     ]);
     const description = describeAvailableTraces(scanStatelog(text));
-    expect(description).toContain("A");
-    expect(description).toContain("[coder]");
+    // Column headers, so the values are self-explaining.
+    expect(description).toMatch(/TRACE ID\s+AGENT\s+COST\s+TASK/);
+    expect(description).toContain("coder");
     expect(description).toContain("$0.5000");
-    expect(description).toContain("[(unnamed)]");
+    // A trace that never named its agent, spelled out rather than as "[]".
+    expect(description).toContain("(unnamed)");
+    expect(description).not.toContain("[coder]");
+    // Tells the user the id can be shortened, which is the whole point.
+    expect(description).toContain("unique prefix");
+  });
+});
+
+describe("matchTraceId", () => {
+  const scan = scanStatelog(
+    jsonl([ev("abc123", "agentStart"), ev("abc999", "agentStart"), ev("xyz", "agentStart")]),
+  );
+
+  it("matches a full id exactly", () => {
+    expect(matchTraceId(scan, "abc123")).toEqual({ kind: "matched", traceId: "abc123" });
+  });
+
+  it("matches a unique prefix to its full id", () => {
+    expect(matchTraceId(scan, "xy")).toEqual({ kind: "matched", traceId: "xyz" });
+  });
+
+  it("reports a prefix shared by several traces as ambiguous", () => {
+    expect(matchTraceId(scan, "abc")).toEqual({ kind: "ambiguous", matches: ["abc123", "abc999"] });
+  });
+
+  it("reports a prefix that matches nothing as none", () => {
+    expect(matchTraceId(scan, "nope")).toEqual({ kind: "none" });
+  });
+
+  it("prefers an exact id over treating it as a prefix of a longer one", () => {
+    const nested = scanStatelog(jsonl([ev("abc", "agentStart"), ev("abcdef", "agentStart")]));
+    expect(matchTraceId(nested, "abc")).toEqual({ kind: "matched", traceId: "abc" });
   });
 });

--- a/packages/agency-lang/lib/eval/label/load/statelogScan.ts
+++ b/packages/agency-lang/lib/eval/label/load/statelogScan.ts
@@ -100,7 +100,7 @@ export type TraceIdMatch =
  * reported as ambiguous so the caller can lengthen it.
  */
 export function matchTraceId(scan: StatelogScan, requested: string): TraceIdMatch {
-  if (requested in scan.eventsByTrace) {
+  if (Object.hasOwn(scan.eventsByTrace, requested)) {
     return { kind: "matched", traceId: requested };
   }
   const matches = scan.traces

--- a/packages/agency-lang/lib/eval/label/load/statelogScan.ts
+++ b/packages/agency-lang/lib/eval/label/load/statelogScan.ts
@@ -84,14 +84,64 @@ function summarizeTrace(traceId: string, events: readonly EventEnvelope[]): Trac
   return { traceId, agentName, firstUserMessage, costUsd };
 }
 
-/** A human-readable list of the traces a statelog holds, for the "which one?"
- *  error when a caller names an id that is not there or omits `--trace`. */
+/** The result of resolving a user-supplied `--trace` value against a scan. */
+export type TraceIdMatch =
+  | { kind: "matched"; traceId: string }
+  | { kind: "none" }
+  | { kind: "ambiguous"; matches: readonly string[] };
+
+/**
+ * Resolve a user-supplied trace id, which may be a prefix, to a full trace id.
+ *
+ * The log viewer and event footers show only the first several characters of a
+ * trace id, so that shortened form is what a user copies. A full id always wins
+ * (an exact match is never treated as an ambiguous prefix); otherwise a prefix
+ * that singles out one trace matches, and a prefix shared by several is
+ * reported as ambiguous so the caller can lengthen it.
+ */
+export function matchTraceId(scan: StatelogScan, requested: string): TraceIdMatch {
+  if (requested in scan.eventsByTrace) {
+    return { kind: "matched", traceId: requested };
+  }
+  const matches = scan.traces
+    .map((trace) => trace.traceId)
+    .filter((id) => id.startsWith(requested));
+  if (matches.length === 1) {
+    return { kind: "matched", traceId: matches[0] };
+  }
+  return matches.length === 0 ? { kind: "none" } : { kind: "ambiguous", matches };
+}
+
+type TraceRow = { id: string; agent: string; cost: string; task: string };
+
+function traceRow(trace: TraceSummary): TraceRow {
+  return {
+    id: trace.traceId,
+    agent: trace.agentName ?? "(unnamed)",
+    cost: `$${trace.costUsd.toFixed(4)}`,
+    task: trace.firstUserMessage === null ? "" : previewLine(trace.firstUserMessage),
+  };
+}
+
+/** A human-readable table of the traces a statelog holds, for the "which one?"
+ *  error when a caller names an id that is not there or omits `--trace`. Column
+ *  headers name each value, and the id column is wide enough that a user can
+ *  copy a full id or any unique prefix of it. */
 export function describeAvailableTraces(scan: StatelogScan): string {
-  const lines = scan.traces.map((trace) => {
-    const label = trace.agentName ?? "(unnamed)";
-    const preview =
-      trace.firstUserMessage === null ? "" : `  ${previewLine(trace.firstUserMessage)}`;
-    return `  ${trace.traceId}  [${label}]  $${trace.costUsd.toFixed(4)}${preview}`;
-  });
-  return `Available traces:\n${lines.join("\n")}`;
+  const header: TraceRow = {
+    id: "TRACE ID",
+    agent: "AGENT",
+    cost: "COST",
+    task: "TASK (first user message)",
+  };
+  const rows = [header, ...scan.traces.map(traceRow)];
+  const idW = Math.max(...rows.map((row) => row.id.length));
+  const agentW = Math.max(...rows.map((row) => row.agent.length));
+  const costW = Math.max(...rows.map((row) => row.cost.length));
+  const format = (row: TraceRow): string =>
+    `  ${row.id.padEnd(idW)}  ${row.agent.padEnd(agentW)}  ${row.cost.padEnd(costW)}  ${row.task}`.trimEnd();
+  return (
+    "Available traces (pass a full id or any unique prefix to --trace):\n" +
+    rows.map(format).join("\n")
+  );
 }

--- a/packages/agency-lang/lib/logsViewer/run.ts
+++ b/packages/agency-lang/lib/logsViewer/run.ts
@@ -22,9 +22,8 @@ import { TreeView } from "./views/treeView.js";
 import { makeViewStack, type ViewAction, type Viewport } from "./views/view.js";
 import type { TreeNode } from "./types.js";
 import { createLabelingHost } from "../eval/label/labelingHost.js";
-import { projectArtifactField } from "../eval/label/project.js";
 import type { TaskChoice } from "../eval/label/load/statelog.js";
-import { previewLine } from "../eval/label/load/statelogScan.js";
+import { editTaskOnScreen } from "./taskEditor.js";
 import type { Annotator } from "../eval/label/types.js";
 import type { EventEnvelope } from "../statelog/wireTypes.js";
 import {
@@ -105,16 +104,8 @@ async function runTraceLabeling(params: {
   const { screen, launch, traceId, traceEvents, notify } = params;
   const host = createLabelingHost(screen, () => screen.size());
   const ui: LabelTraceUI = {
-    async editTask(defaultTask): Promise<TaskChoice | null> {
-      const preview =
-        defaultTask === null ? "(none)" : previewLine(projectArtifactField(defaultTask));
-      const answer = await screen.nextLine(
-        `Task [${preview}] — Enter keeps, text replaces, "-" clears: `,
-      );
-      const trimmed = answer.trim();
-      if (trimmed === "") return { kind: "keep-default" };
-      if (trimmed === "-") return { kind: "omit" };
-      return { kind: "replace", value: answer };
+    editTask(defaultTask): Promise<TaskChoice | null> {
+      return editTaskOnScreen(screen, defaultTask);
     },
     notify,
   };

--- a/packages/agency-lang/lib/logsViewer/taskEditor.test.ts
+++ b/packages/agency-lang/lib/logsViewer/taskEditor.test.ts
@@ -65,9 +65,49 @@ describe("editTaskOnScreen", () => {
   });
 
   it("paints the pre-filled default gray and the edited text plain white", () => {
-    const untouched = fieldLines("the recorded task", false, true, 60).join("");
-    const edited = fieldLines("the recorded task!", true, true, 60).join("");
+    const untouched = fieldLines("the recorded task", false, 60).join("");
+    const edited = fieldLines("the recorded task!", true, 60).join("");
     expect(untouched).toContain(GRAY); // gray default
     expect(edited).not.toContain(GRAY); // now the annotator's own text
+  });
+
+  it("shows a typing hint when the recorded task is an empty string", async () => {
+    // defaultTask is "" (not null): pre-filled but empty. The field must still
+    // show a hint rather than a blank line that looks broken.
+    const { screen, out } = makeScreen([{ key: "enter" }]);
+    await editTaskOnScreen(screen, "");
+    expect(out.lastText()).toMatch(/type a task/);
+  });
+
+  it("inserts a newline on Shift+Enter and only finalizes on a plain Enter", async () => {
+    // Shift/Option+Enter is the TUI's newline shape; plain Enter submits.
+    const { screen } = makeScreen([
+      ...chars("line one"),
+      { key: "enter", shift: true },
+      ...chars("line two"),
+      { key: "enter" },
+    ]);
+    expect(await editTaskOnScreen(screen, null)).toEqual({
+      kind: "replace",
+      value: "line one\nline two",
+    });
+  });
+
+  it("keeps the cursor and footer on screen for a task longer than the terminal", async () => {
+    // A recorded task that wraps well past a short terminal must not push the
+    // cursor and controls off screen — the field is windowed to its tail.
+    const longTask = Array.from({ length: 40 }, (_, i) => `sentence number ${i}`).join(". ");
+    const out = new FrameRecorder();
+    const screen = new Screen({
+      output: out,
+      input: new ScriptedInput([{ key: "!" }, { key: "enter" }]),
+      width: 70,
+      height: 16,
+    });
+    await editTaskOnScreen(screen, longTask);
+    const shown = out.textAt(out.frames.length - 2); // the frame before Enter finalized
+    expect(shown).toContain("▏"); // the cursor is visible
+    expect(shown).toContain("Esc cancel"); // the footer is visible
+    expect(shown).toContain("⋯"); // and the hidden head is marked
   });
 });

--- a/packages/agency-lang/lib/logsViewer/taskEditor.test.ts
+++ b/packages/agency-lang/lib/logsViewer/taskEditor.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+
+import { Screen } from "../tui/screen.js";
+import { ScriptedInput } from "../tui/input/scripted.js";
+import { FrameRecorder } from "../tui/output/recorder.js";
+import { editTaskOnScreen, fieldLines } from "./taskEditor.js";
+
+// The gray-until-edited signal is an ANSI bright-black foreground.
+const GRAY = "\x1b[90m";
+
+function makeScreen(keys: ReadonlyArray<string | { key: string; text?: string; ctrl?: boolean }>) {
+  const out = new FrameRecorder();
+  const screen = new Screen({ output: out, input: new ScriptedInput(keys), width: 80, height: 24 });
+  return { screen, out };
+}
+
+function chars(text: string): { key: string }[] {
+  return text.split("").map((key) => ({ key }));
+}
+
+describe("editTaskOnScreen", () => {
+  it("pre-fills the field with the recorded task and names the step", async () => {
+    const { screen, out } = makeScreen([{ key: "enter" }]);
+    await editTaskOnScreen(screen, "Write a 10 word story about a cat and a dog.");
+    const text = out.lastText();
+    expect(text).toMatch(/Set the task/);
+    expect(text).toMatch(/Write a 10 word story about a cat and a dog\./);
+  });
+
+  it("keeps the recorded task when the field is accepted untouched", async () => {
+    const { screen } = makeScreen([{ key: "enter" }]);
+    expect(await editTaskOnScreen(screen, "the recorded task")).toEqual({ kind: "keep-default" });
+  });
+
+  it("treats appended text as a replacement of the pre-filled default", async () => {
+    // The default is pre-filled, so typing appends to it — the whole field is
+    // the new task the annotator committed to.
+    const { screen } = makeScreen([...chars("!"), { key: "enter" }]);
+    expect(await editTaskOnScreen(screen, "old task")).toEqual({
+      kind: "replace",
+      value: "old task!",
+    });
+  });
+
+  it("clears the task when the annotator deletes the default down to nothing", async () => {
+    const backspaces = Array.from({ length: "old".length }, () => ({ key: "backspace" }));
+    const { screen } = makeScreen([...backspaces, { key: "enter" }]);
+    expect(await editTaskOnScreen(screen, "old")).toEqual({ kind: "omit" });
+  });
+
+  it("lets the annotator type a task when the run recorded none", async () => {
+    const { screen } = makeScreen([...chars("judge this"), { key: "enter" }]);
+    expect(await editTaskOnScreen(screen, null)).toEqual({ kind: "replace", value: "judge this" });
+  });
+
+  it("backs out with Escape, returning null so the trace is not labeled", async () => {
+    const { screen } = makeScreen([{ key: "x" }, { key: "escape" }]);
+    expect(await editTaskOnScreen(screen, "old task")).toBeNull();
+  });
+
+  it("shows a typing hint when there is no recorded task to pre-fill", async () => {
+    const { screen, out } = makeScreen([{ key: "enter" }]);
+    await editTaskOnScreen(screen, null);
+    expect(out.lastText()).toMatch(/type a task/);
+  });
+
+  it("paints the pre-filled default gray and the edited text plain white", () => {
+    const untouched = fieldLines("the recorded task", false, true, 60).join("");
+    const edited = fieldLines("the recorded task!", true, true, 60).join("");
+    expect(untouched).toContain(GRAY); // gray default
+    expect(edited).not.toContain(GRAY); // now the annotator's own text
+  });
+});

--- a/packages/agency-lang/lib/logsViewer/taskEditor.test.ts
+++ b/packages/agency-lang/lib/logsViewer/taskEditor.test.ts
@@ -8,7 +8,9 @@ import { editTaskOnScreen, fieldLines } from "./taskEditor.js";
 // The gray-until-edited signal is an ANSI bright-black foreground.
 const GRAY = "\x1b[90m";
 
-function makeScreen(keys: ReadonlyArray<string | { key: string; text?: string; ctrl?: boolean }>) {
+function makeScreen(
+  keys: ReadonlyArray<string | { key: string; text?: string; ctrl?: boolean; shift?: boolean }>,
+) {
   const out = new FrameRecorder();
   const screen = new Screen({ output: out, input: new ScriptedInput(keys), width: 80, height: 24 });
   return { screen, out };

--- a/packages/agency-lang/lib/logsViewer/taskEditor.ts
+++ b/packages/agency-lang/lib/logsViewer/taskEditor.ts
@@ -36,22 +36,15 @@ function defaultDraft(defaultTask: JsonValue | null): string {
 /**
  * The field as display lines, wrapped to the width. Gray (a pre-filled default
  * you can accept) until touched, plain white (your own text) after. The cursor
- * sits at the end. An untouched empty field shows a gray typing hint instead,
- * since there is nothing to accept.
+ * sits at the end. An empty, untouched field shows a gray typing hint so it
+ * never looks blank — whether the run recorded no task or recorded an empty one.
  *
  * Exported so a test can assert the gray-then-white behavior directly.
  */
-export function fieldLines(
-  draft: string,
-  touched: boolean,
-  hasDefault: boolean,
-  width: number,
-): string[] {
+export function fieldLines(draft: string, touched: boolean, width: number): string[] {
   const inner = Math.max(8, width - 2);
   if (!touched && draft === "") {
-    const hint = hasDefault
-      ? ""
-      : "type a task to judge this output against, or press Enter to skip";
+    const hint = "type a task to judge this output against, or press Enter to skip";
     return [`  ${CURSOR}${color.brightBlack(hint)}`];
   }
   const wrapped = wrapText(sanitizeUntrusted(draft), inner);
@@ -61,13 +54,28 @@ export function fieldLines(
   return out;
 }
 
+/** Keep the field within `budget` display rows, showing the tail so the cursor
+ *  (always at the end) stays visible and the footer below is never pushed off
+ *  screen for a task that wraps very long. A hidden head is marked with a
+ *  leading ellipsis. */
+function clampField(all: string[], budget: number): string[] {
+  if (all.length <= budget) return all;
+  if (budget <= 1) return [all[all.length - 1]];
+  return [`  ${color.brightBlack("⋯")}`, ...all.slice(all.length - (budget - 1))];
+}
+
 function explanation(hasDefault: boolean): string {
   return hasDefault
     ? "This output will be judged against a task. We filled in the task this run recorded, shown gray — edit it to change it, or press Enter to accept it."
     : "This output will be judged against a task, but this run recorded none. Type one below, or press Enter to skip and judge without a task.";
 }
 
-function editorScreen(state: EditorState, hasDefault: boolean, width: number): Element {
+function editorScreen(
+  state: EditorState,
+  hasDefault: boolean,
+  width: number,
+  height: number,
+): Element {
   const footer = [
     `${color.cyan("Enter")} accept`,
     `${color.cyan("edit")} to change`,
@@ -75,16 +83,24 @@ function editorScreen(state: EditorState, hasDefault: boolean, width: number): E
     `${color.cyan("Esc")} cancel`,
   ].join(color.brightBlack("  ·  "));
   const prose = wrapText(explanation(hasDefault), Math.max(8, width - 2));
-  return column(
-    { justifyContent: "flex-start", padding: 1 },
+  const top = [
     line(color.bold("Set the task")),
     line(""),
     ...prose.map((l) => line(color.brightBlack(l))),
     line(""),
     line(color.bold.yellow("Task")),
-    ...fieldLines(state.draft, state.touched, hasDefault, width).map((l) => line(l)),
-    line(""),
-    line(footer),
+  ];
+  const bottom = [line(""), line(footer)];
+  // padding:1 costs a row top and bottom; the field takes whatever rows are
+  // left, windowed to its tail, so the footer stays on screen no matter how
+  // long the task wraps.
+  const budget = Math.max(1, height - 2 - top.length - bottom.length);
+  const field = clampField(fieldLines(state.draft, state.touched, width), budget);
+  return column(
+    { justifyContent: "flex-start", padding: 1 },
+    ...top,
+    ...field.map((l) => line(l)),
+    ...bottom,
   );
 }
 
@@ -109,9 +125,13 @@ export async function editTaskOnScreen(
   const start = defaultDraft(defaultTask);
   const final = await screen.runLoop<EditorState>({
     initialState: { draft: start, touched: false, done: false, result: null },
-    render: (state) => editorScreen(state, hasDefault, screen.size().width),
+    render: (state) => editorScreen(state, hasDefault, screen.size().width, screen.size().height),
     handleKey: (state, event) => {
       if (event.key === "escape") return { ...state, done: true, result: null };
+      // Shift/Option+Enter inserts a newline (the TUI's editable-buffer
+      // contract, per ui-smoke); only a plain Enter finalizes.
+      if (event.key === "enter" && event.shift === true)
+        return { ...state, draft: state.draft + "\n", touched: true };
       if (event.key === "enter") return { ...state, done: true, result: finalize(state) };
       if (event.key === "backspace")
         return { ...state, draft: state.draft.slice(0, -1), touched: true };

--- a/packages/agency-lang/lib/logsViewer/taskEditor.ts
+++ b/packages/agency-lang/lib/logsViewer/taskEditor.ts
@@ -1,0 +1,130 @@
+// The task-edit step of labeling a trace, as a full-screen prompt.
+//
+// Before a trace is labeled, the annotator sets the "task" — the prompt this
+// output should be judged against. The field is pre-filled with the task the
+// run recorded and shown gray, the way web forms show a default value: press
+// Enter to accept it, or edit it in place. The moment it is edited it turns
+// white, so it is obvious the text is now the annotator's own.
+import { column, line } from "../tui/builders.js";
+import type { Element } from "../tui/elements.js";
+import type { Screen } from "../tui/screen.js";
+import { wrapText } from "../stdlib/layout/ansi.js";
+import { color } from "../utils/termcolors.js";
+import { projectArtifactField } from "../eval/label/project.js";
+import { sanitizeUntrusted } from "../eval/label/labelTui.js";
+import type { TaskChoice } from "../eval/label/load/statelog.js";
+import type { JsonValue } from "../utils/canonicalize.js";
+
+const CURSOR = color.cyan("▏");
+
+type EditorState = {
+  /** The field's current text. Starts as the recorded task (or empty). */
+  draft: string;
+  /** Whether the annotator has changed the field. Drives gray-vs-white and
+   *  keep-default-vs-replace: an untouched field keeps the recorded task. */
+  touched: boolean;
+  done: boolean;
+  result: TaskChoice | null;
+};
+
+/** The recorded task as its editable starting text: a string the annotator can
+ *  edit directly. `null` (no recorded task) starts the field empty. */
+function defaultDraft(defaultTask: JsonValue | null): string {
+  return defaultTask === null ? "" : projectArtifactField(defaultTask);
+}
+
+/**
+ * The field as display lines, wrapped to the width. Gray (a pre-filled default
+ * you can accept) until touched, plain white (your own text) after. The cursor
+ * sits at the end. An untouched empty field shows a gray typing hint instead,
+ * since there is nothing to accept.
+ *
+ * Exported so a test can assert the gray-then-white behavior directly.
+ */
+export function fieldLines(
+  draft: string,
+  touched: boolean,
+  hasDefault: boolean,
+  width: number,
+): string[] {
+  const inner = Math.max(8, width - 2);
+  if (!touched && draft === "") {
+    const hint = hasDefault
+      ? ""
+      : "type a task to judge this output against, or press Enter to skip";
+    return [`  ${CURSOR}${color.brightBlack(hint)}`];
+  }
+  const wrapped = wrapText(sanitizeUntrusted(draft), inner);
+  const painted = touched ? wrapped : wrapped.map((l) => color.brightBlack(l));
+  const out = painted.map((l) => `  ${l}`);
+  out[out.length - 1] = `${out[out.length - 1]}${CURSOR}`;
+  return out;
+}
+
+function explanation(hasDefault: boolean): string {
+  return hasDefault
+    ? "This output will be judged against a task. We filled in the task this run recorded, shown gray — edit it to change it, or press Enter to accept it."
+    : "This output will be judged against a task, but this run recorded none. Type one below, or press Enter to skip and judge without a task.";
+}
+
+function editorScreen(state: EditorState, hasDefault: boolean, width: number): Element {
+  const footer = [
+    `${color.cyan("Enter")} accept`,
+    `${color.cyan("edit")} to change`,
+    `${color.cyan("empty")} = no task`,
+    `${color.cyan("Esc")} cancel`,
+  ].join(color.brightBlack("  ·  "));
+  const prose = wrapText(explanation(hasDefault), Math.max(8, width - 2));
+  return column(
+    { justifyContent: "flex-start", padding: 1 },
+    line(color.bold("Set the task")),
+    line(""),
+    ...prose.map((l) => line(color.brightBlack(l))),
+    line(""),
+    line(color.bold.yellow("Task")),
+    ...fieldLines(state.draft, state.touched, hasDefault, width).map((l) => line(l)),
+    line(""),
+    line(footer),
+  );
+}
+
+function finalize(state: EditorState): TaskChoice {
+  if (!state.touched) return { kind: "keep-default" };
+  if (state.draft.trim() === "") return { kind: "omit" };
+  return { kind: "replace", value: state.draft };
+}
+
+/**
+ * Run the full-screen task editor on the viewer's own screen and return the
+ * annotator's choice, or `null` if they backed out with Esc.
+ *
+ * Leaving the pre-filled default untouched keeps the recorded task; editing it
+ * to some text replaces it; clearing it out means judge with no task.
+ */
+export async function editTaskOnScreen(
+  screen: Screen,
+  defaultTask: JsonValue | null,
+): Promise<TaskChoice | null> {
+  const hasDefault = defaultTask !== null;
+  const start = defaultDraft(defaultTask);
+  const final = await screen.runLoop<EditorState>({
+    initialState: { draft: start, touched: false, done: false, result: null },
+    render: (state) => editorScreen(state, hasDefault, screen.size().width),
+    handleKey: (state, event) => {
+      if (event.key === "escape") return { ...state, done: true, result: null };
+      if (event.key === "enter") return { ...state, done: true, result: finalize(state) };
+      if (event.key === "backspace")
+        return { ...state, draft: state.draft.slice(0, -1), touched: true };
+      // Bracketed paste arrives as one event carrying the whole clipboard.
+      if (event.key === "paste")
+        return { ...state, draft: state.draft + (event.text ?? ""), touched: true };
+      // A stray Ctrl-key while typing must not land in the text.
+      if (event.ctrl === true) return state;
+      if (event.key.length === 1 && event.key >= " ")
+        return { ...state, draft: state.draft + event.key, touched: true };
+      return state;
+    },
+    isDone: (state) => state.done,
+  });
+  return final.result;
+}


### PR DESCRIPTION
Polish to the label-a-trace flow, in two independent commits.

## 1. Task step: a clear full-screen prompt

Pressing `l` in the log viewer to label a trace first asks you to set the **task** — the prompt the output should be judged against. That step used a one-line readline prompt painted on top of the tree view, so it looked broken and gave no sign it wanted input:

```
Task [Please fetch the latest news for today, 2026-08-15, for the …] — Enter keeps, text replaces, "-" clears:
```

It is now a dedicated full-screen page:

```
 Set the task

 This output will be judged against a task. We filled in the task this
 run recorded, shown gray — edit it to change it, or press Enter to
 accept it.

 Task
   Write a 10 word story about a cat and a dog.▏

 Enter accept  ·  edit to change  ·  empty = no task  ·  Esc cancel
```

One editable field, pre-filled with the recorded task and shown **gray** the way a web form shows a default value. Press Enter to accept it, or edit it in place — the moment you edit, the text turns **white**, so it is obvious it is now yours. Untouched keeps the recorded task; edited-to-text replaces it; cleared out judges with no task; Esc backs out. Built on the same `runLoop`/Element machinery the labeling TUI uses, so the frame clears the tree view instead of drawing over it. Recorded task and draft are sanitized as untrusted model output.

## 2. Ingest: accept a shortened trace id, and label the trace list

`agency label ingest <statelog> --trace <id>` required the full trace id. But the log viewer shows only the first several characters — so a user copies `KQYcet` and gets `Trace "KQYcet" is not in log.jsonl`, which reads as "no such trace" even though it is right there. Ingest now resolves a `--trace` value that is a **prefix** to its full id (exact id always wins; a prefix that singles out one trace matches; a shared prefix is rejected with the candidates listed). The full id is what the occurrence records, so identity stays stable.

The "Available traces" listing was also cryptic — `rpGX…  [(unnamed)]  $0.0000  …` with no headers. It now has column headers, aligned columns, spells an agent-less trace as `(unnamed)` (not `[(unnamed)]`), and says a full id or any unique prefix works:

```
Available traces (pass a full id or any unique prefix to --trace):
  TRACE ID               AGENT         COST     TASK (first user message)
  rpGXbww2gfHaZDLBL8Z2H  (unnamed)     $0.0012  Write a 10 word story about a cat and a dog.
  KQYcet                 news-fetcher  $0.0300  Please fetch the latest news for today, 2026-08-15, for the …
  GY1HnAWAGIV4odc5aMq26  (unnamed)     $0.0000
```

## Tests

`taskEditor.test.ts` drives the editor through a real `Screen` + `ScriptedInput` + `FrameRecorder` (pre-fill/keep/replace/clear/type-when-none/cancel, plus gray-vs-white). `matchTraceId` and the prefix/ambiguity paths of `loadStatelog` are unit-tested, and `describeAvailableTraces` asserts the headers. Full `lib/eval/label` + `lib/logsViewer` suites green. tsc, `lint:structure`, and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
