### PR TITLE
Pin the served-function abort-as-value case (#807)

### DIFF
--- a/packages/agency-lang/lib/serve/http/functionBudget.test.ts
+++ b/packages/agency-lang/lib/serve/http/functionBudget.test.ts
@@ -5,9 +5,27 @@ import { RuntimeContext } from "../../runtime/state/context.js";
 import { runExportedFunctionForServe } from "../../runtime/node.js";
 import { returnedOutcome, unusedPublicInvoke } from "../testOutcome.js";
 import { addCost } from "../../runtime/cost.js";
+import { AbortedResult } from "../../runtime/abortedResult.js";
+import { AgencyCancelledError, makeAbortCause } from "../../runtime/errors.js";
+import { State } from "../../runtime/state/stateStack.js";
 import type { GraphState } from "../../runtime/types.js";
 import type { AgencyFunction } from "../../runtime/agencyFunction.js";
 import type { ServedExportedFunction } from "../types.js";
+
+function makeCtx(budget?: { maxCost?: number; maxTimeMs?: number }): RuntimeContext<GraphState> {
+  return new RuntimeContext<GraphState>({
+    statelogConfig: {
+      host: "",
+      apiKey: "",
+      projectId: "",
+      debugMode: false,
+      observability: false,
+    },
+    smoltalkDefaults: {},
+    dirname: process.cwd(),
+    budget,
+  });
+}
 
 /**
  * Regression test for the root budget on the *served-function* path.
@@ -47,21 +65,6 @@ describe("a served function respects the baked root budget", () => {
       else process.env[key] = saved[key];
     }
   });
-
-  function makeCtx(budget?: { maxCost?: number; maxTimeMs?: number }): RuntimeContext<GraphState> {
-    return new RuntimeContext<GraphState>({
-      statelogConfig: {
-        host: "",
-        apiKey: "",
-        projectId: "",
-        debugMode: false,
-        observability: false,
-      },
-      smoltalkDefaults: {},
-      dirname: process.cwd(),
-      budget,
-    });
-  }
 
   // A minimal exported function whose body charges $1, routed through the real
   // runExportedFunction so it runs inside a node-grade frame with the budget
@@ -110,5 +113,64 @@ describe("a served function respects the baked root budget", () => {
     const result = await handlerFor(makeCtx())("POST", "/function/spend", {});
     expect(result.status).toBe(200);
     expect(result.body).toEqual({ success: true, value: "done" });
+  });
+});
+
+/**
+ * Issue #807: the same trip, arriving as a VALUE rather than a throw.
+ *
+ * Compiled Agency code catches an abort in its own frame and returns an
+ * `AbortedResult`, so a guard trip can reach the serve adapter as a return
+ * value. The adapter classifies by cause on a *thrown* error, so such a trip
+ * skipped the 402 branch entirely and came back as `200 { success: true }`
+ * with the abort buried in `value` — a caller could not tell a budget-halted
+ * run from a completed one. `runExportedFunctionCore` now converts at the
+ * boundary (#906).
+ *
+ * The test above cannot catch this: its `invoke` throws, so it takes the
+ * classification branch either way.
+ */
+describe("a served function surfaces a budget trip that arrives as a value", () => {
+  function abortingFunction(ctx: RuntimeContext<GraphState>): ServedExportedFunction {
+    const cause = makeAbortCause({
+      kind: "guardTrip",
+      dimension: "cost",
+      limit: 0.01,
+      spent: 0.05,
+      guardId: "root",
+    });
+    // Exactly what a compiled def hands back when an abort stops it.
+    const fn = {
+      invoke: async () =>
+        AbortedResult.fromError(new AgencyCancelledError("trip", cause), new State(), "chargeFn"),
+    } as unknown as AgencyFunction;
+    return {
+      kind: "function",
+      ...unusedPublicInvoke,
+      name: "chargeFn",
+      description: "returns an aborted result",
+      parameters: [],
+      agencyFunction: fn,
+      interruptEffects: [],
+      invokeServed: (namedArgs) => runExportedFunctionForServe({ ctx, fn, namedArgs }),
+    };
+  }
+
+  it("returns a typed 402, not 200 with an abortedResult body", async () => {
+    const handler = createHttpHandler({
+      exports: [abortingFunction(makeCtx())],
+      logger: createLogger("error"),
+      hasInterrupts: () => false,
+      respondToInterrupts: async () => returnedOutcome({ data: undefined }),
+    });
+    const result = await handler("POST", "/function/chargeFn", {});
+    expect(result.status).toBe(402);
+    expect(result.body).toMatchObject({
+      success: false,
+      code: "budgetExceeded",
+      dimension: "cost",
+      limit: 0.01,
+      spent: 0.05,
+    });
   });
 });


### PR DESCRIPTION
Follow-up to #906. Test only — no behavior change.

#906 fixed the exported-function boundary you spotted in review, and that fix is what closed #807. But it shipped without a test for the shape that was actually broken, so nothing currently stops it regressing.

### Why the existing test does not cover it

`lib/serve/http/functionBudget.test.ts` (from #799) drives an `invoke` that calls `addCost` and **throws**. A thrown guard trip already reached the adapter's `errorResult` → `readCause` → 402 branch before #906, so that test passes with or without the boundary conversion.

The broken shape was the other one: compiled Agency code catches an abort in its own frame and **returns** an `AbortedResult`. A trip arriving as a return value never reached the classification branch, so `/function` answered `200 { success: true }` with the abort buried in `value` — a caller could not tell a budget-halted run from a completed one.

### What this adds

A second suite in the same file with an exported function whose `invoke()` returns an `AbortedResult` carrying a `guardTrip` cause, driven through the real `createHttpHandler`, asserting the typed 402 body. It lives beside the existing suite rather than in a new file because it is the same subject — how a served function's budget trip surfaces — and `makeCtx` is hoisted to module scope so both share it.

### Verification

Removing the `throwIfValueAborted` call from `runExportedFunctionCore` and re-running gives exactly the split that motivates the PR:

```
✓ trips the root budget and returns a typed 402 budgetExceeded
✓ without a baked budget the same spend runs uncapped (200) — proving the guard is what caps it
× returns a typed 402, not 200 with an abortedResult body
  AssertionError: expected 200 to be 402
```

The two existing tests pass without the fix; only the new one fails, and it fails with the issue's reported status code.

Full `lib/serve` suite green: 15 files, 136 tests. `fmt:ts`, `lint:structure`, `tsc --noEmit`, `sourceIsText` all clean.

One note on running this locally: `lib/serve/http/functionFrame.integration.test.ts` fails in a fresh worktree with `Cannot find package 'agency-lang/stdlib/index.js'` until you run `make` — `pnpm run build` alone does not build the stdlib. I confirmed it fails identically on clean `main` with my change stashed, so it is environmental, and it passes after `make`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JG8vWxnHgaPmosYnkBc4jx
