### PR TITLE
Fix integration tests for the top-level optimize command

### DIFF
--- a/packages/agency-lang/tests/integration/cli/test.mjs
+++ b/packages/agency-lang/tests/integration/cli/test.mjs
@@ -157,7 +157,7 @@ node main(task: string): string {
   assertIncludes(csvOutput, "run");
   console.log("Test 6b passed");
 
-  // --- Test 7: eval optimize baseline-only run ---
+  // --- Test 7: optimize baseline-only run ---
   // --iterations 0 skips the mutator, but the greedy optimizer still grades the
   // baseline with the goal judge — an llm() call. Mock it so the smoke test runs
   // offline (no API key in CI); without a mock the judge's structured output is
@@ -169,10 +169,10 @@ node main(task: string): string {
       { return: { score: 1, reasoning: "mock judge verdict" } },
     ]),
   };
-  console.log("--- Test 7: eval optimize baseline-only ---");
+  console.log("--- Test 7: optimize baseline-only ---");
   const optimizeOutput = run(
     dir,
-    "npx agency eval optimize eval-agent.agency --goal \"Say hello\" --iterations 0 --runs-dir optimize-runs --run-id smoke --no-writeback 2>&1",
+    "npx agency optimize eval-agent.agency --goal \"Say hello\" --iterations 0 --runs-dir optimize-runs --run-id smoke --no-writeback 2>&1",
     { env: judgeMockEnv },
   );
   assertIncludes(optimizeOutput, "1 target(s)");
@@ -184,12 +184,12 @@ node main(task: string): string {
     throw new Error(`optimize summary unexpected: ${JSON.stringify(optimizeSummary)}`);
   }
   // The legacy flag surface must stay dead.
-  const legacyOutput = run(dir, "npx agency eval optimize --agent eval-agent.agency --goal x 2>&1", { expectFail: true });
+  const legacyOutput = run(dir, "npx agency optimize --agent eval-agent.agency --goal x 2>&1", { expectFail: true });
   assertIncludes(legacyOutput, "unknown option");
   // --silent prints nothing.
   const silentOutput = run(
     dir,
-    "npx agency eval optimize eval-agent.agency --goal \"Say hello\" --iterations 0 --runs-dir optimize-runs --run-id silent-smoke --no-writeback --silent 2>&1",
+    "npx agency optimize eval-agent.agency --goal \"Say hello\" --iterations 0 --runs-dir optimize-runs --run-id silent-smoke --no-writeback --silent 2>&1",
     { env: judgeMockEnv },
   );
   if (silentOutput.trim() !== "") {

--- a/packages/agency-lang/tests/integration/optimize-efficacy/test.mjs
+++ b/packages/agency-lang/tests/integration/optimize-efficacy/test.mjs
@@ -52,7 +52,7 @@ const RUNS = [
 function runOnce({ name, flags }) {
   const runId = `${name}-${Date.now()}`;
   const cmd =
-    `node ./dist/scripts/agency.js eval optimize ${q(AGENT)} ${flags} ` +
+    `node ./dist/scripts/agency.js optimize ${q(AGENT)} ${flags} ` +
     `--iterations ${ITERATIONS} --runs-dir ${q(runsDir)} --run-id ${q(runId)} ` +
     `--no-writeback --silent`;
   console.log(`[${name}] ${cmd}`);


### PR DESCRIPTION
## What was wrong

CI on main is red in the integration job. The optimizer CLI was renamed from `agency eval optimize` to the top-level `agency optimize`, but two integration tests still called the old path:

```
CLI test failed: Error: Command failed: npx agency eval optimize eval-agent.agency ...
  stdout: "error: unknown command 'optimize'\n"
```

That killed `tests/integration/cli/test.mjs` at test 7, so tests 8 through 8e never ran.

## The fix

Point both tests at `agency optimize`:

- `tests/integration/cli/test.mjs` (three invocations plus the section comments)
- `tests/integration/optimize-efficacy/test.mjs`

Nothing else in the repo still calls the old path. The `--agent` legacy-flag check in test 7 still works: `--agent` is not an option on the new top-level command either, so it still errors with "unknown option".

## Verification

Packed a tarball with `npm pack` and ran the full CLI integration suite against it:

```
--- Test 7: optimize baseline-only ---
Test 7 passed
...
=== All CLI tests passed ===
```

Tests 8 through 8e, which never got to run in CI, all pass too.

## Not touched

`docs/site/guide/agency-config-file.md`, `docs/site/cli/eval.md`, and `docs/site/cli/optimize.md` still mention `eval optimize` in places. Those are yours to edit, so I left them alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
