### PR TITLE
Every command translates its flags in one place (typecheck was the holdout)

### DIFF
--- a/packages/agency-lang/docs/dev/config.md
+++ b/packages/agency-lang/docs/dev/config.md
@@ -35,17 +35,22 @@ one exception is the root `-v` / `-c`, handled inside `getConfig()` itself, so
 it is still applied in exactly one place for every command.
 
 `typecheck` was the last holdout and was migrated in the change that added this
-section; before that, its `--strict` was written by hand, and it had already
-drifted from the shared version.
+section. Its `--strict` was hand-written rather than shared — but its narrower
+meaning was correct, and is preserved. See the next section.
 
 ### The same flag name may mean different things on different commands
 
 `--strict` is the live example. On `run`/`compile` it sets both `strict` and
 `strictTypes`, because the compile path has a gate that only opens on `strict`.
 On `typecheck` it sets `strictTypes` alone: that command runs the checker
-unconditionally and computes its own exit code, so it never reaches the gate,
-and setting `strict` there would make it fail on errors it currently reports
-and walks past.
+unconditionally and computes its own exit code, so it never reaches the gate.
+
+Setting `strict` on `typecheck` would therefore be **inert**, not harmful —
+`typechecker.strict` has exactly one reader in the repo, the gate itself
+(`lib/compiler/compile.ts`). The narrow field is still the right call for a
+different reason: a setting that reads as meaningful and does nothing is a
+trap, and it would quietly begin to matter the day `typecheck` grows a compile
+path.
 
 The two meanings are two fields on `CliFlags` (`strict` and `strictTypes`), not
 a branch inside `applyCliFlags`. The command picks the meaning it wants by
@@ -54,7 +59,7 @@ choosing a field; the helper never needs to know which command called it.
 ## Flags that are NOT config
 
 Not every flag becomes a setting, and forcing one to be a setting is a mistake.
-There are two channels, and a new flag belongs to exactly one of them:
+There are three channels, and most new flags belong to one of the first two:
 
 - **Config** (this document) — a value the compiler reads, or one that gets
   baked into the generated program. Goes through `applyCliFlags`.
@@ -64,11 +69,18 @@ There are two channels, and a new flag belongs to exactly one of them:
   runner's output sink is a live object with methods, and `--agency-only`
   selects a different compile path (through the closure validator) rather than
   setting a value.
+- **Forwarded verbatim to a child command line** — `agency doctor` accepts
+  `--trace [file]` and `--log-file <path>` and translates neither. It pushes
+  them back onto an argv for a child `agency` invocation (`lib/cli/doctor.ts`),
+  where `applyCliFlags` runs in that process instead. A wrapper command that
+  shells out belongs here, and the flag's meaning is still defined in exactly
+  one place — just not in this one.
 
 The test for which channel a flag belongs in: *is it a plain value the compiled
-program needs baked in, or is it a live object, or a choice of code path?* The
-first is config; the other two are arguments. `agency run` and `agency test run`
-both use both channels, which is expected, not drift.
+program needs baked in, or is it a live object, or a choice of code path, or is
+this command a wrapper that re-invokes `agency`?* The first is config; the next
+two are arguments; the last is forwarding. `agency run` and `agency test run`
+both use the first two channels, which is expected, not drift.
 
 ## What `--model` means
 

--- a/packages/agency-lang/docs/dev/config.md
+++ b/packages/agency-lang/docs/dev/config.md
@@ -26,6 +26,50 @@ Where applied: sources 1⊕2 at the CLI (baked into the generated program);
 source 3 at runtime, in the `RuntimeContext` constructor. Inspect the resolved
 result with `agency config show` (secrets masked; `--show-secrets` to reveal).
 
+### Every command translates its flags in the same place
+
+`applyCliFlags` is the only definition of what a flag means, and every command
+that turns a flag into a setting calls it — `run`, `compile`, `typecheck`, and
+the bundled agents. Do not hand-write `config.x = y` in a command action. The
+one exception is the root `-v` / `-c`, handled inside `getConfig()` itself, so
+it is still applied in exactly one place for every command.
+
+`typecheck` was the last holdout and was migrated in the change that added this
+section; before that, its `--strict` was written by hand, and it had already
+drifted from the shared version.
+
+### The same flag name may mean different things on different commands
+
+`--strict` is the live example. On `run`/`compile` it sets both `strict` and
+`strictTypes`, because the compile path has a gate that only opens on `strict`.
+On `typecheck` it sets `strictTypes` alone: that command runs the checker
+unconditionally and computes its own exit code, so it never reaches the gate,
+and setting `strict` there would make it fail on errors it currently reports
+and walks past.
+
+The two meanings are two fields on `CliFlags` (`strict` and `strictTypes`), not
+a branch inside `applyCliFlags`. The command picks the meaning it wants by
+choosing a field; the helper never needs to know which command called it.
+
+## Flags that are NOT config
+
+Not every flag becomes a setting, and forcing one to be a setting is a mistake.
+There are two channels, and a new flag belongs to exactly one of them:
+
+- **Config** (this document) — a value the compiler reads, or one that gets
+  baked into the generated program. Goes through `applyCliFlags`.
+- **Resolved objects passed as arguments** — `--policy` / `--approve` /
+  `--reject` become an interrupt policy object via `resolveRunPolicy`,
+  `--max-cost` / `--max-time` become a budget via `resolveBudget`, the test
+  runner's output sink is a live object with methods, and `--agency-only`
+  selects a different compile path (through the closure validator) rather than
+  setting a value.
+
+The test for which channel a flag belongs in: *is it a plain value the compiled
+program needs baked in, or is it a live object, or a choice of code path?* The
+first is config; the other two are arguments. `agency run` and `agency test run`
+both use both channels, which is expected, not drift.
+
 ## What `--model` means
 
 `agency run --model` and the `agency <file>` shorthand set the run's default

--- a/packages/agency-lang/lib/config.test.ts
+++ b/packages/agency-lang/lib/config.test.ts
@@ -214,6 +214,26 @@ describe("applyCliFlags", () => {
     });
   });
 
+  // `agency typecheck --strict` is a NARROWER meaning of the same flag name.
+  // That command calls the checker unconditionally and computes its own exit
+  // code, so it never reaches the compile-path gate that `strict` opens.
+  // Setting `strict` here would make typecheck fail on errors it currently
+  // reports and walks past.
+  it("--strict on typecheck sets strictTypes ONLY, never strict", () => {
+    expect(applyCliFlags({}, { strictTypes: true }).typechecker).toEqual({
+      strictTypes: true,
+    });
+  });
+
+  it("an absent typecheck --strict changes nothing", () => {
+    expect(applyCliFlags({}, { strictTypes: undefined }).typechecker).toBeUndefined();
+  });
+
+  it("the narrow meaning preserves other typechecker settings", () => {
+    const out = applyCliFlags({ typechecker: { enabled: true } }, { strictTypes: true });
+    expect(out.typechecker).toEqual({ enabled: true, strictTypes: true });
+  });
+
   it("--max-tool-call-rounds sets the top-level maxToolCallRounds", () => {
     expect(applyCliFlags({}, { maxToolCallRounds: 20 }).maxToolCallRounds).toBe(20);
   });

--- a/packages/agency-lang/lib/config.test.ts
+++ b/packages/agency-lang/lib/config.test.ts
@@ -215,10 +215,18 @@ describe("applyCliFlags", () => {
   });
 
   // `agency typecheck --strict` is a NARROWER meaning of the same flag name.
-  // That command calls the checker unconditionally and computes its own exit
-  // code, so it never reaches the compile-path gate that `strict` opens.
-  // Setting `strict` here would make typecheck fail on errors it currently
-  // reports and walks past.
+  // `typechecker.strict` has one reader — the compile-path gate in
+  // compiler/compile.ts — and typecheck never reaches it, so setting `strict`
+  // there would be inert, not harmful. The narrow field exists so an inert
+  // setting never looks meaningful, and so it cannot start mattering silently
+  // if this command ever grows a compile path.
+  //
+  // These pin applyCliFlags, not the wiring in scripts/agency.ts: tidying that
+  // call site to `{ strict: opts.strict }` leaves them green. Nothing observes
+  // the difference today (that is what inert means), so the only test that
+  // could bite would assert resolved config through an injectable seam that
+  // does not exist yet — production surface added for one test, which is not
+  // worth it while the failure mode is invisible.
   it("--strict on typecheck sets strictTypes ONLY, never strict", () => {
     expect(applyCliFlags({}, { strictTypes: true }).typechecker).toEqual({
       strictTypes: true,

--- a/packages/agency-lang/lib/config.ts
+++ b/packages/agency-lang/lib/config.ts
@@ -739,7 +739,13 @@ export type CliFlags = {
   logFile?: string;
   logStdout?: boolean;
   observability?: boolean;
+  /** `--strict` on `run`/`compile`: fail the run on any fatal type error. */
   strict?: boolean;
+  /** `--strict` on `typecheck`: untyped variables are errors, nothing else.
+   *  Same spelling as `strict`, deliberately narrower, because `typecheck`
+   *  runs the checker unconditionally and computes its own exit code — it
+   *  never reaches the compile-path gate that `strict` exists to open. */
+  strictTypes?: boolean;
   maxToolCallRounds?: number;
   maxToolResultChars?: number;
   model?: ResolvedModelFlag;
@@ -757,7 +763,13 @@ export type CliFlags = {
  *   --log stdout     → log.host="stdout" and observability=true (stream to stdout)
  *   --observability  → observability=true
  *   --strict         → typechecker.strict + strictTypes (the compile-path gate
- *                      never runs the checker on strictTypes alone)
+ *                      never runs the checker on strictTypes alone). This is
+ *                      the `run`/`compile` meaning.
+ *   --strict (tc)    → typechecker.strictTypes ONLY. `agency typecheck` calls
+ *                      the checker unconditionally and computes its own exit
+ *                      code, so it never reaches that gate and must not set
+ *                      `strict`. Same flag name, narrower meaning, which is
+ *                      why it is a separate field rather than a branch here.
  *   --model <m>      → client.defaultModel=<m> and client.defaultProvider
  *                      DELETED, so smoltalk infers the provider
  *   --model <p>/<m>  → client.defaultModel=<m> + client.defaultProvider=<p>
@@ -801,6 +813,9 @@ export function applyCliFlags(config: AgencyConfig, flags: CliFlags, input?: str
   }
   if (flags.strict) {
     next.typechecker = { ...next.typechecker, strict: true, strictTypes: true };
+  }
+  if (flags.strictTypes) {
+    next.typechecker = { ...next.typechecker, strictTypes: true };
   }
   if (flags.maxToolCallRounds !== undefined) {
     next.maxToolCallRounds = flags.maxToolCallRounds;

--- a/packages/agency-lang/lib/config.ts
+++ b/packages/agency-lang/lib/config.ts
@@ -742,9 +742,12 @@ export type CliFlags = {
   /** `--strict` on `run`/`compile`: fail the run on any fatal type error. */
   strict?: boolean;
   /** `--strict` on `typecheck`: untyped variables are errors, nothing else.
-   *  Same spelling as `strict`, deliberately narrower, because `typecheck`
-   *  runs the checker unconditionally and computes its own exit code — it
-   *  never reaches the compile-path gate that `strict` exists to open. */
+   *  Same spelling as `strict`, deliberately narrower. `typechecker.strict`
+   *  has one reader — the compile-path gate at compiler/compile.ts — and
+   *  `typecheck` never reaches it, so setting `strict` here would be inert
+   *  rather than harmful. An inert setting that reads as meaningful is still
+   *  a trap: it would quietly start mattering the day this command grows a
+   *  compile path. */
   strictTypes?: boolean;
   maxToolCallRounds?: number;
   maxToolResultChars?: number;
@@ -767,9 +770,10 @@ export type CliFlags = {
  *                      the `run`/`compile` meaning.
  *   --strict (tc)    → typechecker.strictTypes ONLY. `agency typecheck` calls
  *                      the checker unconditionally and computes its own exit
- *                      code, so it never reaches that gate and must not set
- *                      `strict`. Same flag name, narrower meaning, which is
- *                      why it is a separate field rather than a branch here.
+ *                      code, so it never reaches that gate; `strict` would be
+ *                      inert there, and an inert-but-meaningful-looking
+ *                      setting is a trap. Same flag name, narrower meaning,
+ *                      which is why it is a separate field, not a branch.
  *   --model <m>      → client.defaultModel=<m> and client.defaultProvider
  *                      DELETED, so smoltalk infers the provider
  *   --model <p>/<m>  → client.defaultModel=<m> + client.defaultProvider=<p>

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -1493,7 +1493,10 @@ export function createProgram(deps: CliDependencies = {}): Command {
     .argument("[inputs...]", "Paths to .agency input files")
     .option("--strict", "Enable strict types (untyped variables are errors)")
     .action(async (inputs: string[], opts: { strict?: boolean }) => {
-      const config = getConfig();
+      // `strictTypes`, not `strict`: this command computes its own exit code
+      // and never reaches the compile-path gate. Applied before runTypeCheck
+      // closes over `config`, since applyCliFlags returns a copy.
+      const config = applyCliFlags(getConfig(), { strictTypes: opts.strict });
       let hasErrors = false;
       const runTypeCheck = (contents: string, filePath?: string, symbolTable?: SymbolTable) => {
         const parsed = parse(contents, config);
@@ -1522,9 +1525,6 @@ export function createProgram(deps: CliDependencies = {}): Command {
           console.log("No type errors found.");
         }
       };
-      if (opts.strict) {
-        config.typechecker = { ...config.typechecker, strictTypes: true };
-      }
       const sources = resolveInputSources(inputs);
       if (sources === null) {
         return;

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -1494,8 +1494,9 @@ export function createProgram(deps: CliDependencies = {}): Command {
     .option("--strict", "Enable strict types (untyped variables are errors)")
     .action(async (inputs: string[], opts: { strict?: boolean }) => {
       // `strictTypes`, not `strict`: this command computes its own exit code
-      // and never reaches the compile-path gate. Applied before runTypeCheck
-      // closes over `config`, since applyCliFlags returns a copy.
+      // and never reaches the compile-path gate, so `strict` would be inert
+      // here — and an inert setting that looks meaningful is a trap. Applied
+      // before runTypeCheck closes over `config`, since applyCliFlags copies.
       const config = applyCliFlags(getConfig(), { strictTypes: opts.strict });
       let hasErrors = false;
       const runTypeCheck = (contents: string, filePath?: string, symbolTable?: SymbolTable) => {


### PR DESCRIPTION
Groundwork for #689. Consolidates CLI flag handling so `--refuse-splices` has one place to be added rather than three.

## The problem

`applyCliFlags` (`lib/config.ts`) is supposed to be the only definition of what a CLI flag means in config terms. Its own comment says so — "This is the ONLY place that defines what each flag means in config terms" — and so does `docs/dev/config.md`.

That was not true. `agency typecheck` wrote its `--strict` by hand:

```ts
config.typechecker = { ...config.typechecker, strictTypes: true };
```

This is the only such case in the CLI. (The other direct mutation, `config.verbose` for the root `-v`, lives inside `getConfig()` itself, so it is already applied once and uniformly for every command.)

## Why it existed

An unfinished migration, not a design choice. The dates line up:

- `typecheck`'s wiring landed **2026-05-14** (`60ab190a8`)
- `applyCliFlags` landed **2026-07-08** in #464

#464's design doc stated the goal outright:

> The flag→config mapping is extracted into one exported pure helper … instead of being re-implemented in each command action (**it is currently hand-written inline in `runWithOptions` and again in `typecheck`**). **All commands call the helper.**

`run` and `compile` were migrated; `typecheck` was not.

## The catch

The same flag name legitimately means two different things:

- On `run`/`compile`, `--strict` must set **both** `strict` and `strictTypes` to open a gate on the compile path.
- On `typecheck`, it must set `strictTypes` **alone**. That command runs the checker unconditionally and computes its own exit code, so it never reaches the gate.

**Correction after review:** an earlier version of this description claimed that setting `strict` on `typecheck` would make it fail on errors it currently walks past. That was wrong, and both reviewers caught it. `typechecker.strict` has exactly one reader in the repo — the gate itself at `lib/compiler/compile.ts:189`. Nothing under `lib/typeChecker/` reads it, and the command's exit code comes from diagnostic severity. So setting `strict` there would be **inert**, not harmful.

The narrow field is still the right call, for a better reason: an inert setting that reads as meaningful is a trap, and it would quietly acquire meaning the day `typecheck` grows a compile path. #464 independently said "Do not copy this wiring here.

The fix keeps both meanings as two fields on `CliFlags` rather than a branch keyed on command name. The command picks its meaning by choosing a field, and the helper never learns who called it.

## Behavior is unchanged

`applyCliFlags` guards every effect behind a flag test, so passing only `strictTypes` touches nothing else, and an absent `--strict` leaves `typechecker` untouched. Both are covered by new tests.

One subtlety worth noting for review: the old code mutated `config` *after* `runTypeCheck` had closed over it, which worked only because it mutated in place. `applyCliFlags` returns a copy, so the call is now made before the closure exists.

The three new tests pin `applyCliFlags` itself, not the wiring in `scripts/agency.ts` — tidying that call site to `{ strict: opts.strict }` would leave them green. Since `strict` is inert on this path, nothing can observe that regression, and a test that bites would need an injectable seam on the typecheck path that `CliDependencies` does not have. Adding production surface for one test is not worth it while the failure mode is invisible; the test comment now says exactly that rather than implying a consequence that does not exist.

## Verification

- `npx tsc --noEmit`, `pnpm run lint:structure`, `pnpm run fmt:ts` — all clean
- 107 tests pass across `config`, `config.modelAliases`, `config.providerModules`, `cli/commandLine`, `cli/runBundledAgent`, `sourceIsText`
- I confirmed the new tests actually bite by making `strictTypes` also set `strict`; they fail, and pass again when reverted

I did not run the real-binary CLI tests (`tests/integration/cli/test.mjs`), which need a full `make` and a packed tarball. CI covers those.

## Docs

`docs/dev/config.md` claimed `applyCliFlags` was the only definition of a flag's meaning, which was false with `typecheck` as the counterexample. That claim is now true, and I have added two things it was missing:

- that the same flag name may mean different things per command, with `--strict` as the worked example
- **flags that are NOT config** — the other channels the doc never mentioned. Interrupt policies, budgets, the test runner's output sink, and `--agency-only` (which selects a compile path rather than setting a value) all travel as resolved objects passed as arguments. `agency run` and `agency test run` both use both channels, which is expected rather than drift.

Review also caught that "exactly one of them" was wrong: `agency doctor` accepts `--trace` and `--log-file` and translates neither, forwarding them onto an argv for a child `agency` invocation (`lib/cli/doctor.ts:45`-`49`). That is now named as a third channel — flags forwarded verbatim to a child command line — rather than the claim being softened, since this doc is meant to be the authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QD2WiV5DAqLYC9i1f3FLtn

