### PR TITLE
One-shot agency agent records its input and reply so eval grading sees its output

### DIFF
--- a/packages/agency-lang/docs/dev/eval-command-agents.md
+++ b/packages/agency-lang/docs/dev/eval-command-agents.md
@@ -83,6 +83,16 @@ that cause. Concurrent line-appends to the shared statelog stay parseable
 (per-event `appendFileSync`); writes are sequential in the dominant case
 (parents block on children).
 
+One more consequence of "the record is the agent's record": grading reads
+the agent's OUTPUT from the statelog too, never from stdout. A grader's
+`output` is the last `evalOutputRecorded` event (`lastOutput` in
+`lib/eval/run/runAgent.ts`; `gradeRun` reads `evalOutputs` the same way).
+So a command agent must call `evalOutput(reply)` (and `evalValue(prompt)`
+for the input) from `std::statelog`, or every judge sees `output: null`.
+The Agency agent does this in `oneShotAgent` (`agent.agency`), which also
+keeps the recorded output clean — the `Session cost` trailer is printed
+after the reply is recorded.
+
 ## Process-group lifecycle (the part that bites)
 
 The spawned command is `detached: true` — its own process group — and

--- a/packages/agency-lang/docs/dev/eval-grading.md
+++ b/packages/agency-lang/docs/dev/eval-grading.md
@@ -170,6 +170,64 @@ so editing `graders.ts` in place is a new annotator. `EvalRunGrading` (the
 objective, gates, per-test breakdown) is computed for printing and `-o`; it is
 not stored.
 
+## Coding tests: grading agent-written Agency with the agency test framework
+
+`evals/agency-agent/fib/` is the reference for a coding test whose grader
+runs the agent's code. The reason the agent writes **Agency** rather than
+TypeScript or Python: it is the one language where running the code locally
+is safe without a container, because every effectful stdlib function raises
+an interrupt. Two mechanisms make the guarantee, and both already exist in
+`std::agency`:
+
+1. `compile(source)` allows only `std::` imports — no interop TypeScript, no
+   node builtins, no local files.
+2. `run(compiled, node)` executes in a sandboxed subprocess whose interrupts
+   are all voted on by the parent's handlers, so a harness that wraps the
+   call in `handle { … } with` a reject-everything handler (approving only
+   `std::run`, the sandbox launch itself) vetoes every effect — including a
+   solution's own inline `with approve` and effectful static initializers.
+   Verified empirically in the fib harness against an inline-approved write,
+   a static-initializer write, and a `child_process` import.
+
+The shape, per test directory:
+
+- `files/<x>-harness.agency` + `files/<x>-harness.test.json` — an agency-test
+  harness. It reads the solution file, appends a driver node
+  (`export node __probe(…) { return solution(…) }`), compiles with
+  `std::agency`, and runs assertions in the sandbox, returning `"ok"` or a
+  precise failure string the test's exact-match turns into a diff. Living in
+  `files/`, it is seeded into the agent's workdir, so the agent can check its
+  own work with `agency test <x>-harness.test.json`. Name the harness's
+  `.test.json` differently from the solution file: the test runner derives
+  module names from the json's basename, and `fib.test.json` would collide
+  with `fib.agency`. Harness nodes must be `export`ed.
+- `graders.ts` — a `BaseGrader` subclass that copies ONLY the solution file
+  from the run's workdir into a scratch directory, lays down a fresh harness,
+  and spawns `agency test` there (`process.execPath` + `process.argv[1]`,
+  which is the agency CLI in every grading process). Pass = exit 0; feedback
+  = the run's output tail, which carries the harness diff.
+
+Three rules that are easy to get wrong:
+
+- **Never run the harness from the workdir.** The agent can edit its seeded
+  copy; the grader's copy comes from the graders snapshot (declared via
+  `externalFiles()`, rebound by `rebindExternalFile` when grading from a run
+  directory, resolved against the module dir when grading live).
+- **Spawn `agency test`; do not call `lib/cli/test.ts`'s `test()`
+  in-process.** It `process.exit`s on compile failure, and agent code that
+  fails to compile is a normal grading outcome, not a reason to kill the
+  grading process.
+- **The scratch dir goes under `process.cwd()`, not `os.tmpdir()`** —
+  compiled Agency resolves `agency-lang` from the directory it runs in.
+
+Integration status: this is deliberately a suite-local pattern, not framework
+surface. The framework already carries everything it needs (`workdir` on the
+grader input, the `externalFiles` snapshot, `GraderInput` exported from
+`agency-lang/eval`). When a second coding test wants the same grader, promote
+the pattern to a framework-owned `AgencyTestGrader` (constructor takes the
+harness files and the workdir files to copy; the framework owns the
+scratch-dir, spawn, and feedback mechanics) rather than copy-pasting it.
+
 ## What is gone
 
 `config.json`, `summary.json`, per-input `input.json`, `eval-record.json` on

--- a/packages/agency-lang/docs/dev/eval-grading.md
+++ b/packages/agency-lang/docs/dev/eval-grading.md
@@ -23,6 +23,17 @@ names the GROUP directory; each test's run directory is written at
 and renamed into place so a child appears whole or not at all. A child that
 already exists is an error result for that test (nothing overwritten; the
 others still run). Default `<eval.runsDir or runs>/<timestamp>-<random suffix>`.
+
+**Selecting a subset of a suite.** `--test <glob>` (repeatable, any match
+selects, picomatch on the test id) and `--tags <a,b>` (repeatable; a test
+must carry EVERY listed tag, so `--tags coding,hard` means hard coding
+tests) narrow which tests run; tags live on the test (`tags: ["easy",
+"coding"]`, multiple allowed). Both flags go through one function,
+`selectTests` (`lib/eval/selectTests.ts`), and `agency eval ls --suite …`
+applies the same flags through the same function — so the listing is
+exactly what a run would run, by construction. A filter matching nothing is
+an error naming the suite's ids and tags, never a silent empty run; filter
+flags with `--input` are an error too.
 `eval grade <path…>` takes run directories and groups, grades each run found
 with its own pass, and prints the mean over them (`findRunDirectories`,
 `docs/dev/run-directory.md`); a run named twice, or through a symlink alias,

--- a/packages/agency-lang/evals/agency-agent/fib/files/fib-harness.agency
+++ b/packages/agency-lang/evals/agency-agent/fib/files/fib-harness.agency
@@ -1,0 +1,53 @@
+// Test harness for the fib eval test. Compiles the agent-written fib.agency
+// with std::agency (which allows only std:: imports) and runs it in the
+// sandboxed subprocess, where sandboxHandler rejects every effect the code
+// raises. Together those two make agent-written code safe to run locally.
+import { compile, run } from "std::agency"
+
+// `std::run` is the sandbox launch itself and must be approved; everything
+// the sandboxed code raises after that is rejected.
+def sandboxHandler(intr: any): any {
+  if (intr.effect == "std::run") {
+    return approve()
+  }
+  return reject("sandboxed code raised \"${intr.effect}\", which the harness does not allow")
+}
+
+// fib(0) .. fib(10)
+static const EXPECTED = [0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55]
+
+export node checkFib(): string {
+  const sourceResult = read("fib.agency") with approve
+  if (sourceResult is failure(readError)) {
+    return "could not read fib.agency — the solution must be saved to that exact filename"
+  }
+  let source = ""
+  if (sourceResult is success(text)) {
+    source = text
+  }
+  // The driver node gives run() a fixed entry point whatever else the file
+  // contains; compiling it against the source also proves fib is exported
+  // with the required signature.
+  const driver = "\nexport node __fibProbe(n: number): number { return fib(n) }"
+  const compiled = compile("${source}${driver}")
+  if (compiled is failure(compileError)) {
+    return "fib.agency does not compile: ${compileError}"
+  }
+  if (compiled is success(program)) {
+    handle {
+      for (expected, n in EXPECTED) {
+        const result = run(program, "__fibProbe", { n: n })
+        if (result is failure(runError)) {
+          return "fib(${n}) failed: ${runError}"
+        }
+        if (result is success(value)) {
+          if (value.data != expected) {
+            return "fib(${n}) returned ${value.data}, expected ${expected}"
+          }
+        }
+      }
+    } with sandboxHandler
+    return "ok"
+  }
+  return "unreachable"
+}

--- a/packages/agency-lang/evals/agency-agent/fib/files/fib-harness.test.json
+++ b/packages/agency-lang/evals/agency-agent/fib/files/fib-harness.test.json
@@ -1,0 +1,12 @@
+{
+  "sourceFile": "fib-harness.agency",
+  "tests": [
+    {
+      "nodeName": "checkFib",
+      "input": "",
+      "expectedOutput": "\"ok\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "fib(0)..fib(10) are correct, computed in the std::agency sandbox"
+    }
+  ]
+}

--- a/packages/agency-lang/evals/agency-agent/fib/graders.ts
+++ b/packages/agency-lang/evals/agency-agent/fib/graders.ts
@@ -1,0 +1,103 @@
+import { execFileSync } from "child_process";
+import * as fs from "fs";
+import * as path from "path";
+
+import { BaseGrader } from "agency-lang/eval";
+import type { Grade, GraderInput } from "agency-lang/eval";
+
+/** The harness the grader runs, declared relative to this module. The same
+ *  files are seeded into the agent's workdir (they live under files/), so
+ *  the agent can check its own work with `agency test`. */
+const HARNESS_FILES = ["files/fib-harness.agency", "files/fib-harness.test.json"];
+
+/**
+ * Runs the shipped agency-test harness against the agent-written fib.agency.
+ *
+ * Why this is safe to run on a local machine: the harness compiles the
+ * solution with std::agency, which allows only std:: imports, and runs it in
+ * the sandboxed subprocess, where the harness's handler rejects every effect
+ * the code raises (a solution's own `with approve` cannot outvote it — every
+ * handler up the chain gets a veto). Verified against inline-approved
+ * writes, static-initializer writes, and a child_process import.
+ *
+ * Tamper defense: the harness is copied fresh from the graders snapshot into
+ * a clean scratch directory, and only fib.agency is taken from the agent's
+ * workdir — so edits the agent makes to its seeded harness copy change
+ * nothing about grading.
+ */
+class FibHarnessGrader extends BaseGrader {
+  protected readonly defaultName = "agency-tests";
+  private bound: Record<string, string> = {};
+
+  override externalFiles(): string[] {
+    return HARNESS_FILES;
+  }
+  override rebindExternalFile(from: string, to: string): void {
+    this.bound[from] = to;
+  }
+
+  /** Snapshot grading rebinds each declared path to the stored copy; live
+   *  grading resolves it against this module's directory (the grading bundle
+   *  is imported from there). */
+  private harnessPath(declared: string): string {
+    return this.bound[declared] ?? path.resolve(moduleDir(), declared);
+  }
+
+  protected async _run({ run }: GraderInput): Promise<Grade> {
+    const solution = path.join(run.workdir, "fib.agency");
+    if (run.workdir === "" || !fs.existsSync(solution)) {
+      return fail("the run left no fib.agency in its workdir");
+    }
+    // The scratch dir lives under the grading cwd, not os.tmpdir(): compiled
+    // Agency resolves agency-lang from the directory it runs in.
+    const dir = fs.mkdtempSync(path.join(process.cwd(), ".fib-grade-"));
+    try {
+      fs.copyFileSync(solution, path.join(dir, "fib.agency"));
+      for (const declared of HARNESS_FILES) {
+        fs.copyFileSync(this.harnessPath(declared), path.join(dir, path.basename(declared)));
+      }
+      try {
+        execFileSync(process.execPath, [agencyCli(), "test", "fib-harness.test.json"], {
+          cwd: dir,
+          stdio: "pipe",
+          timeout: 5 * 60 * 1000,
+        });
+        return { score: { kind: "binary", pass: true } };
+      } catch (error) {
+        return fail(testOutput(error));
+      }
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+}
+
+function moduleDir(): string {
+  return path.dirname(new URL(import.meta.url).pathname);
+}
+
+/** Grading always runs inside the agency CLI (`agency eval grade`), so the
+ *  running script is the CLI entry point. */
+function agencyCli(): string {
+  return process.argv[1];
+}
+
+function fail(feedback: string): Grade {
+  return { score: { kind: "binary", pass: false }, feedback };
+}
+
+/** The tail of the failed test run's output, ANSI stripped — it carries the
+ *  harness's exact-match diff ("fib(2) returned 2, expected 1"). */
+function testOutput(error: unknown): string {
+  const e = error as { stdout?: Buffer | string; stderr?: Buffer | string; message?: string };
+  const text = [e.stdout, e.stderr]
+    .map((part) => (part === undefined ? "" : part.toString()))
+    .join("\n")
+    // eslint-disable-next-line no-control-regex
+    .replace(/\x1b\[[0-9;]*m/g, "")
+    .trim();
+  if (text === "") return e.message ?? String(error);
+  return text.length > 2000 ? `…${text.slice(-2000)}` : text;
+}
+
+export default [new FibHarnessGrader({ mustPass: true })];

--- a/packages/agency-lang/evals/agency-agent/fib/test.json
+++ b/packages/agency-lang/evals/agency-agent/fib/test.json
@@ -1,0 +1,5 @@
+{
+  "description": "Basic coding: write a Fibonacci function in Agency. Graded by the shipped agency-test harness, which compiles the solution with std::agency (stdlib-only imports) and runs it in a sandboxed subprocess with every effect rejected.",
+  "tags": ["coding", "easy"],
+  "input": "Write an Agency function that returns the nth Fibonacci number (fib(0) = 0, fib(1) = 1) and save it to a file named fib.agency in the current directory. The file must contain: export def fib(n: number): number. Use only Agency standard library (std::) imports, or no imports at all. Your working directory contains a test harness; you can check your solution by running: agency test fib-harness.test.json"
+}

--- a/packages/agency-lang/evals/agency-agent/hollow-creek/test.json
+++ b/packages/agency-lang/evals/agency-agent/hollow-creek/test.json
@@ -1,4 +1,5 @@
 {
+  "description": "Tests summarizing an article and reading between its lines, using a custom article the model has never seen so it cannot lean on prior knowledge.",
   "input": "Read and summarize the article at article.txt.",
   "goal": "summarizes the article accurately and identifies its unstated implication"
 }

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -1,6 +1,7 @@
 import { parseArgs } from "std::args"
 import { map } from "std::array"
 import { setLlmOptions } from "std::llm"
+import { evalOutput, evalValue } from "std::statelog"
 import { cwd, env, isTTY, readStdin, setTitle } from "std::system"
 import { getCost } from "std::thread"
 import {
@@ -41,6 +42,10 @@ import { resolveMaxToolCallRounds, getCapabilities } from "./shared.agency"
 
 def oneShotAgent(target: string, prompt: string): string {
   setInteractive(false)
+  // Mark the input and reply in the statelog so a one-shot run is gradable:
+  // `agency eval grade` reads the agent's output from the trace's
+  // `evalOutputRecorded` events, not from stdout.
+  evalValue(prompt)
   let reply = ""
   runSession(false) {
     const result = try runTurn(target, prompt)
@@ -52,6 +57,7 @@ def oneShotAgent(target: string, prompt: string): string {
       reply = formatTurnFailure("${f.error}")
     }
   }
+  evalOutput(reply)
   return reply
 }
 

--- a/packages/agency-lang/lib/cli/eval/formatGrade.test.ts
+++ b/packages/agency-lang/lib/cli/eval/formatGrade.test.ts
@@ -43,6 +43,22 @@ describe("formatGradeResult", () => {
     ]);
   });
 
+  it("a test's description prints dim under its score line", () => {
+    const withDescription = grading("a", 1, [{ grader: "gate", kind: "binary", pass: true }]);
+    withDescription.perInput[0].description = "checks the agent reads between the lines";
+    const result: EvalGradeResult = {
+      runs: [{ dir: "/runs/x/a", grading: withDescription }],
+      mean: 1,
+      gatesPassed: true,
+    };
+    const lines = formatGradeResult(result).map(stripAnsi);
+    expect(lines).toEqual([
+      "a  score 1.000",
+      "  checks the agent reads between the lines",
+      "  gate         pass",
+    ]);
+  });
+
   it("a group: every run's block, an ungraded reason where there is one, then the mean over the runs", () => {
     const result: EvalGradeResult = {
       runs: [

--- a/packages/agency-lang/lib/cli/eval/formatGrade.ts
+++ b/packages/agency-lang/lib/cli/eval/formatGrade.ts
@@ -26,6 +26,7 @@ function formatRun(run: GradedRun): string[] {
 function formatInput(input: GradedInput): string[] {
   return [
     `${ttyColor.green(input.inputId)}  score ${formatScore(input.objective)}`,
+    ...(input.description === undefined ? [] : [`  ${ttyColor.dim(input.description)}`]),
     ...input.grades.flatMap(formatGrade),
     ...formatUngradedReason(input.ungradedReason),
   ];

--- a/packages/agency-lang/lib/cli/eval/ls.test.ts
+++ b/packages/agency-lang/lib/cli/eval/ls.test.ts
@@ -1,0 +1,64 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { evalLs } from "./ls.js";
+
+// eslint-disable-next-line no-control-regex
+const stripAnsi = (line: string): string => line.replace(/\x1b\[[0-9;]*m/g, "");
+
+describe("eval ls", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "eval-ls-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeSuite(inputs: unknown[]): string {
+    const file = path.join(tmpDir, "suite.json");
+    fs.writeFileSync(file, JSON.stringify({ inputs }));
+    return file;
+  }
+
+  it("lists every test with its tags and description, then a count", () => {
+    const suite = writeSuite([
+      { id: "a", input: "x", tags: ["easy", "coding"], description: "why a exists" },
+      { id: "b", input: "x" },
+    ]);
+    expect(evalLs({ suite }).map(stripAnsi)).toEqual([
+      "a  [easy, coding]",
+      "  why a exists",
+      "b",
+      "2 tests",
+    ]);
+  });
+
+  it("with a filter, shows the selection and the of-total count", () => {
+    const suite = writeSuite([
+      { id: "sort-a", input: "x", tags: ["easy"] },
+      { id: "sort-b", input: "x", tags: ["hard"] },
+      { id: "find-c", input: "x", tags: ["hard"] },
+    ]);
+    expect(evalLs({ suite, test: ["sort-*"], tags: ["hard"] }).map(stripAnsi)).toEqual([
+      "sort-b  [hard]",
+      "1 of 3 tests selected",
+    ]);
+  });
+
+  it("matching nothing names the suite's tags instead of erroring", () => {
+    const suite = writeSuite([{ id: "a", input: "x", tags: ["easy"] }]);
+    expect(evalLs({ suite, tags: ["nope"] }).map(stripAnsi)).toEqual([
+      "0 of 1 tests selected (suite tags: easy)",
+    ]);
+  });
+
+  it("requires --suite", () => {
+    expect(() => evalLs({})).toThrow(/needs --suite/);
+  });
+});

--- a/packages/agency-lang/lib/cli/eval/ls.ts
+++ b/packages/agency-lang/lib/cli/eval/ls.ts
@@ -1,0 +1,57 @@
+import type { AgencyConfig } from "@/config.js";
+import { isEmptyFilter, selectTests, suiteTags, type TestFilter } from "@/eval/selectTests.js";
+import type { Test } from "@/eval/runTypes.js";
+import { ttyColor } from "@/utils/termcolors.js";
+
+import { loadSuite } from "./run.js";
+
+export type EvalLsOptions = {
+  /** The test suite, same forms as `eval run --suite`. */
+  suite?: string;
+  /** `--test` id patterns. */
+  test?: string[];
+  /** `--tags` values. */
+  tags?: string[];
+  config?: AgencyConfig;
+};
+
+/**
+ * `agency eval ls`: list a suite's tests — and with `--test`/`--tags`,
+ * exactly the tests `eval run` with the same flags would run, because both
+ * commands select through `selectTests`.
+ */
+export function evalLs(opts: EvalLsOptions): string[] {
+  if (opts.suite === undefined || opts.suite === "") {
+    throw new Error("eval ls needs --suite: the suite whose tests to list");
+  }
+  const suite = loadSuite({
+    selection: "suite",
+    source: opts.suite,
+    cacheRoot: opts.config?.eval?.sourceCacheRoot,
+  });
+  const filter: TestFilter = { ids: opts.test, tags: opts.tags };
+  const selected = selectTests(suite.tests, filter);
+  return [...selected.flatMap(formatTest), summaryLine(selected, suite.tests, filter)];
+}
+
+function formatTest(test: Test): string[] {
+  const tags = (test.tags ?? []).length === 0 ? "" : `  [${(test.tags ?? []).join(", ")}]`;
+  return [
+    `${ttyColor.green(test.id ?? "(no id)")}${tags}`,
+    ...(test.description === undefined ? [] : [`  ${ttyColor.dim(test.description)}`]),
+  ];
+}
+
+function summaryLine(selected: Test[], all: Test[], filter: TestFilter): string {
+  if (isEmptyFilter(filter)) {
+    return `${all.length} test${all.length === 1 ? "" : "s"}`;
+  }
+  const head = `${selected.length} of ${all.length} tests selected`;
+  if (selected.length > 0) {
+    return head;
+  }
+  // Nothing matched: name what the suite offers, so the fix is one glance away.
+  const tags = suiteTags(all);
+  const tagLine = tags.length === 0 ? "no test carries tags" : `suite tags: ${tags.join(", ")}`;
+  return `${head} (${tagLine})`;
+}

--- a/packages/agency-lang/lib/cli/eval/run.test.ts
+++ b/packages/agency-lang/lib/cli/eval/run.test.ts
@@ -128,6 +128,50 @@ describe("eval run CLI", () => {
     expect(result.okCount).toBe(1);
   });
 
+  it("--test/--tags run only the selected tests; matching nothing is an error, not an empty run", async () => {
+    const agentFile = path.join(tmpDir, "agent.agency");
+    fs.writeFileSync(agentFile, "node main(input: string) {}\n");
+    const runsDir = path.join(tmpDir, "runs");
+    const suite = path.join(tmpDir, "suite.json");
+    fs.writeFileSync(
+      suite,
+      JSON.stringify({
+        inputs: [
+          { id: "sort-a", input: "t", tags: ["easy"] },
+          { id: "sort-b", input: "t", tags: ["hard"] },
+          { id: "find-c", input: "t", tags: ["hard"] },
+        ],
+      }),
+    );
+
+    const result = await evalRun(
+      {
+        agent: agentFile,
+        suite,
+        out: path.join(runsDir, "picked"),
+        test: ["sort-*"],
+        tags: ["hard"],
+      },
+      { runner: okRunner },
+    );
+    expect(result.tests.map((test) => test.testId)).toEqual(["sort-b"]);
+
+    await expect(
+      evalRun(
+        { agent: agentFile, suite, out: path.join(runsDir, "none"), tags: ["nope"] },
+        { runner: okRunner },
+      ),
+    ).rejects.toThrow(/matches none of the 3 tests/);
+    expect(fs.existsSync(path.join(runsDir, "none"))).toBe(false);
+
+    await expect(
+      evalRun(
+        { agent: agentFile, input: "x", out: path.join(runsDir, "inline"), tags: ["easy"] },
+        { runner: okRunner },
+      ),
+    ).rejects.toThrow(/--test\/--tags select from a suite/);
+  });
+
   it("rejects an empty suite instead of succeeding with zero tests", async () => {
     const agentFile = path.join(tmpDir, "agent.agency");
     fs.writeFileSync(agentFile, "node main(input: string) {}\n");

--- a/packages/agency-lang/lib/cli/eval/run.ts
+++ b/packages/agency-lang/lib/cli/eval/run.ts
@@ -6,6 +6,12 @@ import { runSuite } from "@/eval/run/runSuite.js";
 import type { EvalInputRunner } from "@/eval/run/subprocess.js";
 import type { SuiteRunResult, Test } from "@/eval/runTypes.js";
 import { parseSource, resolveSource } from "@/eval/sources.js";
+import {
+  describeEmptySelection,
+  isEmptyFilter,
+  selectTests,
+  type TestFilter,
+} from "@/eval/selectTests.js";
 import type { SuiteIdentity } from "@/runDirectory/annotations.js";
 import { evalRecordFor } from "@/runDirectory/evalRecord.js";
 import { findRunDirectories } from "@/runDirectory/findRuns.js";
@@ -28,6 +34,10 @@ export type EvalRunCliOptions = {
   config?: AgencyConfig;
   /** Worker-pool size (-n/--parallel); default 1 = sequential. */
   parallel?: number;
+  /** `--test` id patterns; only matching tests run (suite runs only). */
+  test?: string[];
+  /** `--tags` values; only tests carrying every one run (suite runs only). */
+  tags?: string[];
 };
 
 /** `--suite` runs a suite; otherwise the run is one inline test, with
@@ -56,17 +66,25 @@ export async function evalRun(
   // before anything loads or runs.
   const target = resolveEvalTarget({ agent: opts.agent, agentCmd: opts.agentCmd });
   const selection = validateInputSelection(opts);
+  const filter: TestFilter = { ids: opts.test, tags: opts.tags };
+  if (selection === "input" && !isEmptyFilter(filter)) {
+    throw new Error("--test/--tags select from a suite; they do nothing with --input");
+  }
   const suite = loadSuite({
     selection,
     source: opts.suite,
     input: opts.input,
     cacheRoot: opts.config?.eval?.sourceCacheRoot,
   });
+  const tests = selectTests(suite.tests, filter);
+  if (tests.length === 0) {
+    throw new Error(describeEmptySelection(suite.tests, filter));
+  }
 
   return runSuite(
     {
       agent: target,
-      inputs: suite.tests,
+      inputs: tests,
       suite: suite.identity,
       out: opts.out,
       config: opts.config,
@@ -76,13 +94,14 @@ export async function evalRun(
   );
 }
 
-type LoadedSuite = { tests: Test[]; identity: SuiteIdentity };
+export type LoadedSuite = { tests: Test[]; identity: SuiteIdentity };
 
 /** Load the suite named by --suite/--input, resolving a git source when given
  *  one and recording the resolved sha as the suite's identity. Running never
  *  needs a `goal`, so none is required here; `eval grade` takes one (`--goal`)
- *  or reads each test's own when its judge needs it. */
-function loadSuite(args: {
+ *  or reads each test's own when its judge needs it. Exported for `eval ls`,
+ *  which must see the suite exactly as a run would. */
+export function loadSuite(args: {
   selection: "suite" | "input";
   source?: string;
   input?: string;

--- a/packages/agency-lang/lib/eval/grading/gradeBreakdown.ts
+++ b/packages/agency-lang/lib/eval/grading/gradeBreakdown.ts
@@ -8,6 +8,8 @@ export type GradeRow =
 
 export type InputBreakdown = {
   inputId: string;
+  /** The test's own description, when it recorded one. Display only. */
+  description?: string;
   output: unknown;
   objective: number;
   gatesPassed: boolean;
@@ -31,6 +33,7 @@ export function breakdown(scorecard: Scorecard): InputBreakdown[] {
   const objectives = scorecard.inputScores(); // reuse the canonical gate→0 rule; don't re-derive it
   return scorecard.perInput.map((i, idx) => ({
     inputId: i.test.id ?? "(no id)",
+    ...(i.test.description === undefined ? {} : { description: i.test.description }),
     output: i.run?.output ?? null,
     objective: objectives[idx],
     gatesPassed: i.gatesPassed,

--- a/packages/agency-lang/lib/eval/loadInputs.test.ts
+++ b/packages/agency-lang/lib/eval/loadInputs.test.ts
@@ -183,6 +183,22 @@ describe("eval run input loading", () => {
     }
   });
 
+  it("tags are kept when present and must be non-empty strings", () => {
+    const [input] = loadInputsFromFile(
+      writeJson("tags.json", {
+        inputs: [{ id: "t", goal: "g", input: "x", tags: ["easy", "coding"] }],
+      }),
+    );
+    expect(input.tags).toEqual(["easy", "coding"]);
+    for (const bad of ["easy", [""], [7]]) {
+      expect(() =>
+        loadInputsFromFile(
+          writeJson("tags-bad.json", { inputs: [{ id: "t", goal: "g", input: "x", tags: bad }] }),
+        ),
+      ).toThrow(/tags must be an array of non-empty strings/);
+    }
+  });
+
   it("rejects legacy args/node with a migration message", () => {
     expect(() =>
       loadInputsFromFile(

--- a/packages/agency-lang/lib/eval/loadInputs.test.ts
+++ b/packages/agency-lang/lib/eval/loadInputs.test.ts
@@ -161,6 +161,28 @@ describe("eval run input loading", () => {
     }
   });
 
+  it("description is kept when present and must be a non-empty string", () => {
+    const [input] = loadInputsFromFile(
+      writeJson("desc.json", {
+        inputs: [{ id: "t", goal: "g", input: "x", description: "why this test exists" }],
+      }),
+    );
+    expect(input.description).toBe("why this test exists");
+    const [bare] = loadInputsFromFile(
+      writeJson("desc-none.json", { inputs: [{ id: "t", goal: "g", input: "x" }] }),
+    );
+    expect(bare.description).toBeUndefined();
+    for (const bad of ["", 7]) {
+      expect(() =>
+        loadInputsFromFile(
+          writeJson("desc-bad.json", {
+            inputs: [{ id: "t", goal: "g", input: "x", description: bad }],
+          }),
+        ),
+      ).toThrow(/description must be a non-empty string/);
+    }
+  });
+
   it("rejects legacy args/node with a migration message", () => {
     expect(() =>
       loadInputsFromFile(

--- a/packages/agency-lang/lib/eval/loadInputs.ts
+++ b/packages/agency-lang/lib/eval/loadInputs.ts
@@ -218,6 +218,12 @@ function normalizeInput(raw: unknown, baseDir: string, makeId: MakeId, options: 
   if (spec.metadata !== undefined && !isPlainObject(spec.metadata)) {
     throw new Error("Eval input metadata must be an object when provided");
   }
+  if (
+    spec.description !== undefined &&
+    (typeof spec.description !== "string" || spec.description.length === 0)
+  ) {
+    throw new Error("Eval input description must be a non-empty string when provided");
+  }
   const out: Test = {
     id: typeof spec.id === "string" ? spec.id : makeId(),
     expected: spec.expected, // any JSON; absent stays undefined
@@ -227,6 +233,7 @@ function normalizeInput(raw: unknown, baseDir: string, makeId: MakeId, options: 
     spec.input !== undefined &&
     !(isPlainObject(spec.input) && Object.keys(spec.input).length === 0);
   if (hasInput) out.input = spec.input as string | Record<string, any>;
+  if (typeof spec.description === "string") out.description = spec.description;
   if (typeof spec.goal === "string") out.goal = spec.goal;
   if (typeof spec.files === "string")
     out.files = resolveFilesDir(spec.files, baseDir, options, out.id ?? "");

--- a/packages/agency-lang/lib/eval/loadInputs.ts
+++ b/packages/agency-lang/lib/eval/loadInputs.ts
@@ -224,6 +224,13 @@ function normalizeInput(raw: unknown, baseDir: string, makeId: MakeId, options: 
   ) {
     throw new Error("Eval input description must be a non-empty string when provided");
   }
+  if (
+    spec.tags !== undefined &&
+    (!Array.isArray(spec.tags) ||
+      spec.tags.some((tag) => typeof tag !== "string" || tag.length === 0))
+  ) {
+    throw new Error("Eval input tags must be an array of non-empty strings when provided");
+  }
   const out: Test = {
     id: typeof spec.id === "string" ? spec.id : makeId(),
     expected: spec.expected, // any JSON; absent stays undefined
@@ -234,6 +241,7 @@ function normalizeInput(raw: unknown, baseDir: string, makeId: MakeId, options: 
     !(isPlainObject(spec.input) && Object.keys(spec.input).length === 0);
   if (hasInput) out.input = spec.input as string | Record<string, any>;
   if (typeof spec.description === "string") out.description = spec.description;
+  if (Array.isArray(spec.tags)) out.tags = spec.tags as string[];
   if (typeof spec.goal === "string") out.goal = spec.goal;
   if (typeof spec.files === "string")
     out.files = resolveFilesDir(spec.files, baseDir, options, out.id ?? "");

--- a/packages/agency-lang/lib/eval/public.ts
+++ b/packages/agency-lang/lib/eval/public.ts
@@ -13,6 +13,7 @@ export { LlmJudge } from "./grading/graders/llmJudge.js";
 export { goalJudgeFile } from "./grading/goalJudgeFile.js"; // for users who want a custom judge but the bundled prompt
 export type {
   LoadedRun,
+  GraderInput,
   Grade,
   GraderOptions,
   Test,

--- a/packages/agency-lang/lib/eval/runTypes.ts
+++ b/packages/agency-lang/lib/eval/runTypes.ts
@@ -14,6 +14,11 @@ export type Test = {
    *  the agent, and never shown to a judge (a description restating the
    *  intent would leak grading hints — the criterion is `goal`). */
   description?: string;
+  /** Labels for selecting subsets of a suite (`eval run --tags`, previewed
+   *  with `eval ls`): difficulty ("easy"), kind ("coding", "research"), or
+   *  anything else. A test may carry several. Selection only — tags never
+   *  reach the agent or a judge. */
+  tags?: string[];
   /** What the agent is given: an instruction string, or a JSON object for
    *  agents that take structured data. Delivered as the entry node's single
    *  positional parameter (or as `{input}` for a command agent). Optional:

--- a/packages/agency-lang/lib/eval/runTypes.ts
+++ b/packages/agency-lang/lib/eval/runTypes.ts
@@ -8,6 +8,12 @@ export type Test = {
   /** Stable identifier. Auto-derived when omitted: the loader generates one
    *  via nanoid, the optimizer derives it positionally (`input-<index>`). */
   id?: string;
+  /** Why the test exists, for the person reading a grade report or a run
+   *  directory later — e.g. "checks the agent reads between the lines of an
+   *  article the model has never seen". Documentation only: never shown to
+   *  the agent, and never shown to a judge (a description restating the
+   *  intent would leak grading hints — the criterion is `goal`). */
+  description?: string;
   /** What the agent is given: an instruction string, or a JSON object for
    *  agents that take structured data. Delivered as the entry node's single
    *  positional parameter (or as `{input}` for a command agent). Optional:

--- a/packages/agency-lang/lib/eval/selectTests.test.ts
+++ b/packages/agency-lang/lib/eval/selectTests.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import type { Test } from "./runTypes.js";
+import { describeEmptySelection, isEmptyFilter, selectTests, suiteTags } from "./selectTests.js";
+
+const suite: Test[] = [
+  { id: "sort-list", tags: ["easy", "coding"] },
+  { id: "sort-files", tags: ["hard", "coding"] },
+  { id: "find-source", tags: ["hard", "research"] },
+  { id: "untagged" },
+];
+
+const ids = (tests: Test[]): string[] => tests.map((test) => test.id ?? "");
+
+describe("selectTests", () => {
+  it("an empty filter selects every test", () => {
+    expect(selectTests(suite, {})).toEqual(suite);
+    expect(isEmptyFilter({})).toBe(true);
+    expect(isEmptyFilter({ ids: [], tags: [] })).toBe(true);
+    expect(isEmptyFilter({ tags: ["easy"] })).toBe(false);
+  });
+
+  it("an id pattern is a glob; several patterns select any match", () => {
+    expect(ids(selectTests(suite, { ids: ["sort-*"] }))).toEqual(["sort-list", "sort-files"]);
+    expect(ids(selectTests(suite, { ids: ["untagged", "find-*"] }))).toEqual([
+      "find-source",
+      "untagged",
+    ]);
+  });
+
+  it("a bare id is an exact match, not a substring", () => {
+    expect(ids(selectTests(suite, { ids: ["sort"] }))).toEqual([]);
+    expect(ids(selectTests(suite, { ids: ["sort-list"] }))).toEqual(["sort-list"]);
+  });
+
+  it("tags AND together: every listed tag must be on the test", () => {
+    expect(ids(selectTests(suite, { tags: ["coding"] }))).toEqual(["sort-list", "sort-files"]);
+    expect(ids(selectTests(suite, { tags: ["coding", "hard"] }))).toEqual(["sort-files"]);
+    expect(ids(selectTests(suite, { tags: ["nope"] }))).toEqual([]);
+  });
+
+  it("ids and tags both apply", () => {
+    expect(ids(selectTests(suite, { ids: ["sort-*"], tags: ["hard"] }))).toEqual(["sort-files"]);
+  });
+
+  it("suiteTags: first-appearance order, no duplicates", () => {
+    expect(suiteTags(suite)).toEqual(["easy", "coding", "hard", "research"]);
+    expect(suiteTags([{ id: "a" }])).toEqual([]);
+  });
+
+  it("the empty-selection message names the filter, the ids, and the suite's tags", () => {
+    const message = describeEmptySelection(suite, { ids: ["nope-*"], tags: ["easy", "hard"] });
+    expect(message).toContain("--test nope-*");
+    expect(message).toContain("--tags easy,hard");
+    expect(message).toContain("sort-list");
+    expect(message).toContain("easy, coding, hard, research");
+    expect(describeEmptySelection([{ id: "a" }], { tags: ["x"] })).toContain(
+      "No test in this suite carries tags",
+    );
+  });
+});

--- a/packages/agency-lang/lib/eval/selectTests.ts
+++ b/packages/agency-lang/lib/eval/selectTests.ts
@@ -1,0 +1,52 @@
+import picomatch from "picomatch";
+
+import type { Test } from "./runTypes.js";
+
+/**
+ * Which tests of a suite to run. Both `eval run` and `eval ls` apply a
+ * filter through `selectTests`, so `eval ls` with the same flags shows
+ * exactly what a run would run.
+ */
+export type TestFilter = {
+  /** `--test` patterns. A test is selected when its id matches ANY pattern
+   *  (picomatch glob, so `agent-*` works and a bare id is an exact match). */
+  ids?: string[];
+  /** `--tags` values. A test is selected only when it carries EVERY one —
+   *  `--tags coding,hard` means hard coding tests, not hard-or-coding. */
+  tags?: string[];
+};
+
+export function isEmptyFilter(filter: TestFilter): boolean {
+  return (filter.ids ?? []).length === 0 && (filter.tags ?? []).length === 0;
+}
+
+export function selectTests(tests: Test[], filter: TestFilter): Test[] {
+  const ids = filter.ids ?? [];
+  const tags = filter.tags ?? [];
+  return tests.filter(
+    (test) =>
+      (ids.length === 0 || ids.some((pattern) => picomatch(pattern)(test.id ?? ""))) &&
+      tags.every((tag) => (test.tags ?? []).includes(tag)),
+  );
+}
+
+/** The suite's tag vocabulary: every tag any test carries, first appearance
+ *  order, duplicates removed. */
+export function suiteTags(tests: Test[]): string[] {
+  const all = tests.flatMap((test) => test.tags ?? []);
+  return all.filter((tag, index) => all.indexOf(tag) === index);
+}
+
+/** A filter that selects nothing is a mistake worth a specific message: name
+ *  what the suite actually offers, so the fix is one glance away. */
+export function describeEmptySelection(tests: Test[], filter: TestFilter): string {
+  const ids = tests.map((test) => test.id ?? "(no id)").join(", ");
+  const tags = suiteTags(tests);
+  const tagLine =
+    tags.length === 0 ? "No test in this suite carries tags." : `Suite tags: ${tags.join(", ")}.`;
+  const wanted = [
+    ...((filter.ids ?? []).length > 0 ? [`--test ${(filter.ids ?? []).join(", ")}`] : []),
+    ...((filter.tags ?? []).length > 0 ? [`--tags ${(filter.tags ?? []).join(",")}`] : []),
+  ].join(" ");
+  return `${wanted} matches none of the ${tests.length} tests. Test ids: ${ids}. ${tagLine}`;
+}

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -64,6 +64,7 @@ import {
 } from "@/cli/runDirectory/commands.js";
 import { evalGrade } from "@/cli/eval/grade.js";
 import { resolveRunStatelog } from "@/cli/eval/logs.js";
+import { evalLs } from "@/cli/eval/ls.js";
 import { evalRun, totalRunCostUsd } from "@/cli/eval/run.js";
 import { formatGradeResult } from "@/cli/eval/formatGrade.js";
 import { ttyColor } from "@/utils/termcolors.js";
@@ -161,6 +162,15 @@ export function parsePositiveInt(value: string): number {
 // 0 allowed (e.g. to disable a cap).
 export function parseNonNegativeInt(value: string): number {
   return parseBoundedInt(value, 0, "must be a non-negative integer");
+}
+
+// Repeatable-flag accumulators (commander calls the parser with (value, previous)).
+function collectRepeats(value: string, previous: string[]): string[] {
+  return [...previous, value];
+}
+
+function collectCommaSeparated(value: string, previous: string[]): string[] {
+  return [...previous, ...value.split(",").filter((part) => part !== "")];
 }
 
 type CliDependencies = {
@@ -819,6 +829,18 @@ export function createProgram(deps: CliDependencies = {}): Command {
     )
     .option("--input <text>", "Run one inline test whose input is this text (no suite file needed)")
     .option(
+      "--test <pattern>",
+      "Run only tests whose id matches this glob (repeatable; any match selects). Preview with: agency eval ls",
+      collectRepeats,
+      [] as string[],
+    )
+    .option(
+      "--tags <tags>",
+      "Run only tests carrying every one of these comma-separated tags (repeatable). Preview with: agency eval ls",
+      collectCommaSeparated,
+      [] as string[],
+    )
+    .option(
       "-o, --out <dir>",
       "Directory to write the run into; must not exist yet (default: runs/<timestamp>-<random suffix>, or under eval.runsDir from agency.json)",
     )
@@ -834,6 +856,8 @@ export function createProgram(deps: CliDependencies = {}): Command {
           agentCmd?: string;
           suite?: string;
           input?: string;
+          test?: string[];
+          tags?: string[];
           out?: string;
           parallel?: number;
         },
@@ -857,6 +881,37 @@ export function createProgram(deps: CliDependencies = {}): Command {
         console.log(`grade it with: agency eval grade ${result.runDir}`);
       },
     );
+
+  evalCmd
+    .command("ls")
+    .description(
+      "List a suite's tests; with --test/--tags, exactly what eval run with the same flags would run",
+    )
+    .option(
+      "--suite <source>",
+      "Test suite: a JSON file, a directory, or a git source (URL[//subdir][?ref=...])",
+    )
+    .option(
+      "--test <pattern>",
+      "Only tests whose id matches this glob (repeatable; any match selects)",
+      collectRepeats,
+      [] as string[],
+    )
+    .option(
+      "--tags <tags>",
+      "Only tests carrying every one of these comma-separated tags (repeatable)",
+      collectCommaSeparated,
+      [] as string[],
+    )
+    .action((opts: { suite?: string; test?: string[]; tags?: string[] }) => {
+      let lines: string[];
+      try {
+        lines = evalLs({ ...opts, config: getConfig() });
+      } catch (error) {
+        failProjectCommand(error);
+      }
+      for (const line of lines) console.log(line);
+    });
 
   evalCmd
     .command("logs")


### PR DESCRIPTION
## Problem

Grading a run of the agency agent via `--agent-cmd` scored near zero on every judge grader, each with the same rationale: "The agent output is null." The harness captured the run fine (`ended: ok`, statelog present) — but grading defines "the output" as the last `evalOutputRecorded` event in the statelog (`lastOutput` in `lib/eval/run/runAgent.ts`; `gradeRun` reads `evalOutputs` the same way), never stdout. The agency agent in `-p` mode only printed its reply, so `evalOutputs` was empty and judges were handed `null`.

## Fix

`oneShotAgent` now calls `evalValue(prompt)` before the turn and `evalOutput(reply)` after it — the seam `std::statelog` documents for marking an agent user-facing input and response. The failure path is covered too: a failed turn records the formatted failure text, so a judge grades what the user would have seen.

A side benefit of the placement: `evalOutput` fires before `main()` prints the `Session cost: $…` trailer, so the recorded output is the bare reply, not the stdout noise.

## Verification

Live one-shot smoke run of the built agent with the statelog handoff env var (`AGENCY_CONFIG_OVERRIDES` with `log.logFile`), prompt "Reply with exactly the word: pong":

- `evalValueRecorded` → `"Reply with exactly the word: pong"`
- `evalOutputRecorded` → `"pong"`

Also added a paragraph to `docs/dev/eval-command-agents.md` stating the contract: a command agent must call `evalOutput` or every judge sees `output: null`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Also on this branch: optional test descriptions

A test can now carry a `description` — why the test exists, for the person reading a grade report or run directory later. Documentation only: never shown to the agent, and never shown to a judge (a description restating the intent would leak grading hints; the criterion stays `goal`). The loader validates it (non-empty string), the run annotation stores it with the rest of the test for free, and `eval grade` prints it dim under the test id:

```
hollow-creek  score 0.850
  Tests summarizing an article and reading between its lines, using a custom article…
  summary      0.900
```

The hollow-creek test carries the first one. Tests: loader keep/validate/absent cases, and a formatGrade case for the dim line.

## Also: run a subset of a suite (`--test`, `--tags`, `eval ls`)

Modeled on harbor's `--include-task-name` glob include:

- `eval run --test <glob>` — repeatable; a test runs when its id matches any pattern (`--test "sort-*"`, or a bare id for an exact match).
- `eval run --tags coding,hard` — repeatable; a test must carry **every** listed tag (hard coding tests, not hard-or-coding). Tests declare tags in test.json: `"tags": ["easy", "coding"]`, multiple per test.
- `agency eval ls --suite <src> [--test …] [--tags …]` — lists each test with its tags and description, plus a `N of M tests selected` count. Both commands select through one function (`selectTests`), so the listing is exactly what a run with the same flags would run, by construction.

A filter that matches nothing is an error naming the suite's ids and tags — never a silent empty run — and `--test`/`--tags` with `--input` is rejected.

## Also: a coding test — write fib in Agency, graded by a sandboxed harness

`evals/agency-agent/fib/` (tags `coding, easy`) asks the agent to write `export def fib(n: number): number` to `fib.agency`. The grader runs an **agency-test harness** that compiles the solution with `std::agency` — which allows only `std::` imports — and runs it in the sandboxed subprocess under a handler that rejects every effect. That pair is what makes agent-written code safe to run locally with no container, and it held against three attacks: an inline-`with approve` write (vetoed by the parent's handler vote), a static-initializer write (blocked), and a `child_process` import (refused at compile).

The harness is seeded into the agent's workdir so it can check its own work (`agency test fib-harness.test.json`), but the grader never runs the workdir copy: it copies **only** `fib.agency` into a clean scratch dir and lays down a fresh harness from the graders snapshot (`externalFiles`), so tampering with the seeded harness changes nothing. Wrong solutions get the harness diff as stored feedback (`fib(2) returned 2, expected 1`).

End-to-end verified: scripted correct solution → `1.000 / agency-tests pass`; wrong solution → `0.000` with the diff; a run that dies → `0.000, not graded` (errored-runs rule). The real agency agent currently **fails** this test — it never wrote the file and ended in a `find /` crawl until the wall clock killed it — which is the eval earning its keep.

Integration with the agency test framework: deliberately a suite-local pattern for now; the write-up (the shape, the three gotchas — never run the workdir's harness, spawn `agency test` rather than calling `test()` in-process since it `process.exit`s on compile failure, scratch dir under cwd not tmpdir — and the promotion path to a framework `AgencyTestGrader` once a second coding test exists) is in `docs/dev/eval-grading.md`. One small framework change: `GraderInput` is exported from `agency-lang/eval` so a graders.ts can subclass `BaseGrader`.
