### PR TITLE
Name the missing expansion step when a splice reaches codegen (#732)

### DIFF
--- a/packages/agency-lang/docs/dev/splices.md
+++ b/packages/agency-lang/docs/dev/splices.md
@@ -58,6 +58,10 @@ The map of paths is the same one `liftCallbackBlocks` marks. If a sixth appears,
 
 `TypeScriptBuilder.build` has a tripwire for this. A splice reaching code generation means expansion did not run. Without the tripwire the symptom is a raw `Unhandled Agency node type` stack trace that says nothing about the actual mistake.
 
+The tripwire runs before the builder generates anything, and it finds splices by walking the whole tree rather than scanning the top level — a splice in expression position sits several levels down inside a call. The message names the generator when it can read one, so it says *which* splice went unexpanded, and points here for the list of paths that must call expansion.
+
+Because no real compile path can reach the tripwire, its only coverage is `lib/backends/spliceRefusal.test.ts`, which builds a splice program with expansion deliberately skipped, once per splice position. That test is what notices if the tripwire is ever removed.
+
 ## The three phases
 
 `expandSplices` keeps decide, run, and graft separate, because they change for different reasons.

--- a/packages/agency-lang/lib/backends/spliceRefusal.test.ts
+++ b/packages/agency-lang/lib/backends/spliceRefusal.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { parseAgency } from "../parser.js";
+import { TypeScriptBuilder } from "./typescriptBuilder.js";
+import { TypescriptPreprocessor } from "@/preprocessors/typescriptPreprocessor.js";
+import { buildCompilationUnit } from "@/compilationUnit.js";
+import { printTs } from "../ir/prettyPrint.js";
+import type { AgencyConfig } from "@/config.js";
+
+/**
+ * The builder's splice tripwire, exercised by deliberately skipping
+ * expansion — the one thing no real compile path does.
+ *
+ * Every path that compiles or checks a file runs `expandSplices` first, so
+ * nothing else in the suite can reach this throw. That is exactly why it
+ * needs its own test: delete the tripwire and only these tests notice, and
+ * the next compile path added without an expansion call would surface as a
+ * bare "Unhandled Agency node type: splice" instead.
+ */
+function buildWithoutExpansion(source: string): string {
+  const parseResult = parseAgency(source, {}, false, false);
+  if (!parseResult.success) throw new Error(`Failed to parse: ${parseResult.message}`);
+  const info = buildCompilationUnit(parseResult.result);
+  const preprocessor = new TypescriptPreprocessor(parseResult.result, {}, info);
+  const pre = preprocessor.preprocess();
+  const builder = new TypeScriptBuilder({} as AgencyConfig, info, "test.agency");
+  return printTs(builder.build(pre));
+}
+
+const IMPORT = `import { gen } from "./gen.agency"\n\n`;
+
+// One per splice position, because the pre-pass finds splices by walking the
+// whole tree: an expression-position splice is nested several levels down and
+// is the one a shallower walk would miss.
+const POSITIONS: Record<string, string> = {
+  decl: `${IMPORT}$( gen() )\n\nnode main() { print(1) }\n`,
+  statement: `${IMPORT}node main() { $( gen() ) }\n`,
+  expr: `${IMPORT}node main() { print($( gen() )) }\n`,
+};
+
+describe("the builder refuses an unexpanded splice before generating anything", () => {
+  for (const [position, source] of Object.entries(POSITIONS)) {
+    describe(`a splice in ${position} position`, () => {
+      it("names the pass that should have removed it", () => {
+        expect(() => buildWithoutExpansion(source)).toThrow(
+          /expandSplices should have replaced it/,
+        );
+      });
+
+      it("names the generator, so the message says which splice", () => {
+        expect(() => buildWithoutExpansion(source)).toThrow(/generator: gen/);
+      });
+
+      it("does not report a missing language feature", () => {
+        // The crash this replaces. If this assertion ever fails, the
+        // tripwire has stopped running and the useless message is back.
+        expect(() => buildWithoutExpansion(source)).not.toThrow(/Unhandled Agency node type/);
+      });
+    });
+  }
+
+  it("still builds a program with no splices in it", () => {
+    const output = buildWithoutExpansion("const x = 1\n\nnode main() { print(x) }\n");
+    expect(output).toContain("main");
+  });
+});

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -120,6 +120,8 @@ function coarseKindFor(typeHint: VariableType): CoarseKind | null {
 import { printTs } from "../ir/prettyPrint.js";
 import type { TsNode, TsObjectEntry, TsParam, TsTemplatePart } from "../ir/tsIR.js";
 import type { CompilationUnit } from "../compilationUnit.js";
+import type { Splice } from "../types/splice.js";
+import { calleeName } from "../compiler/splice/calleeName.js";
 import { SourceMapBuilder } from "./sourceMap.js";
 import { nodeWrapperParams } from "./typescriptBuilder/nodeWrapperParams.js";
 import { ScopeManager } from "./typescriptBuilder/scopeManager.js";
@@ -508,9 +510,16 @@ export class TypeScriptBuilder {
       (visit) => visit.node.type === "splice",
     );
     if (unexpanded.length > 0) {
+      const named = unexpanded
+        .map((visit) => calleeName(visit.node as Splice))
+        .filter((name): name is string => name !== null);
+      const which =
+        named.length > 0 ? ` (generator${named.length > 1 ? "s" : ""}: ${named.join(", ")})` : "";
       throw new Error(
-        "Internal error: a compile-time splice `$( ... )` reached code " +
-          "generation. Splice expansion did not run on this compile path.",
+        `Internal error: a compile-time splice \`$( ... )\`${which} reached code ` +
+          "generation. Splice expansion did not run on this compile path: " +
+          "expandSplices should have replaced it. See docs/dev/splices.md for " +
+          "the paths that must call it.",
       );
     }
 

--- a/packages/agency-lang/lib/compiler/splice/calleeName.ts
+++ b/packages/agency-lang/lib/compiler/splice/calleeName.ts
@@ -1,0 +1,9 @@
+import type { Splice } from "../../types/splice.js";
+
+/** A splice calls its generator; anything else has no generator to name. */
+export function calleeName(splice: Splice): string | null {
+  const expression = splice.expression as { type: string; functionName?: string };
+  return expression.type === "functionCall" && expression.functionName !== undefined
+    ? expression.functionName
+    : null;
+}

--- a/packages/agency-lang/lib/preprocessors/expandSplices.ts
+++ b/packages/agency-lang/lib/preprocessors/expandSplices.ts
@@ -17,6 +17,7 @@ import {
 } from "../compiler/splice/eligibility.js";
 import type { ImportSource } from "../compiler/splice/eligibility.js";
 import { runGenerator } from "../compiler/splice/runGenerator.js";
+import { calleeName } from "../compiler/splice/calleeName.js";
 import {
   cachedEligibility,
   cachedGeneratorRun,
@@ -261,14 +262,6 @@ function decide(
       ),
     },
   };
-}
-
-/** A splice calls its generator; anything else has no generator to name. */
-function calleeName(splice: Splice): string | null {
-  const expression = splice.expression as { type: string; functionName?: string };
-  return expression.type === "functionCall" && expression.functionName !== undefined
-    ? expression.functionName
-    : null;
 }
 
 /**


### PR DESCRIPTION
Fixes #732.

## What I found first

The issue says a splice reaching code generation reports `Unhandled Agency node type: splice`, and asks for a `case "splice"` in `processNode` next to the `hole` case.

That premise is stale. PR #679 (the splices PR itself) already added a tripwire at the top of `TypeScriptBuilder.build()` that walks the whole tree and refuses an unexpanded splice before generating anything. I checked this rather than assuming: I built a splice program in each of the three splice positions (declaration, statement, expression) with expansion deliberately skipped, and all three already hit the tripwire, not the `default` branch.

So I did **not** add the `processNode` case. It would be a second guard sitting behind a first one that already catches everything, and it can never fire.

## What was actually missing

**The message could say more.** It named neither the pass that should have removed the splice nor which splice it was. Now it does both:

```
Internal error: a compile-time splice `$( ... )` (generator: makeGreet) reached
code generation. Splice expansion did not run on this compile path:
expandSplices should have replaced it. See docs/dev/splices.md for the paths
that must call it.
```

The generator name comes from `calleeName`, which already existed inside `expandSplices`. I moved it to its own module so the builder can use it too. When the splice is not a plain call there is no generator to name, and that clause is simply left out.

**The tripwire had no test at all.** That is the real risk here. No real compile path can reach it, so nothing in the suite touches it, and it could be deleted without a single test going red — which is precisely the drift it exists to prevent. `lib/backends/spliceRefusal.test.ts` builds a splice program with expansion deliberately skipped, once per splice position, modeled on the neighbouring `topLevelRefusal.test.ts` (the issue suggested that model, and it is the right one).

The expression-position case is the one worth having: that splice sits several levels down inside a call argument, so it is what a shallower top-level scan would miss.

## Verification

I removed the tripwire and re-ran the new tests. They failed with exactly the message the issue reported:

```
expected [Function] to throw error matching /expandSplices should have replaced it/
  but got 'Unhandled Agency node type: splice'
```

Restoring it turns them green again, so the tests genuinely bite rather than passing either way.

`npx tsc --noEmit`, `pnpm run lint:structure`, and `pnpm run fmt:ts` are all clean. `spliceRefusal`, `topLevelRefusal`, `utils/topLevel`, and `sourceIsText` all pass (49 tests).

One thing to know: `lib/preprocessors/expandSplices.test.ts` has 22 failures in my worktree, and they are not from this change — I stashed the change and confirmed the identical 22 failures on clean `main`. Those tests run real generators, which shell out to the built CLI, and the worktree has no `dist`. CI builds first, so it will cover them.

## Docs

`docs/dev/splices.md` already described the tripwire. I added how it searches, what the message now says, and where its only coverage lives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QD2WiV5DAqLYC9i1f3FLtn
