### PR TITLE
Coding evals: agent can run its harness with testFile; logs viewer newlines and follow-mode cursor

### DIFF
--- a/packages/agency-lang/docs/site/stdlib/agency.md
+++ b/packages/agency-lang/docs/site/stdlib/agency.md
@@ -142,7 +142,7 @@ Per-exported-symbol effect lists, keyed by node/function name.
 export type EffectsByExport = Record<string, string[]>
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L644))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L662))
 
 ### ExportInfo
 
@@ -178,7 +178,7 @@ export type ExportInfo = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L673))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L691))
 
 ### ModuleInfo
 
@@ -189,7 +189,7 @@ export type ModuleInfo = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L684))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L702))
 
 ### AST
 
@@ -212,7 +212,7 @@ export type AST = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L734))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L751))
 
 ### Code
 
@@ -234,7 +234,7 @@ export type Code = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L791))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L808))
 
 ### HoleInfo
 
@@ -248,7 +248,7 @@ export type HoleInfo = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L798))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L815))
 
 ## Effects
 
@@ -507,7 +507,7 @@ testFile(
 ): Result<TestReport>
 ```
 
-Run the test cases a .test.json file declares against its source file, in the sandboxed subprocess, and return a per-case report. The portable form of test(): the same file `agency test` runs, restricted to the sandbox subset (exact criteria; approve/reject scripted answers; per-case timeoutMs; named args instead of the CLI's input string).
+Run the test cases a .test.json file declares against its source file.
 
   @param dir - The directory holding the .test.json and the file it tests
   @param filename - The .test.json file
@@ -525,7 +525,7 @@ Run the test cases a .test.json file declares against its source file, in the sa
 
 **Throws:** `std::read`, `std::guard`, `std::run`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L442))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L454))
 
 ### runCode
 
@@ -597,7 +597,7 @@ re-raises std::run and the child's own effects re-prompt.
 
 **Throws:** `std::run`, `std::guard`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L548))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L560))
 
 ### typecheck
 
@@ -623,7 +623,7 @@ Relative imports (./foo.agency) cannot be resolved from a source string.
 
 **Returns:** `Result<TypeCheckReport>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L614))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L626))
 
 ### getEffects
 
@@ -652,7 +652,7 @@ Map each exported node and function in the source to the list of
 
 **Returns:** `Result<EffectsByExport>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L646))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L664))
 
 ### describe
 
@@ -678,7 +678,7 @@ one-line summary, extracted the same way `agency doc` extracts it.
 
 **Returns:** `Result<ModuleInfo>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L694))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L712))
 
 ### typecheckFile
 
@@ -704,7 +704,7 @@ Type-check an Agency file on disk. The file is read from dir/filename,
 
 **Throws:** `std::read`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L709))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L726))
 
 ### parseAST
 
@@ -724,7 +724,7 @@ Parse Agency source code into an abstract syntax tree.
 
 **Returns:** `Result<AST>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L740))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L757))
 
 ### writeAST
 
@@ -761,7 +761,7 @@ Output is canonical formatter output (the same style as `pnpm run fmt`):
 
 **Throws:** `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L752))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L769))
 
 ### format
 
@@ -781,7 +781,7 @@ Format Agency source code with the standard Agency formatter.
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L778))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L795))
 
 ### loadTemplate
 
@@ -806,7 +806,7 @@ Load an Agency file containing holes as a template.
 
 **Throws:** `std::read`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L806))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L823))
 
 ### holesOf
 
@@ -826,7 +826,7 @@ The unfilled holes in a template, in the order they appear. Each entry has the h
 
 **Returns:** `HoleInfo[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L825))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L842))
 
 ### fill
 
@@ -848,7 +848,7 @@ Fill holes in a template. Plain values become literals and are never parsed; Cod
 
 **Returns:** `Result<Code>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L834))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L851))
 
 ### combine
 
@@ -872,7 +872,7 @@ Merge several Code fragments into one, in order. Use this to build one
 
 **Returns:** `Result<Code>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L844))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L864))
 
 ### toSource
 
@@ -892,7 +892,7 @@ Print a Code value back to Agency source, including any unfilled holes.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L857))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L877))
 
 ### parseExpr
 
@@ -912,7 +912,7 @@ Parse a single Agency expression into a Code fragment that can fill an expr hole
 
 **Returns:** `Result<Code>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L866))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L886))
 
 ### parseStatements
 
@@ -932,7 +932,7 @@ Parse a list of Agency statements into a Code fragment that can fill a statement
 
 **Returns:** `Result<Code>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L875))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L895))
 
 ### formatFile
 
@@ -960,7 +960,7 @@ Read and write happen inside the same interrupt, so approving it approves both.
 
 **Throws:** `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L886))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L906))
 
 ### walkAST
 
@@ -989,7 +989,7 @@ Walk every node in a deep-cloned copy of the AST, invoking the visitor
 
 **Returns:** [AST](#ast)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L910))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L930))
 
 ### getNodesOfType
 
@@ -1011,7 +1011,7 @@ Parse Agency source code and return every AST node whose `type` field matches an
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L930))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L950))
 
 ### getImports
 
@@ -1031,7 +1031,7 @@ Return every import statement in the source (i.e. `import { x } from "..."`).
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L943))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L963))
 
 ### getFunctions
 
@@ -1051,7 +1051,7 @@ Return every function definition (`def foo(...) { ... }`) in the source.
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L952))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L972))
 
 ### getGraphNodes
 
@@ -1071,7 +1071,7 @@ Return every graph node definition (`node main() { ... }`) in the source.
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L961))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L981))
 
 ### filterImports
 
@@ -1123,7 +1123,7 @@ Parse Agency source, drop imports that fail the policy, and return the resulting
 
 **Returns:** `Result<{ source: string; filtered: boolean }>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L988))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L1008))
 
 ### getVersion
 
@@ -1135,4 +1135,4 @@ Get the current version of the Agency standard library.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L1014))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L1034))

--- a/packages/agency-lang/docs/site/stdlib/agents/agency/coding.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/agency/coding.md
@@ -99,4 +99,4 @@ Write an Agency program for the task. Iterates until the source parses,
 
 **Throws:** `std::guard`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/coding.agency#L237))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/coding.agency#L254))

--- a/packages/agency-lang/docs/site/stdlib/agents/lib/toolkits.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/lib/toolkits.md
@@ -164,8 +164,8 @@ Return the bundled Agency documentation tools: the language guide, the CLI
 agencyCodeTools(): any[]
 ```
 
-Return tools that inspect Agency source without running it: the type
-  checker and the parser.
+Return tools for checking Agency source: the type checker, the parser,
+  and testFile, which runs a .test.json harness in a sandboxed subprocess.
 
 **Returns:** `any[]`
 

--- a/packages/agency-lang/evals/agency-agent/fib/files/fib-tests.agency
+++ b/packages/agency-lang/evals/agency-agent/fib/files/fib-tests.agency
@@ -1,5 +1,6 @@
 // Visible tests for the fib coding eval. The framework grades with
-// `agency test --agency-only --reject '*'`; the agent can run the same file.
+// `agency test --agency-only --reject '*'`; the agent runs the same file
+// with the testFile tool.
 import { fib } from "./fib.agency"
 
 export node base0(): number {

--- a/packages/agency-lang/evals/agency-agent/fib/test.json
+++ b/packages/agency-lang/evals/agency-agent/fib/test.json
@@ -4,5 +4,5 @@
     "coding",
     "easy"
   ],
-  "input": "Write an Agency function that returns the nth Fibonacci number (fib(0) = 0, fib(1) = 1) and save it to a file named fib.agency in the current directory. The file must contain: export def fib(n: number): number. Use only Agency standard library (std::) imports, or no imports at all. Your working directory contains a test harness; you can check your solution by running: agency test fib-tests.test.json"
+  "input": "Write an Agency function that returns the nth Fibonacci number (fib(0) = 0, fib(1) = 1) and save it to a file named fib.agency in the current directory. The file must contain: export def fib(n: number): number. Use only Agency standard library (std::) imports, or no imports at all. Your working directory contains a test harness, fib-tests.test.json, which tests fib-tests.agency (it imports your fib.agency). Check your solution with the testFile tool: testFile(dir: \".\", filename: \"fib-tests.test.json\"). Do not try to run the agency command line; it is not available."
 }

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/prompts/code.md
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/prompts/code.md
@@ -176,7 +176,11 @@ live in `.agency` files you can `read` directly.
    more than one change to make to the same file. The user will be
    prompted to approve every write.
 6. After every change, run `typecheck` (rule 3 above) and any
-   relevant tests via `safeBash`.
+   relevant tests. Agency tests (`*.test.json`) run with the `testFile`
+   tool: `testFile(dir: ".", filename: "x.test.json")`. Write the source
+   files it tests to disk first; it compiles them from disk. Do not look
+   for an `agency` executable to run them; it is often not on PATH, and
+   `safeBash`/`exec` may be refused.
 7. For git operations, use the git tools (`gitStatus`, `gitLog`,
    `gitDiff`, `gitShow`, `gitCommit`, `gitAdd`, `gitSwitch`, ...)
    rather than `safeBash git ...`. The read-only ones

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/subagents/code.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/subagents/code.agency
@@ -13,7 +13,6 @@
 import { filter } from "std::array"
 import { agencyCodingAgent } from "std::agents/agency/coding"
 import { agencyExpertAgent } from "std::agents/agency/expert"
-import { testFile } from "std::agency"
 import { codingAgent, buildTools as codingAgentTools } from "std::agents/coding"
 import { expertAgent } from "std::agents/expert"
 import { verifierAgent } from "std::agents/verifier"
@@ -90,7 +89,6 @@ export static const codeSysPrompt = promptFile("code.md")
 export static const codeTools: any[] = [
   ...codingAgentTools(),
   agencyCli,
-  testFile,
   superpowersSkill,
   oracleAgent,
 ]

--- a/packages/agency-lang/lib/logsViewer/conversation.test.ts
+++ b/packages/agency-lang/lib/logsViewer/conversation.test.ts
@@ -91,6 +91,16 @@ describe("formatConversation", () => {
     ]);
   });
 
+  it("escapes control characters other than newline", () => {
+    const lines = formatConversation([
+      { role: "tool", name: "bash", content: "\x1b[2Jcleared\x1b[1;1H\r\tdone\nnext" },
+    ]);
+    expect(lines).toEqual([
+      `${color.green("[tool: bash]")} \\u001b[2Jcleared\\u001b[1;1H\\r\\tdone`,
+      "  next",
+    ]);
+  });
+
   it("emits a placeholder row for empty turns", () => {
     const lines = formatConversation([{ role: "assistant", content: null }]);
     expect(lines).toEqual([color.green("[assistant]")]);

--- a/packages/agency-lang/lib/logsViewer/conversation.test.ts
+++ b/packages/agency-lang/lib/logsViewer/conversation.test.ts
@@ -8,10 +8,7 @@ describe("formatConversation", () => {
       { role: "user", content: "hi" },
       { role: "assistant", content: "hello" },
     ]);
-    expect(lines).toEqual([
-      `${color.green("[user]")} "hi"`,
-      `${color.green("[assistant]")} "hello"`,
-    ]);
+    expect(lines).toEqual([`${color.green("[user]")} hi`, `${color.green("[assistant]")} hello`]);
   });
 
   it("formats an assistant tool call (camelCase shape)", () => {
@@ -26,10 +23,10 @@ describe("formatConversation", () => {
       { role: "assistant", content: "Hello, Alice!" },
     ]);
     expect(lines).toEqual([
-      `${color.green("[user]")} "Greet Alice using the greet tool"`,
+      `${color.green("[user]")} Greet Alice using the greet tool`,
       `${color.green("[assistant]")} tool call: greet({"name":"Alice"})`,
-      `${color.green("[tool: greet]")} "Hello, Alice!"`,
-      `${color.green("[assistant]")} "Hello, Alice!"`,
+      `${color.green("[tool: greet]")} Hello, Alice!`,
+      `${color.green("[assistant]")} Hello, Alice!`,
     ]);
   });
 
@@ -58,7 +55,7 @@ describe("formatConversation", () => {
         ],
       },
     ]);
-    expect(lines).toEqual([`${color.green("[user]")} "first second"`]);
+    expect(lines).toEqual([`${color.green("[user]")} first second`]);
   });
 
   it("renders a non-content-part array (e.g. a tool result) as JSON", () => {
@@ -77,6 +74,21 @@ describe("formatConversation", () => {
       { role: "tool", name: "t", content: { response: [1, 2] }, tool_call_id: "x" },
     ]);
     expect(lines).toEqual([`${color.green("[tool: t]")} {"response":[1,2]}`]);
+  });
+
+  it("renders newlines as separate rows, continuation lines indented", () => {
+    const lines = formatConversation([
+      { role: "system", content: "You are helpful.\nBe brief.\n\nAnswer in English." },
+      { role: "tool", name: "read", content: "line 1\nline 2", tool_call_id: "x" },
+    ]);
+    expect(lines).toEqual([
+      `${color.green("[system]")} You are helpful.`,
+      "  Be brief.",
+      "  ",
+      "  Answer in English.",
+      `${color.green("[tool: read]")} line 1`,
+      "  line 2",
+    ]);
   });
 
   it("emits a placeholder row for empty turns", () => {

--- a/packages/agency-lang/lib/logsViewer/conversation.ts
+++ b/packages/agency-lang/lib/logsViewer/conversation.ts
@@ -42,7 +42,7 @@ function formatMessage(msg: ConvoMessage): string[] {
   const lines: string[] = [];
   const text = contentText(msg.content);
   if (text !== undefined && text.length > 0) {
-    const [first, ...rest] = text.split("\n");
+    const [first, ...rest] = escapeControls(text).split("\n");
     lines.push(`${prefix} ${first}`);
     for (const line of rest) lines.push(`  ${line}`);
   }
@@ -82,6 +82,14 @@ function contentText(content: unknown): string | undefined {
     return parts.join(" ");
   }
   return JSON.stringify(content);
+}
+
+// Message text reaches the terminal as-is, so every control character
+// except the newline is shown escaped (`\r`, `\t`, `\u001b`): a recorded
+// escape sequence must not clear the screen or move the cursor.
+function escapeControls(text: string): string {
+  // eslint-disable-next-line no-control-regex
+  return text.replace(/[\x00-\x09\x0b-\x1f\x7f]/g, (ch) => JSON.stringify(ch).slice(1, -1));
 }
 
 function contentPartText(part: unknown): string | undefined {

--- a/packages/agency-lang/lib/logsViewer/conversation.ts
+++ b/packages/agency-lang/lib/logsViewer/conversation.ts
@@ -40,9 +40,11 @@ function formatMessage(msg: ConvoMessage): string[] {
   const role = msg.role ?? "unknown";
   const prefix = formatRole(role, msg);
   const lines: string[] = [];
-  const text = stringifyContent(msg.content);
+  const text = contentText(msg.content);
   if (text !== undefined && text.length > 0) {
-    lines.push(`${prefix} ${text}`);
+    const [first, ...rest] = text.split("\n");
+    lines.push(`${prefix} ${first}`);
+    for (const line of rest) lines.push(`  ${line}`);
   }
   const toolCalls = msg.toolCalls ?? msg.tool_calls ?? [];
   for (const tc of toolCalls) {
@@ -65,19 +67,19 @@ function formatRole(role: string, msg: ConvoMessage): string {
 }
 
 // Content can be a string, null, or (for some providers) a structured
-// array of content parts. Normalize to a single short string.
-function stringifyContent(content: unknown): string | undefined {
+// array of content parts. Text is shown as written, newlines included;
+// anything else is shown as JSON.
+function contentText(content: unknown): string | undefined {
   if (content === null || content === undefined) return undefined;
-  if (typeof content === "string") return JSON.stringify(content);
+  if (typeof content === "string") return content;
   if (Array.isArray(content)) {
     const parts = content
       .map((p) => contentPartText(p))
       .filter((s): s is string => s !== undefined);
-    // A multimodal content-parts array yields text parts. A plain data
-    // array (e.g. a tool result like [0,1,1,2,3]) yields none — render
-    // the whole value as JSON rather than showing nothing.
+    // A plain data array (e.g. a tool result like [0,1,1,2,3]) has no
+    // text parts; show the whole value rather than nothing.
     if (parts.length === 0) return JSON.stringify(content);
-    return JSON.stringify(parts.join(" "));
+    return parts.join(" ");
   }
   return JSON.stringify(content);
 }

--- a/packages/agency-lang/lib/logsViewer/followMode.test.ts
+++ b/packages/agency-lang/lib/logsViewer/followMode.test.ts
@@ -44,6 +44,14 @@ async function until(check: () => boolean, ms = 2_000): Promise<void> {
   }
 }
 
+// The rendered row the cursor is on ("> " marker), colors stripped.
+function cursorRow(out: FrameRecorder): string {
+  if (out.frames.length === 0) return "";
+  // eslint-disable-next-line no-control-regex
+  const text = out.lastText().replace(/\x1b\[[0-9;]*m/g, "");
+  return text.split("\n").find((line) => line.trimStart().startsWith("> ")) ?? "";
+}
+
 describe("follow mode", () => {
   let dir: string;
   let file: string;
@@ -94,6 +102,32 @@ describe("follow mode", () => {
     await done;
     expect(out.lastText()).toContain("lateTool");
     expect(out.lastText()).toContain("earlyTool");
+  });
+
+  it("an append keeps the cursor on a conversation line (a synthetic row)", async () => {
+    // Synthetic rows (conversation lines, raw data) are built at render time
+    // and are not in the forest; setData must resolve them through their leaf.
+    fs.appendFileSync(
+      file,
+      envelope("s1", "promptCompletion", 500, {
+        messages: [{ role: "user", content: "hello there" }],
+        completion: { output: "hi back" },
+      }),
+    );
+    const input = new ScriptedInput([]);
+    const out = new FrameRecorder();
+    const done = start(input, out);
+    input.feedKey({ key: "z" }); // expand every span
+    input.feedKey({ key: "G" }); // the promptCompletion leaf is the last row
+    input.feedKey({ key: "Enter" }); // expand it into conversation lines
+    input.feedKey({ key: "j" }); // onto "[user] hello there"
+    await until(() => cursorRow(out).includes("hello there"));
+    input.feedKey({ key: "f" });
+    fs.appendFileSync(file, toolLines("s2", "laterTool", 1_000));
+    await until(() => out.lastText().includes("laterTool"));
+    input.feedKey({ key: "q" });
+    await done;
+    expect(cursorRow(out)).toContain("hello there");
   });
 
   it("a truncated file resets the view without crashing", async () => {

--- a/packages/agency-lang/lib/logsViewer/treeRows.flatten.test.ts
+++ b/packages/agency-lang/lib/logsViewer/treeRows.flatten.test.ts
@@ -70,7 +70,7 @@ describe("llmCall span flatten", () => {
       ]),
     );
     const convos = convoSummaries(rows);
-    expect(convos).toEqual(['[user] "hello"', '[assistant] "hi there"']);
+    expect(convos).toEqual(["[user] hello", "[assistant] hi there"]);
     // No toolExecution row, but a raw-data toggle should be present.
     expect(rows.some((r) => r.node.nodeKind === "rawDataToggle")).toBe(true);
     // The intermediate promptCompletion leaf is absorbed (not shown).
@@ -136,10 +136,10 @@ describe("llmCall span flatten", () => {
     // Conversation appears once, in order, with no duplication.
     const convos = convoSummaries(rows);
     expect(convos).toEqual([
-      '[user] "Get the area of France"',
+      "[user] Get the area of France",
       '[assistant] tool call: getArea({"country":"France"})',
-      '[tool: getArea] "551695"',
-      '[assistant] "The area of France is 551,695 km²"',
+      "[tool: getArea] 551695",
+      "[assistant] The area of France is 551,695 km²",
     ]);
 
     // The toolExecution span is spliced between the assistant tool-call
@@ -152,11 +152,11 @@ describe("llmCall span flatten", () => {
       )
       .map((r) => (r.node.nodeKind === "span" ? "toolExecution" : stripAnsi(r.node.summary)));
     expect(kinds).toEqual([
-      '[user] "Get the area of France"',
+      "[user] Get the area of France",
       '[assistant] tool call: getArea({"country":"France"})',
       "toolExecution",
-      '[tool: getArea] "551695"',
-      '[assistant] "The area of France is 551,695 km²"',
+      "[tool: getArea] 551695",
+      "[assistant] The area of France is 551,695 km²",
     ]);
 
     // Exactly one llmCall span node at the top level (no sibling rounds).
@@ -297,9 +297,9 @@ describe("llmCall span flatten", () => {
     );
     const convos = convoSummaries(rows);
     // Outer conversation + the nested call's own conversation both show.
-    expect(convos).toContain('[user] "outer"');
-    expect(convos).toContain('[user] "What is the area?"');
-    expect(convos).toContain('[assistant] "about 551,695"');
-    expect(convos).toContain('[assistant] "final"');
+    expect(convos).toContain("[user] outer");
+    expect(convos).toContain("[user] What is the area?");
+    expect(convos).toContain("[assistant] about 551,695");
+    expect(convos).toContain("[assistant] final");
   });
 });

--- a/packages/agency-lang/lib/logsViewer/treeRows.test.ts
+++ b/packages/agency-lang/lib/logsViewer/treeRows.test.ts
@@ -171,7 +171,7 @@ describe("promptCompletion expansion", () => {
     // trace, leaf, [user], [assistant], raw-data toggle
     expect(rows).toHaveLength(5);
     expect(rows[2].node.nodeKind).toBe("convoLine");
-    expect(rows[2].node.summary).toBe(`${color.green("[user]")} "hi"`);
+    expect(rows[2].node.summary).toBe(`${color.green("[user]")} hi`);
     expect(rows[3].node.nodeKind).toBe("convoLine");
     expect(rows[4].node.nodeKind).toBe("rawDataToggle");
     expect(rows[4].node.id).toBe("evt-0:raw");

--- a/packages/agency-lang/lib/logsViewer/views/treeView.ts
+++ b/packages/agency-lang/lib/logsViewer/views/treeView.ts
@@ -144,7 +144,9 @@ export class TreeView implements View {
     // rotated to nothing), not a transient to ignore: clearing it keeps the
     // cursor — and so `cursorTraceId()` and the `l` label action — from pointing
     // at a trace no longer in the file.
-    const stillThere = findNode(roots, this.state.cursorId);
+    // A synthetic row (a conversation line, "raw data") is rebuilt from its
+    // leaf on render, so the cursor survives as long as the leaf does.
+    const stillThere = findNode(roots, realIdOf(this.state.cursorId));
     this.state = {
       ...this.state,
       roots,
@@ -205,8 +207,7 @@ export class TreeView implements View {
     const id = this.state.cursorId;
     if (id === "") return undefined;
     if (findNode(this.state.roots, id) !== undefined) return id;
-    const colon = id.indexOf(":");
-    return colon > 0 ? id.slice(0, colon) : id;
+    return realIdOf(id);
   }
 
   private paginate(event: KeyEvent, viewport: Viewport): ViewerState | undefined {
@@ -303,6 +304,12 @@ export class TreeView implements View {
     if (state.messageBar) parts.push(state.messageBar);
     return line(bottomHints(parts.join("  "), "tree", viewport.cols), { fg: "gray" });
   }
+}
+
+/** The leaf a synthetic row id (`<leafId>:convo:…`, `<leafId>:raw`) belongs to. */
+function realIdOf(id: string): string {
+  const colon = id.indexOf(":");
+  return colon > 0 ? id.slice(0, colon) : id;
 }
 
 function findNode(roots: TreeNode[], id: string): TreeNode | undefined {

--- a/packages/agency-lang/lib/runtime/builtinPolicies.ts
+++ b/packages/agency-lang/lib/runtime/builtinPolicies.ts
@@ -36,6 +36,9 @@ export const minimalAutoApprovePolicy: Policy = {
 
 export const recommendedAutoApprovePolicy: Policy = {
   ...minimalAutoApprovePolicy,
+  // A sandboxed subprocess: the code it runs raises its own effects back
+  // through this same policy, so approving the launch grants nothing more.
+  "std::run": approve,
   "std::read": approve,
   "std::readBinary": approve,
   "std::ls": approve,

--- a/packages/agency-lang/stdlib/agency.agency
+++ b/packages/agency-lang/stdlib/agency.agency
@@ -29,7 +29,7 @@ import {
   _parseStatements,
   _toSource,
   _combine,
-} from "agency-lang/stdlib-lib/template.js"
+ } from "agency-lang/stdlib-lib/template.js"
 import { VERSION } from "agency-lang/stdlib-lib/version.js"
 
 /** @module
@@ -205,12 +205,12 @@ export def run(
       // — keep the two in sync).
       return failure(
         {
-        reason: "limit_exceeded",
-        limit: "cost",
-        threshold: maxCost,
-        value: err.actualCost,
-        message: "Subprocess exceeded cost limit of ${maxCost} (used ${err.actualCost})"
-      },
+          reason: "limit_exceeded",
+          limit: "cost",
+          threshold: maxCost,
+          value: err.actualCost,
+          message: "Subprocess exceeded cost limit of ${maxCost} (used ${err.actualCost})"
+        },
       )
     }
   }
@@ -351,7 +351,10 @@ export def test(
       // The scripted-answer state the inline handler mutates: which answer
       // is next, and whether an expectedMessage mismatch already decided
       // this case.
-      const scripted = { index: 0, mismatch: "" }
+      const scripted = {
+        index: 0,
+        mismatch: ""
+      }
       const answers = testCase.interrupts ?? []
       let runResult = null
       handle {
@@ -417,9 +420,18 @@ export def test(
       if (!casePassed) {
         allPass = false
       }
-      caseReports.push({ node: testCase.node, pass: casePassed, feedback: feedback })
+      caseReports.push(
+        {
+          node: testCase.node,
+          pass: casePassed,
+          feedback: feedback
+        },
+      )
     }
-    return success({ pass: allPass, cases: caseReports })
+    return success({
+      pass: allPass,
+      cases: caseReports
+    })
   }
   if (guarded is failure(err)) {
     if (err.type == "guardFailure") {
@@ -427,12 +439,12 @@ export def test(
       // makeLimitFailure in lib/runtime/ipc.ts — keep the two in sync).
       return failure(
         {
-        reason: "limit_exceeded",
-        limit: "cost",
-        threshold: maxCost,
-        value: err.actualCost,
-        message: "Test run exceeded cost limit of ${maxCost} (used ${err.actualCost})"
-      },
+          reason: "limit_exceeded",
+          limit: "cost",
+          threshold: maxCost,
+          value: err.actualCost,
+          message: "Test run exceeded cost limit of ${maxCost} (used ${err.actualCost})"
+        },
       )
     }
   }
@@ -445,7 +457,7 @@ export def testFile(
   maxCost: number | null = null,
 ): Result<TestReport> {
   """
-  Run the test cases a .test.json file declares against its source file, in the sandboxed subprocess, and return a per-case report. The portable form of test(): the same file `agency test` runs, restricted to the sandbox subset (exact criteria; approve/reject scripted answers; per-case timeoutMs; named args instead of the CLI's input string).
+  Run the test cases a .test.json file declares against its source file.
 
   @param dir - The directory holding the .test.json and the file it tests
   @param filename - The .test.json file
@@ -467,12 +479,12 @@ export def testFile(
     for (c in wire.cases) {
       cases.push(
         {
-        node: c.node,
-        args: c.args,
-        expected: c.expected,
-        interrupts: c.interrupts,
-        wallClock: c.wallClock
-      },
+          node: c.node,
+          args: c.args,
+          expected: c.expected,
+          interrupts: c.interrupts,
+          wallClock: c.wallClock
+        },
       )
     }
     return test(
@@ -496,29 +508,29 @@ def checkRunCodeLimits(
 ): string {
   const checks = [
     {
-    name: "wallClock",
-    value: wallClock,
-    max: 3600s,
-    unit: "milliseconds"
-  },
+      name: "wallClock",
+      value: wallClock,
+      max: 3600s,
+      unit: "milliseconds"
+    },
     {
-    name: "memory",
-    value: memory,
-    max: 4096mb,
-    unit: "bytes"
-  },
+      name: "memory",
+      value: memory,
+      max: 4096mb,
+      unit: "bytes"
+    },
     {
-    name: "ipcPayload",
-    value: ipcPayload,
-    max: 1024mb,
-    unit: "bytes"
-  },
+      name: "ipcPayload",
+      value: ipcPayload,
+      max: 1024mb,
+      unit: "bytes"
+    },
     {
-    name: "stdout",
-    value: stdout,
-    max: 100mb,
-    unit: "bytes"
-  },
+      name: "stdout",
+      value: stdout,
+      max: 100mb,
+      unit: "bytes"
+    },
   ]
   for (check in checks) {
     if (check.value <= 0) {
@@ -611,7 +623,10 @@ export def runCode(
 `typecheck` does not restrict imports to the standard library only.
 Relative imports (./foo.agency) cannot be resolved from a source string.
 */
-export idempotent def typecheck(source: string, ignoreCodes: string[] = []): Result<TypeCheckReport> {
+export idempotent def typecheck(
+  source: string,
+  ignoreCodes: string[] = [],
+): Result<TypeCheckReport> {
   """
   Type-check Agency source code.
 
@@ -637,7 +652,10 @@ export idempotent def typecheck(source: string, ignoreCodes: string[] = []): Res
       warnings.push(diag)
     }
   }
-  return success({ errors: errors, warnings: warnings })
+  return success({
+    errors: errors,
+    warnings: warnings
+  })
 }
 
 /** Per-exported-symbol effect lists, keyed by node/function name. */
@@ -671,18 +689,18 @@ when re-exports chain); when that module cannot be read from a source
 string (relative paths), the entry has kind "reexport" and its effects
 are ["unknown"] rather than silently missing. */
 export type ExportInfo = {
-  name: string,
-  kind: "def" | "node" | "type" | "const" | "reexport",
-  signature: string,
-  docstring: string | null,
-  effects: string[],
-  destructive: boolean,
-  idempotent: boolean,
-  reexportedFrom: string | null
+  name: string;
+  kind: "def" | "node" | "type" | "const" | "reexport";
+  signature: string;
+  docstring?: string;
+  effects: string[];
+  destructive: boolean;
+  idempotent: boolean;
+  reexportedFrom?: string
 }
 
 export type ModuleInfo = {
-  description: string | null,
+  description?: string;
   exports: ExportInfo[]
 }
 
@@ -699,7 +717,6 @@ export idempotent def describe(source: string): Result<ModuleInfo> {
   """
   return try _describe(source)
 }
-
 
 type FilterImportsResult = {
   source: string;
@@ -796,11 +813,11 @@ export type Code = {
 }
 
 export type HoleInfo = {
-  name: string,
-  sort: "expr" | "statements" | "identifier" | "decl",
-  splice: boolean,
-  type: string | null,
-  origin: string | null
+  name: string;
+  sort: "expr" | "statements" | "identifier" | "decl";
+  splice: boolean;
+  type?: string;
+  origin?: string
 }
 
 export def loadTemplate(dir: string, filename: string): Result<Code> {
@@ -831,7 +848,10 @@ export idempotent def holesOf(template: Code): HoleInfo[] {
   return _holesOf(template)
 }
 
-export idempotent def fill(template: Code, values: Record<string, Json | Code>): Result<Code> {
+export idempotent def fill(
+  template: Code,
+  values: Record<string, Json | Code>,
+): Result<Code> {
   """
   Fill holes in a template. Plain values become literals and are never parsed; Code values are grafted as trees. Filling some holes and not others returns a template with the rest still in it.
 

--- a/packages/agency-lang/stdlib/agency.agency
+++ b/packages/agency-lang/stdlib/agency.agency
@@ -692,15 +692,15 @@ export type ExportInfo = {
   name: string;
   kind: "def" | "node" | "type" | "const" | "reexport";
   signature: string;
-  docstring?: string;
+  docstring: string | null;
   effects: string[];
   destructive: boolean;
   idempotent: boolean;
-  reexportedFrom?: string
+  reexportedFrom: string | null
 }
 
 export type ModuleInfo = {
-  description?: string;
+  description: string | null;
   exports: ExportInfo[]
 }
 
@@ -816,8 +816,8 @@ export type HoleInfo = {
   name: string;
   sort: "expr" | "statements" | "identifier" | "decl";
   splice: boolean;
-  type?: string;
-  origin?: string
+  type: string | null;
+  origin: string | null
 }
 
 export def loadTemplate(dir: string, filename: string): Result<Code> {

--- a/packages/agency-lang/stdlib/agents/agency/coding.agency
+++ b/packages/agency-lang/stdlib/agents/agency/coding.agency
@@ -18,8 +18,8 @@ import {
   readOnlyGitTools,
  } from "std::agents/lib/toolkits"
 import { fetch, fetchJSON, fetchMarkdown } from "std::http"
-import { Critique, revise } from "std::strategy"
 import { agentSkill } from "std::skills"
+import { Critique, revise } from "std::strategy"
 import { systemMessage, threadIsNew } from "std::thread"
 
 /** A failed generation: the last source attempted, with the problems found
@@ -142,7 +142,10 @@ def outcomeToResult(outcome: WriteOutcome): Result<string, WriteFailure> {
   if (outcome.valid) {
     return success(outcome.source)
   }
-  return failure({ source: outcome.source, problems: outcome.problems })
+  return failure({
+    source: outcome.source,
+    problems: outcome.problems
+  })
 }
 
 // Judge one generated program. The critique it returns becomes the repair
@@ -154,23 +157,26 @@ def checkSource(source: string, requireMain: boolean): Critique {
     const findings = renderFeedback(reviewed)
     return {
       accepted: false,
-      feedback: "That code has problems:\n${findings}\nReturn a corrected complete program.",
+      feedback: "That code has problems:\n${findings}\nReturn a corrected complete program."
     }
   }
   const compiled = compile(source)
   if (compiled is failure(compileErr)) {
     return {
       accepted: false,
-      feedback: "That code failed to compile:\n${compileErr}\nReturn a corrected complete program.",
+      feedback: "That code failed to compile:\n${compileErr}\nReturn a corrected complete program."
     }
   }
   if (requireMain && !hasMainNode(source)) {
     return {
       accepted: false,
-      feedback: "The program compiles but has no `node main`. Every program MUST have a node named `main` as its entry point. Add one and return the complete program.",
+      feedback: "The program compiles but has no `node main`. Every program MUST have a node named `main` as its entry point. Add one and return the complete program."
     }
   }
-  return { accepted: true, feedback: "" }
+  return {
+    accepted: true,
+    feedback: ""
+  }
 }
 
 // The critique doubles as the record of what was wrong with the attempt, so
@@ -179,16 +185,30 @@ def checkSource(source: string, requireMain: boolean): Critique {
 def outcomeFor(source: string, requireMain: boolean): WriteOutcome {
   const critique = checkSource(source, requireMain: requireMain)
   if (critique.accepted) {
-    return { valid: true, source: source, problems: [] }
+    return {
+      valid: true,
+      source: source,
+      problems: []
+    }
   }
-  return { valid: false, source: source, problems: [critique.feedback] }
+  return {
+    valid: false,
+    source: source,
+    problems: [critique.feedback]
+  }
 }
 
 def critiqueOf(outcome: WriteOutcome): Critique {
   if (outcome.valid) {
-    return { accepted: true, feedback: "" }
+    return {
+      accepted: true,
+      feedback: ""
+    }
   }
-  return { accepted: false, feedback: outcome.problems[0] }
+  return {
+    accepted: false,
+    feedback: outcome.problems[0]
+  }
 }
 
 def generateLoop(
@@ -210,10 +230,7 @@ def generateLoop(
     deliverable = "Write Agency module source for this task. The deliverable is the module contents itself: define and export what the task names. A `node main` is not required."
   }
   const opening = "${deliverable}\n<task>\n${withContext(task: task, context: context)}\n</task>"
-  return revise(
-    maxAttempts: maxAttempts,
-    check: critiqueOf,
-  ) as critique {
+  return revise(maxAttempts: maxAttempts, check: critiqueOf) as critique {
     // if/else, not a ternary: a ternary inside a block evaluates to null.
     // See tests/agency/agents/blockProbe.agency.
     let prompt = critique
@@ -265,7 +282,11 @@ export def agencyCodingAgent(
     when the deliverable is a library module whose exports the caller places.
   """
   const captured = guard(cost: maxCost, time: maxTime, label: "agencyCodingAgent") {
-    let outcome: WriteOutcome = { valid: false, source: "", problems: ["generation never ran"] }
+    let outcome: WriteOutcome = {
+      valid: false,
+      source: "",
+      problems: ["generation never ran"]
+    }
     thread(label: "agencyCodingAgent", session: session) {
       outcome = generateLoop(
         task: task,
@@ -292,10 +313,12 @@ export def agencyCodingAgent(
   // interpolated rather than a .type field that only guard trips carry.
   if (isFailure(captured)) {
     // Nothing was ever drafted: the run stopped before the first attempt.
-    return failure({
-      source: "",
-      problems: ["agencyCodingAgent stopped before generating: ${captured.error}"],
-    })
+    return failure(
+      {
+        source: "",
+        problems: ["agencyCodingAgent stopped before generating: ${captured.error}"]
+      },
+    )
   }
   // A rejected trip with a saved draft arrives success-shaped carrying the
   // draft, which has the same WriteOutcome shape as a normal return, so

--- a/packages/agency-lang/stdlib/agents/lib/toolkits.agency
+++ b/packages/agency-lang/stdlib/agents/lib/toolkits.agency
@@ -174,8 +174,8 @@ export def agencyDocTools(): any[] {
 
 export def agencyCodeTools(): any[] {
   """
-  Return tools that inspect Agency source without running it: the type
-  checker and the parser.
+  Return tools for checking Agency source: the type checker, the parser,
+  and testFile, which runs a .test.json harness in a sandboxed subprocess.
   """
   return [typecheck, parseAST, testFile]
 }

--- a/packages/agency-lang/stdlib/agents/lib/toolkits.agency
+++ b/packages/agency-lang/stdlib/agents/lib/toolkits.agency
@@ -10,7 +10,7 @@
   at call time. An agent whose list includes searchTools() must build that
   list inside a function too, or it freezes the environment at module load.
 */
-import { typecheck, parseAST } from "std::agency"
+import { typecheck, parseAST, testFile } from "std::agency"
 import { todoWrite, todoList } from "std::agent"
 import { edit } from "std::fs"
 import {
@@ -35,8 +35,8 @@ import {
  } from "std::git"
 import { fetch, fetchJSON, fetchMarkdown } from "std::http"
 import { remember, recall } from "std::memory"
-import { ls, glob, grep, exec } from "std::shell"
 import { safeBash } from "std::safeBash"
+import { ls, glob, grep, exec } from "std::shell"
 import { docsSkill } from "std::skills"
 import {
   search as wikipediaSearch,
@@ -177,7 +177,7 @@ export def agencyCodeTools(): any[] {
   Return tools that inspect Agency source without running it: the type
   checker and the parser.
   """
-  return [typecheck, parseAST]
+  return [typecheck, parseAST, testFile]
 }
 
 export def memoryTools(): any[] {


### PR DESCRIPTION
## What

Three fixes found while running the fib coding eval, plus two logs-viewer fixes.

**The agent could not check its own work.** In `runs/2026-08-22-151431-k0pBj-` the code subagent spent the run hunting for an `agency` executable (`which agency`, `find /`, `npm ls -g`), every `exec`/`bash` attempt auto-rejected. Three things had to change:

1. `std::run` had no rule in the `recommended` or `with-writes` policy, so `testFile` (which runs the harness in a sandboxed subprocess) would have been auto-rejected in a headless run exactly like `exec` was. It is now approved in `recommended`: the subprocess raises its own effects back through the same policy, so approving the launch grants nothing more. Verified without an LLM: `agency run --policy recommended` of a `testFile` call on the agent's workdir reports 4/4 passing; under `minimal` the same call is "interrupt rejected".
2. `testFile` is in `agencyCodeTools`, so every coding agent has it; the coordinator's `codeTools` no longer lists it a second time.
3. The code subagent's system prompt (rule 6) said to run tests via `safeBash` and advertised `agency test` through the CLI skill. It now says Agency tests run with the `testFile` tool after the sources are written to disk, and not to look for an `agency` executable. The fib task text says the same.

**Logs viewer.** Message content rendered through `JSON.stringify`, so every newline showed as `\n`; it now renders as written, continuation lines indented. And in follow mode the cursor jumped to the top on every append whenever it sat on a conversation line: those rows are synthetic (built at render time, not in the forest), so `setData`'s lookup failed and fell back to the first row. The lookup now resolves a synthetic id through its leaf. Regression test in `followMode.test.ts`; it failed on the old code with the cursor on the trace root.

Also in here: stdlib formatting and the regenerated stdlib docs from the same checkout.

## Verification

`make` clean; 259 logs-viewer tests and the builtin-policy tests pass; `lint:structure` clean; the `testFile` positive/negative control above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9qdZJPTUdY1US8n8f8rTH
