### PR TITLE
Writing-review eval suite: graderFiles/, a rubric judge, and explorer drill-in

### DIFF
--- a/packages/agency-lang/docs/dev/cli/runs-explorer.md
+++ b/packages/agency-lang/docs/dev/cli/runs-explorer.md
@@ -4,8 +4,12 @@
 Those paths may be run directories, a directory of run directories, or
 statelog files. The explorer is one sortable, groupable table with a row
 per run directory or statelog trace. From a row you drill into a run's
-tests, and from a test into the existing log viewer focused on that
-test's trace. A **sole** run directory does not open the explorer. It
+tests, from a test into its graders (one row per effective score, with
+the feedback's first line), and from a grader into the verdict screen:
+that grader's score and feedback beside the input and output it judged.
+`o` opens the existing log viewer on the test's trace from any of those
+screens; Enter never does, since a graded run's first question is "what
+did the graders say", not "what did the agent do". A **sole** run directory does not open the explorer. It
 opens the viewer on the directory's statelog, with each trace's
 annotations summarised on its row ("notes · score 0.70 · labeled", from
 `annotationSummaries` in `lib/runDirectory/list.ts`).
@@ -117,8 +121,12 @@ letting cells collide.
   the key waiter against an always-ready microtask.
 
 Views: a loading splash until the first rows, then three cycling
-variants (runs → compare → trend on `t`/`Shift+T`), with tests/info as
-an overlay stack above. Esc pops the overlay, then falls back to the
+variants (runs → compare → trend on `t`/`Shift+T`), with
+tests/graders/verdict/info as an overlay stack above. The graders table
+and the verdict screen read `TestRow.detail` (`rows.ts`): the trace's
+input and output through `traceText.ts`, and one `GraderVerdict` per
+effective score row, so they show exactly what `eval grade` scored and
+`runs list` sums. Esc pops the overlay, then falls back to the
 runs variant, then goes inert.
 
 ## CSV

--- a/packages/agency-lang/docs/dev/evals/eval-grading.md
+++ b/packages/agency-lang/docs/dev/evals/eval-grading.md
@@ -275,7 +275,7 @@ also name one explicitly, a local directory only).
 (`snapshotGraderFiles`, `lib/eval/grading/graderFilesSnapshot.ts`): under
 `graders/<sha256>/` with its relative names kept, where the hash covers
 every path and content, and the run row records that name as
-`graderFiles`. Symlinks in the tree are refused. At grading time a
+`graderFiles`. Symlinks in the tree are refused, as is an empty directory. At grading time a
 function grader reads the directory as `ctx.graderFiles` (`""` when the
 test has none): the stored copy under `snapshot` and `override`, the
 suite's live directory under `--suite`. A recorded copy missing from the

--- a/packages/agency-lang/docs/dev/evals/eval-grading.md
+++ b/packages/agency-lang/docs/dev/evals/eval-grading.md
@@ -243,6 +243,50 @@ Three rules that are easy to get wrong:
 - **The scratch dir goes under `.agency-tmp/`, not `os.tmpdir()`**: compiled
   Agency resolves `agency-lang` from the directory it runs in.
 
+## Two bundled judges: goal and rubric
+
+A function grader has two LLM judges on its context, `ctx.judges`, and
+they ask different questions. `judges.goal({ goal, output, expected })` runs
+`lib/agents/eval/goalJudge.agency`, a correctness judge: was the output
+the right, direct answer to the goal? Its rules treat any expected text
+as authoritative and penalize extra content, which is right for "name
+the capital" and wrong for grading review findings against a standard.
+`judges.rubric({ standard, output, context })` runs
+`lib/agents/eval/rubricJudge.agency`: how well does the output meet the
+standard, with `context` (the source text, an editor's notes, a
+reference version) read as background and never as an answer to match.
+The writing-review suite learned this the expensive way: phrased for the
+goal judge, its graders scored findings for "matching the expected
+answer" that did not exist. Each judge file is versioned by a pinned
+hash (`goalJudgeFile.ts`, `rubricJudgeFile.ts`); bump the version when
+you edit a prompt. A new judge (pairwise, say) is a new key on `judges`,
+not a new field on the context.
+
+## Grader-only files: `graderFiles/`
+
+A test directory may hold a `graderFiles/` directory beside `test.json`:
+reference answers, an editor's notes, a cleaned version of the text, or
+anything else the graders read and the agent must never see. `files/` is
+the opposite: it is seeded into the agent's workdir. The loader records
+the directory on the test as `graderFiles` (absolute; a `test.json` may
+also name one explicitly, a local directory only).
+
+`eval run` stores the whole tree in the run directory
+(`snapshotGraderFiles`, `lib/eval/grading/graderFilesSnapshot.ts`): under
+`graders/<sha256>/` with its relative names kept, where the hash covers
+every path and content, and the run row records that name as
+`graderFiles`. Symlinks in the tree are refused. At grading time a
+function grader reads the directory as `ctx.graderFiles` (`""` when the
+test has none): the stored copy under `snapshot` and `override`, the
+suite's live directory under `--suite`. A recorded copy missing from the
+run directory is an error naming the test, never a silent `""`.
+`evals/writing-review/` is the reference user: its `harvestedGraders()`
+reads `notes.md` and `cleaned.md` from there.
+
+Grading modules load through the built package (`agency-lang/eval`
+resolves to `dist/`), so a change to what `ctx` carries needs a build
+before a suite sees it.
+
 ## What is gone
 
 `config.json`, `summary.json`, per-input `input.json`, `eval-record.json` on

--- a/packages/agency-lang/docs/dev/evals/run-directory.md
+++ b/packages/agency-lang/docs/dev/evals/run-directory.md
@@ -14,7 +14,7 @@ easy to get wrong.
   annotations.jsonl     # every structured opinion about the run: checklist, score, run
   notes.md              # a person's free-form notes, written with any editor
   code/                 # the agent's closure, as it ran, flat
-  graders/              # the grading module it ran with, bundled, + judge files + harness pairs; content-hash names
+  graders/              # the grading module it ran with, bundled, + judge files + harness pairs + graderFiles/ trees; content-hash names
   workdir/              # filesystem snapshot, flat
   workdir.json          # { snapshotAt, source } — when and where from
   checklists/<id>/      # versioned checklist revisions + labeling drafts (docs/dev/evals/eval-labeling.md)
@@ -145,6 +145,9 @@ The planners (`mergeStatelog.ts`, `attachCode.ts`, `attachWorkdir.ts`):
   `.agency`) go under `graders/` too, as `<sha256>.agency` / `<sha256>.test.json`,
   and the run row's `harness` array maps each name to its stored files and a
   hash over both (`docs/dev/evals/eval-grading.md`).
+- **Grader-only files** (a test's `graderFiles/` directory) go under
+  `graders/<sha256>/` as a whole tree with relative names kept; the run
+  row's `graderFiles` is that name (`docs/dev/evals/eval-grading.md`).
 - **Graders** (`gradersFiles` on `recordCompletedRun`) go under `graders/`
   by content-hash name; the run row's `graders: { source, bundleFile,
   judgeFiles, origin }` says which is the module bundle, which stored file

--- a/packages/agency-lang/docs/site/stdlib/agents/typescript/review.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/typescript/review.md
@@ -106,33 +106,3 @@ Review TypeScript code for readability and architecture and return
 **Throws:** `std::guard`
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/typescript/review.agency#L145))
-
-## Nodes
-
-### evalMain
-
-```ts
-evalMain(input: TsReviewEvalInput): Feedback[]
-```
-
-Eval entry point: `agency eval run stdlib/agents/typescript/review.agency:evalMain
-  --suite <dir>`. A node in a library module never runs when the module is
-  imported; it only exists so a suite can score this reviewer without a
-  wrapper file. Any other reviewer scored on the same suite supplies a node
-  with this signature. Effects are decided at this boundary: reading the
-  seeded input file is this node's own doing (`with approve`), and a budget
-  trip inside the reviewer is rejected (`with reject`) so the caps stay
-  caps and the reviewer's fail-open result comes back instead of an
-  interrupt escaping the entry point.
-
-**Parameters:**
-
-| Name | Type | Default |
-|---|---|---|
-| input | [TsReviewEvalInput](#tsreviewevalinput) |  |
-
-**Returns:** `Feedback[]`
-
-**Throws:** `std::read`, `std::guard`
-
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/typescript/review.agency#L219))

--- a/packages/agency-lang/docs/site/stdlib/agents/writing/review.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/writing/review.md
@@ -32,7 +32,7 @@ export type WritingReviewEvalInput = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/writing/review.agency#L179))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/writing/review.agency#L188))
 
 ## Functions
 
@@ -47,7 +47,7 @@ Return the writing reviewer's tools. Prose review needs nothing beyond
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/writing/review.agency#L67))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/writing/review.agency#L76))
 
 ### writingReviewAgent
 
@@ -103,4 +103,4 @@ Review prose for readability and return findings. error=true marks a
 
 **Throws:** `std::guard`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/writing/review.agency#L119))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/writing/review.agency#L128))

--- a/packages/agency-lang/docs/site/stdlib/agents/writing/review.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/writing/review.md
@@ -104,33 +104,3 @@ Review prose for readability and return findings. error=true marks a
 **Throws:** `std::guard`
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/writing/review.agency#L119))
-
-## Nodes
-
-### evalMain
-
-```ts
-evalMain(input: WritingReviewEvalInput): Feedback[]
-```
-
-Eval entry point: `agency eval run stdlib/agents/writing/review.agency:evalMain
-  --suite <dir>`. A node in a library module never runs when the module is
-  imported; it only exists so a suite can score this reviewer without a
-  wrapper file. Any other reviewer scored on the same suite supplies a node
-  with this signature. Effects are decided at this boundary: reading the
-  seeded input file is this node's own doing (`with approve`), and a budget
-  trip inside the reviewer is rejected (`with reject`) so the caps stay
-  caps and the reviewer's fail-open result comes back instead of an
-  interrupt escaping the entry point.
-
-**Parameters:**
-
-| Name | Type | Default |
-|---|---|---|
-| input | [WritingReviewEvalInput](#writingreviewevalinput) |  |
-
-**Returns:** `Feedback[]`
-
-**Throws:** `std::read`, `std::guard`
-
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/writing/review.agency#L193))

--- a/packages/agency-lang/evals/agency-agent/hollow-creek/graders.ts
+++ b/packages/agency-lang/evals/agency-agent/hollow-creek/graders.ts
@@ -2,8 +2,8 @@ import { grader } from "agency-lang/eval";
 
 export default [
   grader(
-    ({ judge }) =>
-      judge({
+    ({ judges }) =>
+      judges.goal({
         goal:
           "accurately summarizes the article's stated facts: the fishing derby has moved off " +
           "Hollow Creek for the third year due to low catch numbers, the Braxton Polymer plant " +
@@ -15,8 +15,8 @@ export default [
   ),
 
   grader(
-    ({ judge }) =>
-      judge({
+    ({ judges }) =>
+      judges.goal({
         goal:
           "reads between the lines: identifies that the article implies, without stating it, " +
           "that the Braxton Polymer plant is likely polluting Hollow Creek and killed its " +

--- a/packages/agency-lang/evals/agency-agent/news/graders.ts
+++ b/packages/agency-lang/evals/agency-agent/news/graders.ts
@@ -8,14 +8,14 @@ export default [
   grader(({ record }) => record.durationMs < 1000 * 60 * 5, { name: "under-5min", mustPass: true }),
 
   grader(
-    ({ judge, record }) =>
-      judge({
+    ({ judges, record }) =>
+      judges.goal({
         goal: `lists news headlines from ${runDate(record)}, not from an earlier or later date`,
       }),
     { name: "is-today" },
   ),
 
-  grader(({ judge }) => judge({ goal: "returns a list of top news headlines" }), {
+  grader(({ judges }) => judges.goal({ goal: "returns a list of top news headlines" }), {
     name: "headlines",
   }),
 ];

--- a/packages/agency-lang/evals/agency-review/lib/reviewGraders.ts
+++ b/packages/agency-lang/evals/agency-review/lib/reviewGraders.ts
@@ -5,24 +5,26 @@
 import * as fs from "fs";
 import * as path from "path";
 
-import { grader, type Grader } from "agency-lang/eval";
+import { binary, grader, type Grader, type Test } from "agency-lang/eval";
 
 import { AGENCY_FACTS } from "./agencyFacts.js";
+
+/** Mirrors `ReviewEvalInput` in stdlib/agents/agency/review.agency. */
+type ReviewInput = { assignment: string; sourceFile: string };
+type ReviewGrader = Grader<ReviewInput>;
 
 type Feedback = { error: boolean; feedback: string };
 const findings = (output: unknown): Feedback[] => (Array.isArray(output) ? output : []);
 const errors = (output: unknown) => findings(output).filter((item) => item?.error === true);
 const advisories = (output: unknown) => findings(output).filter((item) => item?.error !== true);
-
-type TestShape = { input?: unknown };
+const text = (items: Feedback[]) => items.map((item) => item.feedback);
 
 /** The reviewed source, read from the test's seeded workdir. Fixture paths
  *  are authored, but a path that escapes the workdir reads as missing. */
-function sourceOf(workdir: string, test: TestShape): string {
-  const input = test.input as { sourceFile?: string } | undefined;
-  if (!input?.sourceFile) return "";
+function sourceOf(workdir: string, test: Test<ReviewInput>): string {
+  if (!test.input?.sourceFile) return "";
   const root = path.resolve(workdir);
-  const resolved = path.resolve(root, input.sourceFile);
+  const resolved = path.resolve(root, test.input.sourceFile);
   if (!resolved.startsWith(root + path.sep)) return "";
   try {
     return fs.readFileSync(resolved, "utf8");
@@ -31,33 +33,24 @@ function sourceOf(workdir: string, test: TestShape): string {
   }
 }
 
-function assignmentOf(test: TestShape): string {
-  const input = test.input as { assignment?: string } | undefined;
-  return input?.assignment ?? "";
-}
+const reviewed = (source: string) => `The Agency source that was reviewed:\n\n${source}`;
 
 /** Every claim the findings make about Agency must be true of Agency. Runs on
  *  ALL findings, error and advisory alike: a JS-flavored "error" and a
  *  JS-flavored suggestion are the same failure. Judged against the facts
  *  card, so what counts as true is written down and versioned. */
-function agencyTrue(): Grader {
-  return grader(
-    ({ output, judge }) => {
+function agencyTrue(): ReviewGrader {
+  return grader<ReviewInput>(
+    ({ output, judges }) => {
       const all = findings(output);
       if (all.length === 0) {
-        return { score: { kind: "binary", pass: true }, feedback: "no findings to check" };
+        return binary(true, "no findings to check");
       }
-      return judge({
-        goal:
-          "These are review findings about a piece of Agency-language code. Facts about " +
-          "Agency:\n\n" +
-          AGENCY_FACTS +
-          "\n\nIs every claim these findings make about Agency syntax, semantics, or idiom " +
-          "true of Agency? A finding that treats correct Agency as a mistake, or gives " +
-          "JavaScript advice (like preferring === or for...of), is false and should lower " +
-          "the score in proportion to how many findings are affected.",
+      return judges.rubric({
+        standard:
+          "The work is the findings of a review of Agency-language code, each marked [error] or [advisory]. Every claim a finding makes about Agency syntax, semantics, or idiom is true of Agency, as the facts in the context state it. A finding that treats correct Agency as a mistake, or gives JavaScript advice (like preferring === or for...of), is false and lowers the score in proportion to how many findings are affected.",
+        context: `Facts about Agency:\n\n${AGENCY_FACTS}`,
         output: all.map((item) => (item.error ? "[error] " : "[advisory] ") + item.feedback),
-        expected: "",
       });
     },
     { name: "agency-true" },
@@ -66,139 +59,97 @@ function agencyTrue(): Grader {
 
 /** Advisory findings should be worth reading: true of this code and genuinely
  *  useful (performance, idiom, robustness) for this assignment. A review with
- *  no advisory findings passes vacuously — advice is welcome, not demanded. */
-function advisoryUseful(): Grader {
-  return grader(
-    ({ output, workdir, test, judge }) => {
+ *  no advisory findings passes vacuously; advice is welcome, not demanded. */
+function advisoryUseful(): ReviewGrader {
+  return grader<ReviewInput>(
+    ({ output, workdir, test, judges }) => {
       const advice = advisories(output);
       if (advice.length === 0) {
-        return { score: { kind: "binary", pass: true }, feedback: "no advisory findings" };
+        return binary(true, "no advisory findings");
       }
-      return judge({
-        goal:
-          "This Agency source was reviewed:\n\n" +
-          sourceOf(workdir, test) +
-          "\n\nIt was written for this assignment:\n\n" +
-          assignmentOf(test) +
-          "\n\nThese are the review's ADVISORY findings (not errors). Is each one a useful, " +
-          "accurate pointer for this code — a real performance, idiom, or robustness " +
-          "improvement? Padding (generic advice that fits any code), advice the assignment " +
-          "already settles, and suggestions that are not true of this code should lower the " +
-          "score in proportion.",
-        output: advice.map((item) => item.feedback),
-        expected: "",
+      return judges.rubric({
+        standard:
+          "The work is the ADVISORY findings (not errors) of a review of Agency code. Each finding is a useful, accurate pointer for this code: a real performance, idiom, or robustness improvement for the assignment it was written for. Padding (generic advice that fits any code), advice the assignment already settles, and suggestions that are not true of this code lower the score in proportion.",
+        context: `${reviewed(sourceOf(workdir, test))}\n\nThe assignment the code was written for:\n\n${test.input?.assignment ?? ""}`,
+        output: text(advice),
       });
     },
     { name: "advisory-useful" },
   );
 }
 
-function rejects(): Grader {
+function rejects(): ReviewGrader {
   return grader(
-    ({ output }) => ({
-      score: { kind: "binary", pass: errors(output).length > 0 },
-      feedback: `${errors(output).length} error finding(s), ${findings(output).length} total`,
-    }),
+    ({ output }) =>
+      binary(
+        errors(output).length > 0,
+        `${errors(output).length} error finding(s), ${findings(output).length} total`,
+      ),
     { name: "rejects" },
   );
 }
 
-/** Graders for a mutation-derived bug test. `diff` is the mutation applied
- *  to a correct program — verified at authoring time to typecheck and fail
- *  the test's harness. `reason` is the mutation author's one sentence on
- *  what the change breaks; the judges get both, the reason for semantic
- *  framing and the diff for precision and location. */
-export function mutantGraders(args: { diff: string; reason: string }): Grader[] {
+/** Ground truth for a planted bug: the author's one-sentence `reason` for
+ *  what the change breaks, plus, for a mutation-derived test, the diff
+ *  (minus lines are the correct code, plus lines are what the reviewed
+ *  code says) for precision and location. */
+function plantedProblem(args: { diff?: string; reason: string }): string {
+  const reason = `The code under review is a correct program with exactly one planted problem: ${args.reason}`;
+  if (args.diff === undefined) return reason;
+  return `${reason}\n\nThe change, as a diff (minus lines are the correct code, plus lines are what the reviewed code actually says):\n\n${args.diff}`;
+}
+
+function bugGraders(args: { diff?: string; reason: string }): ReviewGrader[] {
   return [
     rejects(),
-    grader(
-      ({ output, judge }) =>
-        judge({
-          goal:
-            "The code under review is a correct program with exactly one planted change: " +
-            args.reason +
-            "\nThe change, as a diff (minus lines are the correct code, plus lines are what " +
-            "the reviewed code actually says):\n\n" +
-            args.diff +
-            "\n\nDo these review findings identify that problem? Wording may differ; what " +
-            "matters is that some error finding points at the planted change or its behavior.",
-          output: errors(output).map((item) => item.feedback),
-          expected: "",
+    grader<ReviewInput>(
+      ({ output, judges }) =>
+        judges.rubric({
+          standard:
+            "The work is the ERROR findings of a code review. Some finding identifies the planted problem described in the context. Wording may differ; what matters is that a finding points at the planted change or its behavior.",
+          context: plantedProblem(args),
+          output: text(errors(output)),
         }),
       { name: "names-the-bug" },
     ),
-    grader(
-      ({ output, workdir, test, judge }) =>
-        judge({
-          goal:
-            "This Agency source was reviewed:\n\n" +
-            sourceOf(workdir, test) +
-            "\n\nIts only planted problem: " +
-            args.reason +
-            "\nThe change from the correct version:\n\n" +
-            args.diff +
-            "\n\nIs every one of these error findings a real problem with the source — the " +
-            "planted change, or something genuinely wrong? A finding that objects to correct " +
-            "code is invented.",
-          output: errors(output).map((item) => item.feedback),
-          expected: "",
+    grader<ReviewInput>(
+      ({ output, workdir, test, judges }) =>
+        judges.rubric({
+          standard:
+            "The work is the ERROR findings of a code review. Every finding is a real problem with the source: the planted problem, or something genuinely wrong. A finding that objects to correct code is invented and lowers the score in proportion.",
+          context: `${plantedProblem(args)}\n\n${reviewed(sourceOf(workdir, test))}`,
+          output: text(errors(output)),
         }),
       { name: "no-invented-errors" },
     ),
     agencyTrue(),
     advisoryUseful(),
   ];
+}
+
+/** Graders for a mutation-derived bug test. `diff` is the mutation applied
+ *  to a correct program, verified at authoring time to typecheck and fail
+ *  the test's harness; `reason` is the mutation author's one sentence on
+ *  what the change breaks. */
+export function mutantGraders(args: { diff: string; reason: string }): ReviewGrader[] {
+  return bugGraders(args);
 }
 
 /** Graders for a hand-planted bug test (no mutation diff): the author's
  *  `reason` alone is the ground truth for what is wrong. */
-export function plantedBugGraders(args: { reason: string }): Grader[] {
-  return [
-    rejects(),
-    grader(
-      ({ output, judge }) =>
-        judge({
-          goal:
-            "The code under review has exactly one planted problem: " +
-            args.reason +
-            "\n\nDo these review findings identify that problem? Wording may differ; what " +
-            "matters is that some error finding points at it.",
-          output: errors(output).map((item) => item.feedback),
-          expected: "",
-        }),
-      { name: "names-the-bug" },
-    ),
-    grader(
-      ({ output, workdir, test, judge }) =>
-        judge({
-          goal:
-            "This Agency source was reviewed:\n\n" +
-            sourceOf(workdir, test) +
-            "\n\nIts only planted problem: " +
-            args.reason +
-            "\n\nIs every one of these error findings a real problem with the source — the " +
-            "planted problem, or something genuinely wrong? A finding that objects to " +
-            "correct code is invented.",
-          output: errors(output).map((item) => item.feedback),
-          expected: "",
-        }),
-      { name: "no-invented-errors" },
-    ),
-    agencyTrue(),
-    advisoryUseful(),
-  ];
+export function plantedBugGraders(args: { reason: string }): ReviewGrader[] {
+  return bugGraders(args);
 }
 
 /** Graders for a clean test: correct code the reviewer must not reject. */
-export function cleanGraders(): Grader[] {
+export function cleanGraders(): ReviewGrader[] {
   return [
     grader(
-      ({ output }) => ({
-        score: { kind: "binary", pass: errors(output).length === 0 },
-        feedback: `${errors(output).length} error finding(s) on correct code: ${errors(output)
-          .map((item) => item.feedback)
-          .join(" | ")}`,
-      }),
+      ({ output }) =>
+        binary(
+          errors(output).length === 0,
+          `${errors(output).length} error finding(s) on correct code: ${text(errors(output)).join(" | ")}`,
+        ),
       { name: "no-false-positive" },
     ),
     agencyTrue(),

--- a/packages/agency-lang/evals/typescript-review/lib/reviewGraders.ts
+++ b/packages/agency-lang/evals/typescript-review/lib/reviewGraders.ts
@@ -6,22 +6,24 @@
 import * as fs from "fs";
 import * as path from "path";
 
-import { grader, type Grader } from "agency-lang/eval";
+import { binary, grader, type Grader, type Test } from "agency-lang/eval";
+
+/** Mirrors `TsReviewEvalInput` in stdlib/agents/typescript/review.agency. */
+type TsReviewInput = { assignment: string; sourceFile: string };
+type TsReviewGrader = Grader<TsReviewInput>;
 
 type Feedback = { error: boolean; feedback: string };
 const findings = (output: unknown): Feedback[] => (Array.isArray(output) ? output : []);
 const errors = (output: unknown) => findings(output).filter((item) => item?.error === true);
 const advisories = (output: unknown) => findings(output).filter((item) => item?.error !== true);
-
-type TestShape = { input?: unknown };
+const text = (items: Feedback[]) => items.map((item) => item.feedback);
 
 /** The reviewed source, read from the test's seeded workdir. Fixture paths
  *  are authored, but a path that escapes the workdir reads as missing. */
-function sourceOf(workdir: string, test: TestShape): string {
-  const input = test.input as { sourceFile?: string } | undefined;
-  if (!input?.sourceFile) return "";
+function sourceOf(workdir: string, test: Test<TsReviewInput>): string {
+  if (!test.input?.sourceFile) return "";
   const root = path.resolve(workdir);
-  const resolved = path.resolve(root, input.sourceFile);
+  const resolved = path.resolve(root, test.input.sourceFile);
   if (!resolved.startsWith(root + path.sep)) return "";
   try {
     return fs.readFileSync(resolved, "utf8");
@@ -30,42 +32,34 @@ function sourceOf(workdir: string, test: TestShape): string {
   }
 }
 
-function assignmentOf(test: TestShape): string {
-  const input = test.input as { assignment?: string } | undefined;
-  return input?.assignment ?? "";
-}
+const reviewed = (source: string) => `The TypeScript source that was reviewed:\n\n${source}`;
 
-function rejects(): Grader {
+function rejects(): TsReviewGrader {
   return grader(
-    ({ output }) => ({
-      score: { kind: "binary", pass: errors(output).length > 0 },
-      feedback: `${errors(output).length} error finding(s), ${findings(output).length} total`,
-    }),
+    ({ output }) =>
+      binary(
+        errors(output).length > 0,
+        `${errors(output).length} error finding(s), ${findings(output).length} total`,
+      ),
     { name: "rejects" },
   );
 }
 
 /** Advisory findings should be worth reading: true of this code and genuinely
  *  useful for this assignment. A review with no advisory findings passes
- *  vacuously — advice is welcome, not demanded. */
-function advisoryUseful(): Grader {
-  return grader(
-    ({ output, workdir, test, judge }) => {
+ *  vacuously; advice is welcome, not demanded. */
+function advisoryUseful(): TsReviewGrader {
+  return grader<TsReviewInput>(
+    ({ output, workdir, test, judges }) => {
       const advice = advisories(output);
       if (advice.length === 0) {
-        return { score: { kind: "binary", pass: true }, feedback: "no advisory findings" };
+        return binary(true, "no advisory findings");
       }
-      return judge({
-        goal:
-          "This TypeScript source was reviewed for readability and architecture:\n\n" +
-          sourceOf(workdir, test) +
-          "\n\nIt was written for this task:\n\n" +
-          assignmentOf(test) +
-          "\n\nThese are the review's ADVISORY findings (not errors). Is each one a useful, " +
-          "accurate pointer for this code? Padding (generic advice that fits any code) and " +
-          "suggestions that are not true of this code should lower the score in proportion.",
-        output: advice.map((item) => item.feedback),
-        expected: "",
+      return judges.rubric({
+        standard:
+          "The work is the ADVISORY findings (not errors) of a readability and architecture review of TypeScript code. Each finding is a useful, accurate pointer for this code: true of the code, and a real improvement for the assignment it was written for. Padding (generic advice that fits any code) and suggestions that are not true of this code lower the score in proportion to how many findings are affected.",
+        context: `${reviewed(sourceOf(workdir, test))}\n\nThe assignment the code was written for:\n\n${test.input?.assignment ?? ""}`,
+        output: text(advice),
       });
     },
     { name: "advisory-useful" },
@@ -74,36 +68,26 @@ function advisoryUseful(): Grader {
 
 /** Graders for a planted-flaw test: the author's `reason` is the ground
  *  truth for what is wrong with the source. */
-export function plantedFlawGraders(args: { reason: string }): Grader[] {
+export function plantedFlawGraders(args: { reason: string }): TsReviewGrader[] {
   return [
     rejects(),
-    grader(
-      ({ output, judge }) =>
-        judge({
-          goal:
-            "The TypeScript code under review has this planted problem: " +
-            args.reason +
-            "\n\nDo these review findings identify that problem? Wording may differ; what " +
-            "matters is that some error finding points at it.",
-          output: errors(output).map((item) => item.feedback),
-          expected: "",
+    grader<TsReviewInput>(
+      ({ output, judges }) =>
+        judges.rubric({
+          standard:
+            "The work is the ERROR findings of a code review. Some finding identifies the planted problem described in the context. Wording may differ; what matters is that a finding points at that problem or its behavior.",
+          context: `The planted problem: ${args.reason}`,
+          output: text(errors(output)),
         }),
       { name: "names-the-flaw" },
     ),
-    grader(
-      ({ output, workdir, test, judge }) =>
-        judge({
-          goal:
-            "This TypeScript source was reviewed:\n\n" +
-            sourceOf(workdir, test) +
-            "\n\nIts only planted problem: " +
-            args.reason +
-            "\n\nIs every one of these error findings a real problem with the source — the " +
-            "planted problem, or something genuinely wrong? A finding that objects to " +
-            "reasonable code, or that a compiler, linter, or formatter would already catch, " +
-            "is invented.",
-          output: errors(output).map((item) => item.feedback),
-          expected: "",
+    grader<TsReviewInput>(
+      ({ output, workdir, test, judges }) =>
+        judges.rubric({
+          standard:
+            "The work is the ERROR findings of a code review. Every finding is a real problem with the source: the planted problem, or something genuinely wrong. A finding that objects to reasonable code, or to something a compiler, linter, or formatter would already catch, is invented and lowers the score in proportion.",
+          context: `The only planted problem: ${args.reason}\n\n${reviewed(sourceOf(workdir, test))}`,
+          output: text(errors(output)),
         }),
       { name: "no-invented-errors" },
     ),
@@ -112,15 +96,14 @@ export function plantedFlawGraders(args: { reason: string }): Grader[] {
 }
 
 /** Graders for a clean test: well-written code the reviewer must not reject. */
-export function cleanGraders(): Grader[] {
+export function cleanGraders(): TsReviewGrader[] {
   return [
     grader(
-      ({ output }) => ({
-        score: { kind: "binary", pass: errors(output).length === 0 },
-        feedback: `${errors(output).length} error finding(s) on clean code: ${errors(output)
-          .map((item) => item.feedback)
-          .join(" | ")}`,
-      }),
+      ({ output }) =>
+        binary(
+          errors(output).length === 0,
+          `${errors(output).length} error finding(s) on clean code: ${text(errors(output)).join(" | ")}`,
+        ),
       { name: "rejects-nothing" },
     ),
     advisoryUseful(),

--- a/packages/agency-lang/evals/writing-review/README.md
+++ b/packages/agency-lang/evals/writing-review/README.md
@@ -1,14 +1,6 @@
 # writing-review: an eval suite for prose reviewers
 
-The prose sibling of `evals/typescript-review`: a reviewer of writing
-readability, judged on whether it catches text that loses its reader
-without inventing findings on clear prose.
-
-The suite describes the job. It does not name an agent. A reviewer is
-scored on it through an eval entry node with the contract below; the
-stdlib's `writingReviewAgent` carries one (`evalMain` in
-`stdlib/agents/writing/review.agency`), and any other implementation
-supplies its own.
+Evals for a prose reviewer. We want clear and readable prose!
 
 ## Run it
 
@@ -21,36 +13,16 @@ pnpm run agency eval run \
 pnpm run agency eval grade runs/writing-review
 ```
 
-## The contract
+## How its set up
 
-Input, the entry node's single parameter (`WritingReviewEvalInput` in the stdlib
-module):
+Each input has an assignment and a source file:
 
 ```
 { "assignment": string, "sourceFile": string }
 ```
 
-`assignment` says who the text is for and what it must get across.
-`sourceFile` names a file the test seeds into the working directory from
-its `files/` directory. Output is the stdlib `Feedback` shape:
-`error: true` marks a passage the reader will misread or lose, anything
-else is advisory polish.
+The story we are giving is that the assignment was given to an agent, and the source file contains the text that the agent wrote. The review agent now needs to review the text in the source file.
 
 ## Grading
 
-Each test carries a one-liner `graders.ts` over the shared library in
-`lib/reviewGraders.ts`. A planted test's ground truth is the author's
-written `reason` for what makes the text hard to follow; its graders check
-that an error finding exists (`rejects`), that the findings point at the
-planted passages (`names-the-flaw`), and that no error finding objects to
-clear prose or a matter of taste (`no-invented-errors`). A clean test
-checks the reviewer rejects nothing (`rejects-nothing`). Both kinds judge
-advisory findings for usefulness (`advisory-useful`), passing vacuously
-when there are none.
-
-## Growing the suite
-
-Harvested tests: a before/after pair from a real editing round, where
-"before" is the text as first written, "after" is the text after feedback,
-and the editing note is the `reason`. A harvested test is just a planted
-test whose reason and text came from history instead of being authored.
+Each test carries a one-liner `graders.ts` that uses the helpers in the shared library in `lib/reviewGraders.ts`.

--- a/packages/agency-lang/evals/writing-review/README.md
+++ b/packages/agency-lang/evals/writing-review/README.md
@@ -13,7 +13,7 @@ pnpm run agency eval run \
 pnpm run agency eval grade runs/writing-review
 ```
 
-## How its set up
+## How it's set up
 
 Each input has an assignment and a source file:
 

--- a/packages/agency-lang/evals/writing-review/README.md
+++ b/packages/agency-lang/evals/writing-review/README.md
@@ -26,3 +26,5 @@ The story we are giving is that the assignment was given to an agent, and the so
 ## Grading
 
 Each test carries a one-liner `graders.ts` that uses the helpers in the shared library in `lib/reviewGraders.ts`.
+
+The grader that matters most is `recommends-cuts`. Most bad technical prose is not badly phrased; it says things the reader did not need. A reviewer that only fixes sentences leaves that problem in place, so this grader compares the original with the editor's version in `graderFiles/cleaned.md` and checks whether the findings call for the same cuts. A test with a `cleaned.md` gets it automatically through `harvestedGraders()`; a planted test can add it by hand, as `overloaded-paragraph` does.

--- a/packages/agency-lang/evals/writing-review/clean-paragraph/files/notes.md
+++ b/packages/agency-lang/evals/writing-review/clean-paragraph/files/notes.md
@@ -1,12 +1,3 @@
 ## The run directory
 
-Listings show one score per question. Scores come from grading passes
-recorded in the directory, and only a pass that finished completely
-counts. When several complete passes scored the same question, the most
-recent one wins.
-
-Reading the directory never takes a lock. A reader takes a snapshot and
-skips any half-written trailing line, so what it returns is always
-coherent. One directory belongs to one run: both the reader and the
-writer check this, because two runs sharing a directory would corrupt
-the statistics computed over it.
+The listings show one score per question. We grade each run using graders, and the scores come from these grading passes. When several complete passes scored the same question, the most recent one wins. A pass only counts if it finished completely.

--- a/packages/agency-lang/evals/writing-review/clean-paragraph/test.json
+++ b/packages/agency-lang/evals/writing-review/clean-paragraph/test.json
@@ -1,6 +1,5 @@
 {
-  "description": "The planted test's clean sibling: the same content rewritten plainly. Measures false positives on the exact same assignment.",
-  "tags": ["clean"],
+  "description": "Cleanly written text, the review agent shouldn't flag anything",
   "files": "./files",
   "input": {
     "assignment": "Explain to a developer new to the codebase, in one short section, how the run directory decides which scores its listings show.",

--- a/packages/agency-lang/evals/writing-review/examples/misc.txt
+++ b/packages/agency-lang/evals/writing-review/examples/misc.txt
@@ -1,0 +1,30 @@
+Lots of little speech patterns that irk me:
+
+> so an unchanged file costs no parse.
+"costs no parse" is not grammatical. A better version would be "so we don't need to parse an unchanged file".
+
+---
+
+```
+ *
+ *  `@hidden` declarations are left out. A hidden type alias is the case
+ *  that matters: it renders no section, so a link to it from another page
+ *  would point at an anchor that does not exist. */
+ ```
+
+ "A hidden type alias is the case that matters" - you overuse this sentence construction ("X is the case that matters").
+
+ "it renders no section" – The `@hidden` tag doesn't do any rendering. The whole text, rewritten:
+
+ ```
+ `@hidden` declarations are left out. We don't render a hidden type alias, so a link to it from another page would be broken.
+ ```
+
+---
+
+```
+  // Both halves matter: the plain siblings prove the filter is not just
+    // dropping everything with a tag near it.
+```
+
+more sentence constructions that you use all the time. You often tell me that "both matter", and that something "proves the X".

--- a/packages/agency-lang/evals/writing-review/lib/reviewGraders.ts
+++ b/packages/agency-lang/evals/writing-review/lib/reviewGraders.ts
@@ -91,6 +91,25 @@ function rewritesFaithful(): WritingReviewGrader {
   );
 }
 
+/** The editor removed material the reader did not need; the findings must
+ *  say to cut it, not reword it. Needs `graderFiles/cleaned.md`. */
+export function recommendsCuts(): WritingReviewGrader {
+  return grader<WritingReviewInput>(
+    ({ output, workdir, test, graderFiles, judges }) => {
+      const cleanedFile = path.join(graderFiles, "cleaned.md");
+      if (graderFiles === "" || !fs.existsSync(cleanedFile)) {
+        throw new Error("recommendsCuts needs graderFiles/cleaned.md");
+      }
+      const cleaned = fs.readFileSync(cleanedFile, "utf8");
+      return judges.rubric({
+        ...prompts.recommendsCuts({ sourceFileText: getSourceFileText(workdir, test), cleaned }),
+        output: text(findings(output)),
+      });
+    },
+    { name: "recommends-cuts" },
+  );
+}
+
 /** Graders for a planted-flaw test: the author's `reason` is the ground
  *  truth for what makes the text hard to follow. */
 export function plantedFlawGraders(args: { reason: string }): WritingReviewGrader[] {
@@ -152,7 +171,7 @@ function harvest(graderFiles: string): { notes: string; cleaned: string | null }
 /** Graders for a harvested test: a real piece of text, the editor's notes on
  *  it, and the text after editing. The notes are the ground truth for what
  *  the findings must name; the cleaned text is the ground truth for whether
- *  the findings would get a writer there. */
+ *  the findings would get a writer there, and for what it cut. */
 export function harvestedGraders(): WritingReviewGrader[] {
   return [
     rejects(),
@@ -202,6 +221,7 @@ export function harvestedGraders(): WritingReviewGrader[] {
       },
       { name: "fix-lands" },
     ),
+    recommendsCuts(),
     advisoryUseful(),
     rewritesFaithful(),
   ];

--- a/packages/agency-lang/evals/writing-review/lib/reviewGraders.ts
+++ b/packages/agency-lang/evals/writing-review/lib/reviewGraders.ts
@@ -1,27 +1,32 @@
 // The one grading library for writing-review tests. Each test's graders.ts
-// is a one-liner over these; the judge prompts live here so they improve
-// for every test at once. Ground truth is the author's written `reason` for
-// what makes the planted text hard to follow (harvested tests will carry a
-// real editing note as that reason).
+// is a one-liner over these, and every judge prompt lives in templates.ts,
+// so a prompt improves for every test at once. Ground truth is either the
+// author's written `reason` for what makes a planted text hard to follow,
+// or, for a harvested test, the editor's own notes and cleaned version in
+// the test's graderFiles/ directory.
 import * as fs from "fs";
 import * as path from "path";
 
-import { grader, type Grader } from "agency-lang/eval";
+import { binary, grader, scalar, type Grader, type Test } from "agency-lang/eval";
+
+import * as prompts from "./templates.js";
+
+/** Mirrors `WritingReviewEvalInput` in stdlib/agents/writing/review.agency. */
+type WritingReviewInput = { assignment: string; sourceFile: string };
+type WritingReviewGrader = Grader<WritingReviewInput>;
 
 type Feedback = { error: boolean; feedback: string };
 const findings = (output: unknown): Feedback[] => (Array.isArray(output) ? output : []);
 const errors = (output: unknown) => findings(output).filter((item) => item?.error === true);
 const advisories = (output: unknown) => findings(output).filter((item) => item?.error !== true);
-
-type TestShape = { input?: unknown };
+const text = (items: Feedback[]) => items.map((item) => item.feedback);
 
 /** The reviewed text, read from the test's seeded workdir. Fixture paths
  *  are authored, but a path that escapes the workdir reads as missing. */
-function textOf(workdir: string, test: TestShape): string {
-  const input = test.input as { sourceFile?: string } | undefined;
-  if (!input?.sourceFile) return "";
+function getSourceFileText(workdir: string, test: Test<WritingReviewInput>): string {
+  if (!test.input?.sourceFile) return "";
   const root = path.resolve(workdir);
-  const resolved = path.resolve(root, input.sourceFile);
+  const resolved = path.resolve(root, test.input.sourceFile);
   if (!resolved.startsWith(root + path.sep)) return "";
   try {
     return fs.readFileSync(resolved, "utf8");
@@ -30,100 +35,174 @@ function textOf(workdir: string, test: TestShape): string {
   }
 }
 
-function assignmentOf(test: TestShape): string {
-  const input = test.input as { assignment?: string } | undefined;
-  return input?.assignment ?? "";
+function getAssignment(test: Test<WritingReviewInput>): string {
+  return test.input?.assignment ?? "";
 }
 
-function rejects(): Grader {
+function rejects(): WritingReviewGrader {
   return grader(
-    ({ output }) => ({
-      score: { kind: "binary", pass: errors(output).length > 0 },
-      feedback: `${errors(output).length} error finding(s), ${findings(output).length} total`,
-    }),
+    ({ output }) =>
+      binary(
+        errors(output).length > 0,
+        `${errors(output).length} error finding(s), ${findings(output).length} total`,
+      ),
     { name: "rejects" },
   );
 }
 
 /** Advisory findings should be worth reading: true of this text and a real
  *  improvement for its audience. A review with no advisory findings passes
- *  vacuously — polish is welcome, not demanded. */
-function advisoryUseful(): Grader {
-  return grader(
-    ({ output, workdir, test, judge }) => {
+ *  vacuously; polish is welcome, not demanded. */
+function advisoryUseful(): WritingReviewGrader {
+  return grader<WritingReviewInput>(
+    ({ output, workdir, test, judges }) => {
       const advice = advisories(output);
       if (advice.length === 0) {
-        return { score: { kind: "binary", pass: true }, feedback: "no advisory findings" };
+        return binary(true, "no advisory findings");
       }
-      return judge({
-        goal:
-          "This text was reviewed for readability:\n\n" +
-          textOf(workdir, test) +
-          "\n\nIt was written for this task:\n\n" +
-          assignmentOf(test) +
-          "\n\nThese are the review's ADVISORY findings (not errors). Is each one a useful, " +
-          "accurate pointer for this text and its audience? Padding (generic writing advice " +
-          "that fits any text) and suggestions that are not true of this text should lower " +
-          "the score in proportion.",
-        output: advice.map((item) => item.feedback),
-        expected: "",
+      return judges.rubric({
+        ...prompts.advisoryUseful({
+          sourceFileText: getSourceFileText(workdir, test),
+          assignment: getAssignment(test),
+        }),
+        output: text(advice),
       });
     },
     { name: "advisory-useful" },
   );
 }
 
+/** A finding's suggested rewrite must say what the original said: no new
+ *  claim or mechanism, and every identifier copied exactly. A reviewer whose
+ *  rewrites get applied to real docs must not invent facts along the way. */
+function rewritesFaithful(): WritingReviewGrader {
+  return grader<WritingReviewInput>(
+    ({ output, workdir, test, judges }) => {
+      const all = findings(output);
+      if (all.length === 0) {
+        return binary(true, "no findings");
+      }
+      return judges.rubric({
+        ...prompts.rewritesFaithful({ sourceFileText: getSourceFileText(workdir, test) }),
+        output: text(all),
+      });
+    },
+    { name: "rewrites-faithful" },
+  );
+}
+
 /** Graders for a planted-flaw test: the author's `reason` is the ground
  *  truth for what makes the text hard to follow. */
-export function plantedFlawGraders(args: { reason: string }): Grader[] {
+export function plantedFlawGraders(args: { reason: string }): WritingReviewGrader[] {
   return [
     rejects(),
-    grader(
-      ({ output, judge }) =>
-        judge({
-          goal:
-            "The text under review has these planted readability problems: " +
-            args.reason +
-            "\n\nDo these review findings identify those problems? Wording may differ; what " +
-            "matters is that the error findings point at the planted passages and what makes " +
-            "them hard to follow.",
-          output: errors(output).map((item) => item.feedback),
-          expected: "",
+    grader<WritingReviewInput>(
+      ({ output, judges }) =>
+        judges.rubric({
+          ...prompts.namesPlantedFlaw({ reason: args.reason }),
+          output: text(errors(output)),
         }),
       { name: "names-the-flaw" },
     ),
-    grader(
-      ({ output, workdir, test, judge }) =>
-        judge({
-          goal:
-            "This text was reviewed for readability:\n\n" +
-            textOf(workdir, test) +
-            "\n\nIts planted problems: " +
-            args.reason +
-            "\n\nIs every one of these error findings a real obstacle for the text's reader — " +
-            "one of the planted problems, or something genuinely hard to follow? A finding " +
-            "that objects to clear prose, or to a matter of taste, is invented.",
-          output: errors(output).map((item) => item.feedback),
-          expected: "",
+    grader<WritingReviewInput>(
+      ({ output, workdir, test, judges }) =>
+        judges.rubric({
+          ...prompts.noInventedErrorsPlanted({
+            sourceFileText: getSourceFileText(workdir, test),
+            reason: args.reason,
+          }),
+          output: text(errors(output)),
         }),
       { name: "no-invented-errors" },
     ),
     advisoryUseful(),
+    rewritesFaithful(),
   ];
 }
 
 /** Graders for a clean test: clear prose the reviewer must not reject. */
-export function cleanGraders(): Grader[] {
+export function cleanGraders(): WritingReviewGrader[] {
   return [
     grader(
-      ({ output }) => ({
-        score: { kind: "binary", pass: errors(output).length === 0 },
-        feedback: `${errors(output).length} error finding(s) on clear prose: ${errors(output)
-          .map((item) => item.feedback)
-          .join(" | ")}`,
-      }),
+      ({ output }) =>
+        binary(
+          errors(output).length === 0,
+          `${errors(output).length} error finding(s) on clear prose: ${text(errors(output)).join(" | ")}`,
+        ),
       { name: "rejects-nothing" },
     ),
     advisoryUseful(),
+    rewritesFaithful(),
+  ];
+}
+
+/** The editor's files for a harvested test, from its graderFiles/ directory:
+ *  `notes.md` says what was wrong; `cleaned.md` is the text after editing,
+ *  and an empty one means the text should not exist at all. */
+function harvest(graderFiles: string): { notes: string; cleaned: string | null } {
+  if (graderFiles === "") {
+    throw new Error("harvestedGraders needs a graderFiles/ directory holding notes.md");
+  }
+  const notes = fs.readFileSync(path.join(graderFiles, "notes.md"), "utf8");
+  const cleanedFile = path.join(graderFiles, "cleaned.md");
+  const cleaned = fs.existsSync(cleanedFile) ? fs.readFileSync(cleanedFile, "utf8") : null;
+  return { notes, cleaned };
+}
+
+/** Graders for a harvested test: a real piece of text, the editor's notes on
+ *  it, and the text after editing. The notes are the ground truth for what
+ *  the findings must name; the cleaned text is the ground truth for whether
+ *  the findings would get a writer there. */
+export function harvestedGraders(): WritingReviewGrader[] {
+  return [
+    rejects(),
+    grader<WritingReviewInput>(
+      ({ output, graderFiles, judges }) => {
+        if (findings(output).length === 0) {
+          return scalar(0, "no findings to match");
+        }
+        return judges.rubric({
+          ...prompts.namesHarvestedFlaws({ notes: harvest(graderFiles).notes }),
+          output: text(findings(output)),
+        });
+      },
+      { name: "names-the-flaws" },
+    ),
+    grader<WritingReviewInput>(
+      ({ output, workdir, test, graderFiles, judges }) => {
+        if (errors(output).length === 0) {
+          return binary(true, "no error findings");
+        }
+        return judges.rubric({
+          ...prompts.noInventedErrorsHarvested({
+            sourceFileText: getSourceFileText(workdir, test),
+            notes: harvest(graderFiles).notes,
+          }),
+          output: text(errors(output)),
+        });
+      },
+      { name: "no-invented-errors" },
+    ),
+    grader<WritingReviewInput>(
+      ({ output, workdir, test, graderFiles, judges }) => {
+        const { cleaned } = harvest(graderFiles);
+        if (cleaned === null) {
+          return binary(true, "no cleaned version");
+        }
+        if (cleaned.trim() === "") {
+          return judges.rubric({
+            ...prompts.fixLandsOnDelete(),
+            output: text(findings(output)),
+          });
+        }
+        return judges.rubric({
+          ...prompts.fixLands({ sourceFileText: getSourceFileText(workdir, test), cleaned }),
+          output: text(findings(output)),
+        });
+      },
+      { name: "fix-lands" },
+    ),
+    advisoryUseful(),
+    rewritesFaithful(),
   ];
 }

--- a/packages/agency-lang/evals/writing-review/lib/templates.ts
+++ b/packages/agency-lang/evals/writing-review/lib/templates.ts
@@ -1,0 +1,62 @@
+// Every judge prompt the writing-review graders use, as plain typed
+// functions: read them as prose, and a missing field is a type error.
+//
+// Each is a { standard, context } pair for the bundled rubric judge
+// (ctx.judgeRubric): the standard is what the findings must meet, the
+// context is what the judge needs to check them. Nothing here is an
+// answer key; the judge is told so.
+
+type Rubric = { standard: string; context: string };
+
+const reviewed = (sourceFileText: string) => `The text that was reviewed:\n\n${sourceFileText}`;
+
+export const advisoryUseful = (p: { sourceFileText: string; assignment: string }): Rubric => ({
+  standard:
+    "These are the ADVISORY findings (not errors) of a readability review. Findings that are specific to this text and genuinely increase its readability raise the score. Generic writing advice that fits any text, and suggestions that are not true of this text, lower the score in proportion to how many findings are affected.",
+  context: `${reviewed(p.sourceFileText)}\n\nThe task the text was written for:\n\n${p.assignment}`,
+});
+
+export const namesPlantedFlaw = (p: { reason: string }): Rubric => ({
+  standard:
+    "These are the findings of a readability review. Do the findings identify the problems described in the context? Do they point at the planted passages, and at what makes them hard to follow? It's okay if the wording differs, as long as the meaning is the same. Return a score in proportion to how many of the planted problems were found.",
+  context: `The problems we planted: ${p.reason}`,
+});
+
+export const noInventedErrorsPlanted = (p: { sourceFileText: string; reason: string }): Rubric => ({
+  standard:
+    "These are the ERROR findings of a readability review. Every finding is a real obstacle for the text's reader: one of the planted problems, or something genuinely hard to follow. A finding that objects to clear prose, or to a matter of taste, is invented and lowers the score in proportion.",
+  context: `The planted problems: ${p.reason}\n\n${reviewed(p.sourceFileText)}`,
+});
+
+export const namesHarvestedFlaws = (p: { notes: string }): Rubric => ({
+  standard:
+    "These are the findings of a readability review. The findings identify the problems the editor's notes name, pointing at the same passages for the same reasons. Wording may differ, and whether a finding is marked error or advisory does not matter. Score in proportion to how many of the editor's points the findings cover.",
+  context: `The editor's notes:\n\n${p.notes}`,
+});
+
+export const noInventedErrorsHarvested = (p: {
+  sourceFileText: string;
+  notes: string;
+}): Rubric => ({
+  standard:
+    "These are the ERROR findings of a readability review. Is every finding a real obstacle for the text's reader? Does it identify something that's genuinely hard to follow? Findings like that raise the score. Findings that incorrectly flag something that is actually clear or trivial lower the score. We're also adding the editor's notes as context. Score in proportion to how many of the findings are real obstacles.",
+  context: `The editor's notes on what is actually wrong:\n\n${p.notes}\n\n${reviewed(p.sourceFileText)}`,
+});
+
+export const fixLandsOnDelete = (): Rubric => ({
+  standard:
+    "These are the findings of a readability review. The editor's verdict on this text was to delete it entirely: it tells its readers nothing they need. The findings meet the standard when they say the text should be removed rather than reworded. Findings that only suggest rewordings score near 0.",
+  context: "",
+});
+
+export const fixLands = (p: { sourceFileText: string; cleaned: string }): Rubric => ({
+  standard:
+    "These are the findings of a readability review, each with a suggested rewrite. We're also giving you an editor's rewrite. If a writer applied these findings, would they end up with text about as readable as the editor's own rewrite? The word choice itself can be different, you need to judge on the content. What information did the editor choose to cut? What sentences did the editor choose to simplify? Would a rewrite based on these findings make similar cuts and simplifications? Judge the findings together, as one edit, not one at a time: score high if applying all of them would make the same cuts and simplifications the editor made, and low if it would leave the main problems in place.",
+  context: `${reviewed(p.sourceFileText)}\n\nThe editor's rewrite:\n\n${p.cleaned}`,
+});
+
+export const rewritesFaithful = (p: { sourceFileText: string }): Rubric => ({
+  standard:
+    "These are the findings of a readability review, each quoting a passage and suggesting a rewrite. Do the suggested rewrites keep the facts the same as the original, or do they invent facts? A rewrite may cut or simplify freely, but it should never add a claim or detail that the original didn't. For example, if the original text is about art, a rewrite shouldn't mention that Wayne Thiebaud is the best artist, if the original didn't claim that. Also, every identifier, (like a code name, a path, a symbol like `std::notes::create`) must be the same in the rewrite as it was in the original. Lower the score in proportion to the number of rewrites that invent something or alter an identifier.",
+  context: reviewed(p.sourceFileText),
+});

--- a/packages/agency-lang/evals/writing-review/lib/templates.ts
+++ b/packages/agency-lang/evals/writing-review/lib/templates.ts
@@ -2,7 +2,7 @@
 // functions: read them as prose, and a missing field is a type error.
 //
 // Each is a { standard, context } pair for the bundled rubric judge
-// (ctx.judgeRubric): the standard is what the findings must meet, the
+// (ctx.judges.rubric): the standard is what the findings must meet, the
 // context is what the judge needs to check them. Nothing here is an
 // answer key; the judge is told so.
 

--- a/packages/agency-lang/evals/writing-review/lib/templates.ts
+++ b/packages/agency-lang/evals/writing-review/lib/templates.ts
@@ -55,6 +55,12 @@ export const fixLands = (p: { sourceFileText: string; cleaned: string }): Rubric
   context: `${reviewed(p.sourceFileText)}\n\nThe editor's rewrite:\n\n${p.cleaned}`,
 });
 
+export const recommendsCuts = (p: { sourceFileText: string; cleaned: string }): Rubric => ({
+  standard:
+    "These are the findings of a readability review. Compare the original text with the editor's version and list what the editor removed: sentences, details, or whole sections that the reader did not need. (If the editor's version is empty, the editor removed everything.) Then check the findings: do they say that material should be cut, or that it does not belong? A finding that only rewords something the editor removed does not count. Score in proportion to how much of what the editor removed the findings call to cut. If the editor removed nothing, score 1 when the findings recommend no cuts.",
+  context: `${reviewed(p.sourceFileText)}\n\nThe editor's version:\n\n${p.cleaned}`,
+});
+
 export const rewritesFaithful = (p: { sourceFileText: string }): Rubric => ({
   standard:
     "These are the findings of a readability review, each quoting a passage and suggesting a rewrite. Do the suggested rewrites keep the facts the same as the original, or do they invent facts? A rewrite may cut or simplify freely, but it should never add a claim or detail that the original didn't. For example, if the original text is about art, a rewrite shouldn't mention that Wayne Thiebaud is the best artist, if the original didn't claim that. Also, every identifier, (like a code name, a path, a symbol like `std::notes::create`) must be the same in the rewrite as it was in the original. Lower the score in proportion to the number of rewrites that invent something or alter an identifier.",

--- a/packages/agency-lang/evals/writing-review/overloaded-paragraph/graderFiles/cleaned.md
+++ b/packages/agency-lang/evals/writing-review/overloaded-paragraph/graderFiles/cleaned.md
@@ -1,0 +1,3 @@
+## The run directory
+
+The listings show one score per question. We grade each run using graders, and the scores come from these grading passes. When several complete passes scored the same question, the most recent one wins. A pass only counts if it finished completely.

--- a/packages/agency-lang/evals/writing-review/overloaded-paragraph/graders.ts
+++ b/packages/agency-lang/evals/writing-review/overloaded-paragraph/graders.ts
@@ -1,10 +1,14 @@
-import { plantedFlawGraders } from "../lib/reviewGraders.js";
+import { plantedFlawGraders, recommendsCuts } from "../lib/reviewGraders.js";
 
-export default plantedFlawGraders({
-  reason:
-    'The opening sentence is a garden path ("The run directory annotations fold" reads as a ' +
-    'verb phrase until "determines" arrives) and stacks several new concepts with a nested ' +
-    "parenthetical before its verb, so a newcomer loses the thread. The second sentence is " +
-    'passive throughout ("is taken by the reader", "is enforced by") and chains four ideas ' +
-    'with commas and a "which" clause. A reader new to the codebase cannot follow this.',
-});
+export default [
+  ...plantedFlawGraders({
+    reason:
+      'The opening sentence is a garden path ("The run directory annotations fold" reads as a ' +
+      'verb phrase until "determines" arrives) and stacks several new concepts with a nested ' +
+      "parenthetical before its verb, so a newcomer loses the thread. The second sentence is " +
+      'passive throughout ("is taken by the reader", "is enforced by") and chains four ideas ' +
+      'with commas and a "which" clause. A reader new to the codebase cannot follow this.',
+  }),
+  // The editor kept one idea of six; the reviewer should say the rest goes.
+  recommendsCuts(),
+];

--- a/packages/agency-lang/evals/writing-review/overloaded-paragraph/test.json
+++ b/packages/agency-lang/evals/writing-review/overloaded-paragraph/test.json
@@ -1,6 +1,5 @@
 {
-  "description": "Catch prose that loses the reader: a garden-path opening, concept-stacked sentences with nested parentheticals, and passive voice hiding the actors.",
-  "tags": ["planted", "overloaded"],
+  "description": "Poorly written paragraph: a garden-path opening, lots of concepts in one sentence, passive voice.",
   "files": "./files",
   "input": {
     "assignment": "Explain to a developer new to the codebase, in one short section, how the run directory decides which scores its listings show.",

--- a/packages/agency-lang/evals/writing-review/render-key-note/files/note.md
+++ b/packages/agency-lang/evals/writing-review/render-key-note/files/note.md
@@ -1,0 +1,5 @@
+This needs no render-key bump. Adding `@hidden` to a file changes that
+file's source hash, so its page re-renders and contributes a smaller
+symbol set; the `linkTargets` re-check then invalidates exactly the pages
+whose lookups changed. The cache corrects itself through machinery that
+already exists.

--- a/packages/agency-lang/evals/writing-review/render-key-note/graderFiles/notes.md
+++ b/packages/agency-lang/evals/writing-review/render-key-note/graderFiles/notes.md
@@ -1,0 +1,7 @@
+Context for this text: It was added to a doc where we keep implementation notes for this feature. The purpose of this doc is to help guide others who want to make changes to this code in the future.
+
+The rewritten version is intentionally blank. This text should not have been added at all.
+
+> This needs no render-key bump
+
+This is explaining a decision the agent made while working on a feature, but it is not a decision with lasting consequences. Future readers don't need to know this in order to work with this code. This would be equivalent to saying "I was drinking coffee when I wrote this" – it is adding context that is irrelevant to future readers.

--- a/packages/agency-lang/evals/writing-review/render-key-note/graders.ts
+++ b/packages/agency-lang/evals/writing-review/render-key-note/graders.ts
@@ -1,0 +1,3 @@
+import { harvestedGraders } from "../lib/reviewGraders.js";
+
+export default harvestedGraders();

--- a/packages/agency-lang/evals/writing-review/render-key-note/test.json
+++ b/packages/agency-lang/evals/writing-review/render-key-note/test.json
@@ -1,0 +1,7 @@
+{
+  "description": "Records something in the implementation notes even though it has no lasting consequences.",
+  "input": {
+    "assignment": "Write a paragraph in the developer notes for the @hidden doc tag. This document will guide people if they want to change this code later.",
+    "sourceFile": "note.md"
+  }
+}

--- a/packages/agency-lang/evals/writing-review/vitepress-emoji-comment/files/comment.md
+++ b/packages/agency-lang/evals/writing-review/vitepress-emoji-comment/files/comment.md
@@ -1,0 +1,7 @@
+// Agency namespaces with `::`, so a heading like `std::notes::create`
+// contains the substring `:notes:` — which markdown-it-emoji, enabled
+// unconditionally by VitePress, rewrites to 🎶 (GitHub issue 843). No
+// page here uses emoji shortcodes on purpose, so the plugin only ever
+// costs us. The `true` is markdown-it's ignoreInvalid flag: if a later
+// VitePress stops registering the rule, the build still works.
+md.core.ruler.disable("emoji", true);

--- a/packages/agency-lang/evals/writing-review/vitepress-emoji-comment/graderFiles/cleaned.md
+++ b/packages/agency-lang/evals/writing-review/vitepress-emoji-comment/graderFiles/cleaned.md
@@ -1,0 +1,2 @@
+We disable all emoji in Vitepress because agency namespaces use `::`, and a heading like `std::notes::create`, which contains `:notes:`, was getting rewritten to a notes emoji (🎶).
+md.core.ruler.disable("emoji", true);

--- a/packages/agency-lang/evals/writing-review/vitepress-emoji-comment/graderFiles/notes.md
+++ b/packages/agency-lang/evals/writing-review/vitepress-emoji-comment/graderFiles/notes.md
@@ -1,0 +1,15 @@
+- lead with the why ("We disable all emoji in Vitepress because...")
+- clearly signpost – this comment will explain why we do this. Compare that to "Agency namespaces with `::`" -- its unclear why we're talking about namespaces here, and we need to read the rest of the comment to understand why.
+- No irrelevant context. "(GitHub issue 843)" -- The GitHub issue number is not relevant here.
+
+Also removed some lines that were awkwardly phrased:
+- "so the plugin only ever costs us"
+- "The `true` is markdown-it's ignoreInvalid flag: if a later VitePress stops registering the rule, the build still works"
+
+The latter is also a sentence composed of multiple run-on sentences. "The `true` is markdown-it's ignoreInvalid flag" and ": if a later VitePress stops registering the rule".
+
+"The `true` is markdown" – This sentence has a surprising construction. How can `true` be markdown? It is followed by "it's ignoreInvalid flag". Which "ignoreInvalid" flag? Is the user supposed to know? We start with two awkward sentences that assume the user knows the details of the Vitepress API.
+
+"if a later VitePress stops registering the rule" -- The construction of this sentence feels off. "if a later VitePress" would read better as "if a later version of VitePress". "stops registering the rule" -- which rule? This is the first and only time the word "rule" shows up here. What rule are we talking about?
+
+So, a lot of issues with this text. The overall issue is that it is also way too long.

--- a/packages/agency-lang/evals/writing-review/vitepress-emoji-comment/graders.ts
+++ b/packages/agency-lang/evals/writing-review/vitepress-emoji-comment/graders.ts
@@ -1,0 +1,3 @@
+import { harvestedGraders } from "../lib/reviewGraders.js";
+
+export default harvestedGraders();

--- a/packages/agency-lang/evals/writing-review/vitepress-emoji-comment/test.json
+++ b/packages/agency-lang/evals/writing-review/vitepress-emoji-comment/test.json
@@ -1,0 +1,7 @@
+{
+  "description": "A code comment that buries its reason under context",
+  "input": {
+    "assignment": "Write a code comment above the line in a VitePress config that disables the emoji plugin, to explain why it is disabled.",
+    "sourceFile": "comment.md"
+  }
+}

--- a/packages/agency-lang/lib/agents/eval/rubricJudge.agency
+++ b/packages/agency-lang/lib/agents/eval/rubricJudge.agency
@@ -1,0 +1,33 @@
+type RubricVerdict = {
+  @jsonSchema({ description: "a score from 0.0 to 1.0 where 1.0 means the output fully meets the standard" })
+  score: number,
+  @jsonSchema({ description: "brief explanation for the score, naming the specific parts of the output that met or missed the standard" })
+  reasoning: string
+}
+
+node main(standard: string, output: string, context: string = ""): RubricVerdict {
+  result: RubricVerdict = llm("You are a careful reviewer applying a standard to a piece of work. Score how well the work meets the standard.
+
+The standard:
+<standard>
+${standard}
+</standard>
+
+Context the standard refers to (source material, notes, a reference version). This is background for your judgment. It is NOT an answer key: the work is not supposed to reproduce it, and resembling it earns nothing by itself.
+<context>
+${context}
+</context>
+
+The work being judged:
+<work>
+${output}
+</work>
+
+Score from 0.0 to 1.0, where 1.0 means the work fully meets the standard and 0.0 means it does not meet it at all. Apply these rules:
+- Judge only against the standard. Do not reward or penalize anything the standard does not mention.
+- When the standard says to score in proportion, count: how many items meet it, how many do not.
+- Length, thoroughness, and extra content are neutral unless the standard says otherwise.
+- Be concrete in the reasoning: quote or name the specific items that met or missed the standard, so a reader can check your verdict against the work.")
+
+  return result
+}

--- a/packages/agency-lang/lib/eval/grading/functionGrader.test.ts
+++ b/packages/agency-lang/lib/eval/grading/functionGrader.test.ts
@@ -47,14 +47,37 @@ describe("FunctionGrader", () => {
     expect(seen).toEqual(["Paris"]);
   });
 
-  it("provides ctx.judge that runs the bundled goal judge and returns a Grade with its reasoning", async () => {
+  it("provides ctx.judges.rubric that runs the bundled rubric judge with the standard, output, and context", async () => {
+    const runStructured = vi.fn(async () => ({ score: 0.4, reasoning: "two of five" }));
+    const ctxInput: GraderInput = {
+      ...runInput(["finding a", "finding b"]),
+      runAgency: { runStructured } as unknown as AgencyRunner,
+    };
+    const g = new FunctionGrader(({ judges }) =>
+      judges.rubric({ standard: "every finding is true", context: "the source" }),
+    );
+    expect(await g.run(ctxInput)).toEqual({
+      score: { kind: "scalar", value: 0.4 },
+      feedback: "two of five",
+    });
+    const [file, node, args] = runStructured.mock.calls[0] as unknown as [
+      string,
+      string,
+      unknown[],
+    ];
+    expect(file.endsWith("eval/rubricJudge.agency")).toBe(true);
+    expect(node).toBe("main");
+    expect(args).toEqual(["every finding is true", '["finding a","finding b"]', "the source"]);
+  });
+
+  it("provides ctx.judges.goal that runs the bundled goal judge and returns a Grade with its reasoning", async () => {
     const runStructured = vi.fn(async () => ({ score: 0.9, reasoning: "good" }));
     const ctxInput: GraderInput = {
       ...runInput("Paris"),
       runAgency: { runStructured } as unknown as AgencyRunner,
     };
     // The Grade is returnable as-is, so the reasoning lands in the annotation.
-    const g = new FunctionGrader(({ judge, output }) => judge({ goal: "capital", output }));
+    const g = new FunctionGrader(({ judges, output }) => judges.goal({ goal: "capital", output }));
     expect(await g.run(ctxInput)).toEqual({
       score: { kind: "scalar", value: 0.9 },
       feedback: "good",
@@ -62,14 +85,14 @@ describe("FunctionGrader", () => {
     expect(runStructured).toHaveBeenCalledTimes(1);
   });
 
-  it("ctx.judge forwards test.expected as the third judge arg by default", async () => {
+  it("ctx.judges.goal forwards test.expected as the third judge arg by default", async () => {
     const runStructured = vi.fn(async () => ({ score: 1, reasoning: "" }));
     const input: GraderInput = {
       test: { id: "a", input: "t", expected: "New Delhi" },
       run: loadedRun("New Delhi"),
       runAgency: { runStructured } as unknown as AgencyRunner,
     };
-    const g = new FunctionGrader(({ judge }) => judge({ goal: "capital" }));
+    const g = new FunctionGrader(({ judges }) => judges.goal({ goal: "capital" }));
     await g.run(input);
     expect((runStructured.mock.calls[0] as unknown[])[2]).toEqual([
       "capital",
@@ -78,14 +101,16 @@ describe("FunctionGrader", () => {
     ]);
   });
 
-  it("ctx.judge lets the caller override expected explicitly", async () => {
+  it("ctx.judges.goal lets the caller override expected explicitly", async () => {
     const runStructured = vi.fn(async () => ({ score: 1, reasoning: "" }));
     const input: GraderInput = {
       test: { id: "a", input: "t", expected: "New Delhi" },
       run: loadedRun("Mumbai"),
       runAgency: { runStructured } as unknown as AgencyRunner,
     };
-    const g = new FunctionGrader(({ judge }) => judge({ goal: "capital", expected: "Delhi" }));
+    const g = new FunctionGrader(({ judges }) =>
+      judges.goal({ goal: "capital", expected: "Delhi" }),
+    );
     await g.run(input);
     expect((runStructured.mock.calls[0] as unknown[])[2]).toEqual(["capital", "Mumbai", "Delhi"]);
   });

--- a/packages/agency-lang/lib/eval/grading/functionGrader.ts
+++ b/packages/agency-lang/lib/eval/grading/functionGrader.ts
@@ -63,7 +63,7 @@ export class FunctionGrader<T = TestInput> extends BaseGrader {
 
   protected async _run({ test, run, runAgency, graderFiles }: GraderInput): Promise<Grade> {
     // The bundled judge takes (goal, output, expected); default expected to the
-    // test's gold answer so a metric that calls ctx.judge({ goal }) grades the
+    // test's gold answer so a metric that calls ctx.judges.goal({ goal }) grades the
     // same way LlmJudge does when test.expected is present.
     const inputExpected = (test as { expected?: JSON }).expected;
     const goalJudge = async ({

--- a/packages/agency-lang/lib/eval/grading/functionGrader.ts
+++ b/packages/agency-lang/lib/eval/grading/functionGrader.ts
@@ -2,54 +2,71 @@ import { z } from "zod";
 
 import { BaseGrader } from "./baseGrader.js";
 import { asJudgeText, goalJudgeFile, scalarGrade, ScalarVerdict } from "./goalJudgeFile.js";
+import { rubricJudgeFile } from "./rubricJudgeFile.js";
 import type { EvalRecord } from "@/eval/types.js";
 
 import type { Grade, GraderInput, GraderOptions, Test, JSON } from "./types.js";
+import type { TestInput } from "../runTypes.js";
 
 /** What a metric function receives. `test` is the typed Test: what the agent
  *  was given is `test.input`, the gold answer is `test.expected`, and any extra
  *  per-test data lives under `test.metadata`. */
-export type GraderContext = {
+export type GraderContext<T = TestInput> = {
   output: JSON;
-  test: Test;
+  test: Test<T>;
   /** The isolated directory the agent ran in. Read files the agent wrote. */
   workdir: string;
+  /** The test's `graderFiles/` directory: answers and notes the agent never
+   *  saw. "" when the test has none. */
+  graderFiles: string;
   /** The parsed eval record: events, metrics, tool counts, interrupts, cost. */
   record: EvalRecord;
-  /** Run the bundled LLM goal judge. Returns a full Grade — the 0..1 score
-   *  plus the judge's reasoning as `feedback` — so a metric can return it
-   *  directly and the rationale is stored with the score. Defaults: `output`
-   *  falls back to `run.output`, `expected` falls back to `input.expected`
-   *  (so the bundled judge grades against the gold answer when one is
-   *  present, matching `LlmJudge`). */
-  judge: (args: { goal: string; output?: JSON; expected?: JSON }) => Promise<Grade>;
+  /** The bundled LLM judges, one per question a grader can ask. Each
+   *  returns a full Grade (the 0..1 score, the reasoning as `feedback`), so
+   *  a metric can return it directly and the rationale is stored with the
+   *  score. `output` falls back to `run.output` for every judge. */
+  judges: Judges;
+};
+
+export type Judges = {
+  /** Was the output the right answer to the goal? `expected` falls back to
+   *  `test.expected`, so the judge grades against the gold answer when one
+   *  is present, matching `LlmJudge`. Extra content is penalized and any
+   *  expected text is authoritative: right for "name the capital", wrong for
+   *  grading work against a standard. */
+  goal: (args: { goal: string; output?: JSON; expected?: JSON }) => Promise<Grade>;
+  /** How well does the output meet the standard? `context` is material the
+   *  standard refers to (the source text, an editor's notes, a reference
+   *  version), read as background and never as an answer to match. Use it
+   *  when the question is "does this meet the bar", such as review findings. */
+  rubric: (args: { standard: string; output?: JSON; context?: string }) => Promise<Grade>;
 };
 
 /** A metric: return a 0..1 number, a pass/fail boolean, or a full Grade. */
-export type GraderFn = (
-  ctx: GraderContext,
+export type GraderFn<T = TestInput> = (
+  ctx: GraderContext<T>,
 ) => number | boolean | Grade | Promise<number | boolean | Grade>;
 
 /** Public "grader" union: a metric function or a configured grader instance. */
-export type Grader = GraderFn | BaseGrader;
+export type Grader<T = TestInput> = GraderFn<T> | BaseGrader;
 
 /** Adapts a metric function into a single-shot BaseGrader so the whole grading
  *  pipeline (sampling, gating, weighting, scoring) treats it like any grader. */
-export class FunctionGrader extends BaseGrader {
+export class FunctionGrader<T = TestInput> extends BaseGrader {
   protected readonly defaultName = "fn";
   constructor(
-    private readonly fn: GraderFn,
+    private readonly fn: GraderFn<T>,
     options: GraderOptions = {},
   ) {
     super(options);
   }
 
-  protected async _run({ test, run, runAgency }: GraderInput): Promise<Grade> {
+  protected async _run({ test, run, runAgency, graderFiles }: GraderInput): Promise<Grade> {
     // The bundled judge takes (goal, output, expected); default expected to the
     // test's gold answer so a metric that calls ctx.judge({ goal }) grades the
     // same way LlmJudge does when test.expected is present.
     const inputExpected = (test as { expected?: JSON }).expected;
-    const judge = async ({
+    const goalJudge = async ({
       goal,
       output,
       expected,
@@ -68,11 +85,31 @@ export class FunctionGrader extends BaseGrader {
       );
       return scalarGrade(verdict);
     };
+    const rubricJudge = async ({
+      standard,
+      output,
+      context,
+    }: {
+      standard: string;
+      output?: JSON;
+      context?: string;
+    }) => {
+      const verdict = await runAgency.runStructured(
+        rubricJudgeFile(),
+        "main",
+        [standard, asJudgeText(output ?? run.output), context ?? ""],
+        ScalarVerdict,
+      );
+      return scalarGrade(verdict);
+    };
+    // The harness knows nothing about the input's shape; the module that
+    // declared T is promising it, and nothing here checks that promise.
     const result = await this.fn({
       output: run.output,
-      test,
-      judge,
+      test: test as Test<T>,
+      judges: { goal: goalJudge, rubric: rubricJudge },
       workdir: run.workdir,
+      graderFiles: graderFiles ?? "",
       record: run.record,
     });
     return coerce(result);
@@ -99,12 +136,12 @@ function coerce(result: number | boolean | Grade): Grade {
 }
 
 /** Wrap a metric function so it carries policy (mustPass/weight/threshold/samples/name). */
-export function grader(fn: GraderFn, options: GraderOptions = {}): BaseGrader {
+export function grader<T = TestInput>(fn: GraderFn<T>, options: GraderOptions = {}): BaseGrader {
   return new FunctionGrader(fn, options);
 }
 
 /** Normalize a user-supplied grader (function or instance) into a BaseGrader. */
-export function toGrader(spec: Grader): BaseGrader {
+export function toGrader<T = TestInput>(spec: Grader<T>): BaseGrader {
   if (spec instanceof BaseGrader) return spec;
   // A grader loaded from a user module may be a BaseGrader from a *different*
   // realm (its own resolved copy of agency-lang), so `instanceof` can miss it.

--- a/packages/agency-lang/lib/eval/grading/gradeRun.test.ts
+++ b/packages/agency-lang/lib/eval/grading/gradeRun.test.ts
@@ -11,6 +11,7 @@ import { AgencyRunner } from "./agencyRunner.js";
 import { grader } from "./functionGrader.js";
 import { gradeRun, type GradingContext } from "./gradeRun.js";
 import { snapshotHarness } from "./harnessSnapshot.js";
+import { snapshotGraderFiles } from "./graderFilesSnapshot.js";
 
 const capital: Test = { id: "a", goal: "name the capital", input: "t", expected: "New Delhi" };
 
@@ -196,6 +197,73 @@ describe("gradeRun", () => {
     const card = await gradeRun(runDir, ctx([spy]));
     expect(seenId).toBe("adhoc");
     expect(card.objective()).toBe(1);
+  });
+});
+
+describe("grader files from the run row", () => {
+  function graderFilesFixture() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "grader-files-fixture-"));
+    fs.writeFileSync(path.join(dir, "notes.md"), "lead with the why");
+    return { dir, snapshot: snapshotGraderFiles(dir) };
+  }
+
+  it("hands graders the stored copy under an override, and the suite's own directory under --suite", async () => {
+    const { dir, snapshot } = graderFilesFixture();
+    const runDir = makeRun({ output: "x", graderFiles: snapshot });
+    const seen: string[] = [];
+    const spy = grader(
+      ({ graderFiles }) => {
+        seen.push(graderFiles);
+        return 1;
+      },
+      { name: "spy" },
+    );
+
+    await gradeRun(runDir, ctx([spy]));
+    expect(seen[0]).toBe(path.join(runDirPaths(runDir).gradersDir, snapshot.dirName));
+    expect(fs.readFileSync(path.join(seen[0], "notes.md"), "utf8")).toBe("lead with the why");
+
+    // Under --suite the suite test's own directory is handed over, not the
+    // stored copy. A spy in memory cannot be a suite module, so this half
+    // goes through a module file.
+    const live = path.join(dir, "live");
+    fs.mkdirSync(live);
+    const modulePath = path.join(dir, "graders.ts");
+    fs.writeFileSync(
+      modulePath,
+      'import { grader } from "agency-lang/eval";\n' +
+        "export default [grader(({ graderFiles }) => graderFiles.endsWith('/live') ? 1 : 0, { name: 'live' })];",
+    );
+    const card = await gradeRun(runDir, {
+      ...ctx([]),
+      graders: { kind: "suite", tests: [{ ...capital, graders: modulePath, graderFiles: live }] },
+    });
+    expect(card.perInput[0].grades.map((g) => [g.grader.name(), g.grade.score])).toEqual([
+      ["live", { kind: "scalar", value: 1 }],
+    ]);
+  });
+
+  it("a test with no grader files gives the grader an empty path", async () => {
+    const runDir = makeRun({ output: "x" });
+    let seen: string | undefined;
+    const spy = grader(
+      ({ graderFiles }) => {
+        seen = graderFiles;
+        return 1;
+      },
+      { name: "spy" },
+    );
+    await gradeRun(runDir, ctx([spy]));
+    expect(seen).toBe("");
+  });
+
+  it("a recorded copy that is missing from the run directory fails grading by test", async () => {
+    const { snapshot } = graderFilesFixture();
+    const runDir = makeRun({ output: "x", graderFiles: snapshot });
+    fs.rmSync(path.join(runDirPaths(runDir).gradersDir, snapshot.dirName), { recursive: true });
+    await expect(gradeRun(runDir, ctx([]))).rejects.toThrow(
+      /Grader files snapshot not found.*recorded for test a/,
+    );
   });
 });
 

--- a/packages/agency-lang/lib/eval/grading/gradeRun.ts
+++ b/packages/agency-lang/lib/eval/grading/gradeRun.ts
@@ -21,7 +21,7 @@ import { LlmJudge } from "./graders/llmJudge.js";
 import { AgencyTestGrader } from "./agencyTestGrader.js";
 import { loadGradingModule, loadGradingSnapshot } from "./gradingModule.js";
 import { Scorecard, type GraderGrade, type InputGrades } from "./scorecard.js";
-import type { LoadedRun, JSON as Json } from "./types.js";
+import type { GraderInput, LoadedRun, JSON as Json } from "./types.js";
 
 /** Where each test's graders come from. Graders are test-side, like goal and
  *  expected: a test's own `graders.ts` and its harness pairs. The question
@@ -73,8 +73,13 @@ export async function gradeSnapshot(
   const perInput = await Promise.all(
     gradableEntries(snapshot).map(async (bare) => {
       const entry = withDefaultGoal(bare, ctx.defaultGoal);
-      const graders = await effectiveGraders(entry, ctx, moduleCache, snapshot.dir);
-      return gradeEntry(entry, ctx, graders);
+      const { graders, graderFiles } = await effectiveGraders(
+        entry,
+        ctx,
+        moduleCache,
+        snapshot.dir,
+      );
+      return gradeEntry(entry, ctx, graders, graderFiles);
     }),
   );
   return new Scorecard(perInput);
@@ -135,29 +140,48 @@ export function validateGraders(graders: BaseGrader[], test: Test | undefined): 
   }
 }
 
-/** Which graders score this test: its module graders and its harness
- *  graders, each from the source `ctx.graders` names. */
+/** Which graders score this test, and which copy of its grader-only files
+ *  they read: both from the source `ctx.graders` names. */
 async function effectiveGraders(
   entry: Entry,
   ctx: GradingContext,
   cache: (modulePath: string) => Promise<BaseGrader[]>,
   runDir: string,
-): Promise<BaseGrader[]> {
+): Promise<{ graders: BaseGrader[]; graderFiles?: string }> {
   const source = ctx.graders;
   if (source.kind === "suite") {
     const test = suiteTestFor(entry, source.tests);
     const harness = liveHarnessGraders(test);
-    return [...(await suiteModuleGraders(test, cache, harness.length > 0)), ...harness];
+    return {
+      graders: [...(await suiteModuleGraders(test, cache, harness.length > 0)), ...harness],
+      graderFiles: test.graderFiles,
+    };
   }
-  // Harness graders are the test's own: an override leaves them.
+  // Harness graders and grader files are the test's own: an override leaves them.
   const harness = snapshotHarnessGraders(entry, runDir);
+  const graderFiles = snapshotGraderFilesDir(entry, runDir);
   if (source.kind === "override") {
-    return [...source.graders, ...harness];
+    return { graders: [...source.graders, ...harness], graderFiles };
   }
-  return [
-    ...(await snapshotModuleGraders(entry, ctx, cache, runDir, harness.length > 0)),
-    ...harness,
-  ];
+  return {
+    graders: [
+      ...(await snapshotModuleGraders(entry, ctx, cache, runDir, harness.length > 0)),
+      ...harness,
+    ],
+    graderFiles,
+  };
+}
+
+/** The run directory's stored copy of the test's `graderFiles/`. */
+function snapshotGraderFilesDir(entry: Entry, runDir: string): string | undefined {
+  if (entry.graderFiles === undefined) return undefined;
+  const dir = path.join(runDirPaths(runDir).gradersDir, entry.graderFiles);
+  if (!fs.existsSync(dir)) {
+    throw new Error(
+      `Grader files snapshot not found: ${dir} (recorded for test ${entry.test.id ?? "(no id)"}).`,
+    );
+  }
+  return dir;
 }
 
 /** The bundled goal judge: what scores a test that carries no graders. */
@@ -275,6 +299,8 @@ type Entry = {
   humanFeedback: HumanFeedback;
   graders?: GradersIdentity;
   harness?: HarnessRecord[];
+  /** The stored `graderFiles/` copy's name under `graders/`, from the run row. */
+  graderFiles?: string;
 } & (
   | { run: LoadedRun }
   /** The trace cannot be graded at all: skip straight to a scored zero. */
@@ -311,9 +337,10 @@ function entryFor(snapshot: RunDirectorySnapshot, trace: Trace): Entry {
   const humanFeedback = humanFeedbackFor(snapshot, trace.traceId);
   const graders = runRow !== null && runRow.kind === "run" ? runRow.graders : undefined;
   const harness = runRow !== null && runRow.kind === "run" ? runRow.harness : undefined;
+  const graderFiles = runRow !== null && runRow.kind === "run" ? runRow.graderFiles : undefined;
   const ended = runRow !== null && runRow.kind === "run" ? runRow.ended : traceEnding(trace);
   if (ended === "ok") {
-    return { test, run, humanFeedback, graders, harness };
+    return { test, run, humanFeedback, graders, harness, graderFiles };
   }
   const detail =
     runRow !== null && runRow.kind === "run" && runRow.error !== undefined
@@ -324,6 +351,7 @@ function entryFor(snapshot: RunDirectorySnapshot, trace: Trace): Entry {
     humanFeedback,
     graders,
     harness,
+    graderFiles,
     ungradedReason: `the run ended with ${ended}${detail}`,
   };
 }
@@ -346,6 +374,7 @@ async function gradeEntry(
   entry: Entry,
   ctx: GradingContext,
   graders: BaseGrader[],
+  graderFiles: string | undefined,
 ): Promise<InputGrades> {
   if ("ungradedReason" in entry) {
     return {
@@ -357,7 +386,7 @@ async function gradeEntry(
       humanFeedback: entry.humanFeedback,
     };
   }
-  const graded = await gradeInput(entry.test, entry.run, ctx, graders);
+  const graded = await gradeInput(entry.test, entry.run, ctx, graders, graderFiles);
   return { ...graded, humanFeedback: entry.humanFeedback };
 }
 
@@ -370,13 +399,15 @@ async function gradeInput(
   run: LoadedRun,
   ctx: GradingContext,
   graders: BaseGrader[],
+  graderFiles: string | undefined,
 ): Promise<InputGrades> {
   const gates = graders.filter((grader) => grader.mustPass());
   const advisory = graders.filter((grader) => !grader.mustPass());
+  const input: GraderInput = { test, run, runAgency: ctx.runAgency, graderFiles };
 
   const gateGrades: GraderGrade[] = [];
   for (const grader of gates) {
-    const grade = await grader.run({ test, run, runAgency: ctx.runAgency });
+    const grade = await grader.run(input);
     gateGrades.push({ grader, grade });
     if (!grader.passes(grade)) {
       return { test, run, grades: gateGrades, gatesPassed: false };
@@ -386,7 +417,7 @@ async function gradeInput(
   const advisoryGrades = await Promise.all(
     advisory.map(async (grader) => ({
       grader,
-      grade: await grader.run({ test, run, runAgency: ctx.runAgency }),
+      grade: await grader.run(input),
     })),
   );
 

--- a/packages/agency-lang/lib/eval/grading/graderFilesSnapshot.test.ts
+++ b/packages/agency-lang/lib/eval/grading/graderFilesSnapshot.test.ts
@@ -1,0 +1,40 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { describe, expect, test } from "vitest";
+
+import { snapshotGraderFiles } from "./graderFilesSnapshot.js";
+
+function tree(files: Record<string, string>): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "grader-files-"));
+  for (const [rel, content] of Object.entries(files)) {
+    fs.mkdirSync(path.dirname(path.join(dir, rel)), { recursive: true });
+    fs.writeFileSync(path.join(dir, rel), content);
+  }
+  return dir;
+}
+
+describe("snapshotGraderFiles", () => {
+  test("stores the whole tree under one hash-named directory, keeping relative names", () => {
+    const dir = tree({ "notes.md": "lead with the why", "sub/cleaned.md": "short" });
+    const snap = snapshotGraderFiles(dir);
+    expect(snap.dirName).toMatch(/^[0-9a-f]{64}$/);
+    expect(snap.files).toEqual([
+      { name: `${snap.dirName}/notes.md`, content: "lead with the why" },
+      { name: `${snap.dirName}/sub/cleaned.md`, content: "short" },
+    ]);
+  });
+
+  test("the name depends on every path and every content", () => {
+    const base = snapshotGraderFiles(tree({ "notes.md": "a" })).dirName;
+    expect(snapshotGraderFiles(tree({ "notes.md": "a" })).dirName).toBe(base);
+    expect(snapshotGraderFiles(tree({ "notes.md": "b" })).dirName).not.toBe(base);
+    expect(snapshotGraderFiles(tree({ "other.md": "a" })).dirName).not.toBe(base);
+  });
+
+  test("refuses a symlink rather than storing what it pointed at", () => {
+    const dir = tree({ "notes.md": "a" });
+    fs.symlinkSync(path.join(dir, "notes.md"), path.join(dir, "link.md"));
+    expect(() => snapshotGraderFiles(dir)).toThrow(/must not contain symlinks.*link\.md/);
+  });
+});

--- a/packages/agency-lang/lib/eval/grading/graderFilesSnapshot.test.ts
+++ b/packages/agency-lang/lib/eval/grading/graderFilesSnapshot.test.ts
@@ -15,6 +15,17 @@ function tree(files: Record<string, string>): string {
 }
 
 describe("snapshotGraderFiles", () => {
+  test("refuses an empty directory, which would record a hash with nothing stored under it", () => {
+    expect(() => snapshotGraderFiles(tree({}))).toThrow("graderFiles is empty");
+  });
+
+  test("refuses a directory that is itself a symlink", () => {
+    const target = tree({ "notes.md": "a" });
+    const link = path.join(tree({}), "graderFiles");
+    fs.symlinkSync(target, link);
+    expect(() => snapshotGraderFiles(link)).toThrow("must not be a symlink");
+  });
+
   test("stores the whole tree under one hash-named directory, keeping relative names", () => {
     const dir = tree({ "notes.md": "lead with the why", "sub/cleaned.md": "short" });
     const snap = snapshotGraderFiles(dir);

--- a/packages/agency-lang/lib/eval/grading/graderFilesSnapshot.ts
+++ b/packages/agency-lang/lib/eval/grading/graderFilesSnapshot.ts
@@ -15,7 +15,13 @@ export type GraderFilesSnapshot = {
 };
 
 export function snapshotGraderFiles(dir: string): GraderFilesSnapshot {
+  if (fs.lstatSync(dir).isSymbolicLink()) {
+    throw new Error(`graderFiles must not be a symlink: ${dir}`);
+  }
   const entries = readTree(dir, "");
+  if (entries.length === 0) {
+    throw new Error(`graderFiles is empty: ${dir}`);
+  }
   const manifest = entries.map((entry) => `${entry.rel}\0${sha256Text(entry.content)}`).join("\n");
   const dirName = sha256Text(manifest);
   return {

--- a/packages/agency-lang/lib/eval/grading/graderFilesSnapshot.ts
+++ b/packages/agency-lang/lib/eval/grading/graderFilesSnapshot.ts
@@ -1,0 +1,48 @@
+/** Copies a test's `graderFiles/` directory into the run directory, so the
+ *  graders read the same answers days later, wherever the run is opened.
+ *  The tree is stored whole under `graders/<sha256>/`, keeping its relative
+ *  names, and that one name goes on the run row as `graderFiles`. */
+import * as fs from "fs";
+import * as path from "path";
+
+import { sha256Text } from "@/utils/hash.js";
+
+export type GraderFilesSnapshot = {
+  /** Every file, named `<dirName>/<relative path>` for `recordCompletedRun`. */
+  files: { name: string; content: string }[];
+  /** The stored directory's name under `graders/`: a hash of every path and content. */
+  dirName: string;
+};
+
+export function snapshotGraderFiles(dir: string): GraderFilesSnapshot {
+  const entries = readTree(dir, "");
+  const manifest = entries.map((entry) => `${entry.rel}\0${sha256Text(entry.content)}`).join("\n");
+  const dirName = sha256Text(manifest);
+  return {
+    dirName,
+    files: entries.map((entry) => ({ name: `${dirName}/${entry.rel}`, content: entry.content })),
+  };
+}
+
+/** Files under `dir`, sorted by relative path with `/` separators. Symlinks
+ *  are refused: a stored copy must not depend on what a link pointed at. */
+function readTree(dir: string, prefix: string): { rel: string; content: string }[] {
+  const out: { rel: string; content: string }[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true }).sort(byName)) {
+    const rel = prefix === "" ? entry.name : `${prefix}/${entry.name}`;
+    const full = path.join(dir, entry.name);
+    if (entry.isSymbolicLink()) {
+      throw new Error(`graderFiles must not contain symlinks: ${full}`);
+    }
+    if (entry.isDirectory()) {
+      out.push(...readTree(full, rel));
+    } else if (entry.isFile()) {
+      out.push({ rel, content: fs.readFileSync(full, "utf8") });
+    }
+  }
+  return out;
+}
+
+function byName(a: fs.Dirent, b: fs.Dirent): number {
+  return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
+}

--- a/packages/agency-lang/lib/eval/grading/rubricJudgeFile.test.ts
+++ b/packages/agency-lang/lib/eval/grading/rubricJudgeFile.test.ts
@@ -1,0 +1,24 @@
+import * as fs from "fs";
+import { describe, expect, it } from "vitest";
+import { sha256Text } from "@/utils/hash.js";
+import {
+  RUBRIC_JUDGE_PROMPT_SHA256,
+  RUBRIC_JUDGE_VERSION,
+  rubricJudgeFile,
+} from "./rubricJudgeFile.js";
+
+describe("rubricJudgeFile", () => {
+  it("points at the bundled rubricJudge.agency that exists on disk", () => {
+    const file = rubricJudgeFile();
+    expect(file.endsWith("eval/rubricJudge.agency")).toBe(true);
+    expect(fs.existsSync(file)).toBe(true);
+  });
+
+  it("the prompt file still hashes to the pinned RUBRIC_JUDGE_VERSION", () => {
+    const actual = sha256Text(fs.readFileSync(rubricJudgeFile(), "utf8"));
+    expect(
+      actual,
+      `rubricJudge.agency changed. Bump RUBRIC_JUDGE_VERSION (currently ${RUBRIC_JUDGE_VERSION}) in rubricJudgeFile.ts and set RUBRIC_JUDGE_PROMPT_SHA256 to ${actual}.`,
+    ).toBe(RUBRIC_JUDGE_PROMPT_SHA256);
+  });
+});

--- a/packages/agency-lang/lib/eval/grading/rubricJudgeFile.ts
+++ b/packages/agency-lang/lib/eval/grading/rubricJudgeFile.ts
@@ -1,0 +1,18 @@
+import * as path from "path";
+
+import { getAgentsDir } from "@/importPaths.js";
+
+/** Bundled rubric judge: scores how well an output meets a stated standard,
+ *  with reference material as context rather than an answer key. The goal
+ *  judge (`goalJudgeFile.ts`) is the other frame: did the output answer the
+ *  goal correctly. Rubric judging is for "do these findings meet this bar". */
+export function rubricJudgeFile(): string {
+  return path.join(getAgentsDir(), "eval", "rubricJudge.agency");
+}
+
+/** The bundled rubric judge's revision. Bump it whenever you edit
+ *  `rubricJudge.agency`, and update the hash to match; `rubricJudgeFile.test.ts`
+ *  fails when the file no longer hashes to it. */
+export const RUBRIC_JUDGE_VERSION = 1;
+export const RUBRIC_JUDGE_PROMPT_SHA256 =
+  "be940a0c0a1dca039156aa2123c263167167a39edff76e4ff467e682b75df2e5";

--- a/packages/agency-lang/lib/eval/grading/types.ts
+++ b/packages/agency-lang/lib/eval/grading/types.ts
@@ -1,4 +1,4 @@
-import type { Test } from "@/eval/runTypes.js";
+import type { Test, TestInput } from "@/eval/runTypes.js";
 import type { EvalRecord } from "@/eval/types.js";
 
 import type { AgencyRunner } from "./agencyRunner.js";
@@ -39,8 +39,10 @@ export type GraderOptions = {
 };
 
 /** What a grader's `_run` receives. */
-export type GraderInput = {
-  test: Test;
+export type GraderInput<T = TestInput> = {
+  test: Test<T>;
   run: LoadedRun;
   runAgency: AgencyRunner; // capability to invoke a judge .agency file
+  /** The test's grader-only files, as a directory; absent when it has none. */
+  graderFiles?: string;
 };

--- a/packages/agency-lang/lib/eval/loadInputs.test.ts
+++ b/packages/agency-lang/lib/eval/loadInputs.test.ts
@@ -145,6 +145,20 @@ describe("eval run input loading", () => {
     expect(fromTestDir[0].graders).toBe(path.join(testDir, "graders.ts"));
   });
 
+  it("test-directory form auto-discovers graderFiles/, and an explicit path must be a directory", () => {
+    const testDir = path.join(tmpDir, "suite-gf", "essay");
+    fs.mkdirSync(path.join(testDir, "graderFiles"), { recursive: true });
+    fs.writeFileSync(path.join(testDir, "test.json"), JSON.stringify({ input: "t", goal: "g" }));
+    fs.writeFileSync(path.join(testDir, "graderFiles", "notes.md"), "n");
+    expect(loadInputs(testDir)[0].graderFiles).toBe(path.join(testDir, "graderFiles"));
+
+    fs.writeFileSync(
+      path.join(testDir, "test.json"),
+      JSON.stringify({ input: "t", goal: "g", graderFiles: "./missing" }),
+    );
+    expect(() => loadInputs(testDir)).toThrow(/graderFiles must name a directory/);
+  });
+
   it("test-directory form discovers files/ and holdout/ harness pairs and needs no goal", () => {
     const testDir = path.join(tmpDir, "suite-h", "fib");
     fs.mkdirSync(path.join(testDir, "files"), { recursive: true });

--- a/packages/agency-lang/lib/eval/loadInputs.ts
+++ b/packages/agency-lang/lib/eval/loadInputs.ts
@@ -150,6 +150,9 @@ function loadTestDir(testDir: string, makeId: MakeId, options: LoadOptions): Tes
   if (spec.graders === undefined && fs.existsSync(path.join(testDir, "graders.ts"))) {
     spec.graders = "./graders.ts";
   }
+  if (spec.graderFiles === undefined && fs.existsSync(path.join(testDir, "graderFiles"))) {
+    spec.graderFiles = "./graderFiles";
+  }
   const agencyTests = discoverAgencyTests(testDir);
   // A test graded by discovered harness pairs needs no goal of its own.
   const testOptions = agencyTests.length > 0 ? { ...options, requireGoal: false } : options;
@@ -248,6 +251,9 @@ function normalizeInput(raw: unknown, baseDir: string, makeId: MakeId, options: 
   if (spec.graders !== undefined && typeof spec.graders !== "string") {
     throw new Error("Eval input graders must be a path string when provided");
   }
+  if (spec.graderFiles !== undefined && typeof spec.graderFiles !== "string") {
+    throw new Error("Eval input graderFiles must be a path string when provided");
+  }
   if (
     spec.timeoutSec !== undefined &&
     (typeof spec.timeoutSec !== "number" ||
@@ -298,6 +304,8 @@ function normalizeInput(raw: unknown, baseDir: string, makeId: MakeId, options: 
     out.files = resolveFilesDir(spec.files, baseDir, options, out.id ?? "");
   if (typeof spec.graders === "string")
     out.graders = resolveGradersFile(spec.graders, baseDir, out.id ?? "");
+  if (typeof spec.graderFiles === "string")
+    out.graderFiles = resolveGraderFilesDir(spec.graderFiles, baseDir, out.id ?? "");
   if (typeof spec.timeoutSec === "number") out.timeoutSec = spec.timeoutSec;
   if (typeof spec.harnessMaxCost === "number") out.harnessMaxCost = spec.harnessMaxCost;
   if (isPlainObject(spec.metadata)) out.metadata = spec.metadata as Record<string, any>;
@@ -345,6 +353,18 @@ function resolveGradersFile(raw: string, baseDir: string, inputId: string): stri
   if (!fs.existsSync(abs) || !fs.statSync(abs).isFile()) {
     throw new Error(
       `Test ${inputId}: graders must name a TypeScript file (got ${raw}, resolved to ${abs})`,
+    );
+  }
+  return abs;
+}
+
+/** Resolve a test's grader-only directory to an absolute path. A local
+ *  directory only: it holds answers, and answers live beside the test. */
+function resolveGraderFilesDir(raw: string, baseDir: string, inputId: string): string {
+  const abs = path.resolve(baseDir, raw);
+  if (!fs.existsSync(abs) || !fs.statSync(abs).isDirectory()) {
+    throw new Error(
+      `Test ${inputId}: graderFiles must name a directory (got ${raw}, resolved to ${abs})`,
     );
   }
   return abs;

--- a/packages/agency-lang/lib/eval/public.ts
+++ b/packages/agency-lang/lib/eval/public.ts
@@ -12,6 +12,7 @@ export {
 export { LlmJudge } from "./grading/graders/llmJudge.js";
 export { AgencyTestGrader } from "./grading/agencyTestGrader.js";
 export { goalJudgeFile } from "./grading/goalJudgeFile.js"; // for users who want a custom judge but the bundled prompt
+export { rubricJudgeFile } from "./grading/rubricJudgeFile.js";
 export type {
   LoadedRun,
   GraderInput,
@@ -22,6 +23,7 @@ export type {
   JSONPath,
   Score,
 } from "./grading/types.js";
+export type { TestInput } from "./runTypes.js";
 export { Scorecard, inputObjective } from "./grading/scorecard.js";
 export type { GraderGrade, InputGrades } from "./grading/scorecard.js";
 export { breakdown } from "./grading/gradeBreakdown.js";

--- a/packages/agency-lang/lib/eval/run/runSuite.test.ts
+++ b/packages/agency-lang/lib/eval/run/runSuite.test.ts
@@ -517,6 +517,34 @@ describe("runSuite", () => {
     expect((run as unknown as { graders?: unknown }).graders).toBeUndefined();
   });
 
+  it("stores a test's graderFiles/ tree in its run directory and names it on the run row", async () => {
+    const testDir = path.join(proj, "suite", "essay");
+    fs.mkdirSync(path.join(testDir, "graderFiles", "sub"), { recursive: true });
+    fs.writeFileSync(path.join(testDir, "test.json"), JSON.stringify({ input: "t", goal: "g" }));
+    fs.writeFileSync(path.join(testDir, "graderFiles", "notes.md"), "lead with the why");
+    fs.writeFileSync(path.join(testDir, "graderFiles", "sub", "cleaned.md"), "short");
+    const [test] = loadInputs(testDir);
+    const result = await runSuite(
+      {
+        agent: path.join(proj, "agent.agency"),
+        inputs: [test],
+        out: path.join(proj, "runs", "r-grader-files"),
+        config: {},
+        perRun: { pipeOutput: false },
+      },
+      { runner: traceWritingRunner("done") },
+    );
+    const { runDir, traceId } = result.tests[0];
+    const run = readRunDirectory(runDir, quiet).effectiveAnnotations[traceId].run;
+    const stored = (run as unknown as { graderFiles: string }).graderFiles;
+    expect(stored).toMatch(/^[0-9a-f]{64}$/);
+    const storedDir = path.join(runDirPaths(runDir).gradersDir, stored);
+    expect(fs.readFileSync(path.join(storedDir, "notes.md"), "utf8")).toBe("lead with the why");
+    expect(fs.readFileSync(path.join(storedDir, "sub", "cleaned.md"), "utf8")).toBe("short");
+    // The agent never saw them.
+    expect(fs.existsSync(path.join(runDirPaths(runDir).workdirDir, "notes.md"))).toBe(false);
+  });
+
   it("stores each test's grading module in its run directory, and grading uses that copy even after the source changes", async () => {
     const modulePath = path.join(proj, "graders.ts");
     const moduleReturning = (value: number) => `export default [() => ${value}];`;

--- a/packages/agency-lang/lib/eval/run/runSuite.ts
+++ b/packages/agency-lang/lib/eval/run/runSuite.ts
@@ -18,6 +18,10 @@ import { computeCodeIdentity } from "@/runDirectory/codeIdentity.js";
 import { recordCompletedRun } from "@/runDirectory/mutations.js";
 import { snapshotGradingModule, type GradersSnapshot } from "@/eval/grading/gradingModule.js";
 import { snapshotHarness, type HarnessSnapshot } from "@/eval/grading/harnessSnapshot.js";
+import {
+  snapshotGraderFiles,
+  type GraderFilesSnapshot,
+} from "@/eval/grading/graderFilesSnapshot.js";
 import { readTraces } from "@/runDirectory/traces.js";
 import { safeDeleteDirectoryWithin } from "@/utils.js";
 
@@ -296,9 +300,13 @@ function runDirFor(testDir: string, trial: number, trials: number): string {
  *  a test's own. */
 type TestGraders = GradersSnapshot & { origin: "test" | "config" };
 
-/** What a run directory keeps for grading later: the grading module and/or
- *  the harness pairs. */
-type TestSnapshots = { module?: TestGraders; harness?: HarnessSnapshot };
+/** What a run directory keeps for grading later: the grading module, the
+ *  harness pairs, and the grader-only files. */
+type TestSnapshots = {
+  module?: TestGraders;
+  harness?: HarnessSnapshot;
+  graderFiles?: GraderFilesSnapshot;
+};
 
 /** Each test's own grading module, bundled once per distinct module, plus
  *  its discovered harness pairs, preflighted and read now. Tests with
@@ -317,6 +325,9 @@ async function snapshotGraders(tests: Test[]): Promise<Record<string, TestSnapsh
     }
     if (test.agencyTests !== undefined && test.agencyTests.length > 0) {
       snapshots.harness = snapshotHarness(test.agencyTests, test.harnessMaxCost);
+    }
+    if (test.graderFiles !== undefined) {
+      snapshots.graderFiles = snapshotGraderFiles(test.graderFiles);
     }
     byTest[test.id] = snapshots;
   }
@@ -344,6 +355,7 @@ function foldIntoRunDirectory(args: {
   const { run } = args;
   const graders = args.snapshots.module;
   const harness = args.snapshots.harness;
+  const graderFiles = args.snapshots.graderFiles;
   fs.mkdirSync(args.runDir, { recursive: true });
   const staged = run.statelogPath === null ? [] : readTraces(run.statelogPath).traces;
   if (staged.length === 0) fs.writeFileSync(path.join(args.runDir, "statelog.jsonl"), "");
@@ -363,7 +375,11 @@ function foldIntoRunDirectory(args: {
     stagedStatelogFile: run.statelogPath === null ? undefined : run.statelogPath,
     codeEntry,
     workdir: traceRecorded && fs.existsSync(run.workdir) ? { sourceDir: run.workdir } : undefined,
-    gradersFiles: [...(graders?.files ?? []), ...(harness?.files ?? [])],
+    gradersFiles: [
+      ...(graders?.files ?? []),
+      ...(harness?.files ?? []),
+      ...(graderFiles?.files ?? []),
+    ],
     run: {
       traceId: args.traceId,
       annotator: args.harness,
@@ -384,6 +400,7 @@ function foldIntoRunDirectory(args: {
               },
             }),
         ...(harness === undefined ? {} : { harness: harness.records }),
+        ...(graderFiles === undefined ? {} : { graderFiles: graderFiles.dirName }),
         ended: endedFrom(run),
         flags: args.flags,
         batch: args.batch,

--- a/packages/agency-lang/lib/eval/runDirectoryFixture.ts
+++ b/packages/agency-lang/lib/eval/runDirectoryFixture.ts
@@ -8,6 +8,7 @@ import { finishedTraceLines, tempDir } from "@/runDirectory/testFixtures.js";
 
 import type { Test } from "./runTypes.js";
 import type { HarnessSnapshot } from "./grading/harnessSnapshot.js";
+import type { GraderFilesSnapshot } from "./grading/graderFilesSnapshot.js";
 
 /** One fake test run to write into a run directory. */
 export type FakeRun = {
@@ -27,6 +28,9 @@ export type FakeRun = {
   /** Harness pairs to store under graders/ and record on the run row, as
    *  `eval run` does for a test directory with files/ and holdout/. */
   harness?: HarnessSnapshot;
+  /** The test's grader-only files to store under graders/, as `eval run`
+   *  does for a test directory with graderFiles/. */
+  graderFiles?: GraderFilesSnapshot;
   /** Recorded on the run row, as `eval run` does for a suite invocation. */
   batch?: string;
   trial?: number;
@@ -76,7 +80,7 @@ export function writeRunDirectory(run: FakeRun, dir: string = tempDir("run-")): 
     dir,
     stagedStatelogFile: statelogFile,
     workdir,
-    gradersFiles: run.harness?.files,
+    gradersFiles: [...(run.harness?.files ?? []), ...(run.graderFiles?.files ?? [])],
     run: {
       traceId,
       annotator: { kind: "harness", id: "agency-eval@test" },
@@ -89,6 +93,7 @@ export function writeRunDirectory(run: FakeRun, dir: string = tempDir("run-")): 
         batch: run.batch,
         trial: run.trial,
         ...(run.harness === undefined ? {} : { harness: run.harness.records }),
+        ...(run.graderFiles === undefined ? {} : { graderFiles: run.graderFiles.dirName }),
         ...(ended === "ok" ? {} : { error: run.errorMessage ?? `ended with ${ended}` }),
       },
     },

--- a/packages/agency-lang/lib/eval/runTypes.ts
+++ b/packages/agency-lang/lib/eval/runTypes.ts
@@ -14,7 +14,9 @@ export type AgencyTestDefinition = {
   visibility: AgencyTestVisibility;
 };
 
-export type Test = {
+export type TestInput = string | Record<string, any>;
+
+export type Test<T = TestInput> = {
   /** Stable identifier. Auto-derived when omitted: the loader generates one
    *  via nanoid, the optimizer derives it positionally (`input-<index>`). */
   id?: string;
@@ -32,7 +34,7 @@ export type Test = {
    *  an agent that takes no input runs a test with none, and then the entry
    *  node takes no parameter. Within one suite, either every test has an
    *  input or none does. */
-  input?: string | Record<string, any>;
+  input?: T;
   /** The success criterion — read by the goal judge and the pairwise judge
    *  suite, never shown to the agent. Optional; required only when the
    *  default LLM judge will run. */
@@ -53,6 +55,13 @@ export type Test = {
    *  Trust note: graders are code the harness executes — pulling a remote
    *  suite means trusting it. */
   graders?: string;
+  /** A directory of files for the graders alone, never seeded into the
+   *  agent's workdir: reference answers, editing notes, expected output.
+   *  Auto-discovered in the test-directory form as `graderFiles/` beside
+   *  test.json. Relative in a raw spec, absolute after loading. Graders
+   *  read it as `ctx.graderFiles`; `eval run` stores a copy in the run
+   *  directory so a run grades the same later, anywhere. */
+  graderFiles?: string;
   /** Discovered harness pairs (`files/*.test.json` visible, `holdout/*.test.json`
    *  hidden). Set by directory-convention discovery, never by suite JSON. */
   agencyTests?: AgencyTestDefinition[];

--- a/packages/agency-lang/lib/runDirectory/annotations.ts
+++ b/packages/agency-lang/lib/runDirectory/annotations.ts
@@ -91,6 +91,9 @@ export type RunPayload = {
   graders?: GradersIdentity;
   /** The harness pairs this run is graded by. */
   harness?: HarnessRecord[];
+  /** The stored copy of the test's `graderFiles/` directory: its name under
+   *  `graders/`, a hash over every path and content. */
+  graderFiles?: string;
   ended: RunOutcome;
   flags: Record<string, JsonValue>;
   /** The harness's error message when `ended` is not "ok". */
@@ -209,6 +212,10 @@ const RunAnnotationSchema = z
           })
           .strict(),
       )
+      .optional(),
+    graderFiles: z
+      .string()
+      .regex(/^[0-9a-f]{64}$/)
       .optional(),
     ended: z.enum(["ok", "error", "timeout", "cost-cap", "killed"]),
     flags: z.record(z.string(), JsonValueSchema),

--- a/packages/agency-lang/lib/runDirectory/mutations.ts
+++ b/packages/agency-lang/lib/runDirectory/mutations.ts
@@ -373,7 +373,8 @@ export function recordCompletedRun(
 }
 
 /** Content-hash names never collide on different contents; the same name
- *  already present is the same file, so nothing is rewritten. */
+ *  already present is the same file, so nothing is rewritten. A name may
+ *  hold a path (`<hash>/notes.md`: a stored `graderFiles/` tree). */
 function writeGradersFiles(
   paths: RunDirectoryPaths,
   files: readonly { name: string; content: string }[],
@@ -381,7 +382,9 @@ function writeGradersFiles(
   fs.mkdirSync(paths.gradersDir, { recursive: true });
   for (const file of files) {
     const target = path.join(paths.gradersDir, file.name);
-    if (!fs.existsSync(target)) fs.writeFileSync(target, file.content);
+    if (fs.existsSync(target)) continue;
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, file.content);
   }
 }
 

--- a/packages/agency-lang/lib/runsExplorer/csv.ts
+++ b/packages/agency-lang/lib/runsExplorer/csv.ts
@@ -5,6 +5,7 @@
 import * as path from "path";
 
 import type { RunRow } from "./rows.js";
+import { fmtTests } from "./views/rowFormat.js";
 import type { TableProjection } from "./views/tableState.js";
 
 export type CsvRow = Record<string, string | number | null>;
@@ -54,6 +55,7 @@ export function csvRowsFromProjection(projection: TableProjection, allRows: RunR
         date: null,
         agent: display.aggregates.agent,
         suite: display.aggregates.suite,
+        test: null,
         score: display.aggregates.score,
         pass: null,
         status: null,
@@ -84,6 +86,7 @@ function runCsvRow(row: RunRow): CsvRow {
     date: row.startedAtMs === null ? null : new Date(row.startedAtMs).toISOString(),
     agent: row.agent,
     suite: row.suite,
+    test: fmtTests(row),
     score: row.score,
     pass: row.gatesPassed === null ? null : String(row.gatesPassed),
     status: row.status,

--- a/packages/agency-lang/lib/runsExplorer/rows.test.ts
+++ b/packages/agency-lang/lib/runsExplorer/rows.test.ts
@@ -47,6 +47,17 @@ describe("buildRunRowFromDirectory", () => {
     expect(row.gatesPassed).toBe(false);
   });
 
+  it("carries the drill-in detail: input, output, and one verdict per grader in name order", () => {
+    const row = rowFor(writeGradedRun(tmpDir));
+    const detail = row.tests[0].detail;
+    expect(detail?.input).toBe("first");
+    expect(detail?.output).toEqual({ kind: "output", text: "a" });
+    expect(detail?.graders.map((g) => [g.name, g.score, g.mustPass, g.annotator])).toEqual([
+      ["fixture", { kind: "scalar", value: 1 }, false, "fixture@1"],
+      ["gate", { kind: "binary", pass: false }, true, "fixture@1"],
+    ]);
+  });
+
   it("the test opens the run's statelog, so the viewer can focus its trace", () => {
     const dir = writeGradedRun(tmpDir);
     const row = rowFor(dir);

--- a/packages/agency-lang/lib/runsExplorer/rows.ts
+++ b/packages/agency-lang/lib/runsExplorer/rows.ts
@@ -5,14 +5,38 @@
 // recomputed from the per-test rows so no two paths can disagree.
 import * as path from "path";
 
+import type { Annotation, Score } from "@/runDirectory/annotations.js";
+import { evalRecordFor } from "@/runDirectory/evalRecord.js";
 import { summarizeRuns } from "@/runDirectory/list.js";
 import type { RunDirectorySnapshot } from "@/runDirectory/runDir.js";
 import { runDirPaths } from "@/runDirectory/runDir.js";
+import { traceInputText, traceOutputText, type TraceOutputText } from "@/runDirectory/traceText.js";
 
 import { resolveAgentName } from "./identity.js";
 import { suiteFromSource, UNKNOWN_SUITE } from "./suite.js";
 import type { Source } from "./sources.js";
 import type { ScanResult, TraceTotals } from "./mine.js";
+
+/** One grader's effective verdict on a test: the latest complete pass's
+ *  score row, as the graders table and the verdict screen show it. */
+export type GraderVerdict = {
+  name: string;
+  score: Score;
+  weight: number;
+  mustPass: boolean;
+  feedback: string | null;
+  /** The annotator id: `<module>@<revision>` for a grader, the judge's id for a judge. */
+  annotator: string;
+};
+
+/** What a person sees when drilling into a test: the input it was given,
+ *  the output the graders saw, and every grader's verdict. Only a run
+ *  directory has it; a raw statelog trace was never graded. */
+export type TestDetail = {
+  input: string | null;
+  output: TraceOutputText;
+  graders: GraderVerdict[];
+};
 
 export type TestRow = {
   inputId: string;
@@ -28,6 +52,7 @@ export type TestRow = {
   models: string[];
   /** The trace's `agentName` event; feeds run identity. */
   agentName?: string;
+  detail?: TestDetail;
   /** The trace produced events but the run was cut short (timeout, cost
    *  cap, kill) — the signature of a killed run. */
   statelogHadEvents?: boolean;
@@ -89,6 +114,10 @@ export function buildRunRowFromDirectory(snapshot: RunDirectorySnapshot, source:
     if (summary.agentName !== null) {
       test.agentName = summary.agentName;
     }
+    const detail = testDetail(snapshot, summary.traceId);
+    if (detail !== undefined) {
+      test.detail = detail;
+    }
     return test;
   });
 
@@ -114,6 +143,35 @@ export function buildRunRowFromDirectory(snapshot: RunDirectorySnapshot, source:
   }
   recomputeRunAggregates(row);
   return row;
+}
+
+/** The drill-in view of one trace: its texts and the effective score rows
+ *  (one per grader lineage, latest complete pass), in name order. A run
+ *  that wrote no trace has nothing to show. */
+function testDetail(snapshot: RunDirectorySnapshot, traceId: string): TestDetail | undefined {
+  const trace = snapshot.traces.find((candidate) => candidate.traceId === traceId);
+  if (trace === undefined) return undefined;
+  const record = evalRecordFor(trace, snapshot.dir);
+  const scores = Object.values(snapshot.effectiveAnnotations[traceId]?.scores ?? {});
+  return {
+    input: traceInputText(trace, record),
+    output: traceOutputText(trace, record),
+    graders: scores.flatMap(graderVerdict).sort((a, b) => a.name.localeCompare(b.name)),
+  };
+}
+
+function graderVerdict(row: Annotation): GraderVerdict[] {
+  if (row.kind !== "score") return [];
+  return [
+    {
+      name: row.name,
+      score: row.score,
+      weight: row.weight,
+      mustPass: row.mustPass,
+      feedback: row.feedback ?? null,
+      annotator: row.annotator.id,
+    },
+  ];
 }
 
 /** False if any test failed a gate, true if any passed and none failed,

--- a/packages/agency-lang/lib/runsExplorer/rows.ts
+++ b/packages/agency-lang/lib/runsExplorer/rows.ts
@@ -20,6 +20,9 @@ import type { ScanResult, TraceTotals } from "./mine.js";
 /** One grader's effective verdict on a test: the latest complete pass's
  *  score row, as the graders table and the verdict screen show it. */
 export type GraderVerdict = {
+  /** The effective-score key: annotator kind, lineage, and name. Two
+   *  verdicts can share a name (a regrade from a different module), never a key. */
+  key: string;
   name: string;
   score: Score;
   weight: number;
@@ -152,18 +155,21 @@ function testDetail(snapshot: RunDirectorySnapshot, traceId: string): TestDetail
   const trace = snapshot.traces.find((candidate) => candidate.traceId === traceId);
   if (trace === undefined) return undefined;
   const record = evalRecordFor(trace, snapshot.dir);
-  const scores = Object.values(snapshot.effectiveAnnotations[traceId]?.scores ?? {});
+  const scores = Object.entries(snapshot.effectiveAnnotations[traceId]?.scores ?? {});
   return {
     input: traceInputText(trace, record),
     output: traceOutputText(trace, record),
-    graders: scores.flatMap(graderVerdict).sort((a, b) => a.name.localeCompare(b.name)),
+    graders: scores
+      .flatMap(([key, row]) => graderVerdict(key, row))
+      .sort((a, b) => a.name.localeCompare(b.name)),
   };
 }
 
-function graderVerdict(row: Annotation): GraderVerdict[] {
+function graderVerdict(key: string, row: Annotation): GraderVerdict[] {
   if (row.kind !== "score") return [];
   return [
     {
+      key,
       name: row.name,
       score: row.score,
       weight: row.weight,

--- a/packages/agency-lang/lib/runsExplorer/run.test.ts
+++ b/packages/agency-lang/lib/runsExplorer/run.test.ts
@@ -126,7 +126,7 @@ describe("runExplorer", () => {
     ]);
   });
 
-  it("Enter on a run opens its trace directly (one run, one trace); back returns to runs, Esc at runs is inert", async () => {
+  it("Enter on a run drills to its graders, then to one verdict; o opens the trace; back returns to runs, Esc at runs is inert", async () => {
     const runDir = writeGradedRun(tmpDir);
     const viewerCalls: string[] = [];
     const { options, input, recorder } = makeOptions({
@@ -139,11 +139,19 @@ describe("runExplorer", () => {
 
     await drive(options, input, recorder, [
       { when: (frame) => frame.includes("[runs]") && frame.includes("regex-log"), key: "enter" },
-      { when: (frame) => viewerCalls.length === 1 && frame.includes("[runs]"), key: "escape" },
+      { when: (frame) => frame.includes("[graders]") && frame.includes("fixture"), key: "j" },
+      { when: (frame) => frame.includes("[graders]"), key: "enter" },
+      { when: (frame) => frame.includes("[verdict]") && frame.includes("gate"), key: "escape" },
+      { when: (frame) => frame.includes("[graders]"), key: "o" },
+      { when: (frame) => viewerCalls.length === 1 && frame.includes("[graders]"), key: "escape" },
+      { when: (frame) => frame.includes("[runs]"), key: "escape" },
       { when: (frame) => frame.includes("[runs]"), key: "q" },
     ]);
 
     expect(viewerCalls).toEqual(["t1"]);
+    expect(recorder.frames.some((_, i) => recorder.textAt(i).includes("VERDICT  gate on t1"))).toBe(
+      true,
+    );
     expect(lastFrame(recorder)).toContain("[runs]");
   });
 
@@ -163,12 +171,12 @@ describe("runExplorer", () => {
     });
 
     await drive(options, input, recorder, [
-      { when: (frame) => frame.includes("[runs]") && frame.includes("regex-log"), key: "enter" },
+      { when: (frame) => frame.includes("[runs]") && frame.includes("regex-log"), key: "o" },
       { when: () => viewerCalls.length === 1 && viewerKeys.length === 0, key: "x" },
       {
         when: (frame) =>
           viewerCalls.length === 1 && viewerKeys.length === 1 && frame.includes("[runs]"),
-        key: "enter",
+        key: "o",
       },
       { when: () => viewerCalls.length === 2 && viewerKeys.length === 1, key: "y" },
     ]);

--- a/packages/agency-lang/lib/runsExplorer/run.ts
+++ b/packages/agency-lang/lib/runsExplorer/run.ts
@@ -10,7 +10,7 @@
 //
 // View arrangement: three cycling variants (runs → compare → trend) at
 // the bottom, a loading splash before the first rows, and an overlay
-// stack (tests, info) above. Esc pops the overlay, then falls back to
+// stack (tests, graders, verdict, info) above. Esc pops the overlay, then falls back to
 // the runs variant, then goes inert; q quits from anywhere.
 import * as fs from "fs";
 
@@ -24,6 +24,8 @@ import type { Source } from "./sources.js";
 import { exportCsv, csvRowsFromProjection } from "./csv.js";
 import type { ExplorerAction, ExplorerView, Viewport } from "./views/explorerView.js";
 import { CompareView } from "./views/compareView.js";
+import { GradersTableView } from "./views/gradersTableView.js";
+import { VerdictScreen } from "./views/verdictScreen.js";
 import { InfoScreen } from "./views/infoScreen.js";
 import { LoadingScreen } from "./views/loadingScreen.js";
 import { RunsTableView } from "./views/runsTableView.js";
@@ -198,6 +200,18 @@ class ExplorerShell {
       const tests = new TestsTableView(action.parentRunKey);
       tests.setData(this.rows);
       this.overlay.push(tests);
+      return false;
+    }
+    if (action.kind === "openTest") {
+      const graders = new GradersTableView(action.runKey, action.inputId);
+      graders.setData(this.rows);
+      this.overlay.push(graders);
+      return false;
+    }
+    if (action.kind === "openVerdict") {
+      const verdict = new VerdictScreen(action.runKey, action.inputId, action.graderName);
+      verdict.setData(this.rows);
+      this.overlay.push(verdict);
       return false;
     }
     if (action.kind === "openInfo") {

--- a/packages/agency-lang/lib/runsExplorer/run.ts
+++ b/packages/agency-lang/lib/runsExplorer/run.ts
@@ -209,7 +209,7 @@ class ExplorerShell {
       return false;
     }
     if (action.kind === "openVerdict") {
-      const verdict = new VerdictScreen(action.runKey, action.inputId, action.graderName);
+      const verdict = new VerdictScreen(action.runKey, action.inputId, action.graderKey);
       verdict.setData(this.rows);
       this.overlay.push(verdict);
       return false;

--- a/packages/agency-lang/lib/runsExplorer/views/explorerView.ts
+++ b/packages/agency-lang/lib/runsExplorer/views/explorerView.ts
@@ -12,6 +12,10 @@ export type Viewport = { rows: number; cols: number };
 
 export type ExplorerAction =
   | { kind: "openRun"; parentRunKey: string }
+  /** The graders table for one test of one run. */
+  | { kind: "openTest"; runKey: string; inputId: string }
+  /** One grader's verdict on one test, with the input and output it judged. */
+  | { kind: "openVerdict"; runKey: string; inputId: string; graderName: string }
   | { kind: "openLog"; statelogPath: string; title: string; traceId?: string }
   | { kind: "openInfo"; rowKey: string }
   | { kind: "back" }
@@ -21,7 +25,7 @@ export type ExplorerAction =
   | { kind: "none" };
 
 export type ExplorerView = {
-  viewName: "runs" | "tests" | "compare" | "trend" | "info" | "loading";
+  viewName: "runs" | "tests" | "graders" | "verdict" | "compare" | "trend" | "info" | "loading";
   handleKey(event: KeyEvent, viewport: Viewport): ExplorerAction;
   render(viewport: Viewport): Element;
   /** The loader upserted: every view re-derives from the global rows. */

--- a/packages/agency-lang/lib/runsExplorer/views/explorerView.ts
+++ b/packages/agency-lang/lib/runsExplorer/views/explorerView.ts
@@ -15,7 +15,7 @@ export type ExplorerAction =
   /** The graders table for one test of one run. */
   | { kind: "openTest"; runKey: string; inputId: string }
   /** One grader's verdict on one test, with the input and output it judged. */
-  | { kind: "openVerdict"; runKey: string; inputId: string; graderName: string }
+  | { kind: "openVerdict"; runKey: string; inputId: string; graderKey: string }
   | { kind: "openLog"; statelogPath: string; title: string; traceId?: string }
   | { kind: "openInfo"; rowKey: string }
   | { kind: "back" }

--- a/packages/agency-lang/lib/runsExplorer/views/gradersTableView.test.ts
+++ b/packages/agency-lang/lib/runsExplorer/views/gradersTableView.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import type { GraderVerdict, TestDetail } from "../rows.js";
+import { GradersTableView } from "./gradersTableView.js";
+import { runRow, screenText, testRow } from "./viewTestUtils.js";
+
+const viewport = { rows: 24, cols: 120 };
+
+function verdict(name: string, over: Partial<GraderVerdict> = {}): GraderVerdict {
+  return {
+    name,
+    score: { kind: "scalar", value: 0.7 },
+    weight: 1,
+    mustPass: false,
+    feedback: `${name} says so\nsecond line`,
+    annotator: "graders.ts@abc",
+    ...over,
+  };
+}
+
+const detail: TestDetail = {
+  input: "the input",
+  output: { kind: "output", text: "the output" },
+  graders: [
+    verdict("a-judge"),
+    verdict("gate", { score: { kind: "binary", pass: false }, mustPass: true }),
+  ],
+};
+
+function view(over: Partial<TestDetail> | null = {}): GradersTableView {
+  const built = new GradersTableView("r-1", "t1");
+  const test = over === null ? testRow("t1") : testRow("t1", { detail: { ...detail, ...over } });
+  built.setData([runRow("r-1", { agent: "gcode", tests: [test] })]);
+  return built;
+}
+
+describe("GradersTableView", () => {
+  it("renders one row per verdict with its score, gate marker, and first feedback line", () => {
+    const text = screenText(view().render(viewport));
+    expect(text).toContain("TEST t1 — gcode — score 0.50");
+    expect(text).toContain("a-judge");
+    expect(text).toContain("0.70");
+    expect(text).toContain("a-judge says so");
+    expect(text).not.toContain("second line");
+    expect(text).toContain("FAIL");
+    expect(text).toContain("gate");
+    expect(text).toContain("[graders]");
+  });
+
+  it("Enter opens the cursor verdict, o opens the test's log; Esc backs out", () => {
+    const built = view();
+    built.handleKey({ key: "j" }, viewport);
+    expect(built.handleKey({ key: "enter" }, viewport)).toEqual({
+      kind: "openVerdict",
+      runKey: "r-1",
+      inputId: "t1",
+      graderName: "gate",
+    });
+    expect(built.handleKey({ key: "o" }, viewport)).toEqual({
+      kind: "openLog",
+      statelogPath: "/runs/x/inputs/t1/agent/statelog.jsonl",
+      title: "gcode / t1",
+      traceId: undefined,
+    });
+    expect(built.handleKey({ key: "escape" }, viewport)).toEqual({ kind: "back" });
+  });
+
+  it("says why the table is empty: never graded, or never ran", () => {
+    expect(screenText(view({ graders: [] }).render(viewport))).toContain("no grading pass");
+    expect(screenText(view(null).render(viewport))).toContain("wrote no trace");
+    expect(view(null).handleKey({ key: "enter" }, viewport)).toEqual({ kind: "none" });
+  });
+});

--- a/packages/agency-lang/lib/runsExplorer/views/gradersTableView.test.ts
+++ b/packages/agency-lang/lib/runsExplorer/views/gradersTableView.test.ts
@@ -8,6 +8,7 @@ const viewport = { rows: 24, cols: 120 };
 
 function verdict(name: string, over: Partial<GraderVerdict> = {}): GraderVerdict {
   return {
+    key: `grader:graders.ts:${name}`,
     name,
     score: { kind: "scalar", value: 0.7 },
     weight: 1,
@@ -54,7 +55,7 @@ describe("GradersTableView", () => {
       kind: "openVerdict",
       runKey: "r-1",
       inputId: "t1",
-      graderName: "gate",
+      graderKey: "grader:graders.ts:gate",
     });
     expect(built.handleKey({ key: "o" }, viewport)).toEqual({
       kind: "openLog",

--- a/packages/agency-lang/lib/runsExplorer/views/gradersTableView.ts
+++ b/packages/agency-lang/lib/runsExplorer/views/gradersTableView.ts
@@ -102,7 +102,7 @@ export class GradersTableView implements ExplorerView {
           kind: "openVerdict",
           runKey: this.runKey,
           inputId: this.inputId,
-          graderName: verdict.name,
+          graderKey: verdict.key,
         };
       }
     }

--- a/packages/agency-lang/lib/runsExplorer/views/gradersTableView.ts
+++ b/packages/agency-lang/lib/runsExplorer/views/gradersTableView.ts
@@ -1,0 +1,216 @@
+// One test's graders: a row per effective score row, with the score, the
+// gate, the weight, and the first line of the grader's feedback. Enter on
+// a row opens the verdict screen. Holds only the run KEY and test id, and
+// re-resolves the live test on every setData, like the tests table.
+import { column, line } from "../../tui/builders.js";
+import type { Element } from "../../tui/elements.js";
+import { formatKey } from "../../tui/input/format.js";
+import type { KeyEvent } from "../../tui/input/types.js";
+import { TableComponent, type TableColumn } from "../../tui/table.js";
+import { bottomHints } from "../../logsViewer/views/shared.js";
+import type { GraderVerdict, RunRow, TestRow } from "../rows.js";
+import { fmtScore, scoreColor } from "./rowFormat.js";
+import type { ExplorerAction, ExplorerView, Viewport } from "./explorerView.js";
+
+const CHROME_ROWS = 4;
+const HINTS = "Enter verdict  o log  Esc back  q quit";
+
+/** A verdict's score as 0..1, the same number the run row's mean uses. */
+export function verdictValue(verdict: GraderVerdict): number {
+  return verdict.score.kind === "binary" ? (verdict.score.pass ? 1 : 0) : verdict.score.value;
+}
+
+/** "gate" for a must-pass grader, else its weight when not the default 1. */
+function fmtRole(verdict: GraderVerdict): string {
+  if (verdict.mustPass) return "gate";
+  return verdict.weight === 1 ? "" : `×${verdict.weight}`;
+}
+
+function firstLine(text: string | null): string {
+  return text === null ? "" : text.split("\n")[0];
+}
+
+export class GradersTableView implements ExplorerView {
+  readonly viewName = "graders" as const;
+  private parent: RunRow | null = null;
+  private test: TestRow | null = null;
+  private cursorName: string | null = null;
+  private scrollTop = 0;
+  private message = "";
+  private readonly table = new TableComponent<GraderVerdict>();
+
+  constructor(
+    private readonly runKey: string,
+    private readonly inputId: string,
+  ) {}
+
+  setData(rows: RunRow[]): void {
+    this.parent = rows.find((row) => row.key === this.runKey) ?? null;
+    this.test = this.parent?.tests.find((test) => test.inputId === this.inputId) ?? null;
+  }
+
+  setProgress(): void {
+    // The runs table narrates loading; this screen only shows its own rows.
+  }
+
+  notify(message: string): void {
+    this.message = message;
+  }
+
+  helpLines(): string[] {
+    return [
+      "j/k move    Enter this grader's verdict with the input and output it judged",
+      "o this test's log in the viewer    Esc back    q quit",
+    ];
+  }
+
+  handleKey(event: KeyEvent, viewport: Viewport): ExplorerAction {
+    this.message = "";
+    const key = formatKey(event);
+    const verdicts = this.verdicts();
+    const cursor = this.cursorIndex(verdicts);
+    const page = Math.max(1, viewport.rows - CHROME_ROWS);
+
+    if (key === "q" || key === "Ctrl+C") {
+      return { kind: "quit" };
+    }
+    if (key === "Escape" || key === "Left" || key === "h") {
+      return { kind: "back" };
+    }
+    if (key === "Up" || key === "k") {
+      return this.moveTo(verdicts, cursor - 1);
+    }
+    if (key === "Down" || key === "j") {
+      return this.moveTo(verdicts, cursor + 1);
+    }
+    if (key === "g") {
+      return this.moveTo(verdicts, 0);
+    }
+    if (key === "G") {
+      return this.moveTo(verdicts, verdicts.length - 1);
+    }
+    if (key === "Ctrl+F" || key === "Ctrl+D") {
+      return this.moveTo(verdicts, cursor + page);
+    }
+    if (key === "Ctrl+B" || key === "Ctrl+U") {
+      return this.moveTo(verdicts, cursor - page);
+    }
+    if (key === "Enter" || key === "Right" || key === "l") {
+      const verdict = verdicts[cursor];
+      if (verdict !== undefined) {
+        return {
+          kind: "openVerdict",
+          runKey: this.runKey,
+          inputId: this.inputId,
+          graderName: verdict.name,
+        };
+      }
+    }
+    if (key === "o") {
+      const test = this.test;
+      if (test !== null && test.statelogPath !== undefined && this.parent !== null) {
+        return {
+          kind: "openLog",
+          statelogPath: test.statelogPath,
+          title: `${this.parent.agent} / ${test.inputId}`,
+          traceId: test.traceId,
+        };
+      }
+    }
+    return { kind: "none" };
+  }
+
+  render(viewport: Viewport): Element {
+    const verdicts = this.verdicts();
+    const bodyRows = Math.max(1, viewport.rows - CHROME_ROWS);
+    const cursor = this.cursorIndex(verdicts);
+    if (cursor < this.scrollTop) {
+      this.scrollTop = cursor;
+    }
+    if (cursor >= this.scrollTop + bodyRows) {
+      this.scrollTop = cursor - bodyRows + 1;
+    }
+    const visible = verdicts.slice(this.scrollTop, this.scrollTop + bodyRows);
+    const tableElement = this.table.render({
+      columns: this.columns(),
+      rows: visible,
+      cursor:
+        cursor - this.scrollTop >= 0 && cursor - this.scrollTop < visible.length
+          ? cursor - this.scrollTop
+          : null,
+      width: viewport.cols,
+    });
+    return column(
+      { justifyContent: "flex-start" },
+      line(this.title(), { height: 1, fg: "bright-white" }),
+      tableElement,
+      line(this.message || this.emptyNote(verdicts), { height: 1, fg: "gray" }),
+      line(bottomHints(HINTS, "graders", viewport.cols), { height: 1, fg: "gray" }),
+    );
+  }
+
+  private title(): string {
+    if (this.parent === null || this.test === null) {
+      return `TEST ${this.inputId} — waiting for data…`;
+    }
+    return `TEST ${this.inputId} — ${this.parent.agent} — score ${fmtScore(this.test.score)}`;
+  }
+
+  private emptyNote(verdicts: GraderVerdict[]): string {
+    if (this.test === null || verdicts.length > 0) return "";
+    return this.test.detail === undefined
+      ? "this test wrote no trace, so nothing was graded"
+      : "no grading pass has scored this test yet (agency eval grade <dir>)";
+  }
+
+  private verdicts(): GraderVerdict[] {
+    return this.test?.detail?.graders ?? [];
+  }
+
+  private cursorIndex(verdicts: GraderVerdict[]): number {
+    const pinned = verdicts.findIndex((verdict) => verdict.name === this.cursorName);
+    return pinned === -1 ? 0 : pinned;
+  }
+
+  private moveTo(verdicts: GraderVerdict[], index: number): ExplorerAction {
+    if (verdicts.length === 0) {
+      return { kind: "none" };
+    }
+    const clamped = Math.max(0, Math.min(verdicts.length - 1, index));
+    this.cursorName = verdicts[clamped].name;
+    return { kind: "none" };
+  }
+
+  private columns(): TableColumn<GraderVerdict>[] {
+    return [
+      { key: "grader", header: "grader", width: { min: 12 }, cell: (verdict) => verdict.name },
+      {
+        key: "score",
+        header: "score",
+        width: 7,
+        align: "right",
+        cell: (verdict) =>
+          verdict.score.kind === "binary"
+            ? verdict.score.pass
+              ? "pass"
+              : "FAIL"
+            : fmtScore(verdict.score.value),
+        cellStyle: (verdict) => ({ fg: scoreColor(verdictValue(verdict)) }),
+      },
+      {
+        key: "role",
+        header: "",
+        width: 5,
+        cell: fmtRole,
+        cellStyle: () => ({ fg: "gray" }),
+      },
+      {
+        key: "feedback",
+        header: "feedback",
+        width: "flex",
+        cell: (verdict) => firstLine(verdict.feedback),
+        cellStyle: () => ({ fg: "gray" }),
+      },
+    ];
+  }
+}

--- a/packages/agency-lang/lib/runsExplorer/views/rowFormat.ts
+++ b/packages/agency-lang/lib/runsExplorer/views/rowFormat.ts
@@ -46,6 +46,14 @@ export function fmtTime(ms: number | null, pending: boolean): string {
   return fmtDuration(ms, { minutes: true });
 }
 
+/** Which test a run row ran: its id for a one-test run, a count for a
+ *  suite run, blank for a raw statelog trace (which has no test). */
+export function fmtTests(row: RunRow): string {
+  if (row.tests.length === 1) return row.tests[0].inputId;
+  if (row.tests.length > 1) return `${row.tests.length} tests`;
+  return "";
+}
+
 export function fmtModels(models: string[]): string {
   return models.join(",");
 }

--- a/packages/agency-lang/lib/runsExplorer/views/runsTableView.test.ts
+++ b/packages/agency-lang/lib/runsExplorer/views/runsTableView.test.ts
@@ -35,6 +35,7 @@ describe("RunsTableView rendering", () => {
       "date▼",
       "agent",
       "suite",
+      "test",
       "score",
       "pass",
       "status",
@@ -55,14 +56,15 @@ describe("RunsTableView rendering", () => {
   it("narrow viewports drop models, then time, then pass", () => {
     const view = makeView();
     const at = (cols: number) => screenText(view.render({ rows: 24, cols }));
+    // Fixed columns sum to 112; the flex models column needs 8 more.
     expect(at(120)).toContain("models");
-    const noModels = at(95);
+    const noModels = at(115);
     expect(noModels).not.toContain("models");
     expect(noModels).toContain("time");
-    const noTime = at(85);
+    const noTime = at(105);
     expect(noTime).not.toContain("time");
     expect(noTime).toContain("pass");
-    const noPass = at(75);
+    const noPass = at(98);
     expect(noPass).not.toContain("pass");
     expect(noPass).toContain("status");
   });
@@ -111,10 +113,14 @@ describe("RunsTableView keys", () => {
     expect(onTrace).toMatchObject({ kind: "openLog", statelogPath: "/logs/log.jsonl" });
   });
 
-  it("a single-test run opens its log directly", () => {
+  it("a single-test run opens its graders on Enter and its log on o", () => {
     const view = makeView([runRow("solo", { tests: [testRow("only")] })]);
-    const action = view.handleKey({ key: "enter" }, viewport);
-    expect(action).toMatchObject({
+    expect(view.handleKey({ key: "enter" }, viewport)).toEqual({
+      kind: "openTest",
+      runKey: "solo",
+      inputId: "only",
+    });
+    expect(view.handleKey({ key: "o" }, viewport)).toMatchObject({
       kind: "openLog",
       statelogPath: "/runs/x/inputs/only/agent/statelog.jsonl",
     });

--- a/packages/agency-lang/lib/runsExplorer/views/runsTableView.test.ts
+++ b/packages/agency-lang/lib/runsExplorer/views/runsTableView.test.ts
@@ -66,7 +66,10 @@ describe("RunsTableView rendering", () => {
     expect(noTime).toContain("pass");
     const noPass = at(98);
     expect(noPass).not.toContain("pass");
-    expect(noPass).toContain("status");
+    expect(noPass).toContain("test");
+    const noTest = at(80);
+    expect(noTest).not.toContain("test");
+    expect(noTest).toContain("status");
   });
 
   it("loading progress shows in the status line and clears when done", () => {

--- a/packages/agency-lang/lib/runsExplorer/views/runsTableView.ts
+++ b/packages/agency-lang/lib/runsExplorer/views/runsTableView.ts
@@ -17,6 +17,7 @@ import {
   fmtModels,
   fmtPass,
   fmtScore,
+  fmtTests,
   fmtTime,
   passColor,
   scoreColor,
@@ -35,7 +36,8 @@ import {
 const DROP_ORDER = ["models", "time", "pass"];
 const CHROME_ROWS = 4;
 
-const HINTS = "t/T views  s sort  S asc/desc  b group  Enter open/expand  i info  e export  q quit";
+const HINTS =
+  "t/T views  s sort  S asc/desc  b group  Enter open/expand  o log  i info  e export  q quit";
 
 export class RunsTableView implements ExplorerView {
   readonly viewName = "runs" as const;
@@ -64,7 +66,7 @@ export class RunsTableView implements ExplorerView {
     return [
       "j/k or arrows  move    g/G first/last    Ctrl+F/B/D/U page",
       "s cycle sort   S flip direction   b group by agent/suite",
-      "Enter  expand a group, open a run, or open its log",
+      "Enter  expand a group, or open a run's graders    o  open a run's log",
       "i run info    e export CSV    t/T switch view    q quit",
     ];
   }
@@ -122,6 +124,9 @@ export class RunsTableView implements ExplorerView {
     }
     if (key === "e") {
       return { kind: "exportCsv", projection: projectTable(this.rows, this.state) };
+    }
+    if (key === "o") {
+      return this.openCursorLog();
     }
     if (key === "Enter" || key === "Right" || key === "l") {
       return this.openCursorRow();
@@ -197,6 +202,26 @@ export class RunsTableView implements ExplorerView {
     if (row.source.kind === "statelog") {
       return { kind: "openLog", statelogPath: row.source.file, title: row.agent };
     }
+    if (row.tests.length === 1) {
+      return { kind: "openTest", runKey: row.key, inputId: row.tests[0].inputId };
+    }
+    if (row.tests.length > 1) {
+      return { kind: "openRun", parentRunKey: row.key };
+    }
+    return { kind: "openInfo", rowKey: row.key };
+  }
+
+  /** The log viewer on the cursor row's one trace; a run with several
+   *  tests picks one through its tests table instead. */
+  private openCursorLog(): ExplorerAction {
+    const cursorRow = this.cursorRow();
+    if (cursorRow === undefined || cursorRow.kind === "groupHeader") {
+      return { kind: "none" };
+    }
+    const row = cursorRow.row;
+    if (row.source.kind === "statelog") {
+      return { kind: "openLog", statelogPath: row.source.file, title: row.agent };
+    }
     if (row.tests.length === 1 && row.tests[0].statelogPath !== undefined) {
       return {
         kind: "openLog",
@@ -205,10 +230,7 @@ export class RunsTableView implements ExplorerView {
         traceId: row.tests[0].traceId,
       };
     }
-    if (row.tests.length > 1) {
-      return { kind: "openRun", parentRunKey: row.key };
-    }
-    return { kind: "openInfo", rowKey: row.key };
+    return { kind: "none" };
   }
 
   // ── columns ──────────────────────────────────────────────────────
@@ -259,6 +281,12 @@ export class RunsTableView implements ExplorerView {
           row.kind === "groupHeader"
             ? { fg: "bright-cyan", bold: true }
             : { fg: row.row.status === "trace" ? "gray" : undefined },
+      },
+      {
+        key: "test",
+        header: "test",
+        width: 20,
+        cell: (row) => (row.kind === "groupHeader" ? "" : fmtTests(row.row)),
       },
       {
         key: "score",

--- a/packages/agency-lang/lib/runsExplorer/views/runsTableView.ts
+++ b/packages/agency-lang/lib/runsExplorer/views/runsTableView.ts
@@ -33,7 +33,7 @@ import {
 } from "./tableState.js";
 
 /** Columns dropped right-to-left when the terminal is too narrow. */
-const DROP_ORDER = ["models", "time", "pass"];
+const DROP_ORDER = ["models", "time", "pass", "test"];
 const CHROME_ROWS = 4;
 
 const HINTS =
@@ -354,7 +354,7 @@ export class RunsTableView implements ExplorerView {
   }
 }
 
-/** Drop whole columns (models, then time, then pass) until the columns
+/** Drop whole columns (models, time, pass, then test) until the columns
  *  fit the viewport; a flex column claims a little minimum room. */
 export function dropToFit<Row>(all: TableColumn<Row>[], cols: number): TableColumn<Row>[] {
   let columns = all;

--- a/packages/agency-lang/lib/runsExplorer/views/testsTableView.test.ts
+++ b/packages/agency-lang/lib/runsExplorer/views/testsTableView.test.ts
@@ -17,12 +17,17 @@ describe("TestsTableView", () => {
     expect(text).toContain("[pick test]");
   });
 
-  it("Enter opens the cursor test's statelog; Esc backs out; q quits", () => {
+  it("Enter opens the cursor test's graders, o its statelog; Esc backs out; q quits", () => {
     const view = new TestsTableView("r-1");
     view.setData([runRow("r-1", { agent: "gcode", tests: [testRow("t-a"), testRow("t-b")] })]);
 
     view.handleKey({ key: "j" }, viewport);
-    const action = view.handleKey({ key: "enter" }, viewport);
+    expect(view.handleKey({ key: "enter" }, viewport)).toEqual({
+      kind: "openTest",
+      runKey: "r-1",
+      inputId: "t-b",
+    });
+    const action = view.handleKey({ key: "o" }, viewport);
     expect(action).toEqual({
       kind: "openLog",
       statelogPath: "/runs/x/inputs/t-b/agent/statelog.jsonl",
@@ -50,6 +55,6 @@ describe("TestsTableView", () => {
     const text = screenText(view.render(viewport));
     expect(text).toContain("$3.00");
     const action = view.handleKey({ key: "enter" }, viewport);
-    expect(action).toMatchObject({ kind: "openLog", title: "agent-a / t-b" });
+    expect(action).toEqual({ kind: "openTest", runKey: "r-1", inputId: "t-b" });
   });
 });

--- a/packages/agency-lang/lib/runsExplorer/views/testsTableView.ts
+++ b/packages/agency-lang/lib/runsExplorer/views/testsTableView.ts
@@ -27,7 +27,7 @@ import { dropToFit } from "./runsTableView.js";
 import type { ExplorerAction, ExplorerView, Viewport } from "./explorerView.js";
 
 const CHROME_ROWS = 4;
-const HINTS = "Enter open log  Esc back  q quit";
+const HINTS = "Enter graders  o log  Esc back  q quit";
 
 export class TestsTableView implements ExplorerView {
   readonly viewName = "tests" as const;
@@ -53,7 +53,7 @@ export class TestsTableView implements ExplorerView {
 
   helpLines(): string[] {
     return [
-      "j/k move    Enter open this test's log in the viewer",
+      "j/k move    Enter this test's graders    o this test's log in the viewer",
       "Esc back to the runs table    q quit",
     ];
   }
@@ -96,6 +96,12 @@ export class TestsTableView implements ExplorerView {
       return this.moveTo(tests, cursor - page);
     }
     if (key === "Enter" || key === "Right" || key === "l") {
+      const test = tests[cursor];
+      if (test !== undefined && this.parent !== null) {
+        return { kind: "openTest", runKey: this.parent.key, inputId: test.inputId };
+      }
+    }
+    if (key === "o") {
       const test = tests[cursor];
       if (test !== undefined && test.statelogPath !== undefined && this.parent !== null) {
         return {

--- a/packages/agency-lang/lib/runsExplorer/views/verdictScreen.test.ts
+++ b/packages/agency-lang/lib/runsExplorer/views/verdictScreen.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import type { TestDetail } from "../rows.js";
+import { VerdictScreen } from "./verdictScreen.js";
+import { runRow, screenText, testRow } from "./viewTestUtils.js";
+
+const viewport = { rows: 12, cols: 60 };
+
+const detail: TestDetail = {
+  input: '{"assignment":"explain it","sourceFile":"x.md"}',
+  output: { kind: "output", text: '[{"error":true,"feedback":"too long"}]' },
+  graders: [
+    {
+      name: "names-the-flaws",
+      score: { kind: "scalar", value: 0.25 },
+      weight: 1,
+      mustPass: false,
+      feedback: "one of four points covered, ".repeat(6).trim(),
+      annotator: "graders.ts@abc",
+    },
+  ],
+};
+
+function screen(graderName = "names-the-flaws"): VerdictScreen {
+  const built = new VerdictScreen("r-1", "t1", graderName);
+  built.setData([runRow("r-1", { tests: [testRow("t1", { detail })] })]);
+  return built;
+}
+
+describe("VerdictScreen", () => {
+  it("shows the score, the feedback, and the input and output as pretty JSON", () => {
+    const lines = screen()
+      .pageLines(200)
+      .map((entry) => entry.text);
+    expect(lines[0]).toBe("score:    0.25");
+    expect(lines).toContain("── feedback ──");
+    expect(lines).toContain("── input ──");
+    expect(lines).toContain('  "assignment": "explain it",');
+    expect(lines).toContain("── output ──");
+    expect(lines).toContain('    "feedback": "too long"');
+    expect(screenText(screen().render(viewport))).toContain(
+      "VERDICT  names-the-flaws on t1 — 0.25",
+    );
+  });
+
+  it("wraps long feedback to the width and scrolls against the wrapped count", () => {
+    const built = screen();
+    const total = built.pageLines(viewport.cols).length;
+    expect(total).toBeGreaterThan(viewport.rows);
+    built.handleKey({ key: "G" }, viewport);
+    const text = screenText(built.render(viewport));
+    expect(text).toContain(`${total} of ${total}`);
+    expect(built.handleKey({ key: "escape" }, viewport)).toEqual({ kind: "back" });
+  });
+
+  it("names a verdict it cannot find rather than rendering blank", () => {
+    expect(screenText(screen("missing").render(viewport))).toContain("no verdict named missing");
+  });
+});

--- a/packages/agency-lang/lib/runsExplorer/views/verdictScreen.test.ts
+++ b/packages/agency-lang/lib/runsExplorer/views/verdictScreen.test.ts
@@ -11,6 +11,7 @@ const detail: TestDetail = {
   output: { kind: "output", text: '[{"error":true,"feedback":"too long"}]' },
   graders: [
     {
+      key: "grader:graders.ts:names-the-flaws",
       name: "names-the-flaws",
       score: { kind: "scalar", value: 0.25 },
       weight: 1,
@@ -21,9 +22,14 @@ const detail: TestDetail = {
   ],
 };
 
-function screen(graderName = "names-the-flaws"): VerdictScreen {
-  const built = new VerdictScreen("r-1", "t1", graderName);
-  built.setData([runRow("r-1", { tests: [testRow("t1", { detail })] })]);
+function screen(graderKey = "grader:graders.ts:names-the-flaws"): VerdictScreen {
+  const built = new VerdictScreen("r-1", "t1", graderKey);
+  built.setData([
+    runRow("r-1", {
+      agent: "gcode",
+      tests: [testRow("t1", { detail, statelogPath: "/logs/t1.jsonl", traceId: "tr-1" })],
+    }),
+  ]);
   return built;
 }
 
@@ -53,7 +59,16 @@ describe("VerdictScreen", () => {
     expect(built.handleKey({ key: "escape" }, viewport)).toEqual({ kind: "back" });
   });
 
+  it("o opens the test's log without leaving the verdict", () => {
+    expect(screen().handleKey({ key: "o" }, viewport)).toEqual({
+      kind: "openLog",
+      statelogPath: "/logs/t1.jsonl",
+      title: "gcode / t1",
+      traceId: "tr-1",
+    });
+  });
+
   it("names a verdict it cannot find rather than rendering blank", () => {
-    expect(screenText(screen("missing").render(viewport))).toContain("no verdict named missing");
+    expect(screenText(screen("missing").render(viewport))).toContain("no verdict missing");
   });
 });

--- a/packages/agency-lang/lib/runsExplorer/views/verdictScreen.ts
+++ b/packages/agency-lang/lib/runsExplorer/views/verdictScreen.ts
@@ -8,7 +8,7 @@ import { formatKey } from "../../tui/input/format.js";
 import type { KeyEvent } from "../../tui/input/types.js";
 import { bottomHints } from "../../logsViewer/views/shared.js";
 import { wrapLine } from "../../logsViewer/treeRows.js";
-import type { GraderVerdict, RunRow, TestDetail } from "../rows.js";
+import type { GraderVerdict, RunRow, TestDetail, TestRow } from "../rows.js";
 import { verdictValue } from "./gradersTableView.js";
 import { fmtScore, scoreColor } from "./rowFormat.js";
 import type { ExplorerAction, ExplorerView, Viewport } from "./explorerView.js";
@@ -20,6 +20,8 @@ type Styled = { text: string; fg?: string };
 
 export class VerdictScreen implements ExplorerView {
   readonly viewName = "verdict" as const;
+  private parent: RunRow | null = null;
+  private test: TestRow | null = null;
   private detail: TestDetail | null = null;
   private verdict: GraderVerdict | null = null;
   private scroll = 0;
@@ -28,16 +30,15 @@ export class VerdictScreen implements ExplorerView {
   constructor(
     private readonly runKey: string,
     private readonly inputId: string,
-    private readonly graderName: string,
+    private readonly graderKey: string,
   ) {}
 
   setData(rows: RunRow[]): void {
-    const test = rows
-      .find((row) => row.key === this.runKey)
-      ?.tests.find((candidate) => candidate.inputId === this.inputId);
-    this.detail = test?.detail ?? null;
+    this.parent = rows.find((row) => row.key === this.runKey) ?? null;
+    this.test = this.parent?.tests.find((candidate) => candidate.inputId === this.inputId) ?? null;
+    this.detail = this.test?.detail ?? null;
     this.verdict =
-      this.detail?.graders.find((candidate) => candidate.name === this.graderName) ?? null;
+      this.detail?.graders.find((candidate) => candidate.key === this.graderKey) ?? null;
   }
 
   setProgress(): void {
@@ -49,7 +50,9 @@ export class VerdictScreen implements ExplorerView {
   }
 
   helpLines(): string[] {
-    return ["↑↓ / j k scroll    g / G top / bottom    Ctrl+F/B/D/U page    Esc back    q quit"];
+    return [
+      "↑↓ / j k scroll    g / G top / bottom    Ctrl+F/B/D/U page    o log    Esc back    q quit",
+    ];
   }
 
   handleKey(event: KeyEvent, viewport: Viewport): ExplorerAction {
@@ -57,6 +60,18 @@ export class VerdictScreen implements ExplorerView {
     const key = formatKey(event);
     if (key === "q" || key === "Ctrl+C") return { kind: "quit" };
     if (key === "Escape" || key === "Left" || key === "h") return { kind: "back" };
+    if (key === "o") {
+      const test = this.test;
+      if (test !== null && test.statelogPath !== undefined && this.parent !== null) {
+        return {
+          kind: "openLog",
+          statelogPath: test.statelogPath,
+          title: `${this.parent.agent} / ${test.inputId}`,
+          traceId: test.traceId,
+        };
+      }
+      return { kind: "none" };
+    }
     const total = this.pageLines(viewport.cols).length;
     const page = Math.max(1, viewport.rows - CHROME_ROWS);
     const clamp = (value: number) => Math.max(0, Math.min(value, Math.max(0, total - page)));
@@ -95,7 +110,7 @@ export class VerdictScreen implements ExplorerView {
 
   private title(): string {
     const verdict = this.verdict;
-    if (verdict === null) return `VERDICT  ${this.graderName} on ${this.inputId}`;
+    if (verdict === null) return `VERDICT  ${this.graderKey} on ${this.inputId}`;
     return `VERDICT  ${verdict.name} on ${this.inputId} — ${scoreText(verdict)}`;
   }
 
@@ -111,7 +126,7 @@ export class VerdictScreen implements ExplorerView {
     const detail = this.detail;
     const verdict = this.verdict;
     if (detail === null || verdict === null) {
-      return [{ text: `no verdict named ${this.graderName} for ${this.inputId}`, fg: "gray" }];
+      return [{ text: `no verdict ${this.graderKey} for ${this.inputId}`, fg: "gray" }];
     }
     const role = verdict.mustPass ? "must-pass gate" : `weight ${verdict.weight}`;
     return [

--- a/packages/agency-lang/lib/runsExplorer/views/verdictScreen.ts
+++ b/packages/agency-lang/lib/runsExplorer/views/verdictScreen.ts
@@ -1,0 +1,159 @@
+// One grader's verdict on one test, as a scrollable page: the input the
+// agent was given, the output the graders saw, and this grader's score and
+// feedback. Lines wrap, so scrolling clamps against the post-wrap count,
+// the way the logs viewer's detail screen does.
+import { column, line } from "../../tui/builders.js";
+import type { Element } from "../../tui/elements.js";
+import { formatKey } from "../../tui/input/format.js";
+import type { KeyEvent } from "../../tui/input/types.js";
+import { bottomHints } from "../../logsViewer/views/shared.js";
+import { wrapLine } from "../../logsViewer/treeRows.js";
+import type { GraderVerdict, RunRow, TestDetail } from "../rows.js";
+import { verdictValue } from "./gradersTableView.js";
+import { fmtScore, scoreColor } from "./rowFormat.js";
+import type { ExplorerAction, ExplorerView, Viewport } from "./explorerView.js";
+
+const CHROME_ROWS = 3;
+
+/** A page line with the color it renders in. */
+type Styled = { text: string; fg?: string };
+
+export class VerdictScreen implements ExplorerView {
+  readonly viewName = "verdict" as const;
+  private detail: TestDetail | null = null;
+  private verdict: GraderVerdict | null = null;
+  private scroll = 0;
+  private message = "";
+
+  constructor(
+    private readonly runKey: string,
+    private readonly inputId: string,
+    private readonly graderName: string,
+  ) {}
+
+  setData(rows: RunRow[]): void {
+    const test = rows
+      .find((row) => row.key === this.runKey)
+      ?.tests.find((candidate) => candidate.inputId === this.inputId);
+    this.detail = test?.detail ?? null;
+    this.verdict =
+      this.detail?.graders.find((candidate) => candidate.name === this.graderName) ?? null;
+  }
+
+  setProgress(): void {
+    // Nothing to narrate here.
+  }
+
+  notify(message: string): void {
+    this.message = message;
+  }
+
+  helpLines(): string[] {
+    return ["↑↓ / j k scroll    g / G top / bottom    Ctrl+F/B/D/U page    Esc back    q quit"];
+  }
+
+  handleKey(event: KeyEvent, viewport: Viewport): ExplorerAction {
+    this.message = "";
+    const key = formatKey(event);
+    if (key === "q" || key === "Ctrl+C") return { kind: "quit" };
+    if (key === "Escape" || key === "Left" || key === "h") return { kind: "back" };
+    const total = this.pageLines(viewport.cols).length;
+    const page = Math.max(1, viewport.rows - CHROME_ROWS);
+    const clamp = (value: number) => Math.max(0, Math.min(value, Math.max(0, total - page)));
+    if (key === "Up" || key === "k") this.scroll = clamp(this.scroll - 1);
+    if (key === "Down" || key === "j") this.scroll = clamp(this.scroll + 1);
+    if (key === "g") this.scroll = 0;
+    if (key === "G") this.scroll = clamp(total);
+    if (key === "Ctrl+F" || key === "Ctrl+D") this.scroll = clamp(this.scroll + page);
+    if (key === "Ctrl+B" || key === "Ctrl+U") this.scroll = clamp(this.scroll - page);
+    return { kind: "none" };
+  }
+
+  render(viewport: Viewport): Element {
+    const all = this.pageLines(viewport.cols);
+    const page = Math.max(1, viewport.rows - CHROME_ROWS);
+    this.scroll = Math.max(0, Math.min(this.scroll, Math.max(0, all.length - page)));
+    const visible = all.slice(this.scroll, this.scroll + page);
+    const shownTo = Math.min(all.length, this.scroll + page);
+    return column(
+      { justifyContent: "flex-start" },
+      line(this.title(), { height: 1, fg: "bright-white" }),
+      ...visible.map((entry) =>
+        line(entry.text, { height: 1, ...(entry.fg ? { fg: entry.fg } : {}) }),
+      ),
+      line(
+        bottomHints(
+          `↑↓ scroll (${Math.min(this.scroll + 1, all.length)}–${shownTo} of ${all.length})  Esc back  q quit` +
+            (this.message ? `  ${this.message}` : ""),
+          "verdict",
+          viewport.cols,
+        ),
+        { height: 1, fg: "gray" },
+      ),
+    );
+  }
+
+  private title(): string {
+    const verdict = this.verdict;
+    if (verdict === null) return `VERDICT  ${this.graderName} on ${this.inputId}`;
+    return `VERDICT  ${verdict.name} on ${this.inputId} — ${scoreText(verdict)}`;
+  }
+
+  /** The page, wrapped to `cols`. Exposed for tests. */
+  pageLines(cols: number): Styled[] {
+    const width = Math.max(cols - 2, 8);
+    return this.sections().flatMap((entry) =>
+      wrapLine(entry.text, width).map((text) => ({ ...entry, text })),
+    );
+  }
+
+  private sections(): Styled[] {
+    const detail = this.detail;
+    const verdict = this.verdict;
+    if (detail === null || verdict === null) {
+      return [{ text: `no verdict named ${this.graderName} for ${this.inputId}`, fg: "gray" }];
+    }
+    const role = verdict.mustPass ? "must-pass gate" : `weight ${verdict.weight}`;
+    return [
+      { text: `score:    ${scoreText(verdict)}`, fg: scoreColor(verdictValue(verdict)) },
+      { text: `role:     ${role}` },
+      { text: `grader:   ${verdict.annotator}`, fg: "gray" },
+      { text: "" },
+      heading("feedback"),
+      ...body(verdict.feedback ?? "(the grader gave no feedback)"),
+      { text: "" },
+      heading("input"),
+      ...body(detail.input ?? "(no input recorded)"),
+      { text: "" },
+      heading(detail.output.kind === "lastMessage" ? "output (last message)" : "output"),
+      ...body(detail.output.kind === "none" ? "(no output recorded)" : detail.output.text),
+    ];
+  }
+}
+
+function heading(text: string): Styled {
+  return { text: `── ${text} ──`, fg: "bright-white" };
+}
+
+/** A block of text as page lines; JSON is pretty-printed so a structured
+ *  output reads as a document rather than one long line. */
+function body(text: string): Styled[] {
+  return prettyJson(text)
+    .split("\n")
+    .map((entry) => ({ text: entry }));
+}
+
+function prettyJson(text: string): string {
+  const trimmed = text.trim();
+  if (!(trimmed.startsWith("{") || trimmed.startsWith("["))) return text;
+  try {
+    return JSON.stringify(JSON.parse(trimmed), null, 2);
+  } catch {
+    return text;
+  }
+}
+
+function scoreText(verdict: GraderVerdict): string {
+  if (verdict.score.kind === "binary") return verdict.score.pass ? "pass" : "FAIL";
+  return fmtScore(verdict.score.value);
+}

--- a/packages/agency-lang/stdlib/agents/writing/review.agency
+++ b/packages/agency-lang/stdlib/agents/writing/review.agency
@@ -40,23 +40,32 @@ The principles. Every finding names the principle it violates:
   audience the task names.
 - Buried lead: the sentence the reader came for sitting under background
   they did not need first.
+- Text that does not belong: a sentence, a paragraph, or the whole piece
+  that tells this reader nothing they need for the task. Tidying it does
+  not help; say it should be cut. This is the most common flaw in
+  technical writing, and the one a sentence-level read misses.
 
 How to review:
 1. Work out who the text is for and what it must get across; judge
    against that, not against taste.
-2. error=true means the text fails its job on that point: a reader will
+2. Before reading sentence by sentence, ask of each part: does this
+   reader need it? Recommend cutting what they do not, and say why in
+   terms of the reader ("someone choosing a grader does not need the
+   locking details"). Do not reword text that should go. If the whole
+   piece tells the reader nothing they need, say so and stop there.
+3. error=true means the text fails its job on that point: a reader will
    misread it, lose the thread, or miss the point. Quote the exact
    passage and give a concrete rewrite.
-3. error=false is advisory: real polish (a tightening, an active-voice
+4. error=false is advisory: real polish (a tightening, an active-voice
    rewrite, a split) that would help but does not block understanding.
    Calibrate hard: a passage that merely could be smoother, or extra
    information a curious reader might also want, is advisory, not an
    error. Reserve error=true for a demonstrable misreading — one you can
    act out: "the reader parses it as X, but it means Y". When unsure,
    advisory.
-4. When the caller supplies writing guidelines, they outrank this
+5. When the caller supplies writing guidelines, they outrank this
    catalog: apply both, and where they conflict, the guidelines win.
-5. A clean verdict is a fine outcome. Never pad with generic advice, and
+6. A clean verdict is a fine outcome. Never pad with generic advice, and
    report a repeated habit once, saying that it repeats.
 
 Keep each finding brief, quote the passage it is about, and always offer


### PR DESCRIPTION
This PR builds an eval suite for the writing review agent (`stdlib/agents/writing/review.agency`) and adds the eval-framework pieces the suite needed: grader-only reference files, a rubric judge, and a drill-in view for graded runs.

## Grader-only files: `graderFiles/`

A test directory can now hold a `graderFiles/` folder next to `test.json`. The agent never sees these files; only graders do. The writing-review suite uses this for the "answer key" of each harvested example: `notes.md` (what the editor found wrong) and `cleaned.md` (the edited text, empty when the right answer is to delete it).

- `loadInputs.ts` discovers the folder automatically.
- `runSuite.ts` snapshots it into the run directory under `graders/<sha256>/` (hash over every path and content, relative names kept) and records the hash on the run row as `graderFiles`. Symlinks are refused.
- Function graders get `ctx.graderFiles`, the path to the snapshot (`""` when the test has none). `eval grade --suite` reads the live directory.

## Rubric judge

The bundled goal judge is a correctness judge: it treats reference text as an answer key and rewards output for matching it. That is the wrong frame for "do these review findings meet this bar", and it inflated scores. `lib/agents/eval/rubricJudge.agency` is a second bundled judge: it scores against a stated standard and takes `context` explicitly as background, not an answer key. It is pinned by SHA like the goal judge (`rubricJudgeFile.ts`).

Graders reach both through a new `ctx.judges` object: `judges.goal({ goal, output?, expected? })` and `judges.rubric({ standard, output?, context? })`. Adding a judge later means adding a key. The `agency-review` and `typescript-review` suites moved onto `judges.rubric`; the `agency-agent` suites use `judges.goal`.

`Test` is now generic (`Test<T>`), so a suite can type its inputs, and `grader<T>()` passes that type through to `ctx.test`.

## Writing-review suite

`evals/writing-review/` has planted-flaw tests, a clean-text test, and harvested tests built from real reviews (`vitepress-emoji-comment`, `render-key-note`). `harvestedGraders()` reads `graderFiles/` and runs six graders: rejects, names-the-flaws, no-invented-errors, fix-lands, advisory-useful, rewrites-faithful. All judge prompts live in `lib/templates.ts`.

Baseline on the current reviewer: mean 0.765. The two stable weaknesses it exposes are that the reviewer never recommends deleting text (`fix-lands` 0 on render-key-note every run) and that its rewrites invent definitions for terms it does not know (`rewrites-faithful` 0.25 on render-key-note).

## Runs explorer drill-in

`agency logs <group>` now lets you drill into a graded run: Enter on a run opens a table of its graders and scores; Enter on a grader opens a verdict screen with the test input, the agent output, and the judge's feedback. `o` opens the log viewer from any of these. The runs table also has a `test` column.

## Docs

`docs/dev/evals/eval-grading.md` (two judges, `graderFiles/`), `docs/dev/evals/run-directory.md`, `docs/dev/cli/runs-explorer.md`, and `evals/writing-review/README.md`. `docs/site` still mentions `judge({ goal })` in `guide/graders.md`, `cli/eval.md`, and `cli/optimize.md`; those need updating to `judges.goal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XWYYt9i5j2459ywyJPYj5b
