### PR TITLE
Export the node in the doc integration fixture, fixing main CI

### DIFF
--- a/packages/agency-lang/tests/integration/cli-main/fixtures/project/src/doc-target.agency
+++ b/packages/agency-lang/tests/integration/cli-main/fixtures/project/src/doc-target.agency
@@ -13,7 +13,7 @@ export def greet(person: Person): string {
 }
 
 /** Return a greeting for Ada. */
-node main(): string {
+export node main(): string {
   const person: Person = { name: "Ada" }
   return greet(person)
 }


### PR DESCRIPTION
## What is broken

The `integration` job on main fails at the **Main-only CLI command integration tests** step, and has on every push since #905 merged:

```
Main-only CLI command test failed: Error: [ASSERT FAILED] Expected
.../generated-docs/doc-target.md to match
.../fixtures/expected/doc-target.expected.md
```

The generated page is missing its `## Nodes` section.

## Why

#905 added an export rule to `agency doc`: a node that is not exported is not documented, the same rule functions and types already followed. `generateNodeSection` now filters on `isDocumented`.

The cli-main fixture was never updated. It declares:

```
/** Return a greeting for Ada. */
node main(): string { ... }
```

so `main` is dropped from the page, while `doc-target.expected.md` still lists it.

## The fix

Export the node in the fixture. The expected file is unchanged, so the fixture keeps proving that the Nodes section renders. The other half of the rule, a node left out because it is not exported, is already covered by unit tests in `lib/cli/doc.test.ts` ("omits a node that is not exported", "keeps a non-exported node out of the link registry").

## Verification

Ran `agency doc` on the fixture with a current build, before and after. Before: no Nodes section. After: output matches `doc-target.expected.md` exactly, apart from the `([source](...))` links that only appear when the file sits inside this repo. Also ran the fixture program to confirm `export node main` still compiles and runs.

## Not covered here

The **Real-LLM tests (post-merge)** workflow is also red on main, for unrelated and non-deterministic reasons: `tests/agency/fork/llm-tools/multi-tool-all-interrupt` hit an unhandled interrupt, and the optimizer efficacy tests reported "no improvement: champion 0 <= baseline 0". Those need their own look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013AqSsrq53XR3LVnJR9eaJr
