### PR TITLE
typescriptReviewAgent: a TypeScript readability and architecture reviewer

### DIFF
--- a/packages/agency-lang/docs/site/stdlib/agents/typescript/review.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/typescript/review.md
@@ -1,0 +1,86 @@
+---
+name: "review"
+description: "Reviews TypeScript code for readability and architecture."
+---
+
+# review
+
+The judgment layer above what compilers and linters catch.
+
+  Review reads the work and looks things up. This agent never executes the
+  code it reviews and never changes anything, but unlike the other
+  reviewers it carries read-only repository tools: its central checks —
+  "does this duplicate a helper the codebase already has", "does this
+  follow the conventions around it" — cannot be made from the diff alone.
+
+## Functions
+
+### buildTools
+
+```ts
+buildTools(): any[]
+```
+
+Return the TypeScript reviewer's lookup tools: read-only access to the
+  repository under review (for duplication and convention checks), plus
+  web lookups for API claims. Nothing that changes anything.
+
+**Returns:** `any[]`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/typescript/review.agency#L83))
+
+### typescriptReviewAgent
+
+```ts
+typescriptReviewAgent(
+  work: string,
+  task: string = "",
+  guidelines: string = "",
+  context: string = "",
+  maxCost: number = $10.00,
+  maxTime: number = 10m,
+  model: string = "",
+  provider: string = "",
+  session: string = "",
+  extraTools: any[] = [],
+): Result<Feedback[]>
+```
+
+Review TypeScript code for readability and architecture and return
+  findings. error=true marks a problem the change should not merge with;
+  error=false is advisory. Compilers and linters are assumed to run
+  separately: this agent reports only what needs human-style judgment.
+
+  @param work - The code under review: a diff, a file, or several files as text
+  @param task - What the change is supposed to accomplish, or ""
+  @param guidelines - The project's own coding standards, as text (for
+    example the contents of its anti-pattern catalog). Outranks the
+    built-in catalog where they conflict; "" for the built-in catalog alone
+  @param context - Extra material for the judgment, or ""
+  @param maxCost - Hard spend cap
+  @param maxTime - Hard wall-clock cap
+  @param model - Model override, or "" for the ambient model
+  @param provider - Provider for the model override
+  @param session - Session name to share a thread across calls, or "" for isolated
+  @param extraTools - Extra tools to offer the LLM, appended to the built-in set
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| work | `string` |  |
+| task | `string` | "" |
+| guidelines | `string` | "" |
+| context | `string` | "" |
+| maxCost | `number` | $10.00 |
+| maxTime | `number` | 10m |
+| model | `string` | "" |
+| provider | `string` | "" |
+| session | `string` | "" |
+| extraTools | `any[]` | [] |
+
+**Returns:** `Result<Feedback[]>`
+
+**Throws:** `std::guard`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/typescript/review.agency#L144))

--- a/packages/agency-lang/stdlib/agents/typescript/review.agency
+++ b/packages/agency-lang/stdlib/agents/typescript/review.agency
@@ -1,0 +1,198 @@
+/** @module
+  @summary Reviews TypeScript code for readability and architecture.
+
+  The judgment layer above what compilers and linters catch.
+
+  Review reads the work and looks things up. This agent never executes the
+  code it reviews and never changes anything, but unlike the other
+  reviewers it carries read-only repository tools: its central checks —
+  "does this duplicate a helper the codebase already has", "does this
+  follow the conventions around it" — cannot be made from the diff alone.
+*/
+import { Feedback, failOpenFeedback } from "std::agents/lib/feedback"
+import { hostedSearchTools, searchTools } from "std::agents/lib/search"
+import { llmOptions, withContext } from "std::agents/lib/shared"
+import {
+  communicationTools,
+  readOnlyFileTools,
+  readOnlyGitTools,
+  webTools,
+  SAVE_DRAFT_HINT,
+} from "std::agents/lib/toolkits"
+import { agentSkill } from "std::skills"
+import { systemMessage, threadIsNew } from "std::thread"
+
+static const systemPrompt = """You review TypeScript code for readability and architecture.
+Correctness is not your lane: compilers, linters, formatters, and tests
+run separately, so never report type errors, formatting, or anything a
+mechanical tool catches. Your job is the judgment layer — code that works
+but should not merge as written.
+
+The anti-pattern catalog. Every finding names the pattern it violates:
+
+- Duplicating existing code: reimplementing something the codebase
+  already has. This is the most valuable finding you can make and the
+  easiest to get wrong: SEARCH the repository for an existing helper
+  before writing it, and cite the file you found. No citation, no finding.
+- Imperative sprawl: the "what" and the "how" tangled together — loops,
+  conditionals, and accumulators inline where a small declarative
+  interface should hide them. Propose the interface, not just the
+  complaint.
+- Order-dependent mutable state: let-variables that must be assigned in
+  a specific sequence to be correct. Each value should be a const derived
+  from its inputs.
+- Leaky abstraction: callers reading internal fields or reconstructing
+  internal state instead of going through a boundary that hides it.
+- Wrong altitude: functionality pushed into a file that is already a grab
+  bag, or one file mixing two concepts, when a focused module should own
+  it. Cite how big the file already is or what two concepts collide.
+- Inconsistent with convention: the same operation the codebase already
+  does one way, done a new way. Cite the convention you found.
+- Useless special case: a branch whose body the general path already
+  handles correctly.
+- Swallowed errors: a catch that neither logs nor rethrows.
+- Comments that narrate: restating what the next line does, or talking to
+  a reviewer about the change ("now we correctly…"). Comments earn their
+  place only by stating what the code cannot say.
+- Density and naming: nested ternaries, one-line if bodies, several
+  chained operations crammed into one line, magic numbers without a named
+  constant, single-character names outside a trivial lambda, deeply
+  nested object types that should be named types.
+
+How to review:
+1. Work out what the change is trying to do; judge structure against that
+   intent, not against requirements you invent.
+2. Explore before judging. Use the repository tools to read the files the
+   change touches in full, find the conventions it should follow, and
+   check whether a helper it hand-rolls already exists. A duplication or
+   convention finding without a cited file is not a finding.
+3. error=true means the change should not merge as written: name the
+   pattern, the exact place, and the concrete fix. error=false is
+   advisory — a real improvement that could also wait.
+4. When the caller supplies project guidelines, they outrank this
+   catalog: apply both, and where they conflict, the guidelines win.
+5. A clean verdict is a fine outcome. Never pad a review with generic
+   advice, and never restate the same finding at two places it repeats —
+   report it once and say it repeats.
+
+Keep each finding brief, concrete, and pointed at the construct it is
+about.${SAVE_DRAFT_HINT}"""
+
+static const skills = agentSkill("typescript/review")
+
+export def buildTools(): any[] {
+  """
+  Return the TypeScript reviewer's lookup tools: read-only access to the
+  repository under review (for duplication and convention checks), plus
+  web lookups for API claims. Nothing that changes anything.
+  """
+  return [
+    ...readOnlyFileTools(),
+    ...readOnlyGitTools(),
+    ...webTools(),
+    ...searchTools(),
+    skills,
+    ...communicationTools(),
+  ]
+}
+
+def judgeCode(
+  work: string,
+  task: string,
+  guidelines: string,
+  context: string,
+  model: string,
+  provider: string,
+  extraTools: any[],
+): Feedback[] {
+  if (threadIsNew()) {
+    systemMessage(systemPrompt)
+  }
+  let guidelinesSection = ""
+  if (guidelines != "") {
+    guidelinesSection = """This project's own guidelines. They outrank the built-in catalog:
+<guidelines>
+${guidelines}
+</guidelines>
+
+"""
+  }
+  const prompt = """
+${guidelinesSection}The change was made for this task:
+<task>
+${withContext(task: task, context: context)}
+</task>
+
+<code>
+${work}
+</code>
+
+Return a list of feedback items.
+"""
+  // Return position so a model saveDraft propagates as partial findings.
+  return llm(
+    prompt,
+    llmOptions(
+      model: model,
+      provider: provider,
+      tools: buildTools().concat(extraTools).concat([saveDraft]),
+      hostedTools: hostedSearchTools(model, provider),
+    ),
+  )
+}
+
+export def typescriptReviewAgent(
+  work: string,
+  task: string = "",
+  guidelines: string = "",
+  context: string = "",
+  maxCost: number = $10.00,
+  maxTime: number = 10m,
+  model: string = "",
+  provider: string = "",
+  session: string = "",
+  extraTools: any[] = [],
+): Result<Feedback[]> {
+  """
+  Review TypeScript code for readability and architecture and return
+  findings. error=true marks a problem the change should not merge with;
+  error=false is advisory. Compilers and linters are assumed to run
+  separately: this agent reports only what needs human-style judgment.
+
+  @param work - The code under review: a diff, a file, or several files as text
+  @param task - What the change is supposed to accomplish, or ""
+  @param guidelines - The project's own coding standards, as text (for
+    example the contents of its anti-pattern catalog). Outranks the
+    built-in catalog where they conflict; "" for the built-in catalog alone
+  @param context - Extra material for the judgment, or ""
+  @param maxCost - Hard spend cap
+  @param maxTime - Hard wall-clock cap
+  @param model - Model override, or "" for the ambient model
+  @param provider - Provider for the model override
+  @param session - Session name to share a thread across calls, or "" for isolated
+  @param extraTools - Extra tools to offer the LLM, appended to the built-in set
+  """
+  const captured = guard(cost: maxCost, time: maxTime, label: "typescriptReviewAgent") {
+    let items: Feedback[] = []
+    thread(label: "typescriptReviewAgent", session: session) {
+      items = judgeCode(
+        work: work,
+        task: task,
+        guidelines: guidelines,
+        context: context,
+        model: model,
+        provider: provider,
+        extraTools: extraTools,
+      )
+    }
+    return items
+
+    // Salvage the model's partial findings if an outer budget guard trips
+    // mid-review; the assignment above would otherwise drop them.
+    finalize {
+      return items
+    }
+  }
+
+  return failOpenFeedback(captured)
+}


### PR DESCRIPTION
## What this is

The first stab at the TypeScript reviewer we discussed: a stdlib agent (`std::agents/typescript/review`, `typescriptReviewAgent`) that reviews TS for readability and architecture — the judgment layer you currently do by hand on my PRs.

## Design

**It only reports what needs judgment.** The prompt tells it compilers, linters, formatters, and tests run separately, so type errors and mechanical style are out of scope. The built-in catalog is a distilled, project-agnostic version of your anti-patterns doc: duplication of existing code, imperative sprawl, order-dependent mutable state, leaky abstractions, wrong altitude, inconsistency with convention, useless special cases, swallowed errors, narrating comments, density/naming.

**It has read-only repo tools, unlike the other reviewers.** Its most valuable check — "this hand-rolls a helper the codebase already has" — cannot be made from a diff alone. The prompt makes citation a hard requirement: a duplication or convention finding must name the existing file it found, or not be made at all.

**A `guidelines` parameter carries the project's own catalog** and outranks the built-in one. For this repo:

```agency
const guidelines = read("docs/dev/anti-patterns.md", dir: "docs/dev") with approve
const findings = typescriptReviewAgent(work: diff, task: "…", guidelines: guidelines.value) with approve
```

`error: true` means "should not merge as written" with pattern + place + concrete fix; `error: false` is advisory. Structure mirrors `agencyReviewAgent` (thread-scoped system message, saveDraft salvage via return position, guard + finalize, fail-open boundary).

## Smoke test (live, in this repo)

I fed it a small retry helper planted with flaws (two-step `let` initialization, a silent `catch`, `delay * 4` magic, `string | null` return). It searched the repo before judging and every citation checked out:

- flagged the helper as duplicating the stdlib HTTP surface, citing `lib/stdlib/http.ts` (`_fetch`, `readBodyCapped`, `httpStatusFailure`) — real
- pointed the backoff at the existing `backoffMs` in `lib/runtime/llmretry.ts` — real
- caught the swallowed catch, the order-dependent initialization, and the magic numbers, each with a concrete fix
- advisory items stayed advisory (backoff policy naming, return-type consistency)

## What's deliberately not here

No eval suite yet — that's the harvest plan we discussed (mining your past review rounds into before/after pairs), and the suite PR can add an `evalMain` then. No repo-specific rules baked into the stdlib prompt; those come in through `guidelines`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1f3ZTxh92pD7N4DDbDA3h
