### PR TITLE
Read match-expression results from the block frame inside blocks

### DIFF
--- a/packages/agency-lang/TODO.md
+++ b/packages/agency-lang/TODO.md
@@ -222,23 +222,6 @@ Seeing this inside a thread block:
 But the var I'm referencing is declared in the thread block.
 ---
 
-A `match` expression inside a block that pauses and resumes (a guard trip
-answered with `approve`) evaluates to null. Reading the same Result with
-`isFailure(r)` / `r.value` works, and a `match` on the guard's own Result
-outside the block works. Pinned in
-tests/agency/supervise/nestedGuardResume.agency (matchInsideResumedBlock
-currently expects the buggy `null`; flip it when fixed). Agents that may run
-inside a supervised block therefore avoid `match` on guard Results.
-
----
-
-A ternary (`if c then a else b`) inside a block body evaluates to null: the
-ternary's match value is written to the enclosing frame and read from the
-block frame. An if/else statement in the same position works. Pinned in
-tests/agency/agents/blockProbe.agency and filed as #591. Same family as #590.
-
----
-
 Pattern matching on type would help with stuff like this:
 
 ```ts

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -267,13 +267,11 @@ export class TypeScriptBuilder {
   // expression-match regions, every one of which routes through
   // `processMatchExpressionPlain` in a handler, and (b) the builder never
   // switches OUT of plain mode within the IIFE — it does not reset
-  // `insideHandlerBody` at block-argument / nested-frame boundaries, so nothing
-  // stepped compiles inside a handler. At every yield site this flag therefore
-  // currently equals `insideHandlerBody`. If a future change starts compiling
-  // stepped constructs inside a handler (e.g. resetting `insideHandlerBody` per
-  // frame), reset THIS flag at those same boundaries too — otherwise a stepped
-  // match nested in a plain arm would emit a bare `return` inside a step
-  // callback (value discarded, `_matchExit` never set: a silent wrong answer).
+  // `insideHandlerBody` anywhere except at block boundaries, where `stepped()`
+  // resets THIS flag too. Both flags must always be reset together — otherwise
+  // a stepped match inside a block in a plain arm would emit a bare `return`
+  // inside a step callback (value discarded, `_matchExit` never set: a silent
+  // wrong answer).
   private insidePlainMatchExpr: boolean = false;
 
   /*
@@ -1094,11 +1092,9 @@ export class TypeScriptBuilder {
             // to Agency's single nothing-value, `null`. This one read site is
             // the chokepoint for every match-result path (stepped no-arm and
             // the plain-mode IIFE that returns `undefined`). See #409.
-            // `exitMatch` writes to the frame of the runner that ran the
-            // match: `__stack` in a node or function, `__bstack` inside a
-            // block. Read from the same one (#928).
-            const frameScope = this.scopes.current().type === "block" ? "block" : "local";
-            return ts.call(ts.id("__nn"), [ts.scopedVar(literal.value, frameScope, this.moduleId)]);
+            return ts.call(ts.id("__nn"), [
+              ts.scopedVar(literal.value, this.matchValFrameScope(), this.moduleId),
+            ]);
           }
           return ts.id(literal.value);
         }
@@ -1668,9 +1664,19 @@ export class TypeScriptBuilder {
       this.insidePlainMatchExpr = prev;
     }
     return ts.assign(
-      ts.scopedVar(matchValName(matchId), "local", this.moduleId),
+      ts.scopedVar(matchValName(matchId), this.matchValFrameScope(), this.moduleId),
       ts.await(ts.iife({ async: true, body: [ifChain] })),
     );
+  }
+
+  /**
+   * The frame a `__matchval_<id>` temp lives in: `__bstack` inside a block,
+   * `__stack` in a node or function. The stepped writer (`runner.exitMatch`)
+   * uses the running runner's frame, which is the same choice. Every read
+   * and the plain-mode write go through here so they cannot drift (#928).
+   */
+  private matchValFrameScope(): "block" | "local" {
+    return this.scopes.current().type === "block" ? "block" : "local";
   }
 
   private processImportStatement(node: ImportStatement): TsNode {
@@ -1768,6 +1774,26 @@ export class TypeScriptBuilder {
    * Process a block argument into a wrapped AgencyFunction TsNode.
    * Shared by generateFunctionCallExpression and buildCallDescriptor.
    */
+  /**
+   * Compile a block body in stepped mode even when the block appears inside
+   * a handler body. A block gets its own frame and Runner, so its `return`
+   * must be `runner.halt(...)`, not the handler's plain `return` (which would
+   * exit a step callback and drop the value). Resets both plain-mode flags
+   * for the duration of `compile` and restores them after.
+   */
+  private stepped<T>(compile: () => T): T {
+    const prevHandler = this.insideHandlerBody;
+    const prevMatch = this.insidePlainMatchExpr;
+    this.insideHandlerBody = false;
+    this.insidePlainMatchExpr = false;
+    try {
+      return compile();
+    } finally {
+      this.insideHandlerBody = prevHandler;
+      this.insidePlainMatchExpr = prevMatch;
+    }
+  }
+
   private processBlockArgument(
     node: Pick<FunctionCall, "block"> & { functionName?: string },
   ): TsNode {
@@ -1801,12 +1827,14 @@ export class TypeScriptBuilder {
       declaredYieldType: block.declaredYieldType,
     });
     this._sourceMapBuilder.enterScope(this.moduleId, blockName);
-    const compiledFinalize = this.finalize.compileScope({
-      body: block.body,
-      scopeName: blockName,
-      errorVar: "__blockError",
-      compileBodyRest: (rest) => this.processBodyAsParts(rest),
-    });
+    const compiledFinalize = this.stepped(() =>
+      this.finalize.compileScope({
+        body: block.body,
+        scopeName: blockName,
+        errorVar: "__blockError",
+        compileBodyRest: (rest) => this.processBodyAsParts(rest),
+      }),
+    );
     this._sourceMapBuilder.enterScope(this.moduleId, parentScopeName);
     this.scopes.pop();
 
@@ -1851,12 +1879,14 @@ export class TypeScriptBuilder {
     const parentScopeName = this.scopes.currentName();
     this.scopes.push({ type: "block", blockName });
     this._sourceMapBuilder.enterScope(this.moduleId, blockName);
-    const compiledFinalize = this.finalize.compileScope({
-      body: block.body,
-      scopeName: blockName,
-      errorVar: "__blockError",
-      compileBodyRest: (rest) => this.processBodyAsParts(rest),
-    });
+    const compiledFinalize = this.stepped(() =>
+      this.finalize.compileScope({
+        body: block.body,
+        scopeName: blockName,
+        errorVar: "__blockError",
+        compileBodyRest: (rest) => this.processBodyAsParts(rest),
+      }),
+    );
     this._sourceMapBuilder.enterScope(this.moduleId, parentScopeName);
     this.scopes.pop();
 
@@ -2794,7 +2824,7 @@ export class TypeScriptBuilder {
     this.steps.enterForkBlock();
     this.scopes.push({ type: "block", blockName });
     this._sourceMapBuilder.enterScope(this.moduleId, blockName);
-    const bodyParts = this.processBodyAsParts(block.body);
+    const bodyParts = this.stepped(() => this.processBodyAsParts(block.body));
     this._sourceMapBuilder.enterScope(this.moduleId, parentScopeName);
     this.scopes.pop();
     this.steps.exitForkBlock();

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -1077,7 +1077,7 @@ export class TypeScriptBuilder {
           }
           // Synthetic match-expression result temps (`__matchval_<id>`) are
           // written by `runner.exitMatch(id, value)` into
-          // `runner.frame.locals.__matchval_<id>` (i.e. `__stack.locals`), but
+          // `runner.frame.locals.__matchval_<id>`, but
           // pattern lowering emits the *read* as a plain `variableName` with
           // no declaration, so scope resolution leaves it unresolved and it
           // would otherwise compile to a bare, undeclared JS identifier.
@@ -1094,7 +1094,11 @@ export class TypeScriptBuilder {
             // to Agency's single nothing-value, `null`. This one read site is
             // the chokepoint for every match-result path (stepped no-arm and
             // the plain-mode IIFE that returns `undefined`). See #409.
-            return ts.call(ts.id("__nn"), [ts.scopedVar(literal.value, "local", this.moduleId)]);
+            // `exitMatch` writes to the frame of the runner that ran the
+            // match: `__stack` in a node or function, `__bstack` inside a
+            // block. Read from the same one (#928).
+            const frameScope = this.scopes.current().type === "block" ? "block" : "local";
+            return ts.call(ts.id("__nn"), [ts.scopedVar(literal.value, frameScope, this.moduleId)]);
           }
           return ts.id(literal.value);
         }

--- a/packages/agency-lang/tests/agency/agents/blockProbe.agency
+++ b/packages/agency-lang/tests/agency/agents/blockProbe.agency
@@ -1,10 +1,9 @@
 // Characterizes what works inside a block body, which the agents rely on
 // when they pass work to helpers like std::strategy revise.
 //
-// FINDING (2026-07-18): a ternary (`if c then a else b`) inside a block
-// evaluates to null. The codegen stores the ternary's value on the parent
-// frame while the block reads from its own, so the read misses. An if/else
-// statement in the same position works. Closures over enclosing locals work.
+// A ternary (`if c then a else b`) inside a block used to evaluate to null
+// (#591, fixed with #928): the block read the ternary's value from the parent
+// frame instead of its own. Closures over enclosing locals work.
 def runBlock(block: (string) -> any): any {
   return block("arg")
 }
@@ -17,8 +16,7 @@ node closureOverLocal(): string {
   }
 }
 
-// KNOWN BUG, pinned so a fix flips these two: a ternary inside a block
-// evaluates to null, whether or not it touches an enclosing local.
+// A ternary inside a block, with and without an enclosing local.
 node ternaryOnBlockArg(): string {
   return runBlock() as arg {
     const picked = if arg == "" then "empty" else "nonempty"
@@ -34,7 +32,7 @@ node ternaryOverLocal(): string {
   }
 }
 
-// The if/else workaround the agents use instead.
+// An if/else statement in the same position.
 node ifElseInBlockWorks(): string {
   const outer = "outer-value"
   return runBlock() as arg {

--- a/packages/agency-lang/tests/agency/agents/blockProbe.test.json
+++ b/packages/agency-lang/tests/agency/agents/blockProbe.test.json
@@ -1,8 +1,8 @@
 {
   "tests": [
     { "nodeName": "closureOverLocal", "description": "a block closes over an enclosing local", "input": "", "expectedOutput": "\"arg|outer-value\"", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "ternaryOnBlockArg", "description": "KNOWN BUG: a ternary inside a block evaluates to null", "input": "", "expectedOutput": "null", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "ternaryOverLocal", "description": "KNOWN BUG: a ternary inside a block evaluates to null, enclosing local case", "input": "", "expectedOutput": "null", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "ternaryOnBlockArg", "description": "a ternary inside a block reads the block arg", "input": "", "expectedOutput": "\"nonempty\"", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "ternaryOverLocal", "description": "a ternary inside a block, enclosing local case", "input": "", "expectedOutput": "\"arg\"", "evaluationCriteria": [{ "type": "exact" }] },
     { "nodeName": "ifElseInBlockWorks", "description": "an if/else statement in the same position works", "input": "", "expectedOutput": "\"arg\"", "evaluationCriteria": [{ "type": "exact" }] }
   ]
 }

--- a/packages/agency-lang/tests/agency/match-expr-in-block.agency
+++ b/packages/agency-lang/tests/agency/match-expr-in-block.agency
@@ -32,3 +32,29 @@ node matchInNestedBlock() {
   }
   return xs.join(",")
 }
+
+// A handler body compiles in plain mode, and a block inside it inherits that.
+// The plain-mode write and the read must pick the same frame.
+def guarded(): number {
+  const check = interrupt("confirm?")
+  return 42
+}
+
+node matchInBlockInHandler() {
+  handle {
+    const r = guarded()
+    if (isFailure(r)) {
+      return r.error
+    }
+    return "approved"
+  } with (data) {
+    const labels = map([1, 2]) as p {
+      const m = match (p) {
+        1 => "one"
+        _ => "other"
+      }
+      return m
+    }
+    return reject(labels.join(","))
+  }
+}

--- a/packages/agency-lang/tests/agency/match-expr-in-block.agency
+++ b/packages/agency-lang/tests/agency/match-expr-in-block.agency
@@ -1,0 +1,34 @@
+// A value-producing match or if-then-else inside a trailing block must read
+// its result from the block's own frame (#928).
+node matchInBlock() {
+  const xs = map([1, 2]) as p {
+    const m = match (p) {
+      1 => "one"
+      _ => "other"
+    }
+    return m
+  }
+  return xs.join(",")
+}
+
+node ifElseInBlock() {
+  const xs = map([1, 2]) as p {
+    const e = if p == 1 then "one" else "other"
+    return e
+  }
+  return xs.join(",")
+}
+
+node matchInNestedBlock() {
+  const xs = map([1, 2]) as p {
+    const ys = map([10, 20]) as q {
+      const m = match (q) {
+        10 => "ten"
+        _ => "more"
+      }
+      return "${p}${m}"
+    }
+    return ys.join("+")
+  }
+  return xs.join(",")
+}

--- a/packages/agency-lang/tests/agency/match-expr-in-block.test.json
+++ b/packages/agency-lang/tests/agency/match-expr-in-block.test.json
@@ -1,0 +1,22 @@
+{
+  "tests": [
+    {
+      "nodeName": "matchInBlock",
+      "input": "",
+      "expectedOutput": "\"one,other\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "ifElseInBlock",
+      "input": "",
+      "expectedOutput": "\"one,other\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "matchInNestedBlock",
+      "input": "",
+      "expectedOutput": "\"1ten+1more,2ten+2more\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/match-expr-in-block.test.json
+++ b/packages/agency-lang/tests/agency/match-expr-in-block.test.json
@@ -4,19 +4,41 @@
       "nodeName": "matchInBlock",
       "input": "",
       "expectedOutput": "\"one,other\"",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     },
     {
       "nodeName": "ifElseInBlock",
       "input": "",
       "expectedOutput": "\"one,other\"",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     },
     {
       "nodeName": "matchInNestedBlock",
       "input": "",
       "expectedOutput": "\"1ten+1more,2ten+2more\"",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "matchInBlockInHandler",
+      "input": "",
+      "expectedOutput": "\"one,other\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/supervise/nestedGuardResume.agency
+++ b/packages/agency-lang/tests/agency/supervise/nestedGuardResume.agency
@@ -1,12 +1,9 @@
 // Characterizes what survives a guard pause/resume, which is the mechanism
 // supervise is built on.
 //
-// FINDING (2026-07-18): a `match` expression INSIDE a block that gets paused
-// and resumed evaluates to null (matchInsideResumedBlock). Reading the same
-// Result with isFailure/.value works, and a match on the guard's own Result
-// outside the block works. Agents that may run inside a supervised block
-// therefore read guard Results with isFailure, never match. Recorded in
-// TODO.md.
+// A `match` expression inside a block that gets paused and resumed used to
+// evaluate to null (#590, fixed with #928): the block read the match value
+// from the parent frame instead of its own.
 const log = []
 
 def spin(rounds: number): string {
@@ -17,8 +14,7 @@ def spin(rounds: number): string {
   return "spun"
 }
 
-// KNOWN BUG, pinned so a fix flips this test: match inside the resumed
-// block returns null instead of the matched arm.
+// match inside the resumed block returns the matched arm.
 node matchInsideResumedBlock(): string {
   handle {
     const outer = guard(time: 5ms, label: "a") {

--- a/packages/agency-lang/tests/agency/supervise/nestedGuardResume.test.json
+++ b/packages/agency-lang/tests/agency/supervise/nestedGuardResume.test.json
@@ -1,6 +1,6 @@
 {
   "tests": [
-    { "nodeName": "matchInsideResumedBlock", "description": "KNOWN BUG: match inside a resumed block yields null", "input": "", "expectedOutput": "null", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "matchInsideResumedBlock", "description": "match inside a resumed block yields the matched arm", "input": "", "expectedOutput": "\"ok:inner:spun\"", "evaluationCriteria": [{ "type": "exact" }] },
     { "nodeName": "isFailureInsideResumedBlock", "description": "a nested guard Result survives an outer trip and resume", "input": "", "expectedOutput": "\"ok:inner:spun\"", "evaluationCriteria": [{ "type": "exact" }] },
     { "nodeName": "matchOutsideResumedBlock", "description": "match on the guard own Result outside the block is fine", "input": "", "expectedOutput": "\"ok:spun\"", "evaluationCriteria": [{ "type": "exact" }] }
   ]


### PR DESCRIPTION
Fixes #928. Also fixes #590 and #591, which were the same bug filed earlier.

## The bug

A `match` or `if ... then ... else` expression assigned inside a trailing block (`map(xs) as p { ... }`) evaluated to `null`.

## Why

The compiler lowers a value-producing `match` into an if-chain whose arms call `runner.exitMatch(id, value)`. That writes the value into `runner.frame.locals.__matchval_<id>`. Inside a block, the runner's frame is `__bstack`, so the write landed on `__bstack.locals`. But the generated read was hardcoded to `__stack.locals.__matchval_<id>`, the enclosing node's frame, which never had the value:

```js
__bstack.locals.m = __nn(__stack.locals.__matchval_1);   // before
__bstack.locals.m = __nn(__bstack.locals.__matchval_1);  // after
```

## The fix

`matchValFrameScope()` in `typescriptBuilder.ts` picks `"block"` when the current scope is a block, `"local"` otherwise. Both the read and the plain-mode (handler body) write use it.

Review found a second problem in the same shape: a block inside a handler body inherited plain-mode codegen, so its `return` was a bare `return` inside a step callback and the block yielded `undefined`. Blocks get their own `Runner`, so `stepped()` now resets the two plain-mode flags at every block boundary.

## Tests

- `tests/agency/match-expr-in-block.agency`: `match` in a block, `if-then-else` in a block, `match` in a nested block, `match` in a block inside a handler. 0/4 on main, 4/4 here.
- `agents/blockProbe` and `supervise/nestedGuardResume` pinned the old `null` for #590/#591; they now expect the real value. The matching TODO.md entries are gone.
- Builder unit tests and TypeScript generator fixtures (561) pass; `pnpm run typecheck` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8WgPvTTtUyQwJWrXGxAgh
