### PR TITLE
A match expression can be the body of a match arm (#887)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,7 @@ Pipeline and architecture:
 - `docs/dev/eval-command-agents.md` — Running a CLI as the eval agent (`--agent-cmd`): the EvalTarget union, tokenize-then-substitute, the AGENCY_CONFIG_OVERRIDES/AGENCY_TRACE_ID statelog handoff, process-group kill lifecycle, and the two cost-cap feeds
 - `docs/dev/pkg-imports.md` — Importing Agency code from npm packages using `pkg::` prefix
 - `docs/dev/trace.md` — Execution traces capturing checkpoints at every step
+- `docs/dev/match-expression-positions.md` — Where a `match` expression is allowed: `match` is not in `exprParser` but hand-wired into three sites, why folding it in is ruled out, why a nested-match arm must be LOWERED rather than hoisted (one `any` yield makes the whole outer match `any`), the formatter's inline/block re-parse rule, and the open `if ... then ... else` arm gap
 - `docs/dev/binop-parser.md` — Binary expression parser using precedence climbing
 - `docs/dev/locations.md` — How `loc.line` / `loc.col` / parse-mode template offset interact
 - `docs/dev/validation-annotations.md` — `@validate(...)` and `@jsonSchema(...)` internals: tag merging, `__agency_descriptor` contract, descriptor tree, runtime walker

--- a/packages/agency-lang/docs/dev/match-expression-positions.md
+++ b/packages/agency-lang/docs/dev/match-expression-positions.md
@@ -1,0 +1,78 @@
+# Where a `match` expression is allowed
+
+`match` is not an ordinary expression as far as the parser is concerned. It is
+**not** part of `exprParser`. Instead there is a separate `matchBlockExprParser`
+(`lib/parsers/parsers.ts`) that gets wired into each place a match is allowed to
+appear as a value, by hand, one site at a time.
+
+Today there are three such sites:
+
+1. `returnStatementParser` — `return match(x) { ... }`
+2. `assignmentParser` — `const y = match(x) { ... }`
+3. the match-arm body — `success(s) => match(y) { ... }` (added for #887)
+
+If you want `match` to be legal somewhere new, adding it to that site's
+alternatives is the whole parser change. `if ... then ... else` works the same
+way, through `ifExpressionParser`, but is wired into only the first two.
+
+This is deliberate. Folding `match` into `exprParser` would make it legal
+everywhere an expression is — as a function argument, as an operand of `+`, and
+inside the head of another match. That is a much larger ambiguity surface than
+the feature is worth, and the owner has explicitly ruled it out.
+
+## The trap: a nested match must be lowered, not hoisted
+
+`matchBlock` is in the `Expression` union and in `EXPRESSION_NODE_TYPES`
+(`lib/types.ts`), so a single-expression match arm whose body is a nested match
+will happily take the generic "hoist the arm's value to a temp" path in
+`rewriteArmForYield` (`lib/lowering/patternLowering.ts`). That path leaves the
+raw `matchBlock` node as the yield's `typeSource`.
+
+The synthesizer has no case for `matchBlock`, so synthesizing that node returns
+`any`. And in `computeMatchExprTypes`, **one** `any` yield makes the entire
+match's value type `any`:
+
+```ts
+ctx.matchExprTypes[id] = types.some(isAnyType) ? ANY_T : ...
+```
+
+So the failure is not "the nested match is untyped". It is "the whole outer
+match is untyped", and every assignability check on it silently stops running.
+Nothing errors; you just lose the checking.
+
+The fix is for `rewriteArmForYield` to lower a nested match through
+`lowerMatchExpressionCore` first and yield its `__matchval_<id>` ref — exactly
+what `rewriteReturnsToYields` already does for `return match(...)` in a block
+arm. `computeMatchExprTypes` processes match ids in DESCENDING order precisely
+so these resolve bottom-up.
+
+Anything else you make legal in a value position needs the same treatment: if
+the synthesizer cannot type the node, hoisting it poisons its consumer.
+
+## The formatter has to agree
+
+`armPrintsInline` (`lib/backends/agencyGenerator.ts`) decides whether an arm
+prints as `=> expr` or `=> { ... }`. It must not print inline a shape the arm
+grammar cannot re-parse — that is the `#708` rule in its doc comment. A
+`NEVER_INLINE_ARM_TYPES` list used to exist for exactly one entry,
+`"matchBlock"`, because the grammar rejected inline nested matches. Once the
+parser accepted them the list was empty and was deleted.
+
+The whole-corpus print→reparse identity test in
+`lib/backends/agencyGenerator.roundtrip.test.ts` is what catches a mistake here,
+but only for shapes the corpus actually contains — add a targeted case too.
+
+## Known gap: `if ... then ... else` as an arm body
+
+Still a parse error. The parser half is one line (add `ifExpressionParser` to
+the arm alternatives) and the lowering half is already written — the shared
+`expressionRegion()` helper handles `matchBlock` and `ifElse` both. The reason
+it is not done is the formatter.
+
+`ifElse` is one node type for two surface forms: the statement `if (c) { ... }`
+and the expression `if c then a else b`. Nothing on the node records which was
+written. Existing code disambiguates **by position** — see the comment at the
+assignment-value branch in `agencyGenerator.ts`, "a statement `if` is never an
+assignment value". An inline arm body is a value position, so the same argument
+works there, but `armPrintsInline` and the arm-printing path both need to know
+it, or the arm prints in statement form and stops round-tripping.

--- a/packages/agency-lang/docs/dev/match-expression-positions.md
+++ b/packages/agency-lang/docs/dev/match-expression-positions.md
@@ -40,14 +40,62 @@ So the failure is not "the nested match is untyped". It is "the whole outer
 match is untyped", and every assignability check on it silently stops running.
 Nothing errors; you just lose the checking.
 
-The fix is for `rewriteArmForYield` to lower a nested match through
-`lowerMatchExpressionCore` first and yield its `__matchval_<id>` ref — exactly
-what `rewriteReturnsToYields` already does for `return match(...)` in a block
-arm. `computeMatchExprTypes` processes match ids in DESCENDING order precisely
-so these resolve bottom-up.
+The fix is for `rewriteArmForYield` to lower the nested construct first and
+yield its `__matchval_<id>` ref — exactly what `rewriteReturnsToYields` already
+does for `return match(...)` in a block arm. `computeMatchExprTypes` processes
+match ids in DESCENDING order precisely so these resolve bottom-up.
+
+It routes through the shared `expressionRegion()` helper, which owns the
+question "is this an expression-position control-flow construct?" for
+`matchBlock` and `ifElse` alike. The arm lowerer adds the one question only it
+can answer: **is this arm an expression position?**
+
+That second question is load-bearing, not ceremony. `ifElse` is one node type
+for two surface forms (see the last section), and is an expression only in value
+position — for an arm, the inline form. A BLOCK arm whose body is a lone
+statement `if` must NOT take this path: `lowerIfExpressionCore` reads each
+branch as `thenBody[0] as Expression`, so a branch like
+`{ const x = 41  return x + 1 }` yields the value of the `const` binding and
+silently drops the `return`. Calling `expressionRegion()` ungated on every
+one-node arm body makes this arm return 41:
+
+```agency
+true => {
+  if (c) { const x = 41  return x + 1 } else { return 2 }
+}
+```
+
+and makes an arm whose branches yield nothing at all compile silently instead of
+raising "match arm must return a value on every path". `matchBlock` has no such
+ambiguity — it is an expression in both forms — so it takes the path either way.
 
 Anything else you make legal in a value position needs the same treatment: if
 the synthesizer cannot type the node, hoisting it poisons its consumer.
+
+## Known limitation: a nested arm loses literal types
+
+The yield this produces carries no `typeSource`, so `computeMatchExprTypes`
+types it by synthing the `__matchval_<inner>` ref, and that hook returns
+`ctx.matchExprTypes[inner]` — which has already been through `widenType`. A
+nested arm therefore loses literal types, and a literal-union annotation gets a
+false error:
+
+```agency
+const val: "a" | "b" = match(r) {
+  success(v) => match(r2) { success(w) => "a"  failure(e) => "b" }
+  failure(e) => "a"
+}
+// Type 'string' is not assignable to type '"a" | "b"'
+```
+
+Flattened to a single match this is accepted, because a plain arm keeps its
+`typeSource` and the per-arm check runs on the UNWIDENED type. This is not new —
+`=> { return match(...) }` has always behaved this way — but the inline syntax
+is what makes the shape easy to reach.
+
+If you want to close it: the unwidened per-arm types do exist, in
+`ctx.matchExprYieldTypes[inner]`. The nested yield would need to carry them
+through rather than collapsing to the widened union.
 
 ## The formatter has to agree
 
@@ -64,15 +112,42 @@ but only for shapes the corpus actually contains — add a targeted case too.
 
 ## Known gap: `if ... then ... else` as an arm body
 
-Still a parse error. The parser half is one line (add `ifExpressionParser` to
-the arm alternatives) and the lowering half is already written — the shared
-`expressionRegion()` helper handles `matchBlock` and `ifElse` both. The reason
-it is not done is the formatter.
+Still a parse error. The parser half is one line — add `ifExpressionParser` to
+the arm alternatives — and the lowering half really is done: because
+`rewriteArmForYield` routes through `expressionRegion()`, which already handles
+`ifElse`, adding that one parser line is enough to make
 
-`ifElse` is one node type for two surface forms: the statement `if (c) { ... }`
-and the expression `if c then a else b`. Nothing on the node records which was
-written. Existing code disambiguates **by position** — see the comment at the
-assignment-value branch in `agencyGenerator.ts`, "a statement `if` is never an
-assignment value". An inline arm body is a value position, so the same argument
-works there, but `armPrintsInline` and the arm-printing path both need to know
-it, or the arm prints in statement form and stops round-tripping.
+```agency
+match(x) {
+  1 => if (x > 0) then 10 else 20
+  _ => 0
+}
+```
+
+parse, lower, and run correctly. I verified this by temporarily adding the line.
+
+What is NOT done is the formatter, and it fails loudly rather than subtly. With
+the parser line in, `agency fmt` prints the arm above as:
+
+```
+1 => {
+  if (x > 0) {
+10
+  } else {
+20
+  }
+}
+```
+
+— structurally broken, and even repaired it would re-parse as a statement `if`
+whose branches contain no `return`, which dies with "match arm must return a
+value on every path".
+
+The cause is the two-surface-forms problem again: nothing on an `ifElse` node
+records which form was written, and `armPrintsInline` /
+`processMatchBlockCase` fall back to the statement printer. Existing code
+disambiguates **by position** — see the comment at the assignment-value branch
+in `agencyGenerator.ts`, "a statement `if` is never an assignment value". An
+inline arm body is a value position, so the same argument works; both the
+inline decision and the printing path need to route through
+`formatIfExpression`. That, plus a round-trip test, is the whole remaining job.

--- a/packages/agency-lang/lib/backends/agencyGenerator.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.ts
@@ -159,11 +159,6 @@ const INLINE_ARM_STATEMENT_TYPES: readonly string[] = [
   "assignment",
 ];
 
-/** Node types that never print inline even though they are expressions:
- *  a nested match keeps block form so it re-parses as a match, not an
- *  arm body. */
-const NEVER_INLINE_ARM_TYPES: readonly string[] = ["matchBlock"];
-
 export class AgencyGenerator {
   protected graphNodes: GraphNodeDefinition[] = [];
   protected generatedStatements: string[] = [];
@@ -1638,9 +1633,6 @@ export class AgencyGenerator {
       return false;
     }
     const stmt = caseNode.body[0];
-    if (NEVER_INLINE_ARM_TYPES.includes(stmt.type)) {
-      return false;
-    }
     // A raise-form interrupt is a statement, even though the interrupt
     // EXPRESSION shares its `interruptStatement` node type.
     if (stmt.type === "interruptStatement" && (stmt as InterruptStatement).viaRaise) {

--- a/packages/agency-lang/lib/lowering/patternLowering.ts
+++ b/packages/agency-lang/lib/lowering/patternLowering.ts
@@ -638,6 +638,18 @@ class PatternLowerer {
     matchId: number,
     arm: MatchBlockCase,
   ): AgencyNode[] {
+    if (body.length === 1 && body[0].type === "matchBlock") {
+      // A nested match as the arm's whole body: lower the inner match first and
+      // yield its `__matchval_` ref, exactly as `return match(...)` does in a
+      // block arm. Hoisting it as an opaque expression instead would leave the
+      // raw `matchBlock` as this yield's `typeSource`, which the synthesizer
+      // types as `any` — poisoning the outer match's whole value type.
+      const inner = this.lowerMatchExpressionCore(body[0] as MatchBlock, body[0].loc);
+      return [
+        ...inner.statements,
+        { type: "matchYield", matchId, value: inner.valueRef, loc: body[0].loc },
+      ];
+    }
     if (body.length === 1 && isExpressionNode(body[0])) {
       const expr = body[0] as Expression;
       // Always bind a single-expression arm's value to a temp at STATEMENT

--- a/packages/agency-lang/lib/lowering/patternLowering.ts
+++ b/packages/agency-lang/lib/lowering/patternLowering.ts
@@ -638,17 +638,28 @@ class PatternLowerer {
     matchId: number,
     arm: MatchBlockCase,
   ): AgencyNode[] {
-    if (body.length === 1 && body[0].type === "matchBlock") {
-      // A nested match as the arm's whole body: lower the inner match first and
-      // yield its `__matchval_` ref, exactly as `return match(...)` does in a
-      // block arm. Hoisting it as an opaque expression instead would leave the
-      // raw `matchBlock` as this yield's `typeSource`, which the synthesizer
-      // types as `any` — poisoning the outer match's whole value type.
-      const inner = this.lowerMatchExpressionCore(body[0] as MatchBlock, body[0].loc);
-      return [
-        ...inner.statements,
-        { type: "matchYield", matchId, value: inner.valueRef, loc: body[0].loc },
-      ];
+    if (body.length === 1) {
+      // A nested expression-position construct as the arm's whole body: lower it
+      // first and yield its `__matchval_` ref, exactly as `return match(...)` does
+      // in a block arm. Hoisting it as an opaque expression instead would leave the
+      // raw node as this yield's `typeSource`, which the synthesizer types as `any`
+      // — poisoning the outer match's whole value type.
+      //
+      // `expressionRegion` answers "is this an expression-position construct?";
+      // only the arm can answer "is this arm an expression position?". `ifElse` is
+      // ONE node type for two surface forms, and is an expression only in value
+      // position — for an arm, the inline form. A BLOCK arm holding a lone
+      // statement `if` must fall through to the return-rewrite below, or its
+      // branches are read as single expressions and every statement after the
+      // first is silently dropped. `matchBlock` is an expression in both forms.
+      const valuePosition = arm.blockBody !== true || body[0].type === "matchBlock";
+      const inner = valuePosition ? this.expressionRegion(body[0], body[0].loc) : null;
+      if (inner) {
+        return [
+          ...inner.statements,
+          { type: "matchYield", matchId, value: inner.valueRef, loc: body[0].loc },
+        ];
+      }
     }
     if (body.length === 1 && isExpressionNode(body[0])) {
       const expr = body[0] as Expression;

--- a/packages/agency-lang/lib/parsers/matchBlock.test.ts
+++ b/packages/agency-lang/lib/parsers/matchBlock.test.ts
@@ -1045,3 +1045,36 @@ describe("arm arrow", () => {
     );
   });
 });
+
+// #887: `match` is not part of `exprParser` — it is wired into each
+// expression site by hand, and the arm body was missing it.
+describe("a nested match as an arm body", () => {
+  const nested = `node main() {
+  const x = match (a) {
+    success(s) => match (b) {
+      success(t) => t
+      failure(e) => e
+    }
+    failure(err) => err
+  }
+}`;
+
+  it("parses a match expression as the body of a match arm", () => {
+    expect(() => program(nested)).not.toThrow();
+  });
+
+  it("is the same program written as a block arm", () => {
+    expect(program(nested)).toEqualWithoutLoc(
+      program(`node main() {
+  const x = match (a) {
+    success(s) => { return match (b) { success(t) => t failure(e) => e } }
+    failure(err) => err
+  }
+}`),
+    );
+  });
+
+  it("keeps the inline form when formatted", () => {
+    expect(formatSource(nested)).toContain("success(s) => match(b) {");
+  });
+});

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -4757,6 +4757,7 @@ const matchBlockParserCaseInner: Parser<MatchBlockCase> = (
                 returnStatementParser,
                 gotoStatementParser,
                 lazy(() => assignmentParser),
+                lazy(() => matchBlockExprParser),
                 exprParser,
               ),
               "n",

--- a/packages/agency-lang/lib/typeChecker/matchExpression.test.ts
+++ b/packages/agency-lang/lib/typeChecker/matchExpression.test.ts
@@ -302,3 +302,61 @@ describe("memo invalidation across computeMatchExprTypes phases", () => {
     expect(messages).toContain("number");
   });
 });
+
+// #887: an inline nested match must be lowered to its `__matchval_` ref, not
+// hoisted as an opaque expression. The synthesizer has no `matchBlock` case,
+// so an opaque hoist types the yield as `any` — and one `any` yield makes the
+// WHOLE outer match `any`, silently disabling every check on it.
+describe("a nested match as an arm body", () => {
+  it("types the inner match's arms, so a bad arm is still an error", () => {
+    const errs = check(`${TRY}
+node main() {
+  let r = tryParse("ok")
+  let r2 = tryParse("no")
+  const val: string = match(r) {
+    success(v) => match(r2) {
+      success(w) => 1
+      failure(e) => "inner"
+    }
+    failure(e) => "outer"
+  }
+  return val
+}`);
+    expect(errs.join("\n")).toContain("is not assignable to type 'string'");
+  });
+
+  it("does not collapse the OUTER match's type to any", () => {
+    // Every arm here yields a number; assigning to `string` must still fail.
+    const errs = check(`${TRY}
+node main() {
+  let r = tryParse("ok")
+  let r2 = tryParse("no")
+  const val: string = match(r) {
+    success(v) => match(r2) {
+      success(w) => 1
+      failure(e) => 2
+    }
+    failure(e) => 3
+  }
+  return val
+}`);
+    expect(errs.join("\n")).toContain("Type 'number' is not assignable to type 'string'");
+  });
+
+  it("accepts a nested match whose arms all match the annotation", () => {
+    const errs = check(`${TRY}
+node main() {
+  let r = tryParse("ok")
+  let r2 = tryParse("no")
+  const val: string = match(r) {
+    success(v) => match(r2) {
+      success(w) => "a"
+      failure(e) => "b"
+    }
+    failure(e) => "c"
+  }
+  return val
+}`);
+    expect(errs).toEqual([]);
+  });
+});

--- a/packages/agency-lang/tests/agency/match-arm-nested-match.agency
+++ b/packages/agency-lang/tests/agency/match-arm-nested-match.agency
@@ -1,0 +1,23 @@
+// #887: a match expression as the body of a match arm — the natural way to
+// chain two fallible steps.
+def chain(r: Result<string>, r2: Result<string>): string {
+  return match(r) {
+    success(s) => match(r2) {
+      success(t) => "${s}${t}"
+      failure(e) => "inner:${e}"
+    }
+    failure(err) => "outer:${err}"
+  }
+}
+
+node bothSucceed() {
+  return chain(success("a"), success("b"))
+}
+
+node innerFails() {
+  return chain(success("a"), failure("boom"))
+}
+
+node outerFails() {
+  return chain(failure("first"), success("b"))
+}

--- a/packages/agency-lang/tests/agency/match-arm-nested-match.agency
+++ b/packages/agency-lang/tests/agency/match-arm-nested-match.agency
@@ -21,3 +21,20 @@ node innerFails() {
 node outerFails() {
   return chain(failure("first"), success("b"))
 }
+
+// A BLOCK arm whose body is a lone statement `if` is NOT an expression position:
+// its branches must keep flowing through their `return`s. If the arm lowerer
+// ever routes this through `expressionRegion()`, each branch is read as a single
+// expression and this returns 41 (the `const` binding) instead of 42.
+def viaBlockArm(c: boolean): number {
+  return match(c) {
+    true => {
+      if (c) { const x = 41  return x + 1 } else { return 2 }
+    }
+    _ => 0
+  }
+}
+
+node blockArmStatementIf() {
+  return viaBlockArm(true)
+}

--- a/packages/agency-lang/tests/agency/match-arm-nested-match.test.json
+++ b/packages/agency-lang/tests/agency/match-arm-nested-match.test.json
@@ -5,21 +5,44 @@
       "description": "a nested match arm yields the inner match's value",
       "input": "",
       "expectedOutput": "\"ab\"",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     },
     {
       "nodeName": "innerFails",
       "description": "the inner match still dispatches to its own failure arm",
       "input": "",
       "expectedOutput": "\"inner:boom\"",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     },
     {
       "nodeName": "outerFails",
       "description": "the outer failure arm skips the nested match entirely",
       "input": "",
       "expectedOutput": "\"outer:first\"",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "blockArmStatementIf",
+      "description": "a block arm holding a statement if keeps its returns (not read as a single expression)",
+      "input": "",
+      "expectedOutput": "42",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/match-arm-nested-match.test.json
+++ b/packages/agency-lang/tests/agency/match-arm-nested-match.test.json
@@ -1,0 +1,25 @@
+{
+  "tests": [
+    {
+      "nodeName": "bothSucceed",
+      "description": "a nested match arm yields the inner match's value",
+      "input": "",
+      "expectedOutput": "\"ab\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "innerFails",
+      "description": "the inner match still dispatches to its own failure arm",
+      "input": "",
+      "expectedOutput": "\"inner:boom\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "outerFails",
+      "description": "the outer failure arm skips the nested match entirely",
+      "input": "",
+      "expectedOutput": "\"outer:first\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #887.

## What was wrong

A `match` expression could not be the body of a match arm, so the natural way to chain two fallible steps did not parse:

```agency
return match(r) {
  success(s) => match(r2) {
    success(t) => success(t)
    failure(e) => failure(e)
  }
  failure(err) => failure(err)
}
```

The cause is narrow. `match` is **not** part of `exprParser` — there is a separate `matchBlockExprParser` that gets wired into each value position by hand, one site at a time. Before this PR there were two such sites, `return` and assignment. The arm body was simply never wired up.

## The part that would have gone wrong quietly

Adding the parser alternative is one line and makes the snippet parse and run correctly. It also would have shipped a silent hole.

A single-expression arm hoists its value to a temp and yields it, keeping the original expression as the yield's `typeSource`. The synthesizer has no case for `matchBlock`, so it types that node as `any`. And in `computeMatchExprTypes`, one `any` yield makes the **entire outer match** `any`:

```ts
ctx.matchExprTypes[id] = types.some(isAnyType) ? ANY_T : ...
```

So the failure mode is not "the nested match is untyped" — it is "every assignability check on the outer match stops running, and nothing tells you". With only the parser change, this reported no error at all:

```agency
const val: string = match(r) {
  success(v) => match(r2) { success(w) => 1  failure(e) => 2 }
  failure(e) => 3
}
```

The arm lowerer now lowers a nested match through `lowerMatchExpressionCore` first and yields its `__matchval_` ref — exactly what `rewriteReturnsToYields` already does for `return match(...)` inside a block arm. `computeMatchExprTypes` walks match ids in descending order precisely so these resolve bottom-up. The case above is an error again.

## Formatter

`NEVER_INLINE_ARM_TYPES` existed for exactly one entry, `"matchBlock"`, because the grammar used to reject an inline nested match. With the grammar accepting it the list is empty, so it is deleted and the author's inline form now survives `agency fmt`.

## Not in scope

- **`match` as a function argument** — ruled out deliberately; it would mean folding `match` into `exprParser`.
- **`if ... then ... else` as an arm body** — still a parse error. The parser and lowering halves are nearly free (the shared `expressionRegion()` helper already handles `ifElse`), but `ifElse` is one node type for two surface forms with nothing recording which was written, so the formatter needs the position-based rule taught to it or the arm stops round-tripping. `docs/dev/match-expression-positions.md` writes this up.

## Verification

- 4490 tests across `lib/parsers`, `lib/lowering`, `lib/backends`, `lib/typechecker` pass, including the whole-corpus print→reparse identity test.
- New `tests/agency/match-arm-nested-match.agency` — 3/3, covering the inner-success, inner-failure, and outer-failure paths.
- **Negative control:** with the lowering change reverted, 2 of the 3 new typechecker tests fail. They are not passes-either-way checks.
- Formatter output on a nested match is idempotent and re-parses to an AST identical to the source's (ignoring `loc`).
- `lint:structure`, `fmt:ts`, and `lib/sourceIsText.test.ts` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGjKdkGX9qQ2X1FqNYszdj
