### PR TITLE
eval grade: -n parallel, a progress line per run, and the judges' bill

### DIFF
--- a/packages/agency-lang/docs/site/cli/eval.md
+++ b/packages/agency-lang/docs/site/cli/eval.md
@@ -9,7 +9,7 @@ description: How to run an Agency agent against a test suite, score it with grad
 
 ```
 agency eval run (<file>[:<node>] | --agent-cmd '<command with {input}>') (--suite <file|dir|git-url> | --input <text>) [-n <count>] [--trials <count>]
-agency eval grade <runDir> [--suite <file|dir|git-url>] [--goal <text>]
+agency eval grade <runDir> [--suite <file|dir|git-url>] [--goal <text>] [-n <count>]
 agency eval logs <runDir> [-f]
 agency eval optimize <file>[:<node>] [--suite <file|dir>] [--goal <text>] [--graders <file>]
 agency label <runDir> --checklist <file> [--annotator <id>]
@@ -190,6 +190,8 @@ agency eval grade runs/smoke
 #   objective  0.71
 #     goal  0.71
 ```
+
+`-n, --parallel <count>` grades up to that many run directories at once — judge calls are LLM calls, so a big group grades much faster in parallel. A progress line per graded run (`graded 3/15 <dir> — objective 0.933 ($0.02, 12s)`) goes to stderr, and when the pass's judges cost money the report ends with `grading cost: $x.xx`.
 
 Each grader's verdict is appended to `annotations.jsonl` as a **score**. Grading again appends another pass rather than rewriting anything, so every grading pass survives and the latest complete pass is the one listings show. Re-grading costs nothing for `ExactMatch`, `Contains`, `Similarity` and function graders that do not call `judge`; an `LlmJudge` still makes a live LLM call each time.
 

--- a/packages/agency-lang/lib/cli/eval/formatGrade.test.ts
+++ b/packages/agency-lang/lib/cli/eval/formatGrade.test.ts
@@ -39,6 +39,20 @@ describe("formatGradeResult", () => {
     expect(lines).toContain("grading cost: $0.12");
   });
 
+  it("shows a sub-cent but nonzero cost as <$0.01, never $0.00", () => {
+    const result: EvalGradeResult = {
+      runs: [
+        { dir: "/runs/x/a", grading: grading("a", 1, [{ grader: "j", kind: "scalar", value: 1 }]) },
+        { dir: "/runs/x/b", grading: grading("b", 1, [{ grader: "j", kind: "scalar", value: 1 }]) },
+      ],
+      judgeCostUsd: 0.0004,
+      mean: 1,
+      gatesPassed: true,
+      batches: [],
+    };
+    expect(formatGradeResult(result).map(stripAnsi)).toContain("grading cost: <$0.01");
+  });
+
   it("one block per test: the score line, then one line per grader with feedback, no mean for a single run", () => {
     const result: EvalGradeResult = {
       runs: [

--- a/packages/agency-lang/lib/cli/eval/formatGrade.test.ts
+++ b/packages/agency-lang/lib/cli/eval/formatGrade.test.ts
@@ -20,6 +20,25 @@ function grading(
 }
 
 describe("formatGradeResult", () => {
+  it("prints the grading cost after the mean when judge calls cost money", () => {
+    const result: EvalGradeResult = {
+      runs: [
+        { dir: "/runs/x/a", grading: grading("a", 1, [{ grader: "j", kind: "scalar", value: 1 }]) },
+        {
+          dir: "/runs/x/b",
+          grading: grading("b", 0.5, [{ grader: "j", kind: "scalar", value: 0.5 }]),
+        },
+      ],
+      judgeCostUsd: 0.1234,
+      mean: 0.75,
+      gatesPassed: true,
+      batches: [],
+    };
+    const lines = formatGradeResult(result).map(stripAnsi);
+    expect(lines).toContain("mean 0.750 over 2 runs");
+    expect(lines).toContain("grading cost: $0.12");
+  });
+
   it("one block per test: the score line, then one line per grader with feedback, no mean for a single run", () => {
     const result: EvalGradeResult = {
       runs: [
@@ -31,6 +50,7 @@ describe("formatGradeResult", () => {
           ]),
         },
       ],
+      judgeCostUsd: 0,
       mean: 0.75,
       gatesPassed: true,
       batches: [],
@@ -49,6 +69,7 @@ describe("formatGradeResult", () => {
     withDescription.perInput[0].description = "checks the agent reads between the lines";
     const result: EvalGradeResult = {
       runs: [{ dir: "/runs/x/a", grading: withDescription }],
+      judgeCostUsd: 0,
       mean: 1,
       gatesPassed: true,
       batches: [],
@@ -70,6 +91,7 @@ describe("formatGradeResult", () => {
         },
         { dir: "/runs/x/b", grading: grading("b", 0, [], "the run ended with timeout") },
       ],
+      judgeCostUsd: 0,
       mean: 0.5,
       gatesPassed: false,
       batches: [],
@@ -91,6 +113,7 @@ describe("formatGradeResult with trial batches", () => {
   it("one batch of several trials: per-test mean ± SE and the batch accuracy after the run blocks", () => {
     const result: EvalGradeResult = {
       runs: [{ dir: "/runs/b1/fib/1", grading: fib }],
+      judgeCostUsd: 0,
       mean: 1,
       gatesPassed: true,
       batches: [
@@ -105,6 +128,7 @@ describe("formatGradeResult with trial batches", () => {
             {
               testId: "fib",
               trials: 3,
+              judgeCostUsd: 0,
               mean: 2 / 3,
               standardError: 1 / 3,
               meanCostUsd: 1,
@@ -113,6 +137,7 @@ describe("formatGradeResult with trial batches", () => {
             {
               testId: "sum",
               trials: 3,
+              judgeCostUsd: 0,
               mean: null,
               standardError: null,
               meanCostUsd: 1,
@@ -144,6 +169,7 @@ describe("formatGradeResult with trial batches", () => {
         {
           testId: "fib",
           trials: 2,
+          judgeCostUsd: 0,
           mean: accuracy,
           standardError: 0,
           meanCostUsd: 0,
@@ -153,6 +179,7 @@ describe("formatGradeResult with trial batches", () => {
     });
     const result: EvalGradeResult = {
       runs: [],
+      judgeCostUsd: 0,
       mean: 0,
       gatesPassed: true,
       batches: [batch("b1", 1), batch("b2", 0)],

--- a/packages/agency-lang/lib/cli/eval/formatGrade.test.ts
+++ b/packages/agency-lang/lib/cli/eval/formatGrade.test.ts
@@ -128,7 +128,6 @@ describe("formatGradeResult with trial batches", () => {
             {
               testId: "fib",
               trials: 3,
-              judgeCostUsd: 0,
               mean: 2 / 3,
               standardError: 1 / 3,
               meanCostUsd: 1,
@@ -137,7 +136,6 @@ describe("formatGradeResult with trial batches", () => {
             {
               testId: "sum",
               trials: 3,
-              judgeCostUsd: 0,
               mean: null,
               standardError: null,
               meanCostUsd: 1,

--- a/packages/agency-lang/lib/cli/eval/formatGrade.ts
+++ b/packages/agency-lang/lib/cli/eval/formatGrade.ts
@@ -90,8 +90,10 @@ function formatUngradedReason(reason: string | undefined): string[] {
 }
 
 function formatGroupSummary(result: EvalGradeResult): string[] {
+  // Judge calls cost money; deterministic graders are free and get no line.
+  const cost = result.judgeCostUsd > 0 ? [`grading cost: $${result.judgeCostUsd.toFixed(2)}`] : [];
   if (result.runs.length > 1) {
-    return [`mean ${formatScore(result.mean)} over ${result.runs.length} runs`];
+    return [`mean ${formatScore(result.mean)} over ${result.runs.length} runs`, ...cost];
   }
-  return [];
+  return cost;
 }

--- a/packages/agency-lang/lib/cli/eval/formatGrade.ts
+++ b/packages/agency-lang/lib/cli/eval/formatGrade.ts
@@ -89,9 +89,17 @@ function formatUngradedReason(reason: string | undefined): string[] {
   return [`  ${ttyColor.red(`not graded — ${reason}`)}`];
 }
 
+/** Sub-cent but nonzero shows as "<$0.01" so a printed cost never reads $0.00. */
+export function formatUsd(usd: number): string {
+  if (usd > 0 && usd < 0.005) {
+    return "<$0.01";
+  }
+  return `$${usd.toFixed(2)}`;
+}
+
 function formatGroupSummary(result: EvalGradeResult): string[] {
   // Judge calls cost money; deterministic graders are free and get no line.
-  const cost = result.judgeCostUsd > 0 ? [`grading cost: $${result.judgeCostUsd.toFixed(2)}`] : [];
+  const cost = result.judgeCostUsd > 0 ? [`grading cost: ${formatUsd(result.judgeCostUsd)}`] : [];
   if (result.runs.length > 1) {
     return [`mean ${formatScore(result.mean)} over ${result.runs.length} runs`, ...cost];
   }

--- a/packages/agency-lang/lib/cli/eval/grade.test.ts
+++ b/packages/agency-lang/lib/cli/eval/grade.test.ts
@@ -103,6 +103,35 @@ describe("evalGrade", () => {
     expect(Object.values(effective)[0].id).toBe(scores[1].id);
   });
 
+  it("parallel grading grades every run once, keeps walk order, and reports progress", async () => {
+    const group = fs.mkdtempSync(path.join(process.cwd(), ".test-group-"));
+    dirs.push(group);
+    for (const child of ["a", "b", "c"]) {
+      writeRunDirectory({ test: lenTest(child), output: "hello" }, path.join(group, child));
+    }
+    const progress: string[] = [];
+
+    const result = await evalGrade([group], {
+      parallel: 3,
+      progress: (message) => progress.push(message),
+      config: {},
+    });
+
+    // Walk order in the report, whatever the completion order was.
+    expect(result.runs.map((run) => path.basename(run.dir))).toEqual(["a", "b", "c"]);
+    expect(result.judgeCostUsd).toBe(0); // function graders make no LLM calls
+    // One progress line per run, numbered by completion.
+    expect(progress).toHaveLength(3);
+    expect([...progress].sort()).toEqual(progress.map((_, i) => progress[i]).sort());
+    for (const line of progress) {
+      expect(line).toMatch(/^graded [123]\/3 .* — objective 0\.500 \(\$0\.00, \d+s\)$/);
+    }
+    for (const child of ["a", "b", "c"]) {
+      const snapshot = readRunDirectory(path.join(group, child), { reportWarning: () => {} });
+      expect(snapshot.annotationRows.filter((row) => row.kind === "score")).toHaveLength(1);
+    }
+  });
+
   it("grades every run directory in a group, one pass each, and reports the mean", async () => {
     const group = fs.mkdtempSync(path.join(process.cwd(), ".test-group-"));
     dirs.push(group);

--- a/packages/agency-lang/lib/cli/eval/grade.test.ts
+++ b/packages/agency-lang/lib/cli/eval/grade.test.ts
@@ -120,9 +120,11 @@ describe("evalGrade", () => {
     // Walk order in the report, whatever the completion order was.
     expect(result.runs.map((run) => path.basename(run.dir))).toEqual(["a", "b", "c"]);
     expect(result.judgeCostUsd).toBe(0); // function graders make no LLM calls
-    // One progress line per run, numbered by completion.
+    // One progress line per run, numbered by completion: the ordinals are
+    // exactly 1..3 in some order.
     expect(progress).toHaveLength(3);
-    expect([...progress].sort()).toEqual(progress.map((_, i) => progress[i]).sort());
+    const ordinals = progress.map((line) => Number(/^graded (\d+)\/3 /.exec(line)?.[1]));
+    expect([...ordinals].sort()).toEqual([1, 2, 3]);
     for (const line of progress) {
       expect(line).toMatch(/^graded [123]\/3 .* — objective 0\.500 \(\$0\.00, \d+s\)$/);
     }

--- a/packages/agency-lang/lib/cli/eval/grade.ts
+++ b/packages/agency-lang/lib/cli/eval/grade.ts
@@ -23,6 +23,12 @@ export type EvalGradeOptions = {
   goal?: string;
   /** Also write the grading summary here, as JSON. */
   out?: string;
+  /** Grade up to this many run directories at once (default 1). Judge calls
+   *  are LLM calls, so a big group grades much faster in parallel. */
+  parallel?: number;
+  /** Called once per graded run directory, in completion order — the CLI's
+   *  progress line. Omitted (tests, programmatic use) = silent. */
+  progress?: (message: string) => void;
   config?: AgencyConfig;
 };
 
@@ -45,6 +51,8 @@ export type EvalGradeResult = {
   runs: { dir: string; grading: EvalRunGrading }[];
   /** Mean objective over the runs graded. */
   mean: number;
+  /** Total LLM spend of this pass's judge calls, in USD. */
+  judgeCostUsd: number;
   /** Every run passed its gates. */
   gatesPassed: boolean;
   /** Trial statistics for each selected batch that ran more than one trial,
@@ -95,14 +103,38 @@ export async function evalGrade(
   const runDirs = validateGradeTarget(targets, opts);
   const graders = graderSourceFor(opts, config);
 
-  const runs: EvalGradeResult["runs"] = [];
-  for (const dir of runDirs) {
-    const { grading } = await gradeSuite(dir, graders, config, { defaultGoal: opts.goal });
-    runs.push({ dir, grading });
-  }
+  // A bounded worker pool over run directories; slots keep the report in
+  // walk order however completion interleaves. Each directory is one
+  // gradeSuite call (its own pass id and its own judge-cost meter).
+  const parallel = Math.max(1, Math.floor(opts.parallel ?? 1));
+  const slots: (EvalGradeResult["runs"][number] & { judgeCostUsd: number })[] = new Array(
+    runDirs.length,
+  );
+  let nextIndex = 0;
+  let doneCount = 0;
+  const worker = async (): Promise<void> => {
+    for (;;) {
+      const index = nextIndex++;
+      const dir = runDirs[index];
+      if (dir === undefined) return;
+      const startedAt = Date.now();
+      const { grading, judgeCostUsd } = await gradeSuite(dir, graders, config, {
+        defaultGoal: opts.goal,
+      });
+      slots[index] = { dir, grading, judgeCostUsd };
+      doneCount += 1;
+      opts.progress?.(
+        `graded ${doneCount}/${runDirs.length} ${dir} — objective ${grading.objective.toFixed(3)}` +
+          ` ($${judgeCostUsd.toFixed(2)}, ${Math.round((Date.now() - startedAt) / 1000)}s)`,
+      );
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(parallel, runDirs.length) }, () => worker()));
+  const runs: EvalGradeResult["runs"] = slots.map(({ dir, grading }) => ({ dir, grading }));
   const result: EvalGradeResult = {
     runs,
     mean: runs.reduce((sum, run) => sum + run.grading.objective, 0) / runs.length,
+    judgeCostUsd: slots.reduce((sum, slot) => sum + slot.judgeCostUsd, 0),
     gatesPassed: runs.every((run) => run.grading.gatesPassed),
     batches: trialBatches(runDirs),
   };

--- a/packages/agency-lang/lib/cli/eval/grade.ts
+++ b/packages/agency-lang/lib/cli/eval/grade.ts
@@ -10,6 +10,9 @@ import { readRunDirectory } from "@/runDirectory/runDir.js";
 
 import type { GraderSource } from "@/eval/grading/gradeRun.js";
 
+import { mapInParallel } from "@/utils/parallelMap.js";
+
+import { formatGradeResult, formatUsd } from "./formatGrade.js";
 import { loadSuite } from "./run.js";
 
 export type EvalGradeOptions = {
@@ -103,38 +106,26 @@ export async function evalGrade(
   const runDirs = validateGradeTarget(targets, opts);
   const graders = graderSourceFor(opts, config);
 
-  // A bounded worker pool over run directories; slots keep the report in
-  // walk order however completion interleaves. Each directory is one
-  // gradeSuite call (its own pass id and its own judge-cost meter).
-  const parallel = Math.max(1, Math.floor(opts.parallel ?? 1));
-  const slots: (EvalGradeResult["runs"][number] & { judgeCostUsd: number })[] = new Array(
-    runDirs.length,
-  );
-  let nextIndex = 0;
+  // Each directory is one gradeSuite call (its own grading pass id and its
+  // own judge-cost meter); mapInParallel keeps the report in walk order.
   let doneCount = 0;
-  const worker = async (): Promise<void> => {
-    for (;;) {
-      const index = nextIndex++;
-      const dir = runDirs[index];
-      if (dir === undefined) return;
-      const startedAt = Date.now();
-      const { grading, judgeCostUsd } = await gradeSuite(dir, graders, config, {
-        defaultGoal: opts.goal,
-      });
-      slots[index] = { dir, grading, judgeCostUsd };
-      doneCount += 1;
-      opts.progress?.(
-        `graded ${doneCount}/${runDirs.length} ${dir} — objective ${grading.objective.toFixed(3)}` +
-          ` ($${judgeCostUsd.toFixed(2)}, ${Math.round((Date.now() - startedAt) / 1000)}s)`,
-      );
-    }
-  };
-  await Promise.all(Array.from({ length: Math.min(parallel, runDirs.length) }, () => worker()));
-  const runs: EvalGradeResult["runs"] = slots.map(({ dir, grading }) => ({ dir, grading }));
+  const graded = await mapInParallel(runDirs, opts.parallel ?? 1, async (dir) => {
+    const startedAt = Date.now();
+    const { grading, judgeCostUsd } = await gradeSuite(dir, graders, config, {
+      defaultGoal: opts.goal,
+    });
+    doneCount += 1;
+    opts.progress?.(
+      `graded ${doneCount}/${runDirs.length} ${dir} — objective ${grading.objective.toFixed(3)}` +
+        ` (${formatUsd(judgeCostUsd)}, ${Math.round((Date.now() - startedAt) / 1000)}s)`,
+    );
+    return { dir, grading, judgeCostUsd };
+  });
+  const runs: EvalGradeResult["runs"] = graded.map(({ dir, grading }) => ({ dir, grading }));
   const result: EvalGradeResult = {
     runs,
     mean: runs.reduce((sum, run) => sum + run.grading.objective, 0) / runs.length,
-    judgeCostUsd: slots.reduce((sum, slot) => sum + slot.judgeCostUsd, 0),
+    judgeCostUsd: graded.reduce((sum, entry) => sum + entry.judgeCostUsd, 0),
     gatesPassed: runs.every((run) => run.grading.gatesPassed),
     batches: trialBatches(runDirs),
   };
@@ -143,4 +134,18 @@ export async function evalGrade(
     fs.writeFileSync(opts.out, JSON.stringify(result, null, 2));
   }
   return result;
+}
+
+/**
+ * The `agency eval grade` action: progress lines on stderr, the report on
+ * stdout. Returns whether every run passed its gates — the caller owns the
+ * exit code.
+ */
+export async function runGradeCommand(paths: string[], opts: EvalGradeOptions): Promise<boolean> {
+  const result = await evalGrade(paths, {
+    ...opts,
+    progress: (message) => process.stderr.write(`${message}\n`),
+  });
+  for (const line of formatGradeResult(result)) console.log(line);
+  return result.gatesPassed;
 }

--- a/packages/agency-lang/lib/cli/util.ts
+++ b/packages/agency-lang/lib/cli/util.ts
@@ -268,7 +268,7 @@ export async function runAgencyNode({
   rootCarriers,
   preferCompiled,
   allowTestImports,
-}: RunAgencyNodeArgs): Promise<{ data: any; stdout: string; stderr: string }> {
+}: RunAgencyNodeArgs): Promise<{ data: any; stdout: string; stderr: string; costUsd?: number }> {
   let evaluateFile = "";
   let resultsFile = "";
   try {
@@ -329,8 +329,16 @@ export async function runAgencyNode({
       ...(wantsKill ? { killSignal: "SIGKILL" as const } : {}),
       env: withRootCarriers({ ...process.env, ...env }, rootCarriers ?? {}),
     });
-    const results = readFileSync(resultsFile, "utf-8");
-    return { data: JSON.parse(results).data, stdout, stderr };
+    const results = JSON.parse(readFileSync(resultsFile, "utf-8"));
+    // The subprocess reports its own LLM spend in the results file
+    // (`tokens.cost.totalCost`); surface it so callers can account for it.
+    const costUsd = results.tokens?.cost?.totalCost;
+    return {
+      data: results.data,
+      stdout,
+      stderr,
+      ...(typeof costUsd === "number" ? { costUsd } : {}),
+    };
   } finally {
     safeUnlink(evaluateFile);
     safeUnlink(resultsFile);

--- a/packages/agency-lang/lib/eval/grading/agencyRunner.test.ts
+++ b/packages/agency-lang/lib/eval/grading/agencyRunner.test.ts
@@ -6,6 +6,18 @@ import { AgencyRunner, type NodeRunner } from "./agencyRunner.js";
 const fakeRunner = (data: unknown): NodeRunner => vi.fn(async () => ({ data }));
 
 describe("AgencyRunner", () => {
+  it("sums the cost every node run reports; a costless result adds nothing", async () => {
+    let call = 0;
+    const runner = new AgencyRunner(
+      {},
+      vi.fn(async () => (++call === 1 ? { data: 1, costUsd: 0.02 } : { data: 2 })),
+    );
+    expect(runner.costUsd).toBe(0);
+    await runner.run("./judge.agency", "main", []);
+    await runner.run("./judge.agency", "main", []);
+    expect(runner.costUsd).toBeCloseTo(0.02);
+  });
+
   it("run() returns the node's raw value", async () => {
     const runner = new AgencyRunner({}, fakeRunner("New Delhi"));
     expect(await runner.run("./agent.agency", "main", ["India"])).toBe("New Delhi");

--- a/packages/agency-lang/lib/eval/grading/agencyRunner.ts
+++ b/packages/agency-lang/lib/eval/grading/agencyRunner.ts
@@ -19,7 +19,7 @@ export type NodeRunner = (args: {
   scratchDir: string;
   quietCompile: boolean;
   preferCompiled?: boolean;
-}) => Promise<{ data: unknown }>;
+}) => Promise<{ data: unknown; costUsd?: number }>;
 
 const defaultRunner: NodeRunner = (args) => runAgencyNode(args);
 
@@ -29,10 +29,19 @@ const defaultRunner: NodeRunner = (args) => runAgencyNode(args);
  * `runAgencyNode` core; the `runNode` seam keeps it unit-testable.
  */
 export class AgencyRunner {
+  private totalCostUsd = 0;
+
   constructor(
     private readonly config: AgencyConfig,
     private readonly runNode: NodeRunner = defaultRunner,
   ) {}
+
+  /** Total LLM spend of every node this runner has executed, in USD. Judge
+   *  calls are LLM calls; grading a suite is not free, and this is where
+   *  that bill is readable. */
+  get costUsd(): number {
+    return this.totalCostUsd;
+  }
 
   /** Run an agent node and return its raw value. `args` are positional, in node-parameter order. */
   async run(agencyFile: string, nodeName: string, args: JSON[]): Promise<JSON> {
@@ -61,7 +70,7 @@ export class AgencyRunner {
     agencyFile: string,
     nodeName: string,
     args: JSON[],
-  ): Promise<{ data: unknown }> {
+  ): Promise<{ data: unknown; costUsd?: number }> {
     const scratchDir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-runner-"));
     try {
       const config = { ...this.config };
@@ -69,7 +78,7 @@ export class AgencyRunner {
       const argsString = args.map((v) => globalThis.JSON.stringify(v)).join(", ");
       // Judges/proposers are bundled agents with a precompiled .js in dist;
       // reuse it instead of recompiling on every grade/proposal call.
-      return await this.runNode({
+      const result = await this.runNode({
         config,
         agencyFile,
         nodeName,
@@ -79,6 +88,8 @@ export class AgencyRunner {
         quietCompile: true,
         preferCompiled: true,
       });
+      this.totalCostUsd += result.costUsd ?? 0;
+      return result;
     } finally {
       fs.rmSync(scratchDir, { recursive: true, force: true });
     }

--- a/packages/agency-lang/lib/eval/grading/gradeSuite.ts
+++ b/packages/agency-lang/lib/eval/grading/gradeSuite.ts
@@ -12,6 +12,8 @@ export type GradeSuiteResult = {
   grading: EvalRunGrading;
   scorecard: Scorecard;
   passId: string | null;
+  /** LLM spend of this pass's judge calls, in USD. */
+  judgeCostUsd: number;
 };
 
 /**
@@ -35,9 +37,10 @@ export async function gradeSuite(
   const snapshot = readRunDirectory(runDir, {
     reportWarning: (message) => console.warn(`grading: ${message}`),
   });
+  const runAgency = new AgencyRunner(config);
   const scorecard = await gradeSnapshot(snapshot, {
     graders,
-    runAgency: new AgencyRunner(config),
+    runAgency,
     config,
     defaultGoal: options.defaultGoal,
   });
@@ -46,7 +49,7 @@ export async function gradeSuite(
   if (options.record !== false && drafts.length > 0) {
     passId = recordGradingPass({ dir: runDir, scores: drafts }).passId;
   }
-  return { grading: toGrading(scorecard), scorecard, passId };
+  return { grading: toGrading(scorecard), scorecard, passId, judgeCostUsd: runAgency.costUsd };
 }
 
 /** One draft per grade that actually ran. A gate-failed or ungraded trace

--- a/packages/agency-lang/lib/utils/parallelMap.test.ts
+++ b/packages/agency-lang/lib/utils/parallelMap.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { mapInParallel } from "./parallelMap.js";
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe("mapInParallel", () => {
+  it("returns results in item order even when later items finish first", async () => {
+    const result = await mapInParallel([30, 0, 10], 3, async (delay) => {
+      await sleep(delay);
+      return delay;
+    });
+    expect(result).toEqual([30, 0, 10]);
+  });
+
+  it("never runs more than `parallel` calls at once", async () => {
+    let inFlight = 0;
+    let peak = 0;
+    await mapInParallel([1, 2, 3, 4, 5], 2, async () => {
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      await sleep(5);
+      inFlight -= 1;
+    });
+    expect(peak).toBe(2);
+  });
+
+  it("treats a non-finite parallel as one worker", async () => {
+    let inFlight = 0;
+    let peak = 0;
+    await mapInParallel([1, 2, 3], Number.NaN, async () => {
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      await sleep(1);
+      inFlight -= 1;
+    });
+    expect(peak).toBe(1);
+  });
+
+  it("handles an empty list", async () => {
+    expect(await mapInParallel([], 4, async () => 1)).toEqual([]);
+  });
+});

--- a/packages/agency-lang/lib/utils/parallelMap.ts
+++ b/packages/agency-lang/lib/utils/parallelMap.ts
@@ -1,0 +1,26 @@
+/**
+ * Runs `fn` over `items` with at most `parallel` calls in flight. Results
+ * come back in item order, whatever order the calls finish in. `parallel`
+ * is clamped to at least one worker; a non-finite value means one.
+ */
+export async function mapInParallel<T, R>(
+  items: readonly T[],
+  parallel: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const workers = Math.min(
+    Number.isFinite(parallel) ? Math.max(1, Math.floor(parallel)) : 1,
+    items.length,
+  );
+  const results: R[] = new Array(items.length);
+  let nextIndex = 0;
+  const worker = async (): Promise<void> => {
+    for (;;) {
+      const index = nextIndex++;
+      if (index >= items.length) return;
+      results[index] = await fn(items[index], index);
+    }
+  };
+  await Promise.all(Array.from({ length: workers }, () => worker()));
+  return results;
+}

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -979,15 +979,27 @@ export function createProgram(deps: CliDependencies = {}): Command {
       "Judge every trace against this goal with the built-in LLM judge (traces whose test recorded its own goal keep it; not with --suite)",
     )
     .option("-o, --out <path>", "Also write the grading summary here as JSON")
-    .action(async (paths: string[], opts: { suite?: string; goal?: string; out?: string }) => {
-      const result = await evalGrade(paths, { ...opts, config: getConfig() }).catch(
-        failProjectCommand,
-      );
-      for (const line of formatGradeResult(result)) console.log(line);
-      if (!result.gatesPassed) {
-        process.exit(2);
-      }
-    });
+    .option(
+      "-n, --parallel <count>",
+      "Grade up to this many run directories at once (default 1)",
+      parsePositiveInt,
+    )
+    .action(
+      async (
+        paths: string[],
+        opts: { suite?: string; goal?: string; out?: string; parallel?: number },
+      ) => {
+        const result = await evalGrade(paths, {
+          ...opts,
+          progress: (message) => process.stderr.write(`${message}\n`),
+          config: getConfig(),
+        }).catch(failProjectCommand);
+        for (const line of formatGradeResult(result)) console.log(line);
+        if (!result.gatesPassed) {
+          process.exit(2);
+        }
+      },
+    );
 
   evalCmd
     .command("upload")

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -64,11 +64,10 @@ import {
   addRunDirectoryCommands,
   runDirectoryCommandDependencies,
 } from "@/cli/runDirectory/commands.js";
-import { evalGrade } from "@/cli/eval/grade.js";
+import { runGradeCommand } from "@/cli/eval/grade.js";
 import { resolveRunStatelog } from "@/cli/eval/logs.js";
 import { evalLs } from "@/cli/eval/ls.js";
 import { evalRun, totalRunCostUsd } from "@/cli/eval/run.js";
-import { formatGradeResult } from "@/cli/eval/formatGrade.js";
 import { evalUpload, formatUploadResult } from "@/cli/eval/upload.js";
 import { ttyColor } from "@/utils/termcolors.js";
 import { evalOptimize } from "@/cli/eval/optimize.js";
@@ -989,13 +988,10 @@ export function createProgram(deps: CliDependencies = {}): Command {
         paths: string[],
         opts: { suite?: string; goal?: string; out?: string; parallel?: number },
       ) => {
-        const result = await evalGrade(paths, {
-          ...opts,
-          progress: (message) => process.stderr.write(`${message}\n`),
-          config: getConfig(),
-        }).catch(failProjectCommand);
-        for (const line of formatGradeResult(result)) console.log(line);
-        if (!result.gatesPassed) {
+        const gatesPassed = await runGradeCommand(paths, { ...opts, config: getConfig() }).catch(
+          failProjectCommand,
+        );
+        if (!gatesPassed) {
           process.exit(2);
         }
       },


### PR DESCRIPTION
Grading a 15-run group was ~60 judge LLM calls run one directory at a time, in silence, with no bill. Three changes on one seam:

## What

- **Cost.** The judge subprocess already reports its own LLM spend in its results file (`tokens.cost.totalCost`); `runAgencyNode` now surfaces it, `AgencyRunner` sums every node it runs, `gradeSuite` returns the pass's `judgeCostUsd`, and the report ends with `grading cost: $x.xx` when the judges cost money (a free deterministic pass gets no line).
- **Parallelism.** `eval grade -n <count>` grades up to that many run directories at once (default 1, the previous behavior), the same worker-pool shape `runSuite` uses; slots keep the report in walk order however completion interleaves. Each directory is still one `gradeSuite` call with its own pass id.
- **Progress.** One line per graded run to stderr: `graded 3/15 <dir> — objective 0.933 ($0.02, 12s)`.

## Verified

On a real 15-run group (the reviewer suite at `--trials 3`): `-n 5` grades in ~90s where sequential took ~6 minutes, progress lines numbered by completion, the report and batch statistics unchanged. Unit tests: the runner's cost accumulation against a fake node runner, parallel grading with walk-order results and per-run progress lines, and the cost line's appearance (and absence at $0). `pnpm run typecheck` (all three projects), `lib/cli/eval` + `lib/eval/grading` suites, prettier, `lint:structure`, and the text guard pass.

Known gap: the printed judge cost reads $0.00 until the smoltalk fix for API-variant provider pricing lands (`~/smoltalk/2026-08-23-cost-null-for-api-variant-providers.md`); the accounting seam reads the same field that fix restores.

Independent of #895; either merges first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1f3ZTxh92pD7N4DDbDA3h
