### PR TITLE
Eval fixes: portable grader snapshots, visible re-grades, judge versioning, {input} placeholder

### DIFF
--- a/packages/agency-lang/docs/dev/eval-command-agents.md
+++ b/packages/agency-lang/docs/dev/eval-command-agents.md
@@ -1,6 +1,6 @@
 # Command agents: running a CLI under `agency eval run`
 
-`--agent-cmd '<command with {task}>'` runs a CLI as the agent instead of
+`--agent-cmd '<command with {input}>'` runs a CLI as the agent instead of
 compiling an `.agency` file (the positional `<agent>` argument) — the way
 the bundled `agency agent` is benchmarked. This page is the architecture; user-facing rules live in
 `docs/site/cli/eval.md` ("Command agents").
@@ -30,8 +30,8 @@ The command string is tokenized by a tarsec grammar
 (`lib/eval/run/commandLine.ts`): whitespace splits, single/double quotes
 group, adjacent chunks join (`--flag="a b"` is one token), and NOTHING
 shell-like — no expansion, operators, or escapes, because no shell ever
-runs. `{task}` substitution happens AFTER tokenization, per token, so a
-hostile task is inert bytes inside one argv entry. `{task}` is required
+runs. `{input}` substitution happens AFTER tokenization, per token, so a
+hostile task is inert bytes inside one argv entry. `{input}` is required
 exactly when the tests carry an input, and refused when they carry none —
 `assertTargetMatchesInputs` (`lib/agentTarget.ts`) checks that once, before
 any run, for command and file agents alike; an object task substitutes as

--- a/packages/agency-lang/docs/dev/eval-grading.md
+++ b/packages/agency-lang/docs/dev/eval-grading.md
@@ -42,7 +42,7 @@ suite the tests must agree — all with an input or none —
 and `assertTargetMatchesInputs` (`lib/agentTarget.ts`, called from
 `runSuite` and the optimizer's `buildTarget`) checks the agent against
 that once, up front: with inputs the entry node takes exactly one
-parameter / the command contains `{task}`; without, the node takes none /
+parameter / the command contains `{input}`; without, the node takes none /
 the command has no placeholder. Each mismatch names the fix in both
 directions ("pass --input" or "make the node take no parameter"). A test
 with no input reaches the child as a run instruction without `input`,
@@ -95,8 +95,29 @@ path. The suite-level set is `SuiteGraders`: `override` (an explicit
 `--graders` flag) replaces every test's own graders — the experiment knob —
 while `fallback` (the `eval.graders` config module, else the bundled goal
 judge) applies only to tests that carry none. Precedence, one line: flag >
-test's own > config > goal judge. Grader modules load once per path per pass
-(`makeGraderModuleCache`). Trust note: graders are code the harness executes.
+the run directory's stored snapshot > test's own recorded path (directories
+from before snapshots) > config > goal judge. Live modules load once per path
+per pass (`makeGraderModuleCache`). Trust note: graders are code the harness
+executes.
+
+**The run directory stores the graders it ran with.** `eval run` decides
+each test's module up front (its own, else `eval.graders`), bundles it with
+esbuild (`snapshotGradingModule`: one self-contained `.mjs`, everything
+inlined except `agency-lang`), loads it once so a broken module fails before
+any agent runs, and collects the files its graders read by path
+(`BaseGrader.externalFiles()`, which `LlmJudge` implements for a custom
+`agencyFile`). The bundle and those files land in `<runDir>/graders/` by
+content hash, and the run row records `graders: { source, bundleFile,
+judgeFiles }`. `eval grade` loads that copy (`loadGradingSnapshot`, which
+rebinds each judge file to its stored copy via `rebindExternalFile`), so a
+copied run directory grades the same anywhere, and an edited `graders.ts`
+does not silently change what an old run scores; `--graders <file>` is the
+way to grade with a live module. The bundle is imported from a temp file
+next to the snapshot so its `agency-lang` import resolves from there; when
+that fails (a directory copied outside any project) it retries from this
+package's own root, where the name resolves to the package itself. A module's
+revision is `<source>@<sha256 of the bundle>` in both paths, so snapshot and
+unchanged-live grading agree on the annotator.
 
 **A run that did not end cleanly scores zero, always.** The harness's `run`
 row is authoritative when present — only it knows about a wall-clock or
@@ -121,11 +142,15 @@ that need the output fail on their own terms.
 **Every grading pass is recorded as annotations.** `gradeSuite` reads one
 snapshot, grades it, converts each grade to a `ScoreDraft`, and calls
 `recordGradingPass` once: one `score` row per grader per trace, all sharing a
-fresh `passId`, the last marked `completesPass`. The fold counts only complete
+fresh `passId` and stamped with the `passSize`. The fold counts only complete
 passes, so a crash mid-pass never moves effective state, and a re-grade sits
-beside the earlier passes rather than over them. Graders are named by
+beside the earlier passes rather than over them (the latest pass is the
+effective score per grader lineage, any revision; the pass count is shown so
+a re-grade is never silent). Graders are named by
 revision — a module grader is `<path>@<sha256 of file>` (set by
-`loadGradingModule`), the goal judge `goal-judge@<hash of its prompt file>` —
+`loadGradingModule`), the bundled goal judge `goal-judge@<GOAL_JUDGE_VERSION>`
+(bump the constant in `goalJudgeFile.ts` when you edit the prompt; a test pins
+the version to the file's hash), a custom judge file `<path>@<sha256 of file>` —
 so editing `graders.ts` in place is a new annotator. `EvalRunGrading` (the
 objective, gates, per-test breakdown) is computed for printing and `-o`; it is
 not stored.

--- a/packages/agency-lang/docs/dev/eval-grading.md
+++ b/packages/agency-lang/docs/dev/eval-grading.md
@@ -108,7 +108,11 @@ any agent runs, and collects the files its graders read by path
 (`BaseGrader.externalFiles()`, which `LlmJudge` implements for a custom
 `agencyFile`). The bundle and those files land in `<runDir>/graders/` by
 content hash, and the run row records `graders: { source, bundleFile,
-judgeFiles }`. `eval grade` loads that copy (`loadGradingSnapshot`, which
+judgeFiles, origin }`. The origin ("test" or "config") keeps the precedence
+distinction: `--goal` sets a config-origin snapshot aside exactly like the
+config module it came from, while a test-owned snapshot survives it, matching
+the live-module rules. Legacy score rows still carry `completesPass`; the
+schema accepts and ignores it. `eval grade` loads the stored copy (`loadGradingSnapshot`, which
 rebinds each judge file to its stored copy via `rebindExternalFile`), so a
 copied run directory grades the same anywhere, and an edited `graders.ts`
 does not silently change what an old run scores; `--graders <file>` is the

--- a/packages/agency-lang/docs/dev/run-directory.md
+++ b/packages/agency-lang/docs/dev/run-directory.md
@@ -138,8 +138,9 @@ The planners (`mergeStatelog.ts`, `attachCode.ts`, `attachWorkdir.ts`):
   not hash to what the trace recorded is reported as corrupt.
 - **Graders** (`gradersFiles` on `recordCompletedRun`) go under `graders/`
   by content-hash name; the run row's `graders: { source, bundleFile,
-  judgeFiles }` says which is the module bundle and which stored file each
-  declared judge path maps to. Same name = same content, so nothing is ever
+  judgeFiles, origin }` says which is the module bundle, which stored file
+  each declared judge path maps to, and whether the module was the test's
+  own or the `eval.graders` config fallback. Same name = same content, so nothing is ever
   rewritten. See docs/dev/eval-grading.md for why grading prefers this copy.
 - **Workdir** copies to `workdir/` and writes the dated `workdir.json`
   sidecar. A workdir attached later may postdate the run; the sidecar says so.

--- a/packages/agency-lang/docs/dev/run-directory.md
+++ b/packages/agency-lang/docs/dev/run-directory.md
@@ -14,6 +14,7 @@ easy to get wrong.
   annotations.jsonl     # every structured opinion about the run: checklist, score, run
   notes.md              # a person's free-form notes, written with any editor
   code/                 # the agent's closure, as it ran, flat
+  graders/              # the grading module it ran with, bundled, + judge files; content-hash names
   workdir/              # filesystem snapshot, flat
   workdir.json          # { snapshotAt, source } — when and where from
   checklists/<id>/      # versioned checklist revisions + labeling drafts (docs/dev/eval-labeling.md)
@@ -69,7 +70,7 @@ is `notes.md`):
 | kind | who | what |
 |---|---|---|
 | `checklist` | human | one sign-off: `checklist`, `version`, `hash`, `answers`, `note` |
-| `score` | grader / judge | one grader's verdict in one pass: `passId`, `passSize`, `completesPass`, `name`, `score`, `weight`, `mustPass` |
+| `score` | grader / judge | one grader's verdict in one pass: `passId`, `passSize`, `name`, `score`, `weight`, `mustPass` |
 | `run` | harness | which `test`, which `suite`, how it `ended`, `flags` |
 
 Rules:
@@ -84,8 +85,14 @@ Rules:
 - **The fold is per key, append order decides**: checklist
   answers fold per question per `(checklist, annotator)`, so a restored
   question keeps its earlier answer; scores count only from **complete**
-  passes (exactly `passSize` distinct rows and one `completesPass`), so a crash
+  passes (exactly `passSize` distinct rows share the `passId`), so a crash
   mid-pass never moves effective state; the latest `run` row wins.
+- **Score keys are per grader lineage, not per revision**: the key is
+  `kind:lineage:name` where the lineage is the annotator id with its
+  `@<revision>` stripped (`annotatorLineage`), so `goal-judge@2` supersedes
+  `goal-judge@1` rather than averaging with it. Earlier passes stay on disk
+  and are counted in `gradingPasses`, which `runs list` shows as `PASSES` and
+  the summary line as `score 0.70 (3 passes)`.
 - Reading is tolerant (malformed row → warning, torn tail ignored); writing
   validates against `AnnotationSchema` before append.
 
@@ -104,7 +111,7 @@ on success or failure.
   annotation rows go to the child their `traceId` names and must name one of
   the traces. Used by `runs add` and `run --capture-workdir`.
 - `recordCompletedRun({ dir, stagedStatelogFile, codeEntry?, workdir?, run })` — the eval harness's one call per finished test, on a fresh directory
-- `recordGradingPass({ dir, scores })` — mints one `passId`, stamps `passSize`, marks the last row `completesPass`; an empty `scores` is refused
+- `recordGradingPass({ dir, scores })` — mints one `passId`, stamps `passSize`; an empty `scores` is refused
 - `recordChecklistRow({ dir, groupDir, row })` — one labeling sign-off, the completed row as the session built it (its id is content-derived, so a replay lands on the same id): grounded immediately before the append against the run (holds the trace) and the group's lineage (revision exists with that hash; every answer names one of its questions); returns `appended` or `replayed` plus the post-write snapshot
 
 Writer inputs are held to a stricter standard than reads: a statelog file
@@ -129,6 +136,11 @@ The planners (`mergeStatelog.ts`, `attachCode.ts`, `attachWorkdir.ts`):
   directory recorded that hash on `agentStart`; a mismatch is refused, not
   warned. Stored flat under `code/`; a stored tree that is incomplete or does
   not hash to what the trace recorded is reported as corrupt.
+- **Graders** (`gradersFiles` on `recordCompletedRun`) go under `graders/`
+  by content-hash name; the run row's `graders: { source, bundleFile,
+  judgeFiles }` says which is the module bundle and which stored file each
+  declared judge path maps to. Same name = same content, so nothing is ever
+  rewritten. See docs/dev/eval-grading.md for why grading prefers this copy.
 - **Workdir** copies to `workdir/` and writes the dated `workdir.json`
   sidecar. A workdir attached later may postdate the run; the sidecar says so.
   The run directory itself, and the optional `excludeDir` (the group a capture

--- a/packages/agency-lang/docs/site/.vitepress/config.mts
+++ b/packages/agency-lang/docs/site/.vitepress/config.mts
@@ -168,6 +168,14 @@ export default defineConfig({
           ],
         },
         {
+          text: "10. Evals",
+          items: [
+            { text: "Eval Basics", link: "/guide/eval-basics.md" },
+            { text: "Graders", link: "/guide/graders.md" },
+            { text: "Suites", link: "/guide/suites.md" },
+          ]
+        },
+        {
           text: "Appendix",
           collapsed: true,
           items: [

--- a/packages/agency-lang/docs/site/cli/eval.md
+++ b/packages/agency-lang/docs/site/cli/eval.md
@@ -8,7 +8,7 @@ description: How to run an Agency agent against a test suite, score it with grad
 `agency eval` runs, grades and compares agent runs. Everything it produces lives in a **run directory**: a folder with the runs' statelog and an append-only file of annotations (grades, checklist answers), plus a free-form `notes.md` you write yourself. The main commands are:
 
 ```
-agency eval run (--agent <file>[:<node>] | --agent-cmd '<command with {task}>') (--suite <file|dir|git-url> | --goal <text>) [-n <count>]
+agency eval run (--agent <file>[:<node>] | --agent-cmd '<command with {input}>') (--suite <file|dir|git-url> | --goal <text>) [-n <count>]
 agency eval grade <runDir> [--graders <file>]
 agency eval logs <runDir> [-f]
 agency eval optimize <file>[:<node>] [--suite <file|dir>] [--goal <text>] [--graders <file>]
@@ -85,11 +85,11 @@ file — the way to benchmark `agency agent` itself:
 
 ```bash
 agency eval run \
-  --agent-cmd 'agency agent --agent code --policy approve-all --max-tool-call-rounds 100 --verbose -p -- {task}' \
+  --agent-cmd 'agency agent --agent code --policy approve-all --max-tool-call-rounds 100 --verbose -p -- {input}' \
   --suite evals/terminal-bench-mini
 ```
 
-The command string must contain `{task}`; every occurrence is replaced with
+The command string must contain `{input}`; every occurrence is replaced with
 each test's input. The string is tokenized by a minimal quote-aware splitter
 and **never passes through a shell**: no expansion, no operators — and
 substitution happens after tokenization, per token, so a hostile task is
@@ -111,7 +111,7 @@ A non-Agency command writes no statelog and the run fails saying so.
 Rules that follow from the mechanism:
 
 - **The command must run headless and one-shot** (`agency agent --policy
-  approve-all -p -- {task}`). There is no IPC channel, so eval's interrupt
+  approve-all -p -- {input}`). There is no IPC channel, so eval's interrupt
   auto-approval cannot reach a command agent — an interactive command just
   waits for input that never comes until the wall clock kills it.
 - **Do not pass `--log` inside the command** — it overrides the statelog

--- a/packages/agency-lang/docs/site/guide/eval-basics.md
+++ b/packages/agency-lang/docs/site/guide/eval-basics.md
@@ -1,0 +1,128 @@
+# Eval Basics
+
+Evals are a useful but complex topic. I'll take it step by step.
+
+## Run an agent
+
+Example agent:
+
+```ts
+node main() {
+  const response = llm("What is Einstein's birthday?")
+  print(response)
+  return response
+}
+```
+
+Run it:
+
+```bash
+agency eval run test.agency
+```
+
+Will print something like:
+
+```
+run dir: /Users/adit/runs/foo
+Albert Einstein was born on March 14, 1879.
+[input-1] success in 3s
+Run 2026-08-18-191911-rAGQlU completed: 1/1 tests ok
+total LLM cost: $0.00
+/Users/adit/runs/foo
+```
+
+Note the run id is `2026-08-18-191911-rAGQlU`. You can pass in a specific run id:
+
+```bash
+agency eval run test.agency --out foob
+```
+
+Now it will put the results in the dir `foob/`.
+
+## What does the run dir contain?
+
+Everyone's dying to know, so dish the dirt!
+
+- `statelog.jsonl` - Statelog logs for the run
+- `annotations.jsonl` - Grader results, for when you run the grader
+- `code/` - Code used for the run, so we can reproduce if needed
+- `graders/` - The grading code the run was set up with (only when the test has a grading module), so the run grades the same later even if you edit the graders or copy the directory elsewhere
+- `workdir/` and `workdir.json` - Any other relevant files: for example, agency.json for config, and any files that the agents may have created.
+
+## The run directory
+
+You'll see that all of these files aren't in
+
+```
+runs/foo/
+```
+
+They're actually in
+
+```
+runs/foo/input-1/
+```
+
+This is because the `eval run` command lets you run the agent over several different inputs in parallel. Each input gets its own run directory under `runs/foo`.
+
+Note that you have just run an agent. You have not evaluated anything yet. Each time you run an agent using `eval run`, it will create a directory for the run, like the one at `runs/foo/input-1`. This is called a **run directory**. The run directory is the unit that we use for everything else connected with evals and optimization.
+
+## Grading
+Now that you have a run, we can create it. The simplest way to grade is to use LLM as a judge with the `--goal` flag:
+
+```bash
+agency eval grade runs/foo --goal "returns einsteins bday"
+```
+
+This will add something to the annotations file in `input-1/annotations.jsonl` that looks like the following:
+
+```json
++{"v":1,"id":"ann_xyz","traceId":"<trace-id>","createdAt":"2026-08-19T17:39:56.105Z","annotator":{"kind":"judge","id":"goal-judge@1"},"kind":"score","passId":"pass_xvh","passSize":1,"name":"goal","score":{"kind":"scalar","value":1},"weight":1,"mustPass":false,"feedback":"The agent output provides a direct and accurate answer to the goal, stating Albert Einstein's birth date correctly as March 14, 1879, which fully satisfies the requirement.","goal":"returns einsteins bday"}
+```
+
+Here we gave it the parent directory (`runs/foo/`). We could also give it the path to a single run directory:
+
+```bash
+agency eval grade runs/foo/input-1 --goal "returns einsteins bday"
+```
+
+## Suites
+
+Here I have been showing you the building blocks for evals. In reality, you wouldn't grade a run by passing the goal on the command line. In reality, you would have an eval suite that you would use to grade an agent.
+
+Lets make a new suite:
+
+```json
+{
+  "inputs": [
+    {
+      "id": "einstein",
+      "input": {},
+      "goal": "returns Einstein's birthday",
+      "expected": "March 14, 1879"
+    }
+  ]
+}
+```
+
+Now we can run and grade it:
+
+```bash
+agency eval run test.agency --suite inputs.json --out runs/einstein
+agency eval grade runs/einstein
+```
+
+Pretty suite, eh?
+
+Note that you don't need both "goal" and "expected", you only need one. By default, the grader is going to use LLM as a judge, and it will use both if both are provided. So you don't need both but it can be nice to provide both just to give the LLM judge more information.
+
+## List runs
+
+As we have already seen, the grader will add its grade to annotations.jsonl. You can get a nice view of all the grades using:
+
+```
+agency runs list
+```
+
+This will show a list of all the runs and their scores. Note that if you have graded a run multiple times, it will only show the score from the last time it was graded. It will also print the mean of all the scores. This again uses the last score if there are multiple scores for one run.
+

--- a/packages/agency-lang/docs/site/guide/graders.md
+++ b/packages/agency-lang/docs/site/guide/graders.md
@@ -1,0 +1,81 @@
+# Graders
+
+### Grading with code instead of an LLM
+
+An LLM judge is flexible but slow, costs money, and is a little different every time. When you can say what "correct" means in code, do that instead. You write a **grading module**: a TypeScript file that default-exports one grader or a list of them, and pass it with `--graders`:
+
+```ts
+// graders.ts
+import { grader, ExactMatch, Contains, Similarity } from "agency-lang/eval";
+
+export default [
+  // a function over the run: return true/false, a number from 0 to 1, or a full Grade
+  grader(({ output }) => String(output).includes("1879"), { name: "mentions-year" }),
+
+  // compare the output against the test's `expected` field
+  new ExactMatch({ mustPass: true }),
+  new Contains({ name: "has-date" }),
+  new Similarity({ weight: 0.5 }),
+];
+```
+
+```bash
+agency eval grade runs/einstein --graders graders.ts
+```
+
+This appends one score row per grader, all in one pass. The built-in graders are:
+
+- `ExactMatch` — pass if the output deep-equals the test's `expected` value.
+- `Contains` — pass if the stringified output contains `expected`.
+- `Similarity` — a 0 to 1 score based on edit distance between output and `expected`.
+
+All three read `expected` by default; pass `matchOn: ["some", "path"]` to compare against a different field of the test instead.
+
+A `grader(fn, options)` function receives `{ output, test, workdir, record, judge }`:
+
+- `output` is what the agent returned.
+- `test` is the test as you wrote it in the inputs file (so you can read `test.expected` or anything else you put there).
+- `workdir` is the path to the run's working directory, so you can check for files the agent wrote.
+- `record` is the run record, including metrics like `record.metrics.costUsdTotal`.
+- `judge({ goal })` runs the bundled LLM judge on demand, for the cases where you want code to decide *whether* to ask an LLM.
+
+Code graders are free to re-run, so you can grade the same run as many times as you like while you tune them.
+
+### Your own LLM judge
+
+The bundled goal judge is a general-purpose "does the output satisfy the goal" prompt. When you want a judge with its own rubric, write it as an Agency file and point `LlmJudge` at it from a grading module:
+
+```ts
+// graders.ts
+import { LlmJudge } from "agency-lang/eval";
+
+export default [
+  new LlmJudge({ name: "tone", agencyFile: "./toneJudge.agency", goal: "is polite and concise" }),
+];
+```
+
+The judge file is a normal Agency program whose `main` node takes `(goal, output, expected)` and returns `{ score, reasoning }` (or `{ pass, reasoning }` with `binary: true`). It is identified in the annotations by its file path and content hash, so editing the judge prompt in place counts as a new judge rather than silently changing what old scores mean.
+
+### How scores combine
+
+Each test's scores are folded into one number, the **objective**, between 0 and 1:
+
+- Every grader contributes its score times its `weight` (default 1), and the objective is the weighted mean.
+- A grader with `mustPass: true` is a gate: if it fails, that test scores 0 regardless of the others, and `eval grade` exits with code 2. That makes it usable as a CI check.
+- `threshold` is the passing bar for a scalar grader (default 0, so any score passes); it decides whether a scalar gate fails. `samples` runs a grader several times and aggregates the results, which helps with a noisy LLM judge.
+
+`eval grade` prints the objective for each run directory and the mean over all of them. A test whose agent errored scores 0 and fails every gate; it is counted, not skipped.
+
+### Where the graders come from
+
+When you don't pass `--graders` or `--goal`, `eval grade` picks graders in this order:
+
+1. The test's own graders, if the input named a `graders` module (or, in the test-directory form, a `graders.ts` sits beside `test.json`).
+2. The `eval.graders` module in `agency.json`, for tests that have none of their own.
+3. The bundled goal judge, scoring against the test's `goal`.
+
+`--graders <file>` overrides all of that for every test in the pass. `--goal` is the other override and always means the bundled goal judge; the two flags can't be combined, because a grading module brings its own criteria (give `LlmJudge` a `goal` there instead).
+
+### Grading by hand
+
+Some things have no automatic grader. Is this summary actually good? Would you send this email? For those, `agency label` lets you answer a checklist of yes/no questions about each run, and writes your answers into the same `annotations.jsonl`, next to the graders' scores. That deserves its own section, so it comes later.

--- a/packages/agency-lang/docs/site/guide/suites.md
+++ b/packages/agency-lang/docs/site/guide/suites.md
@@ -1,0 +1,99 @@
+# Suites
+
+We had covered suites in the [eval basics](/guide/eval-basics) section. As a reminder, here is how you would write a simple suite:
+
+```json
+{
+  "inputs": [
+    {
+      "id": "einstein",
+      "input": {},
+      "goal": "returns Einstein's birthday",
+      "expected": "March 14, 1879"
+    }
+  ]
+}
+```
+
+Now we can run and grade it:
+
+```bash
+agency eval run test.agency --suite inputs.json --out runs/einstein
+agency eval grade runs/einstein
+```
+
+Note that you don't need both "goal" and "expected", you only need one. By default, the grader is going to use LLM as a judge, and it will use both if both are provided.
+
+## Other ways to write a suite
+
+A single JSON file with an `inputs` array is the quickest way to meet and greet a suite. Here are some other ways to do it.
+
+### A directory of test files
+
+Instead of one file holding every test, you can give each test its own `.json` file and folder. Then point `--suite` at parent folder:
+
+```
+einstein-suite/
+  birthday.json
+  birthplace.json
+```
+
+```json
+// einstein-suite/birthday.json
+{
+  "id": "birthday",
+  "input": {},
+  "goal": "returns Einstein's birthday",
+  "expected": "March 14, 1879"
+}
+```
+
+```bash
+agency eval run test.agency --suite einstein-suite --out runs/einstein
+```
+
+This is nicer once a suite has more than a handful of tests.
+
+### Add files to your test
+
+Some agents work on files, like "summarize report.txt". You can include files as part of your test. You will need to give each test its own directory as shown above, with a `test.json` file, and a `files/` folder:
+
+```
+summarize-suite/
+  quarterly-report/
+    test.json
+    files/
+      report.txt
+```
+
+```json
+// summarize-suite/quarterly-report/test.json
+{
+  "input": "Summarize report.txt into summary.md",
+  "goal": "summary.md captures the report's main findings"
+}
+```
+
+```bash
+agency eval run summarizer.agency --suite summarize-suite --out runs/summaries
+```
+
+Two things happen automatically in this form:
+- The test's `id` defaults to the directory name (`quarterly-report`), so you can leave it out
+- The contents of `files/` are copied into the working directory the agent runs in, so the agent sees `report.txt` in its current directory, and any files it writes (like `summary.md`) get written to the run directory's `workdir/` for the graders to check.
+
+You can also specify custom graders for the test pretty easily: just add a `graders.ts` in the test dir next to `test.json`, and it will be used for grading. Nothing else needed.
+
+#### Other ways to add files
+
+You don't have to use the directory form to attach files. Just name a folder with `"files": "./fixtures/quarterly"` in your JSON. The dir path will be resolved relative to the JSON file it appears in.
+
+### A suite from git
+
+Anywhere a suite directory is accepted, a git URL works too. This is how a team shares one set of tests across repositories, or how you pin an eval to a known version:
+
+```bash
+agency eval run test.agency --suite 'github.com/you/evals//einstein-suite?ref=v1.2'
+```
+
+The address has three parts: the repository (`github.com/you/evals`; a full `https://` URL or a local repo path work too), an optional `//subdir` naming a folder inside it, and an optional `?ref=` naming a branch, tag, or commit. The clone is cached under `~/.agency/cache/git/`. Whatever ref you gave, the run records the exact commit it resolved to, so you can reproduce any past run later by copying that commit into `?ref=`.

--- a/packages/agency-lang/evals/agency-agent/news/graders.ts
+++ b/packages/agency-lang/evals/agency-agent/news/graders.ts
@@ -1,0 +1,19 @@
+import { grader } from "agency-lang/eval";
+
+function runDate(record: { startedAtMs: number }): string {
+  return new Date(record.startedAtMs).toISOString().slice(0, 10); // "2026-08-19"
+}
+
+export default [
+  grader(({ record }) => record.durationMs < 1000 * 60 * 5, { name: "under-5min", mustPass: true }),
+
+  grader(
+    async ({ judge, record }) =>
+      (await judge({ goal: `lists news headlines from ${runDate(record)}, not from an earlier or later date` })).score,
+    { name: "is-today" },
+  ),
+
+  grader(async ({ judge }) => (await judge({ goal: "returns a list of top news headlines" })).score, {
+    name: "headlines",
+  }),
+];

--- a/packages/agency-lang/evals/agency-agent/news/graders.ts
+++ b/packages/agency-lang/evals/agency-agent/news/graders.ts
@@ -9,11 +9,18 @@ export default [
 
   grader(
     async ({ judge, record }) =>
-      (await judge({ goal: `lists news headlines from ${runDate(record)}, not from an earlier or later date` })).score,
+      (
+        await judge({
+          goal: `lists news headlines from ${runDate(record)}, not from an earlier or later date`,
+        })
+      ).score,
     { name: "is-today" },
   ),
 
-  grader(async ({ judge }) => (await judge({ goal: "returns a list of top news headlines" })).score, {
-    name: "headlines",
-  }),
+  grader(
+    async ({ judge }) => (await judge({ goal: "returns a list of top news headlines" })).score,
+    {
+      name: "headlines",
+    },
+  ),
 ];

--- a/packages/agency-lang/evals/agency-agent/news/test.json
+++ b/packages/agency-lang/evals/agency-agent/news/test.json
@@ -1,0 +1,5 @@
+{
+  "id": "news",
+  "input": "What are the top news headlines for today?",
+  "goal": "returns today's news headlines"
+}

--- a/packages/agency-lang/lib/agentTarget.test.ts
+++ b/packages/agency-lang/lib/agentTarget.test.ts
@@ -69,15 +69,15 @@ describe("resolveEvalTarget", () => {
   });
 
   it("resolves --agent-cmd into a command target with the placeholder intact", () => {
-    expect(resolveEvalTarget({ agentCmd: `agency agent -p -- {task}` })).toEqual({
+    expect(resolveEvalTarget({ agentCmd: `agency agent -p -- {input}` })).toEqual({
       kind: "command",
-      tokens: ["agency", "agent", "-p", "--", "{task}"],
-      label: "agency agent -p -- {task}",
+      tokens: ["agency", "agent", "-p", "--", "{input}"],
+      label: "agency agent -p -- {input}",
     });
   });
 
-  it("rejects both and neither; a command without {task} is fine here (the input check decides)", () => {
-    expect(() => resolveEvalTarget({ agent: "a.agency", agentCmd: "x {task}" })).toThrow(
+  it("rejects both and neither; a command without {input} is fine here (the input check decides)", () => {
+    expect(() => resolveEvalTarget({ agent: "a.agency", agentCmd: "x {input}" })).toThrow(
       /exactly one of/,
     );
     expect(() => resolveEvalTarget({})).toThrow(/exactly one of/);
@@ -125,17 +125,23 @@ describe("assertTargetMatchesInputs", () => {
     ).toThrow(/no test provides an input.*--input/);
   });
 
-  it("commands: {task} is required with inputs and refused without", () => {
+  it("commands: the old {task} placeholder is refused with a pointer to {input}", () => {
     expect(() =>
       assertTargetMatchesInputs(command("agency agent -p -- {task}"), withInput),
+    ).toThrow(/\{task\}, which was renamed: write \{input\}/);
+  });
+
+  it("commands: {input} is required with inputs and refused without", () => {
+    expect(() =>
+      assertTargetMatchesInputs(command("agency agent -p -- {input}"), withInput),
     ).not.toThrow();
     expect(() => assertTargetMatchesInputs(command("agency agent -p hello"), withInput)).toThrow(
-      /must contain \{task\}/,
+      /must contain \{input\}/,
     );
     expect(() =>
       assertTargetMatchesInputs(command("agency agent -p hello"), noInput),
     ).not.toThrow();
-    expect(() => assertTargetMatchesInputs(command("agency agent -p -- {task}"), noInput)).toThrow(
+    expect(() => assertTargetMatchesInputs(command("agency agent -p -- {input}"), noInput)).toThrow(
       /no test provides an input/,
     );
   });

--- a/packages/agency-lang/lib/agentTarget.ts
+++ b/packages/agency-lang/lib/agentTarget.ts
@@ -2,8 +2,10 @@ import * as fs from "fs";
 import * as path from "path";
 
 import {
-  MISSING_TASK_PLACEHOLDER_ERROR,
-  TASK_PLACEHOLDER,
+  MISSING_INPUT_PLACEHOLDER_ERROR,
+  INPUT_PLACEHOLDER,
+  OLD_TASK_PLACEHOLDER,
+  OLD_TASK_PLACEHOLDER_ERROR,
   tokenizeCommand,
 } from "@/eval/run/commandLine.js";
 import { parseAgency } from "@/parser.js";
@@ -53,7 +55,7 @@ export type EvalTarget =
   | { kind: "command"; tokens: string[]; label: string };
 
 /** Resolve the runner-side agent choice. Exactly one of --agent /
- *  --agent-cmd; the command's {task} placeholder is validated here, before
+ *  --agent-cmd; the command's {input} placeholder is validated here, before
  *  any run. Commands come ONLY from these flags, never from suite content —
  *  suites can be remote git sources, and a suite that named its own command
  *  would be remote code execution. */
@@ -70,7 +72,7 @@ export function resolveEvalTarget(opts: { agent?: string; agentCmd?: string }): 
 /**
  * Fail fast when the agent's shape does not match what the tests deliver.
  * A test's input reaches a file agent as the entry node's single positional
- * parameter and a command agent as `{task}`; a test with no input reaches a
+ * parameter and a command agent as `{input}`; a test with no input reaches a
  * node that takes none / a command with no placeholder. Within one suite the
  * tests must agree (all carry an input, or none does), so the agent has one
  * shape to be. Checked before any workdir is seeded or agent compiled: a
@@ -91,11 +93,14 @@ export function assertTargetMatchesInputs(target: EvalTarget, tests: { input?: u
   }
   const hasInput = withInput > 0;
   if (target.kind === "command") {
-    const hasPlaceholder = target.tokens.some((t) => t.includes(TASK_PLACEHOLDER));
-    if (hasInput && !hasPlaceholder) throw new Error(MISSING_TASK_PLACEHOLDER_ERROR);
+    if (target.tokens.some((t) => t.includes(OLD_TASK_PLACEHOLDER))) {
+      throw new Error(OLD_TASK_PLACEHOLDER_ERROR);
+    }
+    const hasPlaceholder = target.tokens.some((t) => t.includes(INPUT_PLACEHOLDER));
+    if (hasInput && !hasPlaceholder) throw new Error(MISSING_INPUT_PLACEHOLDER_ERROR);
     if (!hasInput && hasPlaceholder) {
       throw new Error(
-        `--agent-cmd contains ${TASK_PLACEHOLDER} but no test provides an input — pass --input <text> ` +
+        `--agent-cmd contains ${INPUT_PLACEHOLDER} but no test provides an input — pass --input <text> ` +
           `(or give the tests an "input"), or drop the placeholder for an agent that takes none.`,
       );
     }

--- a/packages/agency-lang/lib/cli/eval/grade.test.ts
+++ b/packages/agency-lang/lib/cli/eval/grade.test.ts
@@ -60,7 +60,6 @@ describe("evalGrade", () => {
       kind: "score",
       name: "len",
       passSize: 1,
-      completesPass: true,
       score: { kind: "scalar", value: 0.5 },
     });
     // The grader is identified by its module revision, so an edit in place is a

--- a/packages/agency-lang/lib/cli/eval/run.test.ts
+++ b/packages/agency-lang/lib/cli/eval/run.test.ts
@@ -393,13 +393,13 @@ describe("eval run CLI", () => {
       let job: EvalRunnerJob | undefined;
 
       const result = await evalRun(
-        { agentCmd: "some-agent -p -- {task}", input: "do it", out: path.join(runsDir, "r-cmd") },
+        { agentCmd: "some-agent -p -- {input}", input: "do it", out: path.join(runsDir, "r-cmd") },
         { runner: traceRunner("done", (j) => (job = j)) },
       );
 
       expect(result.okCount).toBe(1);
       expect(job?.kind).toBe("command");
-      // --input is the substituted {task}, so the argv carries it
+      // --input is the substituted {input}, so the argv carries it
       expect(job?.kind === "command" && job.argv).toEqual(["some-agent", "-p", "--", "do it"]);
     });
   });

--- a/packages/agency-lang/lib/cli/eval/run.ts
+++ b/packages/agency-lang/lib/cli/eval/run.ts
@@ -16,7 +16,7 @@ import { resolveEvalTarget } from "@/agentTarget.js";
 export type EvalRunCliOptions = {
   /** File agent target. Exactly one of agent / agentCmd. */
   agent?: string;
-  /** Command agent target: the command string with a {task} placeholder. */
+  /** Command agent target: the command string with a {input} placeholder. */
   agentCmd?: string;
   /** The test suite: a JSON file, a directory, or a git source. */
   suite?: string;
@@ -52,7 +52,7 @@ export async function evalRun(
   /** Test seam — the CLI has no flag for it. */
   deps: { runner?: EvalInputRunner } = {},
 ): Promise<SuiteRunResult> {
-  // Resolve first: exactly-one-of and the {task}-placeholder check belong
+  // Resolve first: exactly-one-of and the {input}-placeholder check belong
   // before anything loads or runs.
   const target = resolveEvalTarget({ agent: opts.agent, agentCmd: opts.agentCmd });
   const selection = validateInputSelection(opts);

--- a/packages/agency-lang/lib/cli/runDirectory/commands.test.ts
+++ b/packages/agency-lang/lib/cli/runDirectory/commands.test.ts
@@ -25,7 +25,7 @@ import {
 } from "./commands.js";
 import { formatTextTable } from "./table.js";
 import { logsExtract } from "./extract.js";
-import { runsList } from "./list.js";
+import { relativeAgentLabel, runsList } from "./list.js";
 
 const quiet = { reportWarning: () => {} };
 
@@ -205,6 +205,22 @@ describe("runs list over groups", () => {
     expect(rowA).toContain("/abs/agents/greeter.agency:main");
     expect(lastLine(listed[0])).toBe("2 runs");
     expect(readRunDirectory(a, quiet).traces).toHaveLength(1);
+  });
+
+  it("AGENT shows a file under the current directory relative to it, everything else as is", () => {
+    expect(relativeAgentLabel("/home/me/proj/test.agency:main", "/home/me/proj")).toBe(
+      "test.agency:main",
+    );
+    expect(relativeAgentLabel("/home/me/proj/agents/a.agency", "/home/me/proj")).toBe(
+      "agents/a.agency",
+    );
+    expect(relativeAgentLabel("/abs/agents/greeter.agency:main", "/home/me/proj")).toBe(
+      "/abs/agents/greeter.agency:main",
+    );
+    expect(relativeAgentLabel("/usr/bin/python /home/me/proj/agent.py", "/home/me/proj")).toBe(
+      "/usr/bin/python /home/me/proj/agent.py",
+    );
+    expect(relativeAgentLabel("greeter", "/home/me/proj")).toBe("greeter");
   });
 
   it("several paths keep the user's order and duplicates; one run directory is a list of one", () => {

--- a/packages/agency-lang/lib/cli/runDirectory/list.ts
+++ b/packages/agency-lang/lib/cli/runDirectory/list.ts
@@ -1,3 +1,5 @@
+import * as path from "path";
+
 import { findRunDirectories } from "@/runDirectory/findRuns.js";
 import {
   buildRunsListing,
@@ -36,13 +38,15 @@ const HEADER = [
   "LLM",
   "TOOLS",
   "SCORE",
+  "PASSES",
   "NOTES",
   "LABELED",
   "INPUT",
 ];
 
-/** The table (omitted when there are no rows) and the footer line. */
-export function formatRunsList(listing: RunsListing): string {
+/** The table (omitted when there are no rows) and the footer line. Agent
+ *  file paths under `cwd` are shown relative to it. */
+export function formatRunsList(listing: RunsListing, cwd: string = process.cwd()): string {
   const footer = footerLine(listing);
   if (listing.summaries.length === 0) {
     return footer;
@@ -50,7 +54,7 @@ export function formatRunsList(listing: RunsListing): string {
   const rows = listing.summaries.map((summary) => [
     summary.traceId.slice(0, 8),
     summary.testId ?? "",
-    displayAgent(summary) ?? "",
+    relativeAgentLabel(displayAgent(summary) ?? "", cwd),
     summary.startedAt === null ? "" : summary.startedAt.slice(0, 16).replace("T", " "),
     summary.ended,
     formatDuration(summary.durationMs),
@@ -58,11 +62,22 @@ export function formatRunsList(listing: RunsListing): string {
     String(summary.llmCalls),
     String(summary.toolCalls),
     summary.latestScore === null ? "" : summary.latestScore.toFixed(2),
+    summary.gradingPasses === 0 ? "" : String(summary.gradingPasses),
     summary.hasNotes ? "yes" : "",
     summary.labeled ? "yes" : "",
     summary.input === null ? "" : oneLine(summary.input, 60),
   ]);
   return `${formatTextTable(HEADER, rows)}\n${footer}`;
+}
+
+/** `/home/me/proj/test.agency:main` reads `test.agency:main` when run from
+ *  `/home/me/proj`. Labels outside `cwd`, and command lines, are unchanged. */
+export function relativeAgentLabel(label: string, cwd: string): string {
+  const match = label.match(/^(\/\S+\.agency)(:\S+)?$/);
+  if (match === null) return label;
+  const relative = path.relative(cwd, match[1]);
+  if (relative.startsWith("..")) return label;
+  return relative + (match[2] ?? "");
 }
 
 /** `N runs · mean 0.720 over G graded · S runs wrote no trace`, clauses present

--- a/packages/agency-lang/lib/cli/runDirectory/list.ts
+++ b/packages/agency-lang/lib/cli/runDirectory/list.ts
@@ -73,10 +73,10 @@ export function formatRunsList(listing: RunsListing, cwd: string = process.cwd()
 /** `/home/me/proj/test.agency:main` reads `test.agency:main` when run from
  *  `/home/me/proj`. Labels outside `cwd`, and command lines, are unchanged. */
 export function relativeAgentLabel(label: string, cwd: string): string {
-  const match = label.match(/^(\/\S+\.agency)(:\S+)?$/);
-  if (match === null) return label;
+  const match = label.match(/^(\S+\.agency)(:\S+)?$/);
+  if (match === null || !path.isAbsolute(match[1])) return label;
   const relative = path.relative(cwd, match[1]);
-  if (relative.startsWith("..")) return label;
+  if (relative.startsWith("..") || path.isAbsolute(relative)) return label;
   return relative + (match[2] ?? "");
 }
 

--- a/packages/agency-lang/lib/eval/grading/baseGrader.ts
+++ b/packages/agency-lang/lib/eval/grading/baseGrader.ts
@@ -11,7 +11,8 @@ export abstract class BaseGrader {
   /** Who this grader is, by revision, for the score rows it writes: a module
    *  grader is `<path>@<sha256 of the file>` (set by loadGradingModule), so
    *  editing the module in place is a new annotator; the bundled goal judge is
-   *  `goal-judge@<hash of its prompt file>`; anything else constructed in
+   *  `goal-judge@<version>` (a test pins the version to the prompt's hash);
+   *  a custom judge file is `<path>@<sha256 of the file>`; anything else constructed in
    *  process is `inline:<name>`. */
   annotator(): { kind: "grader" | "judge"; id: string } {
     if (this.revision !== undefined) return { kind: "grader", id: this.revision };
@@ -20,6 +21,16 @@ export abstract class BaseGrader {
 
   /** @internal Set by loadGradingModule on every grader a module exports. */
   revision?: string;
+
+  /** Files this grader reads from disk at grade time, as the paths were
+   *  declared (relative ones are cwd-relative). A run directory snapshots
+   *  them next to the grading bundle so a copied run still grades;
+   *  `rebindExternalFile` is called with the declared path and the copy's
+   *  absolute path. Default: none. */
+  externalFiles(): string[] {
+    return [];
+  }
+  rebindExternalFile(_from: string, _to: string): void {}
 
   /** Subclasses set a default; `options.name` overrides it. */
   protected abstract readonly defaultName: string;

--- a/packages/agency-lang/lib/eval/grading/goalJudgeFile.test.ts
+++ b/packages/agency-lang/lib/eval/grading/goalJudgeFile.test.ts
@@ -1,12 +1,27 @@
 import * as fs from "fs";
 import { describe, expect, it } from "vitest";
-import { asJudgeText, goalJudgeFile, ScalarVerdict } from "./goalJudgeFile.js";
+import { sha256Text } from "@/utils/hash.js";
+import {
+  asJudgeText,
+  GOAL_JUDGE_PROMPT_SHA256,
+  GOAL_JUDGE_VERSION,
+  goalJudgeFile,
+  ScalarVerdict,
+} from "./goalJudgeFile.js";
 
 describe("goalJudgeFile", () => {
   it("points at the bundled goalJudge.agency that exists on disk", () => {
     const file = goalJudgeFile();
     expect(file.endsWith("eval/goalJudge.agency")).toBe(true);
     expect(fs.existsSync(file)).toBe(true);
+  });
+
+  it("the prompt file still hashes to the pinned GOAL_JUDGE_VERSION", () => {
+    const actual = sha256Text(fs.readFileSync(goalJudgeFile(), "utf8"));
+    expect(
+      actual,
+      `goalJudge.agency changed. Bump GOAL_JUDGE_VERSION (currently ${GOAL_JUDGE_VERSION}) in goalJudgeFile.ts and set GOAL_JUDGE_PROMPT_SHA256 to ${actual}.`,
+    ).toBe(GOAL_JUDGE_PROMPT_SHA256);
   });
 
   it("ScalarVerdict accepts a {score, reasoning} object", () => {

--- a/packages/agency-lang/lib/eval/grading/goalJudgeFile.ts
+++ b/packages/agency-lang/lib/eval/grading/goalJudgeFile.ts
@@ -9,6 +9,14 @@ export function goalJudgeFile(): string {
   return path.join(getAgentsDir(), "eval", "goalJudge.agency");
 }
 
+/** The bundled judge's revision, as written into score rows (`goal-judge@1`).
+ *  Bump it whenever you edit `goalJudge.agency`, and update the hash below to
+ *  match; `goalJudgeFile.test.ts` fails when the file no longer hashes to it,
+ *  so a changed prompt cannot keep an old revision. */
+export const GOAL_JUDGE_VERSION = 1;
+export const GOAL_JUDGE_PROMPT_SHA256 =
+  "3c3e426a4766a33edc02b8997fd4f18a5abe131ea4b463bc7a85ba38953e5bec";
+
 /** Structured verdict shape the goal judge returns (0..1 score + reasoning). */
 export const ScalarVerdict = z.object({ score: z.number(), reasoning: z.string() });
 

--- a/packages/agency-lang/lib/eval/grading/gradeRun.ts
+++ b/packages/agency-lang/lib/eval/grading/gradeRun.ts
@@ -123,9 +123,12 @@ export function validateGraders(graders: BaseGrader[], test: Test | undefined): 
   }
 }
 
-/** Which graders score this test, per the precedence the SuiteGraders doc
- *  states: override > the snapshot the run directory stored > the test's
- *  recorded module path (a directory from before snapshots) > fallback. */
+/** Which graders score this test. Precedence: override > the test-owned
+ *  snapshot the run directory stored > the test's recorded module path (a
+ *  directory from before snapshots) > a config-origin snapshot > fallback.
+ *  A config-origin snapshot is skipped under `--goal` (`ctx.defaultGoal`):
+ *  the goal promises the goal judge and sets configured modules aside, the
+ *  run-time copy included — only a test's OWN graders survive it. */
 async function effectiveGraders(
   entry: Entry,
   ctx: GradingContext,
@@ -135,11 +138,15 @@ async function effectiveGraders(
   if (ctx.suiteGraders.mode === "override") {
     return ctx.suiteGraders.graders;
   }
-  if (entry.graders !== undefined) {
-    return loadGradingSnapshot(runDirPaths(runDir).gradersDir, entry.graders);
+  const snapshot = entry.graders;
+  if (snapshot !== undefined && snapshot.origin === "test") {
+    return loadGradingSnapshot(runDirPaths(runDir).gradersDir, snapshot);
   }
   if (entry.test.graders !== undefined) {
     return cache(entry.test.graders);
+  }
+  if (snapshot !== undefined && ctx.defaultGoal === undefined) {
+    return loadGradingSnapshot(runDirPaths(runDir).gradersDir, snapshot);
   }
   return ctx.suiteGraders.graders;
 }

--- a/packages/agency-lang/lib/eval/grading/gradeRun.ts
+++ b/packages/agency-lang/lib/eval/grading/gradeRun.ts
@@ -4,7 +4,11 @@ import * as path from "path";
 import type { AgencyConfig } from "@/config.js";
 import type { Test } from "@/eval/runTypes.js";
 import type { EvalRecord } from "@/eval/types.js";
-import type { Annotation, EffectiveTraceAnnotations } from "@/runDirectory/annotations.js";
+import type {
+  Annotation,
+  EffectiveTraceAnnotations,
+  GradersIdentity,
+} from "@/runDirectory/annotations.js";
 import { evalRecordFor, traceEnding } from "@/runDirectory/evalRecord.js";
 import { humanFeedbackFor, type HumanFeedback } from "@/runDirectory/humanFeedback.js";
 import { readRunDirectory, runDirPaths, type RunDirectorySnapshot } from "@/runDirectory/runDir.js";
@@ -12,7 +16,7 @@ import type { Trace } from "@/runDirectory/traces.js";
 
 import type { AgencyRunner } from "./agencyRunner.js";
 import type { BaseGrader } from "./baseGrader.js";
-import { loadGradingModule } from "./gradingModule.js";
+import { loadGradingModule, loadGradingSnapshot } from "./gradingModule.js";
 import { Scorecard, type GraderGrade, type InputGrades } from "./scorecard.js";
 import type { LoadedRun, JSON as Json } from "./types.js";
 
@@ -55,7 +59,7 @@ export async function gradeSnapshot(
   const perInput = await Promise.all(
     gradableEntries(snapshot).map(async (bare) => {
       const entry = withDefaultGoal(bare, ctx.defaultGoal);
-      const graders = await effectiveGraders(entry.test, ctx, moduleCache);
+      const graders = await effectiveGraders(entry, ctx, moduleCache, snapshot.dir);
       return gradeEntry(entry, ctx, graders);
     }),
   );
@@ -120,17 +124,22 @@ export function validateGraders(graders: BaseGrader[], test: Test | undefined): 
 }
 
 /** Which graders score this test, per the precedence the SuiteGraders doc
- *  states: override > the test's own recorded module > fallback. */
+ *  states: override > the snapshot the run directory stored > the test's
+ *  recorded module path (a directory from before snapshots) > fallback. */
 async function effectiveGraders(
-  test: Test,
+  entry: Entry,
   ctx: GradingContext,
   cache: (modulePath: string) => Promise<BaseGrader[]>,
+  runDir: string,
 ): Promise<BaseGrader[]> {
   if (ctx.suiteGraders.mode === "override") {
     return ctx.suiteGraders.graders;
   }
-  if (test.graders !== undefined) {
-    return cache(test.graders);
+  if (entry.graders !== undefined) {
+    return loadGradingSnapshot(runDirPaths(runDir).gradersDir, entry.graders);
+  }
+  if (entry.test.graders !== undefined) {
+    return cache(entry.test.graders);
   }
   return ctx.suiteGraders.graders;
 }
@@ -152,10 +161,11 @@ export function makeGraderModuleCache(
 
 /** What grading needs from one trace: the test it ran, its evidence, and
  *  optionally a reason not to grade at all. */
-type Entry =
-  | { test: Test; run: LoadedRun; humanFeedback: HumanFeedback }
+type Entry = { test: Test; humanFeedback: HumanFeedback; graders?: GradersIdentity } & (
+  | { run: LoadedRun }
   /** The trace cannot be graded at all: skip straight to a scored zero. */
-  | { test: Test; humanFeedback: HumanFeedback; ungradedReason: string };
+  | { ungradedReason: string }
+);
 
 /**
  * One entry from a run directory. THE POLICY LIVES HERE: a run that did not
@@ -185,15 +195,16 @@ function entryFor(snapshot: RunDirectorySnapshot, trace: Trace): Entry {
     record,
   };
   const humanFeedback = humanFeedbackFor(snapshot, trace.traceId);
+  const graders = runRow !== null && runRow.kind === "run" ? runRow.graders : undefined;
   const ended = runRow !== null && runRow.kind === "run" ? runRow.ended : traceEnding(trace);
   if (ended === "ok") {
-    return { test, run, humanFeedback };
+    return { test, run, humanFeedback, graders };
   }
   const detail =
     runRow !== null && runRow.kind === "run" && runRow.error !== undefined
       ? `: ${runRow.error}`
       : "";
-  return { test, humanFeedback, ungradedReason: `the run ended with ${ended}${detail}` };
+  return { test, humanFeedback, graders, ungradedReason: `the run ended with ${ended}${detail}` };
 }
 
 /** The test a trace ran, from the harness's `run` row; an ad-hoc trace with

--- a/packages/agency-lang/lib/eval/grading/graders/llmJudge.ts
+++ b/packages/agency-lang/lib/eval/grading/graders/llmJudge.ts
@@ -3,7 +3,7 @@ import * as fs from "fs";
 import { sha256Text } from "@/utils/hash.js";
 import { z } from "zod";
 
-import { asJudgeText, goalJudgeFile, ScalarVerdict } from "../goalJudgeFile.js";
+import { asJudgeText, GOAL_JUDGE_VERSION, goalJudgeFile, ScalarVerdict } from "../goalJudgeFile.js";
 import { BaseGrader } from "../baseGrader.js";
 import { getPath } from "../getPath.js";
 import type { Grade, GraderInput, GraderOptions, JSONPath } from "../types.js";
@@ -21,17 +21,35 @@ const BinaryVerdict = z.object({ pass: z.boolean(), reasoning: z.string() });
 
 /** Grades an output by running a judge .agency file and reading its structured verdict. */
 export class LlmJudge extends BaseGrader {
-  /** The bundled judge is identified by its prompt file's content, so a
-   *  changed judge prompt is a new annotator; a custom agencyFile likewise. */
+  /** The bundled judge is `goal-judge@<GOAL_JUDGE_VERSION>` (a test pins the
+   *  version to the prompt file's hash); a custom agencyFile is identified by
+   *  its content, so editing it in place is a new annotator. */
   override annotator(): { kind: "grader" | "judge"; id: string } {
     if (this.revision !== undefined) return { kind: "grader", id: this.revision };
-    const agencyFile = this.options.agencyFile ?? goalJudgeFile();
-    return { kind: "judge", id: `goal-judge@${sha256Text(fs.readFileSync(agencyFile, "utf8"))}` };
+    const judgeFile = this.customJudgeFile();
+    if (judgeFile === undefined) {
+      return { kind: "judge", id: `goal-judge@${GOAL_JUDGE_VERSION}` };
+    }
+    const hash = sha256Text(fs.readFileSync(judgeFile, "utf8"));
+    return { kind: "judge", id: `${this.options.agencyFile}@${hash}` };
   }
 
   protected readonly defaultName = "llm-judge";
   constructor(protected readonly options: LlmJudgeOptions) {
     super(options);
+  }
+
+  /** The custom judge file; undefined for the bundled judge. A run-directory
+   *  snapshot rebinds it to the stored copy. */
+  private judgeFile: string | undefined = undefined;
+  private customJudgeFile(): string | undefined {
+    return this.judgeFile ?? this.options.agencyFile;
+  }
+  override externalFiles(): string[] {
+    return this.options.agencyFile === undefined ? [] : [this.options.agencyFile];
+  }
+  override rebindExternalFile(from: string, to: string): void {
+    if (this.options.agencyFile === from) this.judgeFile = to;
   }
 
   protected async _run({ test, run, runAgency }: GraderInput): Promise<Grade> {
@@ -45,7 +63,7 @@ export class LlmJudge extends BaseGrader {
         `${this.name()}: no goal (set options.goal or provide one at ${globalThis.JSON.stringify(goalPath)} on test ${test.id ?? "(no id)"}); an LLM judge needs a goal.`,
       );
     }
-    const agencyFile = this.options.agencyFile ?? goalJudgeFile();
+    const agencyFile = this.customJudgeFile() ?? goalJudgeFile();
     // Judges take a string output; stringify structured outputs so they read as JSON
     // rather than "[object Object]".
     const output = asJudgeText(run.output);

--- a/packages/agency-lang/lib/eval/grading/gradingModule.test.ts
+++ b/packages/agency-lang/lib/eval/grading/gradingModule.test.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import type { AgencyConfig } from "@/config.js";
 import { BaseGrader } from "./baseGrader.js";
-import { loadGradingModule } from "./gradingModule.js";
+import { loadGradingModule, loadGradingSnapshot, snapshotGradingModule } from "./gradingModule.js";
 
 const cfg: AgencyConfig = {};
 
@@ -39,13 +39,28 @@ describe("loadGradingModule", () => {
     const file = write(
       "grading.ts",
       `
+      // Grader-shaped objects (the duck type toGrader accepts) so this temp-dir
+      // module needs no import; plain functions would both be named "fn".
+      const named = (name: string) => ({ run: async () => 1, name: () => name, mustPass: () => false });
+      export default [named("a"), named("b")];
+    `,
+    );
+    const graders = await loadGradingModule(file, cfg);
+    expect(graders).toHaveLength(2);
+  });
+
+  it("refuses two graders with the same name, since scores are keyed by name", async () => {
+    const file = write(
+      "grading.ts",
+      `
       const a = ({ output }: any) => output === "x";
       const b = ({ output }: any) => 0.5;
       export default [a, b];
     `,
     );
-    const graders = await loadGradingModule(file, cfg);
-    expect(graders).toHaveLength(2);
+    await expect(loadGradingModule(file, cfg)).rejects.toThrow(
+      /two graders named "fn".*distinct name/,
+    );
   });
 
   it("throws a clear error when there is no default export", async () => {
@@ -58,5 +73,70 @@ describe("loadGradingModule", () => {
     await expect(loadGradingModule(file, cfg)).rejects.toThrow(
       /expected a grader function or grader instance/,
     );
+  });
+});
+
+describe("grading snapshots", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "gs-"));
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  // A grader-shaped object (no import, so the module is hermetic) that reads a
+  // sibling prompt file by path, the way LlmJudge reads a custom judge file.
+  const moduleSource = () => `
+    import { readFileSync } from "fs";
+    const declared = ${JSON.stringify(path.join(dir, "judge.agency"))};
+    let promptFile = declared;
+    export default [{
+      run: async () => ({ score: { kind: "scalar", value: readFileSync(promptFile, "utf8").length } }),
+      name: () => "prompted",
+      mustPass: () => false,
+      externalFiles: () => [declared],
+      rebindExternalFile: (from, to) => { if (from === declared) promptFile = to; },
+    }];
+  `;
+
+  it("bundles the module with its judge file, and loading the snapshot rebinds the file to the stored copy", async () => {
+    const modulePath = path.join(dir, "graders.ts");
+    fs.writeFileSync(modulePath, moduleSource());
+    fs.writeFileSync(path.join(dir, "judge.agency"), "judge v1");
+
+    const snapshot = await snapshotGradingModule(modulePath);
+    expect(snapshot.source).toBe(modulePath);
+    expect(snapshot.files.map((f) => f.name)).toEqual([
+      snapshot.bundleFile,
+      ...Object.values(snapshot.judgeFiles),
+    ]);
+    expect(Object.keys(snapshot.judgeFiles)).toEqual([path.join(dir, "judge.agency")]);
+
+    // Store the snapshot somewhere else entirely, then delete the originals.
+    const gradersDir = path.join(dir, "copied-run", "graders");
+    fs.mkdirSync(gradersDir, { recursive: true });
+    for (const file of snapshot.files)
+      fs.writeFileSync(path.join(gradersDir, file.name), file.content);
+    fs.rmSync(modulePath);
+    fs.rmSync(path.join(dir, "judge.agency"));
+
+    const [loaded] = await loadGradingSnapshot(gradersDir, snapshot);
+    // `externalFiles` still names the declared path; the read below proves the
+    // grader now reads the stored copy (the original is gone).
+    expect(loaded.externalFiles()).toEqual([path.join(dir, "judge.agency")]);
+    expect(loaded.revision).toBe(`${modulePath}@${snapshot.bundleFile.replace(/\.mjs$/, "")}`);
+    const grade = await loaded.run({
+      test: { id: "t" },
+      run: { output: null, traceId: "t", workdir: "", record: {} as never },
+      runAgency: {} as never,
+    });
+    expect(grade.score).toEqual({ kind: "scalar", value: "judge v1".length });
+  });
+
+  it("a missing snapshot file names the recorded source and the --graders escape hatch", async () => {
+    await expect(
+      loadGradingSnapshot(dir, { source: "/x/graders.ts", bundleFile: "nope.mjs", judgeFiles: {} }),
+    ).rejects.toThrow(/Grading snapshot not found.*\/x\/graders\.ts.*--graders/);
   });
 });

--- a/packages/agency-lang/lib/eval/grading/gradingModule.ts
+++ b/packages/agency-lang/lib/eval/grading/gradingModule.ts
@@ -6,46 +6,140 @@ import { pathToFileURL } from "url";
 import { build, stop as stopEsbuild, type BuildOptions } from "esbuild";
 
 import type { AgencyConfig } from "@/config.js";
+import { getPackageRoot } from "@/importPaths.js";
 import type { BaseGrader } from "./baseGrader.js";
 import { toGrader, type Grader } from "./functionGrader.js";
 
 let counter = 0;
 
+/** A grading module bundled into one self-contained file: everything it
+ *  imports inlined, except `agency-lang` itself. The hash names the revision. */
+export type GradingBundle = { source: string; code: string; sha256: string };
+
 /**
  * Load a user-authored TypeScript grading module and return its graders.
- * Transpiles with esbuild (leaving `agency-lang` external so the user's
- * `import { grader } from "agency-lang/optimize"` resolves to the installed
- * package), writes the bundle next to the source so Node finds the project's
- * node_modules, imports the default export, and normalizes it to BaseGrader[].
+ * Bundles with esbuild (leaving `agency-lang` external so the user's
+ * `import { grader } from "agency-lang/eval"` resolves to the installed
+ * package), imports the default export, and normalizes it to BaseGrader[].
  */
 export async function loadGradingModule(
   filePath: string,
   _config: AgencyConfig,
 ): Promise<BaseGrader[]> {
+  const bundle = await bundleGradingModule(filePath);
+  return importBundle(bundle, path.dirname(bundle.source));
+}
+
+/** Bundle a grading module without loading it. */
+export async function bundleGradingModule(filePath: string): Promise<GradingBundle> {
   const absolute = path.resolve(filePath);
   if (!fs.existsSync(absolute)) {
     throw new Error(`Grading module not found: ${absolute}`);
   }
-  counter += 1;
-  const out = path.join(path.dirname(absolute), `.agency-grading-${process.pid}-${counter}.mjs`);
+  const result = await buildSurvivingServiceDeath({
+    entryPoints: [absolute],
+    bundle: true,
+    platform: "node",
+    format: "esm",
+    target: "node18",
+    write: false,
+    logLevel: "silent",
+    external: ["agency-lang", "agency-lang/*"],
+  });
+  const code = result.outputFiles?.[0]?.text ?? "";
+  return { source: absolute, code, sha256: sha256Text(code) };
+}
+
+/**
+ * The files a run directory keeps so the run can be graded later, anywhere,
+ * by the graders it was run with: the bundle, plus any file a grader reads
+ * by path (a custom judge prompt). Names are content hashes. `judgeFiles`
+ * maps each path as the grader declared it to its stored name.
+ */
+export type GradersSnapshot = {
+  source: string;
+  bundleFile: string;
+  judgeFiles: Record<string, string>;
+  files: { name: string; content: string }[];
+};
+
+/** Bundle a grading module and collect its external files. Loads the module
+ *  once, so a broken module fails here, before any agent runs. */
+export async function snapshotGradingModule(filePath: string): Promise<GradersSnapshot> {
+  const bundle = await bundleGradingModule(filePath);
+  const graders = await importBundle(bundle, path.dirname(bundle.source));
+  const bundleFile = `${bundle.sha256}.mjs`;
+  const files: GradersSnapshot["files"] = [{ name: bundleFile, content: bundle.code }];
+  const judgeFiles: Record<string, string> = Object.create(null);
+  for (const grader of graders) {
+    for (const file of grader.externalFiles?.() ?? []) {
+      if (judgeFiles[file] !== undefined) continue;
+      const content = fs.readFileSync(path.resolve(file), "utf8");
+      const name = `${sha256Text(content)}${path.extname(file)}`;
+      judgeFiles[file] = name;
+      if (!files.some((entry) => entry.name === name)) files.push({ name, content });
+    }
+  }
+  return { source: bundle.source, bundleFile, judgeFiles, files };
+}
+
+/** What a run row records about its graders' snapshot: where the module
+ *  came from, and the stored names under the run directory's `graders/`. */
+export type RecordedGraders = {
+  source: string;
+  bundleFile: string;
+  judgeFiles: Record<string, string>;
+};
+
+/** Load graders from a run directory's snapshot. The revision is the stored
+ *  bundle's hash under the original source path, so a row graded from the
+ *  snapshot and one graded live from the unchanged module agree. */
+export async function loadGradingSnapshot(
+  gradersDir: string,
+  recorded: RecordedGraders,
+): Promise<BaseGrader[]> {
+  const bundlePath = path.join(gradersDir, recorded.bundleFile);
+  if (!fs.existsSync(bundlePath)) {
+    throw new Error(
+      `Grading snapshot not found: ${bundlePath} (recorded for ${recorded.source}). ` +
+        `Pass --graders <file> to grade with a module from disk.`,
+    );
+  }
+  const code = fs.readFileSync(bundlePath, "utf8");
+  const bundle: GradingBundle = { source: recorded.source, code, sha256: sha256Text(code) };
+  const graders = await importBundle(bundle, gradersDir);
+  for (const grader of graders) {
+    for (const [original, stored] of Object.entries(recorded.judgeFiles)) {
+      grader.rebindExternalFile?.(original, path.join(gradersDir, stored));
+    }
+  }
+  return graders;
+}
+
+/** Write the bundle to a temp file and import it. The temp file goes in
+ *  `nearDir` so the bundle's `agency-lang` import resolves from there; when
+ *  that fails (a run directory copied outside any project), retry from this
+ *  package's own root, where the name resolves to the package itself. */
+async function importBundle(bundle: GradingBundle, nearDir: string): Promise<BaseGrader[]> {
   try {
-    await buildSurvivingServiceDeath({
-      entryPoints: [absolute],
-      bundle: true,
-      platform: "node",
-      format: "esm",
-      target: "node18",
-      outfile: out,
-      write: true,
-      logLevel: "silent",
-      external: ["agency-lang", "agency-lang/*"],
-    });
+    return await importBundleFrom(bundle, nearDir);
+  } catch (err) {
+    if (!isAgencyLangNotFound(err) || nearDir === getPackageRoot()) throw err;
+    return importBundleFrom(bundle, getPackageRoot());
+  }
+}
+
+async function importBundleFrom(bundle: GradingBundle, dir: string): Promise<BaseGrader[]> {
+  counter += 1;
+  const out = path.join(dir, `.agency-grading-${process.pid}-${counter}.mjs`);
+  try {
+    fs.writeFileSync(out, bundle.code);
     // eslint-disable-next-line no-restricted-syntax -- CLI-layer loading of a user artifact; the bundle path is only known at runtime
     const mod = await import(pathToFileURL(out).href);
     const exported = mod.default;
     if (exported === undefined) {
       throw new Error(
-        `Grading module ${absolute} must default-export a grader or an array of graders ` +
+        `Grading module ${bundle.source} must default-export a grader or an array of graders ` +
           `(e.g. \`export default [...]\`).`,
       );
     }
@@ -53,14 +147,41 @@ export async function loadGradingModule(
     // Name each grader by the module's revision, so a score row says which
     // version of graders.ts produced it and an in-place edit never supersedes
     // the rows an earlier version wrote.
-    const revision = `${absolute}@${sha256Text(fs.readFileSync(absolute, "utf8"))}`;
-    return specs.map((spec) => {
+    const revision = `${bundle.source}@${bundle.sha256}`;
+    const graders = specs.map((spec) => {
       const grader = toGrader(spec);
       grader.revision = revision;
       return grader;
     });
+    assertDistinctNames(graders, bundle.source);
+    return graders;
   } finally {
     if (fs.existsSync(out)) fs.rmSync(out, { force: true });
+  }
+}
+
+function isAgencyLangNotFound(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    (err as { code?: string }).code === "ERR_MODULE_NOT_FOUND" &&
+    err.message.includes("agency-lang")
+  );
+}
+
+/** Score rows are keyed by grader name, so two graders sharing one would
+ *  silently overwrite each other's verdicts. Refuse at load time instead. */
+function assertDistinctNames(graders: BaseGrader[], modulePath: string): void {
+  const seen: Record<string, true> = Object.create(null);
+  for (const grader of graders) {
+    const name = grader.name();
+    if (seen[name]) {
+      throw new Error(
+        `Grading module ${modulePath} has two graders named "${name}". Give each a distinct name ` +
+          `(e.g. \`grader(fn, { name: "..." })\` or \`new LlmJudge({ name: "..." })\`), ` +
+          `because scores are recorded per grader name.`,
+      );
+    }
+    seen[name] = true;
   }
 }
 
@@ -73,14 +194,14 @@ export async function loadGradingModule(
  * retry once starts a fresh service; any other error, or a second failure,
  * propagates untouched.
  */
-async function buildSurvivingServiceDeath(options: BuildOptions): Promise<void> {
+async function buildSurvivingServiceDeath(options: BuildOptions) {
   try {
-    await build(options);
+    return await build(options);
   } catch (err) {
     if (!(err instanceof Error) || !err.message.includes("service is no longer running")) {
       throw err;
     }
     await stopEsbuild();
-    await build(options);
+    return build(options);
   }
 }

--- a/packages/agency-lang/lib/eval/grading/gradingModule.ts
+++ b/packages/agency-lang/lib/eval/grading/gradingModule.ts
@@ -74,7 +74,9 @@ export async function snapshotGradingModule(filePath: string): Promise<GradersSn
   for (const grader of graders) {
     for (const file of grader.externalFiles?.() ?? []) {
       if (judgeFiles[file] !== undefined) continue;
-      const content = fs.readFileSync(path.resolve(file), "utf8");
+      // A relative judge path resolves against the module that declared it,
+      // not the cwd `eval run` happened to start from.
+      const content = fs.readFileSync(path.resolve(path.dirname(bundle.source), file), "utf8");
       const name = `${sha256Text(content)}${path.extname(file)}`;
       judgeFiles[file] = name;
       if (!files.some((entry) => entry.name === name)) files.push({ name, content });

--- a/packages/agency-lang/lib/eval/loadInputs.test.ts
+++ b/packages/agency-lang/lib/eval/loadInputs.test.ts
@@ -88,7 +88,11 @@ describe("eval run input loading", () => {
     expect("input" in noInput).toBe(false);
     expect(() =>
       loadInputsFromFile(writeJson("empty-task.json", { inputs: [{ goal: "g", input: "" }] })),
-    ).toThrow(/must not be empty/);
+    ).toThrow(/must not be an empty string/);
+    const [emptyObject] = loadInputsFromFile(
+      writeJson("empty-object-task.json", { inputs: [{ goal: "g", input: {} }] }),
+    );
+    expect("input" in emptyObject).toBe(false);
     expect(() =>
       loadInputsFromFile(writeJson("array-task.json", { inputs: [{ goal: "g", input: [1] }] })),
     ).toThrow(/input must be a string, or a JSON object/);

--- a/packages/agency-lang/lib/eval/loadInputs.ts
+++ b/packages/agency-lang/lib/eval/loadInputs.ts
@@ -197,10 +197,9 @@ function normalizeInput(raw: unknown, baseDir: string, makeId: MakeId, options: 
     );
   }
   if (typeof spec.input === "string" && spec.input.length === 0) {
-    throw new Error("Eval test input must not be empty");
-  }
-  if (isPlainObject(spec.input) && Object.keys(spec.input).length === 0) {
-    throw new Error("Eval test input must not be empty");
+    throw new Error(
+      'Eval test input must not be an empty string; omit "input" (or give {}) for an agent that takes none',
+    );
   }
   if (spec.files !== undefined && typeof spec.files !== "string") {
     throw new Error("Eval input files must be a string when provided");
@@ -223,7 +222,11 @@ function normalizeInput(raw: unknown, baseDir: string, makeId: MakeId, options: 
     id: typeof spec.id === "string" ? spec.id : makeId(),
     expected: spec.expected, // any JSON; absent stays undefined
   };
-  if (spec.input !== undefined) out.input = spec.input as string | Record<string, any>;
+  // `{}` is the suite's way of saying "no input", like `eval run` without --input.
+  const hasInput =
+    spec.input !== undefined &&
+    !(isPlainObject(spec.input) && Object.keys(spec.input).length === 0);
+  if (hasInput) out.input = spec.input as string | Record<string, any>;
   if (typeof spec.goal === "string") out.goal = spec.goal;
   if (typeof spec.files === "string")
     out.files = resolveFilesDir(spec.files, baseDir, options, out.id ?? "");

--- a/packages/agency-lang/lib/eval/run/commandLine.test.ts
+++ b/packages/agency-lang/lib/eval/run/commandLine.test.ts
@@ -4,14 +4,14 @@ import { substituteInput, tokenizeCommand } from "./commandLine.js";
 
 describe("tokenizeCommand", () => {
   it("splits on whitespace and honors single and double quotes", () => {
-    expect(tokenizeCommand(`agency agent --policy approve-all -p -- {task}`)).toEqual([
+    expect(tokenizeCommand(`agency agent --policy approve-all -p -- {input}`)).toEqual([
       "agency",
       "agent",
       "--policy",
       "approve-all",
       "-p",
       "--",
-      "{task}",
+      "{input}",
     ]);
     expect(tokenizeCommand(`run "a b" 'c d' e`)).toEqual(["run", "a b", "c d", "e"]);
   });
@@ -35,7 +35,7 @@ describe("tokenizeCommand", () => {
 
 describe("substituteInput", () => {
   it("replaces every occurrence, inside tokens too", () => {
-    expect(substituteInput(["-p", "{task}", "--again={task}"], "do it")).toEqual([
+    expect(substituteInput(["-p", "{input}", "--again={input}"], "do it")).toEqual([
       "-p",
       "do it",
       "--again=do it",
@@ -43,10 +43,10 @@ describe("substituteInput", () => {
   });
 
   it("serializes an object task as JSON", () => {
-    expect(substituteInput(["-p", "{task}"], { rows: [1] })).toEqual(["-p", `{"rows":[1]}`]);
+    expect(substituteInput(["-p", "{input}"], { rows: [1] })).toEqual(["-p", `{"rows":[1]}`]);
   });
 
   it("throws when no token carries the placeholder — the task must reach the agent", () => {
-    expect(() => substituteInput(["agency", "agent"], "t")).toThrow(/\{task\}/);
+    expect(() => substituteInput(["agency", "agent"], "t")).toThrow(/\{input\}/);
   });
 });

--- a/packages/agency-lang/lib/eval/run/commandLine.test.ts
+++ b/packages/agency-lang/lib/eval/run/commandLine.test.ts
@@ -48,5 +48,6 @@ describe("substituteInput", () => {
 
   it("throws when no token carries the placeholder — the task must reach the agent", () => {
     expect(() => substituteInput(["agency", "agent"], "t")).toThrow(/\{input\}/);
+    expect(() => substituteInput(["agency", "{task}"], "t")).toThrow(/renamed: write \{input\}/);
   });
 });

--- a/packages/agency-lang/lib/eval/run/commandLine.ts
+++ b/packages/agency-lang/lib/eval/run/commandLine.ts
@@ -11,11 +11,15 @@ import {
   type Parser,
 } from "tarsec";
 
-export const TASK_PLACEHOLDER = "{task}";
+export const INPUT_PLACEHOLDER = "{input}";
+/** The placeholder's old name, refused with a pointer rather than silently
+ *  passed to the agent as literal text. */
+export const OLD_TASK_PLACEHOLDER = "{task}";
 
 /** One message, used by both the early check (resolveEvalTarget) and the
- *  invariant guard (substituteTask), so the two cannot drift. */
-export const MISSING_TASK_PLACEHOLDER_ERROR = `--agent-cmd must contain ${TASK_PLACEHOLDER} — the command never receives the input's task without it`;
+ *  invariant guard (substituteInput), so the two cannot drift. */
+export const MISSING_INPUT_PLACEHOLDER_ERROR = `--agent-cmd must contain ${INPUT_PLACEHOLDER} — the command never receives the test's input without it`;
+export const OLD_TASK_PLACEHOLDER_ERROR = `--agent-cmd uses ${OLD_TASK_PLACEHOLDER}, which was renamed: write ${INPUT_PLACEHOLDER} where the test's input should go`;
 
 // The grammar: a command is tokens separated by whitespace; a token is one
 // or more adjacent chunks; a chunk is a double-quoted span, a single-quoted
@@ -58,9 +62,8 @@ export function tokenizeCommand(command: string): string[] {
   return result.result;
 }
 
-/** Replace every {task} occurrence with the test's input. (The placeholder
- *  token stays `{task}` — it is user-facing; renaming it is a separate
- *  decision.) Objects serialize as JSON. With an input, at least one
+/** Replace every {input} occurrence with the test's input. Objects
+ *  serialize as JSON. With an input, at least one
  *  occurrence is required — a command that never receives the input is the
  *  silent-drop bug in new clothing. A test with no input leaves the command
  *  as written (the preflight already refused a placeholder in that case). */
@@ -70,8 +73,8 @@ export function substituteInput(
 ): string[] {
   if (input === undefined) return tokens;
   const text = typeof input === "string" ? input : JSON.stringify(input);
-  if (!tokens.some((t) => t.includes(TASK_PLACEHOLDER))) {
-    throw new Error(MISSING_TASK_PLACEHOLDER_ERROR);
+  if (!tokens.some((t) => t.includes(INPUT_PLACEHOLDER))) {
+    throw new Error(MISSING_INPUT_PLACEHOLDER_ERROR);
   }
-  return tokens.map((t) => t.split(TASK_PLACEHOLDER).join(text));
+  return tokens.map((t) => t.split(INPUT_PLACEHOLDER).join(text));
 }

--- a/packages/agency-lang/lib/eval/run/commandLine.ts
+++ b/packages/agency-lang/lib/eval/run/commandLine.ts
@@ -73,6 +73,9 @@ export function substituteInput(
 ): string[] {
   if (input === undefined) return tokens;
   const text = typeof input === "string" ? input : JSON.stringify(input);
+  if (tokens.some((t) => t.includes(OLD_TASK_PLACEHOLDER))) {
+    throw new Error(OLD_TASK_PLACEHOLDER_ERROR);
+  }
   if (!tokens.some((t) => t.includes(INPUT_PLACEHOLDER))) {
     throw new Error(MISSING_INPUT_PLACEHOLDER_ERROR);
   }

--- a/packages/agency-lang/lib/eval/run/runAgent.test.ts
+++ b/packages/agency-lang/lib/eval/run/runAgent.test.ts
@@ -173,8 +173,8 @@ describe("runAgent", () => {
     fs.writeFileSync(path.join(filesDir, "data.txt"), "fixture");
     const target = {
       kind: "command" as const,
-      tokens: ["node", "run.js", "-p", "{task}"],
-      label: "node run.js -p {task}",
+      tokens: ["node", "run.js", "-p", "{input}"],
+      label: "node run.js -p {input}",
     };
     let job: unknown;
 
@@ -202,7 +202,7 @@ describe("runAgent", () => {
   });
 
   it("command targets: a missing statelog error names the --log clobber cause", async () => {
-    const target = { kind: "command" as const, tokens: ["x", "{task}"], label: "x {task}" };
+    const target = { kind: "command" as const, tokens: ["x", "{input}"], label: "x {input}" };
     const run = await runAgent(
       target,
       "t",
@@ -225,8 +225,8 @@ describe("runAgent", () => {
   it("command targets: an oversized substituted task is an error result naming the size", async () => {
     const target = {
       kind: "command" as const,
-      tokens: ["node", "-e", "{task}"],
-      label: "node -e {task}",
+      tokens: ["node", "-e", "{input}"],
+      label: "node -e {input}",
     };
     const run = await runAgent(target, "x".repeat(128 * 1024 + 1), {
       runDir: path.join(tmp(), "run-cmd-big"),

--- a/packages/agency-lang/lib/eval/run/runSuite.test.ts
+++ b/packages/agency-lang/lib/eval/run/runSuite.test.ts
@@ -8,6 +8,7 @@ import { readRunDirectory, runDirPaths } from "@/runDirectory/runDir.js";
 import { finishedTraceLines } from "@/runDirectory/testFixtures.js";
 
 import { AgencyRunner } from "@/eval/grading/agencyRunner.js";
+import { grader } from "@/eval/grading/functionGrader.js";
 import { gradeRun } from "@/eval/grading/gradeRun.js";
 
 import { runSuite } from "./runSuite.js";
@@ -367,6 +368,67 @@ describe("runSuite", () => {
       config: {},
     });
     expect(scorecard.objective()).toBe(1);
+  });
+
+  it("a config-origin snapshot grades the run, but --goal sets it aside like the config module it came from", async () => {
+    const modulePath = path.join(proj, "graders.ts");
+    fs.writeFileSync(modulePath, "export default [() => 1];");
+    const result = await runSuite(
+      {
+        agent: path.join(proj, "agent.agency"),
+        inputs: [{ id: "a", goal: "g", input: "t" }],
+        out: path.join(proj, "runs", "r-config-graders"),
+        config: { eval: { graders: modulePath } },
+        perRun: { pipeOutput: false },
+      },
+      { runner: traceWritingRunner("done") },
+    );
+    const { runDir, traceId } = result.tests[0];
+    const run = readRunDirectory(runDir, quiet).effectiveAnnotations[traceId].run;
+    expect((run as unknown as { graders: { origin: string } }).graders.origin).toBe("config");
+
+    // Without --goal: the stored copy grades, even with the source deleted.
+    fs.rmSync(modulePath);
+    const fallback = grader(() => 0, { name: "stand-in-goal-judge" });
+    const plain = await gradeRun(runDir, {
+      suiteGraders: { mode: "fallback", graders: [fallback] },
+      runAgency: new AgencyRunner({}),
+      config: {},
+    });
+    expect(plain.objective()).toBe(1);
+
+    // With --goal (defaultGoal): configured modules are set aside, the
+    // run-time copy included — the suite fallback (the goal judge) grades.
+    const withGoal = await gradeRun(runDir, {
+      suiteGraders: { mode: "fallback", graders: [fallback] },
+      runAgency: new AgencyRunner({}),
+      config: {},
+      defaultGoal: "g",
+    });
+    expect(withGoal.objective()).toBe(0);
+  });
+
+  it("a test-owned snapshot still grades under --goal: a goal never overrides a test's own graders", async () => {
+    const modulePath = path.join(proj, "graders.ts");
+    fs.writeFileSync(modulePath, "export default [() => 1];");
+    const result = await runSuite(
+      {
+        agent: path.join(proj, "agent.agency"),
+        inputs: [{ id: "a", goal: "g", input: "t", graders: modulePath }],
+        out: path.join(proj, "runs", "r-test-graders-goal"),
+        config: {},
+        perRun: { pipeOutput: false },
+      },
+      { runner: traceWritingRunner("done") },
+    );
+    fs.rmSync(modulePath);
+    const withGoal = await gradeRun(result.tests[0].runDir, {
+      suiteGraders: { mode: "fallback", graders: [grader(() => 0, { name: "goalish" })] },
+      runAgency: new AgencyRunner({}),
+      config: {},
+      defaultGoal: "g",
+    });
+    expect(withGoal.objective()).toBe(1);
   });
 
   it("a broken grading module fails before any agent runs", async () => {

--- a/packages/agency-lang/lib/eval/run/runSuite.test.ts
+++ b/packages/agency-lang/lib/eval/run/runSuite.test.ts
@@ -7,6 +7,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { readRunDirectory, runDirPaths } from "@/runDirectory/runDir.js";
 import { finishedTraceLines } from "@/runDirectory/testFixtures.js";
 
+import { AgencyRunner } from "@/eval/grading/agencyRunner.js";
+import { gradeRun } from "@/eval/grading/gradeRun.js";
+
 import { runSuite } from "./runSuite.js";
 import type { EvalRunnerJob } from "./subprocess.js";
 
@@ -223,8 +226,8 @@ describe("runSuite", () => {
       {
         agent: {
           kind: "command",
-          tokens: ["some-agent", "-p", "{task}"],
-          label: "some-agent -p {task}",
+          tokens: ["some-agent", "-p", "{input}"],
+          label: "some-agent -p {input}",
         },
         inputs: [
           { id: "a", goal: "g", input: "first task" },
@@ -331,6 +334,57 @@ describe("runSuite", () => {
     ].run;
     expect((run as unknown as { test: { timeoutSec: number } }).test.timeoutSec).toBe(1200);
     expect(result.okCount).toBe(1);
+  });
+
+  it("stores each test's grading module in its run directory, and grading uses that copy even after the source changes", async () => {
+    const modulePath = path.join(proj, "graders.ts");
+    const moduleReturning = (value: number) => `export default [() => ${value}];`;
+    fs.writeFileSync(modulePath, moduleReturning(1));
+    const result = await runSuite(
+      {
+        agent: path.join(proj, "agent.agency"),
+        inputs: [{ id: "a", goal: "g", input: "t", graders: modulePath }],
+        out: path.join(proj, "runs", "r-graders"),
+        config: {},
+        perRun: { pipeOutput: false },
+      },
+      { runner: traceWritingRunner("done") },
+    );
+    const { runDir, traceId } = result.tests[0];
+    const run = readRunDirectory(runDir, quiet).effectiveAnnotations[traceId].run;
+    const recorded = (run as unknown as { graders: { source: string; bundleFile: string } })
+      .graders;
+    expect(recorded.source).toBe(modulePath);
+    expect(fs.existsSync(path.join(runDirPaths(runDir).gradersDir, recorded.bundleFile))).toBe(
+      true,
+    );
+
+    // The source changes underfoot; the run still grades by the module it ran with.
+    fs.writeFileSync(modulePath, moduleReturning(0));
+    const scorecard = await gradeRun(runDir, {
+      suiteGraders: { mode: "fallback", graders: [] },
+      runAgency: new AgencyRunner({}),
+      config: {},
+    });
+    expect(scorecard.objective()).toBe(1);
+  });
+
+  it("a broken grading module fails before any agent runs", async () => {
+    const modulePath = path.join(proj, "graders.ts");
+    fs.writeFileSync(modulePath, "export const notDefault = 1;");
+    const runner = vi.fn();
+    await expect(
+      runSuite(
+        {
+          agent: path.join(proj, "agent.agency"),
+          inputs: [{ id: "a", goal: "g", input: "t", graders: modulePath }],
+          out: path.join(proj, "runs", "r-broken"),
+          config: {},
+        },
+        { runner },
+      ),
+    ).rejects.toThrow(/must default-export/);
+    expect(runner).not.toHaveBeenCalled();
   });
 
   it("without --out, the run lands under eval.runsDir with a sortable timestamp name", async () => {

--- a/packages/agency-lang/lib/eval/run/runSuite.ts
+++ b/packages/agency-lang/lib/eval/run/runSuite.ts
@@ -90,7 +90,10 @@ export async function runSuite(
   // Each test's graders, bundled now and stored in its run directory, so the
   // run grades later by the graders it ran with, wherever the directory goes.
   // A broken grading module fails here, before any agent runs.
-  const gradersByTest = await snapshotGraders(opts.inputs, config);
+  const gradersByTest: Record<string, TestGraders | undefined> = await snapshotGraders(
+    opts.inputs,
+    config,
+  );
 
   // One closure walk per suite; never per test. Command targets have no
   // closure and nothing to compile. Before any directory is created: a
@@ -254,20 +257,27 @@ export async function runSuite(
   };
 }
 
+/** A test's snapshot plus where its module came from: its own spec, or the
+ *  `eval.graders` config fallback. The origin is recorded on the run row so
+ *  grading can honor `--goal`, which sets configured modules aside but never
+ *  a test's own. */
+type TestGraders = GradersSnapshot & { origin: "test" | "config" };
+
 /** The grading module each test will be graded with — its own, else the
  *  project's `eval.graders` — bundled once per distinct module. Tests with
  *  neither get no snapshot: the bundled goal judge needs none. */
 async function snapshotGraders(
   tests: Test[],
   config: AgencyConfig,
-): Promise<Record<string, GradersSnapshot>> {
+): Promise<Record<string, TestGraders | undefined>> {
   const byModule: Record<string, Promise<GradersSnapshot>> = Object.create(null);
-  const byTest: Record<string, GradersSnapshot> = Object.create(null);
+  const byTest: Record<string, TestGraders | undefined> = Object.create(null);
   for (const test of tests) {
     const modulePath = test.graders ?? config.eval?.graders;
     if (modulePath === undefined || test.id === undefined) continue;
     byModule[modulePath] ??= snapshotGradingModule(modulePath);
-    byTest[test.id] = await byModule[modulePath];
+    const origin = test.graders !== undefined ? ("test" as const) : ("config" as const);
+    byTest[test.id] = { ...(await byModule[modulePath]), origin };
   }
   return byTest;
 }
@@ -285,7 +295,7 @@ function foldIntoRunDirectory(args: {
   run: AgentRun;
   harness: { kind: "harness"; id: string };
   suite: SuiteIdentity | undefined;
-  graders: GradersSnapshot | undefined;
+  graders: TestGraders | undefined;
   flags: Record<string, string | number | boolean>;
 }): void {
   const { run } = args;
@@ -325,6 +335,7 @@ function foldIntoRunDirectory(args: {
                 source: args.graders.source,
                 bundleFile: args.graders.bundleFile,
                 judgeFiles: args.graders.judgeFiles,
+                origin: args.graders.origin,
               },
             }),
         ended: endedFrom(run),

--- a/packages/agency-lang/lib/eval/run/runSuite.ts
+++ b/packages/agency-lang/lib/eval/run/runSuite.ts
@@ -15,6 +15,7 @@ import type { RunOutcome, SuiteIdentity } from "@/runDirectory/annotations.js";
 import { recordedClosureHashes } from "@/runDirectory/attachCode.js";
 import { computeCodeIdentity } from "@/runDirectory/codeIdentity.js";
 import { recordCompletedRun } from "@/runDirectory/mutations.js";
+import { snapshotGradingModule, type GradersSnapshot } from "@/eval/grading/gradingModule.js";
 import { readTraces } from "@/runDirectory/traces.js";
 import { safeDeleteDirectoryWithin } from "@/utils.js";
 
@@ -37,7 +38,7 @@ export type RunSuiteOptions = {
   /** The agent. A string is file-target convenience (path, path:node, or a
    *  directory meaning main.agency) and is resolved here; a resolved
    *  EvalTarget passes through with no re-validation — it already passed
-   *  resolveEvalTarget, including the {task}-placeholder check. */
+   *  resolveEvalTarget, including the {input}-placeholder check. */
   agent: string | EvalTarget;
   inputs: Test[];
   /** The group directory; each test's run directory is written at
@@ -85,6 +86,11 @@ export async function runSuite(
   );
   const config = opts.config ?? {};
   const perRun = opts.perRun ?? {};
+
+  // Each test's graders, bundled now and stored in its run directory, so the
+  // run grades later by the graders it ran with, wherever the directory goes.
+  // A broken grading module fails here, before any agent runs.
+  const gradersByTest = await snapshotGraders(opts.inputs, config);
 
   // One closure walk per suite; never per test. Command targets have no
   // closure and nothing to compile. Before any directory is created: a
@@ -179,6 +185,7 @@ export async function runSuite(
         run,
         harness,
         suite: opts.suite,
+        graders: gradersByTest[testId],
         flags,
       });
       fs.renameSync(assembled, runDir);
@@ -247,6 +254,24 @@ export async function runSuite(
   };
 }
 
+/** The grading module each test will be graded with — its own, else the
+ *  project's `eval.graders` — bundled once per distinct module. Tests with
+ *  neither get no snapshot: the bundled goal judge needs none. */
+async function snapshotGraders(
+  tests: Test[],
+  config: AgencyConfig,
+): Promise<Record<string, GradersSnapshot>> {
+  const byModule: Record<string, Promise<GradersSnapshot>> = Object.create(null);
+  const byTest: Record<string, GradersSnapshot> = Object.create(null);
+  for (const test of tests) {
+    const modulePath = test.graders ?? config.eval?.graders;
+    if (modulePath === undefined || test.id === undefined) continue;
+    byModule[modulePath] ??= snapshotGradingModule(modulePath);
+    byTest[test.id] = await byModule[modulePath];
+  }
+  return byTest;
+}
+
 /** Assemble one finished run's directory: its trace, its workdir, the agent's
  *  code, and the `run` row. A run that never wrote a statelog still gets its
  *  `run` row (keyed by the trace id the harness minted) and an empty
@@ -260,6 +285,7 @@ function foldIntoRunDirectory(args: {
   run: AgentRun;
   harness: { kind: "harness"; id: string };
   suite: SuiteIdentity | undefined;
+  graders: GradersSnapshot | undefined;
   flags: Record<string, string | number | boolean>;
 }): void {
   const { run } = args;
@@ -282,6 +308,7 @@ function foldIntoRunDirectory(args: {
     stagedStatelogFile: run.statelogPath === null ? undefined : run.statelogPath,
     codeEntry,
     workdir: traceRecorded && fs.existsSync(run.workdir) ? { sourceDir: run.workdir } : undefined,
+    gradersFiles: args.graders?.files,
     run: {
       traceId: args.traceId,
       annotator: args.harness,
@@ -291,6 +318,15 @@ function foldIntoRunDirectory(args: {
         // which is not a JSON value; on disk they are simply absent.
         test: JSON.parse(JSON.stringify(args.test)),
         suite: args.suite ?? null,
+        ...(args.graders === undefined
+          ? {}
+          : {
+              graders: {
+                source: args.graders.source,
+                bundleFile: args.graders.bundleFile,
+                judgeFiles: args.graders.judgeFiles,
+              },
+            }),
         ended: endedFrom(run),
         flags: args.flags,
         ...(run.status === "error" ? { error: run.errorMessage } : {}),

--- a/packages/agency-lang/lib/eval/runTypes.ts
+++ b/packages/agency-lang/lib/eval/runTypes.ts
@@ -10,7 +10,7 @@ export type Test = {
   id?: string;
   /** What the agent is given: an instruction string, or a JSON object for
    *  agents that take structured data. Delivered as the entry node's single
-   *  positional parameter (or as `{task}` for a command agent). Optional:
+   *  positional parameter (or as `{input}` for a command agent). Optional:
    *  an agent that takes no input runs a test with none, and then the entry
    *  node takes no parameter. Within one suite, either every test has an
    *  input or none does. */

--- a/packages/agency-lang/lib/importPaths.ts
+++ b/packages/agency-lang/lib/importPaths.ts
@@ -68,7 +68,7 @@ export function findPackageRoot(startDir: string, packageName?: string): string 
 // crash on module load. The failure is only surfaced when something actually
 // asks for the stdlib or tests directory.
 let _packageRoot: string | null = null;
-function getPackageRoot(): string {
+export function getPackageRoot(): string {
   if (_packageRoot === null) {
     _packageRoot = findPackageRoot(__dirname);
   }

--- a/packages/agency-lang/lib/runDirectory/annotations.test.ts
+++ b/packages/agency-lang/lib/runDirectory/annotations.test.ts
@@ -174,6 +174,32 @@ describe("readAnnotations", () => {
     expect(warnings[0]).toContain(":2:");
   });
 
+  it("accepts a pre-change score row carrying the legacy completesPass field, and it still folds", () => {
+    // Verbatim v1 shape from before pass completeness became passSize-only.
+    const legacy = {
+      v: 1,
+      id: "ann_1111111111111111111111111111111111111111111111111111111111111111",
+      traceId: "t1",
+      createdAt: "2026-08-01T00:00:00Z",
+      annotator: { kind: "judge", id: "goal-judge@1" },
+      kind: "score",
+      passId: "pass_legacy",
+      passSize: 1,
+      completesPass: true,
+      name: "goal",
+      score: { kind: "scalar", value: 0.7 },
+      weight: 1,
+      mustPass: false,
+    };
+    const warnings: string[] = [];
+    const rows = readAnnotations(file(JSON.stringify(legacy) + "\n"), (m) => warnings.push(m));
+    expect(warnings).toEqual([]);
+    expect(rows).toHaveLength(1);
+    const folded = foldAnnotations(rows);
+    expect(folded.t1.scores["judge:goal-judge:goal"].id).toBe(legacy.id);
+    expect(folded.t1.gradingPasses).toBe(1);
+  });
+
   it("rejects a row that fails the schema", () => {
     const bad = { ...row(signOff("t1", "x")), extra: true };
     const warnings: string[] = [];

--- a/packages/agency-lang/lib/runDirectory/annotations.test.ts
+++ b/packages/agency-lang/lib/runDirectory/annotations.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 import {
   annotationId,
   completeAnnotation,
+  annotatorLineage,
   foldAnnotations,
   readAnnotations,
   type Annotation,
@@ -34,7 +35,7 @@ function score(
   passId: string,
   name: string,
   value: number,
-  options: { passSize?: number; completesPass?: boolean; annotator?: Annotation["annotator"] } = {},
+  options: { passSize?: number; annotator?: Annotation["annotator"] } = {},
 ): AnnotationDraft {
   return {
     traceId: "t1",
@@ -42,7 +43,6 @@ function score(
     kind: "score",
     passId,
     passSize: options.passSize ?? 1,
-    completesPass: options.completesPass ?? true,
     name,
     score: { kind: "scalar", value },
     weight: 1,
@@ -90,7 +90,7 @@ describe("foldAnnotations", () => {
     };
     const folded = foldAnnotations([row(run)]);
     expect(folded.t1.run?.kind).toBe("run");
-    expect(Object.keys(folded.t1)).toEqual(["scores", "checklists", "run"]);
+    expect(Object.keys(folded.t1)).toEqual(["scores", "gradingPasses", "checklists", "run"]);
   });
 
   it("folds checklist answers per question in append order, keyed per annotator", () => {
@@ -115,27 +115,40 @@ describe("foldAnnotations", () => {
     expect(folded.t1.checklists["news:human:sam"].answers).toEqual({ q_a: false });
   });
 
-  it("takes the latest complete score pass and keeps annotator revisions apart", () => {
+  it("takes the latest complete score pass; a new revision of the same grader supersedes, and passes are counted", () => {
     const rows = [
       row(score("pass_1", "cheap", 0.2)),
       row(score("pass_2", "cheap", 0.9)),
       row(score("pass_3", "cheap", 0.5, { annotator: grader("bbb") })),
+      row(score("pass_4", "fast", 0.1, { annotator: { kind: "judge", id: "goal-judge@1" } })),
+      row(score("pass_5", "fast", 0.3, { annotator: { kind: "judge", id: "goal-judge@2" } })),
     ];
     const folded = foldAnnotations(rows);
-    expect(folded.t1.scores["grader:graders.ts@aaa:cheap"].id).toBe(rows[1].id);
-    expect(folded.t1.scores["grader:graders.ts@bbb:cheap"].id).toBe(rows[2].id);
+    expect(Object.keys(folded.t1.scores).sort()).toEqual([
+      "grader:graders.ts:cheap",
+      "judge:goal-judge:fast",
+    ]);
+    expect(folded.t1.scores["grader:graders.ts:cheap"].id).toBe(rows[2].id);
+    expect(folded.t1.scores["judge:goal-judge:fast"].id).toBe(rows[4].id);
+    expect(folded.t1.gradingPasses).toBe(5);
+  });
+
+  it("annotatorLineage strips the revision and leaves ids without one alone", () => {
+    expect(annotatorLineage("goal-judge@1")).toBe("goal-judge");
+    expect(annotatorLineage("graders.ts@abc")).toBe("graders.ts");
+    expect(annotatorLineage("inline:cheap")).toBe("inline:cheap");
+    expect(annotatorLineage("@odd")).toBe("@odd");
   });
 
   it("ignores a pass that never completed", () => {
     const rows = [
       row(score("pass_1", "cheap", 0.2)),
-      // pass_2 expects two rows but only the first (non-completing) landed
-      row(score("pass_2", "cheap", 0.9, { passSize: 2, completesPass: false })),
-      // pass_3 claims completion but is missing a row
-      row(score("pass_3", "cheap", 0.7, { passSize: 2, completesPass: true })),
+      // pass_2 expects two rows but only one landed
+      row(score("pass_2", "cheap", 0.9, { passSize: 2 })),
     ];
     const folded = foldAnnotations(rows);
-    expect(folded.t1.scores["grader:graders.ts@aaa:cheap"].id).toBe(rows[0].id);
+    expect(folded.t1.scores["grader:graders.ts:cheap"].id).toBe(rows[0].id);
+    expect(folded.t1.gradingPasses).toBe(1);
   });
 });
 

--- a/packages/agency-lang/lib/runDirectory/annotations.ts
+++ b/packages/agency-lang/lib/runDirectory/annotations.ts
@@ -34,14 +34,12 @@ export type ChecklistPayload = {
 };
 
 /** One grader's verdict on one trace in one grading pass. A pass is `passSize`
- *  rows sharing a `passId`, the last of which carries `completesPass: true`;
- *  the fold counts a pass only when it is complete, so a crash mid-pass can
- *  never move effective scores. */
+ *  rows sharing a `passId`; the fold counts a pass only when all of them are
+ *  present, so a crash mid-pass can never move effective scores. */
 export type ScorePayload = {
   kind: "score";
   passId: string;
   passSize: number;
-  completesPass: boolean;
   name: string;
   score: Score;
   weight: number;
@@ -53,6 +51,16 @@ export type ScorePayload = {
 };
 
 export type SuiteIdentity = { source: string; sha?: string };
+
+/** Where a run's graders came from and what the directory's `graders/` holds
+ *  for them: the bundled module under `bundleFile`, and each judge file the
+ *  graders read by path under its stored name. Grading prefers this
+ *  snapshot, so a copied run grades the same anywhere. */
+export type GradersIdentity = {
+  source: string;
+  bundleFile: string;
+  judgeFiles: Record<string, string>;
+};
 export type RunOutcome = "ok" | "error" | "timeout" | "cost-cap" | "killed";
 
 /** The eval harness's own row for a trace it launched: which test, which
@@ -62,6 +70,8 @@ export type RunPayload = {
   kind: "run";
   test: JsonValue;
   suite: SuiteIdentity | null;
+  /** Absent when the run had no grading module (the goal judge grades it). */
+  graders?: GradersIdentity;
   ended: RunOutcome;
   flags: Record<string, JsonValue>;
   /** The harness's error message when `ended` is not "ok". */
@@ -134,7 +144,6 @@ const ScoreAnnotationSchema = z
     kind: z.literal("score"),
     passId: z.string().min(1),
     passSize: z.number().int().positive(),
-    completesPass: z.boolean(),
     name: z.string().min(1),
     score: ScoreSchema,
     weight: z.number().finite().nonnegative(),
@@ -151,6 +160,14 @@ const RunAnnotationSchema = z
     kind: z.literal("run"),
     test: JsonValueSchema,
     suite: z.object({ source: z.string(), sha: z.string().optional() }).strict().nullable(),
+    graders: z
+      .object({
+        source: z.string(),
+        bundleFile: z.string().min(1),
+        judgeFiles: z.record(z.string(), z.string()),
+      })
+      .strict()
+      .optional(),
     ended: z.enum(["ok", "error", "timeout", "cost-cap", "killed"]),
     flags: z.record(z.string(), JsonValueSchema),
     error: z.string().optional(),
@@ -227,9 +244,14 @@ export type EffectiveChecklistJudgement = {
 };
 
 export type EffectiveTraceAnnotations = {
-  /** Keyed by `${annotator.kind}:${annotator.id}:${name}`; the latest row from
-   *  the latest COMPLETE pass wins. */
+  /** Keyed by `${annotator.kind}:${lineage}:${name}`, where the lineage is the
+   *  annotator id without its `@<revision>` suffix, so every version of one
+   *  grader or judge shares a key; the latest row from the latest COMPLETE pass
+   *  wins. */
   scores: Record<string, Annotation>;
+  /** How many complete grading passes scored this trace. The effective scores
+   *  come from the latest; the earlier ones are history, still on disk. */
+  gradingPasses: number;
   /** Keyed by `${checklist}:${annotator.kind}:${annotator.id}`, answers folded
    *  per question in append order so a restored question keeps its answer. */
   checklists: Record<string, EffectiveChecklistJudgement>;
@@ -244,8 +266,14 @@ export function foldAnnotations(
 ): Record<string, EffectiveTraceAnnotations> {
   const byTrace: Record<string, EffectiveTraceAnnotations> = Object.create(null);
   const completePasses = completedPassIds(rows);
+  const passesByTrace: Record<string, Record<string, true>> = Object.create(null);
   for (const row of rows) {
-    const trace = (byTrace[row.traceId] ??= { scores: {}, checklists: {}, run: null });
+    const trace = (byTrace[row.traceId] ??= {
+      scores: {},
+      gradingPasses: 0,
+      checklists: {},
+      run: null,
+    });
     if (row.kind === "checklist") {
       const key = `${row.checklist}:${row.annotator.kind}:${row.annotator.id}`;
       const existing = trace.checklists[key];
@@ -256,7 +284,11 @@ export function foldAnnotations(
       };
     } else if (row.kind === "score") {
       if (completePasses[row.passId]) {
-        trace.scores[`${row.annotator.kind}:${row.annotator.id}:${row.name}`] = row;
+        if (!(passesByTrace[row.traceId] ??= Object.create(null))[row.passId]) {
+          passesByTrace[row.traceId][row.passId] = true;
+          trace.gradingPasses += 1;
+        }
+        trace.scores[scoreKey(row)] = row;
       }
     } else {
       trace.run = row;
@@ -265,24 +297,29 @@ export function foldAnnotations(
   return byTrace;
 }
 
-/** A pass is complete when exactly `passSize` distinct rows carry its id and
- *  one of them says `completesPass`. Anything else is a crash's leftovers. */
+/** `goal-judge@1` and `goal-judge@2` are one judge at two revisions; the
+ *  newer supersedes the older rather than averaging with it. */
+export function annotatorLineage(id: string): string {
+  const at = id.lastIndexOf("@");
+  return at <= 0 ? id : id.slice(0, at);
+}
+
+function scoreKey(row: Annotation & { kind: "score" }): string {
+  return `${row.annotator.kind}:${annotatorLineage(row.annotator.id)}:${row.name}`;
+}
+
+/** A pass is complete when exactly `passSize` distinct rows carry its id.
+ *  Fewer is a crash's leftovers. */
 function completedPassIds(rows: readonly Annotation[]): Record<string, true> {
-  const seen: Record<string, { ids: Record<string, true>; size: number; completed: boolean }> =
-    Object.create(null);
+  const seen: Record<string, { ids: Record<string, true>; size: number }> = Object.create(null);
   for (const row of rows) {
     if (row.kind !== "score") continue;
-    const pass = (seen[row.passId] ??= {
-      ids: Object.create(null),
-      size: row.passSize,
-      completed: false,
-    });
+    const pass = (seen[row.passId] ??= { ids: Object.create(null), size: row.passSize });
     pass.ids[row.id] = true;
-    if (row.completesPass) pass.completed = true;
   }
   const complete: Record<string, true> = Object.create(null);
   for (const [passId, pass] of Object.entries(seen)) {
-    if (pass.completed && Object.keys(pass.ids).length === pass.size) complete[passId] = true;
+    if (Object.keys(pass.ids).length === pass.size) complete[passId] = true;
   }
   return complete;
 }

--- a/packages/agency-lang/lib/runDirectory/annotations.ts
+++ b/packages/agency-lang/lib/runDirectory/annotations.ts
@@ -40,6 +40,8 @@ export type ScorePayload = {
   kind: "score";
   passId: string;
   passSize: number;
+  /** @deprecated Legacy field on old rows; accepted and ignored. */
+  completesPass?: boolean;
   name: string;
   score: Score;
   weight: number;
@@ -60,6 +62,10 @@ export type GradersIdentity = {
   source: string;
   bundleFile: string;
   judgeFiles: Record<string, string>;
+  /** Whether the module was the test's own or the `eval.graders` config
+   *  fallback. Grading needs the distinction: `--goal` sets configured
+   *  modules aside but never a test's own. */
+  origin: "test" | "config";
 };
 export type RunOutcome = "ok" | "error" | "timeout" | "cost-cap" | "killed";
 
@@ -144,6 +150,9 @@ const ScoreAnnotationSchema = z
     kind: z.literal("score"),
     passId: z.string().min(1),
     passSize: z.number().int().positive(),
+    // Written by rows from before pass completeness was passSize-only;
+    // accepted so old directories keep their scores, ignored by the fold.
+    completesPass: z.boolean().optional(),
     name: z.string().min(1),
     score: ScoreSchema,
     weight: z.number().finite().nonnegative(),
@@ -165,6 +174,7 @@ const RunAnnotationSchema = z
         source: z.string(),
         bundleFile: z.string().min(1),
         judgeFiles: z.record(z.string(), z.string()),
+        origin: z.enum(["test", "config"]),
       })
       .strict()
       .optional(),

--- a/packages/agency-lang/lib/runDirectory/list.test.ts
+++ b/packages/agency-lang/lib/runDirectory/list.test.ts
@@ -51,11 +51,30 @@ describe("summarizeRuns", () => {
       input: "summarize x",
       ended: "ok",
       latestScore: 0.75,
+      gradingPasses: 1,
       hasNotes: true,
       labeled: false,
       codeHash: null,
     });
     expect(annotationSummaryText(first)).toBe("notes · score 0.75");
+
+    // A re-grade: the newer pass is the score, and the count says it was not the first.
+    recordGradingPass({
+      dir,
+      scores: [
+        {
+          traceId: "t1",
+          annotator: { kind: "grader", id: "g@2" },
+          name: "a",
+          score: { kind: "binary", pass: false },
+          weight: 1,
+          mustPass: false,
+        },
+      ],
+    });
+    const [regraded] = summarizeRuns(readRunDirectory(dir, quiet));
+    expect(regraded).toMatchObject({ latestScore: 0.25, gradingPasses: 2 });
+    expect(annotationSummaryText(regraded)).toBe("notes · score 0.25 (2 passes)");
 
     const bare = tempDir();
     writeStatelog(bare, statelogLine("t2", "agentStart", { entryNode: "main", args: {} }));

--- a/packages/agency-lang/lib/runDirectory/list.ts
+++ b/packages/agency-lang/lib/runDirectory/list.ts
@@ -25,6 +25,8 @@ export type RunSummary = {
   /** The harness's verdict when it recorded one, else read from the trace. */
   ended: string;
   latestScore: number | null;
+  /** Complete grading passes on this trace; `latestScore` is from the last. */
+  gradingPasses: number;
   /** False when an effective must-pass score failed; null with no scores. */
   gatesPassed: boolean | null;
   /** `notes.md` exists and is not blank. */
@@ -66,6 +68,7 @@ function summarizeTrace(
     models: [...record.metrics.models],
     ended: runRow !== null ? runRow.ended : traceEnding(trace),
     latestScore: latestScore(effective),
+    gradingPasses: effective?.gradingPasses ?? 0,
     gatesPassed: gatesPassed(effective),
     hasNotes,
     labeled: Object.keys(effective?.checklists ?? {}).length > 0,
@@ -75,11 +78,15 @@ function summarizeTrace(
 }
 
 /** One short line about a trace's annotations for a listing or the viewer's
- *  trace row: "notes · score 0.70 · labeled". Empty when there are none. */
+ *  trace row: "notes · score 0.70 (3 passes) · labeled". Empty when there are
+ *  none; the pass count appears only after a re-grade. */
 export function annotationSummaryText(summary: RunSummary): string {
   const parts: string[] = [];
   if (summary.hasNotes) parts.push("notes");
-  if (summary.latestScore !== null) parts.push(`score ${summary.latestScore.toFixed(2)}`);
+  if (summary.latestScore !== null) {
+    const passes = summary.gradingPasses > 1 ? ` (${summary.gradingPasses} passes)` : "";
+    parts.push(`score ${summary.latestScore.toFixed(2)}${passes}`);
+  }
   if (summary.labeled) parts.push("labeled");
   return parts.join(" · ");
 }

--- a/packages/agency-lang/lib/runDirectory/mutations.test.ts
+++ b/packages/agency-lang/lib/runDirectory/mutations.test.ts
@@ -329,11 +329,8 @@ describe("recordGradingPass", () => {
       scores: [scoreDraft("t1", "cheap", 0.2), scoreDraft("t1", "fast", 0.4)],
     });
     expect(first.annotations).toHaveLength(2);
-    expect(first.annotations.map((row) => row.kind === "score" && row.completesPass)).toEqual([
-      false,
-      true,
-    ]);
-    expect(first.snapshot.effectiveAnnotations.t1.scores["grader:graders.ts@aaa:cheap"].id).toBe(
+    expect(first.annotations.map((row) => row.kind === "score" && row.passSize)).toEqual([2, 2]);
+    expect(first.snapshot.effectiveAnnotations.t1.scores["grader:graders.ts:cheap"].id).toBe(
       first.annotations[0].id,
     );
 
@@ -343,7 +340,7 @@ describe("recordGradingPass", () => {
     });
     expect(second.passId).not.toBe(first.passId);
     expect(second.snapshot.annotationRows).toHaveLength(4);
-    expect(second.snapshot.effectiveAnnotations.t1.scores["grader:graders.ts@aaa:cheap"].id).toBe(
+    expect(second.snapshot.effectiveAnnotations.t1.scores["grader:graders.ts:cheap"].id).toBe(
       second.annotations[0].id,
     );
   });
@@ -363,7 +360,7 @@ describe("recordGradingPass", () => {
     const rows = fs.readFileSync(paths.annotations, "utf8").split("\n").filter(Boolean);
     fs.writeFileSync(paths.annotations, rows.slice(0, 3).join("\n") + "\n"); // drop the completing row of pass 2
     const snapshot = readRunDirectory(dir, quiet);
-    expect(snapshot.effectiveAnnotations.t1.scores["grader:graders.ts@aaa:cheap"].id).toBe(
+    expect(snapshot.effectiveAnnotations.t1.scores["grader:graders.ts:cheap"].id).toBe(
       first.annotations[0].id,
     );
     expect(partial.passId).toBeDefined();

--- a/packages/agency-lang/lib/runDirectory/mutations.ts
+++ b/packages/agency-lang/lib/runDirectory/mutations.ts
@@ -40,7 +40,12 @@ import {
   planStatelogMerge,
   type StatelogMergePlan,
 } from "./mergeStatelog.js";
-import { readRunDirectory, runDirPaths, type RunDirectorySnapshot } from "./runDir.js";
+import {
+  readRunDirectory,
+  runDirPaths,
+  type RunDirectoryPaths,
+  type RunDirectorySnapshot,
+} from "./runDir.js";
 import { matchTrace, readTracesOrThrow, type Trace } from "./traces.js";
 
 /**
@@ -318,6 +323,9 @@ export type RecordCompletedRunRequest = {
   stagedStatelogFile?: string;
   codeEntry?: string;
   workdir?: WorkdirAttachmentRequest;
+  /** Files to store under `graders/` (content-hash names); the run row's
+   *  `graders` field says what they are. */
+  gradersFiles?: { name: string; content: string }[];
   run: RunAnnotationDraft;
 };
 
@@ -358,9 +366,23 @@ export function recordCompletedRun(
     applyStatelogMerge(paths, statelogPlan);
     if (codePlan !== undefined) applyCodeAttachment(paths, codePlan);
     if (workdirPlan !== undefined) applyWorkdirAttachment(paths, workdirPlan, now(options));
+    if (request.gradersFiles !== undefined) writeGradersFiles(paths, request.gradersFiles);
     const [annotation] = appendRows(paths.annotations, [draft], options, reportWarning);
     return { annotation };
   });
+}
+
+/** Content-hash names never collide on different contents; the same name
+ *  already present is the same file, so nothing is rewritten. */
+function writeGradersFiles(
+  paths: RunDirectoryPaths,
+  files: readonly { name: string; content: string }[],
+): void {
+  fs.mkdirSync(paths.gradersDir, { recursive: true });
+  for (const file of files) {
+    const target = path.join(paths.gradersDir, file.name);
+    if (!fs.existsSync(target)) fs.writeFileSync(target, file.content);
+  }
 }
 
 /**
@@ -429,9 +451,9 @@ export type RecordGradingPassResult = {
   snapshot: RunDirectorySnapshot;
 };
 
-/** One grading pass: every score draft gets the same fresh `passId`, the
- *  pass size, and `completesPass` on the final row only. A crash before that
- *  row leaves an incomplete pass the fold ignores. */
+/** One grading pass: every score draft gets the same fresh `passId` and the
+ *  pass size. A crash before the last row leaves an incomplete pass the fold
+ *  ignores. */
 export function recordGradingPass(
   request: RecordGradingPassRequest,
   options: MutationOptions = {},
@@ -447,14 +469,13 @@ export function recordGradingPass(
     if (unknown !== undefined) {
       throw new Error(`No trace ${unknown.traceId} in ${request.dir}; nothing was recorded.`);
     }
-    const drafts: AnnotationDraft[] = request.scores.map((score, index) => {
+    const drafts: AnnotationDraft[] = request.scores.map((score) => {
       const draft: AnnotationDraft = {
         traceId: score.traceId,
         annotator: score.annotator,
         kind: "score",
         passId,
         passSize: request.scores.length,
-        completesPass: index === request.scores.length - 1,
         name: score.name,
         score: score.score,
         weight: score.weight,

--- a/packages/agency-lang/lib/runDirectory/runDir.test.ts
+++ b/packages/agency-lang/lib/runDirectory/runDir.test.ts
@@ -48,7 +48,6 @@ describe("readRunDirectory", () => {
         kind: "score",
         passId: "p1",
         passSize: 1,
-        completesPass: true,
         name: "len",
         score: { kind: "scalar", value: 0.5 },
         weight: 1,
@@ -61,7 +60,7 @@ describe("readRunDirectory", () => {
     expect(snapshot.hasStatelog).toBe(true);
     expect(snapshot.traces.map((trace) => trace.traceId)).toEqual(["t1"]);
     expect(snapshot.annotationRows).toEqual([score]);
-    expect(Object.keys(snapshot.effectiveAnnotations.t1)).toEqual(["scores", "checklists", "run"]);
+    expect(Object.keys(snapshot.effectiveAnnotations.t1)).toEqual(["scores", "gradingPasses", "checklists", "run"]);
   });
 
   describe("notes.md", () => {

--- a/packages/agency-lang/lib/runDirectory/runDir.test.ts
+++ b/packages/agency-lang/lib/runDirectory/runDir.test.ts
@@ -60,7 +60,12 @@ describe("readRunDirectory", () => {
     expect(snapshot.hasStatelog).toBe(true);
     expect(snapshot.traces.map((trace) => trace.traceId)).toEqual(["t1"]);
     expect(snapshot.annotationRows).toEqual([score]);
-    expect(Object.keys(snapshot.effectiveAnnotations.t1)).toEqual(["scores", "gradingPasses", "checklists", "run"]);
+    expect(Object.keys(snapshot.effectiveAnnotations.t1)).toEqual([
+      "scores",
+      "gradingPasses",
+      "checklists",
+      "run",
+    ]);
   });
 
   describe("notes.md", () => {

--- a/packages/agency-lang/lib/runDirectory/runDir.ts
+++ b/packages/agency-lang/lib/runDirectory/runDir.ts
@@ -27,6 +27,9 @@ export type RunDirectoryPaths = {
   annotations: string;
   notes: string;
   codeDir: string;
+  /** The graders the run was executed with: the bundled module and any judge
+   *  files, named by content hash; the `run` row says which is which. */
+  gradersDir: string;
   workdirDir: string;
   workdirSidecar: string;
   checklistsDir: string;
@@ -40,6 +43,7 @@ export function runDirPaths(dir: string): RunDirectoryPaths {
     annotations: path.join(dir, "annotations.jsonl"),
     notes: path.join(dir, "notes.md"),
     codeDir: path.join(dir, "code"),
+    gradersDir: path.join(dir, "graders"),
     workdirDir: path.join(dir, "workdir"),
     workdirSidecar: path.join(dir, "workdir.json"),
     checklistsDir: path.join(dir, "checklists"),

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -809,9 +809,9 @@ export function createProgram(deps: CliDependencies = {}): Command {
     )
     .option(
       "--agent-cmd <command>",
-      "Run this command as the agent instead of an agent file; {task} is replaced with each input's task. " +
+      "Run this command as the agent instead of an agent file; {input} is replaced with each test's input. " +
         "Agency CLIs only — the command's process must write the statelog the harness points it at, " +
-        "and it must run headless and one-shot (e.g. agency agent --policy approve-all -p -- {task})",
+        "and it must run headless and one-shot (e.g. agency agent --policy approve-all -p -- {input})",
     )
     .option(
       "--suite <source>",

--- a/packages/agency-lang/tests/integration/eval-run/test.mjs
+++ b/packages/agency-lang/tests/integration/eval-run/test.mjs
@@ -149,7 +149,7 @@ node main(): string {
   writeFileSync(join(TMP_ROOT, "cmd-inputs.json"), JSON.stringify({
     inputs: [{ id: "cmd-e2e", goal: "writes the input to out.txt", input: "hello from a command target", files: cmdFixtures }],
   }));
-  const agentCmd = `node ${AGENCY_CLI} run --policy approve-all writer.agency -- {task}`;
+  const agentCmd = `node ${AGENCY_CLI} run --policy approve-all writer.agency -- {input}`;
   let cmdOutput;
   try {
     cmdOutput = execSync(
@@ -197,7 +197,7 @@ node main(): string {
   try {
     execSync(
       `node ${JSON.stringify(AGENCY_CLI)} eval run` +
-      ` --agent-cmd ${JSON.stringify(`node -e 1+1 {task}`)}` +
+      ` --agent-cmd ${JSON.stringify(`node -e 1+1 {input}`)}` +
       ` --suite ${JSON.stringify(join(TMP_ROOT, "cmd-inputs.json"))}` +
       ` --out ${JSON.stringify(join(runsDir, "cmd-clobber"))}`,
       { cwd: REPO_ROOT, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] },
@@ -212,7 +212,7 @@ node main(): string {
     `the run row's error should name the --log clobber cause, got:\n${clobberRun.error}`);
   console.log("[eval-run-integration] PASS: missing statelog names the --log/non-Agency causes");
 
-  // ── Scenario D: a command without {task} fails at resolution, before any run dir exists ──
+  // ── Scenario D: a command without {input} fails at resolution, before any run dir exists ──
   let noPlaceholderFailed = false;
   try {
     execSync(
@@ -224,11 +224,11 @@ node main(): string {
   } catch (err) {
     noPlaceholderFailed = true;
     const text = `${err.stdout ?? ""}${err.stderr ?? ""}`;
-    assert(text.includes("{task}"), `error should name the {task} requirement, got:\n${text}`);
+    assert(text.includes("{input}"), `error should name the {input} requirement, got:\n${text}`);
   }
-  assert(noPlaceholderFailed, "a command without {task} must be rejected");
+  assert(noPlaceholderFailed, "a command without {input} must be rejected");
   assert(!existsSync(join(runsDir, "cmd-noplaceholder")), "no run directory should exist for a resolution-time failure");
-  console.log("[eval-run-integration] PASS: missing {task} rejected before any run");
+  console.log("[eval-run-integration] PASS: missing {input} rejected before any run");
 
   // ── Scenario E: `agency run --capture-workdir <dir>` writes a run directory ──
   // A plain run, no harness: the trace, the code and the working directory


### PR DESCRIPTION
A batch of eval fixes and improvements from a session of trying the eval workflow end to end. Includes documentation the owner wrote for the new eval guide pages (`docs/site/guide/eval-basics.md`, `graders.md`, `suites.md`).

## Run directories store the graders they ran with

Grading used to load each test's grading module from the absolute path recorded on the run row. That broke the run directory's portability (a copied directory pointed at a module that is not there) and its reproducibility (editing `graders.ts` silently changed what an old run scores).

Now `eval run` bundles each test's module with esbuild (one self-contained `.mjs`, everything inlined except `agency-lang`), loads it once so a broken module fails **before** any agent runs, collects any file the graders read by path (`BaseGrader.externalFiles()`; `LlmJudge` implements it for a custom judge `agencyFile`), and stores it all under `<runDir>/graders/` by content hash. The run row records `graders: { source, bundleFile, judgeFiles }`.

`eval grade` prefers the snapshot: flag > snapshot > recorded path (old directories) > `eval.graders` config > goal judge. Loading the snapshot rebinds judge files to their stored copies, and the bundle import falls back to this package's root when `agency-lang` does not resolve next to a copied directory. A module's revision is `<source>@<sha256 of bundle>` in both paths (previously the hash covered only the entry file, so edits to imported helpers did not change the revision).

## Score fold: last pass wins per grader lineage, and re-grades are visible

- The effective-score key is now `kind:lineage:name`, where the lineage strips the annotator id's `@<revision>` suffix: `goal-judge@2` supersedes `goal-judge@1` instead of averaging with it.
- The fold counts complete grading passes per trace (`gradingPasses`); `runs list` grows a `PASSES` column and the summary line reads `score 0.70 (3 passes)` after a re-grade, so grading three times is no longer silent.
- `completesPass` is dropped from score rows; pass completeness is exactly `passSize` distinct rows sharing the `passId` (the flag was redundant with the count).

## Grader identity and misconfiguration guards

- The bundled goal judge is now `goal-judge@<GOAL_JUDGE_VERSION>` instead of a bare content hash; a test pins the version to the prompt file's hash, so editing the prompt without bumping the version fails CI with a copy-paste fix.
- A grading module with two graders sharing a name is refused at load time (scores are keyed per grader name, so the second silently overwrote the first).

## CLI and loader fixes

- `--agent-cmd`'s placeholder is renamed `{task}` → `{input}` to match the tests' `input` field; a command still using `{task}` is refused up front with the rename spelled out.
- A suite test with `"input": {}` now means "no input" (matching `eval run` without `--input`) instead of erroring; an empty-string input error says what to do instead.
- `runs list` shows an agent file under the current directory relative to it (`test.agency:main` instead of a full absolute path); labels outside cwd, command lines, and agent names are unchanged.

## Docs

Dev notes updated: `eval-grading.md` (snapshot mechanism, lineage fold), `run-directory.md` (`graders/` in the layout and writers), `eval-command-agents.md` (`{input}`). Site docs: the owner's new guide pages, plus matching updates to `cli/eval.md`.

Also includes a first eval for the agency agent (`evals/agency-agent/news`): headlines fetched under five minutes, judged for being today's news via a grade-time goal built from the run's own start date.

## Tests

Each change carries focused tests (fold/lineage, pass counting, snapshot round-trip incl. judge-file rebind and the source-edited-after-run case, duplicate-name refusal, `{task}` refusal, `{}` input, relative agent labels, goal-judge version pin). Suites swept locally: `lib/eval`, `lib/runDirectory`, `lib/cli/eval`, `lib/cli/runDirectory`, `lib/runsExplorer` — 806 tests green; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
