### PR TITLE
Default model: gpt-5-mini through openai-responses, as one named constant

### DIFF
--- a/packages/agency-lang/agency.json
+++ b/packages/agency-lang/agency.json
@@ -8,7 +8,8 @@
   },
   "client": {
     "logLevel": "warn",
-    "defaultModel": "gpt-4o-mini"
+    "defaultModel": "gpt-5-mini",
+    "defaultProvider": "openai-responses"
   },
   "typechecker": {
     "enabled": true

--- a/packages/agency-lang/docs/dev/config.md
+++ b/packages/agency-lang/docs/dev/config.md
@@ -34,12 +34,22 @@ mapped by `applyCliFlags`:
 
 | you write | `client.defaultModel` | `client.defaultProvider` |
 | --- | --- | --- |
-| `gpt-4o-mini` | `gpt-4o-mini` | **deleted** |
+| `gpt-5-mini` | `gpt-5-mini` | **deleted** |
 | `anthropic/claude-opus-4-8` | `claude-opus-4-8` | `anthropic` |
 | `openrouter/anthropic/claude-sonnet-4` | `anthropic/claude-sonnet-4` | `openrouter` |
 
 The split is on the **first** slash only, which is what lets an OpenRouter model
 identifier survive as the model name.
+
+With no model anywhere (no flag, no `client.defaultModel`), codegen bakes
+`DEFAULT_MODEL` and `DEFAULT_PROVIDER` from `lib/config.ts` together
+(`gpt-5-mini` through `openai-responses`; the provider is named because the
+inferred route for an OpenAI model is the base `openai` client, which has no
+hosted web search). A configured model without a provider is baked alone, so
+smoltalk infers the provider for the model the user named. The same constant
+is the fallback in the memory manager, the optimizer's mutator, and
+`SimpleOpenAIClient`. Note that the gpt-5 family rejects `temperature`; a
+program that sets it must also name a model that accepts it.
 
 Three things about this are easy to get wrong later.
 

--- a/packages/agency-lang/docs/site/guide/agency-config-file.md
+++ b/packages/agency-lang/docs/site/guide/agency-config-file.md
@@ -42,7 +42,7 @@ This is where you set your default model, provider, and API keys.
 
 | Option | Description |
 | --- | --- |
-| `defaultModel` / `defaultProvider` | Used when a `llm()` call doesn't specify its own. |
+| `defaultModel` / `defaultProvider` | Used when a `llm()` call doesn't specify its own. With neither set, calls use `gpt-5-mini` through `openai-responses`. Naming a model without a provider lets the provider be inferred from the model. |
 | `apiKey` | Keys for `openAi`, `google`, `anthropic`, `ollama`, `openRouter`, `deepInfra`, `liteLlm`, and `openAiCompat`. |
 | `baseUrl` | Needed if you're using a provider that provides an endpoint compatible with the OpenAI API, such as `openRouter`, `deepInfra`, `liteLlm` and others. |
 | `maxToolResultChars` | Caps how much of a single tool result the model sees (the full value still reaches your code). Default `100000`; `0` disables it. Keeps a chatty tool from blowing the context window. |

--- a/packages/agency-lang/docs/site/guide/memory.md
+++ b/packages/agency-lang/docs/site/guide/memory.md
@@ -332,7 +332,7 @@ Every field beyond `dir` is optional:
 | Field | Default | What it does |
 |---|---|---|
 | `dir` | *(required)* | Directory for per-scope JSON files. |
-| `model` | `agency.json` default, else `gpt-4o-mini` | Model for memory's own LLM work: extraction, recall re-ranking, forget, and compaction. |
+| `model` | `agency.json` default, else `gpt-5-mini` | Model for memory's own LLM work: extraction, recall re-ranking, forget, and compaction. |
 | `autoExtract.interval` | `5` | LLM turns between automatic extraction passes. |
 | `compaction.trigger` | `"messages"` | What the threshold counts — `"messages"` or `"token"`. |
 | `compaction.threshold` | — | Compact once the conversation grows past this. |

--- a/packages/agency-lang/lib/backends/smoltalkDefaults.codegen.test.ts
+++ b/packages/agency-lang/lib/backends/smoltalkDefaults.codegen.test.ts
@@ -61,8 +61,14 @@ describe("smoltalkDefaults codegen", () => {
     expect(out).toContain("https://proxy.test/v1");
   });
 
-  it("omits provider when defaultProvider is unset", () => {
+  it("bakes the built-in provider with the built-in model when nothing is configured", () => {
     const out = generate(PROGRAM);
+    expect(out).toMatch(/model:\s*"gpt-5-mini"/);
+    expect(out).toMatch(/provider:\s*"openai-responses"/);
+  });
+
+  it("omits provider when the user names a model but no provider: smoltalk infers it", () => {
+    const out = generate(PROGRAM, { client: { defaultModel: "claude-opus-4-8" } });
     // anchor to a baked `provider: "<literal>"` pair, not the bare token —
     // `provider` appears elsewhere in generated output (metadata, embed calls).
     expect(out).not.toMatch(/provider:\s*"/);

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -49,7 +49,7 @@ import * as renderBuiltinToolRegistration from "../templates/backends/typescript
 import * as renderResultCheckpointSetup from "../templates/backends/typescriptGenerator/resultCheckpointSetup.js";
 import * as renderFunctionCatchFailure from "../templates/backends/typescriptGenerator/functionCatchFailure.js";
 
-import { AgencyConfig } from "@/config.js";
+import { AgencyConfig, DEFAULT_MODEL, DEFAULT_PROVIDER } from "@/config.js";
 import { parseDurationMs } from "@/duration.js";
 import { BinOpArgument, BinOpExpression, Operator, PRECEDENCE } from "@/types/binop.js";
 import { MessageThread } from "@/types/messageThread.js";
@@ -378,9 +378,11 @@ export class TypeScriptBuilder {
       log: {
         host: "https://statelog.adit.io",
       },
+      // No defaultModel here: the smoltalk-fields builder applies the
+      // built-in model and provider together only when neither is
+      // configured, which a merged default would hide.
       client: {
         logLevel: "warn",
-        defaultModel: "gpt-4o-mini",
         statelog: {
           host: "https://statelog.adit.io",
           projectId: "smoltalk",
@@ -4071,7 +4073,7 @@ export class TypeScriptBuilder {
           : ts.binOp(ts.env("OPENAI_COMPAT_API_KEY"), "||", ts.str("")),
       }),
       baseUrl: ts.obj(baseUrlFields),
-      model: ts.str(cfg.client?.defaultModel || "gpt-4o-mini"),
+      model: ts.str(cfg.client?.defaultModel || DEFAULT_MODEL),
       logLevel: ts.str(cfg.client?.logLevel || "warn"),
       statelog: ts.obj({
         host: ts.str(cfg.client?.statelog?.host || ""),
@@ -4080,10 +4082,13 @@ export class TypeScriptBuilder {
         traceId: $(ts.id("nanoid")).call().done(),
       }),
     };
-    // Emit a default provider only when configured — otherwise leave it unset
-    // so smoltalk's normal model→provider registry lookup still applies.
-    if (cfg.client?.defaultProvider) {
-      smoltalkFields.provider = ts.str(cfg.client.defaultProvider);
+    // The provider: the configured one; else, when the model is the built-in
+    // default too, its built-in provider; else unset, so smoltalk's normal
+    // model→provider registry lookup applies to the model the user named.
+    const provider =
+      cfg.client?.defaultProvider || (cfg.client?.defaultModel ? undefined : DEFAULT_PROVIDER);
+    if (provider) {
+      smoltalkFields.provider = ts.str(provider);
     }
     return ts.obj(smoltalkFields);
   }

--- a/packages/agency-lang/lib/config.ts
+++ b/packages/agency-lang/lib/config.ts
@@ -831,6 +831,13 @@ export function applyCliFlags(config: AgencyConfig, flags: CliFlags, input?: str
   return next;
 }
 
+/** The model every LLM call uses when neither agency.json nor the call names
+ *  one, and the provider it routes through. The provider is named rather than
+ *  inferred because the inferred route for an OpenAI model is the base "openai"
+ *  client, which has no hosted web search; "openai-responses" does. */
+export const DEFAULT_MODEL = "gpt-5-mini";
+export const DEFAULT_PROVIDER = "openai-responses";
+
 /** The one env var carrying a JSON Partial<AgencyConfig> into an already-compiled
  *  process (see the source-of-truth note above, source 3). */
 export const CONFIG_OVERRIDES_ENV = "AGENCY_CONFIG_OVERRIDES";

--- a/packages/agency-lang/lib/optimize/mutator.ts
+++ b/packages/agency-lang/lib/optimize/mutator.ts
@@ -4,7 +4,7 @@ import * as path from "path";
 
 import { z } from "zod";
 
-import type { AgencyConfig } from "@/config.js";
+import { DEFAULT_MODEL, type AgencyConfig } from "@/config.js";
 import { executeNodeAsync } from "@/cli/util.js";
 import type { Test } from "@/eval/runTypes.js";
 import { getAgentsDir } from "@/importPaths.js";
@@ -116,7 +116,7 @@ export function buildMutatorSections(promptInputs: MutatorPromptInputs): Mutator
  * diagnostics come back in via `args.diagnostics` for a retry.
  */
 export async function proposeMutation(args: ProposeMutationArgs): Promise<MutationProposal> {
-  const model = args.model || args.config.client?.defaultModel || "gpt-4o-mini";
+  const model = args.model || args.config.client?.defaultModel || DEFAULT_MODEL;
   const sections = buildMutatorSections(args);
   const raw = await (args.callModel ?? defaultCallModel)({
     sections,

--- a/packages/agency-lang/lib/runtime/memory/manager.ts
+++ b/packages/agency-lang/lib/runtime/memory/manager.ts
@@ -1,6 +1,8 @@
 import { z } from "zod";
 import * as smoltalk from "smoltalk";
 import type { SmolConfig } from "smoltalk";
+
+import { DEFAULT_MODEL } from "@/config.js";
 import {
   EMBEDDING_FORMAT_VERSION,
   type MemoryConfig,
@@ -589,7 +591,7 @@ export class MemoryManager {
     if (this.config.model) return this.config.model;
     const smoltalkModel = (this.smoltalkDefaults as { model?: string }).model;
     if (smoltalkModel) return smoltalkModel;
-    return "gpt-4o-mini";
+    return DEFAULT_MODEL;
   }
 
   /**

--- a/packages/agency-lang/lib/runtime/memory/types.ts
+++ b/packages/agency-lang/lib/runtime/memory/types.ts
@@ -76,7 +76,7 @@ export type MemoryConfig = {
   /** Model used for memory's internal LLM calls (extraction, recall,
    *  forget, compaction, summary merge). Resolution order:
    *  this field > the top-level `defaultModel` from `agency.json` >
-   *  the hardcoded fallback (`"gpt-4o-mini"`). Set this when you want
+   *  the built-in default (`DEFAULT_MODEL` in lib/config.ts). Set this when you want
    *  a specific cheap model for memory work that differs from the
    *  agent's primary model. */
   model?: string;

--- a/packages/agency-lang/lib/runtime/simpleOpenAIClient.ts
+++ b/packages/agency-lang/lib/runtime/simpleOpenAIClient.ts
@@ -1,6 +1,8 @@
 import type { PromptResult, StreamChunk, TokenUsage, CostEstimate } from "smoltalk";
 import type { Result } from "smoltalk";
 import { DEFAULT_EMBEDDING_MODEL } from "../constants.js";
+import { DEFAULT_MODEL } from "@/config.js";
+
 import type { EmbedConfig, EmbedResult, LLMClient, PromptConfig, ToolCall } from "./llmClient.js";
 
 export class SimpleOpenAIClient implements LLMClient {
@@ -15,7 +17,7 @@ export class SimpleOpenAIClient implements LLMClient {
       );
     }
     this.apiKey = apiKey;
-    this.defaultModel = opts?.model ?? "gpt-4o-mini";
+    this.defaultModel = opts?.model ?? DEFAULT_MODEL;
   }
 
   async text(config: PromptConfig): Promise<Result<PromptResult>> {

--- a/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptBuilder/simple.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/simple.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/array.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/array.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/codeLiteral.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/codeLiteral.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/comments.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comments.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/comprehension.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comprehension.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/destructiveBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/destructiveBlock.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/destructiveNested.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/destructiveNested.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/goto.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/goto.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/imports.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/imports.mjs
@@ -79,14 +79,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/input.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/input.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/intersectionTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/intersectionTypes.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlockBlockArms.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlockBlockArms.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/matchExpression.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchExpression.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/recursiveTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recursiveTypes.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/schemaChaining.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaChaining.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
@@ -65,14 +65,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/simple.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/simple.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/skill.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/skill.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/slice.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/slice.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/splat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/splat.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/static.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/static.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/type-patterns.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/type-patterns.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/typeOperators.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeOperators.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/utilityTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/utilityTypes.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",

--- a/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
@@ -64,14 +64,15 @@ const __globalCtx = new RuntimeContext({
       liteLlm: __process.env["LITELLM_BASE_URL"] || "",
       openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
     },
-    model: "gpt-4o-mini",
+    model: "gpt-5-mini",
     logLevel: "warn",
     statelog: {
       host: "https://statelog.adit.io",
       projectId: "smoltalk",
       apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
       traceId: nanoid()
-    }
+    },
+    provider: "openai-responses"
   },
   dirname: __dirname,
   logLevel: "info",


### PR DESCRIPTION
The language's default model moves from `gpt-4o-mini` (provider inferred: the base `openai` client) to `gpt-5-mini` through `openai-responses`. Newer, cheaper on output, and on a route that offers hosted web search, which the base `openai` client does not. The agency agent already ran `gpt-5-mini` as its fast slot; this aligns the language default with it.

## What changes

- **One named default.** `DEFAULT_MODEL` / `DEFAULT_PROVIDER` in `lib/config.ts`. Before, the fallback string was hard-coded in five places (codegen twice, the memory manager, the optimizer's mutator, `SimpleOpenAIClient`); all five read the constant now.
- **Codegen bakes model and provider together only when `agency.json` names neither.** A configured `defaultModel` without a `defaultProvider` is still baked alone, so smoltalk infers the provider for the model the user named (`--model claude-…` keeps working as before). The builder's merged defaults object no longer carries a model, because the deep merge made "unset" indistinguishable from "set to the default"; `smoltalkDefaults.codegen.test.ts` covers both cases.
- **`agency.json`** sets `defaultModel: "gpt-5-mini"` and `defaultProvider: "openai-responses"`.
- **Fixtures** under `tests/typescriptGenerator`, `tests/typescriptBuilder`, `tests/debugger` regenerated with `make fixtures` (the baked `model:` line, plus a `provider:` line). 96 files of mechanical diff.
- Docs: `agency-config-file.md` says what the default is, `memory.md` and `docs/dev/config.md` updated; a paragraph in `docs/dev/config.md` records the baking rule.

## Verified

A probe program on the new default: structured output and a tool call both work. `agencyReviewAgent` runs end to end on it. `lib/runtime`, `lib/stdlib`, `lib/backends`, config, model-flag, and the generator fixture suites pass (256 files, 4125 tests); `make`, `lint:structure`, prettier, and the text guard are clean.

## One thing to know

The gpt-5 family rejects the `temperature` parameter (400 "Unsupported parameter"). No stdlib or agent code sets it; a user program that passes `temperature` under the default model now has to name a model that accepts it. Noted in `docs/dev/config.md`.

Independent of #892 (which fixes the separate hosted-search gate bug); either can land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1f3ZTxh92pD7N4DDbDA3h
