### PR TITLE
Log viewer: Y copies the whole focused trace as JSONL

### DIFF
--- a/packages/agency-lang/docs/dev/logs-viewer.md
+++ b/packages/agency-lang/docs/dev/logs-viewer.md
@@ -132,6 +132,10 @@ rules are its reason to exist.
   and resolves with `"back"` (Esc at the bottom of the stack, nothing
   left to clear) or `"quit"` (`q`), so the host can honor the same
   contract.
+- Copying: `y` copies the focused node's JSON; `Y` in the tree view copies
+  every statelog event of the focused trace as JSONL (one object per line,
+  file order). Views only *name* what to copy (`ViewAction` `copy` /
+  `copyTrace`); the shell in `run.ts` owns the events and the clipboard.
 - Every view pins its name to the bottom-right corner via
   `views/shared.ts`'s `bottomHints(hints, tag, cols)` — the answer to
   "where am I" always lives in the same place.

--- a/packages/agency-lang/lib/logsViewer/copyTrace.test.ts
+++ b/packages/agency-lang/lib/logsViewer/copyTrace.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from "vitest";
+import { runViewer } from "./run.js";
+import { ScriptedInput } from "../tui/input/scripted.js";
+import { FrameRecorder } from "../tui/output/recorder.js";
+
+// The viewer detects the clipboard by probing for pbcopy/xclip; swap in a
+// fake that captures what was written so the test is machine-independent.
+const written: string[] = [];
+vi.mock("./clipboard.js", () => ({
+  detectClipboard: () => ({ write: (text: string) => written.push(text) }),
+}));
+
+function event(traceId: string, spanId: string, type: string, timestamp: string, extra = {}) {
+  return {
+    format_version: 1,
+    trace_id: traceId,
+    project_id: "p",
+    span_id: spanId,
+    parent_span_id: null,
+    data: { type, timestamp, ...extra },
+  };
+}
+
+// Two traces in one file. `Y` on the first trace must copy exactly its
+// events, in file order, and nothing from the second trace.
+const events = [
+  event("abc", "s1", "agentStart", "2026-05-16T00:00:00.000Z", { entryNode: "main" }),
+  event("abc", "s1", "print", "2026-05-16T00:00:00.500Z", { message: "hi" }),
+  event("xyz", "s2", "agentStart", "2026-05-16T00:00:02.000Z", { entryNode: "main" }),
+  event("abc", "s1", "agentEnd", "2026-05-16T00:00:01.000Z", { timeTaken: 1000 }),
+  event("xyz", "s2", "agentEnd", "2026-05-16T00:00:03.000Z", { timeTaken: 1000 }),
+];
+const jsonl = events.map((e) => JSON.stringify(e)).join("\n") + "\n";
+
+describe("Y copies the whole focused trace", () => {
+  it("writes every event of the trace as JSONL and reports the count", async () => {
+    written.length = 0;
+    const out = new FrameRecorder();
+    await runViewer({
+      jsonl,
+      input: new ScriptedInput(["Y", "q"]),
+      output: out,
+      viewport: { rows: 12, cols: 100 },
+    });
+    expect(written).toHaveLength(1);
+    const lines = written[0].split("\n").filter((l) => l !== "");
+    expect(lines.map((l) => JSON.parse(l))).toEqual([events[0], events[1], events[3]]);
+    expect(out.lastText()).toMatch(/copied 3 events of trace abc/);
+  });
+
+  it("y still copies only the focused node", async () => {
+    written.length = 0;
+    await runViewer({
+      jsonl,
+      input: new ScriptedInput(["y", "q"]),
+      output: new FrameRecorder(),
+      viewport: { rows: 12, cols: 100 },
+    });
+    expect(written).toHaveLength(1);
+    expect(written[0]).not.toMatch(/agentEnd/);
+  });
+});

--- a/packages/agency-lang/lib/logsViewer/help.ts
+++ b/packages/agency-lang/lib/logsViewer/help.ts
@@ -40,7 +40,10 @@ export const HELP_GROUPS: BindingGroup[] = [
   },
   {
     heading: "Inspect",
-    bindings: [{ keys: "y", action: "copy JSON of focused node to clipboard" }],
+    bindings: [
+      { keys: "y", action: "copy JSON of focused node to clipboard" },
+      { keys: "Y", action: "copy all events of focused trace as JSONL to clipboard" },
+    ],
   },
   {
     heading: "Modes",

--- a/packages/agency-lang/lib/logsViewer/run.ts
+++ b/packages/agency-lang/lib/logsViewer/run.ts
@@ -20,7 +20,7 @@ import { FlameView } from "./views/flameView.js";
 import { OccurrencesView } from "./views/occurrencesView.js";
 import { TreeView } from "./views/treeView.js";
 import { makeViewStack, type ViewAction, type Viewport } from "./views/view.js";
-import type { TreeNode } from "./types.js";
+import type { EventEnvelope, TreeNode } from "./types.js";
 import { findTrace, writeTraceFile } from "../runDirectory/extractTrace.js";
 
 export type RunViewerOpts = {
@@ -116,6 +116,7 @@ export async function runViewer(opts: RunViewerOpts): Promise<ViewerResolution> 
   const parsed = parseStatelogJsonl(watcher.bootText);
   let roots = buildForest(parsed.events);
   let parseErrors: ReadonlyArray<{ line: number }> = parsed.errors;
+  let allEvents: readonly EventEnvelope[] = parsed.events; // `Y` copies these verbatim
 
   const screen = new Screen({
     input: opts.input,
@@ -141,6 +142,7 @@ export async function runViewer(opts: RunViewerOpts): Promise<ViewerResolution> 
     focusTraceId: opts.focusTraceId,
   });
   const stack = makeViewStack(treeView);
+  const notify = (message: string): void => stack.active().notify(message);
   // The trace timeline views open on: fixed when flame opens from the tree.
   let timelineTraceId = treeView.cursorTraceId();
   let helpOpen = false;
@@ -155,19 +157,20 @@ export async function runViewer(opts: RunViewerOpts): Promise<ViewerResolution> 
     const reparsed = parseStatelogJsonl(text);
     roots = buildForest(reparsed.events);
     parseErrors = reparsed.errors;
+    allEvents = reparsed.events;
     for (const view of stack.all()) view.setData(roots);
     render();
   };
   const toggleFollow = (): void => {
     if (!opts.followPath) {
-      stack.active().notify("follow unavailable when reading from stdin");
+      notify("follow unavailable when reading from stdin");
       return;
     }
     followOn = !followOn;
     for (const view of stack.all()) view.setFollowIndicator(followOn);
     if (followOn) watcher.start(onNewText);
     else watcher.stop();
-    stack.active().notify(followOn ? "follow on" : "follow off");
+    notify(followOn ? "follow on" : "follow off");
   };
 
   if (opts.initialFollow && opts.followPath) {
@@ -219,7 +222,9 @@ export async function runViewer(opts: RunViewerOpts): Promise<ViewerResolution> 
       const text = await screen.nextLine(action.label);
       action.onResult(text);
     } else if (action.kind === "copy") {
-      copyToClipboard(action.text, (message) => stack.active().notify(message));
+      copyToClipboard(action.text, notify);
+    } else if (action.kind === "copyTrace") {
+      copyTraceToClipboard(allEvents, action.traceId, notify);
     } else if (action.kind === "extractTrace" && opts.extract !== undefined) {
       await handleTraceExtract({
         screen,
@@ -229,7 +234,7 @@ export async function runViewer(opts: RunViewerOpts): Promise<ViewerResolution> 
         watcher,
         onNewText,
         render,
-        notify: (message: string) => stack.active().notify(message),
+        notify,
       });
     }
   };
@@ -245,14 +250,8 @@ export async function runViewer(opts: RunViewerOpts): Promise<ViewerResolution> 
       }
       // Esc backs out, never quits: with nothing left to pop or clear,
       // an embedded viewer hands control back to its host.
-      if (
-        opts.embedded &&
-        fmt === "Escape" &&
-        stack.all().length === 1 &&
-        !treeView.hasActiveSearch()
-      ) {
-        return "back";
-      }
+      const nothingLeftToClear = stack.all().length === 1 && !treeView.hasActiveSearch();
+      if (opts.embedded && fmt === "Escape" && nothingLeftToClear) return "back";
       if (helpOpen) {
         helpOpen = false;
         render();
@@ -334,7 +333,27 @@ function makeFollowWatcher(opts: RunViewerOpts): {
   };
 }
 
-function copyToClipboard(text: string, notify: (message: string) => void): void {
+/** `Y` in the tree view: every event of one trace, one JSON object per line. */
+function copyTraceToClipboard(
+  events: readonly EventEnvelope[],
+  traceId: string,
+  notify: (message: string) => void,
+): void {
+  const lines = events
+    .filter((event) => event.trace_id === traceId)
+    .map((event) => JSON.stringify(event));
+  copyToClipboard(
+    lines.join("\n") + "\n",
+    notify,
+    `copied ${lines.length} events of trace ${traceId}`,
+  );
+}
+
+function copyToClipboard(
+  text: string,
+  notify: (message: string) => void,
+  successMessage: string = "copied",
+): void {
   const clipboard = detectClipboard();
   if (clipboard === null) {
     notify("clipboard unavailable");
@@ -342,7 +361,7 @@ function copyToClipboard(text: string, notify: (message: string) => void): void 
   }
   try {
     clipboard.write(text);
-    notify("copied");
+    notify(successMessage);
   } catch (err) {
     notify(`copy failed: ${err instanceof Error ? err.message : String(err)}`);
   }

--- a/packages/agency-lang/lib/logsViewer/views/treeView.ts
+++ b/packages/agency-lang/lib/logsViewer/views/treeView.ts
@@ -82,6 +82,14 @@ export class TreeView implements View {
         return { kind: "extractTrace", traceId };
       }
     }
+    // `Y` copies the whole focused trace (every event, one JSON per line);
+    // lowercase `y` copies just the focused node.
+    if (fmt === "Y") {
+      const traceId = this.cursorTraceId();
+      if (traceId !== "" && this.clipboardReady()) {
+        return { kind: "copyTrace", traceId };
+      }
+    }
     const paged = this.paginate(ev, viewport);
     if (paged !== undefined) {
       this.state = this.applyScroll(paged, viewport);
@@ -148,6 +156,7 @@ export class TreeView implements View {
     return [
       "t — timeline views (flame → by-name)",
       "d — full details of the focused span",
+      "y — copy focused node as JSON; Y — copy the whole trace as JSONL",
       ...(this.extractEnabled ? ["x — extract this trace to a file"] : []),
       "",
       ...treeHelpLines(),
@@ -259,16 +268,19 @@ export class TreeView implements View {
   private copyText(): string | undefined {
     const node = findNode(this.state.roots, this.state.cursorId);
     if (node === undefined) return undefined;
-    if (detectClipboard() === null) {
-      this.notify("clipboard unavailable");
-      return undefined;
-    }
+    if (!this.clipboardReady()) return undefined;
     const payload = node.event ?? {
       label: node.label,
       traceId: node.traceId,
       metrics: { duration: node.duration, tokens: node.tokens, cost: node.cost },
     };
     return JSON.stringify(payload, null, 2);
+  }
+
+  private clipboardReady(): boolean {
+    if (detectClipboard() !== null) return true;
+    this.notify("clipboard unavailable");
+    return false;
   }
 
   private paneRows(viewport: Viewport, _state: ViewerState = this.state): number {

--- a/packages/agency-lang/lib/logsViewer/views/view.ts
+++ b/packages/agency-lang/lib/logsViewer/views/view.ts
@@ -18,6 +18,9 @@ export type ViewAction =
   | { kind: "promptLine"; label: string; onResult: (text: string) => void }
   | { kind: "copy"; text: string }
   | { kind: "extractTrace"; traceId: string }
+  /** Copy every statelog line of one trace as JSONL. The shell owns the
+   *  events, so the view can only name the trace. */
+  | { kind: "copyTrace"; traceId: string }
   | { kind: "none" };
 
 export type View = {


### PR DESCRIPTION
## What

`Y` in the log viewer tree copies every statelog event of the focused trace to the clipboard as JSONL (one object per line, in file order) and reports `copied N events of trace <id>`. `y` still copies just the focused node; `x` still extracts a trace to a file.

## How

- New `ViewAction` `{kind: "copyTrace", traceId}`; the tree view names the trace, `run.ts` filters its `allEvents` and writes through the existing `copyToClipboard`.
- `allEvents` is tracked beside `roots` again and refreshed under follow mode.
- Help overlay, tree help lines, and `docs/dev/logs-viewer.md` mention the key.

## Tests

`lib/logsViewer/copyTrace.test.ts` mocks the clipboard and checks that `Y` copies exactly the three events of the focused trace out of a two-trace file (and nothing else), and that `y` is unchanged. `pnpm run typecheck`, `lint:structure`, prettier clean; logsViewer/logsView/runsExplorer vitest 369 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
