### PR TITLE
Run directory arc, phase 1: agentStart records code identity and input

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,7 @@ Pipeline and architecture:
 - `docs/dev/globalstore.md` — Global variable management with module isolation and serialization
 - `docs/dev/init-topsort.md` — Per-variable init dep graph, topological sort, per-module init plans, runtime init registry
 - `docs/dev/smoltalk.md` — External LLM client library for structured output requests
-- `docs/dev/statelog.md` — Observability and tracing system for execution events
+- `docs/dev/statelog.md` — Observability and tracing system for execution events; `agentStart` records code identity (`code`, cwd-independent closure hash) and the explicit `input`
 - `docs/dev/config.md` — AgencyConfig options for compiler and runtime configuration
 - `docs/dev/cli-arguments.md` — One command line, two programs: the position rule (agency's flags before the filename), the ownership rule (a flag is valid after its owning command, never before), the misplaced-flag warning and its `--` suppression, the shorthand being the real `run` command, the agent's full flag delegation with the minimal launcher pre-scan, and the `--` asymmetry across launchers
 - `docs/dev/vendored-commander.md` — The vendored commander fork: what was copied, the six ledgered modifications (duplicate-name guard, boundaries, provenance, fallback, ownership-aware parsing), the fork-discipline rules, and how to diff against upstream
@@ -126,7 +126,7 @@ Pipeline and architecture:
 - `docs/dev/runBatch.md` — The `runBatch` primitive: signature, three modes, slice rule, invoke no-throw contract, defensive guards
 - `docs/dev/saveDraft.md` — saveDraft salvage-on-abort: aborted functions return their draft (`AbortedResult`), the salvage rules and why they are structural, trade-offs, and easy-to-miss nuances
 - `docs/dev/reply-attachments.md` — How tools hand images back to the model: attachToReply, branch-local queues, harvest/inject in the tool loop, marker-string API
-- `docs/dev/writing-optimizers.md` — How to write a new `eval optimize` strategy on `BaseOptimizer`: the contract, helpers, grading semantics, reflection feedback, registration, testing
+- `docs/dev/writing-optimizers.md` — How to write a new `optimize` strategy on `BaseOptimizer`: the contract, helpers, grading semantics, reflection feedback, registration, testing
 - `docs/dev/eval-grading.md` — The run directory is the interface between running and grading: why `eval run --grade` deliberately re-reads what it just wrote, errored-runs-score-zero, per-test graders and the override/fallback precedence, where loader tolerance lives
 - `docs/dev/logs-viewer.md` — The interactive statelog viewer: the component View classes and view stack, the timeline kernel (self-time, busyness shading, thread-label grouping), and the rebuilt follow mode
 - `docs/dev/runs-explorer.md` — The cross-run explorer behind `agency logs <paths…>`: the loader's two-read phase 1 + bounded backfill, cursor pinned to row identity, the shared column-width table component, the embedded-viewer hand-off rules, CSV semantics

--- a/packages/agency-lang/docs/dev/statelog.md
+++ b/packages/agency-lang/docs/dev/statelog.md
@@ -148,7 +148,7 @@ that let a trace stand on its own as "a run" (see
 - `input` — what the entry node was given, when the caller named it. It is
   never derived from the node's parameters (a plain one-parameter call and an
   eval input look identical there). The generated node wrapper takes a hidden
-  `input` option; the subprocess bootstrap passes `RunInstruction.task` through
+  `invocationInput` option (not `input`, which is a common parameter name); the subprocess bootstrap passes `RunInstruction.task` through
   it, so eval runs record their input and ordinary `agency run` invocations
   record none.
 

--- a/packages/agency-lang/docs/dev/statelog.md
+++ b/packages/agency-lang/docs/dev/statelog.md
@@ -129,6 +129,29 @@ parent/child tree.
 Run lifecycle: `runMetadata`, `agentStart`, `agentEnd` (`agentEnd` posts its
 remote send with `noWait`).
 
+### Code identity and input on `agentStart`
+
+`agentStart` carries two fields that cannot be recovered after the fact and
+that let a trace stand on its own as "a run" (see
+`docs/superpowers/specs/2026-08-18-run-directory-and-annotations-design.md`):
+
+- `code` — `{ entry, closureHash, closure: [{ file, sha256 }] }`, computed by
+  `computeCodeIdentity(entryFile)` in `lib/runDirectory/codeIdentity.ts`.
+  Paths are relative to the closure files' common ancestor (never the cwd),
+  so the same code hashes the same wherever it was run from. It reaches the
+  client as `StatelogConfig.code`, which every launcher fills through the
+  `log.code` config override: `agency run` (`lib/cli/commands.ts`), the eval
+  file runner (`lib/eval/run/runAgent.ts` hashes the *seeded* copy), and
+  `agency agent` (`lib/cli/runBundledAgent.ts`; a precompiled agent shipped
+  without its `.agency` source records nothing). Command agents under
+  `--agent-cmd` get it from the `agency` CLI they invoke.
+- `input` — what the entry node was given, when the caller named it. It is
+  never derived from the node's parameters (a plain one-parameter call and an
+  eval input look identical there). The generated node wrapper takes a hidden
+  `input` option; the subprocess bootstrap passes `RunInstruction.task` through
+  it, so eval runs record their input and ordinary `agency run` invocations
+  record none.
+
 Graph & nodes: `graph`, `enterNode`, `exitNode`, `beforeHook`, `afterHook`,
 `followEdge`.
 

--- a/packages/agency-lang/docs/superpowers/plans/2026-08-18-run-directory-and-annotations-REVIEW-2.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-08-18-run-directory-and-annotations-REVIEW-2.md
@@ -1,0 +1,97 @@
+# Re-review: run directory and annotations implementation plan
+
+**Plan:** `2026-08-18-run-directory-and-annotations.md`  
+**Verdict:** The revision resolves the first review's phase-ordering, atomic
+rename, trace-digest, and score-revision findings. Three correctness issues
+remain; Findings 1 and 2 should be fixed before implementation.
+
+The prior objection to storing harness observations as `run` annotations is
+withdrawn and is not part of this review.
+
+## Resolved from the first review
+
+- Task 3.4 now keeps `labelingHost` and `datasetWriter` until the old label CLI
+  is replaced.
+- Task 4.1 makes `task` → `input` an atomic migration and includes a
+  completeness search and broad verification.
+- Trace digests now canonicalize parsed envelopes, and conflict detection is
+  correctly limited to `mergeStatelog`, where the two streams are separate.
+- Score rows now carry a grading-pass id, and machine annotator ids include a
+  revision hash.
+
+## 1. Checklist folding currently merges different humans' answers
+
+Task 2.3 defines effective checklist state as:
+
+```ts
+checklists: Record<string /*checklist*/, Record<string /*questionId*/, boolean>>
+```
+
+That key omits the annotator. If Alice answers `q1: true` and Bob later answers
+`q1: false` against the same checklist, the fold produces one answer—Bob's—and
+Alice's judgement disappears from effective state. This contradicts the
+annotation rule that named annotators never merge and prevents later agreement
+measurement.
+
+Key checklist folds by `(traceId, checklist, annotator.kind, annotator.id)`, as
+the current label store does. Add a test with two humans answering the same
+question differently and assert that both effective judgements survive.
+
+## 2. A crashed grading pass can become the effective hybrid of two passes
+
+`gradeSuite` mints a random `passId`, then appends one score row at a time. The
+same id makes a retry *inside the same process* idempotent, but after a process
+crash the CLI cannot recover that random id. More importantly, the fold chooses
+the latest row independently per grader.
+
+Example:
+
+1. Pass A writes scores `quality=0.8` and `speed=0.7`.
+2. Pass B writes `quality=0.2`, then crashes before writing `speed`.
+3. The effective fold becomes `quality=0.2` from B plus `speed=0.7` from A.
+
+That combination was never a completed grading pass, yet it can drive the
+reported objective and optimizer.
+
+Give a pass a completion boundary. The simplest append-only shape is a
+`grade-pass` completion row written after all of that pass's scores; readers
+ignore score rows whose pass has no completion row and fold the latest complete
+pass. Alternatively append the whole pass as one annotation row. Add a
+crash-after-first-grader test proving an incomplete pass never changes the
+effective scorecard.
+
+## 3. Ignoring a torn final line is unsafe unless writers repair it before appending
+
+Tasks 2.1 and 2.3 ignore a final line without `\n`, but `mergeStatelog` and
+`appendAnnotation` then append directly to the file. If the file ends with:
+
+```text
+{"v":1,"id":"ann_par
+```
+
+the next JSON row is attached to those bytes. The torn line becomes a malformed
+middle line and the newly written row is lost with it.
+
+Under the writer lock, truncate the file back to its last newline before every
+append (and `fsync` the repair), or refuse writes until the user repairs it.
+Ignoring is fine for readers; it is not sufficient for writers. Test both
+annotation and statelog append after a torn suffix.
+
+## Smaller plan corrections
+
+- Task 3.4 says Task 5.2 will delete `labelingHost.ts` and `datasetWriter.ts`,
+  but Task 5.2's delete list does not include them. Add them there with their
+  tests.
+- A grader id hashes only the entry module file. If grader modules can import
+  local helpers, editing a helper changes behavior without changing identity.
+  Hash the grader's local closure, or explicitly constrain grader identity to a
+  self-contained module and document that limitation.
+- Task 4.2 deletes `prepareInput`, which currently allocates and seeds each
+  test's workdir, but does not name its replacement staging lifecycle. Specify
+  that each test runs in a temporary directory outside the final run directory,
+  is copied to `workdir/<traceId>/`, and is removed afterward; otherwise an
+  implementer can accidentally preserve the old `inputs/<id>/` tree.
+
+After the checklist key and grading-pass completion contract are corrected,
+the plan is ready to execute. The torn-tail rule should be fixed in the same
+core phase because it affects both append-only files.

--- a/packages/agency-lang/docs/superpowers/plans/2026-08-18-run-directory-and-annotations-REVIEW.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-08-18-run-directory-and-annotations-REVIEW.md
@@ -1,0 +1,80 @@
+# Review: run directory and annotations implementation plan
+
+**Plan:** `2026-08-18-run-directory-and-annotations.md`  
+**Verdict:** Strong decomposition, but four sequencing/contract issues must be
+fixed before execution. Finding 5 should also be settled now because it changes
+the annotation identity written in Phase 2.
+
+## 1. Phase 3 deletes services that the still-live label CLI requires
+
+Task 3.4 deletes `labelingHost.ts` and `datasetWriter.ts` at lines 385–393, but
+the replacement label flow does not land until Task 5.2. Today
+`lib/cli/eval/label.ts` imports `createLabelingHost`, and
+`lib/cli/eval/ingest.ts` imports `datasetWriter`. The Phase 3 PR therefore
+cannot typecheck, and `agency label` / `agency label ingest` would be broken for
+the whole Phase 3→5 interval.
+
+Task 3.4 should remove only the viewer hook and its use of those services.
+Keep `labelingHost` and `datasetWriter` until Task 5.2 removes the old CLI flow,
+or move all labeling replacement work into the same phase. Every phase is
+supposed to be independently shippable, so knowingly broken intermediate PRs
+are not an option.
+
+## 2. Task 4.1's `task` → `input` change is much larger than its file list
+
+Task 4.1 changes `Input` into `Test` with an `input` field, then retains
+`type Input = Test` temporarily. A type alias preserves the type's name; it
+does not preserve the removed `.task` property. There are current `.task`
+consumers in `runSuite.ts`, `runAgent.ts`, `subprocess.ts`, the optimizer,
+reflection feedback, fixtures, and many tests. Task 4.1's stated edits therefore
+cannot pass the phase typecheck.
+
+Choose one atomic boundary:
+
+- migrate the field and all consumers in Task 4.1; or
+- make the loader normalize user-facing `input` into a temporary internal
+  shape that still has `task`, then migrate the internal type in a later task.
+
+The first option better satisfies the plan's vocabulary goal. In either case,
+list the affected production files and add a repository search confirming that
+eval-specific `.task` accesses are gone before committing.
+
+## 3. The trace reader cannot implement the promised post-`cat` conflict detection
+
+Task 2.1 groups every line with the same `trace_id` into one trace. Once two
+statelogs have been concatenated, there is no boundary saying “the second copy
+of trace A starts here.” Multiple lines with trace A are also the normal shape
+of one trace. The self-review's proposed test that a “conflicting duplicate id”
+is detected by `readTraces` therefore has no implementable rule.
+
+There is a second mismatch: the spec calls for a canonical event digest, while
+Task 2.1 hashes raw lines. Re-serializing the same JSON with a different object
+key order would then produce a conflict even though the events are equal.
+
+Keep conflict detection at `mergeStatelog`, where existing and incoming traces
+are still separate and can be compared. Digest canonicalized parsed envelopes
+in event order. Do not promise that an arbitrary `cat` result can distinguish
+two conflicting streams unless the statelog format first gains a trace boundary
+or sequence identity that makes that distinction possible.
+
+## 4. Deterministic score ids erase grading passes and merge edited graders
+
+The id in lines 17–18 hashes the complete payload but no grading-pass identity.
+Task 4.3 consequently says an identical re-grade appends nothing. That
+contradicts “one row per grader per grading pass” and makes it impossible to
+observe that a second pass occurred when its score happened to be unchanged.
+
+The annotator ids are also too weak: a module path does not identify a grader
+revision. Editing `graders.ts` in place leaves the same annotator id, so its new
+score silently supersedes the old grader's score. Likewise,
+`goal-judge:<model>` omits the prompt/config revision that the spec says must be
+part of judge identity.
+
+Add a grading-pass id to score rows and their identity, and identify machine
+annotators by configuration/content revision (for example module closure hash,
+or model + prompt hash). Keep the deterministic id for crash replay by deriving
+it from `(passId, traceId, annotator, graderName, payload)`. Add tests for:
+
+1. replaying the same row in one pass → no duplicate;
+2. running a second pass with the same result → a second row;
+3. editing a grader at the same path → a distinct annotator identity.

--- a/packages/agency-lang/docs/superpowers/plans/2026-08-18-run-directory-and-annotations.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-08-18-run-directory-and-annotations.md
@@ -4,7 +4,7 @@
 
 **Goal:** Make the statelog the run, and one plain directory plus one append-only `annotations.jsonl` the single shape that observing, noting, labeling, grading and optimizing all read and write.
 
-**Architecture:** A new `lib/runs/` module owns the run directory behind one declarative read interface (`readRunDirectory`) and four declarative write operations (`addToRunDirectory`, `recordCompletedRun`, `recordNote`, `recordGradingPass`). Those operations—not CLIs or eval callers—own the writer lock, complete preflight, mutation order, safe replacement, torn-tail repair and durable append. The runtime records code identity and input on `agentStart`; then the eval harness, grader, labeling TUI, optimizer and log viewer are re-pointed at the new module, and the redundant formats they replaced are deleted.
+**Architecture:** A new `lib/runDirectory/` module owns the run directory behind one declarative read interface (`readRunDirectory`) and four declarative write operations (`addToRunDirectory`, `recordCompletedRun`, `recordNote`, `recordGradingPass`). Those operations—not CLIs or eval callers—own the writer lock, complete preflight, mutation order, safe replacement, torn-tail repair and durable append. The runtime records code identity and input on `agentStart`; then the eval harness, grader, labeling TUI, optimizer and log viewer are re-pointed at the new module, and the redundant formats they replaced are deleted.
 
 **Tech Stack:** TypeScript, Node `fs`/`crypto`, zod (row schemas), vitest, the vendored commander (CLI), the existing statelog client and JSONL helpers.
 
@@ -43,7 +43,7 @@
 New module, one concept per file:
 
 ```
-lib/runs/
+lib/runDirectory/
   runDir.ts            # paths + readRunDirectory(dir) → one consistent snapshot
   traces.ts            # per-trace digest; readTraces(statelogPath) → Trace[]
   mergeStatelog.ts     # pure preflight + private application of a trace merge
@@ -55,11 +55,11 @@ lib/runs/
   attachWorkdir.ts     # private preflight/application for workdir attachments
   evalRecord.ts        # evalRecordFor(trace) — the in-memory EvalRecord from a Trace
   list.ts              # summarizeRuns(dir) → one row per trace for `runs list`
-lib/cli/runs/
+lib/cli/runDirectory/
   add.ts  list.ts  note.ts  extract.ts   # one command per file
 ```
 
-Existing files that change hands: `lib/eval/label/{checklist,controller,labelTui,session,draft,annotations}.ts` are re-pointed at `lib/runs/annotations.ts`; everything else under `lib/eval/label/` and `lib/eval/label/load/` is deleted in Phase 5.
+Existing files that change hands: `lib/eval/label/{checklist,controller,labelTui,session,draft,annotations}.ts` are re-pointed at `lib/runDirectory/annotations.ts`; everything else under `lib/eval/label/` and `lib/eval/label/load/` is deleted in Phase 5.
 
 ---
 
@@ -113,8 +113,8 @@ git commit -F /private/tmp/…/scratchpad/msg.txt   # "Remove the label-save pro
 ### Task 1.1: `computeCodeIdentity`
 
 **Files:**
-- Create: `lib/runs/codeIdentity.ts`
-- Test: `lib/runs/codeIdentity.test.ts`
+- Create: `lib/runDirectory/codeIdentity.ts`
+- Test: `lib/runDirectory/codeIdentity.test.ts`
 
 **Interfaces:**
 - Produces: `type CodeIdentity = { entry: string; closureHash: string; closure: { file: string; sha256: string }[] }` and `computeCodeIdentity(entryFile: string): CodeIdentity`. `entry` and `closure[].file` are relative to `agentClosure(entryFile).baseDir`, sorted by `file`; `closureHash` = `sha256Text(closure.map(f => `${f.file}\n${f.sha256}\n`).join(""))`.
@@ -122,7 +122,7 @@ git commit -F /private/tmp/…/scratchpad/msg.txt   # "Remove the label-save pro
 - [ ] **Step 1: Write the failing test**
 
 ```ts
-// lib/runs/codeIdentity.test.ts
+// lib/runDirectory/codeIdentity.test.ts
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
@@ -166,13 +166,13 @@ describe("computeCodeIdentity", () => {
 
 - [ ] **Step 2: Run it to see it fail**
 
-Run: `pnpm vitest run lib/runs/codeIdentity.test.ts > /private/tmp/…/scratchpad/t11.log 2>&1`
+Run: `pnpm vitest run lib/runDirectory/codeIdentity.test.ts > /private/tmp/…/scratchpad/t11.log 2>&1`
 Expected: FAIL, cannot find module `./codeIdentity.js`.
 
 - [ ] **Step 3: Implement**
 
 ```ts
-// lib/runs/codeIdentity.ts
+// lib/runDirectory/codeIdentity.ts
 import * as fs from "fs";
 import * as path from "path";
 import { agentClosure } from "@/analysis/closure.js";
@@ -265,13 +265,13 @@ Do not reconstruct input from `RunNodeArgs.data`: an ordinary one-parameter invo
 
 ---
 
-# Phase 2 — `lib/runs/`: the run directory core
+# Phase 2 — `lib/runDirectory/`: the run directory core
 
 ### Task 2.1: Traces and per-trace digest
 
 **Files:**
 - Modify: `lib/statelog/parse.ts`, `lib/statelog/parse.test.ts`
-- Create: `lib/runs/traces.ts`, `lib/runs/traces.test.ts`
+- Create: `lib/runDirectory/traces.ts`, `lib/runDirectory/traces.test.ts`
 
 **Interfaces:**
 - Produces: `type ParsedEventLine = { event: EventEnvelope; raw: string; line: number }`; `parseStatelogJsonlWithLines(text): { lines: ParsedEventLine[]; errors: ParseError[] }`. The existing `parseStatelogJsonl` delegates to it and maps `lines` to events, so JSON decoding, version checks and envelope validation still have one owner.
@@ -281,12 +281,12 @@ Do not reconstruct input from `RunNodeArgs.data`: an ordinary one-parameter invo
 - [ ] **Step 1: Failing tests** — first extend the parser test to prove `parseStatelogJsonlWithLines` returns the validated envelope, original raw line and one-based line number, while `parseStatelogJsonl` retains its existing output. Then write a 3-line statelog with two trace ids and assert `readTraces` returns two traces with the right event counts; assert `traceDigest` is equal for envelopes that differ only in key order and differs when a value changes; assert a duplicated identical line yields one event; assert prefix match works; assert a trailing partial line is not counted.
 - [ ] **Step 2: Run, fail.**
 - [ ] **Step 3: Implement** — move the existing per-line decoding in `parseStatelogJsonl` into `parseStatelogJsonlWithLines`; make the old function delegate. `readTraces` removes only the torn suffix before calling that parser, groups its validated `ParsedEventLine`s by `trace_id`, skips exact duplicate raw lines and computes the canonical digest. It must not call `JSON.parse` itself.
-- [ ] **Step 4: Run, pass.** **Step 5: Commit** ("Add lib/runs/traces: read a statelog into traces with per-trace digests").
+- [ ] **Step 4: Run, pass.** **Step 5: Commit** ("Add lib/runDirectory/traces: read a statelog into traces with per-trace digests").
 
 ### Task 2.2: Named annotation types and effective state
 
 **Files:**
-- Create: `lib/runs/annotations.ts`, `lib/runs/annotations.test.ts`
+- Create: `lib/runDirectory/annotations.ts`, `lib/runDirectory/annotations.test.ts`
 
 **Interfaces:**
 - Produces named types rather than nested anonymous object contracts:
@@ -341,8 +341,8 @@ export function foldAnnotations(rows: Annotation[]): Record<string, EffectiveTra
 ### Task 2.3: One read snapshot and private lock infrastructure
 
 **Files:**
-- Create: `lib/runs/runDir.ts`, `lib/runs/runDir.test.ts`, `lib/runs/lock.ts`
-- Move test: `lib/eval/label/lock.test.ts` → `lib/runs/lock.test.ts`
+- Create: `lib/runDirectory/runDir.ts`, `lib/runDirectory/runDir.test.ts`, `lib/runDirectory/lock.ts`
+- Move test: `lib/eval/label/lock.test.ts` → `lib/runDirectory/lock.test.ts`
 
 **Interfaces:**
 - Produces: `type RunDirectorySnapshot = { dir: string; hasStatelog: boolean; traces: Trace[]; annotationRows: Annotation[]; effectiveAnnotations: Record<string, EffectiveTraceAnnotations> }`; `readRunDirectory(dir, {reportWarning}) → RunDirectorySnapshot`; `runDirPaths(dir) → RunDirectoryPaths` (a named type).
@@ -355,7 +355,7 @@ export function foldAnnotations(rows: Annotation[]): Record<string, EffectiveTra
 ### Task 2.4: Private mutation primitives and safe replacement
 
 **Files:**
-- Create: `lib/runs/mergeStatelog.ts`, `lib/runs/attachCode.ts`, `lib/runs/attachWorkdir.ts`, tests for each
+- Create: `lib/runDirectory/mergeStatelog.ts`, `lib/runDirectory/attachCode.ts`, `lib/runDirectory/attachWorkdir.ts`, tests for each
 - Modify: `lib/utils.ts`, `lib/utils.test.ts`
 
 **Interfaces:**
@@ -372,7 +372,7 @@ export function foldAnnotations(rows: Annotation[]): Record<string, EffectiveTra
 ### Task 2.5: Declarative run-directory mutations
 
 **Files:**
-- Create: `lib/runs/mutations.ts`, `lib/runs/mutations.test.ts`
+- Create: `lib/runDirectory/mutations.ts`, `lib/runDirectory/mutations.test.ts`
 
 **Interfaces:**
 - Produces named request/result types and four public operations. The request describes the desired domain change, not the lock or filesystem steps needed to make it:
@@ -452,7 +452,7 @@ export function recordGradingPass(request: RecordGradingPassRequest): RecordGrad
 ### Task 2.6: `evalRecordFor` and `summarizeRuns`
 
 **Files:**
-- Create: `lib/runs/evalRecord.ts`, `lib/runs/list.ts`, tests
+- Create: `lib/runDirectory/evalRecord.ts`, `lib/runDirectory/list.ts`, tests
 
 **Interfaces:**
 - `evalRecordFor(trace, sourcePath) → EvalRecord`; `summarizeRuns(snapshot: RunDirectorySnapshot) → RunSummary[]`. Define `RunSummary` as a named type with one property per displayed column; callers never reopen or separately fold files.
@@ -471,11 +471,11 @@ export function recordGradingPass(request: RecordGradingPassRequest): RecordGrad
 ### Task 3.1: `agency logs extract <log> --trace <id> [-o <file>]`
 
 **Files:**
-- Create: `lib/cli/runs/extract.ts`, `lib/cli/runs/extract.test.ts`
+- Create: `lib/cli/runDirectory/extract.ts`, `lib/cli/runDirectory/extract.test.ts`
 - Modify: `scripts/agency.ts` (register under the `logs` command at `:683`)
 
 **Interfaces:**
-- `logsExtract({ log, trace?, out? }, deps = { stdout })`: `readTraces(log)`; if `trace` is undefined and there is exactly one trace, use it; if undefined with several, error listing ids (reuse the table from `describeAvailableTraces` — move that helper into `lib/runs/traces.ts` in this task); prefix match via `matchTrace`; write `trace.lines.join("\n") + "\n"` to `out` (create parent dirs) or stdout.
+- `logsExtract({ log, trace?, out? }, deps = { stdout })`: `readTraces(log)`; if `trace` is undefined and there is exactly one trace, use it; if undefined with several, error listing ids (reuse the table from `describeAvailableTraces` — move that helper into `lib/runDirectory/traces.ts` in this task); prefix match via `matchTrace`; write `trace.lines.join("\n") + "\n"` to `out` (create parent dirs) or stdout.
 
 - [ ] **Step 1: Failing test** — two-trace log: no `--trace` → error listing both; `--trace <prefix>` → output has exactly that trace's lines; one-trace log with no `--trace` → succeeds.
 - [ ] **Step 2–4.** **Step 5: Commit** ("agency logs extract: copy one trace out of a statelog").
@@ -483,7 +483,7 @@ export function recordGradingPass(request: RecordGradingPassRequest): RecordGrad
 ### Task 3.2: `agency runs add`
 
 **Files:**
-- Create: `lib/cli/runs/add.ts`, test
+- Create: `lib/cli/runDirectory/add.ts`, test
 - Modify: `scripts/agency.ts` (new `runs` command group with `add`)
 
 **Interfaces:**
@@ -495,7 +495,7 @@ export function recordGradingPass(request: RecordGradingPassRequest): RecordGrad
 ### Task 3.3: `agency note <dir> [--trace <id>] <text>` and `agency runs list <dir>`
 
 **Files:**
-- Create: `lib/cli/runs/note.ts`, `lib/cli/runs/list.ts`, tests
+- Create: `lib/cli/runDirectory/note.ts`, `lib/cli/runDirectory/list.ts`, tests
 - Modify: `scripts/agency.ts`
 
 - `note`: resolve the trace from `readRunDirectory`, call `recordNote({ dir, traceId, annotator, text })`, and print the returned annotation id. It never opens the annotation file or lock.
@@ -583,7 +583,7 @@ Rules to keep from `docs/dev/eval-grading.md`: a trace whose `run.ended !== "ok"
 
 **Files:**
 - Modify: `lib/eval/label/checklist.ts` (paths from `runDirPaths(dir).checklistsDir`; drafts at `checklists/<name>/draft.json`), `lib/eval/label/draft.ts` (draft carries `pendingAnnotation` as today, plus `traceIds` order for the session id)
-- Create: `lib/runs/checklistSignoff.ts`, `lib/runs/checklistSignoff.test.ts`
+- Create: `lib/runDirectory/checklistSignoff.ts`, `lib/runDirectory/checklistSignoff.test.ts`
 - Test: existing checklist/draft tests re-pointed
 
 **Interfaces:**

--- a/packages/agency-lang/docs/superpowers/plans/2026-08-18-run-directory-and-annotations.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-08-18-run-directory-and-annotations.md
@@ -1,0 +1,658 @@
+# Run Directory and Annotations Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task, inline in this session (this repo does not use subagent-driven development). Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the statelog the run, and one plain directory plus one append-only `annotations.jsonl` the single shape that observing, noting, labeling, grading and optimizing all read and write.
+
+**Architecture:** A new `lib/runs/` module owns the run directory behind one declarative read interface (`readRunDirectory`) and four declarative write operations (`addToRunDirectory`, `recordCompletedRun`, `recordNote`, `recordGradingPass`). Those operations—not CLIs or eval callers—own the writer lock, complete preflight, mutation order, safe replacement, torn-tail repair and durable append. The runtime records code identity and input on `agentStart`; then the eval harness, grader, labeling TUI, optimizer and log viewer are re-pointed at the new module, and the redundant formats they replaced are deleted.
+
+**Tech Stack:** TypeScript, Node `fs`/`crypto`, zod (row schemas), vitest, the vendored commander (CLI), the existing statelog client and JSONL helpers.
+
+**Spec:** `/Users/adityabhargava/agency-lang/packages/agency-lang/docs/superpowers/specs/2026-08-18-run-directory-and-annotations-design.md` (and its review, `…-design-REVIEW.md`). Read both first; the plan argues from them.
+
+## Global Constraints
+
+- One word per concept, the same word in CLI, files and code: `run`, `run directory`, `trace`, `input`, `test`, `suite`, `annotation`, `annotator`, `checklist`, `code`, `workdir`. Never introduce `provenance`, `occurrence`, `verifier`, `corpus`, `record` (as a stored thing), `ingest`.
+- A directory holding only `statelog.jsonl` is a valid run directory. Nothing refuses to start because an attachment is missing.
+- Writers take `.lock`; readers never do. Every JSONL append is one whole line + `fsync`. A final line without `\n` is a torn write and is ignored on read.
+- Callers never acquire a run-directory lock or sequence filesystem mutations. Public write operations accept complete declarative requests, acquire/release the lock in `finally`, preflight the whole request before changing disk, repair or refuse a torn tail, and then perform the mutation.
+- Annotation ids are deterministic: `ann_` + sha256 of the canonical JSON of `{traceId, annotator, kind, payload, sessionId|null}`. Score payloads include a pass id, expected pass size and completion bit: replay converges, a second pass adds rows, and an interrupted pass never becomes effective.
+- Machine annotators are identified by revision, not by path: a grader is `<module path>@<sha256 of its local module closure>`; a judge is `goal-judge:<model>@<sha256 of its prompt template>`. Editing the grader or one of its local imports creates a new annotator.
+- Statelog merge: the per-trace digest is sha256 over the *canonicalized parsed envelopes* in event order (key order does not matter). `mergeStatelog` skips a trace whose digest is already present and refuses one whose id is present with a different digest. Conflict detection lives only in `mergeStatelog`; a plain `cat` result cannot be validated after the fact.
+- Code is stored under `code/<closureHash>/`; attaching code that does not hash to what a trace recorded is refused, never warned.
+- Reuse `lib/statelog/parse.ts` for statelog decoding and validation; extend it to preserve raw lines rather than introducing a second JSONL parser.
+- No caller uses `rm -rf`/`fs.rmSync` directly. Replacement goes through `safeDeleteDirectoryWithin(root, target)`, which proves the target is a strict, symlink-resolved descendant of the supplied root and can never delete the root itself.
+- Clean break: no migration of old `runs/` or `labels/` directories.
+- Repo rules from CLAUDE.md apply: types not interfaces, objects not maps, arrays not sets, no dynamic imports, no per-run module globals, save test output to a file, run only tests covering changed files, `pnpm run fmt:ts` before every commit, `make` when stdlib changes, never touch `CHANGELOG.md`, never hand-edit `docs/site/**` (list what the owner should change instead), commit on a branch, never on `main`.
+- Each phase is one PR. Within a phase, commit after every task.
+
+---
+
+## Background for the implementer
+
+**What a statelog is.** Every Agency process appends JSON events, one per line, to a `.jsonl` file (see `lib/statelog/wireTypes.ts` for `EventEnvelope`: `{format_version, trace_id, project_id, span_id, parent_span_id, data}`; `data.type` names the event, e.g. `agentStart`, `promptCompletion`, `toolCall`, `agentEnd`). One *trace* is every event sharing a `trace_id`. `lib/statelog/parse.ts:parseStatelogJsonl(text)` returns `{events, errors}`. `lib/eval/extract.ts:extractEvalRecord(events, sourcePath)` turns one trace's events into an `EvalRecord` (`lib/eval/types.ts`): hoisted `evalValues`/`evalOutputs`, `metrics`, flat `events`. That type stays; the file it was written to goes.
+
+**What exists that we reuse.** `lib/eval/label/jsonl.ts` has `appendDurably(filePath, line)` (write + fsync) and `atomicWriteValidated`. `lib/eval/label/lock.ts` has `acquireDatasetLock({datasetDir, reportWarning})` returning `{holder, release()}` — a pid+token lock file that is never stolen. `lib/analysis/closure.ts:agentClosure(entryFile)` returns `{baseDir, files}` (absolute paths of the entry and everything it imports). `lib/utils/hash.ts:sha256Text(s)`. `lib/eval/label/load/statelogScan.ts:scanStatelog(text)` groups events by trace and `matchTraceId(scan, prefix)` resolves a prefix. `lib/eval/label/checklist.ts` owns checklist revisions and publication; `lib/eval/label/controller.ts` owns the sign-off protocol; `lib/eval/label/labelTui.ts` is the screen.
+
+**How the eval harness works today.** `lib/cli/eval/run.ts:evalRun` → `lib/eval/run/runSuite.ts:runSuite` runs each test in a seeded workdir via `runAgent` and writes `runs/<id>/…` through `lib/eval/runArtifacts.ts` (`initializeEvalRun`, `prepareInput`, `writeEvalRunSummary`, `writeVerifierGrading`, `buildProvenance`). Grading reads the directory back through `lib/eval/readRun.ts:readEvalRun` and `lib/eval/grading/gradeRun.ts:gradeRun(runDir, ctx)` / `gradeSuite.ts`. The child process gets its statelog path and other config through the `AGENCY_CONFIG_OVERRIDES` env var (`lib/config.ts:829`, `lib/eval/run/spawnRunner.ts`).
+
+**How the runtime records a run start.** `lib/runtime/node.ts:431` calls `execCtx.statelogClient.agentStart({entryNode, args})`; `lib/statelogClient.ts:1005` posts `{type:"agentStart", entryNode, args}`. The client is built from `StatelogConfig` (`lib/statelogClient.ts:72`), itself populated from `AgencyConfig.statelog` (`lib/config.ts:540`).
+
+## File structure
+
+New module, one concept per file:
+
+```
+lib/runs/
+  runDir.ts            # paths + readRunDirectory(dir) → one consistent snapshot
+  traces.ts            # per-trace digest; readTraces(statelogPath) → Trace[]
+  mergeStatelog.ts     # pure preflight + private application of a trace merge
+  annotations.ts       # named row types, schemas, ids, read/fold (no public write choreography)
+  mutations.ts         # the four public declarative write operations
+  lock.ts              # private mutation infrastructure, moved from label/lock.ts
+  codeIdentity.ts      # computeCodeIdentity(entryFile) → {entry, closureHash, closure[]}
+  attachCode.ts        # private preflight/application for code attachments
+  attachWorkdir.ts     # private preflight/application for workdir attachments
+  evalRecord.ts        # evalRecordFor(trace) — the in-memory EvalRecord from a Trace
+  list.ts              # summarizeRuns(dir) → one row per trace for `runs list`
+lib/cli/runs/
+  add.ts  list.ts  note.ts  extract.ts   # one command per file
+```
+
+Existing files that change hands: `lib/eval/label/{checklist,controller,labelTui,session,draft,annotations}.ts` are re-pointed at `lib/runs/annotations.ts`; everything else under `lib/eval/label/` and `lib/eval/label/load/` is deleted in Phase 5.
+
+---
+
+# Phase 0 — Clear the ground (tiny PR)
+
+### Task 0.1: Remove the prototype and the `eval optimize` alias
+
+**Files:**
+- Delete: `lib/cli/eval/save.prototype.ts`
+- Modify: `lib/cli/eval/labelCommand.ts` (remove the `save`/`saved` registrations and the import)
+- Modify: `scripts/agency.ts:1056-1057` (call `addOptimizeCommand(program)` only)
+- Test: `lib/cli/eval/optimize.test.ts` remains unchanged; it tests `evalOptimize` rather than command registration
+
+- [ ] **Step 1: Delete the prototype and its wiring**
+
+```bash
+git rm lib/cli/eval/save.prototype.ts
+```
+In `labelCommand.ts` remove the `import { labelSave, labelSaved } from "./save.prototype.js";` line and the block from `// PROTOTYPE — see save.prototype.ts` through the `saved` command's closing `});`.
+
+- [ ] **Step 2: Drop the alias**
+
+In `scripts/agency.ts` replace
+```ts
+  addOptimizeCommand(evalCmd);
+  addOptimizeCommand(program);
+```
+with
+```ts
+  addOptimizeCommand(program);
+```
+and change the comment above `addOptimizeCommand` from "Registered under both …" to "Registered as the top-level `agency optimize`."
+
+- [ ] **Step 3: Typecheck and run the touched tests**
+
+Run: `npx tsc --noEmit -p . > /private/tmp/…/scratchpad/p0-tsc.log 2>&1; pnpm vitest run lib/cli/eval/optimize.test.ts lib/cli/eval/labelCommand.test.ts > /private/tmp/…/scratchpad/p0-tests.log 2>&1`
+Expected: tsc clean; tests pass (fix any test that asserted `eval optimize` exists by removing that assertion).
+
+- [ ] **Step 4: Commit**
+
+```bash
+pnpm run fmt:ts
+git add -A lib/cli/eval scripts/agency.ts
+git commit -F /private/tmp/…/scratchpad/msg.txt   # "Remove the label-save prototype and the eval optimize alias"
+```
+
+---
+
+# Phase 1 — The statelog records code identity and input
+
+### Task 1.1: `computeCodeIdentity`
+
+**Files:**
+- Create: `lib/runs/codeIdentity.ts`
+- Test: `lib/runs/codeIdentity.test.ts`
+
+**Interfaces:**
+- Produces: `type CodeIdentity = { entry: string; closureHash: string; closure: { file: string; sha256: string }[] }` and `computeCodeIdentity(entryFile: string): CodeIdentity`. `entry` and `closure[].file` are relative to `agentClosure(entryFile).baseDir`, sorted by `file`; `closureHash` = `sha256Text(closure.map(f => `${f.file}\n${f.sha256}\n`).join(""))`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// lib/runs/codeIdentity.test.ts
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { describe, expect, it } from "vitest";
+import { computeCodeIdentity } from "./codeIdentity.js";
+
+function proj(files: Record<string, string>): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "codeid-"));
+  for (const [rel, text] of Object.entries(files)) {
+    fs.mkdirSync(path.dirname(path.join(dir, rel)), { recursive: true });
+    fs.writeFileSync(path.join(dir, rel), text);
+  }
+  return dir;
+}
+
+describe("computeCodeIdentity", () => {
+  it("lists the entry and its imports relative to the closure base, sorted, with a stable hash", () => {
+    const dir = proj({
+      "main.agency": 'import { f } from "./lib/util.agency"\nnode main() { return f() }\n',
+      "lib/util.agency": "export def f(): string { return \"x\" }\n",
+    });
+    const firstIdentity = computeCodeIdentity(path.join(dir, "main.agency"));
+    expect(firstIdentity.entry).toBe("main.agency");
+    expect(firstIdentity.closure.map((file) => file.file)).toEqual([
+      "lib/util.agency",
+      "main.agency",
+    ]);
+    expect(firstIdentity.closureHash).toMatch(/^[0-9a-f]{64}$/);
+    const secondIdentity = computeCodeIdentity(path.join(dir, "main.agency"));
+    expect(secondIdentity.closureHash).toBe(firstIdentity.closureHash);
+  });
+
+  it("changes the hash when any closure file changes", () => {
+    const dir = proj({ "main.agency": "node main() { return 1 }\n" });
+    const before = computeCodeIdentity(path.join(dir, "main.agency")).closureHash;
+    fs.writeFileSync(path.join(dir, "main.agency"), "node main() { return 2 }\n");
+    expect(computeCodeIdentity(path.join(dir, "main.agency")).closureHash).not.toBe(before);
+  });
+});
+```
+
+- [ ] **Step 2: Run it to see it fail**
+
+Run: `pnpm vitest run lib/runs/codeIdentity.test.ts > /private/tmp/…/scratchpad/t11.log 2>&1`
+Expected: FAIL, cannot find module `./codeIdentity.js`.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// lib/runs/codeIdentity.ts
+import * as fs from "fs";
+import * as path from "path";
+import { agentClosure } from "@/analysis/closure.js";
+import { sha256Text } from "@/utils/hash.js";
+
+export type ClosureFile = { file: string; sha256: string };
+export type CodeIdentity = { entry: string; closureHash: string; closure: ClosureFile[] };
+
+/** Which code an agent is: the entry file and every file it transitively
+ *  imports, each hashed, plus one hash over the whole list. Paths are relative
+ *  to the closure's base directory so the same code hashes the same anywhere. */
+export function computeCodeIdentity(entryFile: string): CodeIdentity {
+  const { baseDir, files } = agentClosure(entryFile);
+  const closure = files
+    .map((absoluteFile) => ({
+      file: path.relative(baseDir, absoluteFile),
+      sha256: sha256Text(fs.readFileSync(absoluteFile, "utf8")),
+    }))
+    .sort((left, right) => left.file.localeCompare(right.file));
+  return {
+    entry: path.relative(baseDir, fs.realpathSync(path.resolve(entryFile))),
+    closureHash: closureHashOf(closure),
+    closure,
+  };
+}
+
+export function closureHashOf(closure: readonly ClosureFile[]): string {
+  return sha256Text(closure.map((c) => `${c.file}\n${c.sha256}\n`).join(""));
+}
+```
+
+- [ ] **Step 4: Run the test**
+
+Run: same command. Expected: PASS.
+
+- [ ] **Step 5: Commit** — `git add lib/runs && git commit` ("Add computeCodeIdentity: entry, closure hashes, one closure hash").
+
+### Task 1.2: `agentStart` carries `code` and `input`
+
+**Files:**
+- Modify: `lib/statelogClient.ts:64-90` (add `code?: CodeIdentity` to `StatelogConfig`), `:1005-1014` (`agentStart` posts `code` and `input`)
+- Modify: `lib/config.ts:540` (statelog schema accepts `code`)
+- Modify: `lib/statelog/wireTypes.ts` (document `agentStart.code`, `agentStart.input`)
+- Modify: `lib/runtime/node.ts` (`RunNodeArgs.input` and `agentStart.input`), `lib/runtime/subprocess-bootstrap.ts` (pass `RunInstruction.task` as hidden node invocation input), `lib/backends/typescriptBuilder/nodeWrapperParams.ts` and `lib/backends/typescriptBuilder.ts` (accept and forward that hidden option)
+- Test: `lib/statelogClient.test.ts` (or nearest existing agentStart test), `lib/config.test.ts`, `lib/runtime/ipc.test.ts`, `lib/backends/typescriptBuilder/nodeWrapperParams.test.ts`
+
+**Interfaces:**
+- Produces: `agentStart` event data `{ type: "agentStart", entryNode, args, input?: JsonValue, code?: CodeIdentity }`.
+
+- [ ] **Step 1: Failing test** — in the statelog client test file, build a client with `logFile` and `code: {entry:"a.agency", closureHash:"h", closure:[]}`, call `agentStart({entryNode:"main", args:{}, input:"hello"})`, read the file, assert the posted `agentStart` line has `code.closureHash === "h"` and `input === "hello"`.
+- [ ] **Step 2: Run, see it fail** (unknown property `code` on config / missing field).
+- [ ] **Step 3: Implement**
+
+```ts
+// lib/statelogClient.ts (StatelogConfig)
+  /** Which code this process is running; recorded on agentStart so a trace can
+   *  be attributed to a version after the fact. */
+  code?: CodeIdentity;
+```
+```ts
+  async agentStart({ entryNode, args, input }: { entryNode: string; args?: any; input?: unknown }): Promise<void> {
+    await this.post({
+      type: "agentStart",
+      entryNode,
+      args,
+      input,
+      code: this.code,
+    });
+```
+(store `this.code = config.code` in the constructor next to `this.metadata`). In `lib/config.ts` add to the statelog object schema: `code: z.object({ entry: z.string(), closureHash: z.string(), closure: z.array(z.object({ file: z.string(), sha256: z.string() })) }).optional()`.
+
+Do not reconstruct input from `RunNodeArgs.data`: an ordinary one-parameter invocation and an eval input have the same data shape. Add a hidden `input?: unknown` member to the generated node wrapper's trailing options object and to `RunNodeArgs`. In `executeRun`, call the wrapper with `...call.args` followed by `{ input: msg.task }`; direct callers may omit the option. Have `typescriptBuilder.ts` forward `__invocationInput` as `RunNodeArgs.input`, then post `agentStart({ entryNode: nodeName, args: data, input })`. Tests must prove that an IPC run with `task` records it, while a direct one-parameter node call without the hidden option leaves `input` absent. Task 4.1 later renames the IPC field from `task` to `input` without changing this channel.
+
+- [ ] **Step 4: Run tests** — the statelog client test and `lib/config.test.ts`. Expected: PASS.
+- [ ] **Step 5: Commit** ("agentStart records code identity and the input").
+
+### Task 1.3: Every launcher fills `statelog.code`
+
+**Files:**
+- Modify: `scripts/agency.ts:418` (`agency run`), `lib/eval/run/spawnRunner.ts` (eval harness child), `lib/cli/runAgencyAgent.ts` (`agency agent`)
+- Test: `lib/eval/run/spawnRunner.test.ts` (assert the overrides passed to the child include `statelog.code.closureHash`), one agency-js test that runs a tiny agent with `--log` and asserts `agentStart.code.entry` in the log
+
+- [ ] **Step 1: Failing tests** as above.
+- [ ] **Step 2: Run, see them fail.**
+- [ ] **Step 3: Implement** — at each launch site, where the statelog config / `AGENCY_CONFIG_OVERRIDES` is assembled, add `statelog: { ...existing, code: computeCodeIdentity(entryFile) }`. For `agency agent`, use the `agencyFile` already returned by `resolveAgencyAgentPath(args.agent, args.cwd)` as `entryFile`; this preserves bundled-agent lookup as well as cwd-relative paths. For command agents under `--agent-cmd`, do nothing — the invoked `agency` CLI fills it itself.
+- [ ] **Step 4: Run tests.** Expected: PASS.
+- [ ] **Step 5: Commit** ("Fill statelog.code from agency run, eval run, and agency agent").
+
+**Phase 1 PR checklist:** `pnpm run lint:structure`, `pnpm run fmt:ts`, `npx tsc --noEmit -p .`, tests for changed files. Dev note: add a short section "Code identity and input on agentStart" to `docs/dev/statelog.md` and mention it in CLAUDE.md's pointer line. Open the PR; the owner merges.
+
+---
+
+# Phase 2 — `lib/runs/`: the run directory core
+
+### Task 2.1: Traces and per-trace digest
+
+**Files:**
+- Modify: `lib/statelog/parse.ts`, `lib/statelog/parse.test.ts`
+- Create: `lib/runs/traces.ts`, `lib/runs/traces.test.ts`
+
+**Interfaces:**
+- Produces: `type ParsedEventLine = { event: EventEnvelope; raw: string; line: number }`; `parseStatelogJsonlWithLines(text): { lines: ParsedEventLine[]; errors: ParseError[] }`. The existing `parseStatelogJsonl` delegates to it and maps `lines` to events, so JSON decoding, version checks and envelope validation still have one owner.
+- Produces: `type Trace = { traceId: string; events: EventEnvelope[]; lines: string[]; digest: string }`; `readTraces(statelogPath: string): { traces: Trace[]; errors: ParseError[] }`; `traceDigest(events: readonly EventEnvelope[]): string` = sha256 over `canonicalize(event)` (from `lib/utils/canonicalize.ts`) for each event in order, joined with `\n` — so key order in the source JSON does not matter; `matchTrace(traces, idOrPrefix): {kind:"one", trace} | {kind:"none"} | {kind:"ambiguous", ids: string[]}`.
+- `readTraces` groups by `trace_id`; it drops a line that is byte-identical to a line already seen for that trace (the harmless result of `cat`-ing two copies of one trace) and reports nothing else. It does **not** try to detect two different streams sharing an id: after concatenation there is no boundary to compare against. That check lives in `mergeStatelog` (Task 2.4), where the existing and incoming traces are still separate.
+
+- [ ] **Step 1: Failing tests** — first extend the parser test to prove `parseStatelogJsonlWithLines` returns the validated envelope, original raw line and one-based line number, while `parseStatelogJsonl` retains its existing output. Then write a 3-line statelog with two trace ids and assert `readTraces` returns two traces with the right event counts; assert `traceDigest` is equal for envelopes that differ only in key order and differs when a value changes; assert a duplicated identical line yields one event; assert prefix match works; assert a trailing partial line is not counted.
+- [ ] **Step 2: Run, fail.**
+- [ ] **Step 3: Implement** — move the existing per-line decoding in `parseStatelogJsonl` into `parseStatelogJsonlWithLines`; make the old function delegate. `readTraces` removes only the torn suffix before calling that parser, groups its validated `ParsedEventLine`s by `trace_id`, skips exact duplicate raw lines and computes the canonical digest. It must not call `JSON.parse` itself.
+- [ ] **Step 4: Run, pass.** **Step 5: Commit** ("Add lib/runs/traces: read a statelog into traces with per-trace digests").
+
+### Task 2.2: Named annotation types and effective state
+
+**Files:**
+- Create: `lib/runs/annotations.ts`, `lib/runs/annotations.test.ts`
+
+**Interfaces:**
+- Produces named types rather than nested anonymous object contracts:
+```ts
+export type Annotator = { kind: "human" | "grader" | "judge" | "harness"; id: string };
+export type Score = { kind: "binary"; pass: boolean } | { kind: "scalar"; value: number };
+export type NotePayload = { kind: "note"; text: string };
+export type ChecklistPayload = {
+  kind: "checklist";
+  checklist: string;
+  version: number;
+  hash: string;
+  answers: Record<string, boolean>;
+  note: string;
+};
+export type ScorePayload = {
+  kind: "score";
+  passId: string;
+  passSize: number;
+  completesPass: boolean;
+  name: string;
+  score: Score;
+  weight: number;
+  mustPass: boolean;
+  feedback?: string;
+  gradersModule?: string;
+};
+export type SuiteIdentity = { source: string; sha?: string };
+export type RunOutcome = "ok" | "error" | "timeout" | "cost-cap" | "killed";
+export type RunPayload = {
+  kind: "run";
+  test: JsonValue;
+  suite: SuiteIdentity | null;
+  ended: RunOutcome;
+  flags: Record<string, JsonValue>;
+};
+export type AnnotationPayload = NotePayload | ChecklistPayload | ScorePayload | RunPayload;
+export type Annotation = { v: 1; id: string; traceId: string; createdAt: string; annotator: Annotator; sessionId?: string } & AnnotationPayload;
+export type EffectiveChecklistJudgement = { annotator: Annotator; answers: Record<string, boolean>; note: string };
+export type EffectiveTraceAnnotations = { notes: Annotation[]; scores: Record<string, Annotation>; checklists: Record<string, EffectiveChecklistJudgement>; run: Annotation | null };
+export function annotationId(annotation: Omit<Annotation, "id" | "createdAt">): string;
+/** @internal Used by readRunDirectory and mutation owners, not feature callers. */
+export function readAnnotations(dir: string, reportWarning: (message: string) => void): Annotation[];
+/** @internal Exposed for focused pure tests; callers use snapshot.effectiveAnnotations. */
+export function foldAnnotations(rows: Annotation[]): Record<string, EffectiveTraceAnnotations>;
+```
+`foldAnnotations` keys checklist judgements by checklist + annotator kind + annotator id, so two humans never merge. It includes score rows only from completed passes: a pass is complete only when exactly `passSize` unique rows exist and one row has `completesPass: true`; the latest complete pass wins. Incomplete rows left by a crash are retained but never affect effective state.
+
+- [ ] **Step 1: Failing tests** — prove deterministic ids; per-question checklist folding; two humans' conflicting answers survive separately; two machine annotator revisions survive separately; a complete later score pass wins; a pass missing its completion row does not change effective scores; malformed middle rows warn; a torn final row is ignored by readers.
+- [ ] **Step 2: Run, fail.** **Step 3: Implement the named schemas and pure fold.** **Step 4: Run, pass.** **Step 5: Commit** ("Add named annotation types and effective-state folding").
+
+### Task 2.3: One read snapshot and private lock infrastructure
+
+**Files:**
+- Create: `lib/runs/runDir.ts`, `lib/runs/runDir.test.ts`, `lib/runs/lock.ts`
+- Move test: `lib/eval/label/lock.test.ts` → `lib/runs/lock.test.ts`
+
+**Interfaces:**
+- Produces: `type RunDirectorySnapshot = { dir: string; hasStatelog: boolean; traces: Trace[]; annotationRows: Annotation[]; effectiveAnnotations: Record<string, EffectiveTraceAnnotations> }`; `readRunDirectory(dir, {reportWarning}) → RunDirectorySnapshot`; `runDirPaths(dir) → RunDirectoryPaths` (a named type).
+- `readRunDirectory` reads statelog → annotations → statelog and retries when the statelog digest changed, so callers receive one coherent snapshot without taking a reader lock. A missing statelog yields an empty valid snapshot.
+- `acquireRunDirLock` remains internal mutation infrastructure. Only `mutations.ts` and the checklist commit owner may import it; no CLI, eval runner or grader receives a lock handle.
+
+- [ ] **Step 1: Failing tests** — empty directory returns an empty snapshot; a directory with traces and annotations returns both raw and effective state; simulate a statelog change between reads and assert the snapshot retries; lock tests retain their current exclusive-owner behavior.
+- [ ] **Step 2: Run, fail.** **Step 3: Implement.** **Step 4: Run, pass.** **Step 5: Commit** ("Add coherent run-directory snapshots and private writer locking").
+
+### Task 2.4: Private mutation primitives and safe replacement
+
+**Files:**
+- Create: `lib/runs/mergeStatelog.ts`, `lib/runs/attachCode.ts`, `lib/runs/attachWorkdir.ts`, tests for each
+- Modify: `lib/utils.ts`, `lib/utils.test.ts`
+
+**Interfaces:**
+- `planStatelogMerge(existing, incoming) → StatelogMergePlan` is pure and validates the entire incoming set: add absent traces, skip equal digests, refuse any conflicting id. `applyStatelogMerge(paths, plan)` is private and writes only a successful plan.
+- `planCodeAttachment(snapshot, entryFile) → CodeAttachmentPlan` and `planWorkdirAttachment(snapshot, request) → WorkdirAttachmentPlan` perform all validation without changing disk. Private `apply*` functions execute validated plans.
+- `safeDeleteDirectoryWithin(root, target)` resolves symlinks, requires `target` to be a strict descendant of `root`, refuses the root and paths outside it, and deletes only after validation. Workdir replacement uses it inside `applyWorkdirAttachment`; callers never delete first.
+
+- [ ] **Step 1: Failing tests** — all-or-nothing multi-log merge; code match/mismatch; workdir add/refuse/replace; safe deletion succeeds for one strict descendant and refuses the root, a sibling, `..`, and a symlink escape. Tests use temporary directories containing sentinel files and never point at a real project or home directory.
+- [ ] **Step 2: Run the focused tests and see the missing functions fail.**
+- [ ] **Step 3: Implement pure planning separately from private application.**
+- [ ] **Step 4: Run the focused tests and confirm they pass.**
+- [ ] **Step 5: Commit** ("Add preflighted run attachments and contained replacement").
+
+### Task 2.5: Declarative run-directory mutations
+
+**Files:**
+- Create: `lib/runs/mutations.ts`, `lib/runs/mutations.test.ts`
+
+**Interfaces:**
+- Produces named request/result types and four public operations. The request describes the desired domain change, not the lock or filesystem steps needed to make it:
+```ts
+export type WorkdirAttachmentRequest = {
+  traceId: string;
+  sourceDir: string;
+  replace?: boolean;
+};
+export type AddToRunDirectoryRequest = {
+  dir: string;
+  statelogFiles: string[];
+  codeEntries: string[];
+  workdir?: WorkdirAttachmentRequest;
+  annotationFiles: string[];
+};
+export type MutationCounts = { added: number; skipped: number };
+export type AddToRunDirectoryResult = {
+  statelogs: MutationCounts;
+  code: MutationCounts;
+  workdirs: MutationCounts;
+  annotations: MutationCounts;
+  snapshot: RunDirectorySnapshot;
+};
+export type RunAnnotationDraft = {
+  traceId: string;
+  annotator: Annotator;
+  payload: RunPayload;
+};
+export type RecordCompletedRunRequest = {
+  dir: string;
+  stagedStatelogFile: string;
+  codeEntry?: string;
+  workdir?: WorkdirAttachmentRequest;
+  run: RunAnnotationDraft;
+};
+export type RecordCompletedRunResult = {
+  annotation: Annotation;
+  snapshot: RunDirectorySnapshot;
+};
+export type RecordNoteRequest = {
+  dir: string;
+  traceId: string;
+  annotator: Annotator;
+  text: string;
+};
+export type ScoreDraft = {
+  traceId: string;
+  annotator: Annotator;
+  name: string;
+  score: Score;
+  weight: number;
+  mustPass: boolean;
+  feedback?: string;
+  gradersModule?: string;
+};
+export type RecordGradingPassRequest = { dir: string; scores: ScoreDraft[] };
+export type RecordGradingPassResult = {
+  passId: string;
+  annotations: Annotation[];
+  snapshot: RunDirectorySnapshot;
+};
+export function addToRunDirectory(request: AddToRunDirectoryRequest): AddToRunDirectoryResult;
+export function recordCompletedRun(request: RecordCompletedRunRequest): RecordCompletedRunResult;
+export function recordNote(request: RecordNoteRequest): Annotation;
+export function recordGradingPass(request: RecordGradingPassRequest): RecordGradingPassResult;
+```
+- Each operation acquires/releases the lock internally, calls `readRunDirectory`, preflights the complete request with Task 2.4's pure planners, repairs a torn append target by truncating to its last newline and `fsync`ing before append, then applies the plan. No partial change occurs on a preflight error.
+- `recordGradingPass` accepts all already-computed score drafts (including revision-based annotators), mints one pass id, sets `passSize` on every row and `completesPass` only on the final row, then appends them. A crash before the final row leaves an incomplete pass that `foldAnnotations` ignores. Grading owns how a grader revision is computed; run-directory storage only records the supplied identity.
+
+- [ ] **Step 1: Failing tests** — callers can add multiple statelogs/code/workdir/annotations with one request; any conflict leaves every target byte-identical; completed-run recording writes all attachments without exposing a lock; note recording is idempotent; a complete grading pass becomes effective; a simulated failure before its final row leaves prior effective scores unchanged; annotation and statelog appends repair a torn suffix before writing a valid new row; injected failures always release the lock.
+- [ ] **Step 2: Run, fail.**
+- [ ] **Step 3: Implement the four operations; keep lock, append and `apply*` helpers module-private.**
+- [ ] **Step 4: Run, pass.**
+- [ ] **Step 5: Commit** ("Expose declarative run-directory mutations").
+
+### Task 2.6: `evalRecordFor` and `summarizeRuns`
+
+**Files:**
+- Create: `lib/runs/evalRecord.ts`, `lib/runs/list.ts`, tests
+
+**Interfaces:**
+- `evalRecordFor(trace, sourcePath) → EvalRecord`; `summarizeRuns(snapshot: RunDirectorySnapshot) → RunSummary[]`. Define `RunSummary` as a named type with one property per displayed column; callers never reopen or separately fold files.
+
+`ended`: the harness `run` annotation's `ended` if present; else `"ok"` when the trace has an `agentEnd` with a result, `"error"` when it has a `runtimeError` and a result-less `agentEnd`, else `"unknown"`.
+
+- [ ] **Step 1: Failing test** — a fixture dir with one trace + a note + a score → one summary row with `noteCount 1`, `latestScore` set, `ended "ok"`. A trace with no `agentEnd` → `"unknown"`.
+- [ ] **Step 2–5.** Commit ("Add evalRecordFor and summarizeRuns").
+
+**Phase 2 PR checklist:** as Phase 1. Run `pnpm run lint:structure` to catch the catalogued patterns. Dev note: create `docs/dev/run-directory.md` describing the declarative read/write interfaces first, then the private lock, preflight, torn-tail repair, digest merge and code-by-hash machinery they hide. Nothing user-facing changes yet.
+
+---
+
+# Phase 3 — CLI primitives: `logs extract`, `runs add`, `note`, `runs list`
+
+### Task 3.1: `agency logs extract <log> --trace <id> [-o <file>]`
+
+**Files:**
+- Create: `lib/cli/runs/extract.ts`, `lib/cli/runs/extract.test.ts`
+- Modify: `scripts/agency.ts` (register under the `logs` command at `:683`)
+
+**Interfaces:**
+- `logsExtract({ log, trace?, out? }, deps = { stdout })`: `readTraces(log)`; if `trace` is undefined and there is exactly one trace, use it; if undefined with several, error listing ids (reuse the table from `describeAvailableTraces` — move that helper into `lib/runs/traces.ts` in this task); prefix match via `matchTrace`; write `trace.lines.join("\n") + "\n"` to `out` (create parent dirs) or stdout.
+
+- [ ] **Step 1: Failing test** — two-trace log: no `--trace` → error listing both; `--trace <prefix>` → output has exactly that trace's lines; one-trace log with no `--trace` → succeeds.
+- [ ] **Step 2–4.** **Step 5: Commit** ("agency logs extract: copy one trace out of a statelog").
+
+### Task 3.2: `agency runs add`
+
+**Files:**
+- Create: `lib/cli/runs/add.ts`, test
+- Modify: `scripts/agency.ts` (new `runs` command group with `add`)
+
+**Interfaces:**
+- `runsAdd(options)` translates Commander values into one `AddToRunDirectoryRequest`, calls `addToRunDirectory(request)` once, and renders its result. It never imports the lock, merge, attachment, deletion or annotation-log modules. `--replace` becomes `workdir.replace: true`; replacement policy remains inside the domain operation. Render the returned snapshot with `summarizeRuns(result.snapshot)`.
+
+- [ ] **Step 1: Failing test** — assemble a dir from a two-trace log; re-run → all skipped; add code from a matching fixture project → `code/<hash>/`; add code from a non-matching project → exit 2, message contains the recorded hash.
+- [ ] **Step 2–5.** Commit ("agency runs add: assemble a run directory from statelogs, code, workdir, annotations").
+
+### Task 3.3: `agency note <dir> [--trace <id>] <text>` and `agency runs list <dir>`
+
+**Files:**
+- Create: `lib/cli/runs/note.ts`, `lib/cli/runs/list.ts`, tests
+- Modify: `scripts/agency.ts`
+
+- `note`: resolve the trace from `readRunDirectory`, call `recordNote({ dir, traceId, annotator, text })`, and print the returned annotation id. It never opens the annotation file or lock.
+- `runs list`: `summarizeRuns(readRunDirectory(dir, { reportWarning }))` rendered with the shared table component from `lib/runsExplorer/` (see `docs/dev/runs-explorer.md`) — columns: trace (8 chars), started, ended, duration, cost, llm, tools, score, notes, labeled, input preview (60 chars).
+
+- [ ] **Step 1: Failing tests** — `note` on a one-trace dir appends a note row; on a two-trace dir without `--trace` errors listing ids; `runs list` prints one row per trace with the note count.
+- [ ] **Step 2–5.** Commit ("agency note and agency runs list").
+
+### Task 3.4: Viewer: extract key in, `l` key out
+
+**Files:**
+- Modify: `lib/logsViewer/views/treeView.ts` (replace the `labelTrace` ViewAction on `l` with an `extractTrace` action on `x`), `lib/logsViewer/views/view.ts` (action type), `lib/logsViewer/run.ts:303` (handle `extractTrace`: prompt for an output path with a default of `./<traceId>.jsonl`, write via the same function `logsExtract` uses)
+- Delete: `lib/logsViewer/labelTrace.ts` + test, and the `labeling` option in `lib/cli/logsView.ts:102-108,340`. **Keep** `lib/eval/label/labelingHost.ts` and `datasetWriter.ts` for now: `lib/cli/eval/label.ts` and `ingest.ts` still import them, and both CLIs must keep working until Task 5.2 replaces them. Task 5.2 deletes the two services.
+- Test: `lib/logsViewer/views/treeView.test.ts`, `lib/cli/logsView.test.ts`
+
+- [ ] **Step 1: Update tests** — replace the `l`-key assertions with `x` emitting `extractTrace`.
+- [ ] **Step 2: Run, fail.** **Step 3: Implement + delete.** **Step 4: Run, pass.**
+- [ ] **Step 4b: Prove nothing else broke** — `npx tsc --noEmit -p .` clean and `pnpm vitest run lib/cli/eval/label.test.ts lib/cli/eval/ingest.test.ts` still pass (the old CLIs are untouched in this phase).
+- [ ] **Step 5: Commit** ("Viewer: x extracts a trace to a file; drop the l key").
+
+**Phase 3 PR checklist:** dev note `docs/dev/run-directory.md` gains a "Commands" section; delete `docs/dev/statelog-to-dataset.md` and its CLAUDE.md pointer. Tell the owner: `docs/site/cli/logs.md` "Labeling a trace from the viewer" and `docs/site/cli/eval.md` "Labeling a statelog trace" need rewriting.
+
+---
+
+# Phase 4 — Eval: run never grades, grade appends scores, `test`/`input` vocabulary
+
+### Task 4.1: The suite loader and every consumer speak `test` and `input`
+
+This is one atomic rename, not a loader-only change: a `type Input = Test` alias would keep the *name* compiling while every `.task` access fails. Do the whole rename in this task and prove it with a search before committing.
+
+**Files:**
+- Modify: `lib/eval/loadInputs.ts` → rename to `lib/eval/loadSuite.ts` (`loadInputs`/`loadSuite` exports accordingly), `lib/eval/runTypes.ts` (`Input` → `Test`: `{ id, input, goal?, expected?, files?, graders?, timeoutSec?, metadata? }`)
+- Modify every production consumer of `.task` on an eval input, found with the search in Step 0 — at the time of writing: `lib/eval/run/runSuite.ts`, `lib/eval/run/runAgent.ts`, `lib/eval/run/subprocess.ts`, `lib/eval/run/spawnRunner.ts`, `lib/eval/run/commandLine.ts` (the `{task}` placeholder in `--agent-cmd` stays as the user-facing token but is documented as "the input"; rename the internal variable), `lib/runtime/ipc.ts` (`RunInstruction.task` → `input`, `resolveNodeCallArgs`), `lib/eval/grading/*` (`input:` param → `test:`), `lib/eval/judge/*`, `lib/optimize/baseOptimizer.ts`, `lib/optimize/gepaReflect.ts` (`Task:` → `Input:`), `lib/optimize/evalCache.ts`, and the fixtures under `lib/eval/testUtils.ts`, `lib/eval/grading/testUtils.ts`, `lib/eval/label/runFixture.ts`
+- Modify: `lib/cli/eval/run.ts` (`--inputs` → `--suite`; `--goal` sets `input` and `goal`; error text), `lib/cli/eval/optimize.ts` (same flags)
+- Test: every `*.test.ts` that builds an eval input literal (`{ id, task, goal }`) — update to `input`
+
+- [ ] **Step 0: Enumerate** — `grep -rn "\.task\b\|task:" lib/eval lib/optimize lib/runtime/ipc.ts lib/cli/eval --include=*.ts | grep -v test > /private/tmp/…/scratchpad/task-sites.txt` and read it. This is the file list for the task; anything not in the list above goes on it.
+- [ ] **Step 1: Update loader tests** — a suite entry `{ id, input: "…", goal: "…" }` loads; `{ task: "…" }` is rejected with a message saying "`task` was renamed to `input`"; `{ args: … }` still rejected; `--goal x` yields `input === goal === "x"`.
+- [ ] **Step 2: Run the loader test, see it fail.**
+- [ ] **Step 3: Rename the field and fix every site from Step 0**, including `RunInstruction.input` on the IPC wire (bump nothing: the wire is internal to one process tree). Keep `{task}` as the literal placeholder token in `--agent-cmd` strings for now (renaming a user-facing token is a separate decision; note it in the PR).
+- [ ] **Step 4: Prove the rename is complete** — rerun the Step 0 search; expected: zero hits outside `commandLine.ts`'s placeholder handling. Then `npx tsc --noEmit -p .` clean, and `pnpm vitest run lib/eval lib/optimize lib/cli/eval lib/runtime/ipc.test.ts > /private/tmp/…/scratchpad/t41.log 2>&1` green.
+- [ ] **Step 5: Commit** ("Eval: input replaces task everywhere; --suite replaces --inputs").
+
+### Task 4.2: `eval run` writes a run directory and never grades
+
+**Files:**
+- Modify: `lib/eval/run/runSuite.ts`, `lib/eval/run/runAgent.ts`, `lib/eval/run/spawnRunner.ts` (each test runs entirely in a staging directory and hands one complete request to `recordCompletedRun`), `lib/cli/eval/run.ts` (drop grading, `--no-grade`, `--graders`; drop `requireGoal`)
+- Delete: `lib/eval/runArtifacts.ts` + test, `lib/eval/readRun.ts` + test, `lib/eval/run/extract.ts` (the per-input eval-record writer)
+- Test: `lib/eval/run/runSuite.test.ts`, `lib/cli/eval/run.test.ts`, the eval-run integration test
+
+For each test the harness creates one temporary staging directory **outside** the final run directory, seeds and runs the agent there, and captures its statelog there. On finish it calls `recordCompletedRun` once with the staged statelog, workdir, optional agent entry and complete `run` annotation payload. That operation owns merge, code/workdir attachment, annotation append and locking. The harness removes the staging directory through `safeDeleteDirectoryWithin(stagingRoot, testStagingDir)` in `finally`; no old `inputs/<id>/` tree survives. `ended` maps from the existing outcome kinds: ok → `"ok"`, agent error → `"error"`, wall-clock kill → `"timeout"`, cost-cap kill → `"cost-cap"`, SIGINT → `"killed"`. Command agents omit code.
+
+- [ ] **Step 1: Failing test** — after `runSuite` on a two-test suite: `<dir>/statelog.jsonl` has two traces; `annotations.jsonl` has two `run` rows with `ended "ok"`; `code/<hash>/` exists; `workdir/<traceId>/` exists for both; no `config.json`, `summary.json`, `verifier/`.
+- [ ] **Step 2–5.** Commit ("eval run writes a run directory and never grades").
+
+### Task 4.3: `eval grade` reads a run directory and appends `score` rows
+
+**Files:**
+- Modify: `lib/eval/grading/gradeRun.ts` (`gradeRun(snapshot, ctx)` iterates `snapshot.traces`; for each, `record = evalRecordFor(trace)`, `test = snapshot.effectiveAnnotations[traceId]?.run?.test`, `workdir = workdir/<traceId>` if present, and the grader callback receives `{ output, test, workdir, record, judge }`), `lib/eval/grading/gradeSuite.ts` (read one snapshot, convert grader results directly to `ScoreDraft[]`, then call `recordGradingPass({ dir, scores })` once), `lib/cli/eval/grade.ts`
+- Modify: `lib/eval/grading/types.ts` (`LoadedRun` loses `recordPath`; `input: Input` → `test: Test`), every grader under `lib/eval/grading/graders/` that reads `input.` → `test.`
+- Delete: `lib/eval/grading/recordGrading.ts`, `writeVerifierGrading`, and any `verifier-N` reader; the old recorder has no responsibility after `gradeSuite` produces drafts and the run-directory operation persists them
+- Test: `lib/eval/grading/gradeRun.test.ts`, `lib/cli/eval/grade.test.ts`
+
+Rules to keep from `docs/dev/eval-grading.md`: a trace whose `run.ended !== "ok"` (or, without a `run` row, whose trace has no `agentEnd` result) scores 0 on every grader and is never shown to graders; a successful trace with no output grades with `output: null`; precedence flag > `test.graders` > `eval.graders` config > goal judge (which errors *per test* naming the missing `goal`).
+
+- [ ] **Step 1: Failing tests** — (a) grade a fixture dir with one ok trace and one `ended: "timeout"` trace: the ok one gets grader-produced score rows, the timeout one gets zero-valued rows without being shown to the spy grader; (b) `gradeSuite` hands one complete `ScoreDraft[]` to `recordGradingPass`, never appending itself; (c) a second pass with unchanged results produces a second complete pass and the fold picks it; (d) editing an imported grader helper changes annotator identity; (e) a failure before the completing row leaves the prior complete pass effective; (f) objective prints as today.
+- [ ] **Step 2–5.** Commit ("eval grade reads a run directory and appends score annotations").
+
+### Task 4.4: Remove `eval extract` and the on-disk eval record
+
+**Files:**
+- Modify: `scripts/agency.ts:891` (remove `extract`), `lib/eval/public.ts` (drop any file-writing export; keep `extractEvalRecord`)
+- Delete: the CLI extract handler and its test; migrate `lib/eval/statelogParser.ts` to `lib/statelog/parse.ts`, then delete `lib/eval/parseJsonl.ts` and its test
+- Modify: `lib/eval/judge/*` to take two run directories + trace ids (or two statelog files) instead of `.eval.json` paths, computing records in memory
+
+- [ ] **Step 1: Update tests**, **Step 2–5.** Commit ("Remove eval extract; the eval record is computed, never written").
+
+**Phase 4 PR checklist:** update `docs/dev/eval-grading.md` (the interface is now the run directory in the new shape; `run` row replaces `input.json`/`summary.json`), delete `docs/dev/eval-command-agents.md` sections that mention `config.json`. Owner: `docs/site/cli/eval.md` needs a rewrite (run/grade split, `--suite`, `input`, no `extract`).
+
+---
+
+# Phase 5 — Labeling on the run directory
+
+### Task 5.1: Checklists live in the run directory
+
+**Files:**
+- Modify: `lib/eval/label/checklist.ts` (paths from `runDirPaths(dir).checklistsDir`; drafts at `checklists/<name>/draft.json`), `lib/eval/label/draft.ts` (draft carries `pendingAnnotation` as today, plus `traceIds` order for the session id)
+- Create: `lib/runs/checklistSignoff.ts`, `lib/runs/checklistSignoff.test.ts`
+- Test: existing checklist/draft tests re-pointed
+
+**Interfaces:**
+- `commitChecklistSignoff(request: ChecklistSignoffRequest) → ChecklistSignoffResult` is the one imperative safety owner for revision publication, pending-row persistence, durable annotation append and recovery. It receives the session's internal write capability; CLI/TUI callers never receive a lock or call append helpers.
+
+- [ ] **Step 1: Failing tests** — move the existing crash-at-every-boundary protocol tests to the new owner and assert replay converges on one revision and one annotation.
+- [ ] **Step 2: Run and see the new owner is missing.**
+- [ ] **Step 3: Move the protocol without changing its order or behavior.**
+- [ ] **Step 4: Run and confirm every recovery test passes.**
+- [ ] **Step 5: Commit** ("Move checklist sign-off behind one declarative operation").
+
+### Task 5.2: The controller writes `checklist` annotations
+
+**Files:**
+- Modify: `lib/eval/label/controller.ts` (session items come from one `readRunDirectory` snapshot; sign-off constructs one `ChecklistSignoffRequest` and calls `commitChecklistSignoff`; no publication or append order remains in the controller), `lib/eval/label/annotations.ts` (fold now via the snapshot's effective annotations), `lib/eval/label/session.ts`
+- Modify: `lib/eval/label/labelTui.ts` (left pane shows the trace's input and output from `evalRecordFor(trace)`; when there is no output, show the last assistant message clearly marked "last message (no recorded output)")
+- Modify: `lib/cli/eval/label.ts` (`agency label <dir> --checklist <file> [--annotator <id>]`; `--dataset` removed), `lib/cli/eval/labelCommand.ts`
+- Delete: `lib/eval/label/dataset.ts`, `corpus.ts`, `occurrences.ts`, `ids.ts` (record ids), `datasetWriter.ts`, `labelingHost.ts`, the whole `lib/eval/label/load/`, `lib/cli/eval/ingest.ts`, all their tests
+- Test: `lib/eval/label/controller.test.ts` (crash-at-every-fault-point tests must still converge on one row), `lib/cli/eval/label.test.ts`
+
+- [ ] **Step 1: Failing tests** — open a session on a fixture dir with two traces; sign off the first → one `checklist` row for that traceId; simulate a crash after publish-before-append and reopen → still exactly one row; a stale item (a live question with no answer) scores `null`.
+- [ ] **Step 2–5.** Commit ("agency label reads a run directory and appends checklist annotations; ingest and the label store are gone").
+
+**Phase 5 PR checklist:** rewrite `docs/dev/eval-labeling.md` down to what remains (identities: trace id, checklist revision, question id, annotation id, session id; sign-off protocol; why the lock; the per-question fold) and delete the store sections. Owner: `docs/site/cli/eval.md` labeling section.
+
+---
+
+# Phase 6 — Optimize and the viewer read annotations
+
+### Task 6.1: The optimizer reads scores, notes and checklists as feedback
+
+**Files:**
+- Modify: `lib/optimize/baseOptimizer.ts` (after `runSuite` + `gradeSuite`, call `readRunDirectory` once; reflection feedback = grader feedback as today + every `note.text` + each unchecked checklist question's text from the snapshot), `lib/optimize/gepaReflect.ts` (prompt shows `Input:` not `Task:`), tests
+
+- [ ] **Step 1: Failing test** — a candidate dir with a note "too slow" produces a reflection prompt containing "too slow".
+- [ ] **Step 2–5.** Commit ("optimize: notes and checklist misses feed reflection").
+
+### Task 6.2: `agency logs <dir>` opens a run directory and shows annotations
+
+**Files:**
+- Modify: `lib/cli/logsView.ts` (a directory containing `statelog.jsonl` is loaded through `readRunDirectory`; the trace tree shows a one-line annotation summary per trace: `n notes · score 0.7 · labeled`), `lib/logsViewer/summary.ts`, tests
+
+- [ ] **Step 1–5.** Commit ("logs viewer opens a run directory and shows annotations").
+
+### Task 6.3: `agency run --capture-workdir`
+
+**Files:**
+- Modify: `scripts/agency.ts:418` (`agency run`), `lib/config.ts` (`run.captureWorkdir?: string` = a run directory path); at exit, call `addToRunDirectory({ dir, statelogFiles: [logPath], codeEntries: [], annotationFiles: [], workdir: { sourceDir: cwd, traceId } })` once.
+
+- [ ] **Step 1: agency-js test** — run a trivial agent with `--capture-workdir out/` and assert `out/statelog.jsonl`, `out/workdir/<traceId>/`.
+- [ ] **Step 2–5.** Commit ("agency run --capture-workdir writes a run directory").
+
+**Phase 6 PR checklist:** dev notes for `docs/dev/writing-optimizers.md` (feedback sources) and `docs/dev/logs-viewer.md` (run directory + annotation summary). Owner: `docs/site/cli/run.md`, `logs.md`, `optimize.md`.
+
+---
+
+## Self-review against the spec
+
+- Run directory shape (statelog / annotations / code by hash / workdir by trace / checklists / private lock): Tasks 2.2–2.5 and 5.1.
+- Statelog additions (code identity, input): Tasks 1.1–1.3.
+- Annotation kinds `note`/`checklist`/`score`/`run`, named payload types, deterministic ids, completed-pass score folding, annotator-isolated checklist folding, revision-based machine annotator ids and durability: Tasks 2.2 and 2.5; declarative callers: 3.3 (note), 4.3 (score), 4.2 (run), 5.1–5.2 (checklist).
+- Declarative boundary: `readRunDirectory`, `addToRunDirectory`, `recordCompletedRun`, `recordNote`, `recordGradingPass`, and `commitChecklistSignoff` are the public domain operations. Locks, append repair, safe replacement and mutation order remain private.
+- Phase independence: every phase typechecks and ships on its own — 3.4 keeps the two label services alive until 5.2; 4.1 is one atomic rename with a completeness search.
+- Lock kept but hidden from general callers, readers lock-free, checklist draft the only draft: 2.3, 2.5, 5.1.
+- Existing statelog parser reused and extended: 2.1. Digest merge; `cat` readable-not-validated: 2.1 (canonical digest; readers drop byte-identical duplicate lines and make no other promise), 2.4 (conflict detection only while streams are separate).
+- Anti-pattern checks: no conditional spread construction, nested ternaries, single-character sample names, direct recursive deletion, parallel statelog parser, or caller-owned lock choreography. Named types replace nested inline contracts; `lint:structure` runs in every phase.
+- Commands removed (`extract`, `ingest`, `eval optimize`, `l` key, store internals): 0.1, 3.4, 4.4, 5.2. Added (`logs extract`, `runs add`, `note`, `runs list`): 3.1–3.3. Changed (`eval run`, `eval grade`, `label`, `optimize`, `logs`, `run --capture-workdir`): 4.2, 4.3, 5.2, 6.1, 6.2, 6.3.
+- Vocabulary (`test`/`input`/`suite`, grader context `test`): 4.1, 4.3.
+- Migration: none, by decision.
+- Open questions from the spec left open on purpose: command namespace (`runs`), test inlining in `run` rows (inline for now), judge-row volume (one file), multi-trace agent sessions (verify against a real session in Phase 6.2 and note the result in `docs/dev/run-directory.md`).
+
+Type names used consistently: `Trace`, `RunDir`, `Annotation`, `Annotator`, `Score`, `CodeIdentity`, `ClosureFile`, `RunSummary`, `Test`.

--- a/packages/agency-lang/docs/superpowers/specs/2026-08-18-run-directory-and-annotations-design-REVIEW.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-08-18-run-directory-and-annotations-design-REVIEW.md
@@ -1,0 +1,75 @@
+# Review: run directory and annotations design
+
+**Spec:** `2026-08-18-run-directory-and-annotations-design.md`  
+**Verdict:** The unification is compelling, but the durability and identity
+contracts need revision before implementation. Findings 1–3 are blockers.
+
+## What works
+
+The central separation is good: running should not imply grading, and graders
+should derive their input from a captured trace rather than require an
+`eval-record.json`. A directory that remains useful with only a statelog is also
+a much better ad-hoc workflow. The common annotation vocabulary is simpler than
+separate note, label, and grade stores.
+
+## Findings
+
+### 1. Removing the lock and drafts loses the crash-safety the spec says remains
+
+Lines 153 and 255–257 claim that generating an annotation id before append
+makes retries idempotent and that the current sign-off protocol remains. It
+does not remain if the draft is removed at line 221. After a crash, the newly
+generated id exists only in memory; retrying generates another id. More
+importantly, checklist publication and annotation append are still a multi-file
+commit. The current `pendingAnnotation` draft is what lets recovery replay the
+same row after a crash at any boundary.
+
+Removing the lock also permits two label, grade, or note processes to append
+and publish checklists concurrently. A single `write` to an append-open file is
+not a complete cross-platform transaction protocol, and checklist publication
+still updates several files. Append order is semantic in this design, so the
+writer order must be serialized.
+
+Keep a writer lock and the durable pending-row recovery mechanism (they may be
+run-directory infrastructure rather than “label store” concepts). Readers do
+not need the lock. Specify durable append (`fsync`) as the current label store
+does.
+
+Note: how likely is it that two processes will be editing concurrently? We don't have concurrently running evals yet ... though it would be nice to have those.
+
+### 2. The migration claim is false, and the new lifecycle can destroy the only copy of human work
+
+Lines 302–305 say old `labels/` directories are regenerable from traces and
+that every one contains a statelog. They do not: the current dataset stores
+`outputs.jsonl`, `occurrences.jsonl`, and `labels.jsonl`, not source statelogs.
+
+This is completely fine, however. There is not a lot of existing data that needs to be kept around, and this language does not have a lot of users right now, so this is a good time to make a clean breaking change. No need to deprecate or add support for backwards compatibility.
+
+### 3. One `code/` tree cannot represent the multi-version directory the spec allows
+
+The directory has one `code/` tree (lines 100–101), while the statelog may hold
+arbitrarily merged traces (lines 109–115), including the v1/v2 comparison at
+lines 283–285. Two traces can identify different closures with the same
+relative paths. The second attachment then either overwrites the first or
+cannot be added, and `optimize` cannot select the code that produced a trace.
+
+Store code by identity, for example `code/<closureHash>/...`, and have each
+trace's start event name that closure hash. Deduplicate equal closures. The
+attachment command must validate the complete closure and refuse an incomplete
+or mismatched tree; a warning is too weak because optimization would target the
+wrong program.
+
+Would it make more sense to store closure hashes, or to store different copies of the code for each trace? What are the pros and cons of each?
+
+### 4. “Plain `cat`” conflicts with trace-id identity and idempotent merge
+
+Lines 111–112 promise no duplicate trace, but lines 123–125 and 275–276 say
+plain concatenation is a valid merge. `cat` cannot reject a duplicate trace id
+or detect two different event streams using the same id. Once present, all
+workdirs and annotations keyed only by trace id become ambiguous.
+
+Either weaken `cat` to “syntactically readable but requires validation,” or
+define reader behavior for duplicate identical and duplicate conflicting
+traces. `agency runs add` should be the safe merge path and should compare a
+canonical digest per trace before appending.
+

--- a/packages/agency-lang/docs/superpowers/specs/2026-08-18-run-directory-and-annotations-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-08-18-run-directory-and-annotations-design.md
@@ -1,0 +1,381 @@
+# The run directory and annotations: one shape for observing, noting, labeling, grading and optimizing
+
+Date: 2026-08-18
+Status: draft for review
+
+## Background: what exists today and why it is confusing
+
+To evaluate an agent in Agency today you meet four on-disk formats and a
+vocabulary that changes between them.
+
+1. **The statelog** (`*.jsonl`). One event per line, emitted by every Agency
+   process, whether it was started by `agency run`, `agency eval run`, or
+   `agency agent`. It is the only record of what an agent actually did.
+2. **The eval record** (`eval-record.json`, also written by `agency eval
+   extract`). A smaller JSON view of one statelog trace: hoisted inputs and
+   outputs, a flat event list, aggregate metrics. Derivable from the statelog in
+   about 70 ms.
+3. **The eval run directory** (`runs/<id>/`). Written only by `agency eval
+   run`: `config.json` (which code and which suite, called "provenance"),
+   `summary.json`, and per input an `input.json`, the statelog, the eval
+   record, the workdir, and `verifier-N/grading.json` for each grading pass.
+4. **The label dataset** (`labels/`). Written only by `agency label ingest`,
+   which reads a run directory, a folder of files, a JSON array, or one
+   statelog trace, and stores content-hashed *records* with *occurrences*,
+   *annotations* against versioned *checklists*, plus a lock and drafts.
+
+Three separate mechanisms exist for "an opinion about a run": grader scores in
+`verifier-N/`, human checklist answers in `labels/labels.jsonl`, and free-text
+notes, which have no home at all (a prototype, `agency label save`, appended a
+`notes.jsonl` to the label dataset).
+
+The consequences, seen in this session:
+
+- Running an agent is coupled to grading it: `agency eval run` refuses a test
+  without a `goal` unless you find `--no-grade`.
+- A run that went badly cannot be saved for later study, because both grading
+  and labeling refuse a failed or unfinished trace. That is exactly the run you
+  most want to keep.
+- To do anything with an ad-hoc run you must first push it through the right
+  converter (`extract`, `ingest --format …`), each with its own flags.
+- The words do not line up: `task` means "the input" in evals and "context for
+  the labeler" in labeling; `<source>` and `--source` on the same command mean a
+  path and a batch name; `input` means a whole test spec inside graders;
+  `provenance`, `occurrence`, `verifier`, `corpus`, `record`/`example`/`output`
+  are all load-bearing and all opaque.
+
+Other frameworks have the same *number* of concepts (dataset, run, scorer,
+trace, human label). The ones people find clear (Inspect, Braintrust) use one
+plain word per concept everywhere and one artifact per concept. Inspect's whole
+run — samples, transcripts, scores — is one file.
+
+## The design in one paragraph
+
+**The statelog is the run.** Everything else is an optional attachment placed
+next to it in a plain directory: the agent's code, the working directory the
+agent left behind, and one append-only `annotations.jsonl` that holds every
+opinion anyone or anything forms about a trace — a note, a checklist answer, a
+grader score, an LLM judgement, or the eval harness's own observation about how
+the run ended. One directory shape serves an ad-hoc run, a saved reference run,
+and a whole eval; one row shape serves notes, labels and grades. Any tool that
+can read a statelog can work on any of them, and nothing requires the run to
+have gone through `agency eval run`.
+
+## Three rules
+
+Every decision below follows from these.
+
+1. **One word per concept, the same word in the CLI, the files and the code.**
+   Vocabulary is not hidden behind a UI layer; it is made plain instead.
+2. **One artifact per concept.** A concept that can be derived is not stored.
+3. **Degrade, do not refuse.** A directory with only a statelog is a valid run.
+   Each attachment unlocks more; missing ones limit what you can do, never
+   whether you can start.
+
+## Vocabulary
+
+| Concept | Word | Replaces |
+|---|---|---|
+| What the agent did | **statelog** / **trace** (one trace = one thing you judge) | eval record (as a file) |
+| One thing to evaluate | **run** = one trace plus its attachments | eval input result, record, example, output |
+| A folder holding one or more runs | **run directory** | eval run dir, label dataset, corpus |
+| What the agent is given | **input** | task, args |
+| What a benchmark case declares | **test** (`id`, `input`, `goal`, `expected`, `files`, `graders`) | eval input, input spec |
+| A file or folder of tests | **suite** | inputs, input suite |
+| An opinion about a run | **annotation** | grade, label, note, verifier output |
+| Who formed the opinion | **annotator** (`human`, `grader`, `judge`, `harness`) | — |
+| A structured yes/no rubric | **checklist** | (unchanged) |
+| Which code ran | **code** (`entry`, file hashes) | provenance, closure |
+| What the agent left on disk | **workdir** | (unchanged) |
+
+Deleted words: task (in evals), args, provenance, occurrence, verifier, corpus,
+record, example, output (as a stored thing), ingest.
+
+## The run directory
+
+```
+<dir>/
+  statelog.jsonl        # required. any number of traces
+  annotations.jsonl     # created by the first annotation
+  code/<closureHash>/   # optional: one copy per code VERSION, named by the
+    <files relative to the entry's directory>   #   hash the trace recorded
+  workdir/<traceId>/    # optional: filesystem snapshot for that trace
+  .lock                 # writer lock, present only while a writer is open
+  checklists/<name>/    # optional: versioned checklist snapshots (see below)
+    1.json  2.json  current.json
+```
+
+Rules:
+
+- **`statelog.jsonl` may hold many traces.** A directory with one trace is an
+  ad-hoc run; with fifty it is an eval or a reference set. Nothing else changes
+  shape between the two. `agency runs add` merges by trace id: it computes a
+  canonical digest of each incoming trace's events, skips a trace whose digest
+  is already present, and **refuses** a trace whose id is present with a
+  different digest (two different event streams claiming one id would make
+  every workdir and annotation keyed on that id ambiguous).
+- **Code is stored by version, not by trace.** `code/<closureHash>/` holds one
+  copy of the closure for every distinct hash the directory's traces recorded
+  at `agentStart`. Fifty tests of one agent store its code once; a v1/v2
+  comparison stores two trees; `optimize` picks the tree a trace names. `runs
+  add --code` hashes the complete closure it is given, compares it against
+  the trace's recorded hash, and refuses on mismatch or an incomplete tree — a
+  warning is too weak, because optimizing the wrong program is silent.
+- **Everything is keyed by trace id.** Annotations, workdirs and (via the
+  statelog, below) code and inputs all name the trace. Trace id is the identity
+  of "a run"; a resumed trace is still one run.
+- **There is no `run.json`, `summary.json`, `config.json` or `input.json`.**
+  Everything they held is either in the statelog (input, cost, duration,
+  outcome, and — with the change below — code identity), derivable from it, or
+  is an annotation.
+- **There is no `eval-record.json` on disk.** The eval record stays as an
+  in-memory type that graders and judges receive; it is computed from the trace
+  when needed.
+- **A run directory is a plain folder.** Copying or moving it is fine, and
+  readers never need a lock. `cat`-ing two statelogs together produces a file
+  that is *readable* but not *validated*: readers drop byte-identical duplicate
+  lines silently and make no other promise — once two streams sharing an id are
+  interleaved there is no boundary left to compare, so a conflict cannot be
+  detected after the fact. `agency runs add` is the merge path that checks
+  this before writing (existing and incoming traces are still separate there);
+  `cat` is a shortcut you use when you know the inputs are disjoint. The
+  per-trace digest is over the canonicalized parsed events in order, so key
+  order in the JSON does not matter.
+
+### What the statelog must additionally record
+
+Two facts are not in the stream today and cannot be recovered afterwards. Both
+become fields on the existing `agentStart` event, so every launcher (`agency
+run`, `agency eval run`, `agency agent`) records them the same way:
+
+- **Code identity**: the entry file path and the closure's `{file, sha256}`
+  list (the list `config.json` computes today). Lets a later `code/` attachment
+  be checked against what actually ran, and lets `optimize` attribute
+  annotations to a version.
+- **Input**: what the entry node was given. Already present as `args` for
+  `agency run`; `agency agent` records `args: {}` and the task is only
+  recoverable as "the first user message". Record it explicitly.
+
+Everything else needed — cost, duration, tool calls, retries, output — is
+already there. "How it ended" is best-effort: a trace with an `agentEnd` is
+known-finished; one without is *unknown*, which tools show and never treat as a
+reason to refuse.
+
+## Annotations
+
+One append-only JSONL file. Every row:
+
+```jsonc
+{
+  "v": 1,
+  "id": "ann_<hash>",            // sha256 of (traceId, annotator, kind, payload,
+                                 //   sessionId-or-null): the same opinion always
+                                 //   has the same id, so a retry rewrites, never doubles
+  "traceId": "MXEjJo…",
+  "createdAt": "2026-08-18T00:19:08Z",
+  "annotator": { "kind": "human" | "grader" | "judge" | "harness", "id": "adit" },
+  "kind": "note" | "checklist" | "score" | "run",
+  // then one payload, by kind:
+}
+```
+
+Payloads:
+
+- **`note`** — `{ "text": "took 40 min and $5; wanted ≤5 min, ≤$1" }`.
+  The lightest possible annotation. This is the "save this run with my
+  thoughts" case that had no home.
+- **`checklist`** — `{ "checklist": "news-quality", "version": 3,
+  "hash": "sha256:…", "answers": { "q_a1": true, "q_b2": false },
+  "note": "" }`. One row per sign-off. Answers are folded per question in
+  append order, exactly as today, so soft-deleting and restoring a question
+  keeps its earlier answer.
+- **`score`** — `{ "passId": "pass_…", "name": "cheap", "score": { "kind":
+  "binary", "pass": true } | { "kind": "scalar", "value": 0.7 }, "weight": 1,
+  "mustPass": false, "feedback": "…", "gradersModule": "/abs/graders.ts" }`.
+  One row per grader per trace per grading pass; `passId` is minted once per
+  `agency eval grade` invocation and is part of the row's identity, so a replay
+  inside one pass converges on one row and a second pass always adds rows even
+  when the score is unchanged. `agency eval grade` appends; it never rewrites.
+  The objective for a directory is computed from rows, not stored.
+- **`run`** — written by the eval harness (`annotator.kind: "harness"`) for
+  each trace it launched: `{ "test": { "id": "fizzbuzz", "input": …, "goal":
+  …, "expected": …, "graders": "/abs/graders.ts" }, "suite": { "source": "…",
+  "sha": "…" }, "ended": "ok" | "error" | "timeout" | "cost-cap" | "killed",
+  "flags": { … } }`. This is what `config.json`, `summary.json` and
+  `input.json` were for, reduced to one row per run, and it is the only place
+  the harness's privileged knowledge ("I killed it at the cost cap") lives.
+
+Rules:
+
+- **Append-only, order decides.** Later rows about the same trace supersede
+  earlier ones per `(kind, annotator, name/checklist/question)`; timestamps are
+  informational. Because order is semantic, **writers are serialized** (below).
+- **Durability.** Every append is a whole line followed by `fsync`; a reader
+  treats a final line without a newline as a torn write and ignores it.
+- **Annotators are named by revision**, so two humans, two grader modules, or
+  two judge configurations never merge: a human is `$USER`; a grader module is
+  `<path>@<sha256 of the file>`; the goal judge is `goal-judge:<model>@<sha256
+  of its prompt template>`. Editing `graders.ts` in place is therefore a new
+  annotator, and its rows sit beside the old ones rather than superseding them.
+- **Reading is tolerant, writing is strict.** A malformed row is skipped with a
+  warning on read; a writer validates before append. This is the label store's
+  strictness applied only where a mistake is cheap to catch.
+- **No `outputs.jsonl`, no `occurrences.jsonl`.** The output is in the trace;
+  which source produced a trace is `annotator`/`run` metadata. Content-hash
+  dedup ("v1 and v2 produced identical text, judge once") becomes an analysis
+  step over annotations rather than a storage identity. Named loss, accepted.
+
+### The writer lock and crash recovery
+
+Kept from the label store, re-homed as run-directory infrastructure:
+
+- **One writer at a time** per directory: `.lock` with the holder's pid, taken
+  by `note`, `eval grade`, `label`, `runs add`, and the eval harness; released
+  on exit; a stale lock is reported (pid, whether the process still exists)
+  and never stolen automatically. Readers (`logs`, `runs list`) take no lock.
+  Concurrency is rare today (one person, sequential commands), but two
+  terminals running `label` is precisely the case that produced the current
+  lock, and concurrent evals are a wanted feature; the cost of keeping it is
+  small.
+- **Single-row appends** (`note`, `score`, `run`) need nothing more: the id is
+  deterministic, so a crash before the write loses nothing and a retry after
+  the write finds its row already present.
+- **Checklist sign-off** is still a multi-file commit (publish a revision, then
+  append the answer row). It keeps the current draft with its `pendingAnnotation`
+  and the same ordered, idempotent protocol, stored at
+  `checklists/<name>/draft.json`, so a crash at any boundary replays to exactly
+  one revision and one row. This is the only place a draft exists.
+
+### Checklists
+
+Unchanged in substance, relocated: `checklists/<name>/<version>.json` inside the
+run directory, each version an immutable snapshot, `current.json` a pointer.
+The publication rules (add, soft-delete, restore, reweight; never change text
+under the same id; refuse a stale edited file) carry over as they are. A
+directory is therefore self-contained: runs, rubric, and answers travel
+together.
+
+## Commands
+
+### Removed
+
+- `agency eval extract` — the eval record is no longer a file.
+- `agency label ingest` and its four `--format`s — there is nothing to ingest;
+  tools read run directories.
+- `agency eval optimize` — keep only `agency optimize`.
+- The log viewer's `l` key (#848) — replaced by the trace-extract primitive
+  below. Its supporting pieces (`labelTrace`, `datasetWriter`, `labelingHost`,
+  the `statelog` occurrence origin) go with it.
+- The label store's manifest and version gate, `outputs.jsonl` and
+  `occurrences.jsonl`. (Its lock and the checklist draft are kept, re-homed —
+  see "The writer lock and crash recovery".)
+- `agency label save` / `saved` (the prototype from this session).
+
+### New
+
+- **`agency logs extract <log> --trace <id> [-o <file>]`** — copy one trace's
+  lines out of a statelog, to a file or stdout. Also a viewer key. A trace
+  slice is itself a valid statelog, so this is the one primitive that turns
+  "a run I noticed in a big log" into "a run I can attach things to". With a
+  single-trace log, `--trace` defaults to that trace.
+- **`agency runs add <dir> [--statelog <file>…] [--code <entry>] [--workdir <path> --trace <id>] [--annotations <file>]`** — assemble or extend a
+  run directory, under the writer lock. Idempotent: an identical attachment is
+  a no-op, a differing one is refused without `--replace`. Statelogs merge by
+  per-trace digest (skip identical, refuse conflicting). `--code` hashes the
+  complete closure, stores it under `code/<closureHash>/`, and refuses when it
+  does not match the hash a trace recorded or when a closure file is missing.
+  Adding a workdir later records when the snapshot was taken, since it may
+  postdate the run. (Command name is a proposal.)
+- **`agency note <dir> --trace <id> <text>`** — append a `note` annotation.
+  With a single-trace directory, `--trace` defaults.
+- **`agency runs list <dir>`** — one line per trace: id, input preview, cost,
+  duration, ended, latest score, note preview, labeled or not. The browsing
+  view for a reference set. (May fold into `agency logs`.)
+
+### Changed
+
+- **`agency eval run --agent … --suite <file|dir|git>`** — runs the suite and
+  writes a run directory (statelog with one trace per test, `code/`,
+  `workdir/<traceId>/`, and one `run` annotation per trace). **It never
+  grades.** No `goal` is required to run.
+- **`agency eval grade <dir> [--graders <file>]`** — reads the directory,
+  computes eval records from traces, appends `score` annotations, prints the
+  objective. Grader precedence unchanged: flag > test's own > `eval.graders`
+  config > goal judge (which needs the test's `goal`, and says so per test if
+  missing). Grader callbacks receive `({ output, test, workdir, record, judge })`
+  — `test` replaces `input`, and `test.input` is what the agent was given.
+- **`agency label <dir> --checklist <file>`** — walks the directory's traces
+  and appends `checklist` annotations. Same TUI, same keys, same sign-off
+  protocol; it reads a run directory instead of a private store.
+- **`agency optimize`** — reads `code/` (or the live agent) plus annotations of
+  every kind for reflection: scores as today, and notes and checklist answers as
+  additional feedback text.
+- **`agency logs <dir>`** — the viewer opens a run directory directly and shows
+  annotations beside the trace.
+- **`agency run --capture-workdir`** (or a config flag) — snapshot the working
+  directory into a run directory at the end of an ordinary run, for people who
+  know in advance they may want it.
+
+## The workflows, end to end
+
+**I ran something ad hoc and want to keep it with a thought.**
+`agency logs extract log.jsonl --trace MXEjJo -o refs/ficalc/statelog.jsonl`
+then `agency note refs/ficalc "took 40 min and $5; wanted ≤5 min, ≤$1"`. Later:
+`agency runs add refs/ficalc --code lib/agents/agency-agent/agent.agency`. It
+is now a run directory like any other: viewable, gradable, labelable.
+
+**I have several runs and a rubric.** Put their traces in one directory (`runs
+add` or plain `cat`), then `agency label <dir> --checklist news.json`.
+
+**I want a benchmark.** Write a suite of tests; `agency eval run --agent a.agency
+--suite evals/ --run-id v3` writes `runs/v3/`; `agency eval grade runs/v3`
+appends scores. Re-grade any time; every pass is more rows, nothing is
+overwritten. A `mustPass` failure still exits 2, so it still works in CI.
+
+**I want to compare v1 and v2.** Grade or label both directories; the
+comparison reads annotations. Identical outputs across the two are found by
+hashing at that point, if wanted.
+
+**I want to improve the agent.** `agency optimize` over a directory that has
+scores, notes, or labels — all three are feedback.
+
+## What this removes
+
+Roughly: the eval record writer and reader as a disk format; `extract`; the
+whole `lib/eval/label/load/` tree; the label store's ids/occurrences/corpus/
+lock/draft/manifest modules; `config.json`/`summary.json`/`input.json`/
+`verifier-N/` writers and their tolerant readers; the `l` key and its three
+service modules; and the docs for each. What stays: the statelog, the eval
+record *type* and extractor, the graders and judge, the checklist publication
+rules and the labeling TUI, the optimizer, and the eval harness's execution core.
+
+## Migration
+
+A clean break, deliberately. Old `runs/` directories hold their statelogs and
+could be re-assembled with `runs add`; old `labels/` directories hold copies of
+outputs and answers but **not** the traces, so their labels cannot be attached
+to a run and are not carried forward. The language has few users and little
+labeled data today, so no compatibility layer or migration is built.
+
+## Open questions
+
+1. **Command namespace.** `agency runs add/list`, `agency note`, and `agency
+   logs extract` are proposals; the family may want one root (`agency runs
+   …`).
+2. **Where the run annotation's `test` lives when the suite is huge.** Inlining
+   the test spec per row is simple and self-contained; a suite with large
+   `expected` values would bloat the file. Cap or reference by id + suite sha
+   if it bites.
+3. **Judge annotations at volume.** A judge that scores every trace on every
+   pass will outnumber human rows. Same file, or `annotations/<annotator>.jsonl`
+   per annotator? Start with one file; split only if a real directory gets
+   unwieldy.
+4. **Multi-trace `agency agent` sessions.** One trace = one run is the rule; a
+   long session that spawns sub-agents already nests them under one trace, so
+   this holds, but check against a real session before building.
+
+## Out of scope
+
+Agreement measurement between judges and humans, active learning, pairwise
+labeling UI, editing a trace or an annotation in place, and any statelog server
+integration. Each becomes easier on this shape, none is needed to ship it.

--- a/packages/agency-lang/lib/analysis/closure.ts
+++ b/packages/agency-lang/lib/analysis/closure.ts
@@ -60,7 +60,7 @@ export function closureBaseDir(absoluteFiles: string[]): string {
   return isInsideOrSame(ancestor, cwd) ? cwd : ancestor;
 }
 
-function commonAncestor(paths: string[]): string {
+export function commonAncestor(paths: string[]): string {
   if (paths.length === 0) return process.cwd();
   const [first, ...rest] = paths.map((candidate) => path.resolve(candidate).split(path.sep));
   const prefix: string[] = [];

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -4329,6 +4329,7 @@ export class TypeScriptBuilder {
                     config: ts.id("__invocationConfig"),
                     traceId: ts.id("__invocationTraceId"),
                   }),
+                  input: ts.id("__invocationInput"),
                   initializeGlobals: ts.id("__initializeGlobals"),
                 }),
               ])

--- a/packages/agency-lang/lib/backends/typescriptBuilder/nodeWrapperParams.test.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder/nodeWrapperParams.test.ts
@@ -19,7 +19,7 @@ describe("node wrapper per-invocation options", () => {
 
   it("destructures the options into hidden aliases", () => {
     expect(ts).toContain(
-      "{ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }",
+      "{ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }",
     );
   });
 
@@ -30,5 +30,6 @@ describe("node wrapper per-invocation options", () => {
   it("forwards the aliases as the runNode invocation", () => {
     expect(ts).toContain("config: __invocationConfig");
     expect(ts).toContain("traceId: __invocationTraceId");
+    expect(ts).toContain("input: __invocationInput");
   });
 });

--- a/packages/agency-lang/lib/backends/typescriptBuilder/nodeWrapperParams.test.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder/nodeWrapperParams.test.ts
@@ -19,7 +19,7 @@ describe("node wrapper per-invocation options", () => {
 
   it("destructures the options into hidden aliases", () => {
     expect(ts).toContain(
-      "{ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }",
+      "{ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }",
     );
   });
 
@@ -31,5 +31,13 @@ describe("node wrapper per-invocation options", () => {
     expect(ts).toContain("config: __invocationConfig");
     expect(ts).toContain("traceId: __invocationTraceId");
     expect(ts).toContain("input: __invocationInput");
+  });
+
+  it("does not name the carrier `input`, which nodes commonly use as a parameter", () => {
+    const withInput = compile(`node main(input: string) {
+  return input
+}`);
+    expect(withInput).toContain("main(input: string, {");
+    expect(withInput).not.toMatch(/traceId: __invocationTraceId, input: __invocationInput/);
   });
 });

--- a/packages/agency-lang/lib/backends/typescriptBuilder/nodeWrapperParams.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder/nodeWrapperParams.ts
@@ -34,9 +34,13 @@ export function nodeWrapperParams(
   // Alias each option to a hidden name so a node parameter named `config`,
   // `traceId`, `messages`, or `callbacks` cannot collide with the destructured
   // options. The runtime owns all behavior; this only packages the arguments.
+  // `input` is the one value the caller says the node was given (an eval
+  // input, or a harness that names it); the runtime records it on agentStart.
+  // It is never inferred from the parameters, because a plain one-parameter
+  // call and an eval input have the same shape.
   params.push({
-    name: "{ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }",
-    typeAnnotation: "({ messages?: any; callbacks?: any } & InvocationOptions)",
+    name: "{ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }",
+    typeAnnotation: "({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions)",
     defaultValue: ts.obj({}),
   });
   return params;

--- a/packages/agency-lang/lib/backends/typescriptBuilder/nodeWrapperParams.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder/nodeWrapperParams.ts
@@ -34,13 +34,16 @@ export function nodeWrapperParams(
   // Alias each option to a hidden name so a node parameter named `config`,
   // `traceId`, `messages`, or `callbacks` cannot collide with the destructured
   // options. The runtime owns all behavior; this only packages the arguments.
-  // `input` is the one value the caller says the node was given (an eval
-  // input, or a harness that names it); the runtime records it on agentStart.
-  // It is never inferred from the parameters, because a plain one-parameter
-  // call and an eval input have the same shape.
+  // `invocationInput` is the one value the caller says the node was given (an
+  // eval input, or a harness that names it); the runtime records it as
+  // `agentStart.input`. It is never inferred from the parameters, because a
+  // plain one-parameter call and an eval input have the same shape. The key
+  // is deliberately not `input`: nodes often have a parameter of that name,
+  // and `main(input, { input } = {})` would read as the same value twice.
   params.push({
-    name: "{ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }",
-    typeAnnotation: "({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions)",
+    name: "{ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }",
+    typeAnnotation:
+      "({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions)",
     defaultValue: ts.obj({}),
   });
   return params;

--- a/packages/agency-lang/lib/cli/commands.ts
+++ b/packages/agency-lang/lib/cli/commands.ts
@@ -3,11 +3,10 @@ import {
   AgencyConfig,
   CONFIG_OVERRIDES_ENV,
   loadConfigSafe,
-  mergeConfigOverrides,
   readConfigOverrides,
   serializeConfigOverrides,
 } from "@/config.js";
-import { computeCodeIdentity } from "@/runDirectory/codeIdentity.js";
+import { withCodeIdentity } from "@/runDirectory/codeIdentity.js";
 import { AgencyProgram } from "@/index.js";
 import { spawn } from "child_process";
 import * as fs from "fs";
@@ -284,14 +283,12 @@ export function run(
   console.log("---");
 
   const env: NodeJS.ProcessEnv = { ...process.env };
-  // Which code this run is, recorded on the trace's agentStart. Layered under
-  // any inherited overrides (an eval harness hands this process its statelog
-  // path the same way), so nothing a parent set is lost.
+  // Which code this run is, recorded on the trace's agentStart. Inherited
+  // overrides are kept (an eval harness hands this process its statelog path
+  // the same way), but the identity of THIS file wins over any `log.code` a
+  // parent or stale shell left behind: a trace must never name another program.
   env[CONFIG_OVERRIDES_ENV] = serializeConfigOverrides(
-    mergeConfigOverrides(
-      { log: { code: computeCodeIdentity(inputFile) } },
-      readConfigOverrides(env),
-    ),
+    withCodeIdentity(readConfigOverrides(env), inputFile),
   );
   if (resumeFile) env.AGENCY_RESUME_FILE = resumeFile;
   // Make the child's policy behavior fully determined by THIS run's flags — never

--- a/packages/agency-lang/lib/cli/commands.ts
+++ b/packages/agency-lang/lib/cli/commands.ts
@@ -1,5 +1,13 @@
 import { generateAgency } from "@/backends/agencyGenerator.js";
-import { AgencyConfig, loadConfigSafe } from "@/config.js";
+import {
+  AgencyConfig,
+  CONFIG_OVERRIDES_ENV,
+  loadConfigSafe,
+  mergeConfigOverrides,
+  readConfigOverrides,
+  serializeConfigOverrides,
+} from "@/config.js";
+import { computeCodeIdentity } from "@/runDirectory/codeIdentity.js";
 import { AgencyProgram } from "@/index.js";
 import { spawn } from "child_process";
 import * as fs from "fs";
@@ -276,6 +284,15 @@ export function run(
   console.log("---");
 
   const env: NodeJS.ProcessEnv = { ...process.env };
+  // Which code this run is, recorded on the trace's agentStart. Layered under
+  // any inherited overrides (an eval harness hands this process its statelog
+  // path the same way), so nothing a parent set is lost.
+  env[CONFIG_OVERRIDES_ENV] = serializeConfigOverrides(
+    mergeConfigOverrides(
+      { log: { code: computeCodeIdentity(inputFile) } },
+      readConfigOverrides(env),
+    ),
+  );
   if (resumeFile) env.AGENCY_RESUME_FILE = resumeFile;
   // Make the child's policy behavior fully determined by THIS run's flags — never
   // by a stray AGENCY_RUN_POLICY* inherited from the parent shell or an outer run

--- a/packages/agency-lang/lib/cli/runBundledAgent.test.ts
+++ b/packages/agency-lang/lib/cli/runBundledAgent.test.ts
@@ -216,6 +216,27 @@ describe("runBundledAgent passes config overrides to the child via env", () => {
     expect(overrides.observability).toBe(true);
   });
 
+  it("the launcher's own code identity replaces an inherited log.code: a trace never names another program", () => {
+    const spawnMock = vi.fn((..._args: unknown[]) => ({ on: vi.fn() }) as never);
+    vi.stubEnv(
+      CONFIG_OVERRIDES_ENV,
+      JSON.stringify({
+        log: {
+          logFile: "harness.jsonl",
+          code: { entry: "other.agency", closureHash: "stale", closure: [] },
+        },
+      }),
+    );
+
+    runBundledAgent({}, "agency-agent", [], {}, { spawn: spawnMock as never });
+
+    const opts = spawnMock.mock.calls[0][2] as { env: Record<string, string> };
+    const overrides = JSON.parse(opts.env[CONFIG_OVERRIDES_ENV]);
+    expect(overrides.log.code.entry).toBe("agent.agency");
+    expect(overrides.log.code.closureHash).not.toBe("stale");
+    expect(overrides.log.logFile).toBe("harness.jsonl");
+  });
+
   it("sets AGENCY_MAX_COST/AGENCY_MAX_TIME from the forwarded flags and clears stale ones", () => {
     const spawnMock = vi.fn((..._args: unknown[]) => ({ on: vi.fn() }) as never);
     vi.stubEnv("AGENCY_MAX_COST", "999");

--- a/packages/agency-lang/lib/cli/runBundledAgent.test.ts
+++ b/packages/agency-lang/lib/cli/runBundledAgent.test.ts
@@ -169,7 +169,7 @@ describe("runBundledAgent passes config overrides to the child via env", () => {
     expect(overrides).toEqual({
       trace: true,
       traceFile: "t.trace",
-      log: { logFile: "l.jsonl" },
+      log: { logFile: "l.jsonl", code: expect.objectContaining({ entry: "agent.agency" }) },
       observability: true,
     });
     // Parent env is preserved (spread), so PATH survives.
@@ -188,7 +188,8 @@ describe("runBundledAgent passes config overrides to the child via env", () => {
     const opts = spawnMock.mock.calls[0][2] as { env: Record<string, string> };
     expect(JSON.parse(opts.env[CONFIG_OVERRIDES_ENV])).toEqual({
       observability: true,
-      log: { logFile: "harness.jsonl" }, // inherited, survives
+      // inherited logFile survives; the launcher adds which code is running
+      log: { logFile: "harness.jsonl", code: expect.objectContaining({ entry: "agent.agency" }) },
       trace: true,
       traceFile: "t.trace",
     });
@@ -281,11 +282,17 @@ describe("runBundledAgent passes config overrides to the child via env", () => {
     expect(spawnMock).not.toHaveBeenCalled();
   });
 
-  it("does not set the env var when no debug flags are present", () => {
+  it("always records which code is running, even with no debug flags", () => {
     const spawnMock = vi.fn((..._args: unknown[]) => ({ on: vi.fn() }) as never);
     runBundledAgent({}, "agency-agent", ["--print", "hi"], {}, { spawn: spawnMock as never });
     const opts = spawnMock.mock.calls[0][2] as { env: Record<string, string> };
-    expect(opts.env[CONFIG_OVERRIDES_ENV]).toBeUndefined();
+    const overrides = JSON.parse(opts.env[CONFIG_OVERRIDES_ENV]);
+    expect(Object.keys(overrides)).toEqual(["log"]);
+    expect(overrides.log.code.entry).toBe("agent.agency");
+    expect(overrides.log.code.closureHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(overrides.log.code.closure.map((file: { file: string }) => file.file)).toContain(
+      "agent.agency",
+    );
   });
 
   it("--agent-home sets AGENCY_AGENT_HOME in the child env, beating an inherited value", () => {

--- a/packages/agency-lang/lib/cli/runBundledAgent.ts
+++ b/packages/agency-lang/lib/cli/runBundledAgent.ts
@@ -16,7 +16,7 @@ import { spawn as realSpawn } from "child_process";
 import * as fs from "fs";
 import * as path from "path";
 
-import { computeCodeIdentity } from "@/runDirectory/codeIdentity.js";
+import { withCodeIdentity } from "@/runDirectory/codeIdentity.js";
 
 const currentDir = path.dirname(new URL(import.meta.url).pathname);
 
@@ -220,10 +220,12 @@ export function runBundledAgent(
   const env = { ...process.env };
   // Inherited overrides matter: an eval harness hands this process its
   // statelog path via this env var, and flags must layer on top, not
+  // replace it. The code identity goes on last: it names the agent that is
+  // actually about to run, so neither an inherited `log.code` nor a flag may
   // replace it.
-  const merged = mergeConfigOverrides(
-    mergeConfigOverrides(codeIdentityOverrides(agencyFile), readConfigOverrides(env)),
-    launchArgs.configOverrides,
+  const merged = withCodeIdentityIfSourced(
+    mergeConfigOverrides(readConfigOverrides(env), launchArgs.configOverrides),
+    agencyFile,
   );
   if (Object.keys(merged).length > 0) {
     env[CONFIG_OVERRIDES_ENV] = serializeConfigOverrides(merged);
@@ -277,7 +279,10 @@ export function runBundledAgent(
 
 /** Which code the agent is, for the trace's agentStart. A precompiled agent
  *  shipped without its `.agency` source records nothing. */
-function codeIdentityOverrides(agencyFile: string): Partial<AgencyConfig> {
-  if (!fs.existsSync(agencyFile)) return {};
-  return { log: { code: computeCodeIdentity(agencyFile) } };
+function withCodeIdentityIfSourced(
+  overrides: Partial<AgencyConfig>,
+  agencyFile: string,
+): Partial<AgencyConfig> {
+  if (!fs.existsSync(agencyFile)) return overrides;
+  return withCodeIdentity(overrides, agencyFile);
 }

--- a/packages/agency-lang/lib/cli/runBundledAgent.ts
+++ b/packages/agency-lang/lib/cli/runBundledAgent.ts
@@ -16,6 +16,8 @@ import { spawn as realSpawn } from "child_process";
 import * as fs from "fs";
 import * as path from "path";
 
+import { computeCodeIdentity } from "@/runDirectory/codeIdentity.js";
+
 const currentDir = path.dirname(new URL(import.meta.url).pathname);
 
 /**
@@ -219,7 +221,10 @@ export function runBundledAgent(
   // Inherited overrides matter: an eval harness hands this process its
   // statelog path via this env var, and flags must layer on top, not
   // replace it.
-  const merged = mergeConfigOverrides(readConfigOverrides(env), launchArgs.configOverrides);
+  const merged = mergeConfigOverrides(
+    mergeConfigOverrides(codeIdentityOverrides(agencyFile), readConfigOverrides(env)),
+    launchArgs.configOverrides,
+  );
   if (Object.keys(merged).length > 0) {
     env[CONFIG_OVERRIDES_ENV] = serializeConfigOverrides(merged);
   }
@@ -268,4 +273,11 @@ export function runBundledAgent(
       launcher.exit(code || 1);
     }
   });
+}
+
+/** Which code the agent is, for the trace's agentStart. A precompiled agent
+ *  shipped without its `.agency` source records nothing. */
+function codeIdentityOverrides(agencyFile: string): Partial<AgencyConfig> {
+  if (!fs.existsSync(agencyFile)) return {};
+  return { log: { code: computeCodeIdentity(agencyFile) } };
 }

--- a/packages/agency-lang/lib/config.ts
+++ b/packages/agency-lang/lib/config.ts
@@ -102,6 +102,14 @@ export interface AgencyConfig {
       agentVersion?: string;
       custom?: Record<string, string>;
     };
+    /** Which code this run is: entry file, closure file hashes, one closure
+     *  hash. Set by launchers (agency run, eval, agency agent) and recorded on
+     *  the statelog's agentStart event. */
+    code: {
+      entry: string;
+      closureHash: string;
+      closure: { file: string; sha256: string }[];
+    };
   }>;
 
   /** Eval command configuration */
@@ -472,6 +480,11 @@ export const AgencyConfigSchema = z
             custom: z.record(z.string(), z.string()),
           })
           .partial(),
+        code: z.object({
+          entry: z.string(),
+          closureHash: z.string(),
+          closure: z.array(z.object({ file: z.string(), sha256: z.string() })),
+        }),
       })
       .partial(),
     eval: z

--- a/packages/agency-lang/lib/eval/loadInputs.ts
+++ b/packages/agency-lang/lib/eval/loadInputs.ts
@@ -42,7 +42,7 @@ export function loadInputs(
     : loadInputsFromFile(sourcePath, makeId, options);
   // An empty suite is a mistake (wrong path, empty file), never a run:
   // zero inputs would "succeed" with objective 0 and hide the mistake —
-  // and under `eval optimize` it would burn the whole iteration budget
+  // and under `optimize` it would burn the whole iteration budget
   // grading candidates against nothing.
   if (inputs.length === 0) {
     throw new Error(`no inputs loaded from ${sourcePath}`);

--- a/packages/agency-lang/lib/eval/run/runAgent.ts
+++ b/packages/agency-lang/lib/eval/run/runAgent.ts
@@ -211,14 +211,17 @@ class AgentRunner {
       const argv = substituteTask(this.target.tokens, this.task);
       return { kind: "command", argv, traceId: nanoid(), cwd, statelogPath };
     }
+    if (compiledEntryPath === null || this.seededAgentEntry === null) {
+      throw new Error("A file target must be seeded and compiled before its job is built.");
+    }
     return {
       kind: "file",
-      compiledEntryPath: compiledEntryPath as string,
+      compiledEntryPath,
       node: this.target.node,
       task: this.task,
       cwd,
       statelogPath,
-      code: computeCodeIdentity(this.seededAgentEntry as string),
+      code: computeCodeIdentity(this.seededAgentEntry),
     };
   }
 

--- a/packages/agency-lang/lib/eval/run/runAgent.ts
+++ b/packages/agency-lang/lib/eval/run/runAgent.ts
@@ -1,3 +1,5 @@
+import * as path from "path";
+import { computeCodeIdentity } from "@/runDirectory/codeIdentity.js";
 import * as fs from "fs";
 
 import { nanoid } from "nanoid";
@@ -101,6 +103,8 @@ export async function runAgent(
 class AgentRunner {
   private readonly paths: AgentRunPaths;
   private seededFiles: string[] = [];
+  /** The seeded copy of the agent entry — the code that actually runs. */
+  private seededAgentEntry: string | null = null;
 
   constructor(
     private readonly target: EvalTarget,
@@ -181,6 +185,7 @@ class AgentRunner {
     copyFiles(this.paths.workdirPath, files);
     applyOverlay(this.paths.workdirPath, this.options.overlayFiles);
     this.seededFiles = Object.keys(files).sort();
+    this.seededAgentEntry = path.join(this.paths.workdirPath, seed.agentRelPath);
     return compileAgent(this.paths.workdirPath, seed.agentRelPath, this.options.config);
   }
 
@@ -213,6 +218,7 @@ class AgentRunner {
       task: this.task,
       cwd,
       statelogPath,
+      code: computeCodeIdentity(this.seededAgentEntry as string),
     };
   }
 

--- a/packages/agency-lang/lib/eval/run/runSuite.ts
+++ b/packages/agency-lang/lib/eval/run/runSuite.ts
@@ -60,7 +60,7 @@ export type RunSuiteOptions = {
   /** Default true: suite-level progress on stderr (the run-dir line, the
    *  per-input heartbeat and status lines, the parallel status board). The
    *  optimizer turns it off — its reporter owns the narrative, and
-   *  `eval optimize --silent` must print nothing at all. */
+   *  `optimize --silent` must print nothing at all. */
   progress?: boolean;
   /** Source provenance recorded in config.json; "unspecified" when omitted. */
   provenance?: { inputsSource: SourceProvenance; files: Record<string, SourceProvenance> };

--- a/packages/agency-lang/lib/eval/run/subprocess.ts
+++ b/packages/agency-lang/lib/eval/run/subprocess.ts
@@ -1,3 +1,4 @@
+import type { CodeIdentity } from "@/runDirectory/codeIdentity.js";
 import { fork } from "child_process";
 
 import type { AgencyConfig } from "@/config.js";
@@ -21,6 +22,8 @@ export type EvalRunnerJob =
       task: string | Record<string, any>;
       cwd: string;
       statelogPath: string;
+      /** Identity of the seeded agent code, recorded on the trace's agentStart. */
+      code: CodeIdentity;
     }
   | { kind: "command"; argv: string[]; cwd: string; statelogPath: string; traceId: string };
 
@@ -127,6 +130,7 @@ export function makeSubprocessRunner(
       task: job.task,
       cwd: job.cwd,
       statelogPath: job.statelogPath,
+      code: job.code,
       pipeAgentOutput,
       limits,
       maxCostUsd,
@@ -140,6 +144,7 @@ async function runCompiledAgentInSubprocess(args: {
   task: string | Record<string, any>;
   cwd: string;
   statelogPath: string;
+  code: CodeIdentity;
   pipeAgentOutput: boolean;
   limits: RunLimits;
   maxCostUsd: number;
@@ -153,7 +158,7 @@ async function runCompiledAgentInSubprocess(args: {
     limits,
     configOverrides: {
       observability: true,
-      log: { logFile: args.statelogPath },
+      log: { logFile: args.statelogPath, code: args.code },
     },
   });
 

--- a/packages/agency-lang/lib/runDirectory/codeIdentity.test.ts
+++ b/packages/agency-lang/lib/runDirectory/codeIdentity.test.ts
@@ -4,7 +4,7 @@ import * as path from "path";
 
 import { describe, expect, it } from "vitest";
 
-import { computeCodeIdentity } from "./codeIdentity.js";
+import { computeCodeIdentity, withCodeIdentity } from "./codeIdentity.js";
 
 function proj(files: Record<string, string>): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "codeid-"));
@@ -50,5 +50,23 @@ describe("computeCodeIdentity", () => {
     const before = computeCodeIdentity(path.join(dir, "main.agency")).closureHash;
     fs.writeFileSync(path.join(dir, "main.agency"), "node main() { return 2 }\n");
     expect(computeCodeIdentity(path.join(dir, "main.agency")).closureHash).not.toBe(before);
+  });
+});
+
+describe("withCodeIdentity", () => {
+  it("keeps every inherited override but replaces an inherited log.code with the entry file's own", () => {
+    const dir = proj({ "main.agency": "node main() { return 1 }" });
+    const inherited = {
+      observability: true,
+      log: {
+        logFile: "harness.jsonl",
+        code: { entry: "other.agency", closureHash: "stale", closure: [] },
+      },
+    };
+    const merged = withCodeIdentity(inherited, path.join(dir, "main.agency"));
+    expect(merged.observability).toBe(true);
+    expect(merged.log?.logFile).toBe("harness.jsonl");
+    expect(merged.log?.code?.entry).toBe("main.agency");
+    expect(merged.log?.code?.closureHash).not.toBe("stale");
   });
 });

--- a/packages/agency-lang/lib/runDirectory/codeIdentity.test.ts
+++ b/packages/agency-lang/lib/runDirectory/codeIdentity.test.ts
@@ -32,6 +32,19 @@ describe("computeCodeIdentity", () => {
     expect(secondIdentity.closureHash).toBe(firstIdentity.closureHash);
   });
 
+  it("does not depend on the working directory", () => {
+    const dir = proj({ "main.agency": "node main() { return 1 }\n" });
+    const fromOutside = computeCodeIdentity(path.join(dir, "main.agency"));
+    const previous = process.cwd();
+    process.chdir(path.dirname(dir));
+    try {
+      expect(computeCodeIdentity(path.join(dir, "main.agency"))).toEqual(fromOutside);
+    } finally {
+      process.chdir(previous);
+    }
+    expect(fromOutside.entry).toBe("main.agency");
+  });
+
   it("changes the hash when any closure file changes", () => {
     const dir = proj({ "main.agency": "node main() { return 1 }\n" });
     const before = computeCodeIdentity(path.join(dir, "main.agency")).closureHash;

--- a/packages/agency-lang/lib/runDirectory/codeIdentity.test.ts
+++ b/packages/agency-lang/lib/runDirectory/codeIdentity.test.ts
@@ -1,0 +1,41 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import { describe, expect, it } from "vitest";
+
+import { computeCodeIdentity } from "./codeIdentity.js";
+
+function proj(files: Record<string, string>): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "codeid-"));
+  for (const [rel, text] of Object.entries(files)) {
+    fs.mkdirSync(path.dirname(path.join(dir, rel)), { recursive: true });
+    fs.writeFileSync(path.join(dir, rel), text);
+  }
+  return dir;
+}
+
+describe("computeCodeIdentity", () => {
+  it("lists the entry and its imports relative to the closure base, sorted, with a stable hash", () => {
+    const dir = proj({
+      "main.agency": 'import { f } from "./lib/util.agency"\nnode main() { return f() }\n',
+      "lib/util.agency": 'export def f(): string { return "x" }\n',
+    });
+    const firstIdentity = computeCodeIdentity(path.join(dir, "main.agency"));
+    expect(firstIdentity.entry).toBe("main.agency");
+    expect(firstIdentity.closure.map((file) => file.file)).toEqual([
+      "lib/util.agency",
+      "main.agency",
+    ]);
+    expect(firstIdentity.closureHash).toMatch(/^[0-9a-f]{64}$/);
+    const secondIdentity = computeCodeIdentity(path.join(dir, "main.agency"));
+    expect(secondIdentity.closureHash).toBe(firstIdentity.closureHash);
+  });
+
+  it("changes the hash when any closure file changes", () => {
+    const dir = proj({ "main.agency": "node main() { return 1 }\n" });
+    const before = computeCodeIdentity(path.join(dir, "main.agency")).closureHash;
+    fs.writeFileSync(path.join(dir, "main.agency"), "node main() { return 2 }\n");
+    expect(computeCodeIdentity(path.join(dir, "main.agency")).closureHash).not.toBe(before);
+  });
+});

--- a/packages/agency-lang/lib/runDirectory/codeIdentity.ts
+++ b/packages/agency-lang/lib/runDirectory/codeIdentity.ts
@@ -2,6 +2,7 @@ import * as fs from "fs";
 import * as path from "path";
 
 import { agentClosure, commonAncestor } from "@/analysis/closure.js";
+import { mergeConfigOverrides, type AgencyConfig } from "@/config.js";
 import { sha256Text } from "@/utils/hash.js";
 
 export type ClosureFile = { file: string; sha256: string };
@@ -29,4 +30,18 @@ export function computeCodeIdentity(entryFile: string): CodeIdentity {
 
 export function closureHashOf(closure: readonly ClosureFile[]): string {
   return sha256Text(closure.map((file) => `${file.file}\n${file.sha256}\n`).join(""));
+}
+
+/**
+ * The config overrides a launcher hands its child, with `log.code` set to
+ * the identity of the file that is actually about to run. Everything else in
+ * `overrides` (an inherited statelog path, flags) survives; only `log.code`
+ * is forced, because a `log.code` inherited from a parent process or a stale
+ * shell names some other program, and a trace must never do that.
+ */
+export function withCodeIdentity(
+  overrides: Partial<AgencyConfig>,
+  entryFile: string,
+): Partial<AgencyConfig> {
+  return mergeConfigOverrides(overrides, { log: { code: computeCodeIdentity(entryFile) } });
 }

--- a/packages/agency-lang/lib/runDirectory/codeIdentity.ts
+++ b/packages/agency-lang/lib/runDirectory/codeIdentity.ts
@@ -1,0 +1,30 @@
+import * as fs from "fs";
+import * as path from "path";
+
+import { agentClosure } from "@/analysis/closure.js";
+import { sha256Text } from "@/utils/hash.js";
+
+export type ClosureFile = { file: string; sha256: string };
+export type CodeIdentity = { entry: string; closureHash: string; closure: ClosureFile[] };
+
+/** Which code an agent is: the entry file and every file it transitively
+ *  imports, each hashed, plus one hash over the whole list. Paths are relative
+ *  to the closure's base directory so the same code hashes the same anywhere. */
+export function computeCodeIdentity(entryFile: string): CodeIdentity {
+  const { baseDir, files } = agentClosure(entryFile);
+  const closure = files
+    .map((absoluteFile) => ({
+      file: path.relative(baseDir, absoluteFile),
+      sha256: sha256Text(fs.readFileSync(absoluteFile, "utf8")),
+    }))
+    .sort((left, right) => left.file.localeCompare(right.file));
+  return {
+    entry: path.relative(baseDir, fs.realpathSync(path.resolve(entryFile))),
+    closureHash: closureHashOf(closure),
+    closure,
+  };
+}
+
+export function closureHashOf(closure: readonly ClosureFile[]): string {
+  return sha256Text(closure.map((file) => `${file.file}\n${file.sha256}\n`).join(""));
+}

--- a/packages/agency-lang/lib/runDirectory/codeIdentity.ts
+++ b/packages/agency-lang/lib/runDirectory/codeIdentity.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 
-import { agentClosure } from "@/analysis/closure.js";
+import { agentClosure, commonAncestor } from "@/analysis/closure.js";
 import { sha256Text } from "@/utils/hash.js";
 
 export type ClosureFile = { file: string; sha256: string };
@@ -9,9 +9,11 @@ export type CodeIdentity = { entry: string; closureHash: string; closure: Closur
 
 /** Which code an agent is: the entry file and every file it transitively
  *  imports, each hashed, plus one hash over the whole list. Paths are relative
- *  to the closure's base directory so the same code hashes the same anywhere. */
+ *  to the files' common ancestor (never the cwd, unlike `closureBaseDir`), so
+ *  the same code hashes the same wherever it was run from. */
 export function computeCodeIdentity(entryFile: string): CodeIdentity {
-  const { baseDir, files } = agentClosure(entryFile);
+  const { files } = agentClosure(entryFile);
+  const baseDir = commonAncestor(files.map((file) => path.dirname(file)));
   const closure = files
     .map((absoluteFile) => ({
       file: path.relative(baseDir, absoluteFile),

--- a/packages/agency-lang/lib/runtime/node.ts
+++ b/packages/agency-lang/lib/runtime/node.ts
@@ -348,6 +348,10 @@ type RunNodeArgs = {
   abortSignal?: AbortSignal;
   // Per-invocation config override + optional root trace id for this run.
   invocation?: InvocationOptions;
+  // What the entry node was given, when the caller names it (an eval input).
+  // Recorded on agentStart; never derived from `data`, because an ordinary
+  // one-parameter call and an eval input look the same there.
+  input?: unknown;
 };
 
 // eslint-disable-next-line max-lines-per-function -- core node-execution loop; refactor tracked separately
@@ -360,6 +364,7 @@ async function runNodeCore({
   initializeGlobals,
   abortSignal,
   invocation,
+  input,
 }: RunNodeArgs): Promise<ServedInvocationOutcome<RunNodeResult<any>>> {
   // The resolver owns run-id policy: a subprocess INHERITS the parent's runId
   // (seeded from the run instruction) so child statelog events land in the same
@@ -428,7 +433,7 @@ async function runNodeCore({
     );
 
     agentRunSpanId = execCtx.statelogClient.startSpan("agentRun");
-    execCtx.statelogClient.agentStart({ entryNode: nodeName, args: data });
+    execCtx.statelogClient.agentStart({ entryNode: nodeName, args: data, input });
 
     let isResume = false;
     let threadStore = ThreadStore.withDefaultActive(execCtx.statelogClient);

--- a/packages/agency-lang/lib/runtime/subprocess-bootstrap.ts
+++ b/packages/agency-lang/lib/runtime/subprocess-bootstrap.ts
@@ -134,7 +134,10 @@ async function executeRun(mod: any, msg: RunInstruction): Promise<any> {
   // Wrapping again here would attach the subprocess's parent-process
   // context (which doesn't even exist as a peer ALS) instead of the
   // child's own `RuntimeContext`.
-  return nodeFn(...positionalArgs);
+  // The trailing options object names the input explicitly, so the runtime
+  // records it on agentStart without guessing from the parameters. Absent
+  // (`undefined`) for a named-args run.
+  return nodeFn(...positionalArgs, { input: msg.task });
 }
 
 /** Resume-mode body: re-attach the shared checkpoint to each interrupt and

--- a/packages/agency-lang/lib/runtime/subprocess-bootstrap.ts
+++ b/packages/agency-lang/lib/runtime/subprocess-bootstrap.ts
@@ -137,7 +137,7 @@ async function executeRun(mod: any, msg: RunInstruction): Promise<any> {
   // The trailing options object names the input explicitly, so the runtime
   // records it on agentStart without guessing from the parameters. Absent
   // (`undefined`) for a named-args run.
-  return nodeFn(...positionalArgs, { input: msg.task });
+  return nodeFn(...positionalArgs, { invocationInput: msg.task });
 }
 
 /** Resume-mode body: re-attach the shared checkpoint to each interrupt and

--- a/packages/agency-lang/lib/statelog/wireTypes.ts
+++ b/packages/agency-lang/lib/statelog/wireTypes.ts
@@ -19,5 +19,9 @@ export type EventEnvelope = {
 export type EventData = {
   type: string;
   timestamp: string;
+  // Untyped by design (see above). Notable fields for consumers:
+  //   agentStart: `entryNode`, `args`, optional `input` (what the entry node
+  //   was given, when the caller named it) and optional `code`
+  //   ({ entry, closureHash, closure: [{ file, sha256 }] } — which code ran).
   [key: string]: any;
 };

--- a/packages/agency-lang/lib/statelogClient.test.ts
+++ b/packages/agency-lang/lib/statelogClient.test.ts
@@ -550,6 +550,22 @@ describe("StatelogClient", () => {
       expect(evt.data.type).toBe("agentStart");
       expect(evt.data.entryNode).toBe("main");
       expect(evt.data.args).toEqual({ x: 1 });
+      expect(evt.data).not.toHaveProperty("input");
+      expect(evt.data).not.toHaveProperty("code");
+    });
+
+    it("agentStart records the input and the configured code identity", async () => {
+      const file = newLogFile("agent-start-code");
+      const code = {
+        entry: "a.agency",
+        closureHash: "h",
+        closure: [{ file: "a.agency", sha256: "s" }],
+      };
+      const client = fileClient(file, { code });
+      await client.agentStart({ entryNode: "main", args: {}, input: "hello" });
+      const [evt] = readEvents(file);
+      expect(evt.data.input).toBe("hello");
+      expect(evt.data.code).toEqual(code);
     });
 
     it("agentEnd includes timeTaken and tokenStats", async () => {

--- a/packages/agency-lang/lib/statelogClient.ts
+++ b/packages/agency-lang/lib/statelogClient.ts
@@ -1,3 +1,4 @@
+import type { CodeIdentity } from "@/runDirectory/codeIdentity.js";
 import * as fs from "fs";
 import * as path from "path";
 import { AsyncLocalStorage } from "node:async_hooks";
@@ -76,6 +77,9 @@ export type StatelogConfig = {
   projectId: string;
   debugMode: boolean;
   metadata?: RunMetadata;
+  /** Which code this process is running; recorded on agentStart so a trace can
+   *  be attributed to a version after the fact. */
+  code?: CodeIdentity;
   observability?: boolean;
   // Append every event as a JSON line to this file path. Intended for
   // local development and tests. Mutually compatible with host/stdout —
@@ -162,6 +166,7 @@ export class StatelogClient {
   // share this single StatelogClient instance.
   private spanStorage = new AsyncLocalStorage<SpanContext[]>();
   private metadata?: RunMetadata;
+  private code?: CodeIdentity;
   private requestTimeoutMs: number;
   // Fallback tag-store accessor for posts that fire OUTSIDE any ALS frame
   // (agentEnd and the resume-path finalization events post after the run's
@@ -182,6 +187,7 @@ export class StatelogClient {
     this.requestTimeoutMs = config.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
 
     this.metadata = config.metadata;
+    this.code = config.code;
 
     // Observability must be explicitly enabled. When false (the default),
     // the entire client is a no-op — no events emitted, no network calls,
@@ -1002,11 +1008,23 @@ export class StatelogClient {
     });
   }
 
-  async agentStart({ entryNode, args }: { entryNode: string; args?: any }): Promise<void> {
+  async agentStart({
+    entryNode,
+    args,
+    input,
+  }: {
+    entryNode: string;
+    args?: any;
+    /** What the entry node was given, when the caller says so explicitly (an
+     *  eval input, or any single-parameter invocation that names it). */
+    input?: unknown;
+  }): Promise<void> {
     await this.post({
       type: "agentStart",
       entryNode,
       args,
+      input,
+      code: this.code,
     });
     if (this.metadata) {
       await this.runMetadata({ ...this.metadata, entryNode });

--- a/packages/agency-lang/scripts/agency.test.ts
+++ b/packages/agency-lang/scripts/agency.test.ts
@@ -152,14 +152,14 @@ describe("runCli", () => {
 });
 
 describe("agency CLI command tree", () => {
-  it("exposes optimize under both `eval optimize` and the top-level `optimize` alias", () => {
+  it("exposes optimize only at the top level, not as `eval optimize`", () => {
     const program = createProgram();
     const topLevelCommands = program.commands.map((command) => command.name());
     const evalCommand = program.commands.find((command) => command.name() === "eval");
     const evalCommands = evalCommand?.commands.map((command) => command.name()) ?? [];
 
     expect(topLevelCommands).toContain("optimize");
-    expect(evalCommands).toContain("optimize");
+    expect(evalCommands).not.toContain("optimize");
   });
 
   it("makes `view` the default for `logs` so `agency logs <file>` works without the subcommand", () => {

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -990,7 +990,7 @@ export function createProgram(deps: CliDependencies = {}): Command {
       },
     );
 
-  // Registered under both `agency eval optimize` and the top-level `agency optimize`.
+  // Registered as the top-level `agency optimize`.
   const addOptimizeCommand = (parent: Command): void => {
     parent
       .command("optimize")
@@ -1053,7 +1053,6 @@ export function createProgram(deps: CliDependencies = {}): Command {
         },
       );
   };
-  addOptimizeCommand(evalCmd);
   addOptimizeCommand(program);
 
   program

--- a/packages/agency-lang/tests/integration/eval-run/test.mjs
+++ b/packages/agency-lang/tests/integration/eval-run/test.mjs
@@ -94,6 +94,14 @@ node main(task: string) {
   assert(resolved.data.outcome === "approved", `outcome: ${resolved.data.outcome}`);
   assert(resolved.data.resolvedBy === "ipc", `resolvedBy: ${resolved.data.resolvedBy}`);
 
+  // The trace names what ran and what it was given: the eval task arrives as
+  // an explicit `input`, and the seeded agent's code identity is recorded.
+  const started = events.find((e) => e.data?.type === "agentStart");
+  assert(started, "no agentStart event in the statelog");
+  assert(started.data.input === "run", `agentStart.input: ${JSON.stringify(started.data.input)}`);
+  assert(started.data.code?.entry === "agent.agency", `agentStart.code.entry: ${JSON.stringify(started.data.code)}`);
+  assert(/^[0-9a-f]{64}$/.test(started.data.code?.closureHash ?? ""), "agentStart.code.closureHash missing");
+
   // The record survives extraction: the interrupt shows up approved.
   const record = JSON.parse(readFileSync(join(runsDir, "interrupt-e2e", "inputs", "interrupting", "agent", "eval-record.json"), "utf-8"));
   assert(record.interrupts.length === 1, `interrupts: expected 1, got ${record.interrupts.length}`);
@@ -159,6 +167,11 @@ node main(): string {
   const cmdEvents = readFileSync(join(cmdInputDir, "agent", "statelog.jsonl"), "utf-8")
     .trim().split("\n").map((line) => JSON.parse(line));
   assert(cmdEvents.some((e) => e.data?.type === "agentStart"), "no agentStart from the spawned CLI in the harness statelog");
+  // `agency run` fills the code identity itself, and a named-args run
+  // (no eval task delivery) records no `input` — the runtime never guesses one.
+  const cmdStarted = cmdEvents.find((e) => e.data?.type === "agentStart");
+  assert(cmdStarted.data.code?.entry === "writer.agency", `command agentStart.code: ${JSON.stringify(cmdStarted.data.code)}`);
+  assert(!("input" in cmdStarted.data), `command agentStart should not record input, got ${JSON.stringify(cmdStarted.data.input)}`);
   // ...with exactly one trace id across the whole tree
   const traceIds = [...new Set(cmdEvents.map((e) => e.trace_id))];
   assert(traceIds.length === 1, `expected one trace id, got ${traceIds.length}: ${traceIds.join(", ")}`);

--- a/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
@@ -283,7 +283,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -294,6 +294,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
@@ -283,7 +283,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptBuilder/simple.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/simple.mjs
@@ -297,7 +297,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -308,6 +308,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptBuilder/simple.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/simple.mjs
@@ -297,7 +297,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/array.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/array.mjs
@@ -341,7 +341,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -352,6 +352,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/array.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/array.mjs
@@ -341,7 +341,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
@@ -283,7 +283,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -294,6 +294,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
@@ -283,7 +283,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
@@ -473,7 +473,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
@@ -473,7 +473,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -484,6 +484,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
@@ -295,7 +295,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
@@ -295,7 +295,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -306,6 +306,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -476,7 +476,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -487,6 +487,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -476,7 +476,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
@@ -462,7 +462,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
@@ -462,7 +462,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -473,6 +473,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
@@ -442,7 +442,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -453,6 +453,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
@@ -442,7 +442,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
@@ -282,7 +282,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
@@ -282,7 +282,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -293,6 +293,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
@@ -511,7 +511,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -522,6 +522,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
@@ -511,7 +511,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
@@ -534,7 +534,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
@@ -534,7 +534,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -545,6 +545,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
@@ -303,7 +303,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
@@ -303,7 +303,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -314,6 +314,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/codeLiteral.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/codeLiteral.mjs
@@ -339,7 +339,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -350,6 +350,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/codeLiteral.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/codeLiteral.mjs
@@ -339,7 +339,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/comments.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comments.mjs
@@ -483,7 +483,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -494,6 +494,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/comments.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comments.mjs
@@ -483,7 +483,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/comprehension.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comprehension.mjs
@@ -470,7 +470,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/comprehension.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comprehension.mjs
@@ -470,7 +470,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -481,6 +481,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/destructiveBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/destructiveBlock.mjs
@@ -741,7 +741,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -752,6 +752,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/destructiveBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/destructiveBlock.mjs
@@ -741,7 +741,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/destructiveNested.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/destructiveNested.mjs
@@ -411,7 +411,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/destructiveNested.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/destructiveNested.mjs
@@ -411,7 +411,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -422,6 +422,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
@@ -302,7 +302,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
@@ -302,7 +302,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -313,6 +313,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
@@ -300,7 +300,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
@@ -300,7 +300,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -311,6 +311,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
@@ -284,7 +284,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
@@ -284,7 +284,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -295,6 +295,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
@@ -485,7 +485,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -496,6 +496,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
@@ -485,7 +485,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
@@ -663,7 +663,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
@@ -663,7 +663,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -674,6 +674,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
@@ -303,7 +303,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
@@ -303,7 +303,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -314,6 +314,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
@@ -521,7 +521,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -532,6 +532,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
@@ -521,7 +521,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
@@ -601,7 +601,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -612,6 +612,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
@@ -601,7 +601,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
@@ -303,7 +303,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
@@ -303,7 +303,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -314,6 +314,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
@@ -521,7 +521,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -532,6 +532,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
@@ -521,7 +521,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
@@ -365,7 +365,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
@@ -365,7 +365,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -376,6 +376,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
@@ -1302,7 +1302,7 @@ await callHook({
     };
   }
 })
-export async function foo({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function foo({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "foo",
@@ -1318,7 +1318,7 @@ export async function foo({ messages: __invocationMessages, callbacks: __invocat
   });
 }
 export const __fooNodeParams = [];
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
@@ -1302,7 +1302,7 @@ await callHook({
     };
   }
 })
-export async function foo({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function foo({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "foo",
@@ -1313,11 +1313,12 @@ export async function foo({ messages: __invocationMessages, callbacks: __invocat
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }
 export const __fooNodeParams = [];
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -1328,6 +1329,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function.mjs
@@ -586,7 +586,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function.mjs
@@ -586,7 +586,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -597,6 +597,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
@@ -770,7 +770,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -781,6 +781,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
@@ -770,7 +770,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
@@ -488,7 +488,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
@@ -488,7 +488,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -499,6 +499,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/goto.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/goto.mjs
@@ -354,7 +354,7 @@ await callHook({
   }
 })
 graph.conditionalEdge("main", ["foo"])
-export async function foo({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function foo({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "foo",
@@ -370,7 +370,7 @@ export async function foo({ messages: __invocationMessages, callbacks: __invocat
   });
 }
 export const __fooNodeParams = [];
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/goto.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/goto.mjs
@@ -354,7 +354,7 @@ await callHook({
   }
 })
 graph.conditionalEdge("main", ["foo"])
-export async function foo({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function foo({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "foo",
@@ -365,11 +365,12 @@ export async function foo({ messages: __invocationMessages, callbacks: __invocat
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }
 export const __fooNodeParams = [];
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -380,6 +381,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
@@ -525,7 +525,7 @@ await callHook({
   }
 })
 graph.conditionalEdge("main", ["greet"])
-export async function greet(name: string, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function greet(name: string, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "greet",
@@ -538,11 +538,12 @@ export async function greet(name: string, { messages: __invocationMessages, call
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }
 export const __greetNodeParams = ["name"];
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -553,6 +554,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
@@ -525,7 +525,7 @@ await callHook({
   }
 })
 graph.conditionalEdge("main", ["greet"])
-export async function greet(name: string, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function greet(name: string, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "greet",
@@ -543,7 +543,7 @@ export async function greet(name: string, { messages: __invocationMessages, call
   });
 }
 export const __greetNodeParams = ["name"];
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
@@ -301,7 +301,7 @@ await callHook({
     };
   }
 })
-export async function greet(name: string, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function greet(name: string, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "greet",

--- a/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
@@ -301,7 +301,7 @@ await callHook({
     };
   }
 })
-export async function greet(name: string, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function greet(name: string, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "greet",
@@ -314,6 +314,7 @@ export async function greet(name: string, { messages: __invocationMessages, call
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
@@ -454,7 +454,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -465,6 +465,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
@@ -454,7 +454,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
@@ -511,7 +511,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -522,6 +522,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
@@ -511,7 +511,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
@@ -515,7 +515,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
@@ -515,7 +515,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -526,6 +526,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/input.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/input.mjs
@@ -317,7 +317,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/input.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/input.mjs
@@ -317,7 +317,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -328,6 +328,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
@@ -300,7 +300,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
@@ -300,7 +300,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -311,6 +311,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
@@ -744,7 +744,7 @@ await callHook({
     };
   }
 })
-export async function sayHi(name: any, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function sayHi(name: any, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "sayHi",

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
@@ -744,7 +744,7 @@ await callHook({
     };
   }
 })
-export async function sayHi(name: any, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function sayHi(name: any, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "sayHi",
@@ -757,6 +757,7 @@ export async function sayHi(name: any, { messages: __invocationMessages, callbac
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
@@ -333,7 +333,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -344,6 +344,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
@@ -333,7 +333,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
@@ -621,7 +621,7 @@ await callHook({
   }
 })
 graph.conditionalEdge("sayHi", ["foo2"])
-export async function foo2(name: string, age: number, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function foo2(name: string, age: number, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "foo2",
@@ -640,7 +640,7 @@ export async function foo2(name: string, age: number, { messages: __invocationMe
   });
 }
 export const __foo2NodeParams = ["name", "age"];
-export async function sayHi(name: any, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function sayHi(name: any, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "sayHi",

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
@@ -621,7 +621,7 @@ await callHook({
   }
 })
 graph.conditionalEdge("sayHi", ["foo2"])
-export async function foo2(name: string, age: number, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function foo2(name: string, age: number, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "foo2",
@@ -635,11 +635,12 @@ export async function foo2(name: string, age: number, { messages: __invocationMe
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }
 export const __foo2NodeParams = ["name", "age"];
-export async function sayHi(name: any, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function sayHi(name: any, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "sayHi",
@@ -652,6 +653,7 @@ export async function sayHi(name: any, { messages: __invocationMessages, callbac
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/intersectionTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/intersectionTypes.mjs
@@ -278,7 +278,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -289,6 +289,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/intersectionTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/intersectionTypes.mjs
@@ -278,7 +278,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
@@ -329,7 +329,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
@@ -329,7 +329,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -340,6 +340,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
@@ -691,7 +691,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
@@ -691,7 +691,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -702,6 +702,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlockBlockArms.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlockBlockArms.mjs
@@ -331,7 +331,7 @@ await callHook({
     };
   }
 })
-export async function main(x: string, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main(x: string, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -344,6 +344,7 @@ export async function main(x: string, { messages: __invocationMessages, callback
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlockBlockArms.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlockBlockArms.mjs
@@ -331,7 +331,7 @@ await callHook({
     };
   }
 })
-export async function main(x: string, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main(x: string, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/matchExpression.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchExpression.mjs
@@ -333,7 +333,7 @@ await callHook({
     };
   }
 })
-export async function main(x: string, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main(x: string, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -346,6 +346,7 @@ export async function main(x: string, { messages: __invocationMessages, callback
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/matchExpression.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchExpression.mjs
@@ -333,7 +333,7 @@ await callHook({
     };
   }
 })
-export async function main(x: string, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main(x: string, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
@@ -479,7 +479,7 @@ await callHook({
 })
 graph.conditionalEdge("greet", ["processGreeting"])
 graph.conditionalEdge("main", ["greet"])
-export async function greet({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function greet({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "greet",
@@ -495,7 +495,7 @@ export async function greet({ messages: __invocationMessages, callbacks: __invoc
   });
 }
 export const __greetNodeParams = [];
-export async function processGreeting(msg: any, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function processGreeting(msg: any, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "processGreeting",
@@ -513,7 +513,7 @@ export async function processGreeting(msg: any, { messages: __invocationMessages
   });
 }
 export const __processGreetingNodeParams = ["msg"];
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
@@ -479,7 +479,7 @@ await callHook({
 })
 graph.conditionalEdge("greet", ["processGreeting"])
 graph.conditionalEdge("main", ["greet"])
-export async function greet({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function greet({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "greet",
@@ -490,11 +490,12 @@ export async function greet({ messages: __invocationMessages, callbacks: __invoc
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }
 export const __greetNodeParams = [];
-export async function processGreeting(msg: any, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function processGreeting(msg: any, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "processGreeting",
@@ -507,11 +508,12 @@ export async function processGreeting(msg: any, { messages: __invocationMessages
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }
 export const __processGreetingNodeParams = ["msg"];
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -522,6 +524,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
@@ -508,7 +508,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
@@ -508,7 +508,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -519,6 +519,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
@@ -297,7 +297,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -308,6 +308,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
@@ -297,7 +297,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
@@ -300,7 +300,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
@@ -300,7 +300,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -311,6 +311,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
@@ -873,7 +873,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
@@ -873,7 +873,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -884,6 +884,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
@@ -308,7 +308,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
@@ -308,7 +308,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -319,6 +319,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/recursiveTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recursiveTypes.mjs
@@ -384,7 +384,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -400,7 +400,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
   });
 }
 export const __mainNodeParams = [];
-export async function llmTree({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function llmTree({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "llmTree",

--- a/packages/agency-lang/tests/typescriptGenerator/recursiveTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recursiveTypes.mjs
@@ -384,7 +384,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -395,11 +395,12 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }
 export const __mainNodeParams = [];
-export async function llmTree({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function llmTree({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "llmTree",
@@ -410,6 +411,7 @@ export async function llmTree({ messages: __invocationMessages, callbacks: __inv
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
@@ -269,7 +269,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -280,6 +280,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
@@ -269,7 +269,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
@@ -293,7 +293,7 @@ await callHook({
     };
   }
 })
-export async function main(message: string, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main(message: string, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
@@ -293,7 +293,7 @@ await callHook({
     };
   }
 })
-export async function main(message: string, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main(message: string, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -306,6 +306,7 @@ export async function main(message: string, { messages: __invocationMessages, ca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
@@ -287,7 +287,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
@@ -287,7 +287,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -298,6 +298,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/schemaChaining.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaChaining.mjs
@@ -282,7 +282,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/schemaChaining.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaChaining.mjs
@@ -282,7 +282,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -293,6 +293,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
@@ -751,7 +751,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -762,6 +762,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
@@ -751,7 +751,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
@@ -304,7 +304,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
@@ -304,7 +304,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -315,6 +315,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/simple.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/simple.mjs
@@ -297,7 +297,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -308,6 +308,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/simple.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/simple.mjs
@@ -297,7 +297,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/skill.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/skill.mjs
@@ -283,7 +283,7 @@ await callHook({
     };
   }
 })
-export async function analyzeData(input: string, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function analyzeData(input: string, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "analyzeData",

--- a/packages/agency-lang/tests/typescriptGenerator/skill.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/skill.mjs
@@ -283,7 +283,7 @@ await callHook({
     };
   }
 })
-export async function analyzeData(input: string, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function analyzeData(input: string, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "analyzeData",
@@ -296,6 +296,7 @@ export async function analyzeData(input: string, { messages: __invocationMessage
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/slice.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/slice.mjs
@@ -286,7 +286,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/slice.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/slice.mjs
@@ -286,7 +286,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -297,6 +297,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
@@ -271,7 +271,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
@@ -271,7 +271,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -282,6 +282,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
@@ -450,7 +450,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
@@ -450,7 +450,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -461,6 +461,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/static.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/static.mjs
@@ -286,7 +286,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/static.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/static.mjs
@@ -286,7 +286,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -297,6 +297,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
@@ -340,7 +340,7 @@ await callHook({
     };
   }
 })
-export async function foo({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function foo({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "foo",
@@ -351,6 +351,7 @@ export async function foo({ messages: __invocationMessages, callbacks: __invocat
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
@@ -340,7 +340,7 @@ await callHook({
     };
   }
 })
-export async function foo({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function foo({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "foo",

--- a/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
@@ -262,7 +262,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -273,6 +273,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
@@ -262,7 +262,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
@@ -310,7 +310,7 @@ await callHook({
     };
   }
 })
-export async function foo({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function foo({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "foo",
@@ -321,6 +321,7 @@ export async function foo({ messages: __invocationMessages, callbacks: __invocat
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
@@ -310,7 +310,7 @@ await callHook({
     };
   }
 })
-export async function foo({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function foo({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "foo",

--- a/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -794,7 +794,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -794,7 +794,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -805,6 +805,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/type-patterns.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/type-patterns.mjs
@@ -566,7 +566,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/type-patterns.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/type-patterns.mjs
@@ -566,7 +566,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -577,6 +577,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
@@ -338,7 +338,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
@@ -338,7 +338,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -349,6 +349,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/typeOperators.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeOperators.mjs
@@ -278,7 +278,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -289,6 +289,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/typeOperators.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeOperators.mjs
@@ -278,7 +278,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
@@ -302,7 +302,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
@@ -302,7 +302,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -313,6 +313,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
@@ -331,7 +331,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -342,6 +342,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
@@ -331,7 +331,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
@@ -304,7 +304,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
@@ -304,7 +304,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -315,6 +315,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
@@ -302,7 +302,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
@@ -302,7 +302,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -313,6 +313,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
@@ -287,7 +287,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
@@ -287,7 +287,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -298,6 +298,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/utilityTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/utilityTypes.mjs
@@ -533,7 +533,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -544,11 +544,12 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }
 export const __mainNodeParams = [];
-export async function llmPatch({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function llmPatch({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "llmPatch",
@@ -559,6 +560,7 @@ export async function llmPatch({ messages: __invocationMessages, callbacks: __in
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/utilityTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/utilityTypes.mjs
@@ -533,7 +533,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -549,7 +549,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
   });
 }
 export const __mainNodeParams = [];
-export async function llmPatch({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function llmPatch({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "llmPatch",

--- a/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
@@ -306,7 +306,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
@@ -306,7 +306,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -317,6 +317,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
@@ -306,7 +306,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
@@ -306,7 +306,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -317,6 +317,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
@@ -456,7 +456,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -467,6 +467,7 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
@@ -456,7 +456,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
@@ -300,7 +300,7 @@ await callHook({
     };
   }
 })
-export async function main(input: any, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main(input: any, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
@@ -300,7 +300,7 @@ await callHook({
     };
   }
 })
-export async function main(input: any, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId }: ({ messages?: any; callbacks?: any } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main(input: any, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, input: __invocationInput }: ({ messages?: any; callbacks?: any; input?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -313,6 +313,7 @@ export async function main(input: any, { messages: __invocationMessages, callbac
       config: __invocationConfig,
       traceId: __invocationTraceId
     },
+    input: __invocationInput,
     initializeGlobals: __initializeGlobals
   });
 }


### PR DESCRIPTION
First PR of the run-directory arc (spec: `docs/superpowers/specs/2026-08-18-run-directory-and-annotations-design.md`, plan: `docs/superpowers/plans/2026-08-18-run-directory-and-annotations.md`, both included here with their reviews). This covers **Phase 0 + Phase 1**: the statelog gains the two facts that cannot be recovered after the fact, so a trace can later stand on its own as "a run".

## What changes

- **`agentStart` records `code`** — `{ entry, closureHash, closure: [{ file, sha256 }] }`, computed by the new `computeCodeIdentity(entryFile)` (`lib/runDirectory/codeIdentity.ts`). Paths are relative to the closure files' common ancestor, never the cwd, so the hash is the same wherever you ran from (`closureBaseDir` prefers cwd, which is why identity does not use it).
- **`agentStart` records `input`** — what the entry node was given, when the caller says so. It is never guessed from the parameters (a plain one-parameter call and an eval input look identical there). The generated node wrapper takes a hidden `input` option; the subprocess bootstrap fills it from `RunInstruction.task`. Fixtures regenerated for the wrapper signature.
- **Every launcher fills `log.code`** through the existing config-override channel: `agency run` (`lib/cli/commands.ts`), the eval file runner (hashes the *seeded* copy, since that is what executes), and `agency agent` (`runBundledAgent.ts`; a precompiled agent without its `.agency` source records nothing). Command agents under `--agent-cmd` get it from the `agency` CLI they invoke.
- `AgencyConfig.log.code` and `StatelogConfig.code` added (schema + type).
- **Phase 0:** `agency eval optimize` alias removed; only `agency optimize` remains.

Note: the plan said `lib/runs/`; the repo gitignores `**/runs/` (eval output), so the module is `lib/runDirectory/`. Plan updated.

## Testing

- New: `lib/runDirectory/codeIdentity.test.ts` (sorted closure, stable hash, cwd-independence, hash changes with content); statelog client test for `input`/`code` on `agentStart`; wrapper-params test for the hidden option; `runBundledAgent` tests updated to expect `log.code`.
- `tests/integration/eval-run/test.mjs` now proves both channels end to end: the eval task arrives as `agentStart.input` and the seeded code is recorded; a plain `agency run` records `code` and no `input`.
- 339 files / 4870 tests green across `lib/backends lib/cli lib/eval lib/runtime lib/statelogClient* lib/config lib/runDirectory lib/analysis scripts`; `tsc`, `lint:structure`, `fmt:ts` clean.

## Docs

`docs/dev/statelog.md` gains "Code identity and input on `agentStart`"; CLAUDE.md pointer updated. `docs/site/**` untouched: `docs/site/cli/optimize.md` / `eval.md` still mention `agency eval optimize` and are yours to update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
