### PR TITLE
agency agent: --workdir flag + headless rejection of undecided interrupts

### DIFF
--- a/packages/agency-lang/docs/dev/agent-brains.md
+++ b/packages/agency-lang/docs/dev/agent-brains.md
@@ -95,6 +95,15 @@ export def runSession(interactive: boolean, body: () -> void raises <*>) {
 }
 ```
 
+The `interactive` flag is also threaded into the policy handler
+(`cliPolicyHandler(interactive: ...)`). In a one-shot run there is no user
+at a terminal, so an interrupt the policy does not decide is rejected with
+a reason string instead of prompted — the reason becomes the failing
+call's error, which the tool loop feeds back to the model so it can take
+another approach. Before this, an undecided effect in `-p` mode raised a
+prompt nobody could answer: the pending prompt starved the event loop and
+the process died with exit 13 ("unsettled top-level await").
+
 Why this is enough: handlers in Agency are not try/catch. When a function
 raises an interrupt, *every* handler up the chain is consulted, and if any
 one of them rejects, the interrupt is rejected. So a brain that wraps its

--- a/packages/agency-lang/docs/dev/cli-arguments.md
+++ b/packages/agency-lang/docs/dev/cli-arguments.md
@@ -148,6 +148,14 @@ exists**, and the launcher (`lib/cli/runBundledAgent.ts`,
   unconfigured run cannot inherit the config. A forwarded `agent --config`
   beats a root `-c` (the more specific value); a bad explicit config refuses
   to launch rather than silently running unconfigured;
+- `--workdir` — the child's working directory, passed as the spawn `cwd`
+  (never a parent `chdir`, so the launcher keeps resolving its own files
+  where they live). It must exist before the child does: the agent's static
+  initializers resolve paths and discover `agency.json` against cwd before
+  `main()` could parse a flag. A path that is not a directory refuses to
+  launch. The motivating case: an eval harness seeds fixtures into a staged
+  workdir, but a command like `pnpm run agency agent` re-anchors cwd to the
+  package root, so the agent loses the fixtures — `--workdir` puts it back;
 - `--agent-home` — grandfathered: the agent reads it in static initializers.
   A candidate to move into the agent, not a pattern to extend.
 

--- a/packages/agency-lang/docs/site/stdlib/policy.md
+++ b/packages/agency-lang/docs/site/stdlib/policy.md
@@ -238,7 +238,7 @@ export type ParsePolicyFailureStatus =
   | "policy-not-valid"
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L380))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L385))
 
 ### ParsePolicyFailure
 
@@ -249,7 +249,7 @@ export type ParsePolicyFailure = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L386))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L391))
 
 ## Constants
 
@@ -363,7 +363,7 @@ Evaluate a policy against an interrupt. Returns approve(), reject(), or propagat
 | policy | `Record<string, any>` |  |
 | interrupt | `Record<string, any>` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L212))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L217))
 
 ### validatePolicy
 
@@ -391,7 +391,7 @@ Validate that a policy object is well-formed. Returns { success: true } if valid
 
 **Returns:** `Result<void>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L234))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L239))
 
 ### buildScopedMatch
 
@@ -441,7 +441,7 @@ Build a match object for an interrupt, pinned to the configured fields. Returns 
 
 **Returns:** `Record<string, string>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L269))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L274))
 
 ### recordRule
 
@@ -489,7 +489,7 @@ Return a new policy with a catch-all rule for an effect appended. A single bare 
 
 **Returns:** [Policy](#policy)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L319))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L324))
 
 ### recordScopedRule
 
@@ -531,7 +531,7 @@ Return a new policy with a scoped approve rule prepended for the interrupt's eff
 
 **Returns:** [Policy](#policy)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L356))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L361))
 
 ### parsePolicyFile
 
@@ -565,7 +565,7 @@ Read + parse + validate a policy file from disk. Returns {} on any
 
 **Throws:** `std::read`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L402))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L407))
 
 ### setPolicy
 
@@ -588,7 +588,7 @@ Install `policy` as the active policy and persist it to `path`.
 | path | `string` |  |
 | policy | [Policy](#policy) |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L447))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L452))
 
 ### writePolicyFile
 
@@ -619,7 +619,7 @@ Validate and write a policy to a JSON file. Throws if the policy is invalid.
 | policy | [Policy](#policy) |  |
 | allowedPaths | `string[]` | [] |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L464))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L469))
 
 ### flushPolicy
 
@@ -639,7 +639,7 @@ Write any pending always-rule additions to the policy file now.
  * `std::write` via `with approve` (you opted in by installing the
  * handler).
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L529))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L534))
 
 ### cliPolicyHandler
 
@@ -648,6 +648,7 @@ cliPolicyHandler(
   file: string,
   fields: ScopedRuleFields,
   policy: Policy | null = null,
+  interactive: boolean = true,
 ): any
 ```
 
@@ -656,6 +657,7 @@ CLI sugar for an interactive policy handler. Loads and saves the policy file, pr
   @param file - Path to the on-disk policy file.
   @param fields - Per-effect config controlling the "approve-always-here" prompt option.
   @param policy - Optional in-memory policy to use directly instead of loading `file` on startup.
+  @param interactive - Whether a user is at a terminal. When false, an interrupt the policy does not decide is rejected with a reason (surfaced to the raise site, and so to an LLM whose tool raised it) instead of prompting.
 
 * Drop-in policy handler for interactive CLI agents. Returns a
  * function ref you bind to a local variable and install on a `handle`
@@ -721,7 +723,8 @@ CLI sugar for an interactive policy handler. Loads and saves the policy file, pr
 | file | `string` |  |
 | fields | [ScopedRuleFields](#scopedrulefields) |  |
 | policy | `Policy \| null` | null |
+| interactive | `boolean` | true |
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L898))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L913))

--- a/packages/agency-lang/evals/agency-agent/hollow-creek/files/article.txt
+++ b/packages/agency-lang/evals/agency-agent/hollow-creek/files/article.txt
@@ -1,0 +1,39 @@
+# Derby Finds a New Home Again
+
+MARLOWE COUNTY REGISTER — For the third year running, the Hollow Creek
+Fishing Derby will not be held on Hollow Creek. Organizers announced
+Tuesday that the 41st annual derby moves to Lake Arden, citing "continued
+low catch numbers" at the creek that gave the event its name.
+
+"Lake Arden has been a wonderful partner," said derby chair Doreen Maszak.
+"The kids don't care where the fish are, as long as there are fish."
+
+The derby's presenting sponsor is once again Braxton Polymer, whose resin
+plant opened on the creek's north fork four years ago and now employs
+nearly half the working adults in Marlowe. Braxton has covered the
+trophies, the fry tent, and this year, for the first time, the cost of
+busing families out to the lake.
+
+Asked about the creek itself, Braxton spokesperson Carl Ehmke pointed to
+the seasonal algae that residents have noticed foaming along the banks.
+"Algal blooms are a natural part of any warm-water stream," Ehmke said.
+Several residents interviewed for this story noted that the foam has also
+appeared in January.
+
+The state's annual fish-count survey, which recorded a healthy smallmouth
+population as recently as five years ago, has not published Hollow Creek
+numbers since the year the plant opened. A spokesperson for the Department
+of Natural Resources said the county's water-quality report, originally
+due in the spring, has been delayed a second time and gave no new date.
+
+Marion Toll, 81, who has fished the creek since childhood, plans to skip
+the bus to Lake Arden. "It used to run clear enough to count the stones,"
+she said. "I'll sit on my own bank, thank you."
+
+The parks department confirmed that children's swimming lessons, held at
+the creek's Miller Bend for over thirty years, will continue at the
+community pool "for convenience."
+
+Braxton Polymer has renewed its derby sponsorship through 2030. "We are
+proud to invest in Marlowe's traditions," Ehmke said. "This company and
+this creek have a long future together."

--- a/packages/agency-lang/evals/agency-agent/hollow-creek/graders.ts
+++ b/packages/agency-lang/evals/agency-agent/hollow-creek/graders.ts
@@ -1,0 +1,34 @@
+import { grader } from "agency-lang/eval";
+
+export default [
+  grader(
+    async ({ judge }) => {
+      const v = await judge({
+        goal:
+          "accurately summarizes the article's stated facts: the fishing derby has moved off " +
+          "Hollow Creek for the third year due to low catch numbers, the Braxton Polymer plant " +
+          "on the creek is the town's dominant employer and the derby's sponsor, residents see " +
+          "foam the company attributes to algae, and the state's fish counts and water-quality " +
+          "report for the creek have stopped or been delayed",
+      });
+      return { score: { kind: "scalar", value: v.score }, feedback: v.reasoning };
+    },
+    { name: "summary" },
+  ),
+
+  grader(
+    async ({ judge }) => {
+      const v = await judge({
+        goal:
+          "reads between the lines: identifies that the article implies, without stating it, " +
+          "that the Braxton Polymer plant is likely polluting Hollow Creek and killed its " +
+          "fishery (the foam appears in January when algae would not, the fish counts stopped " +
+          "the year the plant opened, swimming lessons quietly left the creek), and that the " +
+          "town and the paper avoid saying so because the plant employs half the town and " +
+          "funds the derby",
+      });
+      return { score: { kind: "scalar", value: v.score }, feedback: v.reasoning };
+    },
+    { name: "between-the-lines" },
+  ),
+];

--- a/packages/agency-lang/evals/agency-agent/hollow-creek/graders.ts
+++ b/packages/agency-lang/evals/agency-agent/hollow-creek/graders.ts
@@ -2,23 +2,21 @@ import { grader } from "agency-lang/eval";
 
 export default [
   grader(
-    async ({ judge }) => {
-      const v = await judge({
+    ({ judge }) =>
+      judge({
         goal:
           "accurately summarizes the article's stated facts: the fishing derby has moved off " +
           "Hollow Creek for the third year due to low catch numbers, the Braxton Polymer plant " +
           "on the creek is the town's dominant employer and the derby's sponsor, residents see " +
           "foam the company attributes to algae, and the state's fish counts and water-quality " +
           "report for the creek have stopped or been delayed",
-      });
-      return { score: { kind: "scalar", value: v.score }, feedback: v.reasoning };
-    },
+      }),
     { name: "summary" },
   ),
 
   grader(
-    async ({ judge }) => {
-      const v = await judge({
+    ({ judge }) =>
+      judge({
         goal:
           "reads between the lines: identifies that the article implies, without stating it, " +
           "that the Braxton Polymer plant is likely polluting Hollow Creek and killed its " +
@@ -26,9 +24,7 @@ export default [
           "the year the plant opened, swimming lessons quietly left the creek), and that the " +
           "town and the paper avoid saying so because the plant employs half the town and " +
           "funds the derby",
-      });
-      return { score: { kind: "scalar", value: v.score }, feedback: v.reasoning };
-    },
+      }),
     { name: "between-the-lines" },
   ),
 ];

--- a/packages/agency-lang/evals/agency-agent/hollow-creek/test.json
+++ b/packages/agency-lang/evals/agency-agent/hollow-creek/test.json
@@ -1,0 +1,4 @@
+{
+  "input": "Read and summarize the article at article.txt.",
+  "goal": "summarizes the article accurately and identifies its unstated implication"
+}

--- a/packages/agency-lang/evals/agency-agent/news/graders.ts
+++ b/packages/agency-lang/evals/agency-agent/news/graders.ts
@@ -8,19 +8,20 @@ export default [
   grader(({ record }) => record.durationMs < 1000 * 60 * 5, { name: "under-5min", mustPass: true }),
 
   grader(
-    async ({ judge, record }) =>
-      (
-        await judge({
-          goal: `lists news headlines from ${runDate(record)}, not from an earlier or later date`,
-        })
-      ).score,
+    async ({ judge, record }) => {
+      const v = await judge({
+        goal: `lists news headlines from ${runDate(record)}, not from an earlier or later date`,
+      });
+      return { score: { kind: "scalar", value: v.score }, feedback: v.reasoning };
+    },
     { name: "is-today" },
   ),
 
   grader(
-    async ({ judge }) => (await judge({ goal: "returns a list of top news headlines" })).score,
-    {
-      name: "headlines",
+    async ({ judge }) => {
+      const v = await judge({ goal: "returns a list of top news headlines" });
+      return { score: { kind: "scalar", value: v.score }, feedback: v.reasoning };
     },
+    { name: "headlines" },
   ),
 ];

--- a/packages/agency-lang/evals/agency-agent/news/graders.ts
+++ b/packages/agency-lang/evals/agency-agent/news/graders.ts
@@ -8,20 +8,14 @@ export default [
   grader(({ record }) => record.durationMs < 1000 * 60 * 5, { name: "under-5min", mustPass: true }),
 
   grader(
-    async ({ judge, record }) => {
-      const v = await judge({
+    ({ judge, record }) =>
+      judge({
         goal: `lists news headlines from ${runDate(record)}, not from an earlier or later date`,
-      });
-      return { score: { kind: "scalar", value: v.score }, feedback: v.reasoning };
-    },
+      }),
     { name: "is-today" },
   ),
 
-  grader(
-    async ({ judge }) => {
-      const v = await judge({ goal: "returns a list of top news headlines" });
-      return { score: { kind: "scalar", value: v.score }, feedback: v.reasoning };
-    },
-    { name: "headlines" },
-  ),
+  grader(({ judge }) => judge({ goal: "returns a list of top news headlines" }), {
+    name: "headlines",
+  }),
 ];

--- a/packages/agency-lang/evals/agency-agent/news/test.json
+++ b/packages/agency-lang/evals/agency-agent/news/test.json
@@ -1,5 +1,5 @@
 {
   "id": "news",
-  "input": "What are the top news headlines for today?",
+  "input": "What are the top news headlines for today? Please return a response in 5 minutes or less.",
   "goal": "returns today's news headlines"
 }

--- a/packages/agency-lang/lib/agents/agency-agent/lib/args.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/args.agency
@@ -58,6 +58,10 @@ export def parseAgentArgs(brainHelp: string) {
         type: "string",
         description: "Directory to use instead of ~/.agency-agent for settings, policy, and history (equivalent to the AGENCY_AGENT_HOME env var; the flag wins when both are set)"
       },
+      workdir: {
+        type: "string",
+        description: "Run the agent from this directory instead of the current one: file reads and writes, config discovery, and relative paths all resolve there"
+      },
       config: {
         type: "string",
         description: "Path to an agency.json config file for this agent run (the agent is recompiled with it)"

--- a/packages/agency-lang/lib/agents/agency-agent/lib/turn.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/turn.agency
@@ -101,6 +101,9 @@ def policyHandlerFor(interactive: boolean): any {
     file: policyFile,
     fields: ALWAYS_FIELDS,
     policy: sessionPolicy,
+    // One-shot (-p) runs have no user at a terminal: an undecided effect
+    // is rejected with a reason the model reads, never prompted.
+    interactive: interactive,
   )
 }
 

--- a/packages/agency-lang/lib/cli/runBundledAgent.test.ts
+++ b/packages/agency-lang/lib/cli/runBundledAgent.test.ts
@@ -8,6 +8,7 @@ vi.mock("fs", async (importOriginal) => {
 });
 
 import { CONFIG_OVERRIDES_ENV } from "@/config.js";
+import * as os from "os";
 import * as path from "path";
 import { resolveAgentLaunchArgs, runBundledAgent } from "./runBundledAgent.js";
 
@@ -103,6 +104,27 @@ describe("resolveAgentLaunchArgs: agent-home", () => {
   it("null when the flag is absent, stops at the -- terminator", () => {
     expect(resolveAgentLaunchArgs(["--print", "hi"]).agentHome).toBeNull();
     expect(resolveAgentLaunchArgs(["--", "--agent-home", "/x"]).agentHome).toBeNull();
+  });
+});
+
+describe("resolveAgentLaunchArgs: --workdir", () => {
+  it("--workdir <dir> → absolute path, space and attached forms", () => {
+    expect(resolveAgentLaunchArgs(["--workdir", "/tmp/w", "-p", "hi"]).workdir).toBe("/tmp/w");
+    expect(resolveAgentLaunchArgs(["--workdir=/tmp/w"]).workdir).toBe("/tmp/w");
+  });
+
+  it("resolves a relative dir against cwd", () => {
+    expect(resolveAgentLaunchArgs(["--workdir", "w"]).workdir).toBe(path.resolve("w"));
+  });
+
+  it("bare --workdir (or one followed by a flag) is ignored", () => {
+    expect(resolveAgentLaunchArgs(["--workdir"]).workdir).toBeNull();
+    expect(resolveAgentLaunchArgs(["--workdir", "--print"]).workdir).toBeNull();
+  });
+
+  it("null when the flag is absent, stops at the -- terminator", () => {
+    expect(resolveAgentLaunchArgs(["-p", "hi"]).workdir).toBeNull();
+    expect(resolveAgentLaunchArgs(["--", "--workdir", "/x"]).workdir).toBeNull();
   });
 });
 
@@ -299,6 +321,40 @@ describe("runBundledAgent passes config overrides to the child via env", () => {
     );
 
     expect(errorMock).toHaveBeenCalledWith(expect.stringMatching(message));
+    expect(exitMock).toHaveBeenCalledWith(2);
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("--workdir becomes the child's spawn cwd; absent means inherit", () => {
+    const spawnMock = vi.fn((..._args: unknown[]) => ({ on: vi.fn() }) as never);
+    runBundledAgent(
+      {},
+      "agency-agent",
+      ["--workdir", os.tmpdir(), "-p", "hi"],
+      {},
+      { spawn: spawnMock as never },
+    );
+    expect((spawnMock.mock.calls[0][2] as { cwd?: string }).cwd).toBe(path.resolve(os.tmpdir()));
+
+    spawnMock.mockClear();
+    runBundledAgent({}, "agency-agent", ["-p", "hi"], {}, { spawn: spawnMock as never });
+    expect((spawnMock.mock.calls[0][2] as { cwd?: string }).cwd).toBeUndefined();
+  });
+
+  it("a --workdir that is not a directory exits before spawn", () => {
+    const spawnMock = vi.fn((..._args: unknown[]) => ({ on: vi.fn() }) as never);
+    const exitMock = vi.fn();
+    const errorMock = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    runBundledAgent(
+      {},
+      "agency-agent",
+      ["--workdir", "/no/such/dir/anywhere", "-p", "hi"],
+      {},
+      { spawn: spawnMock as never, exit: exitMock },
+    );
+
+    expect(errorMock).toHaveBeenCalledWith(expect.stringMatching(/--workdir .* not a directory/));
     expect(exitMock).toHaveBeenCalledWith(2);
     expect(spawnMock).not.toHaveBeenCalled();
   });

--- a/packages/agency-lang/lib/cli/runBundledAgent.ts
+++ b/packages/agency-lang/lib/cli/runBundledAgent.ts
@@ -45,6 +45,7 @@ const LAUNCH_FLAG_POLICIES: Record<
   trace: { acceptsNegativeNumber: false },
   log: { acceptsNegativeNumber: false },
   "agent-home": { acceptsNegativeNumber: false },
+  workdir: { acceptsNegativeNumber: false },
   "max-cost": { acceptsNegativeNumber: true },
   "max-time": { acceptsNegativeNumber: true },
   config: { acceptsNegativeNumber: false },
@@ -91,6 +92,10 @@ function scanLaunchValues(args: readonly string[]): Record<string, string> {
 export type ResolvedAgentLaunch = {
   configOverrides: Partial<AgencyConfig>;
   agentHome: string | null;
+  /** A forwarded `--workdir <dir>`: the child's working directory, absolute.
+   *  It must be the SPAWN cwd — the agent's static initializers resolve
+   *  paths and discover agency.json against cwd before main() runs. */
+  workdir: string | null;
   budgetInput: { maxCost?: string; maxTime?: string };
   /** A forwarded `--config <path>`; wins over the root-level `-c`. */
   configPath?: string;
@@ -151,9 +156,11 @@ export function resolveAgentLaunchArgs(args: readonly string[]): ResolvedAgentLa
   const home = scanned["agent-home"];
   const nonEmpty = (value: string | undefined) =>
     value !== undefined && value !== "" ? value : undefined;
+  const workdir = scanned.workdir;
   return {
     configOverrides: applyCliFlags({}, flags),
     agentHome: home !== undefined && home !== "" ? path.resolve(home) : null,
+    workdir: workdir !== undefined && workdir !== "" ? path.resolve(workdir) : null,
     budgetInput: {
       maxCost: nonEmpty(scanned["max-cost"]),
       maxTime: nonEmpty(scanned["max-time"]),
@@ -182,6 +189,14 @@ export function runBundledAgent(
     budget = resolveBudget(launchArgs.budgetInput);
   } catch (error) {
     console.error(`Error: ${(error as Error).message}`);
+    launcher.exit(2);
+    return;
+  }
+
+  // A bad workdir never launches: the agent would silently run somewhere
+  // the user did not intend, which is exactly what the flag exists to fix.
+  if (launchArgs.workdir !== null && !isDirectory(launchArgs.workdir)) {
+    console.error(`Error: --workdir ${launchArgs.workdir} is not a directory.`);
     launcher.exit(2);
     return;
   }
@@ -255,6 +270,9 @@ export function runBundledAgent(
         stdio: "inherit",
         shell: false,
         env,
+        // The child's cwd, not a parent chdir: the launcher keeps resolving
+        // its own files (agent dir, staging) where they actually live.
+        cwd: launchArgs.workdir ?? undefined,
       },
     );
   } catch (error) {
@@ -275,6 +293,14 @@ export function runBundledAgent(
       launcher.exit(code || 1);
     }
   });
+}
+
+function isDirectory(dir: string): boolean {
+  try {
+    return fs.statSync(dir).isDirectory();
+  } catch {
+    return false;
+  }
 }
 
 /** Which code the agent is, for the trace's agentStart. A precompiled agent

--- a/packages/agency-lang/lib/eval/grading/functionGrader.test.ts
+++ b/packages/agency-lang/lib/eval/grading/functionGrader.test.ts
@@ -47,16 +47,18 @@ describe("FunctionGrader", () => {
     expect(seen).toEqual(["Paris"]);
   });
 
-  it("provides ctx.judge that runs the bundled goal judge and returns its score", async () => {
+  it("provides ctx.judge that runs the bundled goal judge and returns a Grade with its reasoning", async () => {
     const runStructured = vi.fn(async () => ({ score: 0.9, reasoning: "good" }));
     const ctxInput: GraderInput = {
       ...runInput("Paris"),
       runAgency: { runStructured } as unknown as AgencyRunner,
     };
-    const g = new FunctionGrader(
-      async ({ judge, output }) => (await judge({ goal: "capital", output })).score,
-    );
-    expect(await g.run(ctxInput)).toEqual({ score: { kind: "scalar", value: 0.9 } });
+    // The Grade is returnable as-is, so the reasoning lands in the annotation.
+    const g = new FunctionGrader(({ judge, output }) => judge({ goal: "capital", output }));
+    expect(await g.run(ctxInput)).toEqual({
+      score: { kind: "scalar", value: 0.9 },
+      feedback: "good",
+    });
     expect(runStructured).toHaveBeenCalledTimes(1);
   });
 
@@ -67,7 +69,7 @@ describe("FunctionGrader", () => {
       run: loadedRun("New Delhi"),
       runAgency: { runStructured } as unknown as AgencyRunner,
     };
-    const g = new FunctionGrader(async ({ judge }) => (await judge({ goal: "capital" })).score);
+    const g = new FunctionGrader(({ judge }) => judge({ goal: "capital" }));
     await g.run(input);
     expect((runStructured.mock.calls[0] as unknown[])[2]).toEqual([
       "capital",
@@ -83,9 +85,7 @@ describe("FunctionGrader", () => {
       run: loadedRun("Mumbai"),
       runAgency: { runStructured } as unknown as AgencyRunner,
     };
-    const g = new FunctionGrader(
-      async ({ judge }) => (await judge({ goal: "capital", expected: "Delhi" })).score,
-    );
+    const g = new FunctionGrader(({ judge }) => judge({ goal: "capital", expected: "Delhi" }));
     await g.run(input);
     expect((runStructured.mock.calls[0] as unknown[])[2]).toEqual(["capital", "Mumbai", "Delhi"]);
   });

--- a/packages/agency-lang/lib/eval/grading/functionGrader.ts
+++ b/packages/agency-lang/lib/eval/grading/functionGrader.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 import { BaseGrader } from "./baseGrader.js";
-import { asJudgeText, goalJudgeFile, ScalarVerdict } from "./goalJudgeFile.js";
+import { asJudgeText, goalJudgeFile, scalarGrade, ScalarVerdict } from "./goalJudgeFile.js";
 import type { EvalRecord } from "@/eval/types.js";
 
 import type { Grade, GraderInput, GraderOptions, Test, JSON } from "./types.js";
@@ -16,15 +16,13 @@ export type GraderContext = {
   workdir: string;
   /** The parsed eval record: events, metrics, tool counts, interrupts, cost. */
   record: EvalRecord;
-  /** Run the bundled LLM goal judge and get back its 0..1 score + reasoning.
-   *  Defaults: `output` falls back to `run.output`, `expected` falls back to
-   *  `input.expected` (so the bundled judge grades against the gold answer when
-   *  one is present, matching `LlmJudge`). */
-  judge: (args: {
-    goal: string;
-    output?: JSON;
-    expected?: JSON;
-  }) => Promise<{ score: number; reasoning: string }>;
+  /** Run the bundled LLM goal judge. Returns a full Grade — the 0..1 score
+   *  plus the judge's reasoning as `feedback` — so a metric can return it
+   *  directly and the rationale is stored with the score. Defaults: `output`
+   *  falls back to `run.output`, `expected` falls back to `input.expected`
+   *  (so the bundled judge grades against the gold answer when one is
+   *  present, matching `LlmJudge`). */
+  judge: (args: { goal: string; output?: JSON; expected?: JSON }) => Promise<Grade>;
 };
 
 /** A metric: return a 0..1 number, a pass/fail boolean, or a full Grade. */
@@ -51,7 +49,7 @@ export class FunctionGrader extends BaseGrader {
     // test's gold answer so a metric that calls ctx.judge({ goal }) grades the
     // same way LlmJudge does when test.expected is present.
     const inputExpected = (test as { expected?: JSON }).expected;
-    const judge = ({
+    const judge = async ({
       goal,
       output,
       expected,
@@ -62,12 +60,13 @@ export class FunctionGrader extends BaseGrader {
     }) => {
       const exp = expected ?? inputExpected;
       const expectedText = exp === undefined || exp === null ? "" : asJudgeText(exp);
-      return runAgency.runStructured(
+      const verdict = await runAgency.runStructured(
         goalJudgeFile(),
         "main",
         [goal, asJudgeText(output ?? run.output), expectedText],
         ScalarVerdict,
       );
+      return scalarGrade(verdict);
     };
     const result = await this.fn({
       output: run.output,

--- a/packages/agency-lang/lib/eval/grading/goalJudgeFile.ts
+++ b/packages/agency-lang/lib/eval/grading/goalJudgeFile.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 import { z } from "zod";
 
 import { getAgentsDir } from "@/importPaths.js";
+import type { Grade } from "./types.js";
 
 /** Bundled scalar goal judge: scores how well an output satisfies the input's goal. */
 export function goalJudgeFile(): string {
@@ -19,6 +20,12 @@ export const GOAL_JUDGE_PROMPT_SHA256 =
 
 /** Structured verdict shape the goal judge returns (0..1 score + reasoning). */
 export const ScalarVerdict = z.object({ score: z.number(), reasoning: z.string() });
+
+/** The judge's wire verdict as the Grade a grader returns: the score, with
+ *  the reasoning as feedback so the rationale lands in the score annotation. */
+export function scalarGrade(v: z.infer<typeof ScalarVerdict>): Grade {
+  return { score: { kind: "scalar", value: v.score }, feedback: v.reasoning };
+}
 
 /** Render an agent output as the string a judge reads: strings pass through,
  *  everything else is JSON so it reads as data rather than "[object Object]".

--- a/packages/agency-lang/lib/eval/grading/graders/llmJudge.ts
+++ b/packages/agency-lang/lib/eval/grading/graders/llmJudge.ts
@@ -3,7 +3,13 @@ import * as fs from "fs";
 import { sha256Text } from "@/utils/hash.js";
 import { z } from "zod";
 
-import { asJudgeText, GOAL_JUDGE_VERSION, goalJudgeFile, ScalarVerdict } from "../goalJudgeFile.js";
+import {
+  asJudgeText,
+  GOAL_JUDGE_VERSION,
+  goalJudgeFile,
+  scalarGrade,
+  ScalarVerdict,
+} from "../goalJudgeFile.js";
 import { BaseGrader } from "../baseGrader.js";
 import { getPath } from "../getPath.js";
 import type { Grade, GraderInput, GraderOptions, JSONPath } from "../types.js";
@@ -79,6 +85,6 @@ export class LlmJudge extends BaseGrader {
       return { score: { kind: "binary", pass: v.pass }, feedback: v.reasoning };
     }
     const v = await runAgency.runStructured(agencyFile, node, args, ScalarVerdict);
-    return { score: { kind: "scalar", value: v.score }, feedback: v.reasoning };
+    return scalarGrade(v);
   }
 }

--- a/packages/agency-lang/stdlib/policy.agency
+++ b/packages/agency-lang/stdlib/policy.agency
@@ -190,6 +190,11 @@ let globalCliPolicyOpts: CliPolicyOpts = {
 let _policy: Policy | null = null
 let _policyLoaded: boolean = false
 let _pendingSave: boolean = false
+// Whether a user is at a terminal to answer prompts. When false, an
+// interrupt the policy does not decide is rejected with a reason instead
+// of prompting (there is no one to answer, and a pending prompt starves
+// the event loop until the process dies).
+let _interactive: boolean = true
 // True only while the handler is reading or writing its OWN policy file
 // (inside maybeLoadPolicy / maybeFlush / flushPolicy). Those file ops
 // raise std::read / std::write interrupts that re-enter this same
@@ -800,6 +805,16 @@ def _handler(intr: any): any {
     return reject()
   }
 
+  // No rule decided, and no user is at a terminal to ask: reject with a
+  // reason. The reason becomes the failing call's error, so an LLM whose
+  // tool raised this effect reads why and can take another approach
+  // instead of the process dying on a prompt nobody can answer.
+  if (!_interactive) {
+    return reject(
+      "\"${intr.effect}\" was rejected automatically: this is a non-interactive run and the approval policy has no rule for this effect, so there is no one to ask. Take an approach that does not need this permission, or the user must re-run with a policy that decides \"${intr.effect}\".",
+    )
+  }
+
   const answer = askUser(intr)
   if (answer.action == "approve-always") {
     _policy = recordRule(_policy, intr.effect, "approve")
@@ -899,6 +914,7 @@ export def cliPolicyHandler(
   file: string,
   fields: ScopedRuleFields,
   policy: Policy | null = null,
+  interactive: boolean = true,
 ): any {
   """
   CLI sugar for an interactive policy handler. Loads and saves the policy file, prompts the user on new interrupts, records "always" decisions, and returns approve/reject. Install on the outermost `handle`. Call exactly once per program — internal state is module-level.
@@ -906,11 +922,13 @@ export def cliPolicyHandler(
   @param file - Path to the on-disk policy file.
   @param fields - Per-effect config controlling the "approve-always-here" prompt option.
   @param policy - Optional in-memory policy to use directly instead of loading `file` on startup.
+  @param interactive - Whether a user is at a terminal. When false, an interrupt the policy does not decide is rejected with a reason (surfaced to the raise site, and so to an LLM whose tool raised it) instead of prompting.
   """
   globalCliPolicyOpts = {
     file: file,
     fields: fields
   }
+  _interactive = interactive
   if (policy != null) {
     // Seed from the caller and mark loaded so `maybeLoadPolicy` skips the
     // file read; persistence of later decisions still targets `file`.

--- a/packages/agency-lang/tests/agency-js/cli-policy-handler-headless/agent.agency
+++ b/packages/agency-lang/tests/agency-js/cli-policy-handler-headless/agent.agency
@@ -1,0 +1,26 @@
+import { cliPolicyHandler } from "std::policy"
+
+def readSecret(): string {
+  interrupt myapp::secret("Allow reading the secret?", { key: "k" })
+  return "granted"
+}
+
+node main(args: { policyFile: string }): string {
+  // interactive: false — an effect the policy does not decide must be
+  // rejected with a reason, never prompted (there is no user to answer).
+  const handler = cliPolicyHandler(
+    file: args.policyFile,
+    fields: {},
+    interactive: false,
+  )
+  let outcome = ""
+  handle {
+    const result = try readSecret()
+    if (result is success(v)) {
+      outcome = "approved: ${v}"
+    } else if (result is failure(f)) {
+      outcome = "failure: ${f}"
+    }
+  } with handler
+  return outcome
+}

--- a/packages/agency-lang/tests/agency-js/cli-policy-handler-headless/fixture.json
+++ b/packages/agency-lang/tests/agency-js/cli-policy-handler-headless/fixture.json
@@ -1,0 +1,5 @@
+{
+  "rejected": true,
+  "reasonNamesEffect": true,
+  "reasonExplains": true
+}

--- a/packages/agency-lang/tests/agency-js/cli-policy-handler-headless/test.js
+++ b/packages/agency-lang/tests/agency-js/cli-policy-handler-headless/test.js
@@ -1,0 +1,24 @@
+import { main } from "./agent.js";
+import { writeFileSync, mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+const dir = mkdtempSync(join(tmpdir(), "cli-policy-headless-"));
+const policyFile = join(dir, "policy.json");
+
+// Any prompt is the bug under test: a headless run has no one to answer.
+globalThis.__agencyInputOverride = async () => {
+  throw new Error("Prompted in a non-interactive run");
+};
+
+try {
+  const result = await main({ policyFile });
+  const text = String(result.data);
+  writeFileSync("__result.json", JSON.stringify({
+    rejected: text.startsWith("failure:"),
+    reasonNamesEffect: text.includes("myapp::secret"),
+    reasonExplains: text.includes("rejected automatically"),
+  }, null, 2));
+} finally {
+  rmSync(dir, { recursive: true, force: true });
+}


### PR DESCRIPTION
Three related pieces from evaluating the agency agent end to end (plus the eval/grader improvements committed earlier on this branch: the hollow-creek reading-between-the-lines eval, and `ctx.judge()` returning a full Grade so judge rationales are stored as score `feedback`).

## 1. `agency agent --workdir <dir>`

Run the agent from a named directory. It joins the launcher pre-scan (the agent resolves paths and discovers `agency.json` in static initializers, before `main()` could parse a flag) and is applied as the spawn `cwd`, never a parent `chdir`, so the launcher keeps resolving the agent dir and staging where they live. A path that is not a directory refuses to launch before spawn.

Motivating case: the eval harness seeds fixtures into a staged workdir and spawns the agent command there, but wrapping the command in `pnpm run` re-anchors cwd to the package root — the agent then went hunting for `article.txt` with a recursive glob over the whole home directory.

## 2. Headless runs reject undecided interrupts, and tell the model why

`cliPolicyHandler` gains `interactive` (default `true`; REPL behavior unchanged). When `false` and no policy rule decides an effect, the handler rejects with a reason instead of prompting. The reason travels the same path as the existing interactive reject-with-guidance: it becomes the failing call's error, which the tool loop feeds back to the model, so the agent can take an approach that does not need the permission. The agency agent threads its one-shot/REPL mode through `policyHandlerFor`.

Before: an undecided effect in `-p` mode raised a choice prompt nobody could answer. The pending prompt starved the event loop and the process died with exit 13 ("unsettled top-level await") and no explanation — observed live when the agent's verify step ran `bash(...)` under an eval and the whole run silently died.

## Tests

- `runBundledAgent.test.ts`: pre-scan forms, relative resolution, bare-flag ignore, `--` terminator, spawn cwd pass-through/inherit, bad-dir refusal (47 pass)
- New agency-js test `cli-policy-handler-headless`: non-interactive handler rejects an undecided effect without prompting (any prompt throws), and the failure names the effect and the reason
- Existing `cli-policy-handler` interactive test still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
