### PR TITLE
Atomic run directories, PR 2: runs list and eval grade walk groups

### DIFF
--- a/packages/agency-lang/docs/dev/eval-grading.md
+++ b/packages/agency-lang/docs/dev/eval-grading.md
@@ -8,9 +8,11 @@ deliberately (2026-07-30, re-based on the run directory 2026-08-18).
 ## The rules
 
 **`eval run` never grades.** `agency eval run` loads the suite, runs it, and
-writes one run directory: every test's trace in `statelog.jsonl`, its workdir
-under `workdir/<traceId>/`, the agent's code under `code/<closureHash>/`, and
-one `run` annotation per test (`{ test, suite, ended, flags, error? }`). No
+writes one run directory per test at `<out>/<testId>/`: the test's trace in
+`statelog.jsonl` (empty when the test died before its first event, so the
+directory is still a run directory), its workdir flat under `workdir/` with a
+`workdir.json` sidecar, the agent's code flat under `code/`, and one `run`
+annotation (`{ test, suite, ended, flags, error? }`). No
 `goal` is needed to run: `--input <text>` runs one inline test with that
 input and no goal (`inlineInput`; the suite identity is `inline:--input`).
 Grading is `agency eval grade <dir>`, whenever you like, as many times as you
@@ -21,9 +23,10 @@ names the GROUP directory; each test's run directory is written at
 and renamed into place so a child appears whole or not at all. A child that
 already exists is an error result for that test (nothing overwritten; the
 others still run). Default `<eval.runsDir or runs>/<timestamp>-<random suffix>`.
-`eval grade <path>` takes a run directory or a group and grades each run
-with its own pass, printing the mean over the group (`findRunDirectories`,
-`docs/dev/run-directory.md`). There is deliberately no `--goal` (grading's business), no
+`eval grade <path…>` takes run directories and groups, grades each run found
+with its own pass, and prints the mean over them (`findRunDirectories`,
+`docs/dev/run-directory.md`); a run named twice, or through a symlink alias,
+is graded once (`fs.realpathSync.native` identity, first appearance wins). There is deliberately no `--goal` (grading's business), no
 stop-on-error (`--continue-on-error` is gone: an errored test is a `run` row
 that grades 0, and stopping the suite half-way only leaves holes), and no
 agent-config flags (`--strict`, `--max-tool-call-rounds`,

--- a/packages/agency-lang/docs/dev/run-directory.md
+++ b/packages/agency-lang/docs/dev/run-directory.md
@@ -25,9 +25,8 @@ trace, so a run can be moved with `cp -r` and opened anywhere. A **group** is
 any directory of run directories (what `eval run --out` writes); it has no
 index file. `findRunDirectories(paths)` (`findRuns.ts`) is the one walk rule:
 a run directory is itself, a directory of run directories yields its children
-(one level, sorted), anything else is an error. `eval grade` and the logs
-explorer use it; `runs list` and `label` still take a single directory (next
-chunks). The reader still tolerates several traces in one file, because the
+(one level, sorted), anything else is an error. `eval grade`, `runs list` and
+the logs explorer use it; `label` still takes a single directory (next chunk). The reader still tolerates several traces in one file, because the
 labeling and explorer tests were written for that shape; no writer makes one.
 
 **The statelog is the run.** A directory holding only `statelog.jsonl` is a
@@ -177,7 +176,24 @@ One file per command; none imports the lock or the append helpers.
 - `agency runs add <group> [--statelog f]… [--trace id] [--code entry]… [--workdir p] [--annotations f]…`
   — one `wrapTracesAsRunDirectories` request; prints one line per child
   written or skipped.
-- `agency runs list <dir>` — one line per trace (`summarizeRuns`).
+- `agency runs list <path…>` — one line per run across every run directory
+  the paths name (`findRunDirectories`, then `readRunDirectory` each, then
+  `buildRunsListing` → `formatRunsList`). Columns `TRACE TEST AGENT STARTED
+  ENDED TIME COST LLM TOOLS SCORE NOTES LABELED INPUT`: `TEST` is the harness
+  `run` row's test id; `AGENT` is `displayAgent`: the trace's own `agentName`
+  event, else the harness label `flags.agent` unchanged (a command line is
+  not shortened; its basename could be any argument). `SCORE` and the footer
+  mean are the persisted effective score rows (weighted mean per run); a run
+  `eval grade` scored zero without running graders (errored, timed out,
+  traceless) has no score row and is left out of `G graded`, so the two means
+  can differ for such a group. Footer: `N runs · mean 0.720 over G graded ·
+  S runs wrote no trace`, clauses only when they apply (the table is omitted
+  when there are no rows). Duplicate paths are duplicate rows.
+- `agency eval grade <path…>` (`lib/cli/eval/grade.ts`) — the same walk, then
+  duplicates removed by physical identity (`fs.realpathSync.native`) before
+  any pass is written: grading mutates, so `eval grade runs/suite runs/suite/a`
+  grades `a` once. One pass per run directory; per-test blocks and the mean
+  (`formatGrade.ts`).
 - `agency note <dir> <text> [--trace id] [--annotator who]` — `recordNote`.
 - `agency run <file> --capture-workdir <dir>` (`lib/cli/commands.ts`) — mints
   a trace id (`AGENCY_TRACE_ID`), points the child's statelog at a private

--- a/packages/agency-lang/lib/cli/eval/grade.test.ts
+++ b/packages/agency-lang/lib/cli/eval/grade.test.ts
@@ -4,6 +4,7 @@ import * as path from "path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { writeRunDirectory } from "@/eval/runDirectoryFixture.js";
+import { buildRunsListing } from "@/runDirectory/list.js";
 import { readRunDirectory } from "@/runDirectory/runDir.js";
 
 import { evalGrade, gradersFor, validateGradeTarget } from "./grade.js";
@@ -45,10 +46,11 @@ describe("evalGrade", () => {
   it("scores a run directory and records one complete grading pass", async () => {
     const runDir = makeRunDir("hello");
 
-    const result = await evalGrade(runDir, { graders: makeGraders(), config: {} });
+    const result = await evalGrade([runDir], { graders: makeGraders(), config: {} });
 
     expect(result.runs).toHaveLength(1);
-    expect(result.runs[0].dir).toBe(runDir);
+    // Reported directories are canonical (realpath), the same path the pass was written to.
+    expect(result.runs[0].dir).toBe(fs.realpathSync(runDir));
     expect(result.mean).toBeCloseTo(0.5);
     expect(result.runs[0].grading.graders).toEqual(["len"]);
     const snapshot = readRunDirectory(runDir, { reportWarning: () => {} });
@@ -72,7 +74,7 @@ describe("evalGrade", () => {
     const runDir = makeRunDir("hello");
     const out = path.join(runDir, "custom.json");
 
-    await evalGrade(runDir, { graders: makeGraders(), out, config: {} });
+    await evalGrade([runDir], { graders: makeGraders(), out, config: {} });
 
     expect(JSON.parse(fs.readFileSync(out, "utf8")).mean).toBeCloseTo(0.5);
     expect(fs.existsSync(path.join(runDir, "annotations.jsonl"))).toBe(true);
@@ -82,8 +84,8 @@ describe("evalGrade", () => {
     const runDir = makeRunDir("hello");
     const graders = makeGraders(); // the SAME module both times: one annotator, two passes
 
-    await evalGrade(runDir, { graders, config: {} });
-    await evalGrade(runDir, { graders, config: {} });
+    await evalGrade([runDir], { graders, config: {} });
+    await evalGrade([runDir], { graders, config: {} });
 
     const snapshot = readRunDirectory(runDir, { reportWarning: () => {} });
     const scores = snapshot.annotationRows.filter((row) => row.kind === "score");
@@ -103,7 +105,7 @@ describe("evalGrade", () => {
     );
     fs.writeFileSync(path.join(group, "notes.txt"), "not a run");
 
-    const result = await evalGrade(group, { graders: makeGraders(), config: {} });
+    const result = await evalGrade([group], { graders: makeGraders(), config: {} });
 
     expect(result.runs.map((run) => path.basename(run.dir))).toEqual(["a", "b"]);
     expect(result.mean).toBeCloseTo((0.5 + 1.1) / 2);
@@ -127,23 +129,96 @@ describe("evalGrade", () => {
 export default [grader(({ output }) => output === "hello", { name: "gate", mustPass: true })];`,
     );
 
-    const result = await evalGrade(group, { graders: file, config: {} });
+    const result = await evalGrade([group], { graders: file, config: {} });
 
     expect(result.runs.map((run) => run.grading.objective)).toEqual([1, 0]);
     expect(result.gatesPassed).toBe(false);
     expect(result.mean).toBeCloseTo(0.5);
   });
 
+  it("several paths: every run found is graded once, in walk order", async () => {
+    const a = makeRunDir("hello");
+    const group = fs.mkdtempSync(path.join(process.cwd(), ".test-group-"));
+    dirs.push(group);
+    writeRunDirectory([{ test: { id: "b", input: "t" }, output: "hello" }], path.join(group, "b"));
+
+    const result = await evalGrade([a, group], { graders: makeGraders(), config: {} });
+
+    expect(result.runs.map((run) => run.dir)).toEqual(
+      [a, path.join(group, "b")].map((dir) => fs.realpathSync(dir)),
+    );
+    for (const dir of [a, path.join(group, "b")]) {
+      const rows = readRunDirectory(dir, { reportWarning: () => {} }).annotationRows;
+      expect(rows.filter((row) => row.kind === "score")).toHaveLength(1);
+    }
+  });
+
+  it("a run named twice (through its group and directly) is graded once and counted once", async () => {
+    const group = fs.mkdtempSync(path.join(process.cwd(), ".test-group-"));
+    dirs.push(group);
+    const a = path.join(group, "a");
+    writeRunDirectory([{ test: { id: "a", input: "t" }, output: "hello" }], a);
+    writeRunDirectory(
+      [{ test: { id: "b", input: "t" }, output: "hello world" }],
+      path.join(group, "b"),
+    );
+
+    const result = await evalGrade([group, a], { graders: makeGraders(), config: {} });
+
+    expect(result.runs.map((run) => path.basename(run.dir))).toEqual(["a", "b"]);
+    expect(result.mean).toBeCloseTo((0.5 + 1.1) / 2);
+    const rows = readRunDirectory(a, { reportWarning: () => {} }).annotationRows;
+    expect(rows.filter((row) => row.kind === "score")).toHaveLength(1);
+  });
+
+  it("a symlink alias of a run directory is the same run: graded once", async () => {
+    const group = fs.mkdtempSync(path.join(process.cwd(), ".test-group-"));
+    dirs.push(group);
+    const a = path.join(group, "a");
+    writeRunDirectory([{ test: { id: "a", input: "t" }, output: "hello" }], a);
+    const alias = path.join(group, "alias");
+    fs.symlinkSync(a, alias, "dir");
+
+    const result = await evalGrade([a, alias], { graders: makeGraders(), config: {} });
+
+    expect(result.runs).toHaveLength(1);
+    const rows = readRunDirectory(a, { reportWarning: () => {} }).annotationRows;
+    expect(rows.filter((row) => row.kind === "score")).toHaveLength(1);
+  });
+
+  it("an errored run scores zero in eval grade but has no score row, so the listing mean leaves it out", async () => {
+    const group = fs.mkdtempSync(path.join(process.cwd(), ".test-group-"));
+    dirs.push(group);
+    writeRunDirectory([{ test: { id: "a", input: "t" }, output: "hello" }], path.join(group, "a"));
+    writeRunDirectory(
+      [{ test: { id: "b", input: "t" }, output: "hello", ended: "error" }],
+      path.join(group, "b"),
+    );
+
+    const result = await evalGrade([group], { graders: makeGraders(), config: {} });
+
+    expect(result.mean).toBeCloseTo(0.5 / 2);
+    const listing = buildRunsListing(
+      [path.join(group, "a"), path.join(group, "b")].map((dir) =>
+        readRunDirectory(dir, { reportWarning: () => {} }),
+      ),
+    );
+    expect(listing.gradedCount).toBe(1);
+    expect(listing.meanScore).toBeCloseTo(0.5);
+  });
+
   it("refuses a folder with no run directories, naming how to build one", () => {
     const folder = fs.mkdtempSync(path.join(process.cwd(), ".test-not-a-run-dir-"));
     dirs.push(folder);
     fs.writeFileSync(path.join(folder, "statelogs.jsonl"), "");
-    expect(() => validateGradeTarget(folder, {})).toThrow(/not a run directory.*agency runs add/s);
-    expect(() => validateGradeTarget(makeRunDir("x"), {})).not.toThrow();
+    expect(() => validateGradeTarget([folder], {})).toThrow(
+      /not a run directory.*agency runs add/s,
+    );
+    expect(() => validateGradeTarget([makeRunDir("x")], {})).not.toThrow();
   });
 
   it("refuses --goal together with --graders", () => {
-    expect(() => validateGradeTarget(makeRunDir("x"), { goal: "g", graders: "g.ts" })).toThrow(
+    expect(() => validateGradeTarget([makeRunDir("x")], { goal: "g", graders: "g.ts" })).toThrow(
       /only one of --graders or --goal/,
     );
   });

--- a/packages/agency-lang/lib/cli/eval/grade.ts
+++ b/packages/agency-lang/lib/cli/eval/grade.ts
@@ -30,17 +30,26 @@ export type EvalGradeResult = {
 };
 
 /** The command's own preconditions, checked before anything loads: the two
- *  ways of saying "judge against this" are exclusive, and the target must
+ *  ways of saying "judge against this" are exclusive, and the targets must
  *  hold run directories (a bare statelog copied into a folder is the common
- *  miss). Returns the run directories found. */
-export function validateGradeTarget(target: string, opts: EvalGradeOptions): string[] {
+ *  miss). Returns canonical run directories to grade, duplicates removed by
+ *  physical identity: `eval grade runs/suite runs/suite/a` grades `a` once. */
+export function validateGradeTarget(targets: string[], opts: EvalGradeOptions): string[] {
   if (opts.graders !== undefined && opts.goal !== undefined) {
     throw new Error(
       "Provide only one of --graders or --goal: a grading module carries its own criteria " +
         "(give LlmJudge a goal there instead).",
     );
   }
-  return findRunDirectories([target]);
+  return uniqueRunDirectories(findRunDirectories(targets));
+}
+
+/** First appearance wins. Canonical paths, so identity and the mutation
+ *  target come from one source of truth (the walk follows symlinks while
+ *  classifying, so two spellings can name one directory). */
+function uniqueRunDirectories(dirs: string[]): string[] {
+  const canonical = dirs.map((dir) => fs.realpathSync.native(dir));
+  return canonical.filter((dir, index) => canonical.indexOf(dir) === index);
 }
 
 /** The grader set `eval grade` runs with; see `resolveGraders` for the precedence. */
@@ -50,14 +59,17 @@ export async function gradersFor(opts: EvalGradeOptions, config: AgencyConfig) {
 }
 
 /**
- * Score a run directory, or every run directory in a group. Never re-executes
+ * Score run directories, or every run directory in groups. Never re-executes
  * the agent. Each run gets its own grading pass, appended to ITS
  * `annotations.jsonl` — a re-grade sits beside the earlier ones, never over
  * them.
  */
-export async function evalGrade(target: string, opts: EvalGradeOptions): Promise<EvalGradeResult> {
+export async function evalGrade(
+  targets: string[],
+  opts: EvalGradeOptions,
+): Promise<EvalGradeResult> {
   const config = opts.config ?? {};
-  const runDirs = validateGradeTarget(target, opts);
+  const runDirs = validateGradeTarget(targets, opts);
   // `grade` is undefined here: there is no point running this command with
   // grading switched off, so the same resolver's default path applies. An
   // explicit --graders overrides every test's recorded graders; otherwise

--- a/packages/agency-lang/lib/cli/eval/run.test.ts
+++ b/packages/agency-lang/lib/cli/eval/run.test.ts
@@ -314,7 +314,7 @@ describe("eval run CLI", () => {
       // Passes on test "a", fails the gate on test "b".
       const graders = path.join(tmpDir, "gate.ts");
       fs.writeFileSync(graders, `export default ({ test }) => (test.id === "a" ? 1 : 0);`);
-      const result = await evalGrade(summary.runDir, { graders, config: {} });
+      const result = await evalGrade([summary.runDir], { graders, config: {} });
 
       // One of two runs scored 1, the other 0 — the mean is 0.5, not 0.
       expect(result.mean).toBeCloseTo(0.5);
@@ -376,13 +376,13 @@ describe("eval run CLI", () => {
       );
 
       // "self" scored 1 by its own grader; "plain" scored 0 by the fallback.
-      const fallback = await evalGrade(result.runDir, { config });
+      const fallback = await evalGrade([result.runDir], { config });
       expect(fallback.mean).toBeCloseTo(0.5);
 
       // An explicit --graders replaces BOTH tests' graders.
       const overrideModule = path.join(tmpDir, "override.ts");
       fs.writeFileSync(overrideModule, `export default () => 1;`);
-      const overridden = await evalGrade(result.runDir, { graders: overrideModule, config });
+      const overridden = await evalGrade([result.runDir], { graders: overrideModule, config });
       expect(overridden.mean).toBeCloseTo(1);
     });
   });

--- a/packages/agency-lang/lib/cli/runDirectory/commands.test.ts
+++ b/packages/agency-lang/lib/cli/runDirectory/commands.test.ts
@@ -4,7 +4,9 @@ import * as path from "path";
 
 import { describe, expect, it, vi } from "vitest";
 
+import { writeRunDirectory } from "@/eval/runDirectoryFixture.js";
 import { computeCodeIdentity } from "@/runDirectory/codeIdentity.js";
+import { recordGradingPass } from "@/runDirectory/mutations.js";
 import { readRunDirectory, runDirPaths } from "@/runDirectory/runDir.js";
 import {
   agentStartLine,
@@ -13,13 +15,42 @@ import {
   writeProject,
 } from "@/runDirectory/testFixtures.js";
 
+import { Command } from "@/vendor/commander/index.js";
+
 import { runsAdd } from "./add.js";
+import {
+  addRunDirectoryCommands,
+  runDirectoryCommandDependencies,
+  type RunDirectoryCommandDependencies,
+} from "./commands.js";
 import { formatTextTable } from "./table.js";
 import { logsExtract } from "./extract.js";
 import { runsList } from "./list.js";
 import { note } from "./note.js";
 
 const quiet = { reportWarning: () => {} };
+
+function programWith(deps: Partial<RunDirectoryCommandDependencies>): Command {
+  const program = new Command().exitOverride();
+  addRunDirectoryCommands(program, { ...runDirectoryCommandDependencies(), ...deps });
+  return program;
+}
+
+/** A group of two one-run directories, `a` and `b`, as eval run writes them. */
+function writeGroup(): { group: string; a: string; b: string } {
+  const group = tempDir("group-");
+  const a = path.join(group, "a");
+  const b = path.join(group, "b");
+  const agentLabel = "/abs/agents/greeter.agency:main";
+  writeRunDirectory([{ traceId: "ta", test: { id: "a", input: "t" }, output: "x", agentLabel }], a);
+  writeRunDirectory([{ traceId: "tb", test: { id: "b", input: "t" }, output: "y", agentLabel }], b);
+  return { group, a, b };
+}
+
+function lastLine(text: string): string {
+  const lines = text.split("\n");
+  return lines[lines.length - 1];
+}
 
 function statelogFile(...lines: string[]): string {
   const file = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "log-")), "statelog.jsonl");
@@ -156,18 +187,89 @@ describe("note and runs list", () => {
     note({ dir, text: "second", trace: "t2" }, deps);
 
     const listed: string[] = [];
-    const summaries = runsList(dir, { report: (m) => listed.push(m) });
+    const summaries = runsList([dir], { report: (m) => listed.push(m) });
     expect(summaries.map((s) => [s.traceId, s.noteCount])).toEqual([
       ["t1", 1],
       ["t2", 1],
     ]);
     expect(listed[0]).toContain("TRACE");
-    expect(listed[0].split("\n")).toHaveLength(3);
+    // header, two rows, footer
+    expect(listed[0].split("\n")).toHaveLength(4);
+    expect(lastLine(listed[0])).toBe("2 runs");
   });
 
-  it("lists an empty directory without failing", () => {
+  it("refuses a folder holding no run directories", () => {
+    expect(() => runsList([tempDir()], { report: () => {} })).toThrow(/holds no run directories/);
+  });
+});
+
+describe("runs list over groups", () => {
+  it("lists a group: one row per run, TEST and AGENT columns, footer with the run count", () => {
+    const { group, a } = writeGroup();
     const listed: string[] = [];
-    expect(runsList(tempDir(), { report: (m) => listed.push(m) })).toEqual([]);
-    expect(listed[0]).toContain("no traces");
+    const summaries = runsList([group], { report: (m) => listed.push(m) });
+    expect(summaries.map((summary) => summary.testId)).toEqual(["a", "b"]);
+    const [header, rowA] = listed[0].split("\n");
+    expect(header).toContain("TEST");
+    expect(header).toContain("AGENT");
+    expect(rowA).toContain("a");
+    expect(rowA).toContain("/abs/agents/greeter.agency:main");
+    expect(lastLine(listed[0])).toBe("2 runs");
+    expect(readRunDirectory(a, quiet).traces).toHaveLength(1);
+  });
+
+  it("several paths keep the user's order and duplicates; one run directory is a list of one", () => {
+    const { group, a } = writeGroup();
+    const listed: string[] = [];
+    const three = runsList([a, group], { report: (m) => listed.push(m) });
+    expect(three.map((summary) => summary.testId)).toEqual(["a", "a", "b"]);
+    expect(lastLine(listed[0])).toBe("3 runs");
+    const one = runsList([a], { report: (m) => listed.push(m) });
+    expect(one.map((summary) => summary.testId)).toEqual(["a"]);
+    expect(lastLine(listed[1])).toBe("1 run");
+  });
+
+  it("footer: mean over the graded rows, and runs that wrote no trace counted", () => {
+    const { group, a } = writeGroup();
+    recordGradingPass({
+      dir: a,
+      scores: [
+        {
+          traceId: "ta",
+          annotator: { kind: "grader", id: "g@1" },
+          name: "g",
+          score: { kind: "binary", pass: true },
+          weight: 1,
+          mustPass: false,
+        },
+      ],
+    });
+    writeRunDirectory(
+      [{ test: { id: "c", input: "t" }, wroteStatelog: false, ended: "error" }],
+      path.join(group, "c"),
+    );
+    const listed: string[] = [];
+    const summaries = runsList([group], { report: (m) => listed.push(m) });
+    expect(summaries).toHaveLength(2);
+    expect(lastLine(listed[0])).toBe("3 runs · mean 1.000 over 1 graded · 1 run wrote no trace");
+  });
+
+  it("a group of only silent runs prints no table, just the footer", () => {
+    const group = tempDir("group-");
+    writeRunDirectory(
+      [{ test: { id: "c", input: "t" }, wroteStatelog: false, ended: "error" }],
+      path.join(group, "c"),
+    );
+    const listed: string[] = [];
+    expect(runsList([group], { report: (m) => listed.push(m) })).toEqual([]);
+    expect(listed[0]).toBe("1 run · 1 run wrote no trace");
+  });
+
+  it("the CLI passes every positional path through to the command", async () => {
+    const runsListMock = vi.fn(() => []);
+    await programWith({ runsList: runsListMock }).parseAsync(["runs", "list", "/a", "/b"], {
+      from: "user",
+    });
+    expect(runsListMock).toHaveBeenCalledWith(["/a", "/b"]);
   });
 });

--- a/packages/agency-lang/lib/cli/runDirectory/commands.ts
+++ b/packages/agency-lang/lib/cli/runDirectory/commands.ts
@@ -83,11 +83,11 @@ export function addRunDirectoryCommands(
 
   runs
     .command("list")
-    .description("One line per trace: when, how it ended, cost, score, notes")
-    .argument("<dir>", "The run directory")
-    .action((dir: string) => {
+    .description("One line per run: when, how it ended, cost, score, notes")
+    .argument("<paths...>", "Run directories, or directories of run directories")
+    .action((paths: string[]) => {
       try {
-        dependencies.runsList(dir);
+        dependencies.runsList(paths);
       } catch (error) {
         dependencies.fail((error as Error).message);
       }

--- a/packages/agency-lang/lib/cli/runDirectory/list.ts
+++ b/packages/agency-lang/lib/cli/runDirectory/list.ts
@@ -1,40 +1,56 @@
-import { summarizeRuns, type RunSummary } from "@/runDirectory/list.js";
-import { readRunDirectory, type RunDirectorySnapshot } from "@/runDirectory/runDir.js";
+import { findRunDirectories } from "@/runDirectory/findRuns.js";
+import {
+  buildRunsListing,
+  displayAgent,
+  type RunsListing,
+  type RunSummary,
+} from "@/runDirectory/list.js";
+import { readRunDirectory } from "@/runDirectory/runDir.js";
 
 import { formatTextTable, oneLine } from "./table.js";
 
 export type RunsListDependencies = { report(message: string): void };
 
-/** One line per trace in a run directory. */
+/** One line per run across every run directory the paths name (a run
+ *  directory is itself; a directory of run directories is its children). */
 export function runsList(
-  dir: string,
+  paths: string[],
   dependencies: RunsListDependencies = { report: (message) => console.log(message) },
 ): RunSummary[] {
-  const snapshot = readRunDirectory(dir, { reportWarning: (message) => console.warn(message) });
-  dependencies.report(formatRunsList(snapshot));
-  return summarizeRuns(snapshot);
+  const snapshots = findRunDirectories(paths).map((dir) =>
+    readRunDirectory(dir, { reportWarning: (message) => console.warn(message) }),
+  );
+  const listing = buildRunsListing(snapshots);
+  dependencies.report(formatRunsList(listing));
+  return listing.summaries;
 }
 
-export function formatRunsList(snapshot: RunDirectorySnapshot): string {
-  const summaries = summarizeRuns(snapshot);
-  if (summaries.length === 0) {
-    return `${snapshot.dir}: no traces${snapshot.hasStatelog ? "" : " (no statelog.jsonl yet)"}`;
+const HEADER = [
+  "TRACE",
+  "TEST",
+  "AGENT",
+  "STARTED",
+  "ENDED",
+  "TIME",
+  "COST",
+  "LLM",
+  "TOOLS",
+  "SCORE",
+  "NOTES",
+  "LABELED",
+  "INPUT",
+];
+
+/** The table (omitted when there are no rows) and the footer line. */
+export function formatRunsList(listing: RunsListing): string {
+  const footer = footerLine(listing);
+  if (listing.summaries.length === 0) {
+    return footer;
   }
-  const header = [
-    "TRACE",
-    "STARTED",
-    "ENDED",
-    "TIME",
-    "COST",
-    "LLM",
-    "TOOLS",
-    "SCORE",
-    "NOTES",
-    "LABELED",
-    "INPUT",
-  ];
-  const rows = summaries.map((summary) => [
+  const rows = listing.summaries.map((summary) => [
     summary.traceId.slice(0, 8),
+    summary.testId ?? "",
+    displayAgent(summary) ?? "",
     summary.startedAt === null ? "" : summary.startedAt.slice(0, 16).replace("T", " "),
     summary.ended,
     formatDuration(summary.durationMs),
@@ -46,7 +62,33 @@ export function formatRunsList(snapshot: RunDirectorySnapshot): string {
     summary.labeled ? "yes" : "",
     summary.input === null ? "" : oneLine(summary.input, 60),
   ]);
-  return formatTextTable(header, rows);
+  return `${formatTextTable(HEADER, rows)}\n${footer}`;
+}
+
+/** `N runs · mean 0.720 over G graded · S runs wrote no trace`, clauses present
+ *  only when they apply, in that order. */
+function footerLine(listing: RunsListing): string {
+  return [pluralRuns(listing.runCount), ...meanClause(listing), ...silentRunClause(listing)].join(
+    " · ",
+  );
+}
+
+function meanClause(listing: RunsListing): string[] {
+  if (listing.meanScore === null) {
+    return [];
+  }
+  return [`mean ${listing.meanScore.toFixed(3)} over ${listing.gradedCount} graded`];
+}
+
+function silentRunClause(listing: RunsListing): string[] {
+  if (listing.silentRunCount === 0) {
+    return [];
+  }
+  return [`${pluralRuns(listing.silentRunCount)} wrote no trace`];
+}
+
+function pluralRuns(count: number): string {
+  return count === 1 ? "1 run" : `${count} runs`;
 }
 
 function formatDuration(ms: number): string {

--- a/packages/agency-lang/lib/eval/grading/gradeRun.test.ts
+++ b/packages/agency-lang/lib/eval/grading/gradeRun.test.ts
@@ -1,5 +1,5 @@
 import * as fs from "fs";
-
+import * as path from "path";
 import { describe, expect, it } from "vitest";
 
 import { writeRunDirectory, type FakeRun } from "@/eval/runDirectoryFixture.js";
@@ -124,6 +124,8 @@ describe("gradeRun", () => {
         errorMessage: "compile failed",
       },
     ]);
+    // The silent run did not erase its neighbour's trace from the shared fixture statelog.
+    expect(fs.readFileSync(path.join(runDir, "statelog.jsonl"), "utf8")).toContain("trace-1");
     const card = await gradeRun(runDir, ctx([grader(() => 1, { name: "one" })]));
     expect(card.perInput.map((entry) => entry.test.id).sort()).toEqual(["never-started", "ok"]);
     expect(card.objective()).toBe(0.5);
@@ -134,6 +136,8 @@ describe("gradeRun", () => {
 
   it("a suite where every test died before its first event does not pass gates vacuously", async () => {
     const runDir = writeRunDirectory([{ test: capital, wroteStatelog: false, ended: "timeout" }]);
+    // Still a run directory by the walk rule: an empty statelog, as the harness writes.
+    expect(fs.readFileSync(path.join(runDir, "statelog.jsonl"), "utf8")).toBe("");
     const card = await gradeRun(runDir, ctx([grader(() => 1, { name: "one" })]));
     expect(card.perInput).toHaveLength(1);
     expect(card.gatesPassed()).toBe(false);

--- a/packages/agency-lang/lib/eval/runDirectoryFixture.ts
+++ b/packages/agency-lang/lib/eval/runDirectoryFixture.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 
 import type { RunOutcome } from "@/runDirectory/annotations.js";
 import { recordCompletedRun } from "@/runDirectory/mutations.js";
+import { runDirPaths } from "@/runDirectory/runDir.js";
 import { finishedTraceLines, tempDir } from "@/runDirectory/testFixtures.js";
 
 import type { Test } from "./runTypes.js";
@@ -32,6 +33,13 @@ export type FakeRun = {
  */
 export function writeRunDirectory(runs: FakeRun[], dir: string = tempDir("run-")): string {
   fs.mkdirSync(dir, { recursive: true });
+  const statelog = runDirPaths(dir).statelog;
+  if (!fs.existsSync(statelog)) {
+    // The harness creates the statelog before running an input. It remains
+    // empty when the test dies before its first event, so discovery still
+    // recognizes the directory as a run.
+    fs.writeFileSync(statelog, "");
+  }
   runs.forEach((run, index) => {
     const traceId = run.traceId ?? `trace-${index + 1}`;
     const staging = tempDir("staging-");

--- a/packages/agency-lang/lib/runDirectory/list.test.ts
+++ b/packages/agency-lang/lib/runDirectory/list.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { completeAnnotation } from "./annotations.js";
 
-import { summarizeRuns } from "./list.js";
+import { buildRunsListing, displayAgent, summarizeRuns } from "./list.js";
 import { recordGradingPass, recordNote } from "./mutations.js";
 import { readRunDirectory } from "./runDir.js";
 import { agentStartLine, statelogLine, tempDir } from "./testFixtures.js";
@@ -111,5 +111,101 @@ describe("summarizeRuns", () => {
       ) + "\n",
     );
     expect(summarizeRuns(readRunDirectory(dir, quiet))[0].ended).toBe("timeout");
+  });
+});
+
+describe("buildRunsListing", () => {
+  function runRow(traceId: string, flags: Record<string, string>): string {
+    return (
+      JSON.stringify(
+        completeAnnotation(
+          {
+            traceId,
+            annotator: { kind: "harness", id: "eval" },
+            kind: "run",
+            test: null,
+            suite: null,
+            ended: "ok",
+            flags,
+          },
+          "2026-08-18T00:00:00Z",
+        ),
+      ) + "\n"
+    );
+  }
+
+  it("counts rows, silent runs, total runs, and the mean over the graded rows, from the snapshots", () => {
+    const twoTraces = tempDir();
+    writeStatelog(twoTraces, agentStartLine("t1"), agentStartLine("t2"));
+    const graded = tempDir();
+    writeStatelog(graded, agentStartLine("t3"));
+    recordGradingPass({
+      dir: graded,
+      scores: [
+        {
+          traceId: "t3",
+          annotator: { kind: "grader", id: "g@1" },
+          name: "a",
+          score: { kind: "scalar", value: 0.25 },
+          weight: 1,
+          mustPass: false,
+        },
+      ],
+    });
+    const silent = tempDir();
+    writeStatelog(silent);
+    fs.writeFileSync(path.join(silent, "statelog.jsonl"), "");
+
+    const listing = buildRunsListing(
+      [twoTraces, graded, silent].map((dir) => readRunDirectory(dir, quiet)),
+    );
+    expect(listing.summaries.map((summary) => summary.traceId)).toEqual(["t1", "t2", "t3"]);
+    expect(listing.silentRunCount).toBe(1);
+    expect(listing.runCount).toBe(4);
+    expect(listing.gradedCount).toBe(1);
+    expect(listing.meanScore).toBe(0.25);
+  });
+
+  it("no graded rows: null mean and zero graded", () => {
+    const dir = tempDir();
+    writeStatelog(dir, agentStartLine("t1"));
+    const listing = buildRunsListing([readRunDirectory(dir, quiet)]);
+    expect(listing).toMatchObject({
+      runCount: 1,
+      silentRunCount: 0,
+      gradedCount: 0,
+      meanScore: null,
+    });
+  });
+
+  it("displayAgent: the trace's agentName event wins; else the harness label unchanged; else null", () => {
+    const dir = tempDir();
+    writeStatelog(
+      dir,
+      agentStartLine("named"),
+      statelogLine("named", "agentName", { name: "greeter" }),
+      agentStartLine("file"),
+      agentStartLine("command"),
+      agentStartLine("bare"),
+    );
+    const command = "/usr/bin/python /tmp/agent.py --workdir /tmp/data";
+    fs.writeFileSync(
+      path.join(dir, "annotations.jsonl"),
+      runRow("named", { agent: "/abs/agents/other.agency:main" }) +
+        runRow("file", { agent: "/abs/agents/greeter.agency:main" }) +
+        runRow("command", { agent: command }),
+    );
+    const byTrace = Object.fromEntries(
+      summarizeRuns(readRunDirectory(dir, quiet)).map((summary) => [
+        summary.traceId,
+        displayAgent(summary),
+      ]),
+    );
+    expect(byTrace).toEqual({
+      named: "greeter",
+      file: "/abs/agents/greeter.agency:main",
+      command,
+      bare: null,
+    });
   });
 });

--- a/packages/agency-lang/lib/runDirectory/list.ts
+++ b/packages/agency-lang/lib/runDirectory/list.ts
@@ -10,7 +10,11 @@ export type RunSummary = {
   /** The test id from the harness's `run` row; null for an ad-hoc trace. */
   testId: string | null;
   input: string | null;
+  /** The trace's own `agentName` event, when it emitted one. */
   agentName: string | null;
+  /** The harness's agent label from the `run` row (`flags.agent`: an agent
+   *  file target or a command line), unchanged; null for an ad-hoc trace. */
+  agentLabel: string | null;
   startedAt: string | null;
   startedAtMs: number | null;
   durationMs: number;
@@ -49,6 +53,7 @@ function summarizeTrace(
     testId: testIdOf(runRow),
     input: traceInputText(trace, record),
     agentName: record.agentName ?? null,
+    agentLabel: agentLabelOf(runRow),
     startedAt: startedAtMs === null ? null : new Date(startedAtMs).toISOString(),
     startedAtMs,
     durationMs: record.durationMs,
@@ -86,6 +91,50 @@ export function annotationSummaries(snapshot: RunDirectorySnapshot): Record<stri
     if (text !== "") out[summary.traceId] = text;
   }
   return out;
+}
+
+function agentLabelOf(runRow: (Annotation & { kind: "run" }) | null): string | null {
+  const label = runRow?.flags.agent;
+  if (typeof label !== "string" || label === "") {
+    return null;
+  }
+  return label;
+}
+
+/** What a listing shows for "which agent": the trace's own name when it
+ *  emitted one, else the harness label unchanged (a command line is not
+ *  shortened: its basename could be any argument), else null. */
+export function displayAgent(summary: RunSummary): string | null {
+  return summary.agentName ?? summary.agentLabel;
+}
+
+/** What `runs list` renders for a set of run directories. */
+export type RunsListing = {
+  /** One row per trace found (a transitional multi-trace directory is several rows). */
+  summaries: RunSummary[];
+  /** Directories whose statelog holds no trace: a run that died before its first event. */
+  silentRunCount: number;
+  /** summaries.length + silentRunCount. */
+  runCount: number;
+  /** Rows with a persisted score, and their mean; null when none. */
+  gradedCount: number;
+  meanScore: number | null;
+};
+
+export function buildRunsListing(snapshots: RunDirectorySnapshot[]): RunsListing {
+  const summaries = snapshots.flatMap(summarizeRuns);
+  const silentRunCount = snapshots.filter((snapshot) => snapshot.traces.length === 0).length;
+  const scores = summaries.flatMap((summary) =>
+    summary.latestScore === null ? [] : [summary.latestScore],
+  );
+  return {
+    summaries,
+    silentRunCount,
+    runCount: summaries.length + silentRunCount,
+    gradedCount: scores.length,
+    meanScore:
+      scores.length === 0 ? null : scores.reduce((sum, score) => sum + score, 0) / scores.length,
+  };
 }
 
 function testIdOf(runRow: (Annotation & { kind: "run" }) | null): string | null {

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -888,18 +888,15 @@ export function createProgram(deps: CliDependencies = {}): Command {
   evalCmd
     .command("grade")
     .description("Score finished runs without re-running the agent")
-    .argument(
-      "<path>",
-      "A run directory, or a directory of run directories (what `agency eval run --out` writes)",
-    )
+    .argument("<paths...>", "Run directories, or directories of run directories")
     .option("--graders <file>", "TypeScript grading module (default-exports graders)")
     .option(
       "--goal <text>",
       "Judge every trace against this goal with the built-in LLM judge (traces whose test recorded its own goal keep it; not with --graders)",
     )
     .option("-o, --out <path>", "Also write the grading summary here as JSON")
-    .action(async (target: string, opts: { graders?: string; goal?: string; out?: string }) => {
-      const result = await evalGrade(target, { ...opts, config: getConfig() }).catch(
+    .action(async (paths: string[], opts: { graders?: string; goal?: string; out?: string }) => {
+      const result = await evalGrade(paths, { ...opts, config: getConfig() }).catch(
         failProjectCommand,
       );
       for (const line of formatGradeResult(result)) console.log(line);

--- a/packages/agency-lang/tests/integration/cli/test.mjs
+++ b/packages/agency-lang/tests/integration/cli/test.mjs
@@ -10,6 +10,11 @@ import {
 } from "../helpers.mjs";
 
 const tarball = resolve(getTarballPath());
+
+function stripAnsi(text) {
+  // eslint-disable-next-line no-control-regex
+  return text.replace(/\x1b\[[0-9;]*m/g, "");
+}
 const dir = createTempProject("cli");
 
 try {
@@ -155,16 +160,32 @@ node main(task: string): string {
   if (!evalRunRow || evalRunRow.ended !== "ok") {
     throw new Error(`eval run row unexpected: ${JSON.stringify(evalRows)}`);
   }
+  // A second group of one, so grade and list can take several paths below.
+  run(dir, "npx agency eval run eval-agent.agency --input \"Say hello\" --out eval-runs/smoke2");
   console.log("Test 6 passed");
 
-  // --- Test 6a: eval grade --goal over the run directory just written ---
+  // --- Test 6a: eval grade --goal over two groups at once ---
   // The goal judge is an llm() call; mock it so this runs offline (see Test 7).
+  // One mock per judge call, consumed in order: two runs, two entries.
   console.log("--- Test 6a: eval grade --goal ---");
   const gradeMockEnv = {
-    AGENCY_LLM_MOCKS: JSON.stringify([{ return: { score: 1, reasoning: "mock judge verdict" } }]),
+    AGENCY_LLM_MOCKS: JSON.stringify([
+      { return: { score: 1, reasoning: "mock judge verdict 1" } },
+      { return: { score: 1, reasoning: "mock judge verdict 2" } },
+    ]),
   };
-  const gradeOutput = run(dir, "npx agency eval grade eval-runs/smoke --goal \"Say hello\" 2>&1", { env: gradeMockEnv });
-  assertIncludes(gradeOutput, "score 1.000");
+  const gradeOutput = stripAnsi(run(dir, "npx agency eval grade eval-runs/smoke eval-runs/smoke2 --goal \"Say hello\" 2>&1", { env: gradeMockEnv }));
+  const scoreLines = gradeOutput.split("\n").filter((line) => line.startsWith("input-1  score 1.000"));
+  if (scoreLines.length !== 2) {
+    throw new Error(`expected two graded runs, got ${scoreLines.length}:\n${gradeOutput}`);
+  }
+  assertIncludes(gradeOutput, "mean 1.000 over 2 runs");
+  // runs list over the same two groups: one table, the new columns, the mean footer.
+  const listOutput = stripAnsi(run(dir, "npx agency runs list eval-runs/smoke eval-runs/smoke2"));
+  assertIncludes(listOutput, "TEST");
+  assertIncludes(listOutput, "AGENT");
+  assertIncludes(listOutput, "input-1");
+  assertIncludes(listOutput.trim().split("\n").at(-1), "2 runs · mean 1.000 over 2 graded");
   // A folder that is not a run directory is refused with a pointer, not scored 0.
   const notRunDir = run(dir, "npx agency eval grade eval-runs 2>&1", { expectFail: true });
   assertIncludes(notRunDir, "not a run directory");


### PR DESCRIPTION
PR 2 of the "one run = one directory" arc (PR 1 was #866). The two readers that still took a single run directory now walk groups.

## User-facing

- `agency runs list <path…>`: takes run directories and/or directories of run directories, any number, one table. Two new columns: `TEST` (from the harness `run` row) and `AGENT` (the trace's own `agentName` if it emitted one, else the harness label as recorded). Footer line: `N runs · mean 0.720 over G graded · S runs wrote no trace` (clauses only when they apply). A folder with no run directories is an error instead of "no traces".
- `agency eval grade <path…>`: takes several paths. A run named twice (through its group and directly, or through a symlink) is graded once and counted once.

## Design notes (also in `docs/dev/run-directory.md`)

- `SCORE` and the footer mean are the *persisted* effective score rows. A run that `eval grade` scores zero without running graders (errored, timed out, never wrote a trace) has no score row, so `runs list` leaves it out of `G graded`; for such a group the two means differ by design. Matching exactly would need a persisted no-score grading marker (a format change, not for this PR).
- Listing keeps duplicate paths as duplicate rows (display); grading dedupes by `fs.realpathSync.native` (mutation).
- One deviation from the plan: `RunSummary` keeps `agentName` (trace's own) and gains `agentLabel` (harness); `displayAgent()` combines them for the column. The runs explorer already has its own label-shortening rule and reads `agentName` as "the trace named itself", so blending inside `summarizeTrace` would have changed the explorer's output.

## Tests

`buildRunsListing` model (rows / silent / total / graded / mean), `displayAgent` (event wins, file label, command-line label unchanged, none), `runs list` over a group / several paths / footer states / silent-only / error / Commander two-path boundary, `eval grade` several paths / duplicate / symlink alias / errored-run denominator, fixture non-truncation, and the packaged cli integration grades and lists two groups with two judge mocks.

## Try it

```
pnpm run build
pnpm run agency eval run test.agency --suite <suite> --out runs/t2
pnpm run agency runs list runs/t2
pnpm run agency eval grade runs/t2 --goal "…"
pnpm run agency runs list runs/t2                       # footer shows the mean
pnpm run agency runs list runs/t2/<one> runs/t1
pnpm run agency eval grade runs/t2 runs/t2/<one> --goal "…"   # <one> graded once
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
