### PR TITLE
typescript-review eval suite: seed tests and evalMain for the TypeScript reviewer

### DIFF
--- a/packages/agency-lang/docs/site/stdlib/agents/typescript/review.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/typescript/review.md
@@ -15,7 +15,7 @@ The judgment layer above what compilers and linters catch.
 
 ## Types
 
-### ReviewEvalInput
+### TsReviewEvalInput
 
 What an eval hands the reviewer: the task the code was written for, and
   the file holding that code, seeded into the working directory by the
@@ -27,7 +27,7 @@ What an eval hands the reviewer: the task the code was written for, and
   the file holding that code, seeded into the working directory by the
   test's `files/`. The shape the `evals/typescript-review` suite uses as
   its input. */
-export type ReviewEvalInput = {
+export type TsReviewEvalInput = {
   assignment: string;
   sourceFile: string
 }
@@ -112,7 +112,7 @@ Review TypeScript code for readability and architecture and return
 ### evalMain
 
 ```ts
-evalMain(input: ReviewEvalInput): Feedback[]
+evalMain(input: TsReviewEvalInput): Feedback[]
 ```
 
 Eval entry point: `agency eval run stdlib/agents/typescript/review.agency:evalMain
@@ -129,7 +129,7 @@ Eval entry point: `agency eval run stdlib/agents/typescript/review.agency:evalMa
 
 | Name | Type | Default |
 |---|---|---|
-| input | [ReviewEvalInput](#reviewevalinput) |  |
+| input | [TsReviewEvalInput](#tsreviewevalinput) |  |
 
 **Returns:** `Feedback[]`
 

--- a/packages/agency-lang/docs/site/stdlib/agents/typescript/review.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/typescript/review.md
@@ -13,6 +13,28 @@ The judgment layer above what compilers and linters catch.
   "does this duplicate a helper the codebase already has", "does this
   follow the conventions around it" — cannot be made from the diff alone.
 
+## Types
+
+### ReviewEvalInput
+
+What an eval hands the reviewer: the task the code was written for, and
+  the file holding that code, seeded into the working directory by the
+  test's `files/`. The shape the `evals/typescript-review` suite uses as
+  its input.
+
+```ts
+/** What an eval hands the reviewer: the task the code was written for, and
+  the file holding that code, seeded into the working directory by the
+  test's `files/`. The shape the `evals/typescript-review` suite uses as
+  its input. */
+export type ReviewEvalInput = {
+  assignment: string;
+  sourceFile: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/typescript/review.agency#L205))
+
 ## Functions
 
 ### buildTools
@@ -27,7 +49,7 @@ Return the TypeScript reviewer's lookup tools: read-only access to the
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/typescript/review.agency#L83))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/typescript/review.agency#L84))
 
 ### typescriptReviewAgent
 
@@ -83,4 +105,34 @@ Review TypeScript code for readability and architecture and return
 
 **Throws:** `std::guard`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/typescript/review.agency#L144))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/typescript/review.agency#L145))
+
+## Nodes
+
+### evalMain
+
+```ts
+evalMain(input: ReviewEvalInput): Feedback[]
+```
+
+Eval entry point: `agency eval run stdlib/agents/typescript/review.agency:evalMain
+  --suite <dir>`. A node in a library module never runs when the module is
+  imported; it only exists so a suite can score this reviewer without a
+  wrapper file. Any other reviewer scored on the same suite supplies a node
+  with this signature. Effects are decided at this boundary: reading the
+  seeded input file is this node's own doing (`with approve`), and a budget
+  trip inside the reviewer is rejected (`with reject`) so the caps stay
+  caps and the reviewer's fail-open result comes back instead of an
+  interrupt escaping the entry point.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| input | [ReviewEvalInput](#reviewevalinput) |  |
+
+**Returns:** `Feedback[]`
+
+**Throws:** `std::read`, `std::guard`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/typescript/review.agency#L219))

--- a/packages/agency-lang/evals/typescript-review/README.md
+++ b/packages/agency-lang/evals/typescript-review/README.md
@@ -23,7 +23,7 @@ pnpm run agency eval grade runs/typescript-review
 
 ## The contract
 
-Input, the entry node's single parameter (`ReviewEvalInput` in the stdlib
+Input, the entry node's single parameter (`TsReviewEvalInput` in the stdlib
 module):
 
 ```

--- a/packages/agency-lang/evals/typescript-review/README.md
+++ b/packages/agency-lang/evals/typescript-review/README.md
@@ -1,0 +1,55 @@
+# typescript-review: an eval suite for TypeScript code reviewers
+
+The sibling of `evals/agency-review`, aimed at `typescriptReviewAgent`: a
+reviewer of TypeScript readability and architecture, judged on whether it
+catches planted problems without inventing findings on clean code.
+
+The suite describes the job. It does not name an agent. A reviewer is
+scored on it through an eval entry node with the contract below; the
+stdlib's `typescriptReviewAgent` carries one (`evalMain` in
+`stdlib/agents/typescript/review.agency`), and any other implementation
+supplies its own.
+
+## Run it
+
+```bash
+pnpm run agency eval run \
+  stdlib/agents/typescript/review.agency:evalMain \
+  --suite evals/typescript-review \
+  --out runs/typescript-review
+
+pnpm run agency eval grade runs/typescript-review
+```
+
+## The contract
+
+Input, the entry node's single parameter (`ReviewEvalInput` in the stdlib
+module):
+
+```
+{ "assignment": string, "sourceFile": string }
+```
+
+`assignment` is what the code under review was asked to do. `sourceFile`
+names a file the test seeds into the working directory from its `files/`
+directory. Output is the stdlib `Feedback` shape: `error: true` marks a
+problem the change should not merge with, anything else is advisory.
+
+## Grading
+
+Each test carries a one-liner `graders.ts` over the shared library in
+`lib/reviewGraders.ts`. A planted test's ground truth is the author's
+written `reason` for what is wrong; its graders check that an error
+finding exists (`rejects`), that some finding names the planted problem
+(`names-the-flaw`), and that no error finding objects to reasonable code
+or to something a compiler or linter would catch (`no-invented-errors`).
+A clean test checks the reviewer rejects nothing (`rejects-nothing`).
+Both kinds judge advisory findings for usefulness (`advisory-useful`),
+passing vacuously when there are none.
+
+## Growing the suite
+
+The plan is harvested tests: a before/after pair from a real review round,
+where "before" is the code as pushed, "after" is the code following review,
+and the review comment is the `reason`. A harvested test is just a planted
+test whose reason and source came from history instead of being authored.

--- a/packages/agency-lang/evals/typescript-review/clean-slug/files/slug.ts
+++ b/packages/agency-lang/evals/typescript-review/clean-slug/files/slug.ts
@@ -1,0 +1,9 @@
+/** Turns a page title into a URL slug. */
+export function slugify(title: string): string {
+  return title
+    .normalize("NFKD")
+    .replace(/\p{M}/gu, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}

--- a/packages/agency-lang/evals/typescript-review/clean-slug/graders.ts
+++ b/packages/agency-lang/evals/typescript-review/clean-slug/graders.ts
@@ -1,0 +1,3 @@
+import { cleanGraders } from "../lib/reviewGraders.js";
+
+export default cleanGraders();

--- a/packages/agency-lang/evals/typescript-review/clean-slug/test.json
+++ b/packages/agency-lang/evals/typescript-review/clean-slug/test.json
@@ -1,0 +1,9 @@
+{
+  "description": "The planted test's clean sibling: the same helper written plainly. Measures false positives on the exact same assignment.",
+  "tags": ["clean"],
+  "files": "./files",
+  "input": {
+    "assignment": "Add a slugify helper that turns a page title into a URL slug: lowercase, non-alphanumerics collapsed to single hyphens, no leading or trailing hyphen.",
+    "sourceFile": "slug.ts"
+  }
+}

--- a/packages/agency-lang/evals/typescript-review/lib/reviewGraders.ts
+++ b/packages/agency-lang/evals/typescript-review/lib/reviewGraders.ts
@@ -1,0 +1,128 @@
+// The one grading library for typescript-review tests. Each test's graders.ts
+// is a one-liner over these; the judge prompts live here so they improve for
+// every test at once. Ground truth is the author's written `reason` for what
+// is wrong with the planted source (harvested tests will carry the real
+// review comment and rewrite diff as that reason).
+import * as fs from "fs";
+import * as path from "path";
+
+import { grader, type Grader } from "agency-lang/eval";
+
+type Feedback = { error: boolean; feedback: string };
+const findings = (output: unknown): Feedback[] => (Array.isArray(output) ? output : []);
+const errors = (output: unknown) => findings(output).filter((item) => item?.error === true);
+const advisories = (output: unknown) => findings(output).filter((item) => item?.error !== true);
+
+type TestShape = { input?: unknown };
+
+/** The reviewed source, read from the test's seeded workdir. Fixture paths
+ *  are authored, but a path that escapes the workdir reads as missing. */
+function sourceOf(workdir: string, test: TestShape): string {
+  const input = test.input as { sourceFile?: string } | undefined;
+  if (!input?.sourceFile) return "";
+  const root = path.resolve(workdir);
+  const resolved = path.resolve(root, input.sourceFile);
+  if (!resolved.startsWith(root + path.sep)) return "";
+  try {
+    return fs.readFileSync(resolved, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function assignmentOf(test: TestShape): string {
+  const input = test.input as { assignment?: string } | undefined;
+  return input?.assignment ?? "";
+}
+
+function rejects(): Grader {
+  return grader(
+    ({ output }) => ({
+      score: { kind: "binary", pass: errors(output).length > 0 },
+      feedback: `${errors(output).length} error finding(s), ${findings(output).length} total`,
+    }),
+    { name: "rejects" },
+  );
+}
+
+/** Advisory findings should be worth reading: true of this code and genuinely
+ *  useful for this assignment. A review with no advisory findings passes
+ *  vacuously — advice is welcome, not demanded. */
+function advisoryUseful(): Grader {
+  return grader(
+    ({ output, workdir, test, judge }) => {
+      const advice = advisories(output);
+      if (advice.length === 0) {
+        return { score: { kind: "binary", pass: true }, feedback: "no advisory findings" };
+      }
+      return judge({
+        goal:
+          "This TypeScript source was reviewed for readability and architecture:\n\n" +
+          sourceOf(workdir, test) +
+          "\n\nIt was written for this task:\n\n" +
+          assignmentOf(test) +
+          "\n\nThese are the review's ADVISORY findings (not errors). Is each one a useful, " +
+          "accurate pointer for this code? Padding (generic advice that fits any code) and " +
+          "suggestions that are not true of this code should lower the score in proportion.",
+        output: advice.map((item) => item.feedback),
+        expected: "",
+      });
+    },
+    { name: "advisory-useful" },
+  );
+}
+
+/** Graders for a planted-flaw test: the author's `reason` is the ground
+ *  truth for what is wrong with the source. */
+export function plantedFlawGraders(args: { reason: string }): Grader[] {
+  return [
+    rejects(),
+    grader(
+      ({ output, judge }) =>
+        judge({
+          goal:
+            "The TypeScript code under review has this planted problem: " +
+            args.reason +
+            "\n\nDo these review findings identify that problem? Wording may differ; what " +
+            "matters is that some error finding points at it.",
+          output: errors(output).map((item) => item.feedback),
+          expected: "",
+        }),
+      { name: "names-the-flaw" },
+    ),
+    grader(
+      ({ output, workdir, test, judge }) =>
+        judge({
+          goal:
+            "This TypeScript source was reviewed:\n\n" +
+            sourceOf(workdir, test) +
+            "\n\nIts only planted problem: " +
+            args.reason +
+            "\n\nIs every one of these error findings a real problem with the source — the " +
+            "planted problem, or something genuinely wrong? A finding that objects to " +
+            "reasonable code, or that a compiler, linter, or formatter would already catch, " +
+            "is invented.",
+          output: errors(output).map((item) => item.feedback),
+          expected: "",
+        }),
+      { name: "no-invented-errors" },
+    ),
+    advisoryUseful(),
+  ];
+}
+
+/** Graders for a clean test: well-written code the reviewer must not reject. */
+export function cleanGraders(): Grader[] {
+  return [
+    grader(
+      ({ output }) => ({
+        score: { kind: "binary", pass: errors(output).length === 0 },
+        feedback: `${errors(output).length} error finding(s) on clean code: ${errors(output)
+          .map((item) => item.feedback)
+          .join(" | ")}`,
+      }),
+      { name: "rejects-nothing" },
+    ),
+    advisoryUseful(),
+  ];
+}

--- a/packages/agency-lang/evals/typescript-review/swallowed-errors/files/slug.ts
+++ b/packages/agency-lang/evals/typescript-review/swallowed-errors/files/slug.ts
@@ -1,0 +1,15 @@
+/** Turns a page title into a URL slug. */
+export function slugify(title: string): string {
+  let slug = "";
+  try {
+    slug = title
+      .normalize("NFKD")
+      .replace(/\p{M}/gu, "")
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "");
+  } catch (e) {
+    // some titles are weird
+  }
+  return slug;
+}

--- a/packages/agency-lang/evals/typescript-review/swallowed-errors/graders.ts
+++ b/packages/agency-lang/evals/typescript-review/swallowed-errors/graders.ts
@@ -1,0 +1,8 @@
+import { plantedFlawGraders } from "../lib/reviewGraders.js";
+
+export default plantedFlawGraders({
+  reason:
+    "The catch block swallows the error: it neither logs nor rethrows, and the function then " +
+    "returns the empty string as if it were a valid slug, so a failure is indistinguishable " +
+    "from a title that slugifies to nothing. Callers can never find out why slugs went missing.",
+});

--- a/packages/agency-lang/evals/typescript-review/swallowed-errors/test.json
+++ b/packages/agency-lang/evals/typescript-review/swallowed-errors/test.json
@@ -1,0 +1,9 @@
+{
+  "description": "Catch a swallowed error: a catch block that silently discards the failure and lets an empty result stand in for it.",
+  "tags": ["planted", "swallowed-errors"],
+  "files": "./files",
+  "input": {
+    "assignment": "Add a slugify helper that turns a page title into a URL slug: lowercase, non-alphanumerics collapsed to single hyphens, no leading or trailing hyphen.",
+    "sourceFile": "slug.ts"
+  }
+}

--- a/packages/agency-lang/stdlib/agents/typescript/review.agency
+++ b/packages/agency-lang/stdlib/agents/typescript/review.agency
@@ -202,7 +202,7 @@ export def typescriptReviewAgent(
   the file holding that code, seeded into the working directory by the
   test's `files/`. The shape the `evals/typescript-review` suite uses as
   its input. */
-export type ReviewEvalInput = {
+export type TsReviewEvalInput = {
   assignment: string;
   sourceFile: string
 }
@@ -216,7 +216,7 @@ export type ReviewEvalInput = {
   trip inside the reviewer is rejected (`with reject`) so the caps stay
   caps and the reviewer's fail-open result comes back instead of an
   interrupt escaping the entry point. */
-node evalMain(input: ReviewEvalInput): Feedback[] {
+node evalMain(input: TsReviewEvalInput): Feedback[] {
   evalValue(input)
   const source = read(input.sourceFile) with approve
   if (source is failure(readErr)) {

--- a/packages/agency-lang/stdlib/agents/typescript/review.agency
+++ b/packages/agency-lang/stdlib/agents/typescript/review.agency
@@ -20,6 +20,7 @@ import {
   SAVE_DRAFT_HINT,
 } from "std::agents/lib/toolkits"
 import { agentSkill } from "std::skills"
+import { evalValue } from "std::statelog"
 import { systemMessage, threadIsNew } from "std::thread"
 
 static const systemPrompt = """You review TypeScript code for readability and architecture.
@@ -195,4 +196,35 @@ export def typescriptReviewAgent(
   }
 
   return failOpenFeedback(captured)
+}
+
+/** What an eval hands the reviewer: the task the code was written for, and
+  the file holding that code, seeded into the working directory by the
+  test's `files/`. The shape the `evals/typescript-review` suite uses as
+  its input. */
+export type ReviewEvalInput = {
+  assignment: string;
+  sourceFile: string
+}
+
+/** Eval entry point: `agency eval run stdlib/agents/typescript/review.agency:evalMain
+  --suite <dir>`. A node in a library module never runs when the module is
+  imported; it only exists so a suite can score this reviewer without a
+  wrapper file. Any other reviewer scored on the same suite supplies a node
+  with this signature. Effects are decided at this boundary: reading the
+  seeded input file is this node's own doing (`with approve`), and a budget
+  trip inside the reviewer is rejected (`with reject`) so the caps stay
+  caps and the reviewer's fail-open result comes back instead of an
+  interrupt escaping the entry point. */
+node evalMain(input: ReviewEvalInput): Feedback[] {
+  evalValue(input)
+  const source = read(input.sourceFile) with approve
+  if (source is failure(readErr)) {
+    return [{ error: true, feedback: "could not read ${input.sourceFile}: ${readErr}" }]
+  }
+  const reviewed = typescriptReviewAgent(work: source.value, task: input.assignment) with reject
+  if (reviewed is failure(err)) {
+    return [{ error: true, feedback: "review agent failed: ${err}" }]
+  }
+  return reviewed.value
 }


### PR DESCRIPTION
## What this is

The eval suite for `typescriptReviewAgent`, mirroring `evals/agency-review`: an agent-agnostic `{assignment, sourceFile}` contract, an `evalMain` entry node in the stdlib module, and per-test one-liner `graders.ts` over a shared grader library (`rejects`, `names-the-flaw`, `no-invented-errors`, `advisory-useful`; clean tests use `rejects-nothing`). No facts card — TypeScript is the judges' native ground, unlike Agency.

Two seed tests, per your "just set it up" instruction:
- **swallowed-errors** — a slugify helper whose catch silently discards the failure and returns "" as if it were a valid slug.
- **clean-slug** — the same helper written plainly; measures false positives on the identical assignment.

## Built for the harvest

A planted test's ground truth is the author's written `reason` — which is exactly the shape your harvested cases will take: the pre-review code as `sourceFile`, your review comment as `reason`. Adding a harvest case is a directory with `test.json`, `files/`, and a one-liner `graders.ts`; no new machinery.

## Smoke run

First run scored the clean control 0.5 — and the grader was right to: my "clean" fixture normalized NFKD without stripping combining marks, so "Crème brûlée" would slug to `cre-me-bru-le-e`, and the reviewer correctly flagged it. I fixed the fixture, not the reviewer. Final run: planted 1.000 (names the swallowed catch), clean 1.000, total run+grade cost ~$0.02.

```bash
pnpm run agency eval run stdlib/agents/typescript/review.agency:evalMain --suite evals/typescript-review --out runs/typescript-review
pnpm run agency eval grade runs/typescript-review -n 2
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1f3ZTxh92pD7N4DDbDA3h
