### PR TITLE
Contain single-file operations within their directory

### DIFF
--- a/packages/agency-lang/2026-08-20-contained-filename-plan.md
+++ b/packages/agency-lang/2026-08-20-contained-filename-plan.md
@@ -1,0 +1,725 @@
+# Contained Filenames Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax.
+
+**Goal:** A model-chosen filename cannot escape the directory the interrupt
+reported, through absolute paths, `~`, `..`, or stable symlinks.
+
+**Architecture:** One declarative TS preparation function
+(`prepareContainedPath`) canonicalizes `dir`, normalizes `filename`, and
+rejects escapes before any interrupt is raised. The nine scoped Agency
+wrappers call it once and use the prepared values in both the interrupt payload
+and the execution. safeBash, which has no trusted `dir`, resolves each supported
+literal redirect through one Agency-level `prepareRedirectWrite` operation. It
+follows the complete stable target and reports that target's resolved parent.
+Imperative filesystem walking and quote/tilde interpretation stay behind those
+two interfaces. Policy-side `.` expansion realpaths the launch directory so
+both sides share one path identity.
+
+**Tech Stack:** TypeScript (lib/stdlib), Agency (stdlib wrappers), vitest,
+the agency test runner.
+
+**Spec:** `packages/agency-lang/2026-08-20-contained-filename-spec.md` — read
+it first; it defines the ten preparation steps, the trust-level rule, the
+caller inventory, and the error wording.
+
+## Global constraints
+
+- Repo rules: `make` only after `.agency`/agent changes (name the stale
+  artifact); `pnpm run fmt:ts` and `pnpm run lint:structure` before push;
+  save test output to files; never run the full agency suite locally.
+- Commit messages use a file because apostrophes break the CLI.
+- The teaching sentence must appear verbatim in escape errors:
+  `To write somewhere else, pass that directory in dir` (adapted per verb:
+  "read from" for reads).
+- Behavior of the non-raising TS primitives (`_read`, `_write`,
+  `resolvePath`, ...) does not change. `resolvePath`'s existing doc comment
+  remains accurate and must not be rewritten to claim containment; only the
+  scoped Agency wrapper docstrings gain the new contract.
+
+---
+
+### Task 1: `prepareContainedPath` and its unit tests
+
+**Files:**
+- Create: `lib/stdlib/prepareContainedPath.ts`
+- Create: `lib/stdlib/prepareContainedPath.test.ts`
+- Modify: `lib/stdlib/assertContained.ts` (export the private `isContained`)
+
+**Interfaces:**
+- Produces: `type ContainedPath = { dir: string; filename: string }` and
+  `type FileOperation = "read" | "write"` and
+  `async function prepareContainedPath(dir: string, filename: string,
+  operation: FileOperation): Promise<ContainedPath>`.
+  Throws `Error` on every rejection; Agency callers convert with `try`.
+  `operation` is required and only shapes the error message.
+- Consumes: `resolveDir`, `expandPath`, `isContained` (newly exported).
+
+- [ ] **Step 1: export `isContained` from `assertContained.ts`**
+
+Change `function isContained(` to `export function isContained(` and leave
+everything else alone. Its Windows case-folding and `path.relative` logic is
+the containment primitive the spec requires reusing.
+
+- [ ] **Step 2: write the failing unit tests**
+
+`lib/stdlib/prepareContainedPath.test.ts`, following the sandbox pattern in
+`lib/stdlib/writeContained.test.ts` from git history (mkdtemp a base with
+`root/` and `outside/`):
+
+```ts
+import { afterEach, describe, it, expect } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "fs";
+import { realpath } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import { prepareContainedPath } from "./prepareContainedPath.js";
+
+const sandboxes: string[] = [];
+
+function sandbox(): { root: string; outside: string } {
+  const base = mkdtempSync(path.join(tmpdir(), "pcp-"));
+  sandboxes.push(base);
+  const root = path.join(base, "root");
+  const outside = path.join(base, "outside");
+  mkdirSync(root);
+  mkdirSync(outside);
+  return { root, outside };
+}
+
+afterEach(() => {
+  for (const base of sandboxes.splice(0)) {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+describe("prepareContainedPath", () => {
+  it("accepts nested relative filenames and normalizes . and ..", async () => {
+    const { root } = sandbox();
+    expect(await prepareContainedPath(root, "src/lib/file.ts", "write")).toEqual({
+      dir: await realDir(root),
+      filename: path.join("src", "lib", "file.ts"),
+    });
+    expect((await prepareContainedPath(root, "a/./b/../c.txt", "write")).filename).toBe(
+      path.join("a", "c.txt"),
+    );
+  });
+
+  it("rejects absolute, ~, and escaping filenames with the teaching message", async () => {
+    const { root, outside } = sandbox();
+    const absolute = path.join(path.parse(root).root, "pcp-absolute-outside");
+    await expect(prepareContainedPath(root, absolute, "write")).rejects.toThrow(
+      /pass that directory in dir/,
+    );
+    await expect(prepareContainedPath(root, "~/payload.agency", "write")).rejects.toThrow(
+      /pass that directory in dir/,
+    );
+    await expect(
+      prepareContainedPath(root, path.join("..", path.basename(outside), "x"), "write"),
+    ).rejects.toThrow(/pass that directory in dir/);
+  });
+
+  it("realpaths a symlinked dir", async () => {
+    const { root } = sandbox();
+    const link = path.join(path.dirname(root), "rootlink");
+    symlinkSync(root, link);
+    expect((await prepareContainedPath(link, "f.txt", "write")).dir).toBe(await realDir(root));
+  });
+
+  it("follows in-root symlinks and rejects escaping ones", async () => {
+    const { root, outside } = sandbox();
+    mkdirSync(path.join(root, "realsub"));
+    symlinkSync(path.join(root, "realsub"), path.join(root, "insub"));
+    symlinkSync(outside, path.join(root, "outsub"));
+    // In-root parent link: allowed, filename keeps the link spelling.
+    expect((await prepareContainedPath(root, "insub/f.txt", "write")).filename).toBe(
+      path.join("insub", "f.txt"),
+    );
+    // Escaping parent link and escaping final link: rejected.
+    await expect(prepareContainedPath(root, "outsub/f.txt", "write")).rejects.toThrow(/outside dir/);
+    writeFileSync(path.join(outside, "real.txt"), "x");
+    symlinkSync(path.join(outside, "real.txt"), path.join(root, "leaflink"));
+    await expect(prepareContainedPath(root, "leaflink", "write")).rejects.toThrow(/outside dir/);
+    // In-root final link: allowed.
+    writeFileSync(path.join(root, "inner.txt"), "x");
+    symlinkSync(path.join(root, "inner.txt"), path.join(root, "innerlink"));
+    expect((await prepareContainedPath(root, "innerlink", "write")).filename).toBe("innerlink");
+  });
+
+  it("rejects dangling symlinks on the target path", async () => {
+    const { root, outside } = sandbox();
+    symlinkSync(path.join(outside, "missing"), path.join(root, "dangle"));
+    await expect(prepareContainedPath(root, "dangle", "write")).rejects.toThrow(/dangling/);
+    await expect(prepareContainedPath(root, "dangle/deeper.txt", "write")).rejects.toThrow(/dangling/);
+  });
+
+  it("treats missing intermediate directories as contained, not dangling", async () => {
+    const { root } = sandbox();
+    expect((await prepareContainedPath(root, "sub/new/file.txt", "write")).filename).toBe(
+      path.join("sub", "new", "file.txt"),
+    );
+  });
+
+  it("requires dir to exist", async () => {
+    const { root } = sandbox();
+    await expect(
+      prepareContainedPath(path.join(root, "nope"), "f.txt", "write"),
+    ).rejects.toThrow();
+  });
+
+  it("rejects an empty dir instead of silently using cwd", async () => {
+    await expect(prepareContainedPath("", "f.txt", "write")).rejects.toThrow(/dir/);
+  });
+});
+
+async function realDir(p: string): Promise<string> {
+  return realpath(p);
+}
+```
+
+All calls in this test pass an explicit `"read"` or `"write"` operation.
+Extend the cases above with: a two-link in-root chain that succeeds; a symlink
+loop that rejects with `ELOOP`; `file/child` where `file` is regular and the
+walk rejects with `ENOTDIR`; a mocked `lstat` `EACCES` that rejects rather than
+becoming a lexical tail; exact read and write teaching sentences; and a
+Windows-only case-folding assertion guarded by `it.runIf(process.platform ===
+"win32")`. These cases pin every fail-closed branch advertised by the helper.
+
+- [ ] **Step 3: run to verify they fail**
+
+Run: `npx vitest run lib/stdlib/prepareContainedPath.test.ts > /tmp-scratch/pcp1.log 2>&1`
+(use the session scratchpad; path shortened here). Expected: FAIL, module
+not found.
+
+- [ ] **Step 4: implement `prepareContainedPath`**
+
+`lib/stdlib/prepareContainedPath.ts` — the spec's ten steps, numbered in
+comments:
+
+```ts
+import fs from "fs/promises";
+import path from "path";
+import { resolveDir } from "./resolveDir.js";
+import { expandPath } from "./expandPath.js";
+import { isContained } from "./assertContained.js";
+
+export type ContainedPath = {
+  dir: string;
+  filename: string;
+};
+
+export type FileOperation = "read" | "write";
+
+/**
+ * Prepare a (dir, filename) pair for a scoped single-file wrapper: the
+ * returned values go into BOTH the interrupt payload and the execution.
+ * Guarantees the spec's containment contract: the resolved file operand
+ * stays inside the resolved dir operand, or this throws before any
+ * interrupt exists. See 2026-08-20-contained-filename-spec.md.
+ */
+export async function prepareContainedPath(
+  dir: string,
+  filename: string,
+  operation: FileOperation,
+): Promise<ContainedPath> {
+  if (dir.trim() === "") {
+    throw new Error(`${operation} refused: dir must not be empty.`);
+  }
+  // Steps 1-2: expand, absolutize, and realpath dir. It must exist.
+  const baseDir = await resolveDir(dir);
+  const realRoot = await fs.realpath(baseDir);
+
+  // Steps 3-4: expand filename; absolute (including ~-led) is an escape.
+  const expanded = expandPath(filename);
+  if (path.isAbsolute(expanded)) {
+    throw escapeError(operation, filename, realRoot, expanded);
+  }
+
+  // Steps 5-6: lexical resolution and lexical containment.
+  const lexical = path.resolve(realRoot, expanded);
+  if (!isContained(lexical, realRoot)) {
+    throw escapeError(operation, filename, realRoot, lexical);
+  }
+
+  // Steps 7-9: resolve through existing symlinks (dangling ones fail
+  // closed) and check the resolved target too.
+  const resolved = await resolveExistingStrict(lexical);
+  if (!isContained(resolved, realRoot)) {
+    throw escapeError(operation, filename, realRoot, resolved);
+  }
+
+  // Step 10: the real dir plus the normalized relative filename. The
+  // relative form deliberately keeps in-root symlink names (spec: the
+  // payload guarantees containment, not leaf-target naming).
+  return { dir: realRoot, filename: path.relative(realRoot, lexical) };
+}
+
+/** Walk the target path component by component. Existing components are
+ *  realpathed (following healthy symlinks); a component whose lstat says
+ *  "symlink" but whose realpath fails is dangling and fails closed; a
+ *  component that simply does not exist ends the walk, and the remaining
+ *  tail is appended lexically (missing intermediates are contained, not
+ *  dangling). */
+async function resolveExistingStrict(target: string): Promise<string> {
+  const parsed = path.parse(target);
+  const segments = target.slice(parsed.root.length).split(path.sep);
+  let current = parsed.root;
+  for (let i = 0; i < segments.length; i++) {
+    const next = path.join(current, segments[i]);
+    let stat;
+    try {
+      stat = await fs.lstat(next);
+    } catch (error: any) {
+      // Only ENOENT means the rest is a lexical tail. Permission, I/O,
+      // ELOOP, and ENOTDIR failures fail closed.
+      if (error?.code !== "ENOENT") {
+        throw error;
+      }
+      return path.join(next, ...segments.slice(i + 1));
+    }
+    if (stat.isSymbolicLink()) {
+      try {
+        current = await fs.realpath(next);
+      } catch (error: any) {
+        if (error?.code !== "ENOENT") {
+          throw error;
+        }
+        throw new Error(`refused: "${next}" is a dangling symlink.`);
+      }
+    } else {
+      current = next;
+    }
+  }
+  return current;
+}
+
+function escapeError(
+  operation: FileOperation,
+  filename: string,
+  root: string,
+  landed: string,
+): Error {
+  const preposition = operation === "write" ? "somewhere else" : "from somewhere else";
+  return new Error(
+    `${operation} refused: filename "${filename}" is outside dir "${root}" ` +
+      `(it resolves to "${landed}"). To ${operation} ${preposition}, pass that ` +
+      `directory in dir.`,
+  );
+}
+```
+
+Keep `resolveExistingStrict` private to this module and reuse it for redirect
+resolution in Task 7. Add a comment explaining why it cannot call
+`assertContained.ts`'s `realpathOrLexicalAncestor`: that older helper treats
+all `realpath` errors as missing paths, while this safety boundary may treat
+only `ENOENT` as a lexical tail. Do not add a second strict walk elsewhere.
+
+- [ ] **Step 5: run the tests to verify they pass**
+
+Same vitest command. Expected: PASS. Fix until green; the symlink cases are
+the ones most likely to need iteration.
+
+- [ ] **Step 6: commit**
+
+`git add` the three files; message: "Add prepareContainedPath: containment
+preparation for scoped file wrappers".
+
+---
+
+### Task 2: bridge the helper to Agency code
+
+**Files:**
+- Modify: `lib/stdlib/fs.ts` (add
+  `export { prepareContainedPath as _prepareContainedPath } from "./prepareContainedPath.js";`)
+
+**Interfaces:**
+- Produces: `_prepareContainedPath` importable in `.agency` files from
+  `"agency-lang/stdlib-lib/fs.js"`, returning `{ dir, filename }`, throwing
+  on rejection (so Agency `try` yields a failure Result).
+
+- [ ] **Step 1:** add the export line beside the existing re-exports.
+- [ ] **Step 2:** `npx tsc --noEmit -p .` → clean. Commit with Task 3.
+
+---
+
+### Task 3: convert the four `stdlib/index.agency` wrappers
+
+**Files:**
+- Modify: `stdlib/index.agency` (`read`, `write`, `readBinary`,
+  `writeBinary`)
+- Test: `tests/agency/contained-filenames.agency` (+ `.test.json`) — new
+- Test: create `tests/agency-js/contained-filename-wrappers/agent.agency`,
+  `test.js`, and `fixture.json` for symlinked-dir payload recording
+
+**Interfaces:**
+- Consumes: `_prepareContainedPath` from Task 2.
+- Produces: wrapper behavior every later task follows. The pattern, shown for
+  `write` (reads are identical minus `destructive`):
+
+```agency
+  if (useAgentCwd) {
+    dir = applyAgentCwd(dir)
+  }
+  const prepared = try _prepareContainedPath(dir, filename, "write")
+  if (isFailure(prepared)) {
+    return prepared
+  }
+  return interrupt std::write("Are you sure you want to write to this file?", {
+    dir: prepared.value.dir,
+    filename: prepared.value.filename,
+    content: content,
+    mode: mode
+  })
+  destructive {
+    return try _write(prepared.value.dir, prepared.value.filename, content, mode)
+  }
+```
+
+- [ ] **Step 1:** add `_prepareContainedPath` to the
+  `"agency-lang/stdlib-lib/builtins.js"`-adjacent import block (it comes
+  from `fs.js`, so add a new import line).
+- [ ] **Step 2:** apply the pattern to all four wrappers. Pass operation
+  `"read"` for the two read wrappers.
+- [ ] **Step 3:** update the four docstrings. Each `@param filename` gains:
+  "Must stay inside dir: no absolute paths, `~`, upward traversal, or
+  symlinks that leave it. To touch another directory, pass it in `dir`."
+  Delete nothing else.
+- [ ] **Step 4:** write the Agency execution test (no LLM calls). Give each of
+  `read`, `write`, `readBinary`, and `writeBinary` one contained success case
+  and one `../escape` rejection case, so deleting preparation from any one
+  wrapper fails the suite. Also pin `/abs/x` and `~/x` through `write`, and the
+  exact read-versus-write teaching sentence. Run every escape with a handler
+  that would return `reject("HANDLER_REACHED")`; assert the preparation error
+  instead, proving no interrupt existed.
+- [ ] **Step 5:** add Agency-JS recording-handler cases for all four wrappers.
+  `test.js` creates a unique real fixture directory plus `dir-link`, passes
+  both paths into `agent.agency`, and removes the base in `finally`.
+  `agent.agency` uses `nested/../probe` and an inline handler that records the
+  interrupt, rejecting unless `interrupt.data.dir` equals the supplied real
+  directory and `interrupt.data.filename` equals the normalized filename.
+  It then approves, reads back writes, and returns the four payload checks plus
+  execution outcomes for exact comparison in `fixture.json`. Keep binary
+  content tiny (`"aGk="`).
+- [ ] **Step 6:** `make` (stale: compiled stdlib dist), then
+  `pnpm run agency test tests/agency/contained-filenames.test.json`,
+  output to a scratch file. Expected: PASS.
+- [ ] **Step 7:** also run the existing focused binary regressions,
+  `tests/agency/read-binary.test.json` and
+  `tests/agency/write-binary.test.json`, and the new Agency-JS wrapper test,
+  with output saved to scratch files.
+- [ ] **Step 8:** commit: "Contain read/write filenames inside dir".
+
+---
+
+### Task 4: convert `edit` in `stdlib/fs.agency`
+
+**Files:**
+- Modify: `stdlib/fs.agency` (`edit`, around line 63)
+- Test: extend `tests/agency/contained-filenames.agency`
+- Test: extend `tests/agency-js/contained-filename-wrappers/` from Task 3
+
+- [ ] **Step 1:** prepare BEFORE `_previewEdit`; preview, interrupt payload,
+  and `_multiedit` all consume `prepared.value` (spec: preview and eventual
+  write must not refer to different spellings).
+- [ ] **Step 2:** add this sentence to the `filename` documentation: "Must
+  stay inside dir: no absolute paths, `~`, upward traversal, or symlinks that
+  leave it. To edit another directory, pass it in `dir`."
+- [ ] **Step 3:** test `edit("../escape.txt", ...)` with a handler whose unique
+  rejection text proves preparation fails before the interrupt. Then edit a
+  file through a symlinked `dir` with a normalized `sub/../file.txt` filename.
+  Its recording handler approves only when the payload has the real `dir`, the
+  normalized filename, and the expected `before`/`after`; assert the final
+  file content. This detects raw values in preview or payload, not only a
+  successful ordinary edit.
+- [ ] **Step 4:** put the symlinked-dir recording case in the Agency-JS fixture
+  from Task 3, where `test.js` can create and reliably clean the symlink. Return
+  the payload check and final content for exact comparison in `fixture.json`.
+- [ ] **Step 5:** `make` (stale: fs stdlib dist), run the new tests and the
+  existing `tests/agency/agent-cwd.test.json` regression, with output saved,
+  commit: "Contain edit filenames inside dir".
+
+---
+
+### Task 5: convert the four `stdlib/agency.agency` wrappers
+
+**Files:**
+- Modify: `stdlib/agency.agency` (`typecheckFile` ~483, `writeAST` ~527,
+  `loadTemplate` ~570, `formatFile` ~645)
+- Test: extend `tests/agency/contained-filenames.agency`
+- Test: extend `tests/agency-js/contained-filename-wrappers/` from Task 3
+
+- [ ] **Step 1:** import `_prepareContainedPath` from
+  `"agency-lang/stdlib-lib/fs.js"`. In `typecheckFile` and `loadTemplate`, call
+  it with operation `"read"`; in `writeAST` and `formatFile`, call it with
+  operation `"write"`. Convert a preparation failure to the wrapper's failure
+  Result.
+  Put `prepared.value.dir` and `.filename` in each interrupt and pass those
+  same values to `_typecheckFile`, `_loadTemplate`, `_writeAST`, or
+  `_formatFile` after approval.
+- [ ] **Step 2:** add one test per wrapper rejecting a `~` filename with a
+  uniquely rejecting handler, proving preparation happens before the
+  interrupt. Add a contained success smoke test for `typecheckFile`,
+  `writeAST`, and `formatFile`; run an existing focused template test for the
+  `loadTemplate` success half. The write smoke tests read their resulting file
+  so a helper wired only into the payload cannot pass.
+- [ ] **Step 3:** extend the Agency-JS recording fixture with all four
+  wrappers. For each, approve only a payload carrying the real symlink target
+  directory and normalized filename. Assert successful results for the reads
+  and inspect resulting files for the writes. Raw interrupt values in any
+  alternate wrapper must make the fixture fail.
+- [ ] **Step 4:** `make`, run the new tests plus
+  `tests/agency/templates/generatedProgram.test.json`, save both outputs, and
+  commit: "Contain the
+  agency.agency file wrappers".
+
+---
+
+### Task 6: migrate the broken callers and preserve lifecycle coverage
+
+**Files:**
+- Modify: `lib/agents/agency-agent/brains/coordinator/subagents/code.agency:71-79`
+- Modify: `tests/agency/dirname-paths.agency` and
+  `tests/agency/dirname-paths.test.json`
+- Modify: `tests/agency/dirname-paths/helper.agency` (+ its test json if
+  expectations are listed there)
+- Modify: `tests/agency/stdlib-destructive.agency:9` (keep its existing JSON
+  expectation)
+
+- [ ] **Step 1: promptFile.** Change to the dir-based spelling:
+
+```agency
+def promptFile(filename: string): string {
+  const contents = read(filename, __dirname + "/../prompts") with approve
+  if (isFailure(contents)) {
+    return ""
+  }
+  return contents.value
+}
+```
+
+and its two call sites drop the `../prompts/` prefix:
+`promptFile("code.md")`, `promptFile("oneShot.md")`. Add a comment: the
+empty-string fallback makes THIS the silent failure the spec's inventory
+warns about, so the test in Step 2 is the guard.
+
+- [ ] **Step 2: prompt-loading guard test.** Create
+  `tests/agency/agency-agent-code-prompt.agency` and its `.test.json`. Use
+  `import test { promptFile }` from the coordinator's
+  `subagents/code.agency`, call `promptFile("code.md")` and
+  `promptFile("oneShot.md")` independently, and return two booleans asserting
+  each value is nonempty. Expect `[true,true]`. This directly guards both
+  silent-empty failure sites; one successfully loaded prompt cannot hide the
+  other one's failure.
+- [ ] **Step 3: dirname-paths flips.** `readUpward` now asserts the upward
+  read FAILS (pin the new contract), and add `readUpwardViaDir` asserting
+  `read("dirname-paths-shared.txt", __dirname + "/..")` succeeds. Update
+  the `.test.json` expectations. Replace `absoluteFilenameAllowed` with a
+  migration test that passes `tmp-abs.txt` as `filename` and its absolute
+  parent as `dir`; keep the success assertion under the new spelling.
+- [ ] **Step 4: stdlib-destructive.** Preserve this test's lifecycle purpose.
+  Change the write to a contained filename below a nonexistent parent, for
+  example `write("missing-parent/f.txt", "hi", __dirname)`. Preparation then
+  succeeds and `_write` fails after entering `destructive`, so the existing
+  `[true,false]` expectation remains valid.
+- [ ] **Step 5:** `make` (stale: agent brain dist), run the three affected
+  agency tests only, commit: "Migrate upward-path callers to dir-based
+  spellings".
+
+---
+
+### Task 7: safeBash reports the actual literal redirect target
+
+**Files:**
+- Modify: `stdlib/safeBash.agency` (the plan construction that fills the
+  `std::write` payload, near line 207, and the `WriteExec` fill)
+- Test: `lib/stdlib/safeBash.test.ts`
+- Test: `tests/agency/safeBash.agency`
+- Test: create `tests/agency-js/safe-bash-redirect-paths/agent.agency`,
+  `test.js`, and `fixture.json` for real symlink fixtures
+
+`stdlib/safeBash/actions.agency` does not change. `WriteExec` already carries
+the resolved `dir` and `filename` consumed by `runWrite`.
+
+**Interfaces:**
+- Consumes: a new bridge export
+  `_resolveRedirectTarget(target, cwd, tildeMode)` beside
+  `prepareContainedPath`. It resolves the **complete** target, including a
+  healthy final symlink, with the same strict dangling-link rule. It then
+  returns `{ dir, filename }` by splitting the resolved target. There is no
+  containment rejection because safeBash has no trusted `dir`. `tildeMode` is
+  the closed union `"expand" | "literal"`, not a boolean whose meaning callers
+  must remember.
+- Produces in TypeScript:
+  `type TildeMode = "expand" | "literal"` and
+  `async function resolveRedirectTarget(target: string, cwd: string,
+  tildeMode: TildeMode): Promise<ContainedPath>`.
+- Produces: one Agency-level declarative helper
+  `prepareRedirectWrite(redirect: Redirect, cwd: string, content: string): Result<WritePayload>`.
+  It alone validates the redirect, extracts a fully literal word, decides
+  quote-aware tilde behavior, invokes the bridge, chooses `WriteMode`, and
+  converts bridge errors to `Result`. `redirectEffect` and `writePlan` do not
+  repeat that choreography.
+- Produces: `writeEffect(write: WritePayload): Effect` and
+  `writeExecution(write: WritePayload): WriteExec`. The shell-free plan creates
+  one `WritePayload` and derives both sides from it, so approval/execution
+  parity holds by construction. Keep `WriteExec`'s existing flat shape:
+  `writeExecution` is the only place that adds `kind: "write"` and copies the
+  fields from the shared payload.
+
+- [ ] **Step 1:** implement `resolveRedirectTarget` in
+  `lib/stdlib/prepareContainedPath.ts`, reusing `resolveExistingStrict` on the
+  full target. Export it via `fs.ts` as `_resolveRedirectTarget`. Unit-test an
+  absolute target, a relative target, `"expand"` and `"literal"` tilde modes,
+  a symlinked parent, an existing final symlink, a two-link chain, a loop, and
+  dangling parent/final rejection. The existing-final-symlink case must return
+  the target's real parent and basename. All fixtures use unique temporary
+  roots and cleanup.
+- [ ] **Step 2:** replace `literalTarget` with
+  `prepareRedirectWrite`. Its exhaustive `Word` match selects `"expand"` only
+  for unquoted `literal`/`path` words and `"literal"` for single-quoted or
+  fully literal double-quoted words. Variable-bearing words fail and therefore
+  fall back to the broad `std::bash` plan. Keep all interpretation inside this
+  helper; neither caller receives literal text plus a mode to orchestrate.
+  Import `WritePayload` and `WriteExec` from `./safeBash/actions.agency` beside
+  the existing `Effect` and `Plan` imports.
+- [ ] **Step 3:** add `writeEffect` and `writeExecution`. In `writePlan`, bind
+  one `WritePayload`, pass it to both constructors, and remove the duplicate
+  four-field object literals. In `redirectEffect`, use
+  `prepareRedirectWrite(..., content: "")` and `writeEffect`. A bridge failure
+  becomes the surrounding `Result` failure; pin that `planFor` then deliberately
+  chooses the broad `std::bash` plan rather than throwing or executing a narrow
+  write.
+- [ ] **Step 4:** extend `tests/agency/safeBash.agency` with exact structural
+  assertions: an isolated absolute target reports its real parent; a relative
+  target resolves against plan cwd; `WritePayload` and `WriteExec` match in
+  `dir`, `filename`, `content`, and `mode`; a final symlink reports its real
+  target; unquoted `~/f` expands home while both `'~/f'` and `"~/f"` remain
+  beneath cwd; dangling and looping targets produce a broad `std::bash` plan.
+  Cover both shell-free `echo > target` and recognized Bash-backed
+  `git status > target` paths so breaking either caller fails.
+- [ ] **Step 5:** put the real-symlink cases in the new Agency-JS fixture.
+  `test.js` creates a unique base, target file, final symlink, dangling link,
+  and loop, passes their paths to `agent.agency`, and removes the base in
+  `finally`. The Agency node approves the narrow final-symlink write and
+  returns its plan fields and result. `test.js` asserts the real target received
+  the content. Do not write fixed `/tmp/f`.
+- [ ] **Step 6:** `make` (stale: safeBash stdlib dist), run
+  `npx vitest run lib/stdlib/safeBash.test.ts`, the safeBash Agency test, and
+  the new Agency-JS fixture with output saved. Commit: "Report actual safeBash
+  redirect targets".
+
+---
+
+### Task 8: canonicalize the policy-side `.` expansion
+
+**Files:**
+- Modify: `lib/runtime/policy.ts` (`resolveDotDirPattern`)
+- Test: `lib/runtime/policy.test.ts`
+
+- [ ] **Step 1:** failing direct test: with an injected cwd that is a symlink
+  to a real directory, `resolveDotDirPattern("{.,./**}", link)` produces a
+  pattern that matches the real directory and a real descendant, but not an
+  outside sibling or the stale link spelling. (The function already takes cwd
+  as a parameter for tests.)
+- [ ] **Step 2:** realpath the cwd (fall back to the lexical cwd if
+  realpath fails) with `realpathSync` before `escapeForGlob`; this policy path
+  is synchronous. Keep the replacement-callback and glob-escaping behavior;
+  those tests must stay green.
+- [ ] **Step 3:** add an integration assertion through `checkPolicy`: mock
+  `process.cwd()` to return the symlink, configure `{.,./**}` for
+  `std::write`, and verify an interrupt carrying the real directory is
+  approved while an outside sibling propagates. Restore the mock in `finally`.
+  This catches a correct resolver that is not actually wired into policy
+  matching.
+- [ ] **Step 4:** pin the documented fallback with a nonexistent injected cwd:
+  expansion uses that lexical cwd and preserves the existing glob escaping.
+- [ ] **Step 5:** `npx vitest run lib/runtime/policy.test.ts` → all pass.
+  Commit: "Policy dot expansion uses the real launch directory".
+
+---
+
+### Task 9: end-to-end security tests
+
+**Files:**
+- Test: create `tests/agency-js/contained-filenames-policy/agent.agency`,
+  `test.js`, and `fixture.json`, following the policy injection and temporary
+  directory cleanup pattern in `tests/agency-js/cli-policy-handler-headless/`
+
+- [ ] **Step 1:** in `test.js`, create one unique temporary base containing
+  `work/` and `outside/`, plus all symlinks used below. Write a policy that
+  approves `std::write` only for the real workdir and descendants. Pass every
+  fixture path into the Agency node; do not use a fixed `/tmp/report.txt`.
+  Remove the entire base in `finally`, even when an assertion fails.
+- [ ] **Step 2:** prove the migrated destination rule: writing
+  `report.txt` with `dir: outside` is rejected, the same filename with
+  `dir: work` is approved and created, and no outside file exists. Capture the
+  interrupt with an inner recording handler that saves `interrupt.data` then
+  returns `propagate()` to the outer noninteractive `cliPolicyHandler`. Return
+  the recorded `dir` alongside the operation result and assert it is the real
+  outside directory, so rejection for an unrelated reason cannot produce a
+  false positive.
+- [ ] **Step 3:** test filename escapes independently: a unique
+  `~/.agency-contained-test-<random>` name, an absolute filename under
+  `outside`, and `../outside/escape.txt` each fail with the preparation
+  teaching message before the policy handler and create no file. Reset a
+  `handlerReached` flag before each call; the inner recording handler sets it
+  before propagating. Assert it remains false for every escape. Compute the
+  unique home candidate in `test.js`, assert it did not exist beforehand, and
+  remove it in `finally` if broken code creates it.
+- [ ] **Step 4:** create `work/out-link -> outside`. A write through
+  `out-link/f.txt` must fail before the handler and create no outside file.
+  Create `work/in-link -> work/real-sub`; a write through `in-link/f.txt` must
+  be approved and update the in-work target. These two rows catch a wrapper
+  that implements lexical containment but omits stable-symlink resolution.
+- [ ] **Step 5:** create `work/dir-link -> outside`, call
+  `write("f.txt", dir: dir-link)`, assert the interrupt reports the real
+  outside path, the workdir policy rejects it, and no file is created.
+- [ ] **Step 6:** run just this Agency-JS test and save output. The direct
+  `checkPolicy` integration for a symlinked launch directory lives in Task 8,
+  where `process.cwd()` can be injected reliably.
+- [ ] **Step 7:** commit: "End-to-end containment
+  tests under a scoped policy".
+
+---
+
+### Task 10: docs and guards
+
+**Files:**
+- Modify: `docs/dev/approval-policies.md` (containment section + the
+  threat-model boundary: stable escapes are rejected before the interrupt;
+  post-approval races are out of scope and why)
+
+- [ ] **Step 1:** write the doc section: the contract, the migration rule,
+  the safeBash parent-as-dir exception, what is NOT defended.
+- [ ] **Step 2:** full guard pass: `pnpm run fmt:ts`,
+  `pnpm run lint:structure`, `npx vitest run lib/sourceIsText.test.ts`,
+  `npx tsc --noEmit -p .`. All green.
+- [ ] **Step 3:** commit: "Document filename containment in
+  approval-policies". Report the verified branch and ask for separate
+  approval before pushing or opening a PR.
+
+---
+
+## Self-review notes
+
+- Spec coverage: contract → T1; wrappers table → T3/T4/T5; safeBash → T7;
+  canonical `.` → T8; caller inventory → T6; errors/docstrings → T1/T3;
+  migration + e2e tests → T6/T9; docs → T10.
+- Known judgment call: `resolveExistingStrict` follows healthy symlinks
+  during the walk (so a link-to-link chain inside root works) and fails
+  on dangling links, loops, non-directory components, permission errors, and
+  other non-`ENOENT` filesystem failures; the tests pin each branch.
+- Two plan clarifications override ambiguous spec wording: `resolvePath` keeps
+  its accurate unrestricted-helper documentation, and safeBash resolves the
+  complete redirect target with quote-aware tilde semantics before splitting
+  it into `dir` and `filename`.
+- Mutation-sensitivity check: removing preparation from any one scoped wrapper,
+  using raw values in a payload, omitting symlink resolution, breaking either
+  safeBash planning path, loading either coordinator prompt from the old path,
+  or canonicalizing policy patterns without wiring that result through
+  `checkPolicy` makes at least one named test fail.
+- Not in this plan, tracked in the spec's superseded-work section:
+  applyPatch, copy/move/remove, ls/grep/glob, the wider effect audit.

--- a/packages/agency-lang/2026-08-20-contained-filename-spec.md
+++ b/packages/agency-lang/2026-08-20-contained-filename-spec.md
@@ -1,0 +1,468 @@
+# Spec: contain single-file operations within their directory
+
+## Summary
+
+Some standard-library tools accept a directory and a filename separately. The
+interrupt reports those two values before the implementation combines them.
+Today, `resolvePath` lets an absolute filename, a leading `~`, or `..` escape
+the directory. A symlink below the directory can escape it too.
+
+This spec adds one shared preparation function for these tools. The function
+canonicalizes the directory, normalizes the filename, and rejects any stable
+destination outside the directory. The wrapper puts the prepared values in the
+interrupt and uses the same values during execution.
+
+This is a narrow containment fix. It does not attempt to make every
+path-bearing interrupt in the standard library report a canonical destination.
+
+## Problem
+
+The motivating case has a fixed working directory and a model-chosen filename:
+
+```json
+{ "dir": "/tmp/workdir", "filename": "~/payload.agency" }
+```
+
+The interrupt reports `/tmp/workdir`, so a workdir-scoped policy may approve
+the operation. After approval, `resolvePath` expands `~` and writes the file in
+the home directory.
+
+The same escape is possible with an absolute filename or upward traversal:
+
+```text
+filename = "/outside/payload.agency"
+filename = "../../outside/payload.agency"
+```
+
+A lexical containment check does not cover symlinks:
+
+```text
+/tmp/workdir/link -> /outside
+filename = "link/payload.agency"
+```
+
+The fix must reject all four stable escape forms before asking for approval.
+
+## Security contract
+
+For the tools in scope:
+
+> The resolved file operand must remain inside the resolved `dir` operand.
+> The interrupt and the implementation must use the same prepared `dir` and
+> `filename` values.
+
+This contract authorizes a root directory, not every filesystem entry that an
+operation may inspect. A symlink may be followed when its target remains
+inside that root.
+
+The contract does not claim that the payload names the final target of an
+in-directory symlink. It only guarantees containment. This distinction keeps
+the fix small and avoids imposing one leaf-symlink policy on unrelated
+operations.
+
+Containment applies where `dir` and `filename` come from different trust
+levels: the harness supplies `dir`, an untrusted source supplies `filename`.
+Where one source supplies both, containment would be vacuous; those wrappers
+instead report the resolved parent of the target as `dir` (see the safeBash
+section).
+
+The migration rule for every caller this change breaks is a design
+principle, not a workaround: **the destination belongs in `dir`, because
+`dir` is the field the judge reads.** A caller that wants
+`/tmp/report.txt` writes `write("report.txt", dir: "/tmp")`. Nothing is
+lost. The interrupt then reports `/tmp` truthfully, and the policy or the
+human judges the real destination.
+
+## Scope
+
+The change covers the single-file wrappers that already carry separate `dir`
+and `filename` fields:
+
+| Wrapper | Effect | Operation |
+|---|---|---|
+| `stdlib/index.agency:read` | `std::read` | read text |
+| `stdlib/index.agency:write` | `std::write` | write text |
+| `stdlib/index.agency:readBinary` | `std::readBinary` | read bytes |
+| `stdlib/index.agency:writeBinary` | `std::writeBinary` | write bytes |
+| `stdlib/fs.agency:edit` | `std::edit` | preview and edit text |
+| `stdlib/agency.agency:typecheckFile` | `std::read` | read Agency source |
+| `stdlib/agency.agency:writeAST` | `std::write` | write Agency source |
+| `stdlib/agency.agency:loadTemplate` | `std::read` | read a template |
+| `stdlib/agency.agency:formatFile` | `std::write` | rewrite Agency source |
+| safeBash write plan | `std::write` | redirected echo write |
+
+The non-raising TypeScript implementations remain unrestricted. They are
+internal primitives, and existing direct TypeScript callers keep the current
+`resolvePath` behavior. The Agency wrappers own the approval boundary and
+therefore own this check.
+
+## Out of scope
+
+- `applyPatch`, `mkdir`, `copy`, `move`, and `remove`, which do not have the
+  trusted-directory-plus-filename shape.
+- Directory tools such as `ls`, `grep`, and `glob`.
+- Speech, skills, memory, Git, subprocess, and system effects.
+- A global guarantee that every path-bearing interrupt is canonical.
+- Containment parameters for arbitrary shell command strings.
+- Filesystem changes made by another process between preparation and
+  execution.
+
+These operations may deserve separate audits. They do not block this focused
+fix.
+
+## Design
+
+### One shared preparation function
+
+The pattern has prior art in this repository: `runFile`'s `_compileFile`
+already realpaths both `dir` and target and refuses a target outside `dir`
+(pinned by `tests/agency/subprocess/run-file-rejects-escape.agency`). This
+spec gives that idea one shared, tested owner.
+
+Add the function beside `resolvePath`:
+
+```ts
+export type ContainedPath = {
+  dir: string;
+  filename: string;
+};
+
+export type FileOperation = "read" | "write";
+
+export async function prepareContainedPath(
+  dir: string,
+  filename: string,
+  operation: FileOperation,
+): Promise<ContainedPath>;
+```
+
+`operation` is required and closed rather than an optional free-form verb. It
+does not change path resolution; it selects the user-facing rejection wording
+without permitting invalid operations or silently defaulting a read to a write
+message.
+
+Before the numbered path steps, reject an empty or whitespace-only `dir`.
+Otherwise `resolveDir("")` would silently reinterpret a malformed scoped
+request as the process working directory.
+
+`prepareContainedPath` performs these steps:
+
+1. Expand and absolutize `dir` with the same rules as `resolveDir`.
+2. Resolve `dir` with `fs.realpath`. The directory must exist. This matches the
+   scoped operations, which cannot create their `dir` operand themselves.
+3. Expand `filename` with `expandPath`.
+4. Reject an absolute expanded filename. This includes a leading `~`, because
+   expansion turns it into an absolute path.
+5. Resolve the filename lexically against the real directory.
+6. Reject the lexical result unless it is inside the real directory.
+7. Resolve the target through existing symlinks. If the leaf does not exist,
+   resolve its nearest existing ancestor and append the missing tail.
+8. Reject the resolved target unless it is inside the real directory.
+9. Reject a dangling symlink in any existing component **on the target
+   path**. This is a walk of the target's components only, never a scan of
+   the tree under `dir`.
+10. Return the real directory and the normalized relative filename.
+
+Missing intermediate directories are contained, not dangling:
+`write("sub/new/file.txt", dir: root)` with `sub/` absent prepares
+successfully — step 7 resolves through the nearest existing ancestor and
+step 8 judges the lexical remainder under it. Whether the write then
+creates the intermediates is unchanged by this spec.
+
+The result deliberately retains an in-directory symlink in `filename` rather
+than replacing it with its target. Execution therefore preserves existing API
+behavior while the resolved-target check proves that the stable symlink cannot
+escape the directory.
+
+The helper uses the repository's existing path containment primitive. It does
+not add another string-prefix implementation. Containment must continue to use
+`path.relative` and the existing Windows case-folding behavior.
+
+`assertContained.ts` already has a nearest-existing-ancestor walk, but that
+walk deliberately treats every `realpath` failure as a lexical fallback. This
+contract instead distinguishes a genuinely missing component (`ENOENT`) from
+permission, I/O, `ENOTDIR`, and symlink-loop failures, all of which fail
+closed. The implementation must document this semantic difference rather than
+silently cloning the older helper. The new strict walk has one owner and is
+reused by both contained-file preparation and safeBash redirect resolution.
+
+### Dangling symlinks fail closed
+
+A dangling symlink has a known textual target, but handling every relative
+link chain correctly would turn this containment fix into the broader path
+planning project. The smaller rule is:
+
+> If `lstat` finds a symlink and `realpath` cannot resolve it, preparation
+> fails before the interrupt.
+
+This changes writes through dangling symlinks from “create the link target” to
+an error. It avoids approving a destination that the containment helper did
+not prove safe.
+
+### Wrappers prepare before interrupting
+
+Each scoped wrapper prepares once, then uses the result in both places:
+
+```agency
+const path = _prepareContainedPath(dir, filename, "write")
+return interrupt std::write("Are you sure you want to write to this file?", {
+  dir: path.dir,
+  filename: path.filename,
+  content: content,
+  mode: mode
+})
+destructive {
+  return try _write(path.dir, path.filename, content, mode)
+}
+```
+
+Read wrappers follow the same pattern without a `destructive` block.
+
+`edit` must prepare before `_previewEdit`. The preview, interrupt, and
+`_multiedit` call all use the prepared values. This prevents the preview and
+the eventual write from referring to different spellings.
+
+The preparation error occurs before the interrupt. A handler cannot approve an
+escape because no escape request reaches a handler.
+
+### safeBash reports the resolved parent instead of containing
+
+safeBash is the "one source supplies both" case from the security contract:
+the whole command, redirect target included, is untrusted, so there is no
+trusted `dir` to contain within. Containing against the plan's cwd would
+break ordinary shell usage — `echo x > /tmp/notes.txt` would fail at
+preparation with no handler ever asked, even interactively.
+
+Instead, safeBash's write-plan constructor resolves the redirect target
+(same expansion and symlink rules as preparation steps 3 and 7, minus the
+containment rejections) and stores `dir` = the target's resolved parent,
+`filename` = its final name, in **both** the effect payload and the
+`WriteExec`. Containment is trivially satisfied; the payload is truthful
+where it matters: a policy scoped to the workdir does not match `/tmp`,
+and an interactive approver reads the real destination. `runWrite`
+continues to use the non-raising `_write` primitive.
+
+The safeBash callers use one declarative Agency helper:
+
+```agency
+def prepareRedirectWrite(
+  redirect: Redirect,
+  cwd: string,
+  content: string,
+): Result<WritePayload>
+```
+
+That helper owns redirect validation, literal-word extraction, quote-aware
+tilde semantics, path resolution, write mode, and conversion of bridge errors
+to `Result`. `writePlan` and `redirectEffect` ask it for a planned write; they
+do not reproduce those steps or pass an unexplained `expandHome` boolean
+through their own interfaces. The TypeScript bridge may use a closed
+`"expand" | "literal"` tilde mode internally because that is the path-layer
+decision the Agency helper has already made.
+
+For a shell-free redirect, construct one `WritePayload`, derive the
+`std::write` effect from it, and derive `WriteExec` from that same value. The
+approval and execution representations must agree by construction rather than
+by manually copying four fields in two object literals. Bash-backed redirects
+use the same `prepareRedirectWrite` helper to construct their write effect.
+
+The plan test must assert that the payload and `WriteExec` contain
+identical prepared values, and that `echo x > /tmp/f` raises `std::write`
+with `dir` = `/tmp`'s real path.
+
+### Canonical directory in policies
+
+The interrupt reports the real directory. This closes the equivalent escape
+where the caller supplies a symlink as `dir`:
+
+```text
+/tmp/workdir/link -> /outside
+dir = "/tmp/workdir/link"
+filename = "payload.agency"
+```
+
+The payload reports `/outside`, so a policy limited to `/tmp/workdir` does not
+approve it.
+
+Policies use `.` to mean the launch directory. Update
+`resolveDotDirPattern` so it realpaths the launch directory before inserting it
+into a `dir` pattern. A `{.,./**}` policy and a canonical interrupt then use
+the same path identity when the process starts from a symlinked checkout.
+
+## Errors
+
+Preparation reports one of these failures:
+
+- the directory is empty or does not exist;
+- the filename is absolute after expansion;
+- the lexical filename escapes the directory;
+- the resolved symlink target escapes the directory; or
+- an existing path component is a dangling symlink.
+
+Messages name the rejected filename and directory but do not expose unrelated
+filesystem contents.
+
+The escape rejections teach the migration rule, because the models driving
+agent tools will keep producing absolute filenames and must learn the right
+retry from the error itself:
+
+```text
+write refused: filename "/tmp/report.txt" is outside dir "/work". To write
+somewhere else, pass that directory in dir: write("report.txt", dir: "/tmp").
+```
+
+The file-tool docstrings gain the same one sentence, so the rule is visible
+before the first mistake, not only after it.
+
+## Compatibility
+
+This is an intentional behavior change for scoped Agency wrappers:
+
+- Absolute filenames no longer override `dir`.
+- A leading `~` in `filename` no longer selects the home directory.
+- `..` may normalize within `dir`, but it may not escape `dir`.
+- Symlinks that resolve outside `dir` are rejected.
+- Dangling symlinks are rejected.
+- The interrupt's `dir` is canonical and its `filename` is normalized.
+
+Normal nested filenames continue to work:
+
+```text
+dir = "/work"
+filename = "src/lib/file.ts"
+```
+
+Existing symlinks whose targets remain inside `/work` also continue to work.
+Direct TypeScript callers of `resolvePath`, `_read`, `_write`, and related
+primitives retain their current behavior.
+
+Policies that hard-code a symlinked absolute directory must migrate to its
+real path. Policies based on `.` continue to work because policy expansion is
+canonicalized with the interrupt.
+
+### Caller inventory
+
+An audit of `stdlib/`, `lib/agents/`, and `tests/` for callers that pass an
+absolute, `~`-led, or upward-traversing filename through a scoped wrapper
+found four, all migrated in this change:
+
+1. `lib/agents/agency-agent/brains/coordinator/subagents/code.agency:79,102`
+   — `promptFile("../prompts/code.md")` and `("../prompts/oneShot.md")`.
+   The coordinator loads its own prompts through the scoped `read` with an
+   upward-traversing filename, and `promptFile` swallows read failures, so
+   the breakage would be silent empty prompts. Migrates to the rule:
+   `read("code.md", dir: __dirname + "/../prompts")`.
+2. `tests/agency/dirname-paths/helper.agency:14` — `readUpward` exists to
+   pin the OLD contract (upward reads work). The test flips: it now pins
+   the new contract by asserting the upward read is rejected, and a
+   sibling case asserts the dir-based spelling succeeds.
+3. `tests/agency/stdlib-destructive.agency:9` —
+   `write("/nonexistent-dir-xyz/f.txt", "hi")` asserts on the failure
+   shape, which changes from ENOENT to the preparation rejection. The
+   assertion updates.
+4. `stdlib/safeBash` write plan — covered by its own section; absolute
+   redirect targets keep working via parent-as-dir.
+
+The docstrings that become false and must change in the same commit as the
+behavior: `read`, `write`, `readBinary`, `writeBinary` in
+`stdlib/index.agency`, `edit` in `stdlib/fs.agency`, and `resolvePath`
+(`lib/stdlib/resolvePath.ts`), whose text currently promises "upward
+traversal and absolute filenames are allowed."
+
+### Superseded work
+
+This spec supersedes `2026-08-20-resolved-interrupt-destination-spec.md`
+(v3, branch `adit/resolved-destination`). Two pieces carry over verbatim:
+the canonicalized `.` expansion in `resolveDotDirPattern`, and the safeBash
+payload/`WriteExec` parity test. The v3 reviews' remaining findings —
+`applyPatch`'s `{ patch }`-only payload, `copy`/`move`/`remove`,
+`ls`/`grep`/`glob` leaf symlinks, and the wider path-bearing-effect audit
+(`filepath`, `outputFile`, `cwd`, Git `paths`) — are the tracked
+known-exposure list behind this spec's out-of-scope section.
+
+## Tests
+
+### Helper unit tests
+
+- relative nested filename inside `dir`;
+- `.` and `..` that normalize inside `dir`;
+- absolute filename rejection;
+- leading-`~` filename rejection;
+- `..` escape rejection;
+- symlinked `dir` returns its real path;
+- existing parent symlink with an in-directory target;
+- existing parent symlink with an outside target;
+- existing final symlink with an in-directory target;
+- existing final symlink with an outside target;
+- dangling parent and final symlink rejection;
+- missing leaf below an existing real parent;
+- a multi-link in-directory symlink chain;
+- a symlink loop and `ENOTDIR` fail closed;
+- a mocked non-`ENOENT` filesystem error fails closed;
+- exact read and write teaching wording;
+- Windows case-insensitive containment where applicable.
+
+Every temporary filesystem fixture uses a unique `mkdtemp` root and is removed
+in `afterEach`/`finally`. Fixed writable paths such as `/tmp/report.txt` are not
+test fixtures: a failed safety assertion must not overwrite an unrelated file.
+
+### Wrapper tests
+
+- Each of `read`, `write`, `readBinary`, `writeBinary`, and `edit` has a
+  contained success case and an escape-rejection case. A recording handler
+  asserts that a symlinked `dir` is realpathed and `a/../f` is normalized in
+  the interrupt payload; successful execution observes the same destination.
+- `edit`'s recorded payload contains the prepared path and the expected
+  `before`/`after`, while the final file proves the edit executed there.
+- Each of the four `stdlib/agency.agency` wrappers rejects a `~` escape before
+  its handler and has a contained success smoke test (existing focused tests
+  may supply the success half when named in the implementation plan).
+- safeBash stores identical prepared values in its effect and `WriteExec`.
+
+### Migration tests
+
+- Both coordinator prompts load through the dir-based spelling. A test-only
+  import of `promptFile` checks `code.md` and `oneShot.md` independently; one
+  nonempty aggregate prompt cannot hide failure of the other.
+- `readUpward` in `dirname-paths` asserts rejection; its dir-based sibling
+  asserts success.
+- A model-style `write("/abs/x")` produces the teaching error message,
+  verbatim match on the "pass that directory in dir" sentence.
+- preparation of `write("sub/new/file.txt", dir: root)` with `sub/` absent
+  succeeds, then the unchanged `_write` fails after entering its destructive
+  block because it does not create parent directories.
+- safeBash: `echo x > /tmp/f` raises `std::write` with `dir` = `/tmp`'s
+  real path (using an isolated temporary equivalent in executable tests); a
+  workdir-scoped policy rejects it; approving it writes the file. Shell-free
+  and Bash-backed redirects, quoted and unquoted `~`, final symlinks, dangling
+  links, and broad-fallback behavior are pinned separately.
+
+### End-to-end security tests
+
+- A workdir-scoped run rejects `write("~/escape.txt")` before raising and
+  creates no file.
+- Absolute and `..` escapes create no file.
+- A symlink below the workdir that points outside is rejected.
+- A symlink supplied as `dir` appears as its real directory in the interrupt,
+  so a workdir-scoped policy does not approve an outside target.
+- A symlink whose target remains inside the workdir succeeds.
+- A symlinked launch directory still matches a `{.,./**}` policy through
+  `checkPolicy`, not only through a direct `resolveDotDirPattern` assertion.
+
+Run targeted unit and Agency execution tests. Do not run the full Agency test
+suite locally.
+
+## Rollout
+
+Implement this in one focused PR:
+
+1. Add `prepareContainedPath` and its unit tests.
+2. Convert the scoped wrappers and safeBash plan construction.
+3. Canonicalize `.` expansion for `dir` policy patterns.
+4. Add the targeted wrapper, policy, and end-to-end tests.
+5. Document the filename containment rule in the affected stdlib API docs and
+   `docs/dev/approval-policies.md`.
+
+Track any broader audit of path-bearing effects separately. This PR is complete
+when model-controlled filenames cannot escape their prepared directory through
+absolute paths, `~`, `..`, or stable symlinks.

--- a/packages/agency-lang/docs/dev/approval-policies.md
+++ b/packages/agency-lang/docs/dev/approval-policies.md
@@ -54,3 +54,34 @@ by `**`). Either give the eval command `--policy with-writes`, or put a
 `{.,./**}`-scoped rule in the static file (rule 2) — both resolve to the
 staged workdir at launch, where the dot segments are literal prefix and
 match fine.
+
+## Filename containment (the contained-filename wrappers)
+
+The single-file stdlib wrappers (`read`, `write`, `readBinary`,
+`writeBinary`, `edit`, and the four file wrappers in `std::agency`) prepare
+their `(dir, filename)` pair before raising: `dir` is realpathed, the
+filename is normalized, and any stable escape — an absolute path, `~`,
+upward traversal, or a symlink whose target leaves `dir` — is rejected
+BEFORE the interrupt exists. No policy or human can approve an escape,
+because no escape request is ever raised. `prepareContainedPath`
+(`lib/stdlib/prepareContainedPath.ts`) owns the rule; the spec is
+`2026-08-20-contained-filename-spec.md`.
+
+The migration rule doubles as the design principle: **the destination
+belongs in `dir`, because `dir` is the field a policy rule (or a human)
+judges.** `write("/tmp/report.txt")` is refused with an error that teaches
+the fix — `write("report.txt", dir: "/tmp")` — and the interrupt then
+reports `/tmp` truthfully.
+
+safeBash is the exception that proves the trust rule: its whole command is
+untrusted, so there is no trusted `dir` to contain within. Its redirect
+writes instead report the resolved parent of the target (quote-aware: an
+unquoted `~` expands, a quoted one does not), so the policy judges the
+real destination. Targets it cannot resolve (dangling symlinks, loops,
+variables) fall back to the broad `std::bash` question.
+
+What this does NOT defend against: a hostile local process swapping a
+directory for a symlink between approval and execution. Node exposes no
+primitive that closes that race on the platforms we support, and a local
+process with that access already owns the account. Stable escapes are the
+threat model; races are explicitly out of scope.

--- a/packages/agency-lang/docs/site/stdlib/agency.md
+++ b/packages/agency-lang/docs/site/stdlib/agency.md
@@ -30,7 +30,7 @@ export type CompiledProgram = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L70))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L71))
 
 ### SourceLocation
 
@@ -43,7 +43,7 @@ export type SourceLocation = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L74))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L75))
 
 ### TypeCheckDiagnostic
 
@@ -62,7 +62,7 @@ export type TypeCheckDiagnostic = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L81))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L82))
 
 ### TypeCheckReport
 
@@ -73,7 +73,7 @@ export type TypeCheckReport = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L94))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L95))
 
 ### EffectsByExport
 
@@ -84,7 +84,7 @@ Per-exported-symbol effect lists, keyed by node/function name.
 export type EffectsByExport = Record<string, string[]>
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L410))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L411))
 
 ### ExportInfo
 
@@ -120,7 +120,7 @@ export type ExportInfo = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L439))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L440))
 
 ### ModuleInfo
 
@@ -131,7 +131,7 @@ export type ModuleInfo = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L450))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L451))
 
 ### AST
 
@@ -154,7 +154,7 @@ export type AST = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L495))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L501))
 
 ### Code
 
@@ -176,7 +176,7 @@ export type Code = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L548))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L558))
 
 ### HoleInfo
 
@@ -190,7 +190,7 @@ export type HoleInfo = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L555))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L565))
 
 ## Effects
 
@@ -203,7 +203,7 @@ effect std::read {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L52))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L53))
 
 ### std::write
 
@@ -214,7 +214,7 @@ effect std::write {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L56))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L57))
 
 ### std::run
 
@@ -230,7 +230,7 @@ effect std::run {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L60))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L61))
 
 ## Functions
 
@@ -252,7 +252,7 @@ Compile Agency source code. Returns a CompiledProgram on success, or a failure w
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L99))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L100))
 
 ### run
 
@@ -317,7 +317,7 @@ and a child process has maxDepth=5, maxDepth=3 is used.
 
 **Throws:** `std::run`, `std::guard`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L119))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L120))
 
 ### runFile
 
@@ -370,7 +370,7 @@ Exceeding a resource limit kills the subprocess and returns a `limit_exceeded` f
 
 **Throws:** `std::run`, `std::guard`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L219))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L220))
 
 ### runCode
 
@@ -436,7 +436,7 @@ re-raises std::run and the child's own effects re-prompt.
 
 **Throws:** `std::run`, `std::guard`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L319))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L320))
 
 ### typecheck
 
@@ -462,7 +462,7 @@ Relative imports (./foo.agency) cannot be resolved from a source string.
 
 **Returns:** `Result<TypeCheckReport>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L380))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L381))
 
 ### getEffects
 
@@ -491,7 +491,7 @@ Map each exported node and function in the source to the list of
 
 **Returns:** `Result<EffectsByExport>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L412))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L413))
 
 ### describe
 
@@ -517,7 +517,7 @@ one-line summary, extracted the same way `agency doc` extracts it.
 
 **Returns:** `Result<ModuleInfo>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L460))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L461))
 
 ### typecheckFile
 
@@ -529,7 +529,8 @@ Type-check an Agency file on disk. The file is read from dir/filename,
   with relative imports inside it resolved against the file's directory.
 
   @param dir - The directory containing the file
-  @param filename - The agency file to type-check
+  @param filename - The agency file to type-check. Must stay inside dir; to
+    read another directory, pass it in `dir`.
 
 **Parameters:**
 
@@ -542,7 +543,7 @@ Type-check an Agency file on disk. The file is read from dir/filename,
 
 **Throws:** `std::read`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L475))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L476))
 
 ### parseAST
 
@@ -562,7 +563,7 @@ Parse Agency source code into an abstract syntax tree.
 
 **Returns:** `Result<AST>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L501))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L507))
 
 ### writeAST
 
@@ -599,7 +600,7 @@ Output is canonical formatter output (the same style as `pnpm run fmt`):
 
 **Throws:** `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L513))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L519))
 
 ### format
 
@@ -619,7 +620,7 @@ Format Agency source code with the standard Agency formatter.
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L535))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L545))
 
 ### loadTemplate
 
@@ -630,7 +631,8 @@ loadTemplate(dir: string, filename: string): Result<Code>
 Load an Agency file containing holes as a template.
 
   @param dir - The sandbox directory
-  @param filename - The template file, resolved relative to dir
+  @param filename - The template file, resolved relative to dir. Must stay
+    inside dir; to read another directory, pass it in `dir`.
 
 **Parameters:**
 
@@ -643,7 +645,7 @@ Load an Agency file containing holes as a template.
 
 **Throws:** `std::read`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L563))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L573))
 
 ### holesOf
 
@@ -663,7 +665,7 @@ The unfilled holes in a template, in the order they appear. Each entry has the h
 
 **Returns:** `HoleInfo[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L577))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L592))
 
 ### fill
 
@@ -685,7 +687,7 @@ Fill holes in a template. Plain values become literals and are never parsed; Cod
 
 **Returns:** `Result<Code>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L586))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L601))
 
 ### combine
 
@@ -709,7 +711,7 @@ Merge several Code fragments into one, in order. Use this to build one
 
 **Returns:** `Result<Code>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L596))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L611))
 
 ### toSource
 
@@ -729,7 +731,7 @@ Print a Code value back to Agency source, including any unfilled holes.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L609))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L624))
 
 ### parseExpr
 
@@ -749,7 +751,7 @@ Parse a single Agency expression into a Code fragment that can fill an expr hole
 
 **Returns:** `Result<Code>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L618))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L633))
 
 ### parseStatements
 
@@ -769,7 +771,7 @@ Parse a list of Agency statements into a Code fragment that can fill a statement
 
 **Returns:** `Result<Code>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L627))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L642))
 
 ### formatFile
 
@@ -780,7 +782,8 @@ formatFile(dir: string, filename: string): Result
 Format an Agency file in place using the standard Agency formatter.
 
   @param dir - The directory containing the file
-  @param filename - The agency file to format
+  @param filename - The agency file to format. Must stay inside dir; to
+    write another directory, pass it in `dir`.
 
 Read and write happen inside the same interrupt, so approving it approves both.
   If the file is already formatted, no write occurs and its mtime is preserved.
@@ -796,7 +799,7 @@ Read and write happen inside the same interrupt, so approving it approves both.
 
 **Throws:** `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L638))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L653))
 
 ### walkAST
 
@@ -825,7 +828,7 @@ Walk every node in a deep-cloned copy of the AST, invoking the visitor
 
 **Returns:** [AST](#ast)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L657))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L677))
 
 ### getNodesOfType
 
@@ -847,7 +850,7 @@ Parse Agency source code and return every AST node whose `type` field matches an
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L677))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L697))
 
 ### getImports
 
@@ -867,7 +870,7 @@ Return every import statement in the source (i.e. `import { x } from "..."`).
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L690))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L710))
 
 ### getFunctions
 
@@ -887,7 +890,7 @@ Return every function definition (`def foo(...) { ... }`) in the source.
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L699))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L719))
 
 ### getGraphNodes
 
@@ -907,7 +910,7 @@ Return every graph node definition (`node main() { ... }`) in the source.
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L708))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L728))
 
 ### filterImports
 
@@ -959,7 +962,7 @@ Parse Agency source, drop imports that fail the policy, and return the resulting
 
 **Returns:** `Result<{ source: string; filtered: boolean }>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L735))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L755))
 
 ### getVersion
 
@@ -971,4 +974,4 @@ Get the current version of the Agency standard library.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L761))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L781))

--- a/packages/agency-lang/docs/site/stdlib/fs.md
+++ b/packages/agency-lang/docs/site/stdlib/fs.md
@@ -107,7 +107,9 @@ Edit a single file by applying one or more text replacements atomically. Each ed
 
   Prefer one call with multiple edits over many separate calls. Keep each oldText as small as possible while still matching uniquely. Do not pad with unchanged context to bridge distant changes; split them into separate edits instead.
 
-  @param filename - The file to edit
+  @param filename - The file to edit. Must stay inside dir: no absolute
+    paths, `~`, upward traversal, or symlinks that leave it. To edit another
+    directory, pass it in `dir`.
   @param edits - Text replacements to apply in order; each has oldText, newText, and replaceAll (replace every occurrence when true)
   @param dir - The directory to resolve the filename against
   @param useAgentCwd - When true, resolve a relative path against the agent working directory if one is set
@@ -154,7 +156,7 @@ Apply a unified diff to the working tree. Supports file creation (--- /dev/null)
 
 **Throws:** `std::applyPatch`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L81))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L89))
 
 ### mkdir
 
@@ -184,7 +186,7 @@ Create a directory, including any missing parent directories. Idempotent: succee
 
 **Throws:** `std::mkdir`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L97))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L105))
 
 ### copy
 
@@ -217,7 +219,7 @@ Copy a file or directory. Directories are copied recursively. Fails if src does 
 
 **Throws:** `std::copy`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L117))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L125))
 
 ### move
 
@@ -250,7 +252,7 @@ Move or rename a file or directory. Falls back to copy+remove if src and dest ar
 
 **Throws:** `std::move`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L140))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L148))
 
 ### remove
 
@@ -280,4 +282,4 @@ Delete a file or directory. Directories are removed recursively. Does not fail i
 
 **Throws:** `std::remove`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L163))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L171))

--- a/packages/agency-lang/docs/site/stdlib/index.md
+++ b/packages/agency-lang/docs/site/stdlib/index.md
@@ -24,7 +24,7 @@ How an existing file is handled on write:
 export type WriteMode = "overwrite" | "append" | "create-only"
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L51))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L52))
 
 ## Effects
 
@@ -37,7 +37,7 @@ effect std::read {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L35))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L36))
 
 ### std::write
 
@@ -48,7 +48,7 @@ effect std::write {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L39))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L40))
 
 ### std::readImage
 
@@ -59,7 +59,7 @@ effect std::readImage {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L43))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L44))
 
 ## Functions
 
@@ -79,7 +79,7 @@ Print a message to the console.
 |---|---|---|
 | messages | `any[]` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L53))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L54))
 
 ### setAgentCwd
 
@@ -104,7 +104,7 @@ Set the agent working directory. Path-taking tools (read, write, edit,
 |---|---|---|
 | dir | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L82))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L83))
 
 ### getAgentCwd
 
@@ -116,7 +116,7 @@ Return the agent working directory, or an empty string if none is set.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L91))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L92))
 
 ### applyAgentCwd
 
@@ -136,7 +136,7 @@ Resolve a relative path against the agent working directory (set with
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L98))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L99))
 
 ### printJSON
 
@@ -156,7 +156,7 @@ Print an object as formatted JSON to the console.
 | obj | `any` |  |
 | highlight | `boolean` | false |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L109))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L110))
 
 ### input
 
@@ -179,7 +179,7 @@ prompt, which surfaces as an AgencyCancelledError.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L126))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L127))
 
 ### sleep
 
@@ -200,7 +200,7 @@ A long sleep wakes immediately on Ctrl-C, race-loser, or time-guard abort.
 |---|---|---|
 | ms | `number` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L137))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L138))
 
 ### saveDraft
 
@@ -227,7 +227,7 @@ Record a best-so-far value for the current function or guarded block. If an
 |---|---|---|
 | value | `any` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L146))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L147))
 
 ### read
 
@@ -243,7 +243,9 @@ read(
 
 Read the contents of a file and return it as a string.
 
-  @param filename - The file to read
+  @param filename - The file to read. Must stay inside dir: no absolute
+    paths, `~`, upward traversal, or symlinks that leave it. To touch another
+    directory, pass it in `dir`.
   @param dir - The directory to resolve the filename against (defaults to ".")
   @param offset - 1-indexed line to start at (0 means start of file)
   @param limit - Maximum number of lines to return (0 means read to end of file)
@@ -263,7 +265,7 @@ Read the contents of a file and return it as a string.
 
 **Throws:** `std::read`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L164))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L165))
 
 ### write
 
@@ -279,7 +281,9 @@ write(
 
 Write content to a file.
 
-  @param filename - The file to write
+  @param filename - The file to write. Must stay inside dir: no absolute
+    paths, `~`, upward traversal, or symlinks that leave it. To touch another
+    directory, pass it in `dir`.
   @param content - The content to write
   @param dir - The directory to resolve the filename against (defaults to ".")
   @param mode - How to handle an existing file
@@ -299,7 +303,7 @@ Write content to a file.
 
 **Throws:** `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L192))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L199))
 
 ### writeBinary
 
@@ -316,7 +320,9 @@ writeBinary(
 Write base64-encoded binary data to a file: images, audio, video, PDFs, or any
   binary. Decodes the base64 and writes raw bytes rather than UTF-8 text.
 
-  @param filename - The file to write
+  @param filename - The file to write. Must stay inside dir: no absolute
+    paths, `~`, upward traversal, or symlinks that leave it. To touch another
+    directory, pass it in `dir`.
   @param base64 - The binary content, base64-encoded
   @param dir - The directory to resolve the filename against (defaults to ".")
   @param mode - How to handle an existing file
@@ -336,7 +342,7 @@ Write base64-encoded binary data to a file: images, audio, video, PDFs, or any
 
 **Throws:** `std::writeBinary`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L222))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L235))
 
 ### readBinary
 
@@ -351,7 +357,9 @@ readBinary(
 Read a file and return its contents as a Base64-encoded string. Works for any
   binary file: images, audio, video, PDFs.
 
-  @param filename - The file to read
+  @param filename - The file to read. Must stay inside dir: no absolute
+    paths, `~`, upward traversal, or symlinks that leave it. To touch another
+    directory, pass it in `dir`.
   @param dir - The directory to resolve the filename against (defaults to ".")
   @param useAgentCwd - Resolve relative paths against the agent working directory instead of dir
 
@@ -367,7 +375,7 @@ Read a file and return its contents as a Base64-encoded string. Works for any
 
 **Throws:** `std::readBinary`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L252))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L271))
 
 ### range
 
@@ -390,7 +398,7 @@ Generate an array of numbers. With one argument, counts from 0 to start-1;
 
 **Returns:** `number[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L275))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L300))
 
 ### map
 
@@ -412,7 +420,7 @@ Map a function over an array, returning a new array of results.
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L296))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L321))
 
 ### mapWithIndex
 
@@ -435,7 +443,7 @@ Apply a function to each item of an array along with its index, and
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L322))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L347))
 
 ### filter
 
@@ -457,7 +465,7 @@ Return a new array containing only the elements for which the function returns t
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L333))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L358))
 
 ### exclude
 
@@ -479,7 +487,7 @@ Return a new array excluding elements for which the function returns true.
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L349))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L374))
 
 ### find
 
@@ -501,7 +509,7 @@ Return the first element for which the function returns true, or null if none ma
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L365))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L390))
 
 ### findIndex
 
@@ -523,7 +531,7 @@ Return the index of the first element for which the function returns true, or -1
 
 **Returns:** `number`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L380))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L405))
 
 ### reduce
 
@@ -547,7 +555,7 @@ Reduce an array to a single value by applying a function to an accumulator and e
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L395))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L420))
 
 ### flatMap
 
@@ -569,7 +577,7 @@ Map a function over an array and flatten the results by one level.
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L410))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L435))
 
 ### flatten
 
@@ -589,7 +597,7 @@ Flatten an array of arrays by one level.
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L427))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L452))
 
 ### every
 
@@ -611,7 +619,7 @@ Return true if the function returns true for every element in the array.
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L442))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L467))
 
 ### some
 
@@ -633,7 +641,7 @@ Return true if the function returns true for at least one element in the array.
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L457))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L482))
 
 ### count
 
@@ -655,7 +663,7 @@ Count the number of elements in the array for which the function returns true.
 
 **Returns:** `number`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L472))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L497))
 
 ### sortBy
 
@@ -677,7 +685,7 @@ Return a new array sorted by the values returned by the function, in ascending o
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L488))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L513))
 
 ### unique
 
@@ -699,7 +707,7 @@ Return a new array with duplicate elements removed, using the function to determ
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L515))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L540))
 
 ### groupBy
 
@@ -721,7 +729,7 @@ Group elements of an array by the value returned by the function. Returns an obj
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L540))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L565))
 
 ### callback
 
@@ -743,4 +751,4 @@ Register a callback for a lifecycle event. A callback registered inside a
 | name | `string` |  |
 | fn | `any` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L560))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L585))

--- a/packages/agency-lang/docs/site/stdlib/safeBash.md
+++ b/packages/agency-lang/docs/site/stdlib/safeBash.md
@@ -19,7 +19,7 @@ export type Word =
   | InterpolatedVariableWord
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L21))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L26))
 
 ### ScriptName
 
@@ -27,7 +27,7 @@ export type Word =
 export type ScriptName = LiteralWord | PathWord
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L30))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L35))
 
 ### LiteralWord
 
@@ -38,7 +38,7 @@ export type LiteralWord = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L32))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L37))
 
 ### PathWord
 
@@ -49,7 +49,7 @@ export type PathWord = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L37))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L42))
 
 ### FlagWord
 
@@ -61,7 +61,7 @@ export type FlagWord = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L42))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L47))
 
 ### SingleQuotedWord
 
@@ -72,7 +72,7 @@ export type SingleQuotedWord = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L48))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L53))
 
 ### DoubleQuotedWord
 
@@ -83,7 +83,7 @@ export type DoubleQuotedWord = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L53))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L58))
 
 ### VariableWord
 
@@ -94,7 +94,7 @@ export type VariableWord = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L58))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L63))
 
 ### InterpolatedVariableWord
 
@@ -117,7 +117,7 @@ export type InterpolatedVariableWord = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L67))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L72))
 
 ### Assignment
 
@@ -132,7 +132,7 @@ export type Assignment = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L77))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L82))
 
 ### Redirect
 
@@ -154,7 +154,7 @@ export type Redirect = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L87))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L92))
 
 ### SimpleCommand
 
@@ -174,7 +174,7 @@ export type SimpleCommand = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L94))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L99))
 
 ### Command
 
@@ -182,7 +182,7 @@ export type SimpleCommand = {
 export type Command = SimpleCommand | And | Or | Parens
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L108))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L113))
 
 ### And
 
@@ -194,7 +194,7 @@ export type And = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L110))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L115))
 
 ### Or
 
@@ -206,7 +206,7 @@ export type Or = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L116))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L121))
 
 ### Parens
 
@@ -217,7 +217,7 @@ export type Parens = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L122))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L127))
 
 ### BashNode
 
@@ -231,7 +231,7 @@ export type BashNode =
   | ScriptName
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L127))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L132))
 
 ### BashAST
 
@@ -239,7 +239,7 @@ export type BashNode =
 export type BashAST = Command[]
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L135))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L140))
 
 ## Functions
 
@@ -267,7 +267,7 @@ Which interrupts this one command needs raised.
 
 **Returns:** `Result<Effect[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L244))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L273))
 
 ### planFor
 
@@ -293,7 +293,7 @@ Decide everything about a call before any of it happens.
 
 **Returns:** [Plan](safeBash/actions.md#plan)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L616))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L622))
 
 ### isRefused
 
@@ -318,7 +318,7 @@ True when this command must not run, whatever anyone approves.
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L702))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L708))
 
 ### bashParser
 
@@ -336,7 +336,7 @@ Parse a string of bash code into an AST.
 
 **Returns:** `Result<BashAST>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L778))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L784))
 
 ### resolveCwd
 
@@ -359,7 +359,7 @@ Which directory a command runs in: the caller's, or the agent's when the
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L802))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L808))
 
 ### safeBash
 
@@ -395,4 +395,4 @@ Run a shell command, asking the narrowest question that describes it.
 
 **Throws:** `std::bash`, `std::write`, `std::git::status`, `std::git::log`, `std::git::diff`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L823))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L829))

--- a/packages/agency-lang/docs/site/stdlib/safeBash.md
+++ b/packages/agency-lang/docs/site/stdlib/safeBash.md
@@ -267,7 +267,7 @@ Which interrupts this one command needs raised.
 
 **Returns:** `Result<Effect[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L273))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L267))
 
 ### planFor
 
@@ -293,7 +293,7 @@ Decide everything about a call before any of it happens.
 
 **Returns:** [Plan](safeBash/actions.md#plan)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L622))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L616))
 
 ### isRefused
 
@@ -318,7 +318,7 @@ True when this command must not run, whatever anyone approves.
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L708))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L702))
 
 ### bashParser
 
@@ -336,7 +336,7 @@ Parse a string of bash code into an AST.
 
 **Returns:** `Result<BashAST>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L784))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L778))
 
 ### resolveCwd
 
@@ -359,7 +359,7 @@ Which directory a command runs in: the caller's, or the agent's when the
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L808))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L802))
 
 ### safeBash
 
@@ -395,4 +395,4 @@ Run a shell command, asking the narrowest question that describes it.
 
 **Throws:** `std::bash`, `std::write`, `std::git::status`, `std::git::log`, `std::git::diff`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L829))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash.agency#L823))

--- a/packages/agency-lang/docs/site/stdlib/safeBash/actions.md
+++ b/packages/agency-lang/docs/site/stdlib/safeBash/actions.md
@@ -68,7 +68,7 @@ export type GitDiffPayload = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L41))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L61))
 
 ### Execution
 
@@ -89,7 +89,7 @@ What happens if every effect in the plan is approved.
 export type Execution = BashExec | EchoExec | WriteExec | RefuseExec
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L55))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L75))
 
 ### BashExec
 
@@ -100,7 +100,7 @@ export type BashExec = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L57))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L77))
 
 ### EchoExec
 
@@ -111,7 +111,7 @@ export type EchoExec = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L62))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L82))
 
 ### WriteExec
 
@@ -125,7 +125,7 @@ export type WriteExec = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L67))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L87))
 
 ### RefuseExec
 
@@ -136,7 +136,7 @@ export type RefuseExec = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L75))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L95))
 
 ### Plan
 
@@ -150,7 +150,7 @@ export type Plan = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L81))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L101))
 
 ## Constants
 
@@ -163,6 +163,42 @@ export static const MAX_STDOUT_LEN = 2000
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L20))
 
 ## Functions
+
+### writeEffect
+
+```ts
+writeEffect(write: WritePayload): Effect
+```
+
+The one shared description of a planned redirect write. Both the
+  approval side (writeEffect) and the execution side (writeExecution)
+  derive from it, so payload/execution parity holds by construction.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| write | [WritePayload](#writepayload) |  |
+
+**Returns:** [Effect](#effect)
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L44))
+
+### writeExecution
+
+```ts
+writeExecution(write: WritePayload): WriteExec
+```
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| write | [WritePayload](#writepayload) |  |
+
+**Returns:** [WriteExec](#writeexec)
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L51))
 
 ### runBash
 
@@ -191,7 +227,7 @@ Run a command string through bash and return what it printed.
 
 **Returns:** `Result<string>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L86))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L106))
 
 ### truncate
 
@@ -210,7 +246,7 @@ Cap output length. Raw output with no bound is a context-window hazard,
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L135))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L155))
 
 ### runWrite
 
@@ -233,4 +269,4 @@ Perform the write a redirected echo asked for. Returns the empty string,
 
 **Returns:** `Result<string>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L146))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L166))

--- a/packages/agency-lang/docs/site/stdlib/safeBash/actions.md
+++ b/packages/agency-lang/docs/site/stdlib/safeBash/actions.md
@@ -68,7 +68,7 @@ export type GitDiffPayload = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L61))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L60))
 
 ### Execution
 
@@ -89,7 +89,7 @@ What happens if every effect in the plan is approved.
 export type Execution = BashExec | EchoExec | WriteExec | RefuseExec
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L75))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L74))
 
 ### BashExec
 
@@ -100,7 +100,7 @@ export type BashExec = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L77))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L76))
 
 ### EchoExec
 
@@ -111,7 +111,7 @@ export type EchoExec = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L82))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L81))
 
 ### WriteExec
 
@@ -125,7 +125,7 @@ export type WriteExec = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L87))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L86))
 
 ### RefuseExec
 
@@ -136,7 +136,7 @@ export type RefuseExec = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L95))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L94))
 
 ### Plan
 
@@ -150,7 +150,7 @@ export type Plan = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L101))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L100))
 
 ## Constants
 
@@ -170,9 +170,8 @@ export static const MAX_STDOUT_LEN = 2000
 writeEffect(write: WritePayload): Effect
 ```
 
-The one shared description of a planned redirect write. Both the
-  approval side (writeEffect) and the execution side (writeExecution)
-  derive from it, so payload/execution parity holds by construction.
+Both plan sides derive from one WritePayload, so payload/execution
+  parity holds by construction.
 
 **Parameters:**
 
@@ -182,7 +181,7 @@ The one shared description of a planned redirect write. Both the
 
 **Returns:** [Effect](#effect)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L44))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L43))
 
 ### writeExecution
 
@@ -198,7 +197,7 @@ writeExecution(write: WritePayload): WriteExec
 
 **Returns:** [WriteExec](#writeexec)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L51))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L50))
 
 ### runBash
 
@@ -227,7 +226,7 @@ Run a command string through bash and return what it printed.
 
 **Returns:** `Result<string>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L106))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L105))
 
 ### truncate
 
@@ -246,7 +245,7 @@ Cap output length. Raw output with no bound is a context-window hazard,
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L155))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L154))
 
 ### runWrite
 
@@ -269,4 +268,4 @@ Perform the write a redirected echo asked for. Returns the empty string,
 
 **Returns:** `Result<string>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L166))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/safeBash/actions.agency#L165))

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/subagents/code.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/subagents/code.agency
@@ -67,16 +67,19 @@ export def agencyCli(args: string[]): any {
 
 /** Read a bundled prompt file, or "" when it cannot be read. The prompts
   ship with the agent, so a missing one means a packaging problem, not a
-  runtime condition worth failing the turn over. */
-def promptFile(filename: string): string {
-  const contents = read(filename) with approve
+  runtime condition worth failing the turn over. The empty-string fallback
+  makes a broken path a SILENT failure (the agent runs with no system
+  prompt), which is why tests/agency/agency-agent-code-prompt.agency
+  asserts both prompts load. Exported for that test. */
+export def promptFile(filename: string): string {
+  const contents = read(filename, __dirname + "/../prompts") with approve
   if (isFailure(contents)) {
     return ""
   }
   return contents.value
 }
 
-export static const codeSysPrompt = promptFile("../prompts/code.md")
+export static const codeSysPrompt = promptFile("code.md")
 
 // The file-system / shell tools are partially applied with
 // `useAgentCwd: true` so that, as agent tools, they resolve relative
@@ -99,7 +102,7 @@ and do NOT decline a task as "needs research / out of scope": search for
 what you need and keep going."""
 
 // Appended in one-shot / autonomous mode (`agency agent -p`)
-static const ONE_SHOT_NOTE = promptFile("../prompts/oneShot.md")
+static const ONE_SHOT_NOTE = promptFile("oneShot.md")
 
 // Set by `agent.agency` (`setCodeOneShot`) before the first dispatch when the
 // run is non-interactive. Gates `ONE_SHOT_NOTE`.

--- a/packages/agency-lang/lib/runtime/policy.test.ts
+++ b/packages/agency-lang/lib/runtime/policy.test.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { checkPolicy, resolveDotDirPattern, validatePolicy } from "./policy.js";
+import { mkdtempSync, mkdirSync, symlinkSync, rmSync, realpathSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
 import picomatch from "picomatch";
 
 describe("checkPolicy", () => {
@@ -513,5 +516,54 @@ describe("resolveDotDirPattern escaping", () => {
     const resolved = resolveDotDirPattern("./sub/**", "/tmp/plain");
     expect(picomatch.isMatch("/tmp/plain/sub/a/b", resolved)).toBe(true);
     expect(picomatch.isMatch("/tmp/plain/other", resolved)).toBe(false);
+  });
+});
+
+describe("dot expansion canonicalizes the launch directory", () => {
+  it("a symlinked cwd resolves to its real directory in the pattern", () => {
+    const base = mkdtempSync(path.join(tmpdir(), "policy-dot-"));
+    try {
+      const real = path.join(base, "real");
+      mkdirSync(real);
+      const link = path.join(base, "link");
+      symlinkSync(real, link);
+      const resolved = resolveDotDirPattern("{.,./**}", link);
+      const realRoot = realpathSync(real);
+      expect(picomatch.isMatch(realRoot, resolved)).toBe(true);
+      expect(picomatch.isMatch(path.join(realRoot, "sub", "deep"), resolved)).toBe(true);
+      expect(picomatch.isMatch(path.join(base, "outside"), resolved)).toBe(false);
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  it("is wired through checkPolicy, not only the resolver", () => {
+    const base = mkdtempSync(path.join(tmpdir(), "policy-dot-"));
+    const cwdSpy = vi.spyOn(process, "cwd");
+    try {
+      const real = path.join(base, "real");
+      mkdirSync(real);
+      const link = path.join(base, "link");
+      symlinkSync(real, link);
+      cwdSpy.mockReturnValue(link);
+      const policy = { "std::write": [{ match: { dir: "{.,./**}" }, action: "approve" as const }] };
+      const intr = (dir: string) => ({
+        effect: "std::write",
+        message: "",
+        data: { dir, filename: "x.txt" },
+        origin: "",
+      });
+      expect(checkPolicy(policy, intr(realpathSync(real))).type).toBe("approve");
+      expect(checkPolicy(policy, intr(path.join(base, "outside"))).type).toBe("propagate");
+    } finally {
+      cwdSpy.mockRestore();
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps the lexical cwd when realpath fails, with escaping intact", () => {
+    const resolved = resolveDotDirPattern("./**", "/nonexistent-policy-cwd*");
+    expect(picomatch.isMatch("/nonexistent-policy-cwd*/x", resolved)).toBe(true);
+    expect(picomatch.isMatch("/nonexistent-policy-cwdX/x", resolved)).toBe(false);
   });
 });

--- a/packages/agency-lang/lib/runtime/policy.ts
+++ b/packages/agency-lang/lib/runtime/policy.ts
@@ -1,4 +1,5 @@
 import picomatch from "picomatch";
+import { realpathSync } from "fs";
 import { z } from "zod";
 
 export const PolicyRuleSchema = z.object({
@@ -81,13 +82,24 @@ function escapeForGlob(s: string): string {
 // same caveat as every dir glob: `**` does not descend into dot-led
 // subdirectories (picomatch's dot rule), though a launch directory whose
 // own path contains dot segments is fine — those sit in the literal prefix.
+// The cwd is realpathed so a symlinked launch directory (a linked
+// checkout, macOS /tmp) shares one path identity with interrupt payloads,
+// which the contained-filename wrappers now canonicalize the same way.
 // Exported for tests, which inject the cwd.
 export function resolveDotDirPattern(pattern: string, cwd: string = process.cwd()): string {
+  let realCwd: string;
+  try {
+    realCwd = realpathSync(cwd);
+  } catch {
+    // A cwd that cannot be resolved keeps its lexical spelling: matching
+    // stays exactly as before rather than failing every rule.
+    realCwd = cwd;
+  }
   // Callback, not a replacement string: a legal cwd containing `$&`/`$'`
   // would otherwise be interpreted as replacement-string syntax.
   return pattern.replace(
     /(^|\{|,)\.(?=$|\/|,|\})/g,
-    (_match, prefix) => prefix + escapeForGlob(cwd),
+    (_match, prefix) => prefix + escapeForGlob(realCwd),
   );
 }
 

--- a/packages/agency-lang/lib/stdlib/assertContained.ts
+++ b/packages/agency-lang/lib/stdlib/assertContained.ts
@@ -81,7 +81,7 @@ export async function assertContained(
  * would become `//`/`C:\\` and a naive `startsWith` check would refuse
  * every descendant. Path comparison is case-insensitive on Windows.
  */
-function isContained(target: string, root: string): boolean {
+export function isContained(target: string, root: string): boolean {
   const t = process.platform === "win32" ? target.toLowerCase() : target;
   const r = process.platform === "win32" ? root.toLowerCase() : root;
   if (t === r) return true;

--- a/packages/agency-lang/lib/stdlib/fs.ts
+++ b/packages/agency-lang/lib/stdlib/fs.ts
@@ -8,6 +8,8 @@ import { resolveDir } from "./resolveDir.js";
 import { expandPath } from "./expandPath.js";
 
 export { resolvePath } from "./resolvePath.js";
+export { prepareContainedPath as _prepareContainedPath } from "./prepareContainedPath.js";
+export { resolveRedirectTarget as _resolveRedirectTarget } from "./prepareContainedPath.js";
 
 export type MultiEdit = {
   oldText: string;

--- a/packages/agency-lang/lib/stdlib/prepareContainedPath.test.ts
+++ b/packages/agency-lang/lib/stdlib/prepareContainedPath.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "fs";
 import { realpath } from "fs/promises";
 import { tmpdir } from "os";
 import path from "path";
-import { prepareContainedPath } from "./prepareContainedPath.js";
+import { prepareContainedPath, resolveRedirectTarget } from "./prepareContainedPath.js";
 
 const sandboxes: string[] = [];
 
@@ -107,9 +107,7 @@ describe("prepareContainedPath", () => {
   it("rejects a regular file used as a directory with ENOTDIR", async () => {
     const { root } = sandbox();
     writeFileSync(path.join(root, "plain.txt"), "x");
-    await expect(prepareContainedPath(root, "plain.txt/child", "write")).rejects.toThrow(
-      /ENOTDIR/,
-    );
+    await expect(prepareContainedPath(root, "plain.txt/child", "write")).rejects.toThrow(/ENOTDIR/);
   });
 
   it("fails closed on a permission error instead of treating it as a lexical tail", async () => {
@@ -138,9 +136,7 @@ describe("prepareContainedPath", () => {
 
   it("requires dir to exist", async () => {
     const { root } = sandbox();
-    await expect(
-      prepareContainedPath(path.join(root, "nope"), "f.txt", "write"),
-    ).rejects.toThrow();
+    await expect(prepareContainedPath(path.join(root, "nope"), "f.txt", "write")).rejects.toThrow();
   });
 
   it("rejects an empty dir instead of silently using cwd", async () => {
@@ -158,4 +154,66 @@ describe("prepareContainedPath", () => {
 
 async function realDir(p: string): Promise<string> {
   return realpath(p);
+}
+
+describe("resolveRedirectTarget", () => {
+  it("splits absolute and relative targets into real parent + name", async () => {
+    const { root, outside } = sandbox();
+    expect(await resolveRedirectTarget(join2(outside, "out.txt"), root, "expand")).toEqual({
+      dir: await realDir(outside),
+      filename: "out.txt",
+    });
+    expect(await resolveRedirectTarget("sub/out.txt", root, "expand")).toEqual({
+      dir: path.join(await realDir(root), "sub"),
+      filename: "out.txt",
+    });
+  });
+
+  it("expands or preserves ~ per tildeMode", async () => {
+    const { root } = sandbox();
+    const expanded = await resolveRedirectTarget("~/cf-rrt.txt", root, "expand");
+    expect(expanded.dir.includes("~")).toBe(false);
+    expect(expanded.filename).toBe("cf-rrt.txt");
+    const literal = await resolveRedirectTarget("~/cf-rrt.txt", root, "literal");
+    expect(literal.dir).toBe(path.join(await realDir(root), "~"));
+  });
+
+  it("resolves symlinked parents and existing final symlinks to real locations", async () => {
+    const { root, outside } = sandbox();
+    symlinkSync(outside, path.join(root, "plink"));
+    expect(await resolveRedirectTarget("plink/out.txt", root, "expand")).toEqual({
+      dir: await realDir(outside),
+      filename: "out.txt",
+    });
+    writeFileSync(path.join(outside, "real.txt"), "x");
+    symlinkSync(path.join(outside, "real.txt"), path.join(root, "flink"));
+    expect(await resolveRedirectTarget("flink", root, "expand")).toEqual({
+      dir: await realDir(outside),
+      filename: "real.txt",
+    });
+  });
+
+  it("follows a two-link chain and fails closed on loops and dangling links", async () => {
+    const { root, outside } = sandbox();
+    writeFileSync(path.join(outside, "end.txt"), "x");
+    symlinkSync(path.join(outside, "end.txt"), path.join(root, "hop2"));
+    symlinkSync(path.join(root, "hop2"), path.join(root, "hop1"));
+    expect((await resolveRedirectTarget("hop1", root, "expand")).filename).toBe("end.txt");
+    symlinkSync(path.join(root, "loopB"), path.join(root, "loopA"));
+    symlinkSync(path.join(root, "loopA"), path.join(root, "loopB"));
+    await expect(resolveRedirectTarget("loopA", root, "expand")).rejects.toThrow(/ELOOP/);
+    symlinkSync(path.join(outside, "missing"), path.join(root, "dangle"));
+    await expect(resolveRedirectTarget("dangle", root, "expand")).rejects.toThrow(/dangling/);
+    await expect(resolveRedirectTarget("dangle/deep.txt", root, "expand")).rejects.toThrow(
+      /dangling/,
+    );
+  });
+
+  it("rejects an empty cwd", async () => {
+    await expect(resolveRedirectTarget("f.txt", "", "expand")).rejects.toThrow(/cwd/);
+  });
+});
+
+function join2(a: string, b: string): string {
+  return path.join(a, b);
 }

--- a/packages/agency-lang/lib/stdlib/prepareContainedPath.test.ts
+++ b/packages/agency-lang/lib/stdlib/prepareContainedPath.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, describe, it, expect, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "fs";
+import { realpath } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import { prepareContainedPath } from "./prepareContainedPath.js";
+
+const sandboxes: string[] = [];
+
+function sandbox(): { root: string; outside: string } {
+  const base = mkdtempSync(path.join(tmpdir(), "pcp-"));
+  sandboxes.push(base);
+  const root = path.join(base, "root");
+  const outside = path.join(base, "outside");
+  mkdirSync(root);
+  mkdirSync(outside);
+  return { root, outside };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const base of sandboxes.splice(0)) {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+describe("prepareContainedPath", () => {
+  it("accepts nested relative filenames and normalizes . and ..", async () => {
+    const { root } = sandbox();
+    expect(await prepareContainedPath(root, "src/lib/file.ts", "write")).toEqual({
+      dir: await realDir(root),
+      filename: path.join("src", "lib", "file.ts"),
+    });
+    expect((await prepareContainedPath(root, "a/./b/../c.txt", "write")).filename).toBe(
+      path.join("a", "c.txt"),
+    );
+  });
+
+  it("rejects absolute, ~, and escaping filenames with the teaching message", async () => {
+    const { root, outside } = sandbox();
+    const absolute = path.join(path.parse(root).root, "pcp-absolute-outside");
+    await expect(prepareContainedPath(root, absolute, "write")).rejects.toThrow(
+      /pass that directory in dir/,
+    );
+    await expect(prepareContainedPath(root, "~/payload.agency", "write")).rejects.toThrow(
+      /pass that directory in dir/,
+    );
+    await expect(
+      prepareContainedPath(root, path.join("..", path.basename(outside), "x"), "write"),
+    ).rejects.toThrow(/pass that directory in dir/);
+  });
+
+  it("phrases the teaching sentence per operation", async () => {
+    const { root } = sandbox();
+    await expect(prepareContainedPath(root, "../x", "write")).rejects.toThrow(
+      "To write somewhere else, pass that directory in dir.",
+    );
+    await expect(prepareContainedPath(root, "../x", "read")).rejects.toThrow(
+      "To read from somewhere else, pass that directory in dir.",
+    );
+  });
+
+  it("realpaths a symlinked dir", async () => {
+    const { root } = sandbox();
+    const link = path.join(path.dirname(root), "rootlink");
+    symlinkSync(root, link);
+    expect((await prepareContainedPath(link, "f.txt", "write")).dir).toBe(await realDir(root));
+  });
+
+  it("follows in-root symlinks and rejects escaping ones", async () => {
+    const { root, outside } = sandbox();
+    mkdirSync(path.join(root, "realsub"));
+    symlinkSync(path.join(root, "realsub"), path.join(root, "insub"));
+    symlinkSync(outside, path.join(root, "outsub"));
+    // In-root parent link: allowed, filename keeps the link spelling.
+    expect((await prepareContainedPath(root, "insub/f.txt", "write")).filename).toBe(
+      path.join("insub", "f.txt"),
+    );
+    // Escaping parent link and escaping final link: rejected.
+    await expect(prepareContainedPath(root, "outsub/f.txt", "write")).rejects.toThrow(
+      /outside dir/,
+    );
+    writeFileSync(path.join(outside, "real.txt"), "x");
+    symlinkSync(path.join(outside, "real.txt"), path.join(root, "leaflink"));
+    await expect(prepareContainedPath(root, "leaflink", "write")).rejects.toThrow(/outside dir/);
+    // In-root final link: allowed.
+    writeFileSync(path.join(root, "inner.txt"), "x");
+    symlinkSync(path.join(root, "inner.txt"), path.join(root, "innerlink"));
+    expect((await prepareContainedPath(root, "innerlink", "write")).filename).toBe("innerlink");
+  });
+
+  it("follows a two-link in-root chain", async () => {
+    const { root } = sandbox();
+    writeFileSync(path.join(root, "end.txt"), "x");
+    symlinkSync(path.join(root, "end.txt"), path.join(root, "hop2"));
+    symlinkSync(path.join(root, "hop2"), path.join(root, "hop1"));
+    expect((await prepareContainedPath(root, "hop1", "write")).filename).toBe("hop1");
+  });
+
+  it("rejects a symlink loop with ELOOP", async () => {
+    const { root } = sandbox();
+    symlinkSync(path.join(root, "loopB"), path.join(root, "loopA"));
+    symlinkSync(path.join(root, "loopA"), path.join(root, "loopB"));
+    await expect(prepareContainedPath(root, "loopA", "write")).rejects.toThrow(/ELOOP/);
+  });
+
+  it("rejects a regular file used as a directory with ENOTDIR", async () => {
+    const { root } = sandbox();
+    writeFileSync(path.join(root, "plain.txt"), "x");
+    await expect(prepareContainedPath(root, "plain.txt/child", "write")).rejects.toThrow(
+      /ENOTDIR/,
+    );
+  });
+
+  it("fails closed on a permission error instead of treating it as a lexical tail", async () => {
+    const { root } = sandbox();
+    const fsPromises = await import("fs/promises");
+    const denied = Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" });
+    vi.spyOn(fsPromises.default, "lstat").mockRejectedValueOnce(denied);
+    await expect(prepareContainedPath(root, "secret/f.txt", "write")).rejects.toThrow(/EACCES/);
+  });
+
+  it("rejects dangling symlinks on the target path", async () => {
+    const { root, outside } = sandbox();
+    symlinkSync(path.join(outside, "missing"), path.join(root, "dangle"));
+    await expect(prepareContainedPath(root, "dangle", "write")).rejects.toThrow(/dangling/);
+    await expect(prepareContainedPath(root, "dangle/deeper.txt", "write")).rejects.toThrow(
+      /dangling/,
+    );
+  });
+
+  it("treats missing intermediate directories as contained, not dangling", async () => {
+    const { root } = sandbox();
+    expect((await prepareContainedPath(root, "sub/new/file.txt", "write")).filename).toBe(
+      path.join("sub", "new", "file.txt"),
+    );
+  });
+
+  it("requires dir to exist", async () => {
+    const { root } = sandbox();
+    await expect(
+      prepareContainedPath(path.join(root, "nope"), "f.txt", "write"),
+    ).rejects.toThrow();
+  });
+
+  it("rejects an empty dir instead of silently using cwd", async () => {
+    await expect(prepareContainedPath("", "f.txt", "write")).rejects.toThrow(/dir/);
+  });
+
+  it.runIf(process.platform === "win32")("contains case-insensitively on Windows", async () => {
+    const { root } = sandbox();
+    const upper = root.toUpperCase();
+    expect((await prepareContainedPath(upper, "f.txt", "write")).dir.toLowerCase()).toBe(
+      (await realDir(root)).toLowerCase(),
+    );
+  });
+});
+
+async function realDir(p: string): Promise<string> {
+  return realpath(p);
+}

--- a/packages/agency-lang/lib/stdlib/prepareContainedPath.test.ts
+++ b/packages/agency-lang/lib/stdlib/prepareContainedPath.test.ts
@@ -112,9 +112,11 @@ describe("prepareContainedPath", () => {
 
   it("fails closed on a permission error instead of treating it as a lexical tail", async () => {
     const { root } = sandbox();
-    const fsPromises = await import("fs/promises");
+    const fsSync = await import("fs");
     const denied = Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" });
-    vi.spyOn(fsPromises.default, "lstat").mockRejectedValueOnce(denied);
+    vi.spyOn(fsSync.default, "lstatSync").mockImplementationOnce(() => {
+      throw denied;
+    });
     await expect(prepareContainedPath(root, "secret/f.txt", "write")).rejects.toThrow(/EACCES/);
   });
 

--- a/packages/agency-lang/lib/stdlib/prepareContainedPath.ts
+++ b/packages/agency-lang/lib/stdlib/prepareContainedPath.ts
@@ -1,0 +1,116 @@
+import fs from "fs/promises";
+import path from "path";
+import { resolveDir } from "./resolveDir.js";
+import { expandPath } from "./expandPath.js";
+import { isContained } from "./assertContained.js";
+
+export type ContainedPath = {
+  dir: string;
+  filename: string;
+};
+
+export type FileOperation = "read" | "write";
+
+/**
+ * Prepare a (dir, filename) pair for a scoped single-file wrapper: the
+ * returned values go into BOTH the interrupt payload and the execution.
+ * Guarantees the spec's containment contract: the resolved file operand
+ * stays inside the resolved dir operand, or this throws before any
+ * interrupt exists. See 2026-08-20-contained-filename-spec.md.
+ */
+export async function prepareContainedPath(
+  dir: string,
+  filename: string,
+  operation: FileOperation,
+): Promise<ContainedPath> {
+  if (dir.trim() === "") {
+    throw new Error(`${operation} refused: dir must not be empty.`);
+  }
+  // Steps 1-2: expand, absolutize, and realpath dir. It must exist.
+  const baseDir = await resolveDir(dir);
+  const realRoot = await fs.realpath(baseDir);
+
+  // Steps 3-4: expand filename; absolute (including ~-led) is an escape.
+  const expanded = expandPath(filename);
+  if (path.isAbsolute(expanded)) {
+    throw escapeError(operation, filename, realRoot, expanded);
+  }
+
+  // Steps 5-6: lexical resolution and lexical containment.
+  const lexical = path.resolve(realRoot, expanded);
+  if (!isContained(lexical, realRoot)) {
+    throw escapeError(operation, filename, realRoot, lexical);
+  }
+
+  // Steps 7-9: resolve through existing symlinks (dangling ones fail
+  // closed) and check the resolved target too.
+  const resolved = await resolveExistingStrict(lexical);
+  if (!isContained(resolved, realRoot)) {
+    throw escapeError(operation, filename, realRoot, resolved);
+  }
+
+  // Step 10: the real dir plus the normalized relative filename. The
+  // relative form deliberately keeps in-root symlink names (spec: the
+  // payload guarantees containment, not leaf-target naming).
+  return { dir: realRoot, filename: path.relative(realRoot, lexical) };
+}
+
+/** Walk the target path component by component. Existing components are
+ *  realpathed (following healthy symlinks); a component whose lstat says
+ *  "symlink" but whose realpath fails is dangling and fails closed; a
+ *  component that simply does not exist ends the walk, and the remaining
+ *  tail is appended lexically (missing intermediates are contained, not
+ *  dangling).
+ *
+ *  This deliberately does not reuse assertContained.ts's
+ *  realpathOrLexicalAncestor: that older helper treats every realpath
+ *  error as a missing path, while this safety boundary may treat only
+ *  ENOENT as a lexical tail — loops, non-directories, permission and I/O
+ *  failures all fail closed. Do not add a second strict walk elsewhere;
+ *  reuse this one. */
+async function resolveExistingStrict(target: string): Promise<string> {
+  const parsed = path.parse(target);
+  const segments = target.slice(parsed.root.length).split(path.sep);
+  let current = parsed.root;
+  for (let i = 0; i < segments.length; i++) {
+    const next = path.join(current, segments[i]);
+    let stat;
+    try {
+      stat = await fs.lstat(next);
+    } catch (error) {
+      // Only ENOENT means the rest is a lexical tail. Permission, I/O,
+      // ELOOP, and ENOTDIR failures fail closed.
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+      return path.join(next, ...segments.slice(i + 1));
+    }
+    if (stat.isSymbolicLink()) {
+      try {
+        current = await fs.realpath(next);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+          throw error;
+        }
+        throw new Error(`refused: "${next}" is a dangling symlink.`);
+      }
+    } else {
+      current = next;
+    }
+  }
+  return current;
+}
+
+function escapeError(
+  operation: FileOperation,
+  filename: string,
+  root: string,
+  landed: string,
+): Error {
+  const preposition = operation === "write" ? "somewhere else" : "from somewhere else";
+  return new Error(
+    `${operation} refused: filename "${filename}" is outside dir "${root}" ` +
+      `(it resolves to "${landed}"). To ${operation} ${preposition}, pass that ` +
+      `directory in dir.`,
+  );
+}

--- a/packages/agency-lang/lib/stdlib/prepareContainedPath.ts
+++ b/packages/agency-lang/lib/stdlib/prepareContainedPath.ts
@@ -114,3 +114,29 @@ function escapeError(
       `directory in dir.`,
   );
 }
+
+export type TildeMode = "expand" | "literal";
+
+/**
+ * Where a safeBash redirect will actually land. safeBash has no trusted
+ * dir — the whole command is one untrusted string — so instead of
+ * containment this resolves the COMPLETE target (healthy final symlinks
+ * included, via the same strict walk: dangling links, loops, and
+ * non-directories fail closed) and splits it, so the payload's dir is the
+ * real parent the policy should judge. tildeMode is quote-aware: an
+ * unquoted `~/f` expands, a quoted one stays a literal filename.
+ */
+export async function resolveRedirectTarget(
+  target: string,
+  cwd: string,
+  tildeMode: TildeMode,
+): Promise<ContainedPath> {
+  if (cwd.trim() === "") {
+    throw new Error("redirect refused: cwd must not be empty.");
+  }
+  const baseDir = await resolveDir(cwd);
+  const expanded = tildeMode === "expand" ? expandPath(target) : target;
+  const lexical = path.resolve(baseDir, expanded);
+  const resolved = await resolveExistingStrict(lexical);
+  return { dir: path.dirname(resolved), filename: path.basename(resolved) };
+}

--- a/packages/agency-lang/lib/stdlib/prepareContainedPath.ts
+++ b/packages/agency-lang/lib/stdlib/prepareContainedPath.ts
@@ -1,6 +1,6 @@
-import fs from "fs/promises";
+import fs from "fs";
 import path from "path";
-import { resolveDir } from "./resolveDir.js";
+import { resolveCwdPath } from "./resolveDir.js";
 import { expandPath } from "./expandPath.js";
 import { isContained } from "./assertContained.js";
 
@@ -13,10 +13,9 @@ export type FileOperation = "read" | "write";
 
 /**
  * Prepare a (dir, filename) pair for a scoped single-file wrapper: the
- * returned values go into BOTH the interrupt payload and the execution.
- * Guarantees the spec's containment contract: the resolved file operand
- * stays inside the resolved dir operand, or this throws before any
- * interrupt exists. See 2026-08-20-contained-filename-spec.md.
+ * returned values feed both the interrupt payload and the execution, and
+ * any escape throws before an interrupt exists. Spec:
+ * 2026-08-20-contained-filename-spec.md.
  */
 export async function prepareContainedPath(
   dir: string,
@@ -27,8 +26,12 @@ export async function prepareContainedPath(
     throw new Error(`${operation} refused: dir must not be empty.`);
   }
   // Steps 1-2: expand, absolutize, and realpath dir. It must exist.
-  const baseDir = await resolveDir(dir);
-  const realRoot = await fs.realpath(baseDir);
+  // Sync fs throughout this module (async signature kept so rejections
+  // stay rejections): preparation runs between a wrapper's call and its
+  // interrupt, and real awaits there would hand the event loop to
+  // concurrent branches — enough for a fork sibling to finish and pop
+  // its handler before the interrupt is raised.
+  const realRoot = fs.realpathSync(resolveCwdPath(dir));
 
   // Steps 3-4: expand filename; absolute (including ~-led) is an escape.
   const expanded = expandPath(filename);
@@ -44,7 +47,7 @@ export async function prepareContainedPath(
 
   // Steps 7-9: resolve through existing symlinks (dangling ones fail
   // closed) and check the resolved target too.
-  const resolved = await resolveExistingStrict(lexical);
+  const resolved = resolveExistingStrict(lexical);
   if (!isContained(resolved, realRoot)) {
     throw escapeError(operation, filename, realRoot, resolved);
   }
@@ -55,20 +58,13 @@ export async function prepareContainedPath(
   return { dir: realRoot, filename: path.relative(realRoot, lexical) };
 }
 
-/** Walk the target path component by component. Existing components are
- *  realpathed (following healthy symlinks); a component whose lstat says
- *  "symlink" but whose realpath fails is dangling and fails closed; a
- *  component that simply does not exist ends the walk, and the remaining
- *  tail is appended lexically (missing intermediates are contained, not
- *  dangling).
- *
- *  This deliberately does not reuse assertContained.ts's
- *  realpathOrLexicalAncestor: that older helper treats every realpath
- *  error as a missing path, while this safety boundary may treat only
- *  ENOENT as a lexical tail — loops, non-directories, permission and I/O
- *  failures all fail closed. Do not add a second strict walk elsewhere;
- *  reuse this one. */
-async function resolveExistingStrict(target: string): Promise<string> {
+/** The strict walk: realpath existing components (healthy symlinks
+ *  follow), fail closed on dangling links, loops, non-directories, and
+ *  permission errors; only ENOENT ends the walk with a lexical tail.
+ *  That error taxonomy is why this cannot reuse the more forgiving
+ *  realpathOrLexicalAncestor in assertContained.ts — reuse THIS walk
+ *  rather than adding another. */
+function resolveExistingStrict(target: string): string {
   const parsed = path.parse(target);
   const segments = target.slice(parsed.root.length).split(path.sep);
   let current = parsed.root;
@@ -76,10 +72,8 @@ async function resolveExistingStrict(target: string): Promise<string> {
     const next = path.join(current, segments[i]);
     let stat;
     try {
-      stat = await fs.lstat(next);
+      stat = fs.lstatSync(next);
     } catch (error) {
-      // Only ENOENT means the rest is a lexical tail. Permission, I/O,
-      // ELOOP, and ENOTDIR failures fail closed.
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
         throw error;
       }
@@ -87,7 +81,7 @@ async function resolveExistingStrict(target: string): Promise<string> {
     }
     if (stat.isSymbolicLink()) {
       try {
-        current = await fs.realpath(next);
+        current = fs.realpathSync(next);
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
           throw error;
@@ -118,13 +112,11 @@ function escapeError(
 export type TildeMode = "expand" | "literal";
 
 /**
- * Where a safeBash redirect will actually land. safeBash has no trusted
- * dir — the whole command is one untrusted string — so instead of
- * containment this resolves the COMPLETE target (healthy final symlinks
- * included, via the same strict walk: dangling links, loops, and
- * non-directories fail closed) and splits it, so the payload's dir is the
- * real parent the policy should judge. tildeMode is quote-aware: an
- * unquoted `~/f` expands, a quoted one stays a literal filename.
+ * Where a safeBash redirect will actually land: the complete target
+ * resolved through the strict walk, split into real parent + name so the
+ * payload's dir is the destination the policy judges. No containment —
+ * safeBash has no trusted dir. tildeMode is quote-aware: unquoted
+ * expands, quoted stays literal.
  */
 export async function resolveRedirectTarget(
   target: string,
@@ -134,9 +126,9 @@ export async function resolveRedirectTarget(
   if (cwd.trim() === "") {
     throw new Error("redirect refused: cwd must not be empty.");
   }
-  const baseDir = await resolveDir(cwd);
+  const baseDir = resolveCwdPath(cwd);
   const expanded = tildeMode === "expand" ? expandPath(target) : target;
   const lexical = path.resolve(baseDir, expanded);
-  const resolved = await resolveExistingStrict(lexical);
+  const resolved = resolveExistingStrict(lexical);
   return { dir: path.dirname(resolved), filename: path.basename(resolved) };
 }

--- a/packages/agency-lang/stdlib/agency.agency
+++ b/packages/agency-lang/stdlib/agency.agency
@@ -17,6 +17,7 @@ import {
   _filterImports,
   _subprocessDepth,
  } from "agency-lang/stdlib-lib/agency.js"
+import { _prepareContainedPath } from "agency-lang/stdlib-lib/fs.js"
 import {
   _loadTemplate,
   _holesOf,
@@ -478,13 +479,18 @@ export idempotent def typecheckFile(dir: string, filename: string): Result {
   with relative imports inside it resolved against the file's directory.
 
   @param dir - The directory containing the file
-  @param filename - The agency file to type-check
+  @param filename - The agency file to type-check. Must stay inside dir; to
+    read another directory, pass it in `dir`.
   """
+  const prepared = try _prepareContainedPath(dir, filename, "read")
+  if (isFailure(prepared)) {
+    return prepared
+  }
   return interrupt std::read("Are you sure you want to read this file?", {
-    dir: dir,
-    filename: filename
+    dir: prepared.value.dir,
+    filename: prepared.value.filename
   })
-  return try _typecheckFile(dir, filename)
+  return try _typecheckFile(prepared.value.dir, prepared.value.filename)
 }
 
 /** A parsed Agency program, the value `parseAST` returns on success.
@@ -524,12 +530,16 @@ export def writeAST(
   @param filename - The agency file to write, resolved relative to dir
   @param overwrite - If false, fail when the file already exists (default true)
   """
+  const prepared = try _prepareContainedPath(dir, filename, "write")
+  if (isFailure(prepared)) {
+    return prepared
+  }
   return interrupt std::write("Are you sure you want to write this file?", {
-    dir: dir,
-    filename: filename,
+    dir: prepared.value.dir,
+    filename: prepared.value.filename,
     overwrite: overwrite
   })
-  return try _writeAST(ast, dir, filename, overwrite)
+  return try _writeAST(ast, prepared.value.dir, prepared.value.filename, overwrite)
 }
 
 export idempotent def format(source: string): Result {
@@ -565,13 +575,18 @@ export def loadTemplate(dir: string, filename: string): Result<Code> {
   Load an Agency file containing holes as a template.
 
   @param dir - The sandbox directory
-  @param filename - The template file, resolved relative to dir
+  @param filename - The template file, resolved relative to dir. Must stay
+    inside dir; to read another directory, pass it in `dir`.
   """
+  const prepared = try _prepareContainedPath(dir, filename, "read")
+  if (isFailure(prepared)) {
+    return prepared
+  }
   return interrupt std::read("Can I read this template?", {
-    dir: dir,
-    filename: filename
+    dir: prepared.value.dir,
+    filename: prepared.value.filename
   })
-  return try _loadTemplate(dir, filename)
+  return try _loadTemplate(prepared.value.dir, prepared.value.filename)
 }
 
 export idempotent def holesOf(template: Code): HoleInfo[] {
@@ -640,13 +655,18 @@ export idempotent def formatFile(dir: string, filename: string): Result {
   Format an Agency file in place using the standard Agency formatter.
 
   @param dir - The directory containing the file
-  @param filename - The agency file to format
+  @param filename - The agency file to format. Must stay inside dir; to
+    write another directory, pass it in `dir`.
   """
+  const prepared = try _prepareContainedPath(dir, filename, "write")
+  if (isFailure(prepared)) {
+    return prepared
+  }
   return interrupt std::write("Are you sure you want to format this file in place?", {
-    dir: dir,
-    filename: filename
+    dir: prepared.value.dir,
+    filename: prepared.value.filename
   })
-  return try _formatFile(dir, filename)
+  return try _formatFile(prepared.value.dir, prepared.value.filename)
 }
 
 /**

--- a/packages/agency-lang/stdlib/fs.agency
+++ b/packages/agency-lang/stdlib/fs.agency
@@ -1,4 +1,4 @@
-import { _multiedit, _previewEdit, _applyPatch, _mkdir, _copy, _move, _remove } from "agency-lang/stdlib-lib/fs.js"
+import { _multiedit, _previewEdit, _applyPatch, _mkdir, _copy, _move, _remove, _prepareContainedPath } from "agency-lang/stdlib-lib/fs.js"
 import { bash, glob, ls, grep } from "std::shell"
 import { applyAgentCwd } from "std::index"
 
@@ -51,7 +51,9 @@ export def edit(filename: string, edits: Edit[], dir: string = ".", useAgentCwd:
 
   Prefer one call with multiple edits over many separate calls. Keep each oldText as small as possible while still matching uniquely. Do not pad with unchanged context to bridge distant changes; split them into separate edits instead.
 
-  @param filename - The file to edit
+  @param filename - The file to edit. Must stay inside dir: no absolute
+    paths, `~`, upward traversal, or symlinks that leave it. To edit another
+    directory, pass it in `dir`.
   @param edits - Text replacements to apply in order; each has oldText, newText, and replaceAll (replace every occurrence when true)
   @param dir - The directory to resolve the filename against
   @param useAgentCwd - When true, resolve a relative path against the agent working directory if one is set
@@ -59,17 +61,23 @@ export def edit(filename: string, edits: Edit[], dir: string = ".", useAgentCwd:
   if (useAgentCwd) {
     dir = applyAgentCwd(dir)
   }
-  const preview = _previewEdit(dir, filename, edits)
+  // Prepared BEFORE the preview: the preview, the interrupt payload, and
+  // the eventual write must all refer to the same spelling.
+  const prepared = try _prepareContainedPath(dir, filename, "write")
+  if (isFailure(prepared)) {
+    return prepared
+  }
+  const preview = _previewEdit(prepared.value.dir, prepared.value.filename, edits)
   return interrupt std::edit("Are you sure you want to apply these edits?", {
-    dir: dir,
-    filename: filename,
+    dir: prepared.value.dir,
+    filename: prepared.value.filename,
     edits: edits,
     before: preview.before,
     after: preview.after
   })
 
   destructive {
-    return try _multiedit(dir, filename, edits)
+    return try _multiedit(prepared.value.dir, prepared.value.filename, edits)
   }
 }
 

--- a/packages/agency-lang/stdlib/index.agency
+++ b/packages/agency-lang/stdlib/index.agency
@@ -17,6 +17,7 @@ import {
   _pairsOf as _pairsOfImpl,
  } from "agency-lang/stdlib-lib/builtins.js"
 import { _resolve } from "agency-lang/stdlib-lib/path.js"
+import { _prepareContainedPath } from "agency-lang/stdlib-lib/fs.js"
 import {
   syntaxHighlight as _syntaxHighlight,
  } from "agency-lang/stdlib-lib/syntax.js"
@@ -171,7 +172,9 @@ export idempotent def read(
   """
   Read the contents of a file and return it as a string.
 
-  @param filename - The file to read
+  @param filename - The file to read. Must stay inside dir: no absolute
+    paths, `~`, upward traversal, or symlinks that leave it. To touch another
+    directory, pass it in `dir`.
   @param dir - The directory to resolve the filename against (defaults to ".")
   @param offset - 1-indexed line to start at (0 means start of file)
   @param limit - Maximum number of lines to return (0 means read to end of file)
@@ -180,13 +183,17 @@ export idempotent def read(
   if (useAgentCwd) {
     dir = applyAgentCwd(dir)
   }
+  const prepared = try _prepareContainedPath(dir, filename, "read")
+  if (isFailure(prepared)) {
+    return prepared
+  }
   return interrupt std::read("Are you sure you want to read this file?", {
-    dir: dir,
-    filename: filename,
+    dir: prepared.value.dir,
+    filename: prepared.value.filename,
     offset: offset,
     limit: limit
   })
-  return try _read(dir, filename, offset, limit)
+  return try _read(prepared.value.dir, prepared.value.filename, offset, limit)
 }
 
 export def write(
@@ -199,7 +206,9 @@ export def write(
   """
   Write content to a file.
 
-  @param filename - The file to write
+  @param filename - The file to write. Must stay inside dir: no absolute
+    paths, `~`, upward traversal, or symlinks that leave it. To touch another
+    directory, pass it in `dir`.
   @param content - The content to write
   @param dir - The directory to resolve the filename against (defaults to ".")
   @param mode - How to handle an existing file
@@ -208,14 +217,18 @@ export def write(
   if (useAgentCwd) {
     dir = applyAgentCwd(dir)
   }
+  const prepared = try _prepareContainedPath(dir, filename, "write")
+  if (isFailure(prepared)) {
+    return prepared
+  }
   return interrupt std::write("Are you sure you want to write to this file?", {
-    dir: dir,
-    filename: filename,
+    dir: prepared.value.dir,
+    filename: prepared.value.filename,
     content: content,
     mode: mode
   })
   destructive {
-    return try _write(dir, filename, content, mode)
+    return try _write(prepared.value.dir, prepared.value.filename, content, mode)
   }
 }
 
@@ -230,7 +243,9 @@ export def writeBinary(
   Write base64-encoded binary data to a file: images, audio, video, PDFs, or any
   binary. Decodes the base64 and writes raw bytes rather than UTF-8 text.
 
-  @param filename - The file to write
+  @param filename - The file to write. Must stay inside dir: no absolute
+    paths, `~`, upward traversal, or symlinks that leave it. To touch another
+    directory, pass it in `dir`.
   @param base64 - The binary content, base64-encoded
   @param dir - The directory to resolve the filename against (defaults to ".")
   @param mode - How to handle an existing file
@@ -239,13 +254,17 @@ export def writeBinary(
   if (useAgentCwd) {
     dir = applyAgentCwd(dir)
   }
+  const prepared = try _prepareContainedPath(dir, filename, "write")
+  if (isFailure(prepared)) {
+    return prepared
+  }
   return interrupt std::writeBinary("Are you sure you want to write this file?", {
-    dir: dir,
-    filename: filename,
+    dir: prepared.value.dir,
+    filename: prepared.value.filename,
     mode: mode
   })
   destructive {
-    return try _writeBinary(dir, filename, base64, mode)
+    return try _writeBinary(prepared.value.dir, prepared.value.filename, base64, mode)
   }
 }
 
@@ -258,18 +277,24 @@ export idempotent def readBinary(
   Read a file and return its contents as a Base64-encoded string. Works for any
   binary file: images, audio, video, PDFs.
 
-  @param filename - The file to read
+  @param filename - The file to read. Must stay inside dir: no absolute
+    paths, `~`, upward traversal, or symlinks that leave it. To touch another
+    directory, pass it in `dir`.
   @param dir - The directory to resolve the filename against (defaults to ".")
   @param useAgentCwd - Resolve relative paths against the agent working directory instead of dir
   """
   if (useAgentCwd) {
     dir = applyAgentCwd(dir)
   }
+  const prepared = try _prepareContainedPath(dir, filename, "read")
+  if (isFailure(prepared)) {
+    return prepared
+  }
   return interrupt std::readBinary("Are you sure you want to read this file?", {
-    dir: dir,
-    filename: filename
+    dir: prepared.value.dir,
+    filename: prepared.value.filename
   })
-  return try _readBinary(dir, filename)
+  return try _readBinary(prepared.value.dir, prepared.value.filename)
 }
 
 export def range(start: number, end: number = -1): number[] {

--- a/packages/agency-lang/stdlib/safeBash.agency
+++ b/packages/agency-lang/stdlib/safeBash.agency
@@ -174,11 +174,8 @@ def flagNames(command: SimpleCommand): string[] {
   return out
 }
 
-/** Quote-aware tilde behavior for a redirect target: bash expands `~`
-  only when it is unquoted, so `> ~/f` writes to the home directory while
-  `> '~/f'` and `> "~/f"` name a literal `~/f` beneath the cwd. Only the
-  unquoted word tags expand; everything literalTarget accepts and this
-  does not list stays literal. */
+/** Bash expands `~` only when unquoted, so only the unquoted word tags
+  expand; everything else literalTarget accepts stays literal. */
 def tildeModeFor(word: Word): string {
   return match(word) {
     { tag: "literal" } => "expand"
@@ -187,13 +184,10 @@ def tildeModeFor(word: Word): string {
   }
 }
 
-/** The ONE owner of redirect-write preparation: validates the redirect
-  shape, extracts the fully literal target (a variable target fails, which
-  sends the whole command to the broad std::bash question), applies
-  quote-aware tilde behavior, resolves the complete stable target through
-  the strict symlink walk (dangling links and loops fail, same fallback),
-  and returns the shared payload both the effect and the execution derive
-  from. Neither caller repeats any of this choreography. */
+/** The one owner of redirect-write preparation: validate the redirect,
+  extract the literal target, resolve it (quote-aware tilde, strict
+  symlink walk), and return the payload both plan sides derive from. Any
+  failure sends the whole command to the broad std::bash question. */
 def prepareRedirectWrite(redirect: Redirect, cwd: string, content: string): Result<WritePayload> {
   if (redirect.fd != null) {
     return failure("redirect with an explicit file descriptor")

--- a/packages/agency-lang/stdlib/safeBash.agency
+++ b/packages/agency-lang/stdlib/safeBash.agency
@@ -10,11 +10,16 @@ import { bash } from "std::shell"
 import {
   Effect,
   Plan,
+  WritePayload,
+  WriteExec,
+  writeEffect,
+  writeExecution,
   runBash,
   runWrite,
   truncate,
  } from "./safeBash/actions.agency"
 import { _bashParser, _astToBash } from "agency-lang/stdlib-lib/safeBash.js"
+import { _resolveRedirectTarget } from "agency-lang/stdlib-lib/fs.js"
 
 export { MAX_STDOUT_LEN } from "./safeBash/actions.agency"
 
@@ -169,6 +174,49 @@ def flagNames(command: SimpleCommand): string[] {
   return out
 }
 
+/** Quote-aware tilde behavior for a redirect target: bash expands `~`
+  only when it is unquoted, so `> ~/f` writes to the home directory while
+  `> '~/f'` and `> "~/f"` name a literal `~/f` beneath the cwd. Only the
+  unquoted word tags expand; everything literalTarget accepts and this
+  does not list stays literal. */
+def tildeModeFor(word: Word): string {
+  return match(word) {
+    { tag: "literal" } => "expand"
+    { tag: "path" } => "expand"
+    _ => "literal"
+  }
+}
+
+/** The ONE owner of redirect-write preparation: validates the redirect
+  shape, extracts the fully literal target (a variable target fails, which
+  sends the whole command to the broad std::bash question), applies
+  quote-aware tilde behavior, resolves the complete stable target through
+  the strict symlink walk (dangling links and loops fail, same fallback),
+  and returns the shared payload both the effect and the execution derive
+  from. Neither caller repeats any of this choreography. */
+def prepareRedirectWrite(redirect: Redirect, cwd: string, content: string): Result<WritePayload> {
+  if (redirect.fd != null) {
+    return failure("redirect with an explicit file descriptor")
+  }
+  if (redirect.op != ">" && redirect.op != ">>") {
+    return failure("`${redirect.op}` is not an output redirect")
+  }
+  const target = literalTarget(redirect.target)
+  if (target is failure(why)) {
+    return failure(why)
+  }
+  const resolved = try _resolveRedirectTarget(target.value, cwd, tildeModeFor(redirect.target))
+  if (resolved is failure(why)) {
+    return failure("${why}")
+  }
+  return success({
+    dir: resolved.value.dir,
+    filename: resolved.value.filename,
+    content: content,
+    mode: writeMode(redirect.op)
+  })
+}
+
 def redirectEffect(redirects: Redirect[], cwd: string): Result<Effect[]> {
   """
   What a command's redirects contribute, independently of its verb.
@@ -190,30 +238,11 @@ def redirectEffect(redirects: Redirect[], cwd: string): Result<Effect[]> {
     return failure("more than one redirect")
   }
   const only = redirects[0]
-  if (only.fd != null) {
-    return failure("redirect with an explicit file descriptor")
-  }
-  if (only.op != ">" && only.op != ">>") {
-    return failure("`${only.op}` is not an output redirect")
-  }
-  const target = literalTarget(only.target)
-  if (target is failure(why)) {
+  const prepared = prepareRedirectWrite(only, cwd, "")
+  if (prepared is failure(why)) {
     return failure(why)
   }
-  const mode = writeMode(only.op)
-  return success(
-    [
-    {
-    name: "std::write",
-    payload: {
-      dir: cwd,
-      filename: target.value,
-      content: "",
-      mode: mode
-    }
-  },
-  ],
-  )
+  return success([writeEffect(prepared.value)])
 }
 
 def literalTarget(word: Word): Result<string> {
@@ -563,41 +592,18 @@ def writePlan(command: SimpleCommand, cwd: string): Result<Plan> {
     return failure("`echo` with flags prints differently")
   }
   const only = command.redirects[0]
-  if (only.fd != null) {
-    return failure("redirect with an explicit file descriptor")
-  }
-  if (only.op != ">" && only.op != ">>") {
-    return failure("`${only.op}` is not an output redirect")
-  }
-  const target = literalTarget(only.target)
-  if (target is failure(why)) {
-    return failure(why)
-  }
   const words = echoWords(command)
   if (words is failure(why)) {
     return failure(why)
   }
-  const content = echoOutput(words.value)
-  const mode = writeMode(only.op)
-  const effect: Effect = {
-    name: "std::write",
-    payload: {
-      dir: cwd,
-      filename: target.value,
-      content: content,
-      mode: mode
-    }
+  const prepared = prepareRedirectWrite(only, cwd, echoOutput(words.value))
+  if (prepared is failure(why)) {
+    return failure(why)
   }
   return success(
     {
-    effects: [effect],
-    execution: {
-      kind: "write",
-      filename: target.value,
-      dir: cwd,
-      content: content,
-      mode: mode
-    }
+    effects: [writeEffect(prepared.value)],
+    execution: writeExecution(prepared.value)
   },
   )
 }

--- a/packages/agency-lang/stdlib/safeBash/actions.agency
+++ b/packages/agency-lang/stdlib/safeBash/actions.agency
@@ -38,9 +38,8 @@ export type WritePayload = {
   mode: WriteMode
 }
 
-/** The one shared description of a planned redirect write. Both the
-  approval side (writeEffect) and the execution side (writeExecution)
-  derive from it, so payload/execution parity holds by construction. */
+/** Both plan sides derive from one WritePayload, so payload/execution
+  parity holds by construction. */
 export def writeEffect(write: WritePayload): Effect {
   return {
     name: "std::write",

--- a/packages/agency-lang/stdlib/safeBash/actions.agency
+++ b/packages/agency-lang/stdlib/safeBash/actions.agency
@@ -38,6 +38,26 @@ export type WritePayload = {
   mode: WriteMode
 }
 
+/** The one shared description of a planned redirect write. Both the
+  approval side (writeEffect) and the execution side (writeExecution)
+  derive from it, so payload/execution parity holds by construction. */
+export def writeEffect(write: WritePayload): Effect {
+  return {
+    name: "std::write",
+    payload: write
+  }
+}
+
+export def writeExecution(write: WritePayload): WriteExec {
+  return {
+    kind: "write",
+    filename: write.filename,
+    dir: write.dir,
+    content: write.content,
+    mode: write.mode
+  }
+}
+
 export type GitDiffPayload = {
   cwd: string;
   ref: string;

--- a/packages/agency-lang/tests/agency-js/contained-filename-wrappers/agent.agency
+++ b/packages/agency-lang/tests/agency-js/contained-filename-wrappers/agent.agency
@@ -1,0 +1,188 @@
+import { write, read, writeBinary, readBinary } from "std::index"
+import { remove, edit } from "std::fs"
+import { typecheckFile, writeAST, loadTemplate, formatFile, parseAST } from "std::agency"
+
+// One recording slot, reset before each wrapper call. The handler stores
+// the interrupt payload so the test can prove the wrapper raised the
+// PREPARED values (real dir, normalized filename), not the raw arguments.
+let recorded: any = null
+
+def payloadMatches(realDir: string, filename: string): boolean {
+  if (recorded == null) {
+    return false
+  }
+  return recorded.dir == realDir && recorded.filename == filename
+}
+
+def checkWrite(realDir: string, linkDir: string): boolean {
+  recorded = null
+  handle {
+    write("nested/../probe.txt", "cf", linkDir)
+  } with (interrupt) {
+    recorded = interrupt.data
+    return approve()
+  }
+  const back = read("probe.txt", realDir) with approve
+  remove(realDir + "/probe.txt") with approve
+  if (back is success(content)) {
+    return payloadMatches(realDir, "probe.txt") && content == "cf"
+  }
+  return false
+}
+
+def checkRead(realDir: string, linkDir: string): boolean {
+  write("probe-read.txt", "cf-read", realDir) with approve
+  recorded = null
+  let value = ""
+  handle {
+    const r = read("nested/../probe-read.txt", linkDir)
+    if (r is success(content)) {
+      value = content
+    }
+  } with (interrupt) {
+    recorded = interrupt.data
+    return approve()
+  }
+  remove(realDir + "/probe-read.txt") with approve
+  return payloadMatches(realDir, "probe-read.txt") && value == "cf-read"
+}
+
+def checkWriteBinary(realDir: string, linkDir: string): boolean {
+  recorded = null
+  handle {
+    writeBinary("nested/../probe.bin", "aGk=", linkDir)
+  } with (interrupt) {
+    recorded = interrupt.data
+    return approve()
+  }
+  const back = readBinary("probe.bin", realDir) with approve
+  remove(realDir + "/probe.bin") with approve
+  if (back is success(content)) {
+    return payloadMatches(realDir, "probe.bin") && content == "aGk="
+  }
+  return false
+}
+
+def checkReadBinary(realDir: string, linkDir: string): boolean {
+  writeBinary("probe-rb.bin", "aGk=", realDir) with approve
+  recorded = null
+  let value = ""
+  handle {
+    const r = readBinary("nested/../probe-rb.bin", linkDir)
+    if (r is success(content)) {
+      value = content
+    }
+  } with (interrupt) {
+    recorded = interrupt.data
+    return approve()
+  }
+  remove(realDir + "/probe-rb.bin") with approve
+  return payloadMatches(realDir, "probe-rb.bin") && value == "aGk="
+}
+
+
+def checkEdit(realDir: string, linkDir: string): boolean {
+  write("probe-edit.txt", "before-text", realDir) with approve
+  recorded = null
+  handle {
+    edit("nested/../probe-edit.txt", [{ oldText: "before", newText: "after", replaceAll: false }], linkDir)
+  } with (interrupt) {
+    recorded = interrupt.data
+    return approve()
+  }
+  const back = read("probe-edit.txt", realDir) with approve
+  remove(realDir + "/probe-edit.txt") with approve
+  if (recorded == null) {
+    return false
+  }
+  const target = recorded.dir == realDir && recorded.filename == "probe-edit.txt"
+  const preview = recorded.before == "before-text" && recorded.after == "after-text"
+  const payloadOk = target && preview
+  if (back is success(content)) {
+    return payloadOk && content == "after-text"
+  }
+  return false
+}
+
+static const TINY_PROGRAM = "node main() {\n  return 1\n}\n"
+
+def checkTypecheckFile(realDir: string, linkDir: string): boolean {
+  write("probe-tc.agency", TINY_PROGRAM, realDir) with approve
+  recorded = null
+  let ok = false
+  handle {
+    const r = typecheckFile(linkDir, "nested/../probe-tc.agency")
+    ok = !isFailure(r)
+  } with (interrupt) {
+    recorded = interrupt.data
+    return approve()
+  }
+  remove(realDir + "/probe-tc.agency") with approve
+  return payloadMatches(realDir, "probe-tc.agency") && ok
+}
+
+def checkWriteAST(realDir: string, linkDir: string): boolean {
+  const parsed = parseAST(TINY_PROGRAM)
+  if (parsed is failure(e)) {
+    return false
+  }
+  recorded = null
+  handle {
+    writeAST(parsed.value, linkDir, "nested/../probe-ast.agency")
+  } with (interrupt) {
+    recorded = interrupt.data
+    return approve()
+  }
+  const back = read("probe-ast.agency", realDir) with approve
+  remove(realDir + "/probe-ast.agency") with approve
+  if (back is success(content)) {
+    return payloadMatches(realDir, "probe-ast.agency") && content =~ re/node main/
+  }
+  return false
+}
+
+def checkLoadTemplate(realDir: string, linkDir: string): boolean {
+  write("probe-tpl.agency", TINY_PROGRAM, realDir) with approve
+  recorded = null
+  let ok = false
+  handle {
+    const r = loadTemplate(linkDir, "nested/../probe-tpl.agency")
+    ok = !isFailure(r)
+  } with (interrupt) {
+    recorded = interrupt.data
+    return approve()
+  }
+  remove(realDir + "/probe-tpl.agency") with approve
+  return payloadMatches(realDir, "probe-tpl.agency") && ok
+}
+
+def checkFormatFile(realDir: string, linkDir: string): boolean {
+  write("probe-fmt.agency", TINY_PROGRAM, realDir) with approve
+  recorded = null
+  handle {
+    formatFile(linkDir, "nested/../probe-fmt.agency")
+  } with (interrupt) {
+    recorded = interrupt.data
+    return approve()
+  }
+  const back = read("probe-fmt.agency", realDir) with approve
+  remove(realDir + "/probe-fmt.agency") with approve
+  if (back is success(content)) {
+    return payloadMatches(realDir, "probe-fmt.agency") && content =~ re/node main/
+  }
+  return false
+}
+
+node main(args: { realDir: string; linkDir: string }): any {
+  return {
+    write: checkWrite(args.realDir, args.linkDir),
+    read: checkRead(args.realDir, args.linkDir),
+    writeBinary: checkWriteBinary(args.realDir, args.linkDir),
+    readBinary: checkReadBinary(args.realDir, args.linkDir),
+    edit: checkEdit(args.realDir, args.linkDir),
+    typecheckFile: checkTypecheckFile(args.realDir, args.linkDir),
+    writeAST: checkWriteAST(args.realDir, args.linkDir),
+    loadTemplate: checkLoadTemplate(args.realDir, args.linkDir),
+    formatFile: checkFormatFile(args.realDir, args.linkDir)
+  }
+}

--- a/packages/agency-lang/tests/agency-js/contained-filename-wrappers/fixture.json
+++ b/packages/agency-lang/tests/agency-js/contained-filename-wrappers/fixture.json
@@ -1,0 +1,11 @@
+{
+  "write": true,
+  "read": true,
+  "writeBinary": true,
+  "readBinary": true,
+  "edit": true,
+  "typecheckFile": true,
+  "writeAST": true,
+  "loadTemplate": true,
+  "formatFile": true
+}

--- a/packages/agency-lang/tests/agency-js/contained-filename-wrappers/test.js
+++ b/packages/agency-lang/tests/agency-js/contained-filename-wrappers/test.js
@@ -1,0 +1,20 @@
+import { main } from "./agent.js";
+import { writeFileSync, mkdtempSync, mkdirSync, symlinkSync, rmSync, realpathSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+// A real directory plus a symlink to it: every wrapper is called through
+// the LINK with an un-normalized filename, and the recording handler in
+// agent.agency approves only payloads carrying the REAL dir and the
+// normalized filename.
+const base = mkdtempSync(join(tmpdir(), "cf-wrappers-"));
+try {
+  const real = join(base, "real");
+  mkdirSync(real);
+  const linkDir = join(base, "dir-link");
+  symlinkSync(real, linkDir);
+  const result = await main({ realDir: realpathSync(real), linkDir });
+  writeFileSync("__result.json", JSON.stringify(result.data, null, 2));
+} finally {
+  rmSync(base, { recursive: true, force: true });
+}

--- a/packages/agency-lang/tests/agency-js/contained-filenames-policy/agent.agency
+++ b/packages/agency-lang/tests/agency-js/contained-filenames-policy/agent.agency
@@ -1,0 +1,73 @@
+import { cliPolicyHandler } from "std::policy"
+import { write } from "std::index"
+
+// Inner recording handler + outer noninteractive policy: the recorder
+// proves WHAT the policy was shown (the prepared dir), and handlerReached
+// proves WHETHER an interrupt existed at all — escapes must fail in
+// preparation with the flag still false.
+let recorded: any = null
+let handlerReached = false
+
+def recordedDir(): string {
+  if (recorded == null) {
+    return ""
+  }
+  return recorded.dir
+}
+
+def attempt(filename: string, dir: string): any {
+  recorded = null
+  handlerReached = false
+  const r = try write(filename, "cf-e2e", dir)
+  let outcome = "ok"
+  if (isFailure(r)) {
+    if ("${r.error}" =~ re/pass that directory in dir/) {
+      outcome = "prep-rejected"
+    } else {
+      outcome = "policy-rejected"
+    }
+  }
+  return {
+    outcome: outcome,
+    reached: handlerReached,
+    dir: recordedDir()
+  }
+}
+
+node main(args: {
+  policyFile: string;
+  workDir: string;
+  outsideDir: string;
+  homeProbe: string
+}): any {
+  const policyHandler = cliPolicyHandler(
+    file: args.policyFile,
+    fields: {},
+    interactive: false,
+  )
+  let results: any = {}
+  handle {
+    handle {
+      results = {
+        outsideDir: attempt("report.txt", args.outsideDir),
+        workDir: attempt("report.txt", args.workDir),
+        tildeEscape: attempt(args.homeProbe, args.workDir),
+        absoluteEscape: attempt(args.outsideDir + "/abs-escape.txt", args.workDir),
+        upwardEscape: attempt("../outside/up-escape.txt", args.workDir),
+        outLinkEscape: attempt("out-link/link-escape.txt", args.workDir),
+        inLinkWrite: attempt("in-link/linked.txt", args.workDir),
+        dirLinkWrite: attempt("f.txt", args.workDir + "/../dir-link")
+      }
+    } with (interrupt) {
+      // Only the write under test: the policy handler lazily reads its
+      // policy.json through this same chain on its first decision, and
+      // that read must not clobber the recorded write payload.
+      if (interrupt.effect == "std::write") {
+        handlerReached = true
+        recorded = interrupt.data
+      }
+      return pass()
+    }
+  } with policyHandler
+  return results
+}

--- a/packages/agency-lang/tests/agency-js/contained-filenames-policy/fixture.json
+++ b/packages/agency-lang/tests/agency-js/contained-filenames-policy/fixture.json
@@ -1,0 +1,11 @@
+{
+  "outsideRejectedByPolicy": true,
+  "workApproved": true,
+  "noOutsideReport": true,
+  "tildePrep": true,
+  "absolutePrep": true,
+  "upwardPrep": true,
+  "outLinkPrep": true,
+  "inLinkApproved": true,
+  "dirLinkRejected": true
+}

--- a/packages/agency-lang/tests/agency-js/contained-filenames-policy/test.js
+++ b/packages/agency-lang/tests/agency-js/contained-filenames-policy/test.js
@@ -1,0 +1,76 @@
+import { main } from "./agent.js";
+import {
+  writeFileSync, readFileSync, mkdtempSync, mkdirSync, symlinkSync, rmSync,
+  realpathSync, existsSync,
+} from "fs";
+import { join } from "path";
+import { tmpdir, homedir } from "os";
+import { randomBytes } from "crypto";
+
+// One unique base holding work/, outside/, and every symlink; a policy
+// that approves std::write ONLY under the real workdir. Cleaned in
+// finally, assertion failures included.
+const base = mkdtempSync(join(tmpdir(), "cf-policy-"));
+const homeProbeName = `.agency-contained-test-${randomBytes(6).toString("hex")}`;
+const homeProbePath = join(homedir(), homeProbeName);
+if (existsSync(homeProbePath)) {
+  throw new Error(`home probe already exists: ${homeProbePath}`);
+}
+try {
+  const work = join(base, "work");
+  const outside = join(base, "outside");
+  mkdirSync(work);
+  mkdirSync(outside);
+  mkdirSync(join(work, "real-sub"));
+  symlinkSync(outside, join(work, "out-link"));
+  symlinkSync(join(work, "real-sub"), join(work, "in-link"));
+  symlinkSync(outside, join(base, "dir-link"));
+  const realWork = realpathSync(work);
+  const realOutside = realpathSync(outside);
+
+  const policyFile = join(base, "policy.json");
+  writeFileSync(policyFile, JSON.stringify({
+    "std::write": [
+      { match: { dir: `{${realWork},${realWork}/**}` }, action: "approve" },
+    ],
+  }));
+
+  const result = await main({
+    policyFile,
+    workDir: work,
+    outsideDir: outside,
+    homeProbe: `~/${homeProbeName}`,
+  });
+  const r = result.data;
+
+  writeFileSync("__result.json", JSON.stringify({
+    // The migrated destination rule: dir carries the destination, the
+    // policy judges it truthfully in both directions.
+    outsideRejectedByPolicy: r.outsideDir.outcome === "policy-rejected"
+      && r.outsideDir.reached && r.outsideDir.dir === realOutside,
+    workApproved: r.workDir.outcome === "ok"
+      && readFileSync(join(work, "report.txt"), "utf8") === "cf-e2e",
+    noOutsideReport: !existsSync(join(outside, "report.txt")),
+    // Escapes die in preparation: the handler never sees them.
+    tildePrep: r.tildeEscape.outcome === "prep-rejected" && !r.tildeEscape.reached
+      && !existsSync(homeProbePath),
+    absolutePrep: r.absoluteEscape.outcome === "prep-rejected" && !r.absoluteEscape.reached
+      && !existsSync(join(outside, "abs-escape.txt")),
+    upwardPrep: r.upwardEscape.outcome === "prep-rejected" && !r.upwardEscape.reached
+      && !existsSync(join(outside, "up-escape.txt")),
+    // Stable symlinks: an escaping one dies in preparation, an in-work one
+    // is approved and lands on the real target.
+    outLinkPrep: r.outLinkEscape.outcome === "prep-rejected" && !r.outLinkEscape.reached
+      && !existsSync(join(outside, "link-escape.txt")),
+    inLinkApproved: r.inLinkWrite.outcome === "ok"
+      && readFileSync(join(work, "real-sub", "linked.txt"), "utf8") === "cf-e2e",
+    // A symlink supplied AS dir: the interrupt reports the real outside
+    // path, the workdir policy rejects it, and nothing is created.
+    dirLinkRejected: r.dirLinkWrite.outcome === "policy-rejected"
+      && r.dirLinkWrite.reached && r.dirLinkWrite.dir === realOutside
+      && !existsSync(join(outside, "f.txt")),
+  }, null, 2));
+} finally {
+  rmSync(base, { recursive: true, force: true });
+  rmSync(homeProbePath, { force: true });
+}

--- a/packages/agency-lang/tests/agency-js/safe-bash-redirect-paths/agent.agency
+++ b/packages/agency-lang/tests/agency-js/safe-bash-redirect-paths/agent.agency
@@ -1,0 +1,43 @@
+import { planFor, safeBash } from "std::safeBash"
+
+// Real-symlink redirect behavior, with fixtures the JS side creates:
+// a final symlink resolves to its real target in the plan and the write
+// lands there; dangling links and loops cannot be narrowed, so the plan
+// falls back to the broad std::bash question.
+node main(args: {
+  base: string;
+  realTargetDir: string;
+  linkPath: string;
+  danglePath: string;
+  loopPath: string
+}): any {
+  const linkPlan = planFor("echo via-link > ${args.linkPath}", args.base)
+  const linkFields = match(linkPlan.execution) {
+    { kind: "write", dir, filename, mode } => {
+      return { kind: "write", dir: dir, filename: filename, mode: mode }
+    }
+    { kind } => {
+      return { kind: kind }
+    }
+  }
+
+  let writeResult = ""
+  handle {
+    const r = safeBash("echo via-link > ${args.linkPath}", args.base)
+    if (r is success(out)) {
+      writeResult = "ok"
+    } else {
+      writeResult = "failed: ${r.error}"
+    }
+  } with approve
+
+  const danglePlan = planFor("echo x > ${args.danglePath}", args.base)
+  const loopPlan = planFor("echo x > ${args.loopPath}", args.base)
+
+  return {
+    linkFields: linkFields,
+    writeResult: writeResult,
+    dangleKind: danglePlan.execution.kind,
+    loopKind: loopPlan.execution.kind
+  }
+}

--- a/packages/agency-lang/tests/agency-js/safe-bash-redirect-paths/fixture.json
+++ b/packages/agency-lang/tests/agency-js/safe-bash-redirect-paths/fixture.json
@@ -1,0 +1,9 @@
+{
+  "planReportsRealParent": true,
+  "planReportsRealName": true,
+  "planMode": "overwrite",
+  "writeResult": "ok",
+  "realTargetReceivedWrite": true,
+  "dangleFallsBackToBash": true,
+  "loopFallsBackToBash": true
+}

--- a/packages/agency-lang/tests/agency-js/safe-bash-redirect-paths/test.js
+++ b/packages/agency-lang/tests/agency-js/safe-bash-redirect-paths/test.js
@@ -1,0 +1,42 @@
+import { main } from "./agent.js";
+import { writeFileSync, readFileSync, mkdtempSync, mkdirSync, symlinkSync, rmSync, realpathSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+// Real symlinks on disk: a healthy final link must resolve to its target
+// in the PLAN (payload truth) and receive the write; dangling links and
+// loops cannot be narrowed and fall back to the broad bash plan.
+const base = mkdtempSync(join(tmpdir(), "sb-redirect-"));
+try {
+  const realTargetDir = join(base, "real");
+  mkdirSync(realTargetDir);
+  writeFileSync(join(realTargetDir, "target.txt"), "old");
+  const linkPath = join(base, "final-link");
+  symlinkSync(join(realTargetDir, "target.txt"), linkPath);
+  const danglePath = join(base, "dangle");
+  symlinkSync(join(base, "missing"), danglePath);
+  const loopA = join(base, "loopA");
+  const loopB = join(base, "loopB");
+  symlinkSync(loopB, loopA);
+  symlinkSync(loopA, loopB);
+
+  const result = await main({
+    base,
+    realTargetDir: realpathSync(realTargetDir),
+    linkPath,
+    danglePath,
+    loopPath: loopA,
+  });
+  const out = result.data;
+  writeFileSync("__result.json", JSON.stringify({
+    planReportsRealParent: out.linkFields.dir === realpathSync(realTargetDir),
+    planReportsRealName: out.linkFields.filename === "target.txt",
+    planMode: out.linkFields.mode,
+    writeResult: out.writeResult,
+    realTargetReceivedWrite: readFileSync(join(realTargetDir, "target.txt"), "utf8").trim() === "via-link",
+    dangleFallsBackToBash: out.dangleKind === "bash",
+    loopFallsBackToBash: out.loopKind === "bash",
+  }, null, 2));
+} finally {
+  rmSync(base, { recursive: true, force: true });
+}

--- a/packages/agency-lang/tests/agency-js/stdlib/std-fs-edit-reject/agent.agency
+++ b/packages/agency-lang/tests/agency-js/stdlib/std-fs-edit-reject/agent.agency
@@ -10,7 +10,7 @@ node readBack(filename: string) {
   return result
 }
 
-node runEdit(filename: string, oldText: string, newText: string, replaceAll: boolean) {
-  const result = edit(filename, [{ oldText: oldText, newText: newText, replaceAll: replaceAll }])
+node runEdit(filename: string, dir: string, oldText: string, newText: string, replaceAll: boolean) {
+  const result = edit(filename, [{ oldText: oldText, newText: newText, replaceAll: replaceAll }], dir)
   return result
 }

--- a/packages/agency-lang/tests/agency-js/stdlib/std-fs-edit-reject/test.js
+++ b/packages/agency-lang/tests/agency-js/stdlib/std-fs-edit-reject/test.js
@@ -1,13 +1,16 @@
 import { mkdtempSync, writeFileSync, readFileSync } from "fs";
 import { tmpdir } from "os";
-import { join } from "path";
+import { join, dirname, basename } from "path";
 import { runEdit, respondToInterrupts, reject } from "./agent.js";
 
 const TMP = mkdtempSync(join(tmpdir(), "agency-edit-reject-"));
 
 const path = join(TMP, "reject.txt");
 writeFileSync(path, "alpha\n");
-const r = await runEdit(path, "alpha", "OMEGA", false);
+// dir + basename, not an absolute filename: the containment preparation
+// would refuse the absolute spelling before any interrupt, and this
+// fixture exists to exercise rejection of the std::edit interrupt itself.
+const r = await runEdit(basename(path), dirname(path), "alpha", "OMEGA", false);
 const rejected = await respondToInterrupts(r.data, [reject()]);
 const contents = readFileSync(path, "utf8");
 

--- a/packages/agency-lang/tests/agency/agency-agent-code-prompt.agency
+++ b/packages/agency-lang/tests/agency/agency-agent-code-prompt.agency
@@ -1,0 +1,13 @@
+import test { promptFile } from "../../lib/agents/agency-agent/brains/coordinator/subagents/code.agency"
+
+// The coordinator loads its prompts through the contained read wrapper,
+// and promptFile falls back to "" on failure — a SILENT empty system
+// prompt. These two nodes are the guard: each prompt must load
+// independently, so one healthy prompt cannot hide the other's failure.
+node codePromptLoads(): boolean {
+  return promptFile("code.md") != ""
+}
+
+node oneShotPromptLoads(): boolean {
+  return promptFile("oneShot.md") != ""
+}

--- a/packages/agency-lang/tests/agency/agency-agent-code-prompt.test.json
+++ b/packages/agency-lang/tests/agency/agency-agent-code-prompt.test.json
@@ -1,0 +1,6 @@
+{
+  "tests": [
+    { "nodeName": "codePromptLoads", "description": "the coordinator code prompt loads via the contained read", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "oneShotPromptLoads", "description": "the one-shot note loads via the contained read", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] }
+  ]
+}

--- a/packages/agency-lang/tests/agency/contained-filenames.agency
+++ b/packages/agency-lang/tests/agency/contained-filenames.agency
@@ -1,0 +1,241 @@
+import { write, read, writeBinary, readBinary } from "std::index"
+import { remove, edit } from "std::fs"
+import { typecheckFile, writeAST, loadTemplate, formatFile, parseAST } from "std::agency"
+
+// Every escape must fail in preparation, BEFORE any interrupt exists. The
+// handler in each escape node returns a unique rejection, so if the error
+// classifies as "handler" the interrupt was raised and containment failed.
+def classify(err: string): string {
+  if (err =~ re/HANDLER_REACHED/) {
+    return "handler"
+  }
+  if (err =~ re/pass that directory in dir/) {
+    return "prep"
+  }
+  return "other: ${err}"
+}
+
+node containedWriteReadRoundtrip(): boolean {
+  const w = write("cf-tmp.txt", "contained", __dirname) with approve
+  const back = read("cf-tmp.txt", __dirname) with approve
+  remove(__dirname + "/cf-tmp.txt") with approve
+  if (w is failure(e)) {
+    return false
+  }
+  if (back is success(content)) {
+    return content == "contained"
+  }
+  return false
+}
+
+node containedBinaryRoundtrip(): boolean {
+  const w = writeBinary("cf-tmp.bin", "aGk=", __dirname) with approve
+  const back = readBinary("cf-tmp.bin", __dirname) with approve
+  remove(__dirname + "/cf-tmp.bin") with approve
+  if (w is failure(e)) {
+    return false
+  }
+  if (back is success(content)) {
+    return content == "aGk="
+  }
+  return false
+}
+
+node writeEscapeDotDot(): string {
+  handle {
+    const r = try write("../cf-escape.txt", "x", __dirname)
+    if (isFailure(r)) {
+      return classify("${r.error}")
+    }
+    return "unexpected success"
+  } with (interrupt) {
+    return reject("HANDLER_REACHED")
+  }
+}
+
+node readEscapeDotDot(): string {
+  handle {
+    const r = try read("../cf-escape.txt", __dirname)
+    if (isFailure(r)) {
+      return classify("${r.error}")
+    }
+    return "unexpected success"
+  } with (interrupt) {
+    return reject("HANDLER_REACHED")
+  }
+}
+
+node writeBinaryEscape(): string {
+  handle {
+    const r = try writeBinary("../cf-escape.bin", "aGk=", __dirname)
+    if (isFailure(r)) {
+      return classify("${r.error}")
+    }
+    return "unexpected success"
+  } with (interrupt) {
+    return reject("HANDLER_REACHED")
+  }
+}
+
+node readBinaryEscape(): string {
+  handle {
+    const r = try readBinary("../cf-escape.bin", __dirname)
+    if (isFailure(r)) {
+      return classify("${r.error}")
+    }
+    return "unexpected success"
+  } with (interrupt) {
+    return reject("HANDLER_REACHED")
+  }
+}
+
+node writeAbsoluteEscape(): string {
+  handle {
+    const r = try write("/cf-absolute-escape.txt", "x", __dirname)
+    if (isFailure(r)) {
+      return classify("${r.error}")
+    }
+    return "unexpected success"
+  } with (interrupt) {
+    return reject("HANDLER_REACHED")
+  }
+}
+
+node writeTildeEscape(): string {
+  handle {
+    const r = try write("~/cf-tilde-escape.txt", "x", __dirname)
+    if (isFailure(r)) {
+      return classify("${r.error}")
+    }
+    return "unexpected success"
+  } with (interrupt) {
+    return reject("HANDLER_REACHED")
+  }
+}
+
+// The exact teaching sentences, per operation, so the error keeps telling
+// the model the right retry.
+node exactTeachingSentences(): boolean {
+  const w = try write("../x", "x", __dirname) with approve
+  const r = try read("../x", __dirname) with approve
+  if (!isFailure(w) || !isFailure(r)) {
+    return false
+  }
+  const writeOk = "${w.error}" =~ re/To write somewhere else, pass that directory in dir\./
+  const readOk = "${r.error}" =~ re/To read from somewhere else, pass that directory in dir\./
+  return writeOk && readOk
+}
+
+// --- edit (std::fs) ---
+
+node editEscapeDotDot(): string {
+  handle {
+    const r = try edit("../cf-escape.txt", [{ oldText: "a", newText: "b", replaceAll: false }], __dirname)
+    if (isFailure(r)) {
+      return classify("${r.error}")
+    }
+    return "unexpected success"
+  } with (interrupt) {
+    return reject("HANDLER_REACHED")
+  }
+}
+
+// --- the four agency.agency wrappers ---
+
+node typecheckFileTildeEscape(): string {
+  handle {
+    const r = try typecheckFile(__dirname, "~/cf-escape.agency")
+    if (isFailure(r)) {
+      return classify("${r.error}")
+    }
+    return "unexpected success"
+  } with (interrupt) {
+    return reject("HANDLER_REACHED")
+  }
+}
+
+node writeASTTildeEscape(): string {
+  const parsed = parseAST("node main() {\n  return 1\n}")
+  if (parsed is failure(e)) {
+    return "parse failed"
+  }
+  handle {
+    const r = try writeAST(parsed.value, __dirname, "~/cf-escape.agency")
+    if (isFailure(r)) {
+      return classify("${r.error}")
+    }
+    return "unexpected success"
+  } with (interrupt) {
+    return reject("HANDLER_REACHED")
+  }
+}
+
+node loadTemplateTildeEscape(): string {
+  handle {
+    const r = try loadTemplate(__dirname, "~/cf-escape.agency")
+    if (isFailure(r)) {
+      return classify("${r.error}")
+    }
+    return "unexpected success"
+  } with (interrupt) {
+    return reject("HANDLER_REACHED")
+  }
+}
+
+node formatFileTildeEscape(): string {
+  handle {
+    const r = try formatFile(__dirname, "~/cf-escape.agency")
+    if (isFailure(r)) {
+      return classify("${r.error}")
+    }
+    return "unexpected success"
+  } with (interrupt) {
+    return reject("HANDLER_REACHED")
+  }
+}
+
+// Contained success smokes for the write-shaped wrappers: each reads the
+// resulting file back, so a helper wired only into the payload cannot pass.
+node writeASTContained(): boolean {
+  const parsed = parseAST("node main() {\n  return 1\n}")
+  if (parsed is failure(e)) {
+    return false
+  }
+  const w = writeAST(parsed.value, __dirname, "cf-ast-tmp.agency") with approve
+  const back = read("cf-ast-tmp.agency", __dirname) with approve
+  remove(__dirname + "/cf-ast-tmp.agency") with approve
+  if (w is failure(e2)) {
+    return false
+  }
+  if (back is success(content)) {
+    return content =~ re/node main/
+  }
+  return false
+}
+
+node formatFileContained(): boolean {
+  const w = write("cf-fmt-tmp.agency", "node main() {\n  return 1\n}\n", __dirname) with approve
+  if (w is failure(e)) {
+    return false
+  }
+  const f = formatFile(__dirname, "cf-fmt-tmp.agency") with approve
+  const back = read("cf-fmt-tmp.agency", __dirname) with approve
+  remove(__dirname + "/cf-fmt-tmp.agency") with approve
+  if (f is failure(e2)) {
+    return false
+  }
+  if (back is success(content)) {
+    return content =~ re/node main/
+  }
+  return false
+}
+
+node typecheckFileContained(): boolean {
+  const w = write("cf-tc-tmp.agency", "node main() {\n  return 1\n}\n", __dirname) with approve
+  if (w is failure(e)) {
+    return false
+  }
+  const tc = typecheckFile(__dirname, "cf-tc-tmp.agency") with approve
+  remove(__dirname + "/cf-tc-tmp.agency") with approve
+  return !isFailure(tc)
+}

--- a/packages/agency-lang/tests/agency/contained-filenames.agency
+++ b/packages/agency-lang/tests/agency/contained-filenames.agency
@@ -43,7 +43,7 @@ node containedBinaryRoundtrip(): boolean {
 
 node writeEscapeDotDot(): string {
   handle {
-    const r = try write("../cf-escape.txt", "x", __dirname)
+    const r = try write("../cf-escape.txt", "x", __dirname, "create-only")
     if (isFailure(r)) {
       return classify("${r.error}")
     }
@@ -67,7 +67,7 @@ node readEscapeDotDot(): string {
 
 node writeBinaryEscape(): string {
   handle {
-    const r = try writeBinary("../cf-escape.bin", "aGk=", __dirname)
+    const r = try writeBinary("../cf-escape.bin", "aGk=", __dirname, "create-only")
     if (isFailure(r)) {
       return classify("${r.error}")
     }
@@ -91,7 +91,7 @@ node readBinaryEscape(): string {
 
 node writeAbsoluteEscape(): string {
   handle {
-    const r = try write("/cf-absolute-escape.txt", "x", __dirname)
+    const r = try write("/cf-absolute-escape.txt", "x", __dirname, "create-only")
     if (isFailure(r)) {
       return classify("${r.error}")
     }
@@ -103,7 +103,9 @@ node writeAbsoluteEscape(): string {
 
 node writeTildeEscape(): string {
   handle {
-    const r = try write("~/cf-tilde-escape.txt", "x", __dirname)
+    // create-only and an improbable dotted name: if containment ever
+    // breaks, this test must not overwrite anything a user owns.
+    const r = try write("~/.agency-cf-escape-probe-3f9d.txt", "x", __dirname, "create-only")
     if (isFailure(r)) {
       return classify("${r.error}")
     }
@@ -144,7 +146,7 @@ node editEscapeDotDot(): string {
 
 node typecheckFileTildeEscape(): string {
   handle {
-    const r = try typecheckFile(__dirname, "~/cf-escape.agency")
+    const r = try typecheckFile(__dirname, "~/.agency-cf-escape-probe-3f9d.agency")
     if (isFailure(r)) {
       return classify("${r.error}")
     }
@@ -160,7 +162,7 @@ node writeASTTildeEscape(): string {
     return "parse failed"
   }
   handle {
-    const r = try writeAST(parsed.value, __dirname, "~/cf-escape.agency")
+    const r = try writeAST(parsed.value, __dirname, "~/.agency-cf-escape-probe-3f9d.agency", overwrite: false)
     if (isFailure(r)) {
       return classify("${r.error}")
     }
@@ -172,7 +174,7 @@ node writeASTTildeEscape(): string {
 
 node loadTemplateTildeEscape(): string {
   handle {
-    const r = try loadTemplate(__dirname, "~/cf-escape.agency")
+    const r = try loadTemplate(__dirname, "~/.agency-cf-escape-probe-3f9d.agency")
     if (isFailure(r)) {
       return classify("${r.error}")
     }
@@ -184,7 +186,7 @@ node loadTemplateTildeEscape(): string {
 
 node formatFileTildeEscape(): string {
   handle {
-    const r = try formatFile(__dirname, "~/cf-escape.agency")
+    const r = try formatFile(__dirname, "~/.agency-cf-escape-probe-3f9d.agency")
     if (isFailure(r)) {
       return classify("${r.error}")
     }

--- a/packages/agency-lang/tests/agency/contained-filenames.test.json
+++ b/packages/agency-lang/tests/agency/contained-filenames.test.json
@@ -1,0 +1,191 @@
+{
+  "tests": [
+    {
+      "nodeName": "containedWriteReadRoundtrip",
+      "description": "a contained write and read round-trip inside dir",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "containedBinaryRoundtrip",
+      "description": "a contained binary write and read round-trip inside dir",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "writeEscapeDotDot",
+      "description": "an upward write escape fails in preparation, before any interrupt",
+      "input": "",
+      "expectedOutput": "\"prep\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "readEscapeDotDot",
+      "description": "an upward read escape fails in preparation, before any interrupt",
+      "input": "",
+      "expectedOutput": "\"prep\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "writeBinaryEscape",
+      "description": "an upward binary write escape fails in preparation",
+      "input": "",
+      "expectedOutput": "\"prep\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "readBinaryEscape",
+      "description": "an upward binary read escape fails in preparation",
+      "input": "",
+      "expectedOutput": "\"prep\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "writeAbsoluteEscape",
+      "description": "an absolute filename fails in preparation",
+      "input": "",
+      "expectedOutput": "\"prep\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "writeTildeEscape",
+      "description": "a tilde filename fails in preparation",
+      "input": "",
+      "expectedOutput": "\"prep\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "exactTeachingSentences",
+      "description": "escape errors carry the exact per-operation teaching sentence",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "editEscapeDotDot",
+      "description": "an upward edit escape fails in preparation",
+      "input": "",
+      "expectedOutput": "\"prep\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "typecheckFileTildeEscape",
+      "description": "typecheckFile rejects a tilde filename in preparation",
+      "input": "",
+      "expectedOutput": "\"prep\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "writeASTTildeEscape",
+      "description": "writeAST rejects a tilde filename in preparation",
+      "input": "",
+      "expectedOutput": "\"prep\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "loadTemplateTildeEscape",
+      "description": "loadTemplate rejects a tilde filename in preparation",
+      "input": "",
+      "expectedOutput": "\"prep\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "formatFileTildeEscape",
+      "description": "formatFile rejects a tilde filename in preparation",
+      "input": "",
+      "expectedOutput": "\"prep\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "writeASTContained",
+      "description": "writeAST still writes a contained file",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "formatFileContained",
+      "description": "formatFile still formats a contained file",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "typecheckFileContained",
+      "description": "typecheckFile still checks a contained file",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/dirname-paths.agency
+++ b/packages/agency-lang/tests/agency/dirname-paths.agency
@@ -1,4 +1,4 @@
-import { readColocated, readUpward } from "./dirname-paths/helper.agency"
+import { readColocated, readUpward, readUpwardViaDir } from "./dirname-paths/helper.agency"
 import { ls, exists } from "std::shell"
 import { remove } from "std::fs"
 
@@ -8,10 +8,14 @@ node colocatedRead(): string {
   return readColocated()
 }
 
-// Upward traversal through __dirname: the old resolvePath guards
-// rejected this even with the right anchor.
+// Upward traversal in a FILENAME is now a containment escape; the
+// migrated spelling puts the parent in dir instead.
 node upwardRead(): string {
   return readUpward()
+}
+
+node upwardReadViaDir(): string {
+  return readUpwardViaDir()
 }
 
 // A write anchored to this file via an absolute dir argument.
@@ -29,13 +33,13 @@ node dirAnchoredWrite(): boolean {
   return false
 }
 
-// Absolute FILENAME (not just dir) now allowed: resolvePath previously
-// hard-threw on any absolute filename.
+// Migrated from the old absolute-FILENAME spelling: the destination now
+// travels in dir, and the interrupt reports it truthfully.
 node absoluteFilenameAllowed(): boolean {
-  const outPath = __dirname + "/dirname-paths/tmp-abs.txt"
-  const w = write(outPath, "abs") with approve
-  const back = read(outPath) with approve
-  remove(outPath) with approve
+  const outDir = __dirname + "/dirname-paths"
+  const w = write("tmp-abs.txt", "abs", outDir) with approve
+  const back = read("tmp-abs.txt", outDir) with approve
+  remove(outDir + "/tmp-abs.txt") with approve
   if (w is failure(e)) {
     return false
   }

--- a/packages/agency-lang/tests/agency/dirname-paths.test.json
+++ b/packages/agency-lang/tests/agency/dirname-paths.test.json
@@ -1,10 +1,74 @@
 {
   "tests": [
-    { "nodeName": "colocatedRead", "input": "", "expectedOutput": "\"colocated\"", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "upwardRead", "input": "", "expectedOutput": "\"shared\"", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "dirAnchoredWrite", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "absoluteFilenameAllowed", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "probeAgreesWithRead", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "allowListStillCloses", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] }
+    {
+      "nodeName": "colocatedRead",
+      "input": "",
+      "expectedOutput": "\"colocated\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "upwardRead",
+      "input": "",
+      "expectedOutput": "\"REJECTED\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "upwardReadViaDir",
+      "input": "",
+      "expectedOutput": "\"shared\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "dirAnchoredWrite",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "absoluteFilenameAllowed",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "probeAgreesWithRead",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "allowListStillCloses",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
   ]
 }

--- a/packages/agency-lang/tests/agency/dirname-paths/helper.agency
+++ b/packages/agency-lang/tests/agency/dirname-paths/helper.agency
@@ -10,8 +10,21 @@ export def readColocated(): string {
   return "READ_FAILED"
 }
 
+/** Upward traversal in FILENAME is now a containment escape: this pins
+  the rejection, and readUpwardViaDir pins the migrated spelling. */
 export def readUpward(): string {
-  const result = read("../dirname-paths-shared.txt", __dirname) with approve
+  const result = try read("../dirname-paths-shared.txt", __dirname) with approve
+  if (result is success(content)) {
+    return "UNEXPECTED_SUCCESS"
+  }
+  if ("${result.error}" =~ re/pass that directory in dir/) {
+    return "REJECTED"
+  }
+  return "READ_FAILED"
+}
+
+export def readUpwardViaDir(): string {
+  const result = read("dirname-paths-shared.txt", __dirname + "/..") with approve
   if (result is success(content)) {
     return content
   }

--- a/packages/agency-lang/tests/agency/safeBash.agency
+++ b/packages/agency-lang/tests/agency/safeBash.agency
@@ -276,3 +276,62 @@ node longOutputIsTruncated() {
   }
   return [result.value.length, result.value.endsWith("\n[truncated]")]
 }
+
+// --- resolved redirect targets (contained-filenames spec) ---
+
+def writeExecOf(source: string, cwd: string): any {
+  return match(planFor(source, cwd).execution) {
+    { kind: "write", content, filename, dir, mode } => {
+      return { dir: dir, filename: filename, content: content, mode: mode }
+    }
+    { kind } => {
+      return { kind: kind }
+    }
+  }
+}
+
+def writePayloadOf(source: string, cwd: string): any {
+  const plan = planFor(source, cwd)
+  for (e in plan.effects) {
+    if (e.name == "std::write") {
+      return e.payload
+    }
+  }
+  return { kind: "no-write-effect" }
+}
+
+// An absolute redirect target reports its own parent, not the cwd: the
+// policy judges the real destination.
+node absoluteRedirectReportsParent(): boolean {
+  const exec = writeExecOf("echo hi > /cf-sb-nonexistent-abs/out.txt", "/repo")
+  return exec.dir == "/cf-sb-nonexistent-abs" && exec.filename == "out.txt"
+}
+
+// The payload and the execution derive from one shared WritePayload, so
+// they must agree field for field — on the shell-free echo path AND the
+// recognized-command path (git status > target).
+node payloadExecutionParity(): boolean {
+  const exec = writeExecOf("echo hi > sub/out.txt", "/repo")
+  const payload = writePayloadOf("echo hi > sub/out.txt", "/repo")
+  const fieldsAgree = exec.dir == payload.dir && exec.filename == payload.filename
+  const contentAgrees = exec.content == payload.content && exec.mode == payload.mode
+  const resolvedRight = exec.dir == "/repo/sub" && exec.filename == "out.txt"
+  const gitPayload = writePayloadOf("git status > sub/g.txt", "/repo")
+  const gitOk = gitPayload.dir == "/repo/sub" && gitPayload.filename == "g.txt"
+  return fieldsAgree && contentAgrees && resolvedRight && gitOk
+}
+
+// Quote-aware tilde. The bash word grammar refuses an unquoted `~`
+// outright, so that spelling can never reach the narrow write path: the
+// whole command falls back to the broad std::bash question, which is
+// strictly safer than expanding it ourselves. Quoted tildes parse and
+// stay a literal name beneath the cwd, exactly as bash treats them.
+node tildeRedirectQuoting(): boolean {
+  const unquoted = writeExecOf("echo hi > ~/cf-sb-tilde.txt", "/repo")
+  const single = writeExecOf("echo hi > '~/cf-sb-tilde.txt'", "/repo")
+  const double = writeExecOf("echo hi > \"~/cf-sb-tilde.txt\"", "/repo")
+  const unquotedBroad = unquoted.kind == "bash"
+  const singleLiteral = single.dir == "/repo/~" && single.filename == "cf-sb-tilde.txt"
+  const doubleLiteral = double.dir == "/repo/~" && double.filename == "cf-sb-tilde.txt"
+  return unquotedBroad && singleLiteral && doubleLiteral
+}

--- a/packages/agency-lang/tests/agency/safeBash.test.json
+++ b/packages/agency-lang/tests/agency/safeBash.test.json
@@ -225,6 +225,39 @@
           "type": "exact"
         }
       ]
+    },
+    {
+      "nodeName": "absoluteRedirectReportsParent",
+      "description": "an absolute redirect target reports its own parent directory",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "payloadExecutionParity",
+      "description": "write payload and execution derive from one shared WritePayload",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "tildeRedirectQuoting",
+      "description": "unquoted tilde expands; quoted tilde stays beneath the cwd",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/safeBash.test.json
+++ b/packages/agency-lang/tests/agency/safeBash.test.json
@@ -250,7 +250,7 @@
     },
     {
       "nodeName": "tildeRedirectQuoting",
-      "description": "unquoted tilde expands; quoted tilde stays beneath the cwd",
+      "description": "unquoted tilde cannot be narrowed and takes the broad bash question; quoted tilde stays beneath the cwd",
       "input": "",
       "expectedOutput": "true",
       "evaluationCriteria": [

--- a/packages/agency-lang/tests/agency/stdlib-destructive.agency
+++ b/packages/agency-lang/tests/agency/stdlib-destructive.agency
@@ -2,11 +2,12 @@ import { write } from "std::index"
 import { read } from "std::index"
 
 // write is destructive; a failure after its extern started must carry
-// destructiveRan. Writing under a nonexistent directory forces the
-// failure inside write's extern (its std::write interrupt is approved).
+// destructiveRan. A contained filename below a missing parent passes
+// preparation but fails inside write's extern (its std::write interrupt
+// is approved), which is exactly the lifecycle this test pins.
 node writeFails() {
   handle {
-    const r = try write("/nonexistent-dir-xyz/f.txt", "hi")
+    const r = try write("nonexistent-dir-xyz/f.txt", "hi", __dirname)
     if (isFailure(r)) {
       return [r.destructiveRan, r.neverStarted]
     }


### PR DESCRIPTION
Implements `2026-08-20-contained-filename-spec.md` per `2026-08-20-contained-filename-plan.md` (both ride in the first commit). A model-chosen filename can no longer escape the directory the interrupt reported — not through absolute paths, `~`, `..`, or stable symlinks.

## The contract

For the nine scoped single-file wrappers (`read`, `write`, `readBinary`, `writeBinary`, `edit`, `typecheckFile`, `writeAST`, `loadTemplate`, `formatFile`), one shared `prepareContainedPath` canonicalizes `dir`, normalizes `filename`, and rejects every stable escape **before the interrupt exists** — no policy or human can approve an escape, because no escape request is ever raised. The interrupt and the execution consume the same prepared values. Only `ENOENT` is treated as "does not exist yet": dangling links, loops, non-directories, and permission errors all fail closed.

The migration rule doubles as the design principle: **the destination belongs in `dir`**, because `dir` is the field the judge reads. Escape errors teach it verbatim ("To write somewhere else, pass that directory in dir."), and the tool docstrings state it up front.

## safeBash: the one-source exception

safeBash has no trusted `dir` (the whole command is untrusted), so its redirect writes instead resolve the complete target and report the **real parent** as `dir` — the policy judges the true destination. `prepareRedirectWrite` owns all the choreography; `writeEffect`/`writeExecution` derive both plan sides from one `WritePayload`, so payload/execution parity holds by construction. Dangling links and loops fall back to the broad `std::bash` question.

One behavior pinned as found, deviating from the plan's expectation: the bash word grammar refuses an **unquoted** `~` outright, so that spelling always takes the broad `std::bash` question rather than expanding — strictly safer than the planned expansion. Quoted tildes parse and stay literal beneath the cwd, as in bash.

## Caller migrations (the spec inventory)

- `promptFile` loads the coordinator prompts dir-anchored; a new test pins both prompts non-empty (the empty-string fallback made breakage silent).
- `dirname-paths` flips `readUpward` to pin the rejection, adds the dir-based sibling, and migrates the absolute-filename node.
- `stdlib-destructive` keeps its destructive-marker purpose via a contained filename below a missing parent (same `[true,false]` expectation).

## Policy side

`resolveDotDirPattern` realpaths the launch directory (lexical fallback), so a `{.,./**}` rule and the canonicalized payloads share one path identity under symlinked checkouts — wired through `checkPolicy` in tests, not just the resolver.

## Verified

- 94 vitest cases across the resolver, redirect resolver, policy, and containment suites (1 Windows-only skip); every fail-closed branch pinned (ELOOP, ENOTDIR, mocked EACCES, dangling chains).
- Agency execution tests: contained-filenames 17/17 (every escape proves the handler was never reached via a HANDLER_REACHED sentinel), safeBash 21/21, dirname-paths 7/7, stdlib-destructive, prompt guard, read/write-binary, agent-cwd 13/13, generatedProgram — all green.
- Agency-JS fixtures: recording handlers prove payloads carry prepared values through symlinked dirs for all nine wrappers; real-symlink safeBash redirects land on real targets with truthful plans; the end-to-end policy fixture drives the full contract through a noninteractive `cliPolicyHandler` (9/9 assertions, including no-file-created proofs and the symlink-as-dir case).
- `make`, tsc, prettier, structural linter, text guard all green. The one typecheck warning (`AG4004 _run`) pre-exists on main.

## Out of scope (tracked in the spec)

`applyPatch`, `copy`/`move`/`remove`, `ls`/`grep`/`glob` leaf symlinks, the wider path-bearing-effect audit, and post-approval symlink races (threat-model boundary documented in `docs/dev/approval-policies.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
