### PR TITLE
Atomic run directories, chunk 1: writers produce one run per directory

### DIFF
--- a/packages/agency-lang/docs/dev/eval-grading.md
+++ b/packages/agency-lang/docs/dev/eval-grading.md
@@ -16,10 +16,14 @@ input and no goal (`inlineInput`; the suite identity is `inline:--input`).
 Grading is `agency eval grade <dir>`, whenever you like, as many times as you
 like. `eval run` takes the agent file as its positional argument (or
 `--agent-cmd`), plus `--suite`/`--input`, `--out <dir>` and `-n`. `--out`
-names the directory the run is written into (default
-`<eval.runsDir or runs>/<timestamp>-<random suffix>`); it replaced the `--runs-dir`/`--run-id`
-pair, which called one harness invocation a "run" while everywhere else in
-the data model a run is one trace. There is deliberately no `--goal` (grading's business), no
+names the GROUP directory; each test's run directory is written at
+`<out>/<testId>/` (`input-1` for `--input`), assembled in `<out>/.staging/`
+and renamed into place so a child appears whole or not at all. A child that
+already exists is an error result for that test (nothing overwritten; the
+others still run). Default `<eval.runsDir or runs>/<timestamp>-<random suffix>`.
+`eval grade <path>` takes a run directory or a group and grades each run
+with its own pass, printing the mean over the group (`findRunDirectories`,
+`docs/dev/run-directory.md`). There is deliberately no `--goal` (grading's business), no
 stop-on-error (`--continue-on-error` is gone: an errored test is a `run` row
 that grades 0, and stopping the suite half-way only leaves holes), and no
 agent-config flags (`--strict`, `--max-tool-call-rounds`,

--- a/packages/agency-lang/docs/dev/run-directory.md
+++ b/packages/agency-lang/docs/dev/run-directory.md
@@ -10,14 +10,25 @@ easy to get wrong.
 
 ```
 <dir>/
-  statelog.jsonl        # required; any number of traces (one trace = one run)
-  annotations.jsonl     # every opinion about a trace: note, checklist, score, run
-  code/<closureHash>/   # one copy of the agent's closure per code VERSION
-  workdir/<traceId>/    # filesystem snapshot for that trace
-  workdir/<traceId>.json  # { snapshotAt, source } — when and where from
+  statelog.jsonl        # required; ONE trace (one trace = one run; subagents share the id)
+  annotations.jsonl     # every opinion about the run: note, checklist, score, run
+  notes.md              # free-form notes (reserved; not read yet)
+  code/                 # the agent's closure, as it ran, flat
+  workdir/              # filesystem snapshot, flat
+  workdir.json          # { snapshotAt, source } — when and where from
   checklists/<id>/      # versioned checklist revisions + labeling drafts (docs/dev/eval-labeling.md)
   .lock                 # present only while a writer is open
 ```
+
+**One run per directory.** Writers only ever produce directories with one
+trace, so a run can be moved with `cp -r` and opened anywhere. A **group** is
+any directory of run directories (what `eval run --out` writes); it has no
+index file. `findRunDirectories(paths)` (`findRuns.ts`) is the one walk rule:
+a run directory is itself, a directory of run directories yields its children
+(one level, sorted), anything else is an error. `eval grade` and the logs
+explorer use it; `runs list` and `label` still take a single directory (next
+chunks). The reader still tolerates several traces in one file, because the
+labeling and explorer tests were written for that shape; no writer makes one.
 
 **The statelog is the run.** A directory holding only `statelog.jsonl` is a
 valid run directory; every other entry is an attachment that unlocks more.
@@ -74,8 +85,14 @@ with the pure planners before writing a byte**, repairs a torn final line on
 each append target, applies, and returns a fresh snapshot; the lock is released
 on success or failure.
 
-- `addToRunDirectory({ dir, statelogFiles, codeEntries, workdir?, annotationFiles })`
-- `recordCompletedRun({ dir, stagedStatelogFile, codeEntry?, workdir?, run })` — the eval harness's one call per finished test
+- `wrapTracesAsRunDirectories({ groupDir, statelogFiles, trace?, codeEntries, workdir?, annotationFiles })`
+  — one `<groupDir>/<traceId>/` per trace, each assembled under
+  `<groupDir>/.staging/` and renamed into place; an existing child is skipped,
+  never touched; `--trace` narrows; a workdir needs exactly one trace; code
+  must match at least one trace and attaches to the ones that recorded it;
+  annotation rows go to the child their `traceId` names and must name one of
+  the traces. Used by `runs add` and `run --capture-workdir`.
+- `recordCompletedRun({ dir, stagedStatelogFile, codeEntry?, workdir?, run })` — the eval harness's one call per finished test, on a fresh directory
 - `recordNote({ dir, traceId, annotator, text })`
 - `recordGradingPass({ dir, scores })` — mints one `passId`, stamps `passSize`, marks the last row `completesPass`; an empty `scores` is refused
 
@@ -99,16 +116,15 @@ The planners (`mergeStatelog.ts`, `attachCode.ts`, `attachWorkdir.ts`):
 - **Code** hashes the closure it is given (`computeCodeIdentity`, relative to
   the closure's common ancestor, never cwd) and requires that some trace in the
   directory recorded that hash on `agentStart`; a mismatch is refused, not
-  warned. Stored under `code/<closureHash>/`; a stored tree that is incomplete
-  or does not hash to its own name is reported as corrupt.
-- **Workdir** copies to `workdir/<traceId>/` and writes the dated sidecar. A
-  workdir attached later may postdate the run; the sidecar says so. The trace
-  id comes from the statelog, so the plan checks that both resolved paths are
-  direct children of `workdir/` before anything is written; an id like
-  `../escaped` is refused.
+  warned. Stored flat under `code/`; a stored tree that is incomplete or does
+  not hash to what the trace recorded is reported as corrupt.
+- **Workdir** copies to `workdir/` and writes the dated `workdir.json`
+  sidecar. A workdir attached later may postdate the run; the sidecar says so.
+  The run directory itself, and the optional `excludeDir` (the group a capture
+  is written into), are left out of the copy.
   Replacement goes through `safeDeleteDirectoryWithin(root, target)`
   (`lib/utils.ts`), which deletes only a strict descendant of the run
-  directory's `workdir/` after resolving symlinks.
+  directory after resolving symlinks.
 
 ## The lock (`lock.ts`)
 
@@ -158,19 +174,20 @@ One file per command; none imports the lock or the append helpers.
   source log itself is never a valid output. The viewer's `x` key does the
   same for the focused trace, prompting for a path, and also refuses an
   existing file.
-- `agency runs add <dir> [--statelog f]… [--code entry]… [--workdir p [--trace id]] [--annotations f]… [--replace]`
-  — one `addToRunDirectory` request; prints counts and the listing.
+- `agency runs add <group> [--statelog f]… [--trace id] [--code entry]… [--workdir p] [--annotations f]… [--replace]`
+  — one `wrapTracesAsRunDirectories` request; prints one line per child
+  written or skipped.
 - `agency runs list <dir>` — one line per trace (`summarizeRuns`).
 - `agency note <dir> <text> [--trace id] [--annotator who]` — `recordNote`.
 - `agency run <file> --capture-workdir <dir>` (`lib/cli/commands.ts`) — mints
   a trace id (`AGENCY_TRACE_ID`), points the child's statelog at a private
   staging file (`log.logFile` + `observability` overrides), and after exit
-  makes one `addToRunDirectory` call: that statelog, the entry file's code
-  closure, and the working directory as the trace's workdir snapshot. The
+  wraps that one trace as `<dir>/<traceId>/`: the statelog, the entry file's
+  code closure, and the working directory as the workdir snapshot. The
   snapshot is the whole cwd, so run it from the project you mean to capture.
-  The destination may sit inside that cwd (`--capture-workdir ./runs/x` is
-  the natural call); the run directory is left out of its own snapshot rather
-  than copied into itself. The capture statelog and the code identity always
+  The destination may sit inside that cwd (`--capture-workdir ./runs` is the
+  natural call); `<dir>` is left out of the snapshot rather than copied into
+  itself. The capture statelog and the code identity always
   win over inherited config overrides (`runChildOverrides`), and the temp
   staging directory is removed whether or not the fold succeeded.
 - `agency logs <dir>` — the viewer on the directory's statelog with each

--- a/packages/agency-lang/docs/dev/run-directory.md
+++ b/packages/agency-lang/docs/dev/run-directory.md
@@ -174,7 +174,7 @@ One file per command; none imports the lock or the append helpers.
   source log itself is never a valid output. The viewer's `x` key does the
   same for the focused trace, prompting for a path, and also refuses an
   existing file.
-- `agency runs add <group> [--statelog f]… [--trace id] [--code entry]… [--workdir p] [--annotations f]… [--replace]`
+- `agency runs add <group> [--statelog f]… [--trace id] [--code entry]… [--workdir p] [--annotations f]…`
   — one `wrapTracesAsRunDirectories` request; prints one line per child
   written or skipped.
 - `agency runs list <dir>` — one line per trace (`summarizeRuns`).

--- a/packages/agency-lang/lib/cli/commands.ts
+++ b/packages/agency-lang/lib/cli/commands.ts
@@ -9,7 +9,7 @@ import {
   TRACE_ID_ENV,
 } from "@/config.js";
 import { withCodeIdentity } from "@/runDirectory/codeIdentity.js";
-import { addToRunDirectory } from "@/runDirectory/mutations.js";
+import { wrapTracesAsRunDirectories } from "@/runDirectory/mutations.js";
 import { AgencyProgram } from "@/index.js";
 import { spawn } from "child_process";
 import * as fs from "fs";
@@ -275,8 +275,8 @@ export function run(
    *  itself to read — `std::args` is how. They are NOT mapped onto the entry
    *  node's parameters, which receive `undefined` on this path. */
   nodeArgs: string[] = [],
-  /** `--capture-workdir <dir>`: after the run, fold its statelog, code and a
-   *  snapshot of the working directory into that run directory. */
+  /** `--capture-workdir <dir>`: after the run, write its statelog, code and a
+   *  snapshot of the working directory as the run directory `<dir>/<traceId>/`. */
   capture?: { runDir: string },
 ): void {
   const output = compile(config, inputFile, outputFile, {
@@ -370,7 +370,8 @@ export function runChildOverrides(args: {
 }
 
 type Capture = {
-  runDir: string;
+  /** The group directory the run directory is written into. */
+  groupDir: string;
   traceId: string;
   statelogFile: string;
   /** A fresh, empty directory this process created under the OS temp dir. It
@@ -380,40 +381,42 @@ type Capture = {
 
 /** A fresh trace id and a private statelog file for this run, so the fold
  *  into the run directory sees exactly this run's events. */
-function prepareCapture(runDir: string): Capture {
+function prepareCapture(groupDir: string): Capture {
   const traceId = nanoid();
   const captureTempDir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-capture-"));
   return {
-    runDir,
+    groupDir,
     traceId,
     statelogFile: path.join(captureTempDir, "statelog.jsonl"),
     captureTempDir,
   };
 }
 
-/** One `addToRunDirectory`: the staged statelog, the code that ran, and the
- *  working directory as this trace's workdir snapshot. The temp dir goes
- *  whether or not the fold succeeded. */
+/** One run directory at `<group>/<traceId>/`: the staged statelog, the code
+ *  that ran, and the working directory as its workdir snapshot (the group
+ *  itself left out of the snapshot when it sits inside the working directory).
+ *  The temp dir goes whether or not the write succeeded. */
 function finishCapture(capture: Capture, inputFile: string): void {
+  let written: string[];
   try {
     if (!fs.existsSync(capture.statelogFile)) {
       throw new Error(`the run wrote no statelog at ${capture.statelogFile}`);
     }
-    addToRunDirectory(
+    written = wrapTracesAsRunDirectories(
       {
-        dir: capture.runDir,
+        groupDir: capture.groupDir,
         statelogFiles: [capture.statelogFile],
         codeEntries: [inputFile],
         annotationFiles: [],
-        workdir: { traceId: capture.traceId, sourceDir: process.cwd() },
+        workdir: { sourceDir: process.cwd(), excludeDir: capture.groupDir },
       },
       { reportWarning: (message) => console.warn(message) },
-    );
+    ).written;
   } finally {
     removeCaptureTempDir(capture.captureTempDir);
   }
   console.log(`---
-Captured trace ${capture.traceId} into ${capture.runDir}`);
+Captured trace ${capture.traceId} into ${written[0] ?? capture.groupDir}`);
 }
 
 /** Only ever removes the mkdtemp directory prepareCapture made: it must sit

--- a/packages/agency-lang/lib/cli/eval/formatGrade.test.ts
+++ b/packages/agency-lang/lib/cli/eval/formatGrade.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import type { EvalRunGrading } from "@/eval/runTypes.js";
+
+import { formatGradeResult } from "./formatGrade.js";
+import type { EvalGradeResult } from "./grade.js";
+
+function grading(
+  inputId: string,
+  objective: number,
+  grades: EvalRunGrading["perInput"][number]["grades"],
+  ungradedReason?: string,
+): EvalRunGrading {
+  return {
+    graders: grades.map((grade) => grade.grader),
+    objective,
+    gatesPassed: true,
+    perInput: [{ inputId, output: null, objective, gatesPassed: true, grades, ungradedReason }],
+  };
+}
+
+describe("formatGradeResult", () => {
+  it("one block per test: the score line, then one line per grader with feedback, no mean for a single run", () => {
+    const result: EvalGradeResult = {
+      runs: [
+        {
+          dir: "/runs/x/a",
+          grading: grading("a", 0.75, [
+            { grader: "len", kind: "scalar", value: 0.5, feedback: "too short" },
+            { grader: "gate", kind: "binary", pass: true },
+          ]),
+        },
+      ],
+      mean: 0.75,
+      gatesPassed: true,
+    };
+    const lines = formatGradeResult(result).map(stripAnsi);
+    expect(lines).toEqual([
+      "a  score 0.750",
+      "  len          0.500",
+      "      too short",
+      "  gate         pass",
+    ]);
+  });
+
+  it("a group: every run's block, an ungraded reason where there is one, then the mean over the runs", () => {
+    const result: EvalGradeResult = {
+      runs: [
+        {
+          dir: "/runs/x/a",
+          grading: grading("a", 1, [{ grader: "g", kind: "binary", pass: true }]),
+        },
+        { dir: "/runs/x/b", grading: grading("b", 0, [], "the run ended with timeout") },
+      ],
+      mean: 0.5,
+      gatesPassed: false,
+    };
+    const lines = formatGradeResult(result).map(stripAnsi);
+    expect(lines).toEqual([
+      "a  score 1.000",
+      "  g            pass",
+      "b  score 0.000",
+      "  not graded — the run ended with timeout",
+      "mean 0.500 over 2 runs",
+    ]);
+  });
+});
+
+function stripAnsi(text: string): string {
+  // eslint-disable-next-line no-control-regex
+  return text.replace(/\x1b\[[0-9;]*m/g, "");
+}

--- a/packages/agency-lang/lib/cli/eval/formatGrade.ts
+++ b/packages/agency-lang/lib/cli/eval/formatGrade.ts
@@ -1,6 +1,13 @@
+import { formatScore } from "@/eval/grading/gradeBreakdown.js";
 import { ttyColor } from "@/utils/termcolors.js";
 
 import type { EvalGradeResult } from "./grade.js";
+
+const GRADER_COLUMN_WIDTH = 12;
+
+type GradedRun = EvalGradeResult["runs"][number];
+type GradedInput = GradedRun["grading"]["perInput"][number];
+type Grade = GradedInput["grades"][number];
 
 /**
  * `eval grade` output: one block per run, the test id and its score on the
@@ -9,30 +16,46 @@ import type { EvalGradeResult } from "./grade.js";
  * zeroed when a must-pass grader fails or the run did not finish.
  */
 export function formatGradeResult(result: EvalGradeResult): string[] {
-  const lines: string[] = [];
-  for (const run of result.runs) {
-    for (const input of run.grading.perInput) {
-      lines.push(`${ttyColor.green(input.inputId)}  score ${colorScore(input.objective)}`);
-      for (const grade of input.grades) {
-        const value =
-          grade.kind === "scalar" ? grade.value.toFixed(3) : grade.pass ? "pass" : "fail";
-        lines.push(`  ${grade.grader.padEnd(12)} ${value}`);
-        if (grade.feedback) lines.push(`      ${grade.feedback}`);
-      }
-      if (input.ungradedReason !== undefined) {
-        lines.push(`  ${ttyColor.red(`not graded — ${input.ungradedReason}`)}`);
-      }
-    }
-  }
-  if (result.runs.length > 1) {
-    lines.push(`mean ${colorScore(result.mean)} over ${result.runs.length} runs`);
-  }
-  return lines;
+  return [...result.runs.flatMap(formatRun), ...formatGroupSummary(result)];
 }
 
-function colorScore(score: number): string {
-  const text = score.toFixed(3);
-  if (score === 0) return ttyColor.red(text);
-  if (score === 1) return ttyColor.green(text);
-  return text;
+function formatRun(run: GradedRun): string[] {
+  return run.grading.perInput.flatMap(formatInput);
+}
+
+function formatInput(input: GradedInput): string[] {
+  return [
+    `${ttyColor.green(input.inputId)}  score ${formatScore(input.objective)}`,
+    ...input.grades.flatMap(formatGrade),
+    ...formatUngradedReason(input.ungradedReason),
+  ];
+}
+
+function formatGrade(grade: Grade): string[] {
+  const line = `  ${grade.grader.padEnd(GRADER_COLUMN_WIDTH)} ${formatGradeValue(grade)}`;
+  if (grade.feedback === undefined || grade.feedback === "") {
+    return [line];
+  }
+  return [line, `      ${grade.feedback}`];
+}
+
+function formatGradeValue(grade: Grade): string {
+  if (grade.kind === "scalar") {
+    return grade.value.toFixed(3);
+  }
+  return grade.pass ? "pass" : "fail";
+}
+
+function formatUngradedReason(reason: string | undefined): string[] {
+  if (reason === undefined) {
+    return [];
+  }
+  return [`  ${ttyColor.red(`not graded — ${reason}`)}`];
+}
+
+function formatGroupSummary(result: EvalGradeResult): string[] {
+  if (result.runs.length > 1) {
+    return [`mean ${formatScore(result.mean)} over ${result.runs.length} runs`];
+  }
+  return [];
 }

--- a/packages/agency-lang/lib/cli/eval/formatGrade.ts
+++ b/packages/agency-lang/lib/cli/eval/formatGrade.ts
@@ -1,0 +1,38 @@
+import { ttyColor } from "@/utils/termcolors.js";
+
+import type { EvalGradeResult } from "./grade.js";
+
+/**
+ * `eval grade` output: one block per run, the test id and its score on the
+ * first line, then one line per grader with that grader's score, then the
+ * mean over the group. The score is the weighted mean of the graders' scores,
+ * zeroed when a must-pass grader fails or the run did not finish.
+ */
+export function formatGradeResult(result: EvalGradeResult): string[] {
+  const lines: string[] = [];
+  for (const run of result.runs) {
+    for (const input of run.grading.perInput) {
+      lines.push(`${ttyColor.green(input.inputId)}  score ${colorScore(input.objective)}`);
+      for (const grade of input.grades) {
+        const value =
+          grade.kind === "scalar" ? grade.value.toFixed(3) : grade.pass ? "pass" : "fail";
+        lines.push(`  ${grade.grader.padEnd(12)} ${value}`);
+        if (grade.feedback) lines.push(`      ${grade.feedback}`);
+      }
+      if (input.ungradedReason !== undefined) {
+        lines.push(`  ${ttyColor.red(`not graded — ${input.ungradedReason}`)}`);
+      }
+    }
+  }
+  if (result.runs.length > 1) {
+    lines.push(`mean ${colorScore(result.mean)} over ${result.runs.length} runs`);
+  }
+  return lines;
+}
+
+function colorScore(score: number): string {
+  const text = score.toFixed(3);
+  if (score === 0) return ttyColor.red(text);
+  if (score === 1) return ttyColor.green(text);
+  return text;
+}

--- a/packages/agency-lang/lib/cli/eval/grade.test.ts
+++ b/packages/agency-lang/lib/cli/eval/grade.test.ts
@@ -45,10 +45,12 @@ describe("evalGrade", () => {
   it("scores a run directory and records one complete grading pass", async () => {
     const runDir = makeRunDir("hello");
 
-    const grading = await evalGrade(runDir, { graders: makeGraders(), config: {} });
+    const result = await evalGrade(runDir, { graders: makeGraders(), config: {} });
 
-    expect(grading.objective).toBeCloseTo(0.5);
-    expect(grading.graders).toEqual(["len"]);
+    expect(result.runs).toHaveLength(1);
+    expect(result.runs[0].dir).toBe(runDir);
+    expect(result.mean).toBeCloseTo(0.5);
+    expect(result.runs[0].grading.graders).toEqual(["len"]);
     const snapshot = readRunDirectory(runDir, { reportWarning: () => {} });
     const scores = snapshot.annotationRows.filter((row) => row.kind === "score");
     expect(scores).toHaveLength(1);
@@ -72,7 +74,7 @@ describe("evalGrade", () => {
 
     await evalGrade(runDir, { graders: makeGraders(), out, config: {} });
 
-    expect(JSON.parse(fs.readFileSync(out, "utf8")).objective).toBeCloseTo(0.5);
+    expect(JSON.parse(fs.readFileSync(out, "utf8")).mean).toBeCloseTo(0.5);
     expect(fs.existsSync(path.join(runDir, "annotations.jsonl"))).toBe(true);
   });
 
@@ -91,7 +93,27 @@ describe("evalGrade", () => {
     expect(Object.values(effective)[0].id).toBe(scores[1].id);
   });
 
-  it("refuses a folder with no statelog.jsonl, naming how to build a run directory", () => {
+  it("grades every run directory in a group, one pass each, and reports the mean", async () => {
+    const group = fs.mkdtempSync(path.join(process.cwd(), ".test-group-"));
+    dirs.push(group);
+    writeRunDirectory([{ test: { id: "a", input: "t" }, output: "hello" }], path.join(group, "a"));
+    writeRunDirectory(
+      [{ test: { id: "b", input: "t" }, output: "hello world" }],
+      path.join(group, "b"),
+    );
+    fs.writeFileSync(path.join(group, "notes.txt"), "not a run");
+
+    const result = await evalGrade(group, { graders: makeGraders(), config: {} });
+
+    expect(result.runs.map((run) => path.basename(run.dir))).toEqual(["a", "b"]);
+    expect(result.mean).toBeCloseTo((0.5 + 1.1) / 2);
+    for (const child of ["a", "b"]) {
+      const snapshot = readRunDirectory(path.join(group, child), { reportWarning: () => {} });
+      expect(snapshot.annotationRows.filter((row) => row.kind === "score")).toHaveLength(1);
+    }
+  });
+
+  it("refuses a folder with no run directories, naming how to build one", () => {
     const folder = fs.mkdtempSync(path.join(process.cwd(), ".test-not-a-run-dir-"));
     dirs.push(folder);
     fs.writeFileSync(path.join(folder, "statelogs.jsonl"), "");

--- a/packages/agency-lang/lib/cli/eval/grade.test.ts
+++ b/packages/agency-lang/lib/cli/eval/grade.test.ts
@@ -113,6 +113,27 @@ describe("evalGrade", () => {
     }
   });
 
+  it("a group where one run fails a must-pass gate: that run scores 0, gatesPassed is false, the other keeps its score", async () => {
+    const group = fs.mkdtempSync(path.join(process.cwd(), ".test-group-"));
+    dirs.push(group);
+    writeRunDirectory([{ test: { id: "a", input: "t" }, output: "hello" }], path.join(group, "a"));
+    writeRunDirectory([{ test: { id: "b", input: "t" }, output: "bye" }], path.join(group, "b"));
+    const dir = fs.mkdtempSync(path.join(process.cwd(), ".test-grading-"));
+    dirs.push(dir);
+    const file = path.join(dir, "graders.ts");
+    fs.writeFileSync(
+      file,
+      `import { grader } from "agency-lang/eval";
+export default [grader(({ output }) => output === "hello", { name: "gate", mustPass: true })];`,
+    );
+
+    const result = await evalGrade(group, { graders: file, config: {} });
+
+    expect(result.runs.map((run) => run.grading.objective)).toEqual([1, 0]);
+    expect(result.gatesPassed).toBe(false);
+    expect(result.mean).toBeCloseTo(0.5);
+  });
+
   it("refuses a folder with no run directories, naming how to build one", () => {
     const folder = fs.mkdtempSync(path.join(process.cwd(), ".test-not-a-run-dir-"));
     dirs.push(folder);

--- a/packages/agency-lang/lib/cli/eval/grade.ts
+++ b/packages/agency-lang/lib/cli/eval/grade.ts
@@ -1,11 +1,9 @@
 import * as fs from "fs";
-import * as path from "path";
 
 import type { AgencyConfig } from "@/config.js";
 import { gradeSuite } from "@/eval/grading/gradeSuite.js";
 import type { EvalRunGrading } from "@/eval/runTypes.js";
-
-import { runDirPaths } from "@/runDirectory/runDir.js";
+import { findRunDirectories } from "@/runDirectory/findRuns.js";
 
 import { goalJudgeGraders, resolveGraders } from "./graders.js";
 
@@ -22,24 +20,27 @@ export type EvalGradeOptions = {
   config?: AgencyConfig;
 };
 
+/** One graded run directory and the mean over them all. */
+export type EvalGradeResult = {
+  runs: { dir: string; grading: EvalRunGrading }[];
+  /** Mean objective over the runs graded. */
+  mean: number;
+  /** Every run passed its gates. */
+  gatesPassed: boolean;
+};
+
 /** The command's own preconditions, checked before anything loads: the two
- *  ways of saying "judge against this" are exclusive, and the target must be
- *  a run directory (a bare statelog copied into a folder is the common miss). */
-export function validateGradeTarget(runDir: string, opts: EvalGradeOptions): void {
+ *  ways of saying "judge against this" are exclusive, and the target must
+ *  hold run directories (a bare statelog copied into a folder is the common
+ *  miss). Returns the run directories found. */
+export function validateGradeTarget(target: string, opts: EvalGradeOptions): string[] {
   if (opts.graders !== undefined && opts.goal !== undefined) {
     throw new Error(
       "Provide only one of --graders or --goal: a grading module carries its own criteria " +
         "(give LlmJudge a goal there instead).",
     );
   }
-  const statelog = runDirPaths(runDir).statelog;
-  if (!fs.existsSync(statelog)) {
-    throw new Error(
-      `${runDir} is not a run directory: no ${path.basename(statelog)} in it. Build one with ` +
-        `\`agency runs add ${runDir} --statelog <file>\` or run the agent with ` +
-        `\`agency run --capture-workdir ${runDir} <file.agency>\`.`,
-    );
-  }
+  return findRunDirectories([target]);
 }
 
 /** The grader set `eval grade` runs with; see `resolveGraders` for the precedence. */
@@ -49,14 +50,14 @@ export async function gradersFor(opts: EvalGradeOptions, config: AgencyConfig) {
 }
 
 /**
- * Score a run directory. Never re-executes the agent. Every pass appends
- * `score` annotations to the directory — a re-grade sits beside the earlier
- * ones, never over them — and prints the objective.
+ * Score a run directory, or every run directory in a group. Never re-executes
+ * the agent. Each run gets its own grading pass, appended to ITS
+ * `annotations.jsonl` — a re-grade sits beside the earlier ones, never over
+ * them.
  */
-export async function evalGrade(runDir: string, opts: EvalGradeOptions): Promise<EvalRunGrading> {
+export async function evalGrade(target: string, opts: EvalGradeOptions): Promise<EvalGradeResult> {
   const config = opts.config ?? {};
-  const resolvedRunDir = path.resolve(runDir);
-  validateGradeTarget(resolvedRunDir, opts);
+  const runDirs = validateGradeTarget(target, opts);
   // `grade` is undefined here: there is no point running this command with
   // grading switched off, so the same resolver's default path applies. An
   // explicit --graders overrides every test's recorded graders; otherwise
@@ -70,12 +71,19 @@ export async function evalGrade(runDir: string, opts: EvalGradeOptions): Promise
     throw new Error(`The grading module at ${opts.graders} exported no graders.`);
   }
 
-  const { grading } = await gradeSuite(resolvedRunDir, graders, config, {
-    defaultGoal: opts.goal,
-  });
+  const runs: EvalGradeResult["runs"] = [];
+  for (const dir of runDirs) {
+    const { grading } = await gradeSuite(dir, graders, config, { defaultGoal: opts.goal });
+    runs.push({ dir, grading });
+  }
+  const result: EvalGradeResult = {
+    runs,
+    mean: runs.reduce((sum, run) => sum + run.grading.objective, 0) / runs.length,
+    gatesPassed: runs.every((run) => run.grading.gatesPassed),
+  };
 
   if (opts.out !== undefined) {
-    fs.writeFileSync(opts.out, JSON.stringify(grading, null, 2));
+    fs.writeFileSync(opts.out, JSON.stringify(result, null, 2));
   }
-  return grading;
+  return result;
 }

--- a/packages/agency-lang/lib/cli/eval/run.test.ts
+++ b/packages/agency-lang/lib/cli/eval/run.test.ts
@@ -15,6 +15,7 @@ import type { EvalInputRunner, EvalRunnerJob } from "@/eval/run/subprocess.js";
 import { readRunDirectory, runDirPaths } from "@/runDirectory/runDir.js";
 import { finishedTraceLines } from "@/runDirectory/testFixtures.js";
 
+import { evalGrade } from "./grade.js";
 import { evalRun, totalRunCostUsd, validateInputSelection } from "./run.js";
 
 /** A runner that behaves like a real child: a finished trace under the
@@ -70,7 +71,7 @@ describe("eval run CLI", () => {
     );
     expect(result.okCount).toBe(1);
     expect(seenInput).toBeUndefined();
-    const run = readRunDirectory(path.join(runsDir, "no-input"), quiet).effectiveAnnotations[
+    const run = readRunDirectory(result.tests[0].runDir, quiet).effectiveAnnotations[
       result.tests[0].traceId
     ].run as unknown as { test: { input?: unknown } };
     expect(run.test.input).toBeUndefined();
@@ -102,7 +103,7 @@ describe("eval run CLI", () => {
 
     expect(result).toMatchObject({ okCount: 1, errorCount: 0 });
     expect(result.tests[0]).toMatchObject({ status: "success" });
-    const snapshot = readRunDirectory(path.join(runsDir, "r1"), quiet);
+    const snapshot = readRunDirectory(path.join(runsDir, "r1", "input-1"), quiet);
     expect(snapshot.traces).toHaveLength(1);
     // Nothing graded: the only annotation is the harness's run row.
     expect(snapshot.annotationRows.map((row) => row.kind)).toEqual(["run"]);
@@ -176,7 +177,7 @@ describe("eval run CLI", () => {
     );
 
     expect(result.tests[0]).toMatchObject({ status: "success" });
-    expect(readRunDirectory(path.join(runsDir, "fallback"), quiet).traces).toHaveLength(1);
+    expect(readRunDirectory(result.tests[0].runDir, quiet).traces).toHaveLength(1);
   });
 
   it("runs every test even after one errors, recording each failure", async () => {
@@ -213,7 +214,7 @@ describe("eval run CLI", () => {
       // The message carries the seeded-file listing for diagnosability.
       errorMessage: expect.stringMatching(/^nope\n\nWorkdir was seeded with/),
     });
-    const snapshot = readRunDirectory(path.join(runsDir, "all"), quiet);
+    const snapshot = readRunDirectory(result.tests[0].runDir, quiet);
     const run = snapshot.effectiveAnnotations[result.tests[0].traceId].run as {
       ended: string;
       error: string;
@@ -261,13 +262,14 @@ describe("eval run CLI", () => {
 
     expect(sawFixture).toBe(true);
     expect(result.tests[0].status).toBe("success");
-    const snapshot = readRunDirectory(result.runDir, quiet);
+    const snapshot = readRunDirectory(result.tests[0].runDir, quiet);
     const run = snapshot.effectiveAnnotations[result.tests[0].traceId].run as {
       suite: { source: string; sha: string };
     };
     expect(run.suite).toEqual({ source: `${suiteRepo}?ref=${suiteSha}`, sha: suiteSha });
-    // The agent's code is stored under the closure hash the trace recorded.
-    expect(fs.readdirSync(runDirPaths(result.runDir).codeDir)).toHaveLength(1);
+    expect(
+      fs.existsSync(path.join(runDirPaths(result.tests[0].runDir).codeDir, "agent.agency")),
+    ).toBe(true);
   });
 
   describe("grading a run directory", () => {
@@ -285,14 +287,14 @@ describe("eval run CLI", () => {
       const summary = await runSuite(opts, { runner: okRunner });
 
       const { grading } = await gradeSuite(
-        summary.runDir,
+        summary.tests[0].runDir,
         { mode: "override", graders: [grader(() => false, { name: "gate", mustPass: true })] },
         {},
       );
 
       expect(grading.gatesPassed).toBe(false);
       expect(grading.graders).toEqual(["gate"]);
-      const scores = readRunDirectory(summary.runDir, quiet).annotationRows.filter(
+      const scores = readRunDirectory(summary.tests[0].runDir, quiet).annotationRows.filter(
         (row) => row.kind === "score",
       );
       expect(scores).toHaveLength(1);
@@ -303,25 +305,19 @@ describe("eval run CLI", () => {
       });
     });
 
-    it("counts a gate-failed test as a zero rather than zeroing the whole run", async () => {
+    it("a failed run scores zero and the mean over the group is 0.5, not 0", async () => {
       const opts = setup("mixed", [
         { id: "a", goal: "g", input: "t" },
         { id: "b", goal: "g", input: "t" },
       ]);
       const summary = await runSuite(opts, { runner: okRunner });
       // Passes on test "a", fails the gate on test "b".
-      const { grading } = await gradeSuite(
-        summary.runDir,
-        {
-          mode: "override",
-          graders: [grader(({ test }) => test.id === "a", { name: "gate", mustPass: true })],
-        },
-        {},
-      );
+      const graders = path.join(tmpDir, "gate.ts");
+      fs.writeFileSync(graders, `export default ({ test }) => (test.id === "a" ? 1 : 0);`);
+      const result = await evalGrade(summary.runDir, { graders, config: {} });
 
-      // One of two tests scored 1, the other 0 — the mean is 0.5, not 0.
-      expect(grading.objective).toBeCloseTo(0.5);
-      expect(grading.gatesPassed).toBe(false);
+      // One of two runs scored 1, the other 0 — the mean is 0.5, not 0.
+      expect(result.mean).toBeCloseTo(0.5);
     });
 
     it("a misconfigured grader is rejected by validation before any agent runs", () => {
@@ -370,25 +366,16 @@ describe("eval run CLI", () => {
         { agent: agentFile, suite: suiteDir, out: path.join(runsDir, "per-test"), config },
         { runner: okRunner },
       );
-      const { resolveGraders } = await import("./graders.js");
 
       // "self" scored 1 by its own grader; "plain" scored 0 by the fallback.
-      const fallback = await gradeSuite(
-        result.runDir,
-        (await resolveGraders(undefined, undefined, config))!,
-        config,
-      );
-      expect(fallback.grading.objective).toBeCloseTo(0.5);
+      const fallback = await evalGrade(result.runDir, { config });
+      expect(fallback.mean).toBeCloseTo(0.5);
 
       // An explicit --graders replaces BOTH tests' graders.
       const overrideModule = path.join(tmpDir, "override.ts");
       fs.writeFileSync(overrideModule, `export default () => 1;`);
-      const overridden = await gradeSuite(
-        result.runDir,
-        (await resolveGraders(overrideModule, undefined, config))!,
-        config,
-      );
-      expect(overridden.grading.objective).toBeCloseTo(1);
+      const overridden = await evalGrade(result.runDir, { graders: overrideModule, config });
+      expect(overridden.mean).toBeCloseTo(1);
     });
   });
 

--- a/packages/agency-lang/lib/cli/eval/run.test.ts
+++ b/packages/agency-lang/lib/cli/eval/run.test.ts
@@ -328,17 +328,25 @@ describe("eval run CLI", () => {
     });
   });
 
-  it("totalRunCostUsd sums trace costs across a run directory", () => {
-    const dir = writeRunDirectory([
-      { test: { id: "a", input: "t" }, output: "x", costUsd: 0.25 },
-      { test: { id: "b", input: "t" }, output: "y", costUsd: 0.5 },
-      { test: { id: "c", input: "t" }, wroteStatelog: false, ended: "error" },
-    ]);
-    expect(totalRunCostUsd(dir)).toBeCloseTo(0.75);
-    const empty = writeRunDirectory([
-      { test: { id: "a", input: "t" }, wroteStatelog: false, ended: "error" },
-    ]);
-    expect(totalRunCostUsd(empty)).toBeUndefined();
+  it("totalRunCostUsd sums trace costs across the run directories of a group", () => {
+    const group = fs.mkdtempSync(path.join(tmpDir, "group-"));
+    writeRunDirectory(
+      [{ test: { id: "a", input: "t" }, output: "x", costUsd: 0.25 }],
+      path.join(group, "a"),
+    );
+    writeRunDirectory(
+      [{ test: { id: "b", input: "t" }, output: "y", costUsd: 0.5 }],
+      path.join(group, "b"),
+    );
+    writeRunDirectory(
+      [{ test: { id: "c", input: "t" }, wroteStatelog: false, ended: "error" }],
+      path.join(group, "c"),
+    );
+    expect(totalRunCostUsd(group)).toBeCloseTo(0.75);
+    expect(totalRunCostUsd(path.join(group, "a"))).toBeCloseTo(0.25);
+    // A run that never wrote a trace, and a group with no runs at all.
+    expect(totalRunCostUsd(path.join(group, "c"))).toBeUndefined();
+    expect(totalRunCostUsd(fs.mkdtempSync(path.join(tmpDir, "empty-")))).toBeUndefined();
   });
 
   describe("per-test graders", () => {

--- a/packages/agency-lang/lib/cli/eval/run.ts
+++ b/packages/agency-lang/lib/cli/eval/run.ts
@@ -8,6 +8,7 @@ import type { SuiteRunResult, Test } from "@/eval/runTypes.js";
 import { parseSource, resolveSource } from "@/eval/sources.js";
 import type { SuiteIdentity } from "@/runDirectory/annotations.js";
 import { evalRecordFor } from "@/runDirectory/evalRecord.js";
+import { findRunDirectories } from "@/runDirectory/findRuns.js";
 import { readRunDirectory } from "@/runDirectory/runDir.js";
 
 import { resolveEvalTarget } from "@/agentTarget.js";
@@ -21,7 +22,8 @@ export type EvalRunCliOptions = {
   suite?: string;
   /** One inline test with this input text; no suite file needed. */
   input?: string;
-  /** Directory to write the run into (default `<eval.runsDir or runs>/<timestamp>-<random suffix>`). */
+  /** Directory to write the run directories into, one per test at `<out>/<testId>/`
+   *  (default `<eval.runsDir or runs>/<timestamp>-<random suffix>`). */
   out?: string;
   config?: AgencyConfig;
   /** Worker-pool size (-n/--parallel); default 1 = sequential. */
@@ -101,16 +103,25 @@ function loadSuite(args: {
   return { tests: loadInputs(parsed.path, nanoid, loadOptions), identity: { source: parsed.path } };
 }
 
-/** Total LLM spend across a run directory's traces, summed from each trace's
- *  metrics. Traces of interrupted runs count too, so an interrupted run still
- *  reports what it cost. Undefined when no trace carried a cost. */
-export function totalRunCostUsd(runDir: string): number | undefined {
-  const snapshot = readRunDirectory(runDir, { reportWarning: () => {} });
+/** Total LLM spend across the run directories under `groupDir`, summed from
+ *  each trace's metrics. Traces of interrupted runs count too, so an
+ *  interrupted run still reports what it cost. Undefined when no trace
+ *  carried a cost (or the group holds no runs yet). */
+export function totalRunCostUsd(groupDir: string): number | undefined {
   let total: number | undefined;
-  for (const trace of snapshot.traces) {
-    const cost = evalRecordFor(trace, snapshot.dir).metrics.costUsdTotal;
-    if (typeof cost === "number" && Number.isFinite(cost)) {
-      total = (total ?? 0) + cost;
+  let runDirs: string[];
+  try {
+    runDirs = findRunDirectories([groupDir]);
+  } catch {
+    return undefined;
+  }
+  for (const dir of runDirs) {
+    const snapshot = readRunDirectory(dir, { reportWarning: () => {} });
+    for (const trace of snapshot.traces) {
+      const cost = evalRecordFor(trace, snapshot.dir).metrics.costUsdTotal;
+      if (typeof cost === "number" && Number.isFinite(cost)) {
+        total = (total ?? 0) + cost;
+      }
     }
   }
   return total;

--- a/packages/agency-lang/lib/cli/runDirectory/add.ts
+++ b/packages/agency-lang/lib/cli/runDirectory/add.ts
@@ -8,7 +8,6 @@ export type RunsAddOptions = {
   workdir?: string;
   trace?: string;
   annotations: string[];
-  replace?: boolean;
 };
 
 export type RunsAddDependencies = { report(message: string): void };
@@ -24,10 +23,7 @@ export function runsAdd(
       statelogFiles: options.statelog,
       trace: options.trace,
       codeEntries: options.code,
-      workdir:
-        options.workdir === undefined
-          ? undefined
-          : { sourceDir: options.workdir, replace: options.replace === true },
+      workdir: options.workdir === undefined ? undefined : { sourceDir: options.workdir },
       annotationFiles: options.annotations,
     },
     { reportWarning: (message) => console.warn(message) },

--- a/packages/agency-lang/lib/cli/runDirectory/add.ts
+++ b/packages/agency-lang/lib/cli/runDirectory/add.ts
@@ -1,10 +1,7 @@
-import { addToRunDirectory, type AddToRunDirectoryResult } from "@/runDirectory/mutations.js";
-import { readRunDirectory } from "@/runDirectory/runDir.js";
-import { readTraces } from "@/runDirectory/traces.js";
-
-import { formatRunsList } from "./list.js";
+import { wrapTracesAsRunDirectories, type WrapTracesResult } from "@/runDirectory/mutations.js";
 
 export type RunsAddOptions = {
+  /** The group directory; one run directory per trace is written under it. */
   dir: string;
   statelog: string[];
   code: string[];
@@ -20,54 +17,25 @@ export type RunsAddDependencies = { report(message: string): void };
 export function runsAdd(
   options: RunsAddOptions,
   dependencies: RunsAddDependencies = { report: (message) => console.log(message) },
-): AddToRunDirectoryResult {
-  const workdir = workdirRequest(options);
-  const result = addToRunDirectory(
+): WrapTracesResult {
+  const result = wrapTracesAsRunDirectories(
     {
-      dir: options.dir,
+      groupDir: options.dir,
       statelogFiles: options.statelog,
+      trace: options.trace,
       codeEntries: options.code,
-      workdir,
+      workdir:
+        options.workdir === undefined
+          ? undefined
+          : { sourceDir: options.workdir, replace: options.replace === true },
       annotationFiles: options.annotations,
     },
     { reportWarning: (message) => console.warn(message) },
   );
-  dependencies.report(
-    [
-      `Updated ${options.dir}:`,
-      `  statelog traces: ${result.statelogSummary}`,
-      `  code versions:   ${result.code.added} added, ${result.code.skipped} already present`,
-      `  workdirs:        ${result.workdirs.added} added`,
-      `  annotations:     ${result.annotations.added} added, ${result.annotations.skipped} already present`,
-      "",
-      formatRunsList(result.snapshot),
-    ].join("\n"),
-  );
+  const lines = [
+    ...result.written.map((dir) => `wrote ${dir}`),
+    ...result.skipped.map((skip) => `skipped ${skip.traceId}: ${skip.reason}`),
+  ];
+  dependencies.report(lines.length === 0 ? "No traces to wrap." : lines.join("\n"));
   return result;
-}
-
-function workdirRequest(options: RunsAddOptions) {
-  if (options.workdir === undefined) return undefined;
-  const traceId = options.trace ?? singleTraceId(options);
-  return { traceId, sourceDir: options.workdir, replace: options.replace === true };
-}
-
-/** `--workdir` without `--trace` is fine when the directory (after the
- *  statelogs being added) will hold exactly one trace. */
-function singleTraceId(options: RunsAddOptions): string {
-  const known = readRunDirectory(options.dir, { reportWarning: () => {} }).traces.map(
-    (trace) => trace.traceId,
-  );
-  const ids = [...known];
-  for (const file of options.statelog) {
-    for (const trace of readTraces(file).traces) {
-      if (!ids.includes(trace.traceId)) ids.push(trace.traceId);
-    }
-  }
-  if (ids.length === 1) return ids[0];
-  throw new Error(
-    ids.length === 0
-      ? "--workdir needs a trace to attach to; add a statelog first or pass --trace <id>."
-      : `--workdir needs --trace <id>: the directory holds ${ids.length} traces (${ids.join(", ")}).`,
-  );
 }

--- a/packages/agency-lang/lib/cli/runDirectory/commands.test.ts
+++ b/packages/agency-lang/lib/cli/runDirectory/commands.test.ts
@@ -72,7 +72,7 @@ describe("formatTextTable", () => {
 });
 
 describe("runs add", () => {
-  it("assembles a directory from a statelog and matching code, idempotently", () => {
+  it("wraps each trace as <dir>/<traceId>/, attaching matching code, and skips existing children", () => {
     const project = writeProject({ "main.agency": "node main() { return 1 }\n" });
     const entry = path.join(project, "main.agency");
     const log = statelogFile(
@@ -85,17 +85,17 @@ describe("runs add", () => {
       { dir, statelog: [log], code: [entry], annotations: [] },
       { report: (m) => reports.push(m) },
     );
-    expect(first.statelogs).toEqual({ added: 2, skipped: 0 });
-    expect(first.code).toEqual({ added: 1, skipped: 0 });
-    expect(reports[0]).toContain("Added 2 trace(s)");
+    expect(first.written).toEqual([path.join(dir, "t1"), path.join(dir, "t2")]);
+    expect(fs.existsSync(path.join(dir, "t1", "code", "main.agency"))).toBe(true);
+    expect(fs.existsSync(path.join(dir, "t2", "code"))).toBe(false);
+    expect(reports[0]).toContain(`wrote ${path.join(dir, "t1")}`);
     const again = runsAdd(
       { dir, statelog: [log], code: [], annotations: [] },
       { report: (message) => reports.push(message) },
     );
-    expect(again.statelogs).toEqual({ added: 0, skipped: 2 });
-    expect(reports[1]).toMatch(
-      /Nothing was added.*all 2 trace\(s\) were already present \(t1, t2\)/,
-    );
+    expect(again.written).toEqual([]);
+    expect(again.skipped.map((skip) => skip.traceId)).toEqual(["t1", "t2"]);
+    expect(reports[1]).toMatch(/skipped t1: .*already exists/);
   });
 
   it("refuses code no trace recorded, naming the recorded hash", () => {
@@ -115,44 +115,43 @@ describe("runs add", () => {
         { report: () => {} },
       ),
     ).toThrow(new RegExp(recorded));
-    expect(fs.existsSync(runDirPaths(dir).codeDir)).toBe(false);
+    expect(fs.existsSync(path.join(dir, "t1"))).toBe(false);
   });
 
-  it("attaches a workdir to the only trace without --trace, and demands it otherwise", () => {
+  it("attaches a workdir when the statelog holds one trace, and demands --trace otherwise", () => {
     const dir = tempDir();
     const workdir = writeProject({ "out.txt": "x" });
     runsAdd(
       { dir, statelog: [statelogFile(agentStartLine("t1"))], code: [], workdir, annotations: [] },
       { report: () => {} },
     );
-    expect(fs.existsSync(path.join(runDirPaths(dir).workdirDir, "t1", "out.txt"))).toBe(true);
+    expect(fs.existsSync(path.join(dir, "t1", "workdir", "out.txt"))).toBe(true);
+    const two = statelogFile(agentStartLine("t2"), agentStartLine("t3"));
+    expect(() =>
+      runsAdd({ dir, statelog: [two], code: [], workdir, annotations: [] }, { report: () => {} }),
+    ).toThrow(/--trace/);
     runsAdd(
-      { dir, statelog: [statelogFile(agentStartLine("t2"))], code: [], annotations: [] },
+      { dir, statelog: [two], code: [], workdir, trace: "t3", annotations: [] },
       { report: () => {} },
     );
-    expect(() =>
-      runsAdd({ dir, statelog: [], code: [], workdir, annotations: [] }, { report: () => {} }),
-    ).toThrow(/--trace/);
+    expect(fs.existsSync(path.join(dir, "t3", "workdir", "out.txt"))).toBe(true);
+    expect(fs.existsSync(path.join(dir, "t2"))).toBe(false);
   });
 });
 
 describe("note and runs list", () => {
   it("notes the only trace, demands --trace with several, and lists counts", () => {
+    // Written by hand: a run directory holds one trace now, but the reader
+    // still accepts several, and note/list are rewritten in later chunks.
     const dir = tempDir();
-    runsAdd(
-      { dir, statelog: [statelogFile(agentStartLine("t1"))], code: [], annotations: [] },
-      { report: () => {} },
-    );
+    fs.writeFileSync(runDirPaths(dir).statelog, agentStartLine("t1") + "\n");
     const deps = { report: vi.fn(), user: () => "adit" };
     const row = note({ dir, text: "too slow" }, deps);
     expect(row.kind).toBe("note");
     expect(readRunDirectory(dir, quiet).effectiveAnnotations.t1.notes).toHaveLength(1);
     expect(() => note({ dir, text: "  " }, deps)).toThrow(/needs some text/);
 
-    runsAdd(
-      { dir, statelog: [statelogFile(agentStartLine("t2"))], code: [], annotations: [] },
-      { report: () => {} },
-    );
+    fs.appendFileSync(runDirPaths(dir).statelog, agentStartLine("t2") + "\n");
     expect(() => note({ dir, text: "x" }, deps)).toThrow(/--trace/);
     note({ dir, text: "second", trace: "t2" }, deps);
 

--- a/packages/agency-lang/lib/cli/runDirectory/commands.ts
+++ b/packages/agency-lang/lib/cli/runDirectory/commands.ts
@@ -38,11 +38,13 @@ export function addRunDirectoryCommands(
 
   runs
     .command("add")
-    .description("Add statelogs, agent code, a workdir, or annotations to a run directory")
-    .argument("<dir>", "The run directory (created if missing)")
+    .description(
+      "Wrap each trace of a statelog as a run directory <dir>/<traceId>/, with its code, workdir, and annotations",
+    )
+    .argument("<dir>", "The directory to write the run directories into (created if missing)")
     .option(
       "--statelog <file>",
-      "A statelog to merge in, by trace (repeatable)",
+      "A statelog whose traces to wrap (repeatable)",
       collectRepeated,
       [],
     )
@@ -52,15 +54,15 @@ export function addRunDirectoryCommands(
       collectRepeated,
       [],
     )
-    .option("--workdir <path>", "A directory to snapshot for one trace")
-    .option("--trace <id>", "Which trace the workdir belongs to (default: the only one)")
+    .option("--workdir <path>", "A directory to snapshot as the run's workdir (one trace only)")
+    .option("--trace <id>", "Wrap only this trace (full id or unique prefix)")
     .option(
       "--annotations <file>",
       "An annotations.jsonl to import (repeatable)",
       collectRepeated,
       [],
     )
-    .option("--replace", "Replace an existing workdir snapshot for that trace")
+    .option("--replace", "Replace an existing workdir snapshot")
     .action(
       (
         dir: string,

--- a/packages/agency-lang/lib/cli/runDirectory/commands.ts
+++ b/packages/agency-lang/lib/cli/runDirectory/commands.ts
@@ -62,7 +62,6 @@ export function addRunDirectoryCommands(
       collectRepeated,
       [],
     )
-    .option("--replace", "Replace an existing workdir snapshot")
     .action(
       (
         dir: string,
@@ -72,7 +71,6 @@ export function addRunDirectoryCommands(
           workdir?: string;
           trace?: string;
           annotations: string[];
-          replace?: boolean;
         },
       ) => {
         try {

--- a/packages/agency-lang/lib/eval/grading/gradeBreakdown.ts
+++ b/packages/agency-lang/lib/eval/grading/gradeBreakdown.ts
@@ -93,23 +93,26 @@ export function ungradedInputs(perInput: InputBreakdown[]): { inputId: string; r
  * runTypes.ts imports InputBreakdown from this file.
  */
 export function formatGrading(objective: number, perInput: InputBreakdown[]): string[] {
-  // Perfect green, zero red, in-between plain — the two ends are the ones a
-  // reader scans for. ttyColor: plain text when piped.
-  const objectiveText = objective.toFixed(3);
-  const coloredObjective =
-    objective === 0
-      ? ttyColor.red(objectiveText)
-      : objective === 1
-        ? ttyColor.green(objectiveText)
-        : objectiveText;
   return [
-    `objective  ${coloredObjective}`,
+    `objective  ${formatScore(objective)}`,
     ...summarizeGraders(perInput).map(formatGraderSummary),
     ...ungradedInputs(perInput).map(
       (entry) =>
         `  ${ttyColor.green(entry.inputId)}  ${ttyColor.red(`not graded — ${entry.reason}`)}`,
     ),
   ];
+}
+
+/** Perfect scores are green, zeroes red, and intermediate scores plain. */
+export function formatScore(score: number): string {
+  const text = score.toFixed(3);
+  if (score === 0) {
+    return ttyColor.red(text);
+  }
+  if (score === 1) {
+    return ttyColor.green(text);
+  }
+  return text;
 }
 
 function formatGraderSummary(summary: GraderSummary): string {

--- a/packages/agency-lang/lib/eval/grading/gradeRun.ts
+++ b/packages/agency-lang/lib/eval/grading/gradeRun.ts
@@ -177,7 +177,7 @@ function entryFor(snapshot: RunDirectorySnapshot, trace: Trace): Entry {
   const test = testOf(runRow, trace.traceId);
   const record: EvalRecord = evalRecordFor(trace, snapshot.dir);
   const outputs = record.evalOutputs ?? [];
-  const workdir = path.join(runDirPaths(snapshot.dir).workdirDir, trace.traceId);
+  const workdir = runDirPaths(snapshot.dir).workdirDir;
   const run: LoadedRun = {
     output: outputs.length === 0 ? null : (outputs[outputs.length - 1].value as Json),
     traceId: trace.traceId,

--- a/packages/agency-lang/lib/eval/run/runSuite.test.ts
+++ b/packages/agency-lang/lib/eval/run/runSuite.test.ts
@@ -45,7 +45,7 @@ describe("runSuite", () => {
     fs.rmSync(proj, { recursive: true, force: true });
   });
 
-  it("writes one run directory: traces, workdirs, code, and a run row per test", async () => {
+  it("writes one run directory per test under --out: trace, workdir, code, and a run row each", async () => {
     const runsDir = path.join(proj, "runs");
     const seen: EvalRunnerJob[] = [];
     const runner = traceWritingRunner("done", (job) => seen.push(job));
@@ -78,28 +78,26 @@ describe("runSuite", () => {
       { rows: [1, 2] },
     ]);
 
-    const snapshot = readRunDirectory(result.runDir, quiet);
-    expect(snapshot.traces.map((trace) => trace.traceId)).toEqual(
-      result.tests.map((test) => test.traceId),
-    );
-    const paths = runDirPaths(result.runDir);
+    expect(result.tests.map((test) => test.runDir)).toEqual([
+      path.join(result.runDir, "a"),
+      path.join(result.runDir, "b"),
+    ]);
     for (const test of result.tests) {
-      expect(
-        fs.readFileSync(path.join(paths.workdirDir, test.traceId, "touched.txt"), "utf8"),
-      ).toBe("by the agent");
+      const snapshot = readRunDirectory(test.runDir, quiet);
+      expect(snapshot.traces.map((trace) => trace.traceId)).toEqual([test.traceId]);
+      const paths = runDirPaths(test.runDir);
+      expect(fs.readFileSync(path.join(paths.workdirDir, "touched.txt"), "utf8")).toBe(
+        "by the agent",
+      );
+      expect(fs.existsSync(paths.workdirSidecar)).toBe(true);
       const run = snapshot.effectiveAnnotations[test.traceId].run;
       expect(run).toMatchObject({ kind: "run", ended: "ok", suite: { source: "inputs.json" } });
       expect((run as unknown as { test: { id: string } }).test.id).toBe(test.testId);
+      // The seeded agent code, flat under code/.
+      expect(fs.existsSync(path.join(paths.codeDir, "agent.agency"))).toBe(true);
     }
-    // The seeded agent code is stored once, by its closure hash.
-    const codeVersions = fs.readdirSync(paths.codeDir);
-    expect(codeVersions).toHaveLength(1);
-    expect(fs.existsSync(path.join(paths.codeDir, codeVersions[0], "agent.agency"))).toBe(true);
-    // No old-format artifacts, and no staging left behind.
-    for (const stale of ["config.json", "summary.json", "inputs", "verifier"]) {
-      expect(fs.existsSync(path.join(result.runDir, stale))).toBe(false);
-    }
-    expect(fs.existsSync(path.join(runsDir, ".staging"))).toBe(false);
+    // The group holds only the run directories; no staging left behind.
+    expect(fs.readdirSync(result.runDir).sort()).toEqual(["a", "b"]);
   });
 
   it("module-dir == cwd: compiled entry lives inside the test's staging workdir", async () => {
@@ -203,12 +201,15 @@ describe("runSuite", () => {
     );
 
     expect(result.tests[0].status).toBe("error");
-    const snapshot = readRunDirectory(result.runDir, quiet);
+    const runDir = result.tests[0].runDir;
+    // Still a run directory (empty statelog), so the walk rule finds it.
+    expect(fs.readFileSync(runDirPaths(runDir).statelog, "utf8")).toBe("");
+    const snapshot = readRunDirectory(runDir, quiet);
     expect(snapshot.traces).toEqual([]);
     const run = snapshot.effectiveAnnotations[result.tests[0].traceId].run;
     expect(run).toMatchObject({ kind: "run", ended: "timeout" });
     expect((run as { error: string }).error).toMatch(/wall clock/);
-    expect(fs.existsSync(runDirPaths(result.runDir).workdirDir)).toBe(false);
+    expect(fs.existsSync(runDirPaths(runDir).workdirDir)).toBe(false);
   });
 
   it("runs a resolved command target end-to-end: substituted argv per test, no code stored", async () => {
@@ -279,7 +280,7 @@ describe("runSuite", () => {
     // results in TEST order regardless of completion order
     expect(result.tests.map((test) => test.testId)).toEqual(["a", "b", "c", "d"]);
     expect(result.okCount).toBe(4);
-    expect(readRunDirectory(result.runDir, quiet).traces).toHaveLength(4);
+    expect(fs.readdirSync(result.runDir).sort()).toEqual(["a", "b", "c", "d"]);
   });
 
   it("parallel: an errored test never stops the others; every test records", async () => {
@@ -325,8 +326,9 @@ describe("runSuite", () => {
       },
       { runner: traceWritingRunner("done") },
     );
-    const run = readRunDirectory(result.runDir, quiet).effectiveAnnotations[result.tests[0].traceId]
-      .run;
+    const run = readRunDirectory(result.tests[0].runDir, quiet).effectiveAnnotations[
+      result.tests[0].traceId
+    ].run;
     expect((run as unknown as { test: { timeoutSec: number } }).test.timeoutSec).toBe(1200);
     expect(result.okCount).toBe(1);
   });
@@ -345,22 +347,35 @@ describe("runSuite", () => {
     // e.g. 2026-07-31-143022-Ab3dEf
     expect(path.basename(result.runDir)).toMatch(/^\d{4}-\d{2}-\d{2}-\d{6}-.{6}$/);
     expect(path.dirname(result.runDir)).toBe(path.join(proj, "runs"));
-    expect(fs.existsSync(path.join(result.runDir, "statelog.jsonl"))).toBe(true);
+    expect(fs.existsSync(path.join(result.runDir, "a", "statelog.jsonl"))).toBe(true);
   });
 
-  it("refuses to reuse an existing run directory", async () => {
-    fs.mkdirSync(path.join(proj, "runs", "taken"), { recursive: true });
-    await expect(
-      runSuite(
-        {
-          agent: path.join(proj, "agent.agency"),
-          inputs: [{ id: "a", goal: "g", input: "t" }],
-          out: path.join(proj, "runs", "taken"),
-          config: {},
-        },
-        { runner: traceWritingRunner("done") },
-      ),
-    ).rejects.toThrow(/already exists/);
+  it("a test whose run directory already exists is an error; the others still run; nothing is overwritten", async () => {
+    const out = path.join(proj, "runs", "taken");
+    fs.mkdirSync(path.join(out, "a"), { recursive: true });
+    fs.writeFileSync(path.join(out, "a", "statelog.jsonl"), "");
+    const runner = traceWritingRunner("done");
+    const result = await runSuite(
+      {
+        agent: path.join(proj, "agent.agency"),
+        inputs: [
+          { id: "a", goal: "g", input: "t" },
+          { id: "b", goal: "g", input: "t" },
+        ],
+        out,
+        config: {},
+        perRun: { pipeOutput: false },
+      },
+      { runner },
+    );
+    expect(result.tests.map((test) => [test.testId, test.status])).toEqual([
+      ["a", "error"],
+      ["b", "success"],
+    ]);
+    expect(result.tests[0].errorMessage).toMatch(/already exists/);
+    expect(runner).toHaveBeenCalledTimes(1);
+    expect(fs.readFileSync(path.join(out, "a", "statelog.jsonl"), "utf8")).toBe("");
+    expect(readRunDirectory(path.join(out, "b"), quiet).traces).toHaveLength(1);
   });
 
   it("SIGINT stops the loop after the in-flight test, which is still folded in", async () => {
@@ -394,7 +409,7 @@ describe("runSuite", () => {
     // The in-flight test finished and was recorded; the rest never ran.
     expect(runner).toHaveBeenCalledTimes(1);
     expect(result.tests.map((test) => test.testId)).toEqual(["input-1"]);
-    expect(readRunDirectory(result.runDir, quiet).traces).toHaveLength(1);
+    expect(readRunDirectory(result.tests[0].runDir, quiet).traces).toHaveLength(1);
     // The listener is gone afterwards.
     expect(process.listeners("SIGINT")).toEqual(before);
   });

--- a/packages/agency-lang/lib/eval/run/runSuite.test.ts
+++ b/packages/agency-lang/lib/eval/run/runSuite.test.ts
@@ -378,6 +378,37 @@ describe("runSuite", () => {
     expect(readRunDirectory(path.join(out, "b"), quiet).traces).toHaveLength(1);
   });
 
+  it("a test id that is empty, escapes the group, or is .staging is an error result; the others run", async () => {
+    const out = path.join(proj, "runs", "ids");
+    const runner = traceWritingRunner("done");
+    const result = await runSuite(
+      {
+        agent: path.join(proj, "agent.agency"),
+        inputs: [
+          { id: "", goal: "g", input: "t" },
+          { id: "../escape", goal: "g", input: "t" },
+          { id: "a/b", goal: "g", input: "t" },
+          { id: ".staging", goal: "g", input: "t" },
+          { id: "fine", goal: "g", input: "t" },
+        ],
+        out,
+        config: {},
+        perRun: { pipeOutput: false },
+      },
+      { runner },
+    );
+    expect(result.tests.map((test) => test.status)).toEqual([
+      "error",
+      "error",
+      "error",
+      "error",
+      "success",
+    ]);
+    expect(runner).toHaveBeenCalledTimes(1);
+    expect(fs.readdirSync(out)).toEqual(["fine"]);
+    expect(fs.existsSync(path.join(proj, "runs", "escape"))).toBe(false);
+  });
+
   it("SIGINT stops the loop after the in-flight test, which is still folded in", async () => {
     const runsDir = path.join(proj, "runs");
     const before = process.listeners("SIGINT");

--- a/packages/agency-lang/lib/eval/run/runSuite.ts
+++ b/packages/agency-lang/lib/eval/run/runSuite.ts
@@ -138,6 +138,10 @@ export async function runSuite(
     const testId = test.id ?? "";
     const traceId = nanoid();
     const runDir = path.join(groupDir, testId);
+    const idProblem = testIdProblem(testId, groupDir, runDir);
+    if (idProblem !== undefined) {
+      return { testId, traceId, runDir, status: "error", errorMessage: idProblem };
+    }
     if (fs.existsSync(runDir)) {
       // Someone's data; not ours to touch. (Resume is deliberately not here.)
       return {
@@ -374,6 +378,18 @@ async function runPool(args: {
     board.stop();
   }
   return slots.filter((entry): entry is SuiteTestResult => entry !== undefined);
+}
+
+/** A test id is a directory name under the group: it must be non-empty and
+ *  resolve to a direct child (no separators, no `..`, not `.staging`). Suite
+ *  loaders already restrict ids, but `runSuite` is also called directly. */
+function testIdProblem(testId: string, groupDir: string, runDir: string): string | undefined {
+  if (testId === "") return "test has no id; a run directory needs a name";
+  if (path.dirname(path.resolve(runDir)) !== groupDir || path.basename(runDir) !== testId) {
+    return `test id "${testId}" is not a valid directory name under ${groupDir}`;
+  }
+  if (testId === ".staging") return `test id ".staging" is reserved`;
+  return undefined;
 }
 
 /** Default group directory name: local-time timestamp then a short random

--- a/packages/agency-lang/lib/eval/run/runSuite.ts
+++ b/packages/agency-lang/lib/eval/run/runSuite.ts
@@ -40,8 +40,8 @@ export type RunSuiteOptions = {
    *  resolveEvalTarget, including the {task}-placeholder check. */
   agent: string | EvalTarget;
   inputs: Test[];
-  /** The directory to write the run into. Must not exist yet. Default:
-   *  `<eval.runsDir or runs>/<timestamp>-<random suffix>`. */
+  /** The group directory; each test's run directory is written at
+   *  `<out>/<testId>/`. Default: `<eval.runsDir or runs>/<timestamp>-<random suffix>`. */
   out?: string;
   /** Default true. */
   config?: AgencyConfig;
@@ -62,11 +62,12 @@ export type RunSuiteOptions = {
 export type RunSuiteDeps = { runner?: EvalInputRunner };
 
 /**
- * Run an agent against a loaded suite and write ONE run directory: every
- * test's trace in `statelog.jsonl`, its workdir under `workdir/<traceId>/`,
- * the agent's code under `code/<closureHash>/`, and one `run` annotation per
- * test saying which test it was and how it ended. Executes only — grading is
- * a separate pass over the finished directory (docs/dev/eval-grading.md).
+ * Run an agent against a loaded suite and write one run directory per test
+ * at `<out>/<testId>/`: the test's trace in `statelog.jsonl`, its workdir
+ * under `workdir/`, the agent's code under `code/`, and one `run` annotation
+ * saying which test it was and how it ended. A test whose directory already
+ * exists is an error result; the others still run. Executes only — grading is
+ * a separate pass over the finished directories (docs/dev/eval-grading.md).
  */
 export async function runSuite(
   opts: RunSuiteOptions,
@@ -79,15 +80,9 @@ export async function runSuite(
   // per-test run failure.
   assertTargetMatchesInputs(target, opts.inputs);
 
-  const runDir = path.resolve(
-    opts.out ?? path.join(opts.config?.eval?.runsDir ?? "runs", defaultRunDirName()),
+  const groupDir = path.resolve(
+    opts.out ?? path.join(opts.config?.eval?.runsDir ?? "runs", defaultGroupName()),
   );
-  if (fs.existsSync(runDir)) {
-    throw new Error(
-      `Run directory already exists: ${runDir}\nChoose a different --out directory or delete the existing one.`,
-    );
-  }
-  const stagingParent = path.join(path.dirname(runDir), ".staging");
   const config = opts.config ?? {};
   const perRun = opts.perRun ?? {};
 
@@ -97,17 +92,16 @@ export async function runSuite(
   const defaultSeed =
     target.kind === "file" ? (perRun.seed ?? seedFromAgentFile(target.agentFile)) : undefined;
 
-  // Each test runs in its own staging directory OUTSIDE the run directory and
-  // is folded in when it finishes; the staging root lives beside the run
-  // directory so the fold never crosses filesystems.
-  const stagingRoot = path.join(stagingParent, path.basename(runDir));
+  // Each test runs in its own staging directory inside the group and its run
+  // directory is assembled there too, then renamed into place: a child appears
+  // whole or not at all, and the rename never crosses filesystems.
+  const stagingRoot = path.join(groupDir, ".staging");
   fs.mkdirSync(stagingRoot, { recursive: true });
-  fs.mkdirSync(runDir, { recursive: true });
 
   // Up front, not just at the end: a long run's evidence (statelogs, the
   // live `eval logs -f` view) lives here while it is still running.
   const progress = opts.progress ?? true;
-  if (progress) console.error(`run dir: ${runDir}`);
+  if (progress) console.error(`run dir: ${groupDir}`);
 
   // Ctrl-C mid-suite must still produce a run directory the toolchain can
   // read: the in-flight test finishes as an error result (the runner kills
@@ -143,6 +137,17 @@ export async function runSuite(
   ): Promise<SuiteTestResult> => {
     const testId = test.id ?? "";
     const traceId = nanoid();
+    const runDir = path.join(groupDir, testId);
+    if (fs.existsSync(runDir)) {
+      // Someone's data; not ours to touch. (Resume is deliberately not here.)
+      return {
+        testId,
+        traceId,
+        runDir,
+        status: "error",
+        errorMessage: `run directory already exists: ${runDir}`,
+      };
+    }
     const stagingDir = path.join(stagingRoot, testId);
     onStarted?.(agentRunPaths(stagingDir).statelogPath);
     try {
@@ -161,10 +166,22 @@ export async function runSuite(
         },
         { runner: deps.runner },
       );
-      foldIntoRunDirectory({ runDir, test, traceId, run, harness, suite: opts.suite, flags });
+      const assembled = path.join(stagingRoot, `${testId}.rundir`);
+      fs.rmSync(assembled, { recursive: true, force: true });
+      foldIntoRunDirectory({
+        runDir: assembled,
+        test,
+        traceId,
+        run,
+        harness,
+        suite: opts.suite,
+        flags,
+      });
+      fs.renameSync(assembled, runDir);
       return {
         testId,
         traceId,
+        runDir,
         status: run.status,
         errorMessage: run.status === "error" ? run.errorMessage : undefined,
       };
@@ -214,12 +231,11 @@ export async function runSuite(
     }
   } finally {
     process.removeListener("SIGINT", onSigint);
-    safeDeleteDirectoryWithin(stagingParent, stagingRoot);
-    removeIfEmpty(stagingParent);
+    removeIfEmpty(stagingRoot);
   }
 
   return {
-    runDir,
+    runDir: groupDir,
     agentLabel: target.label,
     tests: results,
     okCount: results.filter((result) => result.status === "success").length,
@@ -227,11 +243,12 @@ export async function runSuite(
   };
 }
 
-/** Fold one finished run into the run directory: its trace, its workdir, the
- *  agent's code, and the `run` row. A run that never wrote a statelog still
- *  gets its `run` row (keyed by the trace id the harness minted), so a
- *  failure is recorded rather than lost; it gets no workdir, because a
- *  workdir needs a trace to hang off. */
+/** Assemble one finished run's directory: its trace, its workdir, the agent's
+ *  code, and the `run` row. A run that never wrote a statelog still gets its
+ *  `run` row (keyed by the trace id the harness minted) and an empty
+ *  `statelog.jsonl`, so a failure is recorded rather than lost and the
+ *  directory is still a run directory; it gets no workdir, because a workdir
+ *  needs a trace to hang off. */
 function foldIntoRunDirectory(args: {
   runDir: string;
   test: Test;
@@ -242,7 +259,9 @@ function foldIntoRunDirectory(args: {
   flags: Record<string, string | number | boolean>;
 }): void {
   const { run } = args;
+  fs.mkdirSync(args.runDir, { recursive: true });
   const staged = run.statelogPath === null ? [] : readTraces(run.statelogPath).traces;
+  if (staged.length === 0) fs.writeFileSync(path.join(args.runDir, "statelog.jsonl"), "");
   const trace = staged.find((entry) => entry.traceId === args.traceId);
   const traceRecorded = trace !== undefined;
   // Attach the seeded code only when the trace itself recorded that closure
@@ -258,10 +277,7 @@ function foldIntoRunDirectory(args: {
     dir: args.runDir,
     stagedStatelogFile: run.statelogPath === null ? undefined : run.statelogPath,
     codeEntry,
-    workdir:
-      traceRecorded && fs.existsSync(run.workdir)
-        ? { traceId: args.traceId, sourceDir: run.workdir }
-        : undefined,
+    workdir: traceRecorded && fs.existsSync(run.workdir) ? { sourceDir: run.workdir } : undefined,
     run: {
       traceId: args.traceId,
       annotator: args.harness,
@@ -360,10 +376,10 @@ async function runPool(args: {
   return slots.filter((entry): entry is SuiteTestResult => entry !== undefined);
 }
 
-/** Default run directory name: local-time timestamp then a short random
+/** Default group directory name: local-time timestamp then a short random
  *  suffix, so runs/ lists in creation order. An explicit --out is resolved to
- *  an absolute path and used as the run directory. */
-function defaultRunDirName(): string {
+ *  an absolute path and used as the group directory. */
+function defaultGroupName(): string {
   const now = new Date();
   const pad = (n: number) => String(n).padStart(2, "0");
   const stamp =
@@ -372,8 +388,8 @@ function defaultRunDirName(): string {
   return `${stamp}-${nanoid(6)}`;
 }
 
-/** The staging root is shared by concurrent suites in one runs dir; only the
- *  last one out removes it. */
+/** The staging root is shared by concurrent suites writing one group; only
+ *  the last one out removes it. */
 function removeIfEmpty(dir: string): void {
   try {
     fs.rmdirSync(dir);

--- a/packages/agency-lang/lib/eval/runDirectoryFixture.ts
+++ b/packages/agency-lang/lib/eval/runDirectoryFixture.ts
@@ -25,9 +25,10 @@ export type FakeRun = {
 };
 
 /**
- * Write a run directory the way `eval run` does — one trace per test, a
- * workdir per trace, and a `run` row per test — for tests of grading, the
- * optimizer, and the CLI. Returns the directory.
+ * Write a run directory the way `eval run` does — the trace, its workdir, and
+ * the `run` row — for tests of grading, the optimizer, and the CLI. Returns
+ * the directory. Several runs in one directory is the pre-atomic shape that
+ * the labeling and explorer tests still read; writers no longer produce it.
  */
 export function writeRunDirectory(runs: FakeRun[], dir: string = tempDir("run-")): string {
   fs.mkdirSync(dir, { recursive: true });
@@ -46,14 +47,14 @@ export function writeRunDirectory(runs: FakeRun[], dir: string = tempDir("run-")
         }).join("\n") + "\n",
       );
     }
-    let workdir: { traceId: string; sourceDir: string } | undefined;
+    let workdir: { sourceDir: string } | undefined;
     if (run.workdirFiles !== undefined && statelogFile !== undefined) {
       const source = path.join(staging, "workdir");
       for (const [rel, text] of Object.entries(run.workdirFiles)) {
         fs.mkdirSync(path.dirname(path.join(source, rel)), { recursive: true });
         fs.writeFileSync(path.join(source, rel), text);
       }
-      workdir = { traceId, sourceDir: source };
+      workdir = { sourceDir: source };
     }
     const ended = run.ended ?? "ok";
     recordCompletedRun({

--- a/packages/agency-lang/lib/eval/runTypes.ts
+++ b/packages/agency-lang/lib/eval/runTypes.ts
@@ -48,11 +48,14 @@ export type Test = {
 export type SuiteTestResult = {
   testId: string;
   traceId: string;
+  /** This test's run directory, `<group>/<testId>/`. */
+  runDir: string;
   status: "success" | "error";
   errorMessage?: string;
 };
 
 export type SuiteRunResult = {
+  /** The group directory holding one run directory per test. */
   runDir: string;
   /** Display label, "<absolute agent path>:<node>" or the command string. */
   agentLabel: string;

--- a/packages/agency-lang/lib/optimize/baseOptimizer.ts
+++ b/packages/agency-lang/lib/optimize/baseOptimizer.ts
@@ -346,7 +346,8 @@ export abstract class BaseOptimizer {
         `agent run failed for input ${input.id ?? "(no id)"}: ${testResult?.errorMessage ?? "unknown error"}`,
       );
     }
-    return result.runDir;
+    // The one test's run directory, `<out>/<id>/`; `gradeRun` sees exactly one input.
+    return testResult.runDir;
   }
 
   protected async eachIteration(step: (iter: number) => Promise<void>): Promise<void> {

--- a/packages/agency-lang/lib/optimize/baseOptimizer.workdir.test.ts
+++ b/packages/agency-lang/lib/optimize/baseOptimizer.workdir.test.ts
@@ -67,7 +67,10 @@ describe("BaseOptimizer.runInputViaEval threads seed + overlayFiles", () => {
       const input = args.inputs[0];
       // A real one-input run directory: the optimizer grades it via gradeRun.
       const runDir = fakeRun(input.id ?? "a", "out", input);
-      return { runDir, tests: [{ testId: input.id ?? "a", traceId: "t", status: "success" }] };
+      return {
+        runDir: path.dirname(runDir),
+        tests: [{ testId: input.id ?? "a", traceId: "t", runDir, status: "success" }],
+      };
     });
   });
   afterEach(() => {

--- a/packages/agency-lang/lib/runDirectory/attachCode.test.ts
+++ b/packages/agency-lang/lib/runDirectory/attachCode.test.ts
@@ -19,7 +19,7 @@ function directoryWithTraceFor(project: string): { dir: string; entry: string } 
 const quiet = { reportWarning: () => {} };
 
 describe("code attachment", () => {
-  it("stores a matching closure under code/<hash>/ and is idempotent", () => {
+  it("stores a matching closure under code/ and is idempotent", () => {
     const project = writeProject({
       "main.agency": 'import { f } from "./lib/util.agency"\nnode main() { return f() }\n',
       "lib/util.agency": 'export def f(): string { return "x" }\n',
@@ -29,7 +29,7 @@ describe("code attachment", () => {
     const plan = planCodeAttachment(readRunDirectory(dir, quiet), entry, paths);
     expect(plan.status).toBe("add");
     applyCodeAttachment(paths, plan);
-    const stored = path.join(paths.codeDir, plan.identity.closureHash);
+    const stored = paths.codeDir;
     expect(fs.existsSync(path.join(stored, "main.agency"))).toBe(true);
     expect(fs.existsSync(path.join(stored, "lib", "util.agency"))).toBe(true);
 
@@ -67,7 +67,7 @@ describe("code attachment", () => {
     const paths = runDirPaths(dir);
     const plan = planCodeAttachment(readRunDirectory(dir, quiet), entry, paths);
     applyCodeAttachment(paths, plan);
-    const stored = path.join(paths.codeDir, plan.identity.closureHash, "main.agency");
+    const stored = path.join(paths.codeDir, "main.agency");
     fs.writeFileSync(stored, "node main() { return 999 }\n");
     expect(() => planCodeAttachment(readRunDirectory(dir, quiet), entry, paths)).toThrow(/corrupt/);
     fs.rmSync(stored);

--- a/packages/agency-lang/lib/runDirectory/attachCode.ts
+++ b/packages/agency-lang/lib/runDirectory/attachCode.ts
@@ -8,10 +8,10 @@ import type { RunDirectoryPaths, RunDirectorySnapshot } from "./runDir.js";
 import type { Trace } from "./traces.js";
 
 /**
- * Attaching agent code to a run directory, stored by version under
- * `code/<closureHash>/`. The plan is pure: it hashes the closure it is given
- * and checks that some trace in the directory recorded that hash on its
- * `agentStart`. A mismatch is refused, not warned — optimizing the wrong
+ * Attaching agent code to a run directory, stored directly under `code/` (a
+ * run directory holds one run, so one code version). The plan is pure: it
+ * hashes the closure it is given and checks that the directory's trace
+ * recorded that hash on its `agentStart`. A mismatch is refused, not warned — optimizing the wrong
  * program would be silent otherwise.
  */
 export class CodeMismatchError extends Error {}
@@ -51,7 +51,7 @@ export function planCodeAttachment(
     );
   }
   const baseDir = closureBaseDirOf(entryFile, identity);
-  const target = path.join(paths.codeDir, identity.closureHash);
+  const target = paths.codeDir;
   if (fs.existsSync(target)) {
     assertStoredTreeMatches(target, identity);
     return { identity, baseDir, status: "already-present" };
@@ -59,10 +59,10 @@ export function planCodeAttachment(
   return { identity, baseDir, status: "add" };
 }
 
-/** @internal Copies the closure into `code/<hash>/`. Caller holds the lock. */
+/** @internal Copies the closure into `code/`. Caller holds the lock. */
 export function applyCodeAttachment(paths: RunDirectoryPaths, plan: CodeAttachmentPlan): void {
   if (plan.status === "already-present") return;
-  const target = path.join(paths.codeDir, plan.identity.closureHash);
+  const target = paths.codeDir;
   for (const file of plan.identity.closure) {
     const destination = path.join(target, file.file);
     fs.mkdirSync(path.dirname(destination), { recursive: true });
@@ -92,7 +92,7 @@ function assertStoredTreeMatches(target: string, identity: CodeIdentity): void {
   const storedHash = closureHashOf(stored);
   if (storedHash !== identity.closureHash) {
     throw new CodeMismatchError(
-      `${target} is named for closure hash ${identity.closureHash} but its files hash to ` +
+      `${target} should hold closure hash ${identity.closureHash} but its files hash to ` +
         `${storedHash}; the stored code tree is corrupt.`,
     );
   }

--- a/packages/agency-lang/lib/runDirectory/attachWorkdir.test.ts
+++ b/packages/agency-lang/lib/runDirectory/attachWorkdir.test.ts
@@ -20,76 +20,58 @@ function directoryWithTrace(): string {
 }
 
 describe("workdir attachment", () => {
-  it("copies the tree under workdir/<traceId>/ and writes a dated sidecar", () => {
+  it("copies the tree under workdir/ and writes a dated sidecar", () => {
     const dir = directoryWithTrace();
     const paths = runDirPaths(dir);
     const source = writeProject({ "out.txt": "hello", "nested/deep.txt": "x" });
-    const plan = planWorkdirAttachment(
-      readRunDirectory(dir, quiet),
-      { traceId: "t1", sourceDir: source },
-      paths,
-    );
+    const plan = planWorkdirAttachment(readRunDirectory(dir, quiet), { sourceDir: source }, paths);
     expect(plan.status).toBe("add");
     applyWorkdirAttachment(paths, plan, "2026-08-18T01:02:03Z");
-    expect(fs.readFileSync(path.join(paths.workdirDir, "t1", "nested", "deep.txt"), "utf8")).toBe(
-      "x",
-    );
-    const sidecar = JSON.parse(fs.readFileSync(path.join(paths.workdirDir, "t1.json"), "utf8"));
+    expect(fs.readFileSync(path.join(paths.workdirDir, "nested", "deep.txt"), "utf8")).toBe("x");
+    const sidecar = JSON.parse(fs.readFileSync(paths.workdirSidecar, "utf8"));
     expect(sidecar).toEqual({ snapshotAt: "2026-08-18T01:02:03Z", source: path.resolve(source) });
   });
 
-  it("refuses an unknown trace and a missing source", () => {
+  it("refuses a directory with no trace and a missing source", () => {
+    const empty = tempDir();
+    const source = writeProject({ "out.txt": "hello" });
+    expect(() =>
+      planWorkdirAttachment(
+        readRunDirectory(empty, quiet),
+        { sourceDir: source },
+        runDirPaths(empty),
+      ),
+    ).toThrow(WorkdirAttachmentError);
     const dir = directoryWithTrace();
-    const paths = runDirPaths(dir);
-    const source = writeProject({ "out.txt": "hello" });
     expect(() =>
       planWorkdirAttachment(
         readRunDirectory(dir, quiet),
-        { traceId: "nope", sourceDir: source },
-        paths,
-      ),
-    ).toThrow(WorkdirAttachmentError);
-    expect(() =>
-      planWorkdirAttachment(
-        readRunDirectory(dir, quiet),
-        { traceId: "t1", sourceDir: path.join(source, "missing") },
-        paths,
+        { sourceDir: path.join(source, "missing") },
+        runDirPaths(dir),
       ),
     ).toThrow(WorkdirAttachmentError);
   });
 
-  it("refuses a trace id that would place the workdir outside workdir/", () => {
-    const dir = tempDir();
-    fs.writeFileSync(runDirPaths(dir).statelog, agentStartLine("../escaped") + "\n");
-    const paths = runDirPaths(dir);
-    const source = writeProject({ "out.txt": "hello" });
-    expect(() =>
-      planWorkdirAttachment(
-        readRunDirectory(dir, quiet),
-        { traceId: "../escaped", sourceDir: source },
-        paths,
-      ),
-    ).toThrow(/outside/);
-    expect(fs.existsSync(path.join(dir, "escaped"))).toBe(false);
-  });
-
-  it("leaves the run directory itself out when it sits inside the tree being captured", () => {
-    const source = writeProject({ "note.txt": "keep", "sub/deep.txt": "keep too" });
+  it("leaves the run directory (and an excluded group) out when they sit inside the tree being captured", () => {
+    const source = writeProject({
+      "note.txt": "keep",
+      "sub/deep.txt": "keep too",
+      "runs/other/statelog.jsonl": "",
+    });
     const dir = path.join(source, "runs", "r1");
     fs.mkdirSync(dir, { recursive: true });
     fs.writeFileSync(runDirPaths(dir).statelog, agentStartLine("t1") + "\n");
     const paths = runDirPaths(dir);
     const plan = planWorkdirAttachment(
       readRunDirectory(dir, quiet),
-      { traceId: "t1", sourceDir: source },
+      { sourceDir: source, excludeDir: path.join(source, "runs") },
       paths,
     );
     applyWorkdirAttachment(paths, plan, "2026-08-18T00:00:00.000Z");
-    const captured = path.join(paths.workdirDir, "t1");
+    const captured = paths.workdirDir;
     expect(fs.readFileSync(path.join(captured, "note.txt"), "utf8")).toBe("keep");
     expect(fs.readFileSync(path.join(captured, "sub", "deep.txt"), "utf8")).toBe("keep too");
-    expect(fs.existsSync(path.join(captured, "runs", "r1"))).toBe(false);
-    expect(fs.existsSync(path.join(captured, "runs"))).toBe(true);
+    expect(fs.existsSync(path.join(captured, "runs"))).toBe(false);
   });
 
   it("refuses to overwrite without replace, and replaces cleanly with it", () => {
@@ -98,27 +80,23 @@ describe("workdir attachment", () => {
     const first = writeProject({ "a.txt": "1" });
     const firstPlan = planWorkdirAttachment(
       readRunDirectory(dir, quiet),
-      { traceId: "t1", sourceDir: first },
+      { sourceDir: first },
       paths,
     );
     applyWorkdirAttachment(paths, firstPlan, "2026-08-18T00:00:00Z");
 
     const second = writeProject({ "b.txt": "2" });
     expect(() =>
-      planWorkdirAttachment(
-        readRunDirectory(dir, quiet),
-        { traceId: "t1", sourceDir: second },
-        paths,
-      ),
+      planWorkdirAttachment(readRunDirectory(dir, quiet), { sourceDir: second }, paths),
     ).toThrow(/replace/);
     const replacePlan = planWorkdirAttachment(
       readRunDirectory(dir, quiet),
-      { traceId: "t1", sourceDir: second, replace: true },
+      { sourceDir: second, replace: true },
       paths,
     );
     expect(replacePlan.status).toBe("replace");
     applyWorkdirAttachment(paths, replacePlan, "2026-08-18T00:00:01Z");
-    expect(fs.existsSync(path.join(paths.workdirDir, "t1", "a.txt"))).toBe(false);
-    expect(fs.existsSync(path.join(paths.workdirDir, "t1", "b.txt"))).toBe(true);
+    expect(fs.existsSync(path.join(paths.workdirDir, "a.txt"))).toBe(false);
+    expect(fs.existsSync(path.join(paths.workdirDir, "b.txt"))).toBe(true);
   });
 });

--- a/packages/agency-lang/lib/runDirectory/attachWorkdir.ts
+++ b/packages/agency-lang/lib/runDirectory/attachWorkdir.ts
@@ -6,26 +6,28 @@ import { isStrictDescendant, safeDeleteDirectoryWithin } from "@/utils.js";
 import type { RunDirectoryPaths, RunDirectorySnapshot } from "./runDir.js";
 
 /**
- * Attaching a filesystem snapshot to one trace, at `workdir/<traceId>/`, with
- * a sidecar `workdir/<traceId>.json` recording when the snapshot was taken and
- * where from — a workdir attached after the fact may postdate the run, and a
- * grader deserves to know. The plan is pure; replacement (`replace: true`) is
- * carried out inside the apply step through `safeDeleteDirectoryWithin`, so no
- * caller ever deletes first.
+ * Attaching a filesystem snapshot to a run directory, at `workdir/`, with a
+ * sidecar `workdir.json` recording when the snapshot was taken and where
+ * from — a workdir attached after the fact may postdate the run, and a grader
+ * deserves to know. The plan is pure; replacement (`replace: true`) is carried
+ * out inside the apply step through `safeDeleteDirectoryWithin`, so no caller
+ * ever deletes first.
  */
 export class WorkdirAttachmentError extends Error {}
 
 export type WorkdirAttachmentRequest = {
-  traceId: string;
   sourceDir: string;
   replace?: boolean;
+  /** A directory inside `sourceDir` to leave out of the copy, on top of the
+   *  run directory itself: the group a captured run is being written into. */
+  excludeDir?: string;
 };
 
 export type WorkdirAttachmentPlan = {
-  traceId: string;
   sourceDir: string;
   target: string;
   sidecar: string;
+  excludeDirs: string[];
   status: "add" | "replace";
 };
 
@@ -36,46 +38,31 @@ export function planWorkdirAttachment(
   request: WorkdirAttachmentRequest,
   paths: RunDirectoryPaths,
 ): WorkdirAttachmentPlan {
-  if (!snapshot.traces.some((trace) => trace.traceId === request.traceId)) {
+  if (snapshot.traces.length === 0) {
     throw new WorkdirAttachmentError(
-      `No trace ${request.traceId} in ${snapshot.dir}; add its statelog before its workdir.`,
+      `No trace in ${snapshot.dir}; add its statelog before its workdir.`,
     );
   }
   if (!fs.existsSync(request.sourceDir) || !fs.statSync(request.sourceDir).isDirectory()) {
     throw new WorkdirAttachmentError(`${request.sourceDir} is not a directory.`);
   }
-  const target = path.join(paths.workdirDir, request.traceId);
-  const sidecar = path.join(paths.workdirDir, `${request.traceId}.json`);
-  // A trace id is whatever the statelog said it was. One like `../escaped`
-  // would put both files outside workdir/, so the resolved paths are checked
-  // here, before anything is written, not just on replacement.
-  const workdirRoot = path.resolve(paths.workdirDir);
-  const contained = [target, sidecar].every(
-    (file) =>
-      isStrictDescendant(workdirRoot, path.resolve(file)) &&
-      path.dirname(path.resolve(file)) === workdirRoot,
-  );
-  if (!contained) {
-    throw new WorkdirAttachmentError(
-      `Refusing to attach a workdir for trace "${request.traceId}": its id would place files ` +
-        `outside ${paths.workdirDir}.`,
-    );
-  }
+  const target = paths.workdirDir;
+  const sidecar = paths.workdirSidecar;
+  // The run directory may sit inside the tree being captured (`agency run
+  // --capture-workdir ./runs from the project root); copying it into itself
+  // would recurse forever, so its subtree is left out.
+  const excludeDirs = [path.resolve(paths.dir)];
+  if (request.excludeDir !== undefined) excludeDirs.push(path.resolve(request.excludeDir));
+  const plan = { sourceDir: request.sourceDir, target, sidecar, excludeDirs };
   if (fs.existsSync(target)) {
     if (request.replace !== true) {
       throw new WorkdirAttachmentError(
-        `${target} already holds a workdir for this trace; pass replace to overwrite it.`,
+        `${target} already holds a workdir; pass replace to overwrite it.`,
       );
     }
-    return {
-      traceId: request.traceId,
-      sourceDir: request.sourceDir,
-      target,
-      sidecar,
-      status: "replace",
-    };
+    return { ...plan, status: "replace" };
   }
-  return { traceId: request.traceId, sourceDir: request.sourceDir, target, sidecar, status: "add" };
+  return { ...plan, status: "add" };
 }
 
 /** @internal Copies the tree and writes the sidecar. Caller holds the lock. */
@@ -85,31 +72,28 @@ export function applyWorkdirAttachment(
   snapshotAt: string,
 ): void {
   if (plan.status === "replace") {
-    const deleted = safeDeleteDirectoryWithin(paths.workdirDir, plan.target);
+    const deleted = safeDeleteDirectoryWithin(paths.dir, plan.target);
     if (!deleted.success) {
       throw new WorkdirAttachmentError(deleted.message ?? `Could not replace ${plan.target}`);
     }
   }
   fs.mkdirSync(plan.target, { recursive: true });
-  // The run directory may sit inside the tree being captured (`agency run
-  // --capture-workdir ./runs/x` from the project root); copying it into itself
-  // would recurse forever, so its subtree is left out.
-  copyTreeExcluding(path.resolve(plan.sourceDir), plan.target, path.resolve(paths.dir));
+  copyTreeExcluding(path.resolve(plan.sourceDir), plan.target, plan.excludeDirs);
   const sidecar: WorkdirSidecar = { snapshotAt, source: path.resolve(plan.sourceDir) };
   fs.writeFileSync(plan.sidecar, JSON.stringify(sidecar, null, 2) + "\n");
 }
 
-/** Copy `source` into `target`, skipping the `excluded` directory. `cpSync`
+/** Copy `source` into `target`, skipping the `excluded` directories. `cpSync`
  *  refuses a tree that contains its own destination outright, so the walk
- *  descends only along the path to `excluded` and copies whole subtrees
- *  everywhere else. */
-function copyTreeExcluding(source: string, target: string, excluded: string): void {
+ *  descends only along the paths to the excluded directories and copies whole
+ *  subtrees everywhere else. */
+function copyTreeExcluding(source: string, target: string, excluded: string[]): void {
   fs.mkdirSync(target, { recursive: true });
   for (const entry of fs.readdirSync(source, { withFileTypes: true })) {
     const from = path.join(source, entry.name);
     const to = path.join(target, entry.name);
-    if (from === excluded) continue;
-    if (entry.isDirectory() && isStrictDescendant(from, excluded)) {
+    if (excluded.includes(from)) continue;
+    if (entry.isDirectory() && excluded.some((dir) => isStrictDescendant(from, dir))) {
       copyTreeExcluding(from, to, excluded);
     } else {
       fs.cpSync(from, to, { recursive: true });

--- a/packages/agency-lang/lib/runDirectory/findRuns.test.ts
+++ b/packages/agency-lang/lib/runDirectory/findRuns.test.ts
@@ -39,6 +39,13 @@ describe("findRunDirectories", () => {
     expect(() => findRunDirectories([folder])).toThrow(/holds no run directories.*runs add/s);
   });
 
+  it("a child named statelog.jsonl does not make the group look like a run directory", () => {
+    const group = tempDir();
+    const child = runDirAt(path.join(group, "statelog.jsonl"));
+    expect(isRunDirectory(group)).toBe(false);
+    expect(findRunDirectories([group])).toEqual([child]);
+  });
+
   it("returns absolute paths for a relative argument", () => {
     const group = tempDir();
     runDirAt(path.join(group, "a"));

--- a/packages/agency-lang/lib/runDirectory/findRuns.test.ts
+++ b/packages/agency-lang/lib/runDirectory/findRuns.test.ts
@@ -1,0 +1,48 @@
+import * as fs from "fs";
+import * as path from "path";
+
+import { describe, expect, it } from "vitest";
+
+import { childRunDirectories, findRunDirectories, isRunDirectory } from "./findRuns.js";
+import { tempDir } from "./testFixtures.js";
+
+function runDirAt(dir: string): string {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, "statelog.jsonl"), "");
+  return dir;
+}
+
+describe("findRunDirectories", () => {
+  it("a run directory is itself; a group yields its run-directory children, sorted, one level down", () => {
+    const group = tempDir();
+    const b = runDirAt(path.join(group, "b"));
+    const a = runDirAt(path.join(group, "a"));
+    fs.writeFileSync(path.join(group, "notes.txt"), "not a run");
+    fs.mkdirSync(path.join(group, "empty-folder"));
+    runDirAt(path.join(group, "deeper", "nested")); // two levels down: not found
+
+    expect(findRunDirectories([a])).toEqual([a]);
+    expect(findRunDirectories([group])).toEqual([a, b]);
+    expect(findRunDirectories([group, a])).toEqual([a, b, a]);
+    expect(childRunDirectories(group)).toEqual([a, b]);
+    expect(isRunDirectory(group)).toBe(false);
+    expect(isRunDirectory(a)).toBe(true);
+  });
+
+  it("refuses a missing path, a file, and a directory holding no run directories", () => {
+    const folder = tempDir();
+    fs.writeFileSync(path.join(folder, "statelogs.jsonl"), "");
+    expect(() => findRunDirectories([path.join(folder, "missing")])).toThrow(/not a directory/);
+    expect(() => findRunDirectories([path.join(folder, "statelogs.jsonl")])).toThrow(
+      /not a directory/,
+    );
+    expect(() => findRunDirectories([folder])).toThrow(/holds no run directories.*runs add/s);
+  });
+
+  it("returns absolute paths for a relative argument", () => {
+    const group = tempDir();
+    runDirAt(path.join(group, "a"));
+    const relative = path.relative(process.cwd(), group);
+    expect(findRunDirectories([relative])).toEqual([path.resolve(group, "a")]);
+  });
+});

--- a/packages/agency-lang/lib/runDirectory/findRuns.ts
+++ b/packages/agency-lang/lib/runDirectory/findRuns.ts
@@ -10,7 +10,13 @@ import * as path from "path";
  * anything else is an error. Resolved, absolute paths come back.
  */
 export function isRunDirectory(dir: string): boolean {
-  return fs.existsSync(path.join(dir, "statelog.jsonl"));
+  // A file, not merely present: a test id may itself be `statelog.jsonl`,
+  // making `<group>/statelog.jsonl/` a child run directory, not a statelog.
+  try {
+    return fs.statSync(path.join(dir, "statelog.jsonl")).isFile();
+  } catch {
+    return false;
+  }
 }
 
 export function childRunDirectories(dir: string): string[] {

--- a/packages/agency-lang/lib/runDirectory/findRuns.ts
+++ b/packages/agency-lang/lib/runDirectory/findRuns.ts
@@ -1,0 +1,46 @@
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * The one rule every command over "several runs" uses to turn paths into run
+ * directories: a path that is a run directory (has `statelog.jsonl`) is that
+ * run; a directory whose children include run directories is a group, and
+ * yields those children, sorted, ONE level down (a suite run is
+ * `<group>/<testId>/`; going deeper would make `runs/` mean every run ever);
+ * anything else is an error. Resolved, absolute paths come back.
+ */
+export function isRunDirectory(dir: string): boolean {
+  return fs.existsSync(path.join(dir, "statelog.jsonl"));
+}
+
+export function childRunDirectories(dir: string): string[] {
+  return fs
+    .readdirSync(dir)
+    .sort()
+    .map((child) => path.join(dir, child))
+    .filter(isRunDirectory);
+}
+
+export function findRunDirectories(paths: string[]): string[] {
+  const found: string[] = [];
+  for (const given of paths) {
+    const resolved = path.resolve(given);
+    if (!fs.existsSync(resolved) || !fs.statSync(resolved).isDirectory()) {
+      throw new Error(`${given} is not a directory.`);
+    }
+    if (isRunDirectory(resolved)) {
+      found.push(resolved);
+      continue;
+    }
+    const children = childRunDirectories(resolved);
+    if (children.length === 0) {
+      throw new Error(
+        `${given} is not a run directory (no statelog.jsonl) and holds no run directories. ` +
+          `Write one with \`agency eval run\`, \`agency run --capture-workdir ${given} <file.agency>\`, ` +
+          `or \`agency runs add ${given} --statelog <file>\`.`,
+      );
+    }
+    found.push(...children);
+  }
+  return found;
+}

--- a/packages/agency-lang/lib/runDirectory/list.test.ts
+++ b/packages/agency-lang/lib/runDirectory/list.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { completeAnnotation } from "./annotations.js";
 
 import { summarizeRuns } from "./list.js";
-import { addToRunDirectory, recordGradingPass, recordNote } from "./mutations.js";
+import { recordGradingPass, recordNote } from "./mutations.js";
 import { readRunDirectory } from "./runDir.js";
 import { agentStartLine, statelogLine, tempDir } from "./testFixtures.js";
 import * as fs from "fs";
@@ -11,27 +11,19 @@ import * as path from "path";
 
 const quiet = { reportWarning: () => {} };
 
-function statelogFile(...lines: string[]): string {
-  const file = path.join(tempDir("log-"), "statelog.jsonl");
-  fs.writeFileSync(file, lines.join("\n") + "\n");
-  return file;
+function writeStatelog(dir: string, ...lines: string[]): void {
+  fs.writeFileSync(path.join(dir, "statelog.jsonl"), lines.join("\n") + "\n");
 }
 
 describe("summarizeRuns", () => {
   it("summarizes a finished trace with a note and a score", () => {
     const dir = tempDir();
-    addToRunDirectory({
+    writeStatelog(
       dir,
-      statelogFiles: [
-        statelogFile(
-          statelogLine("t1", "agentStart", { entryNode: "main", args: {}, input: "summarize x" }),
-          statelogLine("t1", "agentEnd", { result: "done", timeTaken: 5 }),
-          statelogLine("t2", "agentStart", { entryNode: "main", args: {} }),
-        ),
-      ],
-      codeEntries: [],
-      annotationFiles: [],
-    });
+      statelogLine("t1", "agentStart", { entryNode: "main", args: {}, input: "summarize x" }),
+      statelogLine("t1", "agentEnd", { result: "done", timeTaken: 5 }),
+      statelogLine("t2", "agentStart", { entryNode: "main", args: {} }),
+    );
     recordNote({ dir, traceId: "t1", annotator: { kind: "human", id: "adit" }, text: "fine" });
     recordGradingPass({
       dir,
@@ -75,17 +67,11 @@ describe("summarizeRuns", () => {
 
   it("reports gates as unknown (null) when a must-pass score is scalar, since its threshold is not on the row", () => {
     const dir = tempDir();
-    addToRunDirectory({
+    writeStatelog(
       dir,
-      statelogFiles: [
-        statelogFile(
-          statelogLine("t1", "agentStart", { entryNode: "main", args: {} }),
-          statelogLine("t1", "agentEnd", { result: "done", timeTaken: 1 }),
-        ),
-      ],
-      codeEntries: [],
-      annotationFiles: [],
-    });
+      statelogLine("t1", "agentStart", { entryNode: "main", args: {} }),
+      statelogLine("t1", "agentEnd", { result: "done", timeTaken: 1 }),
+    );
     const score = (name: string, kind: "binary" | "scalar", mustPass: boolean) => ({
       traceId: "t1",
       annotator: { kind: "grader" as const, id: "g@1" },
@@ -105,16 +91,10 @@ describe("summarizeRuns", () => {
 
   it("prefers the harness verdict over the trace's own ending", () => {
     const dir = tempDir();
-    addToRunDirectory({
-      dir,
-      statelogFiles: [statelogFile(agentStartLine("t1"))],
-      codeEntries: [],
-      annotationFiles: [],
-    });
-    // A run row written directly through the annotation import path.
-    const rowFile = path.join(tempDir("ann-"), "annotations.jsonl");
+    writeStatelog(dir, agentStartLine("t1"));
+    // A run row written directly, as an import would.
     fs.writeFileSync(
-      rowFile,
+      path.join(dir, "annotations.jsonl"),
       JSON.stringify(
         completeAnnotation(
           {
@@ -130,7 +110,6 @@ describe("summarizeRuns", () => {
         ),
       ) + "\n",
     );
-    addToRunDirectory({ dir, statelogFiles: [], codeEntries: [], annotationFiles: [rowFile] });
     expect(summarizeRuns(readRunDirectory(dir, quiet))[0].ended).toBe("timeout");
   });
 });

--- a/packages/agency-lang/lib/runDirectory/mutations.test.ts
+++ b/packages/agency-lang/lib/runDirectory/mutations.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from "vitest";
 
 import { computeCodeIdentity } from "./codeIdentity.js";
 import {
-  addToRunDirectory,
+  wrapTracesAsRunDirectories,
   recordCompletedRun,
   recordGradingPass,
   recordNote,
@@ -24,6 +24,16 @@ function statelogFile(...lines: string[]): string {
   return file;
 }
 
+/** A run directory written by hand; the reader still accepts several traces. */
+function directoryWithTraces(...traceIds: string[]): string {
+  const dir = tempDir();
+  fs.writeFileSync(
+    runDirPaths(dir).statelog,
+    traceIds.map((id) => agentStartLine(id)).join("\n") + "\n",
+  );
+  return dir;
+}
+
 function scoreDraft(traceId: string, name: string, value: number): ScoreDraft {
   return {
     traceId,
@@ -35,90 +45,119 @@ function scoreDraft(traceId: string, name: string, value: number): ScoreDraft {
   };
 }
 
-describe("addToRunDirectory", () => {
-  it("adds statelogs, code, workdir and annotations in one request", () => {
+describe("wrapTracesAsRunDirectories", () => {
+  it("writes one run directory per trace, with code where it matches, and skips existing children", () => {
     const project = writeProject({ "main.agency": "node main() { return 1 }\n" });
     const entry = path.join(project, "main.agency");
     const identity = computeCodeIdentity(entry);
-    const dir = tempDir();
-    const log = statelogFile(agentStartLine("t1", identity), statelogLine("t1", "agentEnd"));
-    const workdir = writeProject({ "out.txt": "done" });
+    const group = tempDir();
+    const log = statelogFile(
+      agentStartLine("t1", identity),
+      statelogLine("t1", "agentEnd"),
+      agentStartLine("t2"),
+      agentStartLine("t3"),
+    );
 
-    const result = addToRunDirectory({
-      dir,
-      statelogFiles: [log],
-      codeEntries: [entry],
-      workdir: { traceId: "t1", sourceDir: workdir },
-      annotationFiles: [],
-    });
-    expect(result.statelogs).toEqual({ added: 1, skipped: 0 });
-    expect(result.code).toEqual({ added: 1, skipped: 0 });
-    expect(result.workdirs).toEqual({ added: 1, skipped: 0 });
-    expect(result.snapshot.traces.map((trace) => trace.traceId)).toEqual(["t1"]);
-    const paths = runDirPaths(dir);
-    expect(fs.existsSync(path.join(paths.codeDir, identity.closureHash, "main.agency"))).toBe(true);
-    expect(fs.existsSync(path.join(paths.workdirDir, "t1", "out.txt"))).toBe(true);
-    expect(fs.existsSync(paths.lock)).toBe(false);
-
-    const again = addToRunDirectory({
-      dir,
+    const result = wrapTracesAsRunDirectories({
+      groupDir: group,
       statelogFiles: [log],
       codeEntries: [entry],
       annotationFiles: [],
     });
-    expect(again.statelogs).toEqual({ added: 0, skipped: 1 });
-    expect(again.code).toEqual({ added: 0, skipped: 1 });
+    expect(result.written).toEqual(["t1", "t2", "t3"].map((id) => path.join(group, id)));
+    expect(result.skipped).toEqual([]);
+    const t1 = runDirPaths(path.join(group, "t1"));
+    expect(readRunDirectory(t1.dir, quiet).traces.map((trace) => trace.traceId)).toEqual(["t1"]);
+    expect(fs.existsSync(path.join(t1.codeDir, "main.agency"))).toBe(true);
+    expect(fs.existsSync(runDirPaths(path.join(group, "t2")).codeDir)).toBe(false);
+    expect(fs.existsSync(t1.lock)).toBe(false);
+    expect(fs.existsSync(path.join(group, ".staging"))).toBe(false);
+
+    const again = wrapTracesAsRunDirectories({
+      groupDir: group,
+      statelogFiles: [log],
+      codeEntries: [],
+      annotationFiles: [],
+    });
+    expect(again.written).toEqual([]);
+    expect(again.skipped.map((skip) => skip.traceId)).toEqual(["t1", "t2", "t3"]);
   });
 
-  it("leaves every target byte-identical when any statelog conflicts", () => {
-    const dir = tempDir();
-    const first = statelogFile(agentStartLine("t1"));
-    addToRunDirectory({ dir, statelogFiles: [first], codeEntries: [], annotationFiles: [] });
-    const paths = runDirPaths(dir);
-    const before = fs.readFileSync(paths.statelog, "utf8");
+  it("--trace picks one; a workdir needs one trace; a conflicting id writes nothing", () => {
+    const group = tempDir();
+    const log = statelogFile(agentStartLine("t1"), agentStartLine("t2"));
+    const workdir = writeProject({ "out.txt": "done" });
+    expect(() =>
+      wrapTracesAsRunDirectories({
+        groupDir: group,
+        statelogFiles: [log],
+        codeEntries: [],
+        workdir: { sourceDir: workdir },
+        annotationFiles: [],
+      }),
+    ).toThrow(/--trace/);
+    const one = wrapTracesAsRunDirectories({
+      groupDir: group,
+      statelogFiles: [log],
+      trace: "t2",
+      codeEntries: [],
+      workdir: { sourceDir: workdir },
+      annotationFiles: [],
+    });
+    expect(one.written).toEqual([path.join(group, "t2")]);
+    const t2 = runDirPaths(path.join(group, "t2"));
+    expect(fs.existsSync(path.join(t2.workdirDir, "out.txt"))).toBe(true);
+    expect(fs.existsSync(t2.workdirSidecar)).toBe(true);
 
-    const fresh = statelogFile(agentStartLine("t2"));
     const conflicting = statelogFile(statelogLine("t1", "agentStart", { changed: true }));
     expect(() =>
-      addToRunDirectory({
-        dir,
-        statelogFiles: [fresh, conflicting],
+      wrapTracesAsRunDirectories({
+        groupDir: group,
+        statelogFiles: [log, conflicting],
         codeEntries: [],
         annotationFiles: [],
       }),
     ).toThrow(/t1/);
-    expect(fs.readFileSync(paths.statelog, "utf8")).toBe(before);
-    expect(fs.existsSync(paths.lock)).toBe(false);
+    expect(fs.existsSync(path.join(group, "t1"))).toBe(false);
   });
 
-  it("imports annotation rows idempotently", () => {
-    const dir = tempDir();
-    addToRunDirectory({
-      dir,
+  it("routes annotation rows to the child their trace names, idempotently, and refuses orphans", () => {
+    const source = tempDir();
+    wrapTracesAsRunDirectories({
+      groupDir: source,
       statelogFiles: [statelogFile(agentStartLine("t1"))],
       codeEntries: [],
       annotationFiles: [],
     });
-    recordNote({ dir, traceId: "t1", annotator: human, text: "slow" });
+    const sourceRun = path.join(source, "t1");
+    recordNote({ dir: sourceRun, traceId: "t1", annotator: human, text: "slow" });
+    const rows = runDirPaths(sourceRun).annotations;
+
+    const group = tempDir();
+    wrapTracesAsRunDirectories({
+      groupDir: group,
+      statelogFiles: [statelogFile(agentStartLine("t1"), agentStartLine("t2"))],
+      codeEntries: [],
+      annotationFiles: [rows, rows],
+    });
+    expect(readRunDirectory(path.join(group, "t1"), quiet).annotationRows).toHaveLength(1);
+    expect(readRunDirectory(path.join(group, "t2"), quiet).annotationRows).toHaveLength(0);
+
     const other = tempDir();
-    addToRunDirectory({
-      dir: other,
-      statelogFiles: [statelogFile(agentStartLine("t1"))],
-      codeEntries: [],
-      annotationFiles: [],
-    });
-    const imported = addToRunDirectory({
-      dir: other,
-      statelogFiles: [],
-      codeEntries: [],
-      annotationFiles: [runDirPaths(dir).annotations, runDirPaths(dir).annotations],
-    });
-    expect(imported.annotations).toEqual({ added: 1, skipped: 1 });
+    expect(() =>
+      wrapTracesAsRunDirectories({
+        groupDir: other,
+        statelogFiles: [statelogFile(agentStartLine("t9"))],
+        codeEntries: [],
+        annotationFiles: [rows],
+      }),
+    ).toThrow(/t1/);
+    expect(fs.existsSync(path.join(other, "t9"))).toBe(false);
   });
 });
 
 describe("recordCompletedRun", () => {
-  it("merges the staged statelog, attaches code and workdir, and appends the run row", () => {
+  it("writes the staged statelog, attaches code and workdir, and appends the run row", () => {
     const project = writeProject({ "main.agency": "node main() { return 1 }\n" });
     const entry = path.join(project, "main.agency");
     const dir = tempDir();
@@ -131,7 +170,7 @@ describe("recordCompletedRun", () => {
       dir,
       stagedStatelogFile: staged,
       codeEntry: entry,
-      workdir: { traceId: "t1", sourceDir: workdir },
+      workdir: { sourceDir: workdir },
       run: {
         traceId: "t1",
         annotator: { kind: "harness", id: "eval@test" },
@@ -146,7 +185,8 @@ describe("recordCompletedRun", () => {
     });
     expect(result.annotation.kind).toBe("run");
     expect(result.snapshot.effectiveAnnotations.t1.run?.id).toBe(result.annotation.id);
-    expect(fs.existsSync(path.join(runDirPaths(dir).workdirDir, "t1", "out.txt"))).toBe(true);
+    expect(fs.existsSync(path.join(runDirPaths(dir).workdirDir, "out.txt"))).toBe(true);
+    expect(fs.existsSync(path.join(runDirPaths(dir).codeDir, "main.agency"))).toBe(true);
     expect(fs.existsSync(runDirPaths(dir).lock)).toBe(false);
   });
 });
@@ -192,22 +232,22 @@ describe("recordCompletedRun preflight", () => {
       recordCompletedRun({ dir, stagedStatelogFile: staged, run: { traceId: "t1", ...run } }),
     ).toThrow(/could not be parsed/);
     expect(fs.existsSync(runDirPaths(dir).statelog)).toBe(false);
+    const group = tempDir();
     expect(() =>
-      addToRunDirectory({ dir, statelogFiles: [staged], codeEntries: [], annotationFiles: [] }),
+      wrapTracesAsRunDirectories({
+        groupDir: group,
+        statelogFiles: [staged],
+        codeEntries: [],
+        annotationFiles: [],
+      }),
     ).toThrow(/could not be parsed/);
-    expect(fs.existsSync(runDirPaths(dir).statelog)).toBe(false);
+    expect(fs.existsSync(path.join(group, "t1"))).toBe(false);
   });
 });
 
 describe("recordNote", () => {
   it("is idempotent and refuses an unknown trace", () => {
-    const dir = tempDir();
-    addToRunDirectory({
-      dir,
-      statelogFiles: [statelogFile(agentStartLine("t1"))],
-      codeEntries: [],
-      annotationFiles: [],
-    });
+    const dir = directoryWithTraces("t1");
     const first = recordNote({ dir, traceId: "t1", annotator: human, text: "slow" });
     const second = recordNote({ dir, traceId: "t1", annotator: human, text: "slow" });
     expect(second.id).toBe(first.id);
@@ -220,14 +260,7 @@ describe("recordNote", () => {
 
 describe("recordGradingPass", () => {
   function directory(): string {
-    const dir = tempDir();
-    addToRunDirectory({
-      dir,
-      statelogFiles: [statelogFile(agentStartLine("t1"), agentStartLine("t2"))],
-      codeEntries: [],
-      annotationFiles: [],
-    });
-    return dir;
+    return directoryWithTraces("t1", "t2");
   }
 
   it("records a complete pass that becomes effective; a second pass supersedes it", () => {
@@ -292,13 +325,7 @@ describe("recordGradingPass", () => {
 
 describe("torn-tail repair", () => {
   it("truncates a partial final line before appending", () => {
-    const dir = tempDir();
-    addToRunDirectory({
-      dir,
-      statelogFiles: [statelogFile(agentStartLine("t1"))],
-      codeEntries: [],
-      annotationFiles: [],
-    });
+    const dir = directoryWithTraces("t1");
     const paths = runDirPaths(dir);
     fs.appendFileSync(paths.annotations, '{"v":1,"id":"ann_torn');
     fs.appendFileSync(paths.statelog, '{"trace_id":"half');

--- a/packages/agency-lang/lib/runDirectory/mutations.test.ts
+++ b/packages/agency-lang/lib/runDirectory/mutations.test.ts
@@ -121,6 +121,29 @@ describe("wrapTracesAsRunDirectories", () => {
     expect(fs.existsSync(path.join(group, "t1"))).toBe(false);
   });
 
+  it("--trace that matches nothing or several is an error; an id that would escape the group is refused", () => {
+    const group = tempDir();
+    const log = statelogFile(agentStartLine("abc-1"), agentStartLine("abc-2"));
+    const request = { groupDir: group, statelogFiles: [log], codeEntries: [], annotationFiles: [] };
+    expect(() => wrapTracesAsRunDirectories({ ...request, trace: "zzz" })).toThrow(/No trace/);
+    expect(() => wrapTracesAsRunDirectories({ ...request, trace: "abc" })).toThrow(/ambiguous/);
+    // A unique prefix is enough.
+    expect(wrapTracesAsRunDirectories({ ...request, trace: "abc-2" }).written).toEqual([
+      path.join(group, "abc-2"),
+    ]);
+
+    const escaping = tempDir();
+    expect(() =>
+      wrapTracesAsRunDirectories({
+        groupDir: escaping,
+        statelogFiles: [statelogFile(agentStartLine("../escaped"))],
+        codeEntries: [],
+        annotationFiles: [],
+      }),
+    ).toThrow(/outside/);
+    expect(fs.existsSync(path.join(escaping, "..", "escaped"))).toBe(false);
+  });
+
   it("routes annotation rows to the child their trace names, idempotently, and refuses orphans", () => {
     const source = tempDir();
     wrapTracesAsRunDirectories({

--- a/packages/agency-lang/lib/runDirectory/mutations.test.ts
+++ b/packages/agency-lang/lib/runDirectory/mutations.test.ts
@@ -142,6 +142,47 @@ describe("wrapTracesAsRunDirectories", () => {
       }),
     ).toThrow(/outside/);
     expect(fs.existsSync(path.join(escaping, "..", "escaped"))).toBe(false);
+
+    expect(() =>
+      wrapTracesAsRunDirectories({
+        groupDir: escaping,
+        statelogFiles: [statelogFile(agentStartLine(".staging"))],
+        codeEntries: [],
+        annotationFiles: [],
+      }),
+    ).toThrow(/reserved/);
+  });
+
+  it("validates every child path before publishing any run directory", () => {
+    const group = tempDir();
+
+    expect(() =>
+      wrapTracesAsRunDirectories({
+        groupDir: group,
+        statelogFiles: [statelogFile(agentStartLine("valid"), agentStartLine("../escaped"))],
+        codeEntries: [],
+        annotationFiles: [],
+      }),
+    ).toThrow(/outside/);
+
+    expect(fs.existsSync(path.join(group, "valid"))).toBe(false);
+  });
+
+  it("removes staging when assembling a run directory fails", () => {
+    const group = tempDir();
+
+    expect(() =>
+      wrapTracesAsRunDirectories({
+        groupDir: group,
+        statelogFiles: [statelogFile(agentStartLine("t1"))],
+        codeEntries: [],
+        workdir: { sourceDir: path.join(group, "missing") },
+        annotationFiles: [],
+      }),
+    ).toThrow(/not a directory/);
+
+    expect(fs.existsSync(path.join(group, ".staging"))).toBe(false);
+    expect(fs.existsSync(path.join(group, "t1"))).toBe(false);
   });
 
   it("routes annotation rows to the child their trace names, idempotently, and refuses orphans", () => {

--- a/packages/agency-lang/lib/runDirectory/mutations.ts
+++ b/packages/agency-lang/lib/runDirectory/mutations.ts
@@ -3,6 +3,8 @@ import * as path from "path";
 
 import { nanoid } from "nanoid";
 
+import { safeDeleteDirectoryWithin } from "@/utils.js";
+
 import { appendDurably } from "./durableWrite.js";
 
 import {
@@ -26,6 +28,7 @@ import {
   applyWorkdirAttachment,
   planWorkdirAttachment,
   type WorkdirAttachmentRequest,
+  type WorkdirAttachmentPlan,
 } from "./attachWorkdir.js";
 import { acquireRunDirLock } from "./lock.js";
 import {
@@ -76,10 +79,30 @@ export type WrapTracesResult = {
   skipped: { traceId: string; reason: string }[];
 };
 
+type RunDirectoryAssemblyPlan = {
+  dir: string;
+  statelog: StatelogMergePlan;
+  code: CodeAttachmentPlan[];
+  workdir?: WorkdirAttachmentPlan;
+  annotationDrafts: AnnotationDraft[];
+};
+
+type WrappedRunPlan = {
+  childDir: string;
+  stagingDir: string;
+  assembly: RunDirectoryAssemblyPlan;
+};
+
+type WrapTracesPlan = {
+  stagingRoot: string;
+  writes: WrappedRunPlan[];
+  skipped: { traceId: string; reason: string }[];
+};
+
 /**
  * `agency runs add` and `agency run --capture-workdir`: make one run directory
  * per trace in the given statelogs, under `groupDir`. Each child is assembled
- * in `<groupDir>/.staging/<traceId>` and renamed into place, so a child is
+ * below `<groupDir>/.staging/` and renamed into place, so a child is
  * either whole or absent. A child that already exists is skipped, never
  * touched. Code is attached to the traces that recorded its closure hash and
  * must match at least one; annotation rows go to the child their `traceId`
@@ -89,6 +112,13 @@ export function wrapTracesAsRunDirectories(
   request: WrapTracesRequest,
   options: MutationOptions = {},
 ): WrapTracesResult {
+  const plan = planWrappedRuns(request, options);
+  return applyWrappedRuns(plan, options);
+}
+
+/** Resolve and validate every child before creating the group or staging any
+ *  run. The executor therefore receives only complete, writable requests. */
+function planWrappedRuns(request: WrapTracesRequest, options: MutationOptions): WrapTracesPlan {
   const reportWarning = options.reportWarning ?? (() => {});
   const traces = selectTraces(request);
   if (request.workdir !== undefined && traces.length > 1) {
@@ -113,45 +143,47 @@ export function wrapTracesAsRunDirectories(
     hash: computeCodeIdentity(entry).closureHash,
   }));
   const recordedAnywhere = recordedClosureHashes(traces);
-  for (const code of codeIdentities) {
-    if (!recordedAnywhere.includes(code.hash)) {
-      const known = recordedAnywhere.length === 0 ? "none recorded" : recordedAnywhere.join(", ");
-      throw new CodeMismatchError(
-        `${code.entry} hashes to ${code.hash}, which none of the traces recorded as its code ` +
-          `(${known}). Attach the code that actually ran.`,
-      );
-    }
+  const unmatchedCode = codeIdentities.find((code) => !recordedAnywhere.includes(code.hash));
+  if (unmatchedCode !== undefined) {
+    const known = recordedAnywhere.length === 0 ? "none recorded" : recordedAnywhere.join(", ");
+    throw new CodeMismatchError(
+      `${unmatchedCode.entry} hashes to ${unmatchedCode.hash}, which none of the traces recorded ` +
+        `as its code (${known}). Attach the code that actually ran.`,
+    );
   }
 
-  const result: WrapTracesResult = { written: [], skipped: [] };
-  const stagingRoot = path.join(request.groupDir, ".staging");
-  for (const trace of traces) {
-    const child = childDirFor(request.groupDir, trace.traceId);
-    if (fs.existsSync(child)) {
-      result.skipped.push({ traceId: trace.traceId, reason: `${child} already exists` });
-      continue;
-    }
-    const staging = path.join(stagingRoot, trace.traceId);
-    fs.rmSync(staging, { recursive: true, force: true });
-    fs.mkdirSync(staging, { recursive: true });
-    const recorded = recordedClosureHashes([trace]);
-    assembleRunDirectory(
-      {
-        dir: staging,
-        trace,
-        codeEntries: codeIdentities
-          .filter((code) => recorded.includes(code.hash))
-          .map((code) => code.entry),
-        workdir: request.workdir,
-        annotationDrafts: annotationDrafts.filter((draft) => draft.traceId === trace.traceId),
-      },
-      options,
-    );
-    fs.renameSync(staging, child);
-    result.written.push(child);
-  }
-  removeIfEmpty(stagingRoot);
-  return result;
+  const groupDir = path.resolve(request.groupDir);
+  const stagingRoot = path.join(groupDir, ".staging");
+  const children = traces.map((trace) => {
+    const childDir = childDirFor(groupDir, trace.traceId);
+    return { trace, childDir, exists: fs.existsSync(childDir) };
+  });
+  const skipped = children
+    .filter((child) => child.exists)
+    .map(({ trace, childDir }) => ({
+      traceId: trace.traceId,
+      reason: `${childDir} already exists`,
+    }));
+  const writes = children
+    .filter((child) => !child.exists)
+    .map(({ trace, childDir }) => {
+      const stagingDir = path.join(stagingRoot, nanoid());
+      const recorded = recordedClosureHashes([trace]);
+      return {
+        childDir,
+        stagingDir,
+        assembly: planRunDirectoryAssembly({
+          dir: stagingDir,
+          trace,
+          codeEntries: codeIdentities
+            .filter((code) => recorded.includes(code.hash))
+            .map((code) => code.entry),
+          workdir: request.workdir,
+          annotationDrafts: annotationDrafts.filter((draft) => draft.traceId === trace.traceId),
+        }),
+      };
+    });
+  return { stagingRoot, writes, skipped };
 }
 
 /** The traces the request is about, with the same id never carrying two
@@ -181,39 +213,93 @@ function childDirFor(groupDir: string, traceId: string): string {
         `${groupDir}.`,
     );
   }
+  if (child === path.join(path.resolve(groupDir), ".staging")) {
+    throw new Error(`Refusing to write trace "${traceId}": .staging is reserved for assembly.`);
+  }
   return child;
 }
 
-/** Write one trace's statelog into `dir`, then attach code, workdir and rows
- *  under the directory's writer lock. */
-function assembleRunDirectory(
-  args: {
-    dir: string;
-    trace: Trace;
-    codeEntries: string[];
-    workdir?: WorkdirAttachmentRequest;
-    annotationDrafts: AnnotationDraft[];
-  },
-  options: MutationOptions,
-): void {
-  withWriter(args.dir, options, (paths, snapshot, reportWarning) => {
-    applyStatelogMerge(paths, planStatelogMerge(snapshot.traces, [args.trace]));
-    const merged: RunDirectorySnapshot = { ...snapshot, traces: [args.trace] };
-    const codePlans = args.codeEntries.map((entry) => planCodeAttachment(merged, entry, paths));
-    const workdirPlan =
-      args.workdir === undefined ? undefined : planWorkdirAttachment(merged, args.workdir, paths);
-    for (const plan of codePlans) applyCodeAttachment(paths, plan);
-    if (workdirPlan !== undefined) applyWorkdirAttachment(paths, workdirPlan, now(options));
-    appendRows(paths.annotations, args.annotationDrafts, options, reportWarning);
+function planRunDirectoryAssembly(args: {
+  dir: string;
+  trace: Trace;
+  codeEntries: string[];
+  workdir?: WorkdirAttachmentRequest;
+  annotationDrafts: AnnotationDraft[];
+}): RunDirectoryAssemblyPlan {
+  const paths = runDirPaths(args.dir);
+  const snapshot: RunDirectorySnapshot = {
+    dir: args.dir,
+    hasStatelog: false,
+    traces: [args.trace],
+    annotationRows: [],
+    effectiveAnnotations: {},
+  };
+  return {
+    dir: args.dir,
+    statelog: planStatelogMerge([], [args.trace]),
+    code: args.codeEntries.map((entry) => planCodeAttachment(snapshot, entry, paths)),
+    workdir:
+      args.workdir === undefined ? undefined : planWorkdirAttachment(snapshot, args.workdir, paths),
+    annotationDrafts: args.annotationDrafts,
+  };
+}
+
+function applyWrappedRuns(plan: WrapTracesPlan, options: MutationOptions): WrapTracesResult {
+  const result: WrapTracesResult = { written: [], skipped: plan.skipped };
+  try {
+    for (const run of plan.writes) {
+      fs.mkdirSync(plan.stagingRoot, { recursive: true });
+      fs.mkdirSync(run.stagingDir);
+      try {
+        applyRunDirectoryAssembly(run.assembly, options);
+        fs.renameSync(run.stagingDir, run.childDir);
+        result.written.push(run.childDir);
+      } catch (error) {
+        removeStagedRun(plan.stagingRoot, run.stagingDir);
+        throw error;
+      }
+    }
+  } finally {
+    removeEmptyDirectory(plan.stagingRoot);
+  }
+  return result;
+}
+
+function applyRunDirectoryAssembly(plan: RunDirectoryAssemblyPlan, options: MutationOptions): void {
+  withWriter(plan.dir, options, (paths, _snapshot, reportWarning) => {
+    applyStatelogMerge(paths, plan.statelog);
+    for (const codePlan of plan.code) {
+      applyCodeAttachment(paths, codePlan);
+    }
+    if (plan.workdir !== undefined) {
+      applyWorkdirAttachment(paths, plan.workdir, now(options));
+    }
+    appendRows(paths.annotations, plan.annotationDrafts, options, reportWarning);
     return {};
   });
 }
 
-function removeIfEmpty(dir: string): void {
+function removeStagedRun(stagingRoot: string, stagingDir: string): void {
+  if (!fs.existsSync(stagingDir)) {
+    return;
+  }
+  const deleted = safeDeleteDirectoryWithin(stagingRoot, stagingDir);
+  if (!deleted.success) {
+    throw new Error(deleted.message ?? `Could not remove ${stagingDir}.`);
+  }
+}
+
+function removeEmptyDirectory(dir: string): void {
+  if (!fs.existsSync(dir)) {
+    return;
+  }
   try {
     fs.rmdirSync(dir);
-  } catch {
-    // not empty, or already gone — either is fine
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code !== "ENOENT" && code !== "ENOTEMPTY") {
+      throw error;
+    }
   }
 }
 

--- a/packages/agency-lang/lib/runDirectory/mutations.ts
+++ b/packages/agency-lang/lib/runDirectory/mutations.ts
@@ -1,4 +1,5 @@
 import * as fs from "fs";
+import * as path from "path";
 
 import { nanoid } from "nanoid";
 
@@ -13,11 +14,17 @@ import {
   type RunPayload,
   type Score,
 } from "./annotations.js";
-import { applyCodeAttachment, planCodeAttachment, type CodeAttachmentPlan } from "./attachCode.js";
+import {
+  applyCodeAttachment,
+  CodeMismatchError,
+  planCodeAttachment,
+  recordedClosureHashes,
+  type CodeAttachmentPlan,
+} from "./attachCode.js";
+import { computeCodeIdentity } from "./codeIdentity.js";
 import {
   applyWorkdirAttachment,
   planWorkdirAttachment,
-  type WorkdirAttachmentPlan,
   type WorkdirAttachmentRequest,
 } from "./attachWorkdir.js";
 import { acquireRunDirLock } from "./lock.js";
@@ -28,7 +35,7 @@ import {
   type StatelogMergePlan,
 } from "./mergeStatelog.js";
 import { readRunDirectory, runDirPaths, type RunDirectorySnapshot } from "./runDir.js";
-import { readTracesOrThrow } from "./traces.js";
+import { matchTrace, readTracesOrThrow, type Trace } from "./traces.js";
 
 /**
  * The public writes on a run directory. Each operation describes a domain
@@ -51,75 +58,163 @@ export type MutationOptions = {
   now?(): string;
 };
 
-// --- addToRunDirectory ----------------------------------------------------
+// --- wrapTracesAsRunDirectories --------------------------------------------
 
-export type AddToRunDirectoryRequest = {
-  dir: string;
+export type WrapTracesRequest = {
+  /** The group directory; one `<groupDir>/<traceId>/` is written per trace. */
+  groupDir: string;
   statelogFiles: string[];
+  /** Keep only this trace (full id or unique prefix). */
+  trace?: string;
   codeEntries: string[];
   workdir?: WorkdirAttachmentRequest;
   annotationFiles: string[];
 };
 
-export type MutationCounts = { added: number; skipped: number };
-
-export type AddToRunDirectoryResult = {
-  statelogs: MutationCounts;
-  /** `describeStatelogMerge` for this request: names what was already there. */
-  statelogSummary: string;
-  code: MutationCounts;
-  workdirs: MutationCounts;
-  annotations: MutationCounts;
-  snapshot: RunDirectorySnapshot;
+export type WrapTracesResult = {
+  written: string[];
+  skipped: { traceId: string; reason: string }[];
 };
 
-export function addToRunDirectory(
-  request: AddToRunDirectoryRequest,
+/**
+ * `agency runs add` and `agency run --capture-workdir`: make one run directory
+ * per trace in the given statelogs, under `groupDir`. Each child is assembled
+ * in `<groupDir>/.staging/<traceId>` and renamed into place, so a child is
+ * either whole or absent. A child that already exists is skipped, never
+ * touched. Code is attached to the traces that recorded its closure hash and
+ * must match at least one; annotation rows go to the child their `traceId`
+ * names and must each name one of the traces.
+ */
+export function wrapTracesAsRunDirectories(
+  request: WrapTracesRequest,
   options: MutationOptions = {},
-): AddToRunDirectoryResult {
-  return withWriter(request.dir, options, (paths, snapshot, reportWarning) => {
-    // Plan everything first. Statelogs are planned as one incoming set so a
-    // conflict in the third file also stops the first from being written.
-    const incoming = request.statelogFiles.flatMap(readTracesOrThrow);
-    const statelogPlan = planStatelogMerge(snapshot.traces, incoming);
-    if (statelogPlan.refused.length > 0) {
-      throw new Error(describeStatelogMerge(statelogPlan, request.dir));
-    }
-    // Code and workdir plans need the traces the statelogs are about to add,
-    // so plan them against the merged view.
-    const merged: RunDirectorySnapshot = {
-      ...snapshot,
-      traces: [...snapshot.traces, ...statelogPlan.add],
-    };
-    const codePlans = request.codeEntries.map((entry) => planCodeAttachment(merged, entry, paths));
-    const workdirPlan =
-      request.workdir === undefined
-        ? undefined
-        : planWorkdirAttachment(merged, request.workdir, paths);
-    const annotationDrafts = request.annotationFiles.flatMap((file) =>
-      readAnnotations(file, reportWarning).map(draftOf),
+): WrapTracesResult {
+  const reportWarning = options.reportWarning ?? (() => {});
+  const traces = selectTraces(request);
+  if (request.workdir !== undefined && traces.length > 1) {
+    throw new Error(
+      `--workdir needs --trace <id>: the statelog holds ${traces.length} traces ` +
+        `(${traces.map((trace) => trace.traceId).join(", ")}).`,
     );
+  }
+  const annotationDrafts = request.annotationFiles.flatMap((file) =>
+    readAnnotations(file, reportWarning).map(draftOf),
+  );
+  const ids = traces.map((trace) => trace.traceId);
+  const orphan = annotationDrafts.find((draft) => !ids.includes(draft.traceId));
+  if (orphan !== undefined) {
+    throw new Error(
+      `An annotation row names trace ${orphan.traceId}, which is not among the traces being ` +
+        `wrapped (${ids.join(", ")}). Nothing was written.`,
+    );
+  }
+  const codeIdentities = request.codeEntries.map((entry) => ({
+    entry,
+    hash: computeCodeIdentity(entry).closureHash,
+  }));
+  const recordedAnywhere = recordedClosureHashes(traces);
+  for (const code of codeIdentities) {
+    if (!recordedAnywhere.includes(code.hash)) {
+      const known = recordedAnywhere.length === 0 ? "none recorded" : recordedAnywhere.join(", ");
+      throw new CodeMismatchError(
+        `${code.entry} hashes to ${code.hash}, which none of the traces recorded as its code ` +
+          `(${known}). Attach the code that actually ran.`,
+      );
+    }
+  }
 
-    // Apply, in the order that keeps a crash recoverable: traces before the
-    // things that point at them.
-    applyStatelogMerge(paths, statelogPlan);
+  const result: WrapTracesResult = { written: [], skipped: [] };
+  const stagingRoot = path.join(request.groupDir, ".staging");
+  for (const trace of traces) {
+    const child = childDirFor(request.groupDir, trace.traceId);
+    if (fs.existsSync(child)) {
+      result.skipped.push({ traceId: trace.traceId, reason: `${child} already exists` });
+      continue;
+    }
+    const staging = path.join(stagingRoot, trace.traceId);
+    fs.rmSync(staging, { recursive: true, force: true });
+    fs.mkdirSync(staging, { recursive: true });
+    const recorded = recordedClosureHashes([trace]);
+    assembleRunDirectory(
+      {
+        dir: staging,
+        trace,
+        codeEntries: codeIdentities
+          .filter((code) => recorded.includes(code.hash))
+          .map((code) => code.entry),
+        workdir: request.workdir,
+        annotationDrafts: annotationDrafts.filter((draft) => draft.traceId === trace.traceId),
+      },
+      options,
+    );
+    fs.renameSync(staging, child);
+    result.written.push(child);
+  }
+  removeIfEmpty(stagingRoot);
+  return result;
+}
+
+/** The traces the request is about, with the same id never carrying two
+ *  different event streams, and narrowed to `--trace` when given. */
+function selectTraces(request: WrapTracesRequest): Trace[] {
+  const incoming = request.statelogFiles.flatMap(readTracesOrThrow);
+  const plan = planStatelogMerge([], incoming);
+  if (plan.refused.length > 0) {
+    const ids = plan.refused.map((refusal) => refusal.traceId).join(", ");
+    throw new Error(
+      `Trace id(s) ${ids} appear more than once with different content. Nothing was written.`,
+    );
+  }
+  if (request.trace === undefined) return plan.add;
+  const match = matchTrace(plan.add, request.trace);
+  if (match.kind === "one") return [match.trace];
+  if (match.kind === "none") throw new Error(`No trace matches ${request.trace}.`);
+  throw new Error(`--trace ${request.trace} is ambiguous: ${match.ids.join(", ")}.`);
+}
+
+/** `<groupDir>/<traceId>`, refusing an id that would land outside the group. */
+function childDirFor(groupDir: string, traceId: string): string {
+  const child = path.resolve(groupDir, traceId);
+  if (path.dirname(child) !== path.resolve(groupDir)) {
+    throw new Error(
+      `Refusing to write trace "${traceId}": its id would place the run directory outside ` +
+        `${groupDir}.`,
+    );
+  }
+  return child;
+}
+
+/** Write one trace's statelog into `dir`, then attach code, workdir and rows
+ *  under the directory's writer lock. */
+function assembleRunDirectory(
+  args: {
+    dir: string;
+    trace: Trace;
+    codeEntries: string[];
+    workdir?: WorkdirAttachmentRequest;
+    annotationDrafts: AnnotationDraft[];
+  },
+  options: MutationOptions,
+): void {
+  withWriter(args.dir, options, (paths, snapshot, reportWarning) => {
+    applyStatelogMerge(paths, planStatelogMerge(snapshot.traces, [args.trace]));
+    const merged: RunDirectorySnapshot = { ...snapshot, traces: [args.trace] };
+    const codePlans = args.codeEntries.map((entry) => planCodeAttachment(merged, entry, paths));
+    const workdirPlan =
+      args.workdir === undefined ? undefined : planWorkdirAttachment(merged, args.workdir, paths);
     for (const plan of codePlans) applyCodeAttachment(paths, plan);
     if (workdirPlan !== undefined) applyWorkdirAttachment(paths, workdirPlan, now(options));
-    const annotationCounts = appendAnnotations(
-      paths.annotations,
-      annotationDrafts,
-      options,
-      reportWarning,
-    );
-
-    return {
-      statelogs: { added: statelogPlan.add.length, skipped: statelogPlan.skipped.length },
-      statelogSummary: describeStatelogMerge(statelogPlan, request.dir),
-      code: countPlans(codePlans.map((plan) => plan.status === "add")),
-      workdirs: countWorkdir(workdirPlan),
-      annotations: annotationCounts,
-    };
+    appendRows(paths.annotations, args.annotationDrafts, options, reportWarning);
+    return {};
   });
+}
+
+function removeIfEmpty(dir: string): void {
+  try {
+    fs.rmdirSync(dir);
+  } catch {
+    // not empty, or already gone — either is fine
+  }
 }
 
 // --- recordCompletedRun ---------------------------------------------------
@@ -138,8 +233,8 @@ export type RecordCompletedRunRequest = {
 
 export type RecordCompletedRunResult = { annotation: Annotation; snapshot: RunDirectorySnapshot };
 
-/** The eval harness's one call per finished test: merge the staged statelog,
- *  attach code and workdir, append the `run` row. */
+/** The eval harness's one call per finished test, on a fresh directory:
+ *  write the staged statelog, attach code and workdir, append the `run` row. */
 export function recordCompletedRun(
   request: RecordCompletedRunRequest,
   options: MutationOptions = {},
@@ -367,31 +462,9 @@ function appendRows(
   return rows;
 }
 
-function appendAnnotations(
-  annotationsPath: string,
-  drafts: readonly AnnotationDraft[],
-  options: MutationOptions,
-  reportWarning: (message: string) => void,
-): MutationCounts {
-  const before = readAnnotations(annotationsPath, reportWarning).length;
-  const rows = appendRows(annotationsPath, drafts, options, reportWarning);
-  const after = readAnnotations(annotationsPath, reportWarning).length;
-  return { added: after - before, skipped: rows.length - (after - before) };
-}
-
 function draftOf(row: Annotation): AnnotationDraft {
   const { v: _v, id: _id, createdAt: _createdAt, ...draft } = row;
   return draft;
-}
-
-function countPlans(added: boolean[]): MutationCounts {
-  const count = added.filter(Boolean).length;
-  return { added: count, skipped: added.length - count };
-}
-
-function countWorkdir(plan: WorkdirAttachmentPlan | undefined): MutationCounts {
-  if (plan === undefined) return { added: 0, skipped: 0 };
-  return { added: 1, skipped: 0 };
 }
 
 function now(options: MutationOptions): string {

--- a/packages/agency-lang/lib/runDirectory/runDir.ts
+++ b/packages/agency-lang/lib/runDirectory/runDir.ts
@@ -12,16 +12,21 @@ import type { ParseError } from "@/statelog/parse.js";
 import { readTraces, type Trace } from "./traces.js";
 
 /**
- * A run directory is a plain folder: `statelog.jsonl` (any number of traces),
- * `annotations.jsonl`, and optional attachments. This module names its paths
- * and reads it into one coherent snapshot. It never writes; `mutations.ts` does.
+ * A run directory is a plain folder holding one run: `statelog.jsonl` (one
+ * trace), `annotations.jsonl`, and optional attachments — the agent's code
+ * closure directly under `code/`, a working-directory snapshot directly under
+ * `workdir/` with its `workdir.json` sidecar, free-form `notes.md`. This
+ * module names its paths and reads it into one coherent snapshot. It never
+ * writes; `mutations.ts` does.
  */
 export type RunDirectoryPaths = {
   dir: string;
   statelog: string;
   annotations: string;
+  notes: string;
   codeDir: string;
   workdirDir: string;
+  workdirSidecar: string;
   checklistsDir: string;
   lock: string;
 };
@@ -31,8 +36,10 @@ export function runDirPaths(dir: string): RunDirectoryPaths {
     dir,
     statelog: path.join(dir, "statelog.jsonl"),
     annotations: path.join(dir, "annotations.jsonl"),
+    notes: path.join(dir, "notes.md"),
     codeDir: path.join(dir, "code"),
     workdirDir: path.join(dir, "workdir"),
+    workdirSidecar: path.join(dir, "workdir.json"),
     checklistsDir: path.join(dir, "checklists"),
     lock: path.join(dir, ".lock"),
   };

--- a/packages/agency-lang/lib/runsExplorer/sources.ts
+++ b/packages/agency-lang/lib/runsExplorer/sources.ts
@@ -7,6 +7,8 @@
 import * as fs from "fs";
 import * as path from "path";
 
+import { childRunDirectories, isRunDirectory } from "@/runDirectory/findRuns.js";
+
 export type Source = { kind: "runDir"; dir: string } | { kind: "statelog"; file: string };
 
 export type Discovery = {
@@ -92,10 +94,7 @@ function classifyDirectory(
     sources.push({ kind: "runDir", dir: resolved });
     return;
   }
-  const childRuns = fs
-    .readdirSync(resolved)
-    .map((child) => path.join(resolved, child))
-    .filter(isRunDirectory);
+  const childRuns = childRunDirectories(resolved);
   if (childRuns.length === 0) {
     errors.push(`${rawPath}: directory contains no run directories — ${ACCEPTED_KINDS}`);
     return;
@@ -103,10 +102,6 @@ function classifyDirectory(
   for (const dir of childRuns) {
     sources.push({ kind: "runDir", dir });
   }
-}
-
-export function isRunDirectory(dir: string): boolean {
-  return fs.existsSync(path.join(dir, "statelog.jsonl"));
 }
 
 type FirstLineSniff =

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -426,7 +426,7 @@ export function createProgram(deps: CliDependencies = {}): Command {
         )
         .option(
           "--capture-workdir <dir>",
-          "After the run, add its trace, code and a snapshot of the working directory to this run directory (see: agency runs list)",
+          "After the run, write its trace, code and a snapshot of the working directory as the run directory <dir>/<traceId>/ (see: agency runs list)",
         )
     );
   }
@@ -847,7 +847,7 @@ export function createProgram(deps: CliDependencies = {}): Command {
         if (costUsd !== undefined) {
           console.log(`total LLM cost: $${costUsd.toFixed(2)}`);
         }
-        console.log(result.runDir);
+        console.log(`${result.tests.length} run(s) written to ${result.runDir}`);
         console.log(`grade it with: agency eval grade ${result.runDir}`);
       },
     );
@@ -881,10 +881,10 @@ export function createProgram(deps: CliDependencies = {}): Command {
 
   evalCmd
     .command("grade")
-    .description("Score a finished eval run without re-running the agent")
+    .description("Score finished runs without re-running the agent")
     .argument(
-      "<runDir>",
-      "A run directory: from `agency eval run`, `agency run --capture-workdir`, or `agency runs add`",
+      "<path>",
+      "A run directory, or a directory of run directories (what `agency eval run --out` writes)",
     )
     .option("--graders <file>", "TypeScript grading module (default-exports graders)")
     .option(
@@ -892,14 +892,20 @@ export function createProgram(deps: CliDependencies = {}): Command {
       "Judge every trace against this goal with the built-in LLM judge (traces whose test recorded its own goal keep it; not with --graders)",
     )
     .option("-o, --out <path>", "Also write the grading summary here as JSON")
-    .action(async (runDir: string, opts: { graders?: string; goal?: string; out?: string }) => {
-      const grading = await evalGrade(runDir, { ...opts, config: getConfig() }).catch(
+    .action(async (target: string, opts: { graders?: string; goal?: string; out?: string }) => {
+      const result = await evalGrade(target, { ...opts, config: getConfig() }).catch(
         failProjectCommand,
       );
-      for (const line of formatGrading(grading.objective, grading.perInput)) {
-        console.log(line);
+      for (const run of result.runs) {
+        if (result.runs.length > 1) console.log(run.dir);
+        for (const line of formatGrading(run.grading.objective, run.grading.perInput)) {
+          console.log(line);
+        }
       }
-      if (!grading.gatesPassed) {
+      if (result.runs.length > 1) {
+        console.log(`mean ${result.mean.toFixed(3)} over ${result.runs.length} runs`);
+      }
+      if (!result.gatesPassed) {
         process.exit(2);
       }
     });

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -65,7 +65,8 @@ import {
 import { evalGrade } from "@/cli/eval/grade.js";
 import { resolveRunStatelog } from "@/cli/eval/logs.js";
 import { evalRun, totalRunCostUsd } from "@/cli/eval/run.js";
-import { formatGrading } from "@/eval/grading/gradeBreakdown.js";
+import { formatGradeResult } from "@/cli/eval/formatGrade.js";
+import { ttyColor } from "@/utils/termcolors.js";
 import { evalOptimize } from "@/cli/eval/optimize.js";
 import { renderDiagnosticText, renderDiagnosticList } from "@/cli/explain.js";
 import { AgencyConfig, applyCliFlags, type CliFlags, redactConfigSecrets } from "@/config.js";
@@ -843,11 +844,16 @@ export function createProgram(deps: CliDependencies = {}): Command {
         // beside the agent, not from eval flags.
         const result = await evalRun({ agent, ...opts, config: getConfig() });
         console.log(`Run completed: ${result.okCount}/${result.tests.length} tests ok`);
+        for (const test of result.tests) {
+          if (test.status === "error") {
+            console.log(`  ${ttyColor.red(`${test.testId} error:`)} ${test.errorMessage ?? ""}`);
+          }
+        }
         const costUsd = totalRunCostUsd(result.runDir);
         if (costUsd !== undefined) {
           console.log(`total LLM cost: $${costUsd.toFixed(2)}`);
         }
-        console.log(`${result.tests.length} run(s) written to ${result.runDir}`);
+        console.log(`runs written under ${result.runDir}`);
         console.log(`grade it with: agency eval grade ${result.runDir}`);
       },
     );
@@ -896,15 +902,7 @@ export function createProgram(deps: CliDependencies = {}): Command {
       const result = await evalGrade(target, { ...opts, config: getConfig() }).catch(
         failProjectCommand,
       );
-      for (const run of result.runs) {
-        if (result.runs.length > 1) console.log(run.dir);
-        for (const line of formatGrading(run.grading.objective, run.grading.perInput)) {
-          console.log(line);
-        }
-      }
-      if (result.runs.length > 1) {
-        console.log(`mean ${result.mean.toFixed(3)} over ${result.runs.length} runs`);
-      }
+      for (const line of formatGradeResult(result)) console.log(line);
       if (!result.gatesPassed) {
         process.exit(2);
       }

--- a/packages/agency-lang/tests/integration/cli-tier2/test.mjs
+++ b/packages/agency-lang/tests/integration/cli-tier2/test.mjs
@@ -416,21 +416,24 @@ function checkRunDirectory() {
   assert(existsSync(join(rdDir, "hello.jsonl")), "run --log-file wrote no statelog");
 
   const first = runCleanAgency(rdDir, ["runs", "add", "runs/hello", "--statelog", "hello.jsonl"], "runs add");
-  assertIncludes(stripAnsi(first.stdout), "Added 1 trace(s)");
-  const statelogPath = join(rdDir, "runs", "hello", "statelog.jsonl");
-  const annotationsPath = join(rdDir, "runs", "hello", "annotations.jsonl");
+  const written = stripAnsi(first.stdout).match(/wrote (\S+)/);
+  assert(written, `runs add reported no written directory:\n${first.stdout}`);
+  const runDir = written[1];
+  const statelogPath = join(runDir, "statelog.jsonl");
+  const annotationsPath = join(runDir, "annotations.jsonl");
   assert(existsSync(statelogPath), "runs add wrote no statelog.jsonl");
   const traces = readJsonLines(statelogPath);
   assert(traces.length > 0, "statelog.jsonl is empty");
   const traceId = traces[0].trace_id;
+  assert(runDir.endsWith(traceId), `run directory ${runDir} is not named for trace ${traceId}`);
 
-  // Re-adding the same statelog is idempotent: nothing new, bytes unchanged.
+  // Re-adding the same statelog skips the existing child: bytes unchanged.
   const statelogBefore = readFileSync(statelogPath);
   const second = runCleanAgency(rdDir, ["runs", "add", "runs/hello", "--statelog", "hello.jsonl"], "runs add re-run");
-  assertIncludes(stripAnsi(second.stdout), "already present");
+  assertIncludes(stripAnsi(second.stdout), "already exists");
   assert(readFileSync(statelogPath).equals(statelogBefore), "statelog.jsonl bytes changed on re-add");
 
-  const noted = runCleanAgency(rdDir, ["note", "runs/hello", "wanted a greeting", "--annotator", "tier2"], "note");
+  const noted = runCleanAgency(rdDir, ["note", runDir, "wanted a greeting", "--annotator", "tier2"], "note");
   assertIncludes(stripAnsi(noted.stdout), `Noted on trace ${traceId}`);
   const notes = readJsonLines(annotationsPath).filter((row) => row.kind === "note");
   assert(notes.length === 1, `expected 1 note annotation, got ${notes.length}`);
@@ -438,7 +441,7 @@ function checkRunDirectory() {
   assert(notes[0].text === "wanted a greeting", `note text was ${JSON.stringify(notes[0].text)}`);
 
   // `runs list` is one table row per trace; the NOTES column counts them.
-  const listed = runCleanAgency(rdDir, ["runs", "list", "runs/hello"], "runs list");
+  const listed = runCleanAgency(rdDir, ["runs", "list", runDir], "runs list");
   const listRows = stripAnsi(listed.stdout).trim().split("\n");
   assertIncludes(listRows[0], "NOTES");
   const traceRow = listRows.find((row) => row.startsWith(traceId.slice(0, 8)));

--- a/packages/agency-lang/tests/integration/cli/test.mjs
+++ b/packages/agency-lang/tests/integration/cli/test.mjs
@@ -176,7 +176,7 @@ node main(task: string): string {
 
   // --- Test 6b: agency logs --csv over the run directory just written ---
   console.log("--- Test 6b: agency logs --csv ---");
-  const csvOutput = run(dir, "npx agency logs eval-runs --csv");
+  const csvOutput = run(dir, "npx agency logs eval-runs/smoke --csv");
   assertIncludes(csvOutput, "agent");
   assertIncludes(csvOutput, "run");
   console.log("Test 6b passed");

--- a/packages/agency-lang/tests/integration/cli/test.mjs
+++ b/packages/agency-lang/tests/integration/cli/test.mjs
@@ -164,7 +164,7 @@ node main(task: string): string {
     AGENCY_LLM_MOCKS: JSON.stringify([{ return: { score: 1, reasoning: "mock judge verdict" } }]),
   };
   const gradeOutput = run(dir, "npx agency eval grade eval-runs/smoke --goal \"Say hello\" 2>&1", { env: gradeMockEnv });
-  assertIncludes(gradeOutput, "objective  1.000");
+  assertIncludes(gradeOutput, "score 1.000");
   // A folder that is not a run directory is refused with a pointer, not scored 0.
   const notRunDir = run(dir, "npx agency eval grade eval-runs 2>&1", { expectFail: true });
   assertIncludes(notRunDir, "not a run directory");

--- a/packages/agency-lang/tests/integration/cli/test.mjs
+++ b/packages/agency-lang/tests/integration/cli/test.mjs
@@ -143,7 +143,7 @@ node main(task: string): string {
   // annotations.jsonl) and `agency eval grade <dir>` scores it later. This test
   // checks the run plumbing only, so no LLM call and no API key are needed.
   run(dir, "npx agency eval run eval-agent.agency --input \"Say hello\" --out eval-runs/smoke");
-  const evalRunDir = join(dir, "eval-runs", "smoke");
+  const evalRunDir = join(dir, "eval-runs", "smoke", "input-1");
   if (!existsSync(join(evalRunDir, "statelog.jsonl"))) {
     throw new Error("eval run wrote no statelog.jsonl");
   }

--- a/packages/agency-lang/tests/integration/eval-run/test.mjs
+++ b/packages/agency-lang/tests/integration/eval-run/test.mjs
@@ -205,7 +205,7 @@ node main(): string {
   } catch {
     // exit code is not the assertion; error.txt is
   }
-  const clobberRows = readFileSync(join(runsDir, "cmd-clobber", "annotations.jsonl"), "utf-8").trim().split("\n").map((line) => JSON.parse(line));
+  const clobberRows = readFileSync(join(runsDir, "cmd-clobber", "cmd-e2e", "annotations.jsonl"), "utf-8").trim().split("\n").map((line) => JSON.parse(line));
   const clobberRun = clobberRows.find((row) => row.kind === "run");
   assert(clobberRun && clobberRun.ended === "error", `clobber run row: ${JSON.stringify(clobberRun)}`);
   assert(clobberRun.error.includes("If your command passes --log, remove it"),

--- a/packages/agency-lang/tests/integration/eval-run/test.mjs
+++ b/packages/agency-lang/tests/integration/eval-run/test.mjs
@@ -84,7 +84,7 @@ node main(task: string) {
 
   // The run directory: one statelog holding the test's trace, plus the
   // harness's `run` row saying which test it was and how it ended.
-  const runDir = join(runsDir, "interrupt-e2e");
+  const runDir = join(runsDir, "interrupt-e2e", "interrupting");
   const rows = readFileSync(join(runDir, "annotations.jsonl"), "utf-8").trim().split("\n").map((line) => JSON.parse(line));
   const runRow = rows.find((row) => row.kind === "run");
   assert(runRow, "no run annotation in annotations.jsonl");
@@ -111,9 +111,10 @@ node main(task: string) {
   assert(started.data.code?.entry === "agent.agency", `agentStart.code.entry: ${JSON.stringify(started.data.code)}`);
   assert(/^[0-9a-f]{64}$/.test(started.data.code?.closureHash ?? ""), "agentStart.code.closureHash missing");
 
-  // The workdir snapshot and the agent's code are attached, keyed by trace and closure hash.
-  assert(existsSync(join(runDir, "workdir", runRow.traceId)), "no workdir snapshot for the trace");
-  assert(existsSync(join(runDir, "code", started.data.code.closureHash, "agent.agency")), "agent code not stored under its closure hash");
+  // The workdir snapshot and the agent's code are attached, flat.
+  assert(existsSync(join(runDir, "workdir")), "no workdir snapshot for the run");
+  assert(existsSync(join(runDir, "workdir.json")), "no workdir sidecar");
+  assert(existsSync(join(runDir, "code", "agent.agency")), "agent code not stored under code/");
 
   console.log("[eval-run-integration] PASS: interrupting agent auto-approved over IPC, verdict recorded");
 
@@ -167,12 +168,12 @@ node main(): string {
   }
   assert(cmdOutput.includes("1/1 tests ok"), `expected a fully-ok command run, got:\n${cmdOutput}`);
 
-  const cmdRunDir = join(runsDir, "cmd-e2e");
+  const cmdRunDir = join(runsDir, "cmd-e2e", "cmd-e2e");
   const cmdRows = readFileSync(join(cmdRunDir, "annotations.jsonl"), "utf-8").trim().split("\n").map((line) => JSON.parse(line));
   const cmdRunRow = cmdRows.find((row) => row.kind === "run");
   assert(cmdRunRow && cmdRunRow.ended === "ok", `command run row: ${JSON.stringify(cmdRunRow)}`);
   // argv delivery through a real CLI: the agent wrote the task text
-  const outTxt = readFileSync(join(cmdRunDir, "workdir", cmdRunRow.traceId, "out.txt"), "utf-8");
+  const outTxt = readFileSync(join(cmdRunDir, "workdir", "out.txt"), "utf-8");
   assert(outTxt === "hello from a command target", `out.txt: ${JSON.stringify(outTxt)}`);
   // the spawned agent's own events landed at the harness statelog path...
   const cmdEvents = readFileSync(join(cmdRunDir, "statelog.jsonl"), "utf-8")
@@ -258,15 +259,16 @@ node main(): string {
   const capturedMatch = captureOutput.match(/Captured trace (\S+) into/);
   assert(capturedMatch, `no capture line in output:\n${captureOutput}`);
   const capturedTraceId = capturedMatch[1];
-  const capturedEvents = readFileSync(join(captureDir, "statelog.jsonl"), "utf-8")
+  const capturedRunDir = join(captureDir, capturedTraceId);
+  const capturedEvents = readFileSync(join(capturedRunDir, "statelog.jsonl"), "utf-8")
     .trim().split("\n").map((line) => JSON.parse(line));
   assert(capturedEvents.length > 0 && capturedEvents.every((e) => e.trace_id === capturedTraceId),
     "captured statelog does not hold exactly the run's trace");
   const capturedStart = capturedEvents.find((e) => e.data?.type === "agentStart");
   assert(capturedStart?.data.code?.entry === "trivial.agency", `captured code identity: ${JSON.stringify(capturedStart?.data.code)}`);
-  assert(existsSync(join(captureDir, "code", capturedStart.data.code.closureHash, "trivial.agency")), "captured code not stored");
-  assert(readFileSync(join(captureDir, "workdir", capturedTraceId, "note.txt"), "utf-8") === "in the working directory",
-    "working directory not captured under the trace id");
+  assert(existsSync(join(capturedRunDir, "code", "trivial.agency")), "captured code not stored");
+  assert(readFileSync(join(capturedRunDir, "workdir", "note.txt"), "utf-8") === "in the working directory",
+    "working directory not captured");
   console.log("[eval-run-integration] PASS: run --capture-workdir writes a run directory");
 
   // ── Scenario F: the capture destination sits INSIDE the working directory ──
@@ -280,12 +282,12 @@ node main(): string {
   );
   const inTreeMatch = inTreeOutput.match(/Captured trace (\S+) into/);
   assert(inTreeMatch, `no capture line in output:\n${inTreeOutput}`);
-  const inTreeDir = join(captureCwd, "runs", "example");
-  const inTreeWorkdir = join(inTreeDir, "workdir", inTreeMatch[1]);
+  const inTreeDir = join(captureCwd, "runs", "example", inTreeMatch[1]);
+  const inTreeWorkdir = join(inTreeDir, "workdir");
   assert(readFileSync(join(inTreeWorkdir, "note.txt"), "utf-8") === "in the working directory",
     "in-tree capture did not snapshot the working directory");
   assert(!existsSync(join(inTreeWorkdir, "runs", "example")),
-    "in-tree capture copied the run directory into itself");
+    "in-tree capture copied the group directory into itself");
   assert(existsSync(join(inTreeDir, "statelog.jsonl")), "in-tree capture wrote no statelog");
   console.log("[eval-run-integration] PASS: run --capture-workdir with a destination inside cwd");
 


### PR DESCRIPTION
Prototype, chunk 1 of 4 of the "one run = one directory" change (spec and plan are local, gitignored). Minimal tests, no docs/site, no polish: try it and say whether the shape is right.

## What changes

A run directory holds exactly one run; `code/` and `workdir/` are flat (`workdir.json` sidecar beside them). A **group** is any directory of run directories. No back-compat for directories written before this.

- `eval run --out <dir>` writes `<dir>/<testId>/` per test (`input-1` for `--input`). An existing child is an error for that test only; nothing is overwritten; the others run. Children are assembled in `<dir>/.staging/` and renamed into place.
- `agency run --capture-workdir <dir>` writes `<dir>/<traceId>/` (the group is left out of its own snapshot).
- `agency runs add <group> --statelog f [--trace id] [--code e] [--workdir p] [--annotations f]` wraps each trace as `<group>/<traceId>/`; existing children are skipped.
- `eval grade <path>` takes a run directory or a group: one grading pass per run, mean printed over the group. `findRunDirectories` is the one walk rule (shared with `agency logs`).
- Optimizer: grades the one child; its own flags untouched.

Not done (later chunks): `runs list` / `note` / `label` over groups, `notes.md`, the reader refusing multi-trace statelogs (kept tolerant so the labeling/explorer tests still pass).

## Try it

```
pnpm run build
pnpm run agency eval run test.agency --input "hi" --out runs/t1     # runs/t1/input-1/{statelog.jsonl,annotations.jsonl,code/,workdir/,workdir.json}
pnpm run agency eval run test.agency --input "hi" --out runs/t1     # "run directory already exists" for that input; 0/1 ok; nothing overwritten
pnpm run agency eval run test.agency --suite <suite> --out runs/t2   # runs/t2/<testId>/ each
pnpm run agency run --capture-workdir runs/scratch test.agency       # runs/scratch/<traceId>/
pnpm run agency runs add runs/wrapped --statelog log.jsonl           # one dir per trace; run twice → skipped
cp -r runs/t2/<testId> /tmp/x && pnpm run agency logs /tmp/x         # a run travels
pnpm run agency eval grade runs/t2 --goal "..."                      # per-run objective + mean line
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
