### PR TITLE
writingReviewAgent: a prose readability reviewer, with its eval suite

### DIFF
--- a/packages/agency-lang/docs/site/stdlib/agents/writing/review.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/writing/review.md
@@ -1,0 +1,136 @@
+---
+name: "review"
+description: "Reviews prose for readability: the judgment layer above spelling"
+---
+
+# review
+
+and grammar.
+
+  Review reads the work and looks things up; this agent changes nothing and
+  needs no tools beyond the text itself. It judges whether a reader can
+  follow the writing, using a small catalog of readability principles, and
+  a caller can supply its own writing guidelines to extend or override them.
+
+## Types
+
+### WritingReviewEvalInput
+
+What an eval hands the reviewer: the task the text was written for, and
+  the file holding that text, seeded into the working directory by the
+  test's `files/`. The shape the `evals/writing-review` suite uses as its
+  input.
+
+```ts
+/** What an eval hands the reviewer: the task the text was written for, and
+  the file holding that text, seeded into the working directory by the
+  test's `files/`. The shape the `evals/writing-review` suite uses as its
+  input. */
+export type WritingReviewEvalInput = {
+  assignment: string;
+  sourceFile: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/writing/review.agency#L179))
+
+## Functions
+
+### buildTools
+
+```ts
+buildTools(): any[]
+```
+
+Return the writing reviewer's tools. Prose review needs nothing beyond
+  the text, so this is only the shipped skills and progress reporting.
+
+**Returns:** `any[]`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/writing/review.agency#L67))
+
+### writingReviewAgent
+
+```ts
+writingReviewAgent(
+  work: string,
+  task: string = "",
+  guidelines: string = "",
+  context: string = "",
+  maxCost: number = $5.00,
+  maxTime: number = 10m,
+  model: string = "",
+  provider: string = "",
+  session: string = "",
+  extraTools: any[] = [],
+): Result<Feedback[]>
+```
+
+Review prose for readability and return findings. error=true marks a
+  passage a reader will misread or lose; error=false is advisory polish.
+  Spelling and grammar are assumed checked separately: this agent reports
+  only what needs judgment.
+
+  @param work - The text under review
+  @param task - Who the text is for and what it must get across, or ""
+  @param guidelines - The caller's own writing guidelines, as text (for
+    example the contents of a project's writing-tips document). Outranks
+    the built-in catalog where they conflict; "" for the built-in catalog alone
+  @param context - Extra material for the judgment, or ""
+  @param maxCost - Hard spend cap
+  @param maxTime - Hard wall-clock cap
+  @param model - Model override, or "" for the ambient model
+  @param provider - Provider for the model override
+  @param session - Session name to share a thread across calls, or "" for isolated
+  @param extraTools - Extra tools to offer the LLM, appended to the built-in set
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| work | `string` |  |
+| task | `string` | "" |
+| guidelines | `string` | "" |
+| context | `string` | "" |
+| maxCost | `number` | $5.00 |
+| maxTime | `number` | 10m |
+| model | `string` | "" |
+| provider | `string` | "" |
+| session | `string` | "" |
+| extraTools | `any[]` | [] |
+
+**Returns:** `Result<Feedback[]>`
+
+**Throws:** `std::guard`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/writing/review.agency#L119))
+
+## Nodes
+
+### evalMain
+
+```ts
+evalMain(input: WritingReviewEvalInput): Feedback[]
+```
+
+Eval entry point: `agency eval run stdlib/agents/writing/review.agency:evalMain
+  --suite <dir>`. A node in a library module never runs when the module is
+  imported; it only exists so a suite can score this reviewer without a
+  wrapper file. Any other reviewer scored on the same suite supplies a node
+  with this signature. Effects are decided at this boundary: reading the
+  seeded input file is this node's own doing (`with approve`), and a budget
+  trip inside the reviewer is rejected (`with reject`) so the caps stay
+  caps and the reviewer's fail-open result comes back instead of an
+  interrupt escaping the entry point.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| input | [WritingReviewEvalInput](#writingreviewevalinput) |  |
+
+**Returns:** `Feedback[]`
+
+**Throws:** `std::read`, `std::guard`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/writing/review.agency#L193))

--- a/packages/agency-lang/evals/writing-review/README.md
+++ b/packages/agency-lang/evals/writing-review/README.md
@@ -1,0 +1,56 @@
+# writing-review: an eval suite for prose reviewers
+
+The prose sibling of `evals/typescript-review`: a reviewer of writing
+readability, judged on whether it catches text that loses its reader
+without inventing findings on clear prose.
+
+The suite describes the job. It does not name an agent. A reviewer is
+scored on it through an eval entry node with the contract below; the
+stdlib's `writingReviewAgent` carries one (`evalMain` in
+`stdlib/agents/writing/review.agency`), and any other implementation
+supplies its own.
+
+## Run it
+
+```bash
+pnpm run agency eval run \
+  stdlib/agents/writing/review.agency:evalMain \
+  --suite evals/writing-review \
+  --out runs/writing-review
+
+pnpm run agency eval grade runs/writing-review
+```
+
+## The contract
+
+Input, the entry node's single parameter (`WritingReviewEvalInput` in the stdlib
+module):
+
+```
+{ "assignment": string, "sourceFile": string }
+```
+
+`assignment` says who the text is for and what it must get across.
+`sourceFile` names a file the test seeds into the working directory from
+its `files/` directory. Output is the stdlib `Feedback` shape:
+`error: true` marks a passage the reader will misread or lose, anything
+else is advisory polish.
+
+## Grading
+
+Each test carries a one-liner `graders.ts` over the shared library in
+`lib/reviewGraders.ts`. A planted test's ground truth is the author's
+written `reason` for what makes the text hard to follow; its graders check
+that an error finding exists (`rejects`), that the findings point at the
+planted passages (`names-the-flaw`), and that no error finding objects to
+clear prose or a matter of taste (`no-invented-errors`). A clean test
+checks the reviewer rejects nothing (`rejects-nothing`). Both kinds judge
+advisory findings for usefulness (`advisory-useful`), passing vacuously
+when there are none.
+
+## Growing the suite
+
+Harvested tests: a before/after pair from a real editing round, where
+"before" is the text as first written, "after" is the text after feedback,
+and the editing note is the `reason`. A harvested test is just a planted
+test whose reason and text came from history instead of being authored.

--- a/packages/agency-lang/evals/writing-review/clean-paragraph/files/notes.md
+++ b/packages/agency-lang/evals/writing-review/clean-paragraph/files/notes.md
@@ -1,0 +1,12 @@
+## The run directory
+
+Listings show one score per question. Scores come from grading passes
+recorded in the directory, and only a pass that finished completely
+counts. When several complete passes scored the same question, the most
+recent one wins.
+
+Reading the directory never takes a lock. A reader takes a snapshot and
+skips any half-written trailing line, so what it returns is always
+coherent. One directory belongs to one run: both the reader and the
+writer check this, because two runs sharing a directory would corrupt
+the statistics computed over it.

--- a/packages/agency-lang/evals/writing-review/clean-paragraph/graders.ts
+++ b/packages/agency-lang/evals/writing-review/clean-paragraph/graders.ts
@@ -1,0 +1,3 @@
+import { cleanGraders } from "../lib/reviewGraders.js";
+
+export default cleanGraders();

--- a/packages/agency-lang/evals/writing-review/clean-paragraph/test.json
+++ b/packages/agency-lang/evals/writing-review/clean-paragraph/test.json
@@ -1,0 +1,9 @@
+{
+  "description": "The planted test's clean sibling: the same content rewritten plainly. Measures false positives on the exact same assignment.",
+  "tags": ["clean"],
+  "files": "./files",
+  "input": {
+    "assignment": "Explain to a developer new to the codebase, in one short section, how the run directory decides which scores its listings show.",
+    "sourceFile": "notes.md"
+  }
+}

--- a/packages/agency-lang/evals/writing-review/lib/reviewGraders.ts
+++ b/packages/agency-lang/evals/writing-review/lib/reviewGraders.ts
@@ -1,0 +1,129 @@
+// The one grading library for writing-review tests. Each test's graders.ts
+// is a one-liner over these; the judge prompts live here so they improve
+// for every test at once. Ground truth is the author's written `reason` for
+// what makes the planted text hard to follow (harvested tests will carry a
+// real editing note as that reason).
+import * as fs from "fs";
+import * as path from "path";
+
+import { grader, type Grader } from "agency-lang/eval";
+
+type Feedback = { error: boolean; feedback: string };
+const findings = (output: unknown): Feedback[] => (Array.isArray(output) ? output : []);
+const errors = (output: unknown) => findings(output).filter((item) => item?.error === true);
+const advisories = (output: unknown) => findings(output).filter((item) => item?.error !== true);
+
+type TestShape = { input?: unknown };
+
+/** The reviewed text, read from the test's seeded workdir. Fixture paths
+ *  are authored, but a path that escapes the workdir reads as missing. */
+function textOf(workdir: string, test: TestShape): string {
+  const input = test.input as { sourceFile?: string } | undefined;
+  if (!input?.sourceFile) return "";
+  const root = path.resolve(workdir);
+  const resolved = path.resolve(root, input.sourceFile);
+  if (!resolved.startsWith(root + path.sep)) return "";
+  try {
+    return fs.readFileSync(resolved, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function assignmentOf(test: TestShape): string {
+  const input = test.input as { assignment?: string } | undefined;
+  return input?.assignment ?? "";
+}
+
+function rejects(): Grader {
+  return grader(
+    ({ output }) => ({
+      score: { kind: "binary", pass: errors(output).length > 0 },
+      feedback: `${errors(output).length} error finding(s), ${findings(output).length} total`,
+    }),
+    { name: "rejects" },
+  );
+}
+
+/** Advisory findings should be worth reading: true of this text and a real
+ *  improvement for its audience. A review with no advisory findings passes
+ *  vacuously — polish is welcome, not demanded. */
+function advisoryUseful(): Grader {
+  return grader(
+    ({ output, workdir, test, judge }) => {
+      const advice = advisories(output);
+      if (advice.length === 0) {
+        return { score: { kind: "binary", pass: true }, feedback: "no advisory findings" };
+      }
+      return judge({
+        goal:
+          "This text was reviewed for readability:\n\n" +
+          textOf(workdir, test) +
+          "\n\nIt was written for this task:\n\n" +
+          assignmentOf(test) +
+          "\n\nThese are the review's ADVISORY findings (not errors). Is each one a useful, " +
+          "accurate pointer for this text and its audience? Padding (generic writing advice " +
+          "that fits any text) and suggestions that are not true of this text should lower " +
+          "the score in proportion.",
+        output: advice.map((item) => item.feedback),
+        expected: "",
+      });
+    },
+    { name: "advisory-useful" },
+  );
+}
+
+/** Graders for a planted-flaw test: the author's `reason` is the ground
+ *  truth for what makes the text hard to follow. */
+export function plantedFlawGraders(args: { reason: string }): Grader[] {
+  return [
+    rejects(),
+    grader(
+      ({ output, judge }) =>
+        judge({
+          goal:
+            "The text under review has these planted readability problems: " +
+            args.reason +
+            "\n\nDo these review findings identify those problems? Wording may differ; what " +
+            "matters is that the error findings point at the planted passages and what makes " +
+            "them hard to follow.",
+          output: errors(output).map((item) => item.feedback),
+          expected: "",
+        }),
+      { name: "names-the-flaw" },
+    ),
+    grader(
+      ({ output, workdir, test, judge }) =>
+        judge({
+          goal:
+            "This text was reviewed for readability:\n\n" +
+            textOf(workdir, test) +
+            "\n\nIts planted problems: " +
+            args.reason +
+            "\n\nIs every one of these error findings a real obstacle for the text's reader — " +
+            "one of the planted problems, or something genuinely hard to follow? A finding " +
+            "that objects to clear prose, or to a matter of taste, is invented.",
+          output: errors(output).map((item) => item.feedback),
+          expected: "",
+        }),
+      { name: "no-invented-errors" },
+    ),
+    advisoryUseful(),
+  ];
+}
+
+/** Graders for a clean test: clear prose the reviewer must not reject. */
+export function cleanGraders(): Grader[] {
+  return [
+    grader(
+      ({ output }) => ({
+        score: { kind: "binary", pass: errors(output).length === 0 },
+        feedback: `${errors(output).length} error finding(s) on clear prose: ${errors(output)
+          .map((item) => item.feedback)
+          .join(" | ")}`,
+      }),
+      { name: "rejects-nothing" },
+    ),
+    advisoryUseful(),
+  ];
+}

--- a/packages/agency-lang/evals/writing-review/overloaded-paragraph/files/notes.md
+++ b/packages/agency-lang/evals/writing-review/overloaded-paragraph/files/notes.md
@@ -1,0 +1,11 @@
+## The run directory
+
+The run directory annotations fold, which is applied per-question after the
+complete-pass filter (score, checklist, and note annotations — each with
+deterministic ids — are folded separately), determines which scores listings
+show. A coherent lock-free read snapshot (plus the best-effort `notes.md`
+read outside it) is taken by the reader, torn tails being skipped, and the
+one-run invariant is enforced by a reader guard and a writer preflight so
+that a directory is never shared by two runs, which would corrupt the
+statistics that batch summaries (mean, standard error, per-trial cost) are
+derived from.

--- a/packages/agency-lang/evals/writing-review/overloaded-paragraph/graders.ts
+++ b/packages/agency-lang/evals/writing-review/overloaded-paragraph/graders.ts
@@ -1,0 +1,10 @@
+import { plantedFlawGraders } from "../lib/reviewGraders.js";
+
+export default plantedFlawGraders({
+  reason:
+    'The opening sentence is a garden path ("The run directory annotations fold" reads as a ' +
+    'verb phrase until "determines" arrives) and stacks several new concepts with a nested ' +
+    "parenthetical before its verb, so a newcomer loses the thread. The second sentence is " +
+    'passive throughout ("is taken by the reader", "is enforced by") and chains four ideas ' +
+    'with commas and a "which" clause. A reader new to the codebase cannot follow this.',
+});

--- a/packages/agency-lang/evals/writing-review/overloaded-paragraph/test.json
+++ b/packages/agency-lang/evals/writing-review/overloaded-paragraph/test.json
@@ -1,0 +1,9 @@
+{
+  "description": "Catch prose that loses the reader: a garden-path opening, concept-stacked sentences with nested parentheticals, and passive voice hiding the actors.",
+  "tags": ["planted", "overloaded"],
+  "files": "./files",
+  "input": {
+    "assignment": "Explain to a developer new to the codebase, in one short section, how the run directory decides which scores its listings show.",
+    "sourceFile": "notes.md"
+  }
+}

--- a/packages/agency-lang/stdlib/agents/writing/review.agency
+++ b/packages/agency-lang/stdlib/agents/writing/review.agency
@@ -1,0 +1,204 @@
+/** @module
+  @summary Reviews prose for readability: the judgment layer above spelling
+  and grammar.
+
+  Review reads the work and looks things up; this agent changes nothing and
+  needs no tools beyond the text itself. It judges whether a reader can
+  follow the writing, using a small catalog of readability principles, and
+  a caller can supply its own writing guidelines to extend or override them.
+*/
+import { Feedback, failOpenFeedback } from "std::agents/lib/feedback"
+import { llmOptions, withContext } from "std::agents/lib/shared"
+import { communicationTools, SAVE_DRAFT_HINT } from "std::agents/lib/toolkits"
+import { agentSkill } from "std::skills"
+import { evalValue } from "std::statelog"
+import { systemMessage, threadIsNew } from "std::thread"
+
+static const systemPrompt = """You review prose for readability. Spelling and grammar checkers run
+separately; your job is the judgment layer — writing that is technically
+correct but hard to follow.
+
+The principles. Every finding names the principle it violates:
+
+- Garden-path sentences: an opening that makes the reader parse the
+  sentence one way, then forces a re-read when the real structure lands
+  ("The name lists partition the catalog…" — "name lists" is a noun).
+  Quote the misleading opening and give a rewrite that cannot be misread.
+- Passive voice: the actor hidden behind "is/was …-ed by" (or dropped
+  entirely) when naming who does what would read faster. Flag it where it
+  costs the reader; technical prose sometimes has no actor worth naming.
+- Too many concepts in one sentence: several commas, semicolons,
+  conjunctions, or a parenthetical stacked into one sentence, so the end
+  arrives after the reader has dropped the beginning. Propose the split.
+- Needless detail: parentheticals and qualifier lists that make the
+  reader stack a new mental frame for information the sentence does not
+  need. Ask whether the speed bump is worth what it carries.
+- Emdash overuse: one emdash can add life; emdashes in every sentence are
+  jarring. Suggest a comma or a conjunction for the excess.
+- Unexplained jargon and shorthand: terms, codenames, or bare issue
+  numbers the intended reader has not been given. Judge against the
+  audience the task names.
+- Buried lead: the sentence the reader came for sitting under background
+  they did not need first.
+
+How to review:
+1. Work out who the text is for and what it must get across; judge
+   against that, not against taste.
+2. error=true means the text fails its job on that point: a reader will
+   misread it, lose the thread, or miss the point. Quote the exact
+   passage and give a concrete rewrite.
+3. error=false is advisory: real polish (a tightening, an active-voice
+   rewrite, a split) that would help but does not block understanding.
+   Calibrate hard: a passage that merely could be smoother, or extra
+   information a curious reader might also want, is advisory, not an
+   error. Reserve error=true for a demonstrable misreading — one you can
+   act out: "the reader parses it as X, but it means Y". When unsure,
+   advisory.
+4. When the caller supplies writing guidelines, they outrank this
+   catalog: apply both, and where they conflict, the guidelines win.
+5. A clean verdict is a fine outcome. Never pad with generic advice, and
+   report a repeated habit once, saying that it repeats.
+
+Keep each finding brief, quote the passage it is about, and always offer
+the fixed version.${SAVE_DRAFT_HINT}"""
+
+static const skills = agentSkill("writing/review")
+
+export def buildTools(): any[] {
+  """
+  Return the writing reviewer's tools. Prose review needs nothing beyond
+  the text, so this is only the shipped skills and progress reporting.
+  """
+  return [skills, ...communicationTools()]
+}
+
+def judgeText(
+  work: string,
+  task: string,
+  guidelines: string,
+  context: string,
+  model: string,
+  provider: string,
+  extraTools: any[],
+): Feedback[] {
+  if (threadIsNew()) {
+    systemMessage(systemPrompt)
+  }
+  let guidelinesSection = ""
+  if (guidelines != "") {
+    guidelinesSection = """The caller's own writing guidelines. They outrank the built-in catalog:
+<guidelines>
+${guidelines}
+</guidelines>
+
+"""
+  }
+  const prompt = """
+${guidelinesSection}The text was written for this task:
+<task>
+${withContext(task: task, context: context)}
+</task>
+
+<text>
+${work}
+</text>
+
+Return a list of feedback items.
+"""
+  // Return position so a model saveDraft propagates as partial findings.
+  return llm(
+    prompt,
+    llmOptions(
+      model: model,
+      provider: provider,
+      tools: buildTools().concat(extraTools).concat([saveDraft]),
+    ),
+  )
+}
+
+export def writingReviewAgent(
+  work: string,
+  task: string = "",
+  guidelines: string = "",
+  context: string = "",
+  maxCost: number = $5.00,
+  maxTime: number = 10m,
+  model: string = "",
+  provider: string = "",
+  session: string = "",
+  extraTools: any[] = [],
+): Result<Feedback[]> {
+  """
+  Review prose for readability and return findings. error=true marks a
+  passage a reader will misread or lose; error=false is advisory polish.
+  Spelling and grammar are assumed checked separately: this agent reports
+  only what needs judgment.
+
+  @param work - The text under review
+  @param task - Who the text is for and what it must get across, or ""
+  @param guidelines - The caller's own writing guidelines, as text (for
+    example the contents of a project's writing-tips document). Outranks
+    the built-in catalog where they conflict; "" for the built-in catalog alone
+  @param context - Extra material for the judgment, or ""
+  @param maxCost - Hard spend cap
+  @param maxTime - Hard wall-clock cap
+  @param model - Model override, or "" for the ambient model
+  @param provider - Provider for the model override
+  @param session - Session name to share a thread across calls, or "" for isolated
+  @param extraTools - Extra tools to offer the LLM, appended to the built-in set
+  """
+  const captured = guard(cost: maxCost, time: maxTime, label: "writingReviewAgent") {
+    let items: Feedback[] = []
+    thread(label: "writingReviewAgent", session: session) {
+      items = judgeText(
+        work: work,
+        task: task,
+        guidelines: guidelines,
+        context: context,
+        model: model,
+        provider: provider,
+        extraTools: extraTools,
+      )
+    }
+    return items
+
+    // Salvage the model's partial findings if an outer budget guard trips
+    // mid-review; the assignment above would otherwise drop them.
+    finalize {
+      return items
+    }
+  }
+
+  return failOpenFeedback(captured)
+}
+
+/** What an eval hands the reviewer: the task the text was written for, and
+  the file holding that text, seeded into the working directory by the
+  test's `files/`. The shape the `evals/writing-review` suite uses as its
+  input. */
+export type WritingReviewEvalInput = {
+  assignment: string;
+  sourceFile: string
+}
+
+/** Eval entry point: `agency eval run stdlib/agents/writing/review.agency:evalMain
+  --suite <dir>`. A node in a library module never runs when the module is
+  imported; it only exists so a suite can score this reviewer without a
+  wrapper file. Any other reviewer scored on the same suite supplies a node
+  with this signature. Effects are decided at this boundary: reading the
+  seeded input file is this node's own doing (`with approve`), and a budget
+  trip inside the reviewer is rejected (`with reject`) so the caps stay
+  caps and the reviewer's fail-open result comes back instead of an
+  interrupt escaping the entry point. */
+node evalMain(input: WritingReviewEvalInput): Feedback[] {
+  evalValue(input)
+  const source = read(input.sourceFile) with approve
+  if (source is failure(readErr)) {
+    return [{ error: true, feedback: "could not read ${input.sourceFile}: ${readErr}" }]
+  }
+  const reviewed = writingReviewAgent(work: source.value, task: input.assignment) with reject
+  if (reviewed is failure(err)) {
+    return [{ error: true, feedback: "review agent failed: ${err}" }]
+  }
+  return reviewed.value
+}


### PR DESCRIPTION
## What this is

The general writing reviewer we discussed, plus its eval suite. `writingReviewAgent` at `std::agents/writing/review` reviews prose for the judgment layer above spelling and grammar. The built-in catalog distills `docs/dev/general-writing-tips.md` — garden-path sentences, passive voice hiding the actor, concept-stacked sentences, needless parenthetical detail, emdash overuse — plus unexplained jargon and buried leads. A `guidelines` parameter takes your actual tips doc and outranks the built-in catalog, same pattern as the TypeScript reviewer.

Calibration is written into the prompt: `error: true` is reserved for a demonstrable misreading ("the reader parses it as X, but it means Y"); everything that merely could be smoother is advisory. It carries no tools beyond the text — prose review needs no lookups.

## The suite

`evals/writing-review` mirrors `evals/typescript-review`: agent-agnostic `{assignment, sourceFile}` contract, `evalMain` in the module, one-liner `graders.ts` per test over a shared grader library, ground truth as an author-written `reason` — the exact shape your harvested editing rounds will take.

Seed tests: **overloaded-paragraph** (a run-directory explainer with a garden-path opening and concept-stacked passive sentences, aimed at a stated newcomer audience) and **clean-paragraph** (the same content rewritten plainly).

## Smoke baseline — the suite has headroom by design

The fixture rounds were instructive: my first two "clean" rewrites weren't clean — the reviewer correctly flagged undefined codebase jargon for the stated newcomer audience, so the fixture got fixed, twice. Final baseline: **planted 1.000, clean 0.500** — the reviewer still promotes a definitional nitpick to `error` on the clean control. I deliberately stopped tuning there: that residual is a genuine false-positive miscalibration in the agent, which is what the clean control exists to measure, and a suite with headroom is more useful than one tuned to saturation.

## One incidental fix

The eval input type is `WritingReviewEvalInput` rather than `ReviewEvalInput`: the doc generator links type names across modules, and a second `ReviewEvalInput` silently stole the agency reviewer's doc link target. #900 (the typescript-review suite) has the same latent collision; I'll fix it there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1f3ZTxh92pD7N4DDbDA3h
