### PR TITLE
docs: give pass() a home on the handlers page

### DIFF
--- a/packages/agency-lang/docs/site/guide/handlers.md
+++ b/packages/agency-lang/docs/site/guide/handlers.md
@@ -179,39 +179,22 @@ Now, all of their interrupts get rejected. As long as all destructive actions ar
 
 ## Propagate
 
-Besides `approve` and `reject,` the other keyword is `propagate.` `propagate` means "I don't want to reject the interrupt, but I don't want anyone to be able to programmatically approve it either. I want to make sure it always goes to a user for approval or rejection."
+`propagate` means "I don't want to reject the interrupt, but I don't want anyone to be able to programmatically approve it either. I want to make sure it always goes to a user for approval or rejection."
 
 ## Pass
 
-Sometimes a handler looks at an interrupt and decides it has no opinion about it. Maybe it only cares about budget guards, and this interrupt was a file write. `pass()` is how you say that: "not my question, ask the next handler."
-
-```ts
-handle {
-  doSomeWork()
-} with (intr) {
-  if (intr.effect == "std::guard") {
-    return reject()
-  }
-  return pass()
-}
-```
-
-A handler that just falls off the end without returning anything means the same thing. So why have a keyword for it at all?
-
-Because sometimes you are in a spot where you have to produce a value. A `match` has to have a value in every arm, so there is nowhere to "return nothing":
+The final keyword is `pass`. `pass` just says, "I don't have an opinion about this interrupt." If you don't return anything, `pass` is the default. It's useful in match blocks, when you need some sort of value to return:
 
 ```ts
 handle {
   doSomeWork()
 } with (intr) {
   return match (intr.effect) {
-    "std::guard" -> reject()
+    "std::guard" -> reject()    
     _ -> pass()
   }
 }
 ```
-
-That last arm is the whole reason `pass()` exists.
 
 ## The rules of handlers
 

--- a/packages/agency-lang/docs/site/guide/handlers.md
+++ b/packages/agency-lang/docs/site/guide/handlers.md
@@ -181,14 +181,47 @@ Now, all of their interrupts get rejected. As long as all destructive actions ar
 
 Besides `approve` and `reject,` the other keyword is `propagate.` `propagate` means "I don't want to reject the interrupt, but I don't want anyone to be able to programmatically approve it either. I want to make sure it always goes to a user for approval or rejection."
 
+## Pass
+
+Sometimes a handler looks at an interrupt and decides it has no opinion about it. Maybe it only cares about budget guards, and this interrupt was a file write. `pass()` is how you say that: "not my question, ask the next handler."
+
+```ts
+handle {
+  doSomeWork()
+} with (intr) {
+  if (intr.effect == "std::guard") {
+    return reject()
+  }
+  return pass()
+}
+```
+
+A handler that just falls off the end without returning anything means the same thing. So why have a keyword for it at all?
+
+Because sometimes you are in a spot where you have to produce a value. A `match` has to have a value in every arm, so there is nowhere to "return nothing":
+
+```ts
+handle {
+  doSomeWork()
+} with (intr) {
+  return match (intr.effect) {
+    "std::guard" -> reject()
+    _ -> pass()
+  }
+}
+```
+
+That last arm is the whole reason `pass()` exists.
+
 ## The rules of handlers
 
 The rules of handlers are thus:
 1. If any handler rejects, the interrupt is rejected.
 2. Otherwise, if any handler propagates, the interrupt propagates to the user for a decision.
 3. Otherwise, if a handler approves, the interrupt is approved.
+4. A handler that passes does none of these. It steps aside and lets the rest of the chain decide.
 
-Of course, a handler doesn't need to approve, reject, or propagate. It can simply choose to log the interrupt data, print out the lyrics to "A Day in the Life," or whatever. If no handler approves, rejects, or propagates, by default, the interrupt propagates up to the user for a decision.
+Of course, a handler doesn't need to approve, reject, or propagate. It can simply choose to log the interrupt data, print out the lyrics to "A Day in the Life," or whatever. A handler that never returns a verdict has passed, whether or not it said `pass()` out loud. And if *every* handler passes, nobody in the chain made a decision, so the interrupt propagates up to the user — the same safe default you get when there is no handler at all.
 
 ## Raising interrupts inside a handler function
 


### PR DESCRIPTION
Closes #572.

The handlers guide walked through `approve`, `reject`, and `propagate` but never mentioned `pass()`. It was documented only in the guards guide, as the fall-through for unrecognized effects. This gives it a home on the page where the other verdicts live.

Two changes, both in the verdict part of the page:

**A new `## Pass` section, right after `## Propagate`.** It says what passing means, then makes the case for why the keyword exists at all given that falling off the end of a handler does the same thing: a `match` arm has to produce a value, so there is nowhere to return nothing. That is the motivation from the doc comment on `pass()` itself.

**Rule 4 in `## The rules of handlers`.** The existing three rules are unchanged. The paragraph under them already described passing without using the word, so it now uses the word, and says out loud that when every handler passes the interrupt goes to the user.

### On the owner-voice note in the issue

The issue says the guide pages are owner-voiced and this was a reminder rather than a request to rewrite. I raised that first and Aditya asked for the PR anyway. Treat the prose as a starting point, not a proposal to accept as-is.

### Checks

Both new code snippets were compiled with `pnpm run compile` before being written down, including the `match` one with the `_ -> pass()` arm. No code changed, so nothing else to run.

Each claim in the new text traces to the runtime:

- "falling off the end means the same thing" is `lib/runtime/interrupts.ts:328-331`, which normalizes an `undefined` return to `{ type: "pass" }` before the chain sees it
- the `match` motivation is the doc comment on `pass()`, `lib/runtime/interrupts.ts:42-45`
- "every handler passes goes to the user" is `lib/runtime/interrupts.ts:397-402`, where none of the reject, propagate, or approve branches fire

### Not done

I left `guards.md` alone, so `pass()` stays documented there too. I also left the page's frontmatter `description` alone, which still reads "approving, rejecting, or propagating them" — say the word and I will add passing to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JG8vWxnHgaPmosYnkBc4jx
