### PR TITLE
Give the GEPA proposer the goals, and cover every optimizer input mode in CI

### DIFF
--- a/packages/agency-lang/docs/dev/evals/writing-optimizers.md
+++ b/packages/agency-lang/docs/dev/evals/writing-optimizers.md
@@ -146,7 +146,7 @@ Note the `targetSet` carried on each candidate. It reflects *that candidate's* t
 A mutation is proposed by a model and applied to the source. There are two proposer front-ends, both returning a `MutationProposal` (`{ operations, rationale }`):
 
 - **`proposeMutation`** (`lib/optimize/mutator.ts`) is the greedy and example proposer. It renders TARGETS, GOALS, per-input FEEDBACK, and HISTORY into `lib/agents/optimize/mutatePrompt.agency`.
-- **`proposeReflective`** (`lib/optimize/gepaReflect.ts`) is GEPA's reflective proposer, backed by `lib/agents/optimize/gepaReflect.agency`. It renders the same TARGETS and GOALS sections (`renderTargetsSection`, `renderGoalsSection`), plus the minibatch's FEEDBACK and any retry HISTORY. GOALS is not optional: without it the model reads the graders' feedback as a one-off user request and keeps the current instruction, adding an exception to it ("be chatty, unless the user asks for brevity"), which never scores.
+- **`proposeReflective`** (`lib/optimize/gepaReflect.ts`) is GEPA's reflective proposer, backed by `lib/agents/optimize/gepaReflect.agency`. It renders TARGETS, GOALS, the minibatch's FEEDBACK, and HISTORY (validation errors from a rejected attempt).
 
 You hand `proposeValidMutation` two callbacks:
 

--- a/packages/agency-lang/docs/dev/evals/writing-optimizers.md
+++ b/packages/agency-lang/docs/dev/evals/writing-optimizers.md
@@ -146,7 +146,7 @@ Note the `targetSet` carried on each candidate. It reflects *that candidate's* t
 A mutation is proposed by a model and applied to the source. There are two proposer front-ends, both returning a `MutationProposal` (`{ operations, rationale }`):
 
 - **`proposeMutation`** (`lib/optimize/mutator.ts`) is the greedy and example proposer. It renders TARGETS, GOALS, per-input FEEDBACK, and HISTORY into `lib/agents/optimize/mutatePrompt.agency`.
-- **`proposeReflective`** (`lib/optimize/gepaReflect.ts`) is GEPA's reflective proposer, backed by `lib/agents/optimize/gepaReflect.agency`.
+- **`proposeReflective`** (`lib/optimize/gepaReflect.ts`) is GEPA's reflective proposer, backed by `lib/agents/optimize/gepaReflect.agency`. It renders the same TARGETS and GOALS sections (`renderTargetsSection`, `renderGoalsSection`), plus the minibatch's FEEDBACK and any retry HISTORY. GOALS is not optional: without it the model reads the graders' feedback as a one-off user request and keeps the current instruction, adding an exception to it ("be chatty, unless the user asks for brevity"), which never scores.
 
 You hand `proposeValidMutation` two callbacks:
 

--- a/packages/agency-lang/docs/misc/TESTING.md
+++ b/packages/agency-lang/docs/misc/TESTING.md
@@ -468,6 +468,11 @@ AGENCY_USE_TEST_LLM_PROVIDER=1 pnpm run test:agency-js
 - **Vite test** (`tests/integration/bundlers/test-vite.mjs`) — builds a compiled Agency project with Vite (SSR mode).
 - **CLI tests** (`tests/integration/cli/test.mjs`) — tests `agency run`, stdlib imports, interrupts/handlers, and the `agency test` runner.
 
+**Eval tests** — run in-tree against the built `dist/` (no tarball), because the eval harness resolves `agency-lang` from this package's `node_modules`.
+
+- **Eval-run test** (`tests/integration/eval-run/test.mjs`, every PR, no LLM) — `eval run` over an interrupting agent, a command target, `run --capture-workdir`, and a suite written as test directories (`tests/integration/eval-suite/capitals`: `test.json` + `graders.ts` per test). The suite is run and then graded with `eval grade` against a reference solution (mean 1) and an always-wrong agent (mean 0), so a grader that cannot fail is caught.
+- **Optimizer efficacy test** (`tests/integration/optimize-efficacy/test.mjs`, post-merge only, real LLM) — one `agency optimize` run per way the optimizer takes inputs and grades: `--goal` alone, a suite directory with per-test graders, `--graders` overriding them, `--validation-split`, GEPA, a custom optimizer module, and a single test directory with the grader coming from `agency.json`. Each run must beat its baseline and answer with the bare city name. `OPTIMIZE_EFFICACY_ONLY=suite-gepa` runs one row; `OPTIMIZE_EFFICACY_KEEP_RUNS=1` keeps the run directories.
+
 **Stdlib sandbox tests** (`tests/integration/stdlib-sandbox/run.mjs`) — exercise real side effects (filesystem, shell, network) in controlled environments. Guarded by `CI=true` so they don't run locally. Node 22 only. Includes:
 
 - `fs.agency` — mkdir, edit, copy, move, remove in a `/tmp` sandbox

--- a/packages/agency-lang/lib/agents/optimize/gepaReflect.agency
+++ b/packages/agency-lang/lib/agents/optimize/gepaReflect.agency
@@ -13,6 +13,7 @@ type OptimizeMutationProposal = {
 
 node gepaReflect(
   targets: string,
+  goals: string,
   feedback: string,
   history: string,
 ): OptimizeMutationProposal {
@@ -22,6 +23,10 @@ node gepaReflect(
 
   OPTIMIZE TARGETS:
   ${targets}
+
+  GOALS (what the assistant's output must achieve; these outrank the current
+  instructions, so replace whatever in them works against a goal):
+  ${goals}
 
   The following are examples of task inputs given to the assistant, the assistant's
   response for each, its execution trace (errors and tool calls), and feedback on how

--- a/packages/agency-lang/lib/optimize/constraint.ts
+++ b/packages/agency-lang/lib/optimize/constraint.ts
@@ -87,5 +87,5 @@ export function describeConstraint(target: {
 }): string {
   if (target.declaredType !== null) return target.declaredType;
   if (target.valueKind === "literal") return "any literal value";
-  return "free text (any string; keep every ${...} placeholder)";
+  return "free text (any string; keep every interpolation placeholder the current value uses)";
 }

--- a/packages/agency-lang/lib/optimize/gepaReflect.test.ts
+++ b/packages/agency-lang/lib/optimize/gepaReflect.test.ts
@@ -21,6 +21,7 @@ describe("proposeReflective", () => {
     }));
     const proposal = await proposeReflective(runner, {
       targets: "id: prompt",
+      goals: "- [q1] be brief",
       feedback: "[q1] too verbose",
       history: "",
     });
@@ -47,16 +48,16 @@ describe("proposeReflective", () => {
         },
       };
     });
-    await proposeReflective(runner, { targets: "", feedback: "", history: "" }, "gpt-5");
+    await proposeReflective(runner, { targets: "", goals: "", feedback: "", history: "" }, "gpt-5");
     expect(seen).toBe("gpt-5");
-    await proposeReflective(runner, { targets: "", feedback: "", history: "" });
+    await proposeReflective(runner, { targets: "", goals: "", feedback: "", history: "" });
     expect(seen).toBe("gpt-5-mini");
   });
 
   it("throws on a malformed reflective response", async () => {
     const runner = new AgencyRunner({}, async () => ({ data: { rationale: "" } }));
     await expect(
-      proposeReflective(runner, { targets: "", feedback: "", history: "" }),
+      proposeReflective(runner, { targets: "", goals: "", feedback: "", history: "" }),
     ).rejects.toThrow();
   });
 });

--- a/packages/agency-lang/lib/optimize/gepaReflect.ts
+++ b/packages/agency-lang/lib/optimize/gepaReflect.ts
@@ -7,7 +7,12 @@ import type { JSON } from "@/eval/grading/types.js";
 import { MutationProposalSchema } from "./mutator.js";
 import type { MutationProposal } from "./types.js";
 
-export type ReflectionSections = { targets: string; feedback: string; history: string };
+export type ReflectionSections = {
+  targets: string;
+  goals: string;
+  feedback: string;
+  history: string;
+};
 
 /** Run the GEPA reflective proposer and validate its structured proposal. */
 export async function proposeReflective(
@@ -16,7 +21,7 @@ export async function proposeReflective(
   model?: string,
 ): Promise<MutationProposal> {
   const agentFile = path.join(getAgentsDir(), "optimize", "gepaReflect.agency");
-  const args: JSON[] = [sections.targets, sections.feedback, sections.history];
+  const args: JSON[] = [sections.targets, sections.goals, sections.feedback, sections.history];
   return runAgency.runStructured(
     agentFile,
     "gepaReflect",

--- a/packages/agency-lang/lib/optimize/mutator.test.ts
+++ b/packages/agency-lang/lib/optimize/mutator.test.ts
@@ -60,6 +60,16 @@ describe("buildMutatorSections", () => {
     expect(sections.targets).toContain("be brief");
   });
 
+  it("says so when no input has a goal", () => {
+    const sections = buildMutatorSections({
+      targets,
+      inputs: [{ id: "task-1", input: "t" }],
+      history: "",
+    });
+
+    expect(sections.goals).toBe("(no goals given: the graders' feedback below is the standard)");
+  });
+
   it("lists suite goals in task id order", () => {
     const sections = buildMutatorSections({ targets, inputs, history: "" });
 

--- a/packages/agency-lang/lib/optimize/mutator.ts
+++ b/packages/agency-lang/lib/optimize/mutator.ts
@@ -82,12 +82,17 @@ export function renderTargetsSection(targets: OptimizeTarget[]): string {
     .join("\n");
 }
 
-export function buildMutatorSections(promptInputs: MutatorPromptInputs): MutatorMessageSections {
-  const targets = renderTargetsSection(promptInputs.targets);
-  const goals = [...promptInputs.inputs]
+/** Render the inputs' goals as the prompt's GOALS section. Shared by greedy and GEPA. */
+export function renderGoalsSection(inputs: Test[]): string {
+  return [...inputs]
     .sort((a, b) => (a.id ?? "").localeCompare(b.id ?? ""))
     .map((input) => `- [${input.id ?? ""}] ${input.goal ?? ""}`)
     .join("\n");
+}
+
+export function buildMutatorSections(promptInputs: MutatorPromptInputs): MutatorMessageSections {
+  const targets = renderTargetsSection(promptInputs.targets);
+  const goals = renderGoalsSection(promptInputs.inputs);
   const diagnostics =
     (promptInputs.diagnostics ?? []).length === 0
       ? ""

--- a/packages/agency-lang/lib/optimize/mutator.ts
+++ b/packages/agency-lang/lib/optimize/mutator.ts
@@ -82,8 +82,13 @@ export function renderTargetsSection(targets: OptimizeTarget[]): string {
     .join("\n");
 }
 
-/** Render the inputs' goals as the prompt's GOALS section. Shared by greedy and GEPA. */
+/** Render the inputs' goals as the prompt's GOALS section. Shared by greedy and GEPA.
+ *  A suite whose tests grade only through graders.ts has no goals at all; say
+ *  so rather than listing empty bullets under a heading that says they rule. */
 export function renderGoalsSection(inputs: Test[]): string {
+  if (inputs.every((input) => !input.goal)) {
+    return "(no goals given: the graders' feedback below is the standard)";
+  }
   return [...inputs]
     .sort((a, b) => (a.id ?? "").localeCompare(b.id ?? ""))
     .map((input) => `- [${input.id ?? ""}] ${input.goal ?? ""}`)

--- a/packages/agency-lang/lib/optimize/optimizers/gepa.test.ts
+++ b/packages/agency-lang/lib/optimize/optimizers/gepa.test.ts
@@ -191,6 +191,31 @@ describe("Gepa (reflective Pareto optimizer)", () => {
     expect(targetSections[2]).toContain("t-alpha");
   });
 
+  it("tells the proposer the goal of every minibatch input", async () => {
+    // Without the goals the mutator reads the grader feedback as a one-off
+    // user request and keeps the old instruction, adding an exception to it.
+    const runInput = vi.fn(scoredRunner([0.1, 0.2, 0.3, 0.4]));
+    const proposeSpy = vi.fn<NonNullable<GepaDeps["propose"]>>(async () => ({
+      rationale: "r",
+      operations: [],
+    }));
+    const opt = new Gepa(config({ runId: "goals", minibatch: 2 }), deps(runInput, proposeSpy));
+    await opt.optimize({
+      agent: path.join(src, "agent.agency"),
+      inputs: [
+        { id: "a", input: "t", goal: "goal-a" },
+        { id: "b", input: "t", goal: "goal-b" },
+        { id: "c", input: "t", goal: "goal-c" },
+      ],
+    });
+    expect(proposeSpy).toHaveBeenCalled();
+    for (const call of proposeSpy.mock.calls) {
+      const lines = call[1].goals.split("\n");
+      expect(lines).toHaveLength(2);
+      for (const line of lines) expect(line).toMatch(/^- \[[abc]\] goal-[abc]$/);
+    }
+  });
+
   it("reports run start, baseline, and a decision per iteration through the injected reporter", async () => {
     const runInput = vi.fn(scoredRunner([0.1, 0.2, 0.3, 0.4]));
     const events: string[] = [];

--- a/packages/agency-lang/lib/optimize/optimizers/gepa.ts
+++ b/packages/agency-lang/lib/optimize/optimizers/gepa.ts
@@ -6,7 +6,7 @@ import { proposeReflective, type ReflectionSections } from "../gepaReflect.js";
 import type { AgencyRunner } from "@/eval/grading/agencyRunner.js";
 import { inputObjective, type InputGrades, type Scorecard } from "@/eval/grading/scorecard.js";
 import type { Test } from "@/eval/grading/types.js";
-import { renderTargetsSection } from "../mutator.js";
+import { renderGoalsSection, renderTargetsSection } from "../mutator.js";
 import type { BaseOptimizerConfig } from "../optimizer.js";
 import { formatDiagnostics } from "../reporter.js";
 import { makeRng, sampleWithoutReplacement, type Rng } from "../rng.js";
@@ -191,6 +191,7 @@ export class Gepa extends BaseOptimizer {
           this.agencyRunner,
           {
             targets: renderTargetsSection(selected),
+            goals: renderGoalsSection(minibatch),
             feedback,
             // Feed validation errors from the previous attempt back so the model corrects itself.
             history:

--- a/packages/agency-lang/tests/integration/eval-run/test.mjs
+++ b/packages/agency-lang/tests/integration/eval-run/test.mjs
@@ -46,7 +46,9 @@ try {
   const agentDir = join(TMP_ROOT, "agent");
   mkdirSync(agentDir, { recursive: true });
 
-  writeFileSync(join(agentDir, "agent.agency"), `def check() {
+  writeFileSync(
+    join(agentDir, "agent.agency"),
+    `def check() {
   return interrupt("confirm the thing")
 }
 
@@ -56,19 +58,23 @@ node main(task: string) {
   check()
   return "made it past the interrupt"
 }
-`);
-  writeFileSync(join(TMP_ROOT, "inputs.json"), JSON.stringify({
-    inputs: [{ id: "interrupting", goal: "finish despite the interrupt", input: "run" }],
-  }));
+`,
+  );
+  writeFileSync(
+    join(TMP_ROOT, "inputs.json"),
+    JSON.stringify({
+      inputs: [{ id: "interrupting", goal: "finish despite the interrupt", input: "run" }],
+    }),
+  );
 
   const runsDir = join(TMP_ROOT, "runs");
   let output;
   try {
     output = execSync(
       `node ${JSON.stringify(AGENCY_CLI)} eval run` +
-      ` ${JSON.stringify(join(agentDir, "agent.agency"))}` +
-      ` --suite ${JSON.stringify(join(TMP_ROOT, "inputs.json"))}` +
-      ` --out ${JSON.stringify(join(runsDir, "interrupt-e2e"))}`,
+        ` ${JSON.stringify(join(agentDir, "agent.agency"))}` +
+        ` --suite ${JSON.stringify(join(TMP_ROOT, "inputs.json"))}` +
+        ` --out ${JSON.stringify(join(runsDir, "interrupt-e2e"))}`,
       { cwd: REPO_ROOT, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] },
     );
   } catch (err) {
@@ -85,7 +91,10 @@ node main(task: string) {
   // The run directory: one statelog holding the test's trace, plus the
   // harness's `run` row saying which test it was and how it ended.
   const runDir = join(runsDir, "interrupt-e2e", "interrupting");
-  const rows = readFileSync(join(runDir, "annotations.jsonl"), "utf-8").trim().split("\n").map((line) => JSON.parse(line));
+  const rows = readFileSync(join(runDir, "annotations.jsonl"), "utf-8")
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line));
   const runRow = rows.find((row) => row.kind === "run");
   assert(runRow, "no run annotation in annotations.jsonl");
   assert(runRow.ended === "ok", `run row ended: ${runRow.ended}`);
@@ -96,8 +105,14 @@ node main(task: string) {
 
   // The auto-approval must be auditable from the run's own statelog.
   const statelogPath = join(runDir, "statelog.jsonl");
-  const events = readFileSync(statelogPath, "utf-8").trim().split("\n").map((line) => JSON.parse(line));
-  assert(events.every((e) => e.trace_id === runRow.traceId), "statelog trace id does not match the run row");
+  const events = readFileSync(statelogPath, "utf-8")
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line));
+  assert(
+    events.every((e) => e.trace_id === runRow.traceId),
+    "statelog trace id does not match the run row",
+  );
   const resolved = events.find((e) => e.data?.type === "interruptResolved");
   assert(resolved, "no interruptResolved event in the statelog");
   assert(resolved.data.outcome === "approved", `outcome: ${resolved.data.outcome}`);
@@ -108,15 +123,23 @@ node main(task: string) {
   const started = events.find((e) => e.data?.type === "agentStart");
   assert(started, "no agentStart event in the statelog");
   assert(started.data.input === "run", `agentStart.input: ${JSON.stringify(started.data.input)}`);
-  assert(started.data.code?.entry === "agent.agency", `agentStart.code.entry: ${JSON.stringify(started.data.code)}`);
-  assert(/^[0-9a-f]{64}$/.test(started.data.code?.closureHash ?? ""), "agentStart.code.closureHash missing");
+  assert(
+    started.data.code?.entry === "agent.agency",
+    `agentStart.code.entry: ${JSON.stringify(started.data.code)}`,
+  );
+  assert(
+    /^[0-9a-f]{64}$/.test(started.data.code?.closureHash ?? ""),
+    "agentStart.code.closureHash missing",
+  );
 
   // The workdir snapshot and the agent's code are attached, flat.
   assert(existsSync(join(runDir, "workdir")), "no workdir snapshot for the run");
   assert(existsSync(join(runDir, "workdir.json")), "no workdir sidecar");
   assert(existsSync(join(runDir, "code", "agent.agency")), "agent code not stored under code/");
 
-  console.log("[eval-run-integration] PASS: interrupting agent auto-approved over IPC, verdict recorded");
+  console.log(
+    "[eval-run-integration] PASS: interrupting agent auto-approved over IPC, verdict recorded",
+  );
 
   // ── Scenario B: a COMMAND target, end to end ──
   // The load-bearing check for --agent-cmd: the spawned CLI (a real `agency
@@ -131,7 +154,9 @@ node main(task: string) {
   // the program's argv rather than in a node parameter. `args()` reads it raw:
   // an eval task is arbitrary text and may begin with a dash, which `parseArgs`
   // would try to read as a flag.
-  writeFileSync(join(cmdFixtures, "writer.agency"), `import { args } from "std::system"
+  writeFileSync(
+    join(cmdFixtures, "writer.agency"),
+    `import { args } from "std::system"
 
 node main(): string {
   const task = args()[0]
@@ -145,18 +170,29 @@ node main(): string {
   }
   return "wrote out.txt"
 }
-`);
-  writeFileSync(join(TMP_ROOT, "cmd-inputs.json"), JSON.stringify({
-    inputs: [{ id: "cmd-e2e", goal: "writes the input to out.txt", input: "hello from a command target", files: cmdFixtures }],
-  }));
+`,
+  );
+  writeFileSync(
+    join(TMP_ROOT, "cmd-inputs.json"),
+    JSON.stringify({
+      inputs: [
+        {
+          id: "cmd-e2e",
+          goal: "writes the input to out.txt",
+          input: "hello from a command target",
+          files: cmdFixtures,
+        },
+      ],
+    }),
+  );
   const agentCmd = `node ${AGENCY_CLI} run --policy approve-all writer.agency -- {input}`;
   let cmdOutput;
   try {
     cmdOutput = execSync(
       `node ${JSON.stringify(AGENCY_CLI)} eval run` +
-      ` --agent-cmd ${JSON.stringify(agentCmd)}` +
-      ` --suite ${JSON.stringify(join(TMP_ROOT, "cmd-inputs.json"))}` +
-      ` --out ${JSON.stringify(join(runsDir, "cmd-e2e"))}`,
+        ` --agent-cmd ${JSON.stringify(agentCmd)}` +
+        ` --suite ${JSON.stringify(join(TMP_ROOT, "cmd-inputs.json"))}` +
+        ` --out ${JSON.stringify(join(runsDir, "cmd-e2e"))}`,
       { cwd: REPO_ROOT, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] },
     );
   } catch (err) {
@@ -169,7 +205,10 @@ node main(): string {
   assert(cmdOutput.includes("1/1 tests ok"), `expected a fully-ok command run, got:\n${cmdOutput}`);
 
   const cmdRunDir = join(runsDir, "cmd-e2e", "cmd-e2e");
-  const cmdRows = readFileSync(join(cmdRunDir, "annotations.jsonl"), "utf-8").trim().split("\n").map((line) => JSON.parse(line));
+  const cmdRows = readFileSync(join(cmdRunDir, "annotations.jsonl"), "utf-8")
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line));
   const cmdRunRow = cmdRows.find((row) => row.kind === "run");
   assert(cmdRunRow && cmdRunRow.ended === "ok", `command run row: ${JSON.stringify(cmdRunRow)}`);
   // argv delivery through a real CLI: the agent wrote the task text
@@ -177,18 +216,37 @@ node main(): string {
   assert(outTxt === "hello from a command target", `out.txt: ${JSON.stringify(outTxt)}`);
   // the spawned agent's own events landed at the harness statelog path...
   const cmdEvents = readFileSync(join(cmdRunDir, "statelog.jsonl"), "utf-8")
-    .trim().split("\n").map((line) => JSON.parse(line));
-  assert(cmdEvents.some((e) => e.data?.type === "agentStart"), "no agentStart from the spawned CLI in the harness statelog");
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line));
+  assert(
+    cmdEvents.some((e) => e.data?.type === "agentStart"),
+    "no agentStart from the spawned CLI in the harness statelog",
+  );
   // `agency run` fills the code identity itself, and a named-args run
   // (no eval task delivery) records no `input` — the runtime never guesses one.
   const cmdStarted = cmdEvents.find((e) => e.data?.type === "agentStart");
-  assert(cmdStarted.data.code?.entry === "writer.agency", `command agentStart.code: ${JSON.stringify(cmdStarted.data.code)}`);
-  assert(!("input" in cmdStarted.data), `command agentStart should not record input, got ${JSON.stringify(cmdStarted.data.input)}`);
+  assert(
+    cmdStarted.data.code?.entry === "writer.agency",
+    `command agentStart.code: ${JSON.stringify(cmdStarted.data.code)}`,
+  );
+  assert(
+    !("input" in cmdStarted.data),
+    `command agentStart should not record input, got ${JSON.stringify(cmdStarted.data.input)}`,
+  );
   // ...with exactly one trace id across the whole tree
   const traceIds = [...new Set(cmdEvents.map((e) => e.trace_id))];
-  assert(traceIds.length === 1, `expected one trace id, got ${traceIds.length}: ${traceIds.join(", ")}`);
-  assert(traceIds[0] === cmdRunRow.traceId, "the command run's trace id is the one the harness minted");
-  console.log("[eval-run-integration] PASS: command target — argv delivery, statelog handoff, single trace id");
+  assert(
+    traceIds.length === 1,
+    `expected one trace id, got ${traceIds.length}: ${traceIds.join(", ")}`,
+  );
+  assert(
+    traceIds[0] === cmdRunRow.traceId,
+    "the command run's trace id is the one the harness minted",
+  );
+  console.log(
+    "[eval-run-integration] PASS: command target — argv delivery, statelog handoff, single trace id",
+  );
 
   // ── Scenario C: a command that writes no statelog fails with the hint ──
   // (The --log clobber itself lives in `agency agent`, which is LLM-bound;
@@ -197,19 +255,30 @@ node main(): string {
   try {
     execSync(
       `node ${JSON.stringify(AGENCY_CLI)} eval run` +
-      ` --agent-cmd ${JSON.stringify(`node -e 1+1 {input}`)}` +
-      ` --suite ${JSON.stringify(join(TMP_ROOT, "cmd-inputs.json"))}` +
-      ` --out ${JSON.stringify(join(runsDir, "cmd-clobber"))}`,
+        ` --agent-cmd ${JSON.stringify(`node -e 1+1 {input}`)}` +
+        ` --suite ${JSON.stringify(join(TMP_ROOT, "cmd-inputs.json"))}` +
+        ` --out ${JSON.stringify(join(runsDir, "cmd-clobber"))}`,
       { cwd: REPO_ROOT, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] },
     );
   } catch {
     // exit code is not the assertion; error.txt is
   }
-  const clobberRows = readFileSync(join(runsDir, "cmd-clobber", "cmd-e2e", "annotations.jsonl"), "utf-8").trim().split("\n").map((line) => JSON.parse(line));
+  const clobberRows = readFileSync(
+    join(runsDir, "cmd-clobber", "cmd-e2e", "annotations.jsonl"),
+    "utf-8",
+  )
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line));
   const clobberRun = clobberRows.find((row) => row.kind === "run");
-  assert(clobberRun && clobberRun.ended === "error", `clobber run row: ${JSON.stringify(clobberRun)}`);
-  assert(clobberRun.error.includes("If your command passes --log, remove it"),
-    `the run row's error should name the --log clobber cause, got:\n${clobberRun.error}`);
+  assert(
+    clobberRun && clobberRun.ended === "error",
+    `clobber run row: ${JSON.stringify(clobberRun)}`,
+  );
+  assert(
+    clobberRun.error.includes("If your command passes --log, remove it"),
+    `the run row's error should name the --log clobber cause, got:\n${clobberRun.error}`,
+  );
   console.log("[eval-run-integration] PASS: missing statelog names the --log/non-Agency causes");
 
   // ── Scenario D: a command without {input} fails at resolution, before any run dir exists ──
@@ -217,8 +286,8 @@ node main(): string {
   try {
     execSync(
       `node ${JSON.stringify(AGENCY_CLI)} eval run --agent-cmd "echo hello"` +
-      ` --suite ${JSON.stringify(join(TMP_ROOT, "cmd-inputs.json"))}` +
-      ` --out ${JSON.stringify(join(runsDir, "cmd-noplaceholder"))}`,
+        ` --suite ${JSON.stringify(join(TMP_ROOT, "cmd-inputs.json"))}` +
+        ` --out ${JSON.stringify(join(runsDir, "cmd-noplaceholder"))}`,
       { cwd: REPO_ROOT, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] },
     );
   } catch (err) {
@@ -227,7 +296,10 @@ node main(): string {
     assert(text.includes("{input}"), `error should name the {input} requirement, got:\n${text}`);
   }
   assert(noPlaceholderFailed, "a command without {input} must be rejected");
-  assert(!existsSync(join(runsDir, "cmd-noplaceholder")), "no run directory should exist for a resolution-time failure");
+  assert(
+    !existsSync(join(runsDir, "cmd-noplaceholder")),
+    "no run directory should exist for a resolution-time failure",
+  );
   console.log("[eval-run-integration] PASS: missing {input} rejected before any run");
 
   // ── Scenario E: `agency run --capture-workdir <dir>` writes a run directory ──
@@ -238,15 +310,18 @@ node main(): string {
   const captureCwd = join(TMP_ROOT, "capture-cwd");
   mkdirSync(captureCwd, { recursive: true });
   writeFileSync(join(captureCwd, "note.txt"), "in the working directory");
-  writeFileSync(join(cmdFixtures, "trivial.agency"), `node main(): string {
+  writeFileSync(
+    join(cmdFixtures, "trivial.agency"),
+    `node main(): string {
   return "captured"
 }
-`);
+`,
+  );
   let captureOutput;
   try {
     captureOutput = execSync(
       `node ${JSON.stringify(AGENCY_CLI)} run --capture-workdir ${JSON.stringify(captureDir)}` +
-      ` ${JSON.stringify(join(cmdFixtures, "trivial.agency"))}`,
+        ` ${JSON.stringify(join(cmdFixtures, "trivial.agency"))}`,
       { cwd: captureCwd, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] },
     );
   } catch (err) {
@@ -261,14 +336,24 @@ node main(): string {
   const capturedTraceId = capturedMatch[1];
   const capturedRunDir = join(captureDir, capturedTraceId);
   const capturedEvents = readFileSync(join(capturedRunDir, "statelog.jsonl"), "utf-8")
-    .trim().split("\n").map((line) => JSON.parse(line));
-  assert(capturedEvents.length > 0 && capturedEvents.every((e) => e.trace_id === capturedTraceId),
-    "captured statelog does not hold exactly the run's trace");
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line));
+  assert(
+    capturedEvents.length > 0 && capturedEvents.every((e) => e.trace_id === capturedTraceId),
+    "captured statelog does not hold exactly the run's trace",
+  );
   const capturedStart = capturedEvents.find((e) => e.data?.type === "agentStart");
-  assert(capturedStart?.data.code?.entry === "trivial.agency", `captured code identity: ${JSON.stringify(capturedStart?.data.code)}`);
+  assert(
+    capturedStart?.data.code?.entry === "trivial.agency",
+    `captured code identity: ${JSON.stringify(capturedStart?.data.code)}`,
+  );
   assert(existsSync(join(capturedRunDir, "code", "trivial.agency")), "captured code not stored");
-  assert(readFileSync(join(capturedRunDir, "workdir", "note.txt"), "utf-8") === "in the working directory",
-    "working directory not captured");
+  assert(
+    readFileSync(join(capturedRunDir, "workdir", "note.txt"), "utf-8") ===
+      "in the working directory",
+    "working directory not captured",
+  );
   console.log("[eval-run-integration] PASS: run --capture-workdir writes a run directory");
 
   // ── Scenario F: the capture destination sits INSIDE the working directory ──
@@ -277,19 +362,70 @@ node main(): string {
   // workdir snapshot instead of being copied into itself.
   const inTreeOutput = execSync(
     `node ${JSON.stringify(AGENCY_CLI)} run --capture-workdir ./runs/example` +
-    ` ${JSON.stringify(join(cmdFixtures, "trivial.agency"))}`,
+      ` ${JSON.stringify(join(cmdFixtures, "trivial.agency"))}`,
     { cwd: captureCwd, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] },
   );
   const inTreeMatch = inTreeOutput.match(/Captured trace (\S+) into/);
   assert(inTreeMatch, `no capture line in output:\n${inTreeOutput}`);
   const inTreeDir = join(captureCwd, "runs", "example", inTreeMatch[1]);
   const inTreeWorkdir = join(inTreeDir, "workdir");
-  assert(readFileSync(join(inTreeWorkdir, "note.txt"), "utf-8") === "in the working directory",
-    "in-tree capture did not snapshot the working directory");
-  assert(!existsSync(join(inTreeWorkdir, "runs", "example")),
-    "in-tree capture copied the group directory into itself");
+  assert(
+    readFileSync(join(inTreeWorkdir, "note.txt"), "utf-8") === "in the working directory",
+    "in-tree capture did not snapshot the working directory",
+  );
+  assert(
+    !existsSync(join(inTreeWorkdir, "runs", "example")),
+    "in-tree capture copied the group directory into itself",
+  );
   assert(existsSync(join(inTreeDir, "statelog.jsonl")), "in-tree capture wrote no statelog");
   console.log("[eval-run-integration] PASS: run --capture-workdir with a destination inside cwd");
+
+  // ── Scenario G: a suite written as test directories, run and then graded ──
+  // The shape evals are written in now: a directory per test with test.json
+  // and graders.ts beside it. `eval run` must find the graders, `eval grade`
+  // must apply them, and the graders must be able to FAIL: the same suite is
+  // graded against a reference solution (mean 1) and an always-wrong agent
+  // (mean 0).
+  const suite = resolve(REPO_ROOT, "tests", "integration", "eval-suite", "capitals");
+  const gradeSuite = (agent, outName) => {
+    const out = join(runsDir, outName);
+    const runOutput = execSync(
+      `node ${JSON.stringify(AGENCY_CLI)} eval run ${JSON.stringify(join(suite, agent))}` +
+        ` --suite ${JSON.stringify(suite)} --out ${JSON.stringify(out)}`,
+      { cwd: REPO_ROOT, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] },
+    );
+    assert(
+      runOutput.includes("2/2 tests ok"),
+      `expected both suite tests to run, got:\n${runOutput}`,
+    );
+    const summaryPath = join(out, "grade.json");
+    let exitCode = 0;
+    try {
+      execSync(
+        `node ${JSON.stringify(AGENCY_CLI)} eval grade ${JSON.stringify(out)} --out ${JSON.stringify(summaryPath)}`,
+        { cwd: REPO_ROOT, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] },
+      );
+    } catch (err) {
+      exitCode = err.status;
+    }
+    return { exitCode, summary: JSON.parse(readFileSync(summaryPath, "utf-8")) };
+  };
+  const good = gradeSuite("solution.agency", "suite-solution");
+  assert(good.exitCode === 0, `grading the reference solution exited ${good.exitCode}`);
+  const goodGraders = good.summary.runs.flatMap((run) => run.grading.graders);
+  for (const name of ["bare-paris", "bare-tokyo"]) {
+    assert(
+      goodGraders.includes(name),
+      `graders.ts beside test.json was not used (no ${name}): ${goodGraders}`,
+    );
+  }
+  assert(good.summary.mean === 1, `the reference solution scored ${good.summary.mean}, expected 1`);
+  const bad = gradeSuite("wrong.agency", "suite-wrong");
+  assert(bad.exitCode === 0, `grading the always-wrong agent exited ${bad.exitCode}`);
+  assert(bad.summary.mean === 0, `the always-wrong agent scored ${bad.summary.mean}, expected 0`);
+  console.log(
+    "[eval-run-integration] PASS: test-directory suite runs, and eval grade passes and fails it correctly",
+  );
 
   passed = true;
 } finally {

--- a/packages/agency-lang/tests/integration/eval-suite/capitals/bareCity.ts
+++ b/packages/agency-lang/tests/integration/eval-suite/capitals/bareCity.ts
@@ -1,0 +1,19 @@
+import { grader } from "agency-lang/eval";
+
+// Scores 1 only when the output is the bare city name: no sentence around it,
+// no trailing chatter. A score, not a must-pass gate: the optimizer refuses a
+// program whose baseline fails a gate, and this suite exists to be optimized
+// from a failing baseline. Shared by both tests in the suite.
+export function bareCityGrader(city: string) {
+  return grader(
+    ({ output }) => {
+      const text = String(output).trim();
+      if (new RegExp(`^${city}[.!]?$`, "i").test(text)) return 1;
+      return {
+        score: { kind: "scalar" as const, value: 0 },
+        feedback: `expected exactly ${JSON.stringify(city)}, got ${JSON.stringify(text)}`,
+      };
+    },
+    { name: `bare-${city.toLowerCase()}` },
+  );
+}

--- a/packages/agency-lang/tests/integration/eval-suite/capitals/capital-of-france/graders.ts
+++ b/packages/agency-lang/tests/integration/eval-suite/capitals/capital-of-france/graders.ts
@@ -1,0 +1,3 @@
+import { bareCityGrader } from "../bareCity.js";
+
+export default [bareCityGrader("Paris")];

--- a/packages/agency-lang/tests/integration/eval-suite/capitals/capital-of-france/test.json
+++ b/packages/agency-lang/tests/integration/eval-suite/capitals/capital-of-france/test.json
@@ -1,0 +1,5 @@
+{
+  "goal": "Reply with only the capital city name and nothing else.",
+  "input": "What is the capital of France?",
+  "timeoutSec": 120
+}

--- a/packages/agency-lang/tests/integration/eval-suite/capitals/capital-of-japan/graders.ts
+++ b/packages/agency-lang/tests/integration/eval-suite/capitals/capital-of-japan/graders.ts
@@ -1,0 +1,3 @@
+import { bareCityGrader } from "../bareCity.js";
+
+export default [bareCityGrader("Tokyo")];

--- a/packages/agency-lang/tests/integration/eval-suite/capitals/capital-of-japan/test.json
+++ b/packages/agency-lang/tests/integration/eval-suite/capitals/capital-of-japan/test.json
@@ -1,0 +1,5 @@
+{
+  "goal": "Reply with only the capital city name and nothing else.",
+  "input": "What is the capital of Japan?",
+  "timeoutSec": 120
+}

--- a/packages/agency-lang/tests/integration/eval-suite/capitals/solution.agency
+++ b/packages/agency-lang/tests/integration/eval-suite/capitals/solution.agency
@@ -1,0 +1,8 @@
+// Reference solution: answers without an LLM. Running the suite against it
+// must score 1.0, so a failure points at the harness, not at a model.
+node main(task: string): string {
+  if (task.includes("France")) {
+    return "Paris"
+  }
+  return "Tokyo"
+}

--- a/packages/agency-lang/tests/integration/eval-suite/capitals/wrong.agency
+++ b/packages/agency-lang/tests/integration/eval-suite/capitals/wrong.agency
@@ -1,0 +1,5 @@
+// Always wrong on purpose: grading it must FAIL, which proves the graders
+// can fail at all.
+node main(task: string): string {
+  return "The capital is a lovely city."
+}

--- a/packages/agency-lang/tests/integration/optimize-efficacy/fixtures/agent.agency
+++ b/packages/agency-lang/tests/integration/optimize-efficacy/fixtures/agent.agency
@@ -1,12 +1,9 @@
-// task is unused: eval entry nodes take exactly one parameter (the input's
-// task); this fixture's behavior is driven by its optimizable variable.
-//
-// The style line is optimizable, the question is not. The baseline style
-// buries the answer in chatter, so the way to score is a general instruction
-// about how to answer -- which is what mutatePrompt.agency asks the mutator
-// for, and all it will produce: it forbids hard-coding an expected answer.
+// The style line is optimizable, the question (the task) is not. The baseline
+// style buries the answer in a paragraph, so the way to score is a general
+// instruction about how to answer -- which is what the mutator prompts ask
+// for, and all they will produce: they forbid hard-coding an expected answer.
 node main(task: string): string {
-  optimize const style = "Be warm and chatty, and set the scene before answering."
-  const response = llm("${style} What is the capital of France?")
+  optimize const style = "Explain the history of the city in a paragraph before giving your answer."
+  const response = llm("${style} ${task}")
   return response
 }

--- a/packages/agency-lang/tests/integration/optimize-efficacy/fixtures/onlyCityName.ts
+++ b/packages/agency-lang/tests/integration/optimize-efficacy/fixtures/onlyCityName.ts
@@ -2,12 +2,13 @@
 // Imports from the public API exactly as a user outside the repo would
 // (resolved in-tree via Node self-referencing). Needs no LLM, so the
 // custom-grader run is cheap and its grading is deterministic.
-import { type Grader } from "agency-lang/optimize";
+import { grader } from "agency-lang/eval";
 
 // Full marks only for a bare city name: one short line, no sentence around it.
-const onlyCityName: Grader = ({ output }) => {
-  const text = String(output).trim();
-  return /^[A-Za-z][A-Za-z' -]{0,40}$/.test(text) && !/\s(is|the|of)\s/i.test(text) ? 1 : 0;
-};
-
-export default onlyCityName;
+export default grader(
+  ({ output }) => {
+    const text = String(output).trim();
+    return /^[A-Za-z][A-Za-z' -]{0,40}$/.test(text) && !/\s(is|the|of)\s/i.test(text) ? 1 : 0;
+  },
+  { name: "only-city-name" },
+);

--- a/packages/agency-lang/tests/integration/optimize-efficacy/test.mjs
+++ b/packages/agency-lang/tests/integration/optimize-efficacy/test.mjs
@@ -56,7 +56,10 @@ const RUNS = [
   {
     name: "suite-graders-override",
     flags: `--suite ${q(SUITE)} --graders ${q(GRADER)}`,
-    check: ({ runDir }) => expectNoGraderNames(runDir, ["bare-paris", "bare-tokyo"]),
+    check: ({ runDir }) => {
+      expectNoGraderNames(runDir, ["bare-paris", "bare-tokyo"]);
+      expectGraderNames(runDir, ["only-city-name"]);
+    },
   },
   // A held-out validation input picks the champion.
   {
@@ -65,6 +68,9 @@ const RUNS = [
     check: ({ summary }) => {
       if (summary.validationObjective !== 1) {
         throw new Error(`validation objective ${summary.validationObjective}, expected 1`);
+      }
+      if (!summary.iterations.some((i) => i.validationObjective !== undefined)) {
+        throw new Error("no iteration recorded a validation objective");
       }
     },
   },
@@ -79,7 +85,10 @@ const RUNS = [
     name: "one-test-config-graders",
     flags: `--suite ${q(ONE_TEST)}`,
     cwd: projectWithConfig({ eval: { optimize: { graders: GRADER } } }),
-    check: ({ runDir }) => expectNoGraderNames(runDir, ["bare-tokyo"]),
+    check: ({ runDir }) => {
+      expectNoGraderNames(runDir, ["bare-tokyo"]);
+      expectGraderNames(runDir, ["only-city-name"]);
+    },
   },
 ];
 
@@ -89,7 +98,8 @@ function projectWithConfig(extra) {
   const dir = join(runsDir, "project");
   mkdirSync(dir, { recursive: true });
   const base = JSON.parse(readFileSync(join(PACKAGE_DIR, "agency.json"), "utf-8"));
-  writeFileSync(join(dir, "agency.json"), JSON.stringify({ ...base, ...extra }, null, 2));
+  const merged = { ...base, ...extra, eval: { ...base.eval, ...extra.eval } };
+  writeFileSync(join(dir, "agency.json"), JSON.stringify(merged, null, 2));
   return dir;
 }
 

--- a/packages/agency-lang/tests/integration/optimize-efficacy/test.mjs
+++ b/packages/agency-lang/tests/integration/optimize-efficacy/test.mjs
@@ -1,8 +1,8 @@
 // Optimizer efficacy integration test (REAL LLM, main-only).
 //
-// Proves both built-in optimizers (greedy, gepa) plus the custom-grader and
-// custom-optimizer loaders can optimize a trivial agent: replace a chatty
-// style line so the agent answers with the bare city name.
+// One run per way `agency optimize` can take its inputs, grade, and search,
+// each on a trivial agent: replace a style line so the agent answers with the
+// bare city name. Every run must beat its baseline AND produce bare city names.
 //
 // Runs IN-TREE (not via a temp tarball project): the optimizer forks a workspace
 // and runs the agent in a subprocess that resolves `agency-lang` by walking up to
@@ -11,7 +11,7 @@
 // Invoked only by the post-merge `test-with-llm.yml` workflow; never on PRs.
 
 import { execSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -24,7 +24,13 @@ const PACKAGE_DIR = dirname(dirname(dirname(HERE)));
 const AGENT = join(HERE, "fixtures", "agent.agency");
 const GRADER = join(HERE, "fixtures", "onlyCityName.ts");
 const OPTIMIZER = join(HERE, "fixtures", "customOptimizer.ts");
-const GOAL = "Reply with only the capital city name and nothing else";
+// The suite is written the way evals are written now: a directory per test
+// holding test.json and graders.ts. Shared with the no-LLM eval-run test.
+const SUITE = join(PACKAGE_DIR, "tests", "integration", "eval-suite", "capitals");
+const ONE_TEST = join(SUITE, "capital-of-japan");
+// --goal alone is one synthetic input whose task IS the goal text, so the goal
+// has to carry the question too.
+const GOAL = "What is the capital of France? Reply with only the city name and nothing else.";
 
 const ITERATIONS = Number(process.env.OPTIMIZE_EFFICACY_ITERATIONS ?? "3");
 const RETRIES = Number(process.env.OPTIMIZE_EFFICACY_RETRIES ?? "2");
@@ -34,23 +40,94 @@ const q = (s) => JSON.stringify(s);
 
 const runsDir = mkdtempSync(join(PACKAGE_DIR, "optimize-efficacy-runs-"));
 
+// Each row covers one thing the rows above it do not. `check` gets the run's
+// summary.json and the run directory, and throws on anything wrong beyond the
+// shared improvement check.
 const RUNS = [
-  { name: "greedy-judge", flags: `--goal ${q(GOAL)}` },
-  { name: "gepa-judge", flags: `--optimizer gepa --goal ${q(GOAL)} --minibatch 1` },
-  { name: "greedy-grader", flags: `--goal ${q(GOAL)} --graders ${q(GRADER)}` },
-  { name: "custom-optimizer", flags: `--optimizer ${q(OPTIMIZER)} --goal ${q(GOAL)}` },
+  // Inputs from --goal alone; the goal judge grades.
+  { name: "goal-judge", flags: `--goal ${q(GOAL)}` },
+  // Inputs from a suite directory; each test's own graders.ts grades it.
+  {
+    name: "suite-graders",
+    flags: `--suite ${q(SUITE)}`,
+    check: ({ runDir }) => expectGraderNames(runDir, ["bare-paris", "bare-tokyo"]),
+  },
+  // --graders replaces every test's own graders.
+  {
+    name: "suite-graders-override",
+    flags: `--suite ${q(SUITE)} --graders ${q(GRADER)}`,
+    check: ({ runDir }) => expectNoGraderNames(runDir, ["bare-paris", "bare-tokyo"]),
+  },
+  // A held-out validation input picks the champion.
+  {
+    name: "suite-validation-split",
+    flags: `--suite ${q(SUITE)} --validation-split 0.5`,
+    check: ({ summary }) => {
+      if (summary.validationObjective !== 1) {
+        throw new Error(`validation objective ${summary.validationObjective}, expected 1`);
+      }
+    },
+  },
+  // The other built-in optimizer.
+  { name: "suite-gepa", flags: `--suite ${q(SUITE)} --optimizer gepa --minibatch 1` },
+  // A user-written optimizer module.
+  { name: "suite-custom-optimizer", flags: `--suite ${q(SUITE)} --optimizer ${q(OPTIMIZER)}` },
+  // A single test directory as the suite, with the grader override coming from
+  // agency.json's eval.optimize instead of a flag. The CLI reads the nearest
+  // agency.json above its cwd, so this run's cwd is a directory holding one.
+  {
+    name: "one-test-config-graders",
+    flags: `--suite ${q(ONE_TEST)}`,
+    cwd: projectWithConfig({ eval: { optimize: { graders: GRADER } } }),
+    check: ({ runDir }) => expectNoGraderNames(runDir, ["bare-tokyo"]),
+  },
 ];
 
-function runOnce({ name, flags }) {
+// A directory under this package (so `agency-lang` still resolves) whose
+// agency.json is this package's plus `extra`.
+function projectWithConfig(extra) {
+  const dir = join(runsDir, "project");
+  mkdirSync(dir, { recursive: true });
+  const base = JSON.parse(readFileSync(join(PACKAGE_DIR, "agency.json"), "utf-8"));
+  writeFileSync(join(dir, "agency.json"), JSON.stringify({ ...base, ...extra }, null, 2));
+  return dir;
+}
+
+function graderNames(runDir) {
+  const grades = JSON.parse(readFileSync(join(runDir, "champion", "grades.json"), "utf-8"));
+  return grades.flatMap((input) => input.grades.map((g) => g.grader));
+}
+
+function expectGraderNames(runDir, names) {
+  const seen = graderNames(runDir);
+  for (const name of names) {
+    if (!seen.includes(name)) throw new Error(`grader ${name} did not grade the champion: ${seen}`);
+  }
+}
+
+function expectNoGraderNames(runDir, names) {
+  const seen = graderNames(runDir);
+  for (const name of names) {
+    if (seen.includes(name))
+      throw new Error(`grader ${name} graded the champion but was overridden: ${seen}`);
+  }
+}
+
+function runOnce({ name, flags, cwd, check }) {
   const runId = `${name}-${Date.now()}`;
   const cmd =
-    `node ./dist/scripts/agency.js optimize ${q(AGENT)} ${flags} ` +
+    `node ${q(join(PACKAGE_DIR, "dist", "scripts", "agency.js"))} optimize ${q(AGENT)} ${flags} ` +
     `--iterations ${ITERATIONS} --runs-dir ${q(runsDir)} --run-id ${q(runId)} ` +
     `--no-writeback --silent`;
   console.log(`[${name}] ${cmd}`);
-  execSync(cmd, { cwd: PACKAGE_DIR, stdio: "inherit", timeout: 600_000 });
+  execSync(cmd, {
+    cwd: cwd ?? PACKAGE_DIR,
+    stdio: "inherit",
+    timeout: 600_000,
+  });
 
-  const summary = JSON.parse(readFileSync(join(runsDir, runId, "summary.json"), "utf-8"));
+  const runDir = join(runsDir, runId);
+  const summary = JSON.parse(readFileSync(join(runDir, "summary.json"), "utf-8"));
   const { trainObjective, baselineObjective, championBreakdown } = summary;
 
   if (typeof trainObjective !== "number" || typeof baselineObjective !== "number") {
@@ -64,10 +141,11 @@ function runOnce({ name, flags }) {
   // pass, and there has to be at least one -- an empty breakdown would
   // otherwise sail through.
   const outputs = (championBreakdown ?? []).map((b) => String(b.output));
-  const isBareCity = (o) => /^paris[.!]?$/i.test(o.trim());
+  const isBareCity = (o) => /^(paris|tokyo)[.!]?$/i.test(o.trim());
   if (outputs.length === 0 || !outputs.every(isBareCity)) {
     throw new Error(`champion outputs are not all the bare city name: ${JSON.stringify(outputs)}`);
   }
+  if (check) check({ summary, runDir });
   console.log(`[${name}] PASS (baseline ${baselineObjective} -> champion ${trainObjective})`);
 }
 
@@ -87,7 +165,10 @@ function runWithRetries(run) {
 
 let failed = false;
 const skipped = [];
+// OPTIMIZE_EFFICACY_ONLY=a,b runs just those rows, for debugging one case.
+const only = process.env.OPTIMIZE_EFFICACY_ONLY?.split(",");
 for (const run of RUNS) {
+  if (only && !only.includes(run.name)) continue;
   if (run.skip) {
     console.log(`[${run.name}] SKIPPED: ${run.skip}`);
     skipped.push(run.name);


### PR DESCRIPTION
## Why

The post-merge real-LLM workflow was red on `main` at the `gepa-judge` row of the optimizer efficacy test: three attempts, "champion 0 <= baseline 0". Running it locally showed the rewritten prompts. Every one had the shape "be chatty, unless the user asks for brevity":

> By default, be warm and chatty, and set the scene briefly before answering. However, whenever the user gives an explicit output-formatting instruction (for example: "Reply with only the capital city name and nothing else"...), follow that formatting exactly...

The fixture's prompt is `"${style} What is the capital of France?"`. Nobody asks for brevity, so the exception never fires.

The cause: GEPA's reflection prompt (`gepaReflect.agency`) never received the goal. It got the target, the judge's feedback, and the retry history. The only place the goal text appeared was quoted inside the judge's feedback, and the prompt frames everything as "task inputs given to the assistant", so the mutator read it as a user request. Greedy's prompt has a `GOALS:` section and passed every time.

## What changed

- `gepaReflect.agency` gets a `GOALS:` section, rendered by the same `renderGoalsSection` greedy uses (extracted from `buildMutatorSections`). With it, GEPA accepts on iteration 1 locally.
- The free-text type description said `keep every ${...} placeholder`; the mutator pasted that literal `${...}` into a value, which fails to parse as an Agency string (that was the wasted iteration 1). It now describes the placeholders without showing one.
- The efficacy test is a matrix now, one run per way `agency optimize` takes inputs and grades: `--goal` alone, a suite of test directories with per-test `graders.ts`, `--graders` override, `--validation-split`, gepa, a custom optimizer module, and a single test directory with the grader coming from `agency.json`. Before, only `--goal` plus `--graders` were exercised; the `test.json` + `graders.ts` shape was not run by CI anywhere.
- The suite (`tests/integration/eval-suite/capitals`) is written the way evals are written now. The no-LLM `eval-run` test (every PR) runs it and grades it with `eval grade` against `solution.agency` (mean 1) and `wrong.agency` (mean 0), so `graders.ts` discovery and `eval grade` are checked without a model.
- The fixture's bad baseline is now "explain the history in a paragraph" rather than "be warm and chatty".

## Verified

- All seven efficacy rows pass locally with real LLM calls and retries disabled (`OPTIMIZE_EFFICACY_RETRIES=0`).
- `tests/integration/eval-run/test.mjs` passes, including the always-wrong agent scoring 0.
- `pnpm run typecheck`, `pnpm run lint:structure`, prettier on changed files, and the optimize unit tests (new test: the proposer sees every minibatch input's goal).

Not covered by the matrix: `--suite` pointing at a single `{"inputs": [...]}` file (the loader is shared with `eval run`, which the eval-run test already exercises in that form) and `--validation-suite` (same code path as `--validation-split` after loading).

Also noticed, not changed: `docs/site/cli/optimize.md` says `--inputs` and `--validation-inputs`; the flags are `--suite` and `--validation-suite`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Agczg2uKQTbpWanCyHK1vh
