### PR TITLE
Parse unary minus on any expression

### DIFF
--- a/packages/agency-lang/lib/backends/agencyGenerator.roundtrip.test.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.roundtrip.test.ts
@@ -168,6 +168,18 @@ describe("formatter gate: pinned repros", () => {
     );
   });
 
+  it("a prefix operator keeps the parens around a compound operand (#933)", () => {
+    // Dropping them changes the program: -(a + b) vs -a + b.
+    const src = `def f(a: number, b: number, c: boolean, d: boolean): number {\n  const n = -(a + b)\n  const m = -x ** 2\n  const k = !(c && d)\n  return n\n}\n`;
+    const printed = generateAgency(parseTemplateMode(src));
+    expect(printed).toContain("-(a + b)");
+    expect(printed).toContain("-x ** 2");
+    expect(printed).toContain("!(c && d)");
+    expect(normalized(parseTemplateMode(printed).nodes)).toEqual(
+      normalized(parseTemplateMode(src).nodes),
+    );
+  });
+
   it("a zero-parameter signature never wraps to (\\n\\n) (apple corruption)", () => {
     const src = `export idempotent def listAllOfTheThingsInTheApp(): Result<SomeVeryLongTypeName[]> raises <std::notes::list> {\n  return 1\n}\n`;
     const printed = generateAgency(parseTemplateMode(src));

--- a/packages/agency-lang/lib/backends/agencyGenerator.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.ts
@@ -72,7 +72,7 @@ import { AgencyConfig, BUILTIN_VARIABLES } from "@/config.js";
 import { mergeDeep } from "@/utils.js";
 import { MessageThread } from "@/types/messageThread.js";
 import { Skill } from "@/types/skill.js";
-import { BinOpArgument, BinOpExpression, Operator, PRECEDENCE } from "@/types/binop.js";
+import { BinOpArgument, BinOpExpression, Operator, PRECEDENCE, PREFIX_OPS } from "@/types/binop.js";
 import { expressionToString } from "@/utils/node.js";
 import { Keyword } from "@/types/keyword.js";
 import { HandleBlock } from "@/types/handleBlock.js";
@@ -2111,11 +2111,13 @@ export class AgencyGenerator {
   protected processBinOpExpression(node: BinOpExpression, assigned: boolean = false): string {
     const op = node.operator;
 
-    // Unary prefix operators: !x, typeof x, void x
-    if (op === "!" || op === "typeof" || op === "void") {
-      const operand = this.processNode(node.right).trim();
-      const sep = op === "!" ? "" : " ";
-      const result = `${op}${sep}${operand}`;
+    // Unary prefix operators: !x, -x, typeof x, void x
+    if (PREFIX_OPS.includes(op)) {
+      const inner = this.processNode(node.right).trim();
+      const operand = this.needsParensRight(node.right, op) ? `(${inner})` : inner;
+      const symbol = op === "unary-" ? "-" : op;
+      const sep = symbol.length === 1 ? "" : " ";
+      const result = `${symbol}${sep}${operand}`;
       return assigned ? result : this.indentStr(result);
     }
 

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -51,7 +51,7 @@ import * as renderFunctionCatchFailure from "../templates/backends/typescriptGen
 
 import { AgencyConfig, DEFAULT_MODEL, DEFAULT_PROVIDER } from "@/config.js";
 import { parseDurationMs } from "@/duration.js";
-import { BinOpArgument, BinOpExpression, Operator, PRECEDENCE } from "@/types/binop.js";
+import { BinOpArgument, BinOpExpression, Operator, PRECEDENCE, PREFIX_OPS } from "@/types/binop.js";
 import { MessageThread } from "@/types/messageThread.js";
 import { walkNodes } from "@/utils/node.js";
 import { AccessChainElement, ValueAccess } from "../types/access.js";
@@ -463,8 +463,14 @@ export class TypeScriptBuilder {
 
   private needsParensLeft(child: BinOpArgument, parentOp: Operator): boolean {
     if (child.type !== "binOpExpression") return false;
-    // For right-associative ops like **, (2 ** 3) ** 4 needs parens on the left
-    if (parentOp === "**") return PRECEDENCE[child.operator] <= PRECEDENCE[parentOp];
+    // For right-associative ops like **, (2 ** 3) ** 4 needs parens on the left.
+    // JS also refuses a bare prefix operator there: `-x ** 2` is a syntax
+    // error, so it must print as `(-x) ** 2`.
+    if (parentOp === "**") {
+      return (
+        PREFIX_OPS.includes(child.operator) || PRECEDENCE[child.operator] <= PRECEDENCE[parentOp]
+      );
+    }
     return PRECEDENCE[child.operator] < PRECEDENCE[parentOp];
   }
 
@@ -1269,6 +1275,11 @@ export class TypeScriptBuilder {
     }
     if (node.operator === "typeof" || node.operator === "void") {
       return ts.unaryOp(node.operator, this.processNode(node.right));
+    }
+    if (node.operator === "unary-") {
+      return ts.unaryOp("-", this.processNode(node.right), {
+        paren: this.needsParensRight(node.right, node.operator),
+      });
     }
     // Compound assignment to a global variable: globals are accessed via
     // `__ctx.globals.get(...)`, which is not a valid assignment target,

--- a/packages/agency-lang/lib/parsers/expression.test.ts
+++ b/packages/agency-lang/lib/parsers/expression.test.ts
@@ -204,6 +204,51 @@ describe("exprParser", () => {
   });
 
   describe("unary operators", () => {
+    it("parses unary minus on a variable (#933)", () => {
+      const result = exprParser("-x");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.result).toEqualWithoutLoc({
+          type: "binOpExpression",
+          operator: "unary-",
+          left: { type: "boolean", value: true },
+          right: { type: "variableName", value: "x" },
+        });
+      }
+    });
+
+    it("keeps -42 a number literal", () => {
+      const result = exprParser("-42");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.result).toEqualWithoutLoc({ type: "number", value: "-42" });
+      }
+    });
+
+    it("parses -x ** 2 as (-x) ** 2", () => {
+      const result = exprParser("-x ** 2");
+      expect(result.success).toBe(true);
+      if (result.success && result.result.type === "binOpExpression") {
+        expect(result.result.operator).toBe("**");
+        expect(result.result.left.type).toBe("binOpExpression");
+      }
+    });
+
+    it("a prefix operator takes a parenthesized operand", () => {
+      const minus = exprParser("-(a + b)");
+      expect(minus.success).toBe(true);
+      if (minus.success && minus.result.type === "binOpExpression") {
+        expect(minus.result.operator).toBe("unary-");
+        expect(minus.result.right.type).toBe("binOpExpression");
+      }
+      const not = exprParser("!(a && b)");
+      expect(not.success).toBe(true);
+      if (not.success && not.result.type === "binOpExpression") {
+        expect(not.result.operator).toBe("!");
+        expect(not.result.right.type).toBe("binOpExpression");
+      }
+    });
+
     it("should parse logical not", () => {
       const result = exprParser("!x");
       expect(result.success).toBe(true);

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -3502,19 +3502,46 @@ export function valueAccessParser(
 // Desugared to BinOpExpression: !x → { op: "!", left: true, right: x }
 // The builder must generate `!x`, not `true ! x`.
 //
-// Note: unary `-` is NOT included. Negative number literals like `-42` are
-// already handled by numberParser in literals.ts. Adding unary `-` would
-// create ambiguity where `-42` parses as `0 - 42`.
+// What a prefix operator applies to: a parenthesized expression or an atom.
+// Not exprParser, so the operator binds tightly: `!x && y` is `(!x) && y`.
+// parenParser is declared later in this file; calling it inside a function
+// body is fine because parsing only starts after the module has loaded.
+const unaryOperand: Parser<Expression> = (input: string) => {
+  const parenResult = parenParser(input);
+  if (parenResult.success) return parenResult;
+  return atom(input);
+};
+
 const unaryNotParser: Parser<Expression> = (input: string) => {
   const bangResult = char("!")(input);
   if (!bangResult.success) return bangResult;
-  // Recurse to atom (not exprParser) so `!` binds tightly: `!x && y` = `(!x) && y`
-  const atomResult = atom(bangResult.rest);
+  const atomResult = unaryOperand(bangResult.rest);
   if (!atomResult.success) return failure("expected expression after !", input);
   return success(
     {
       type: "binOpExpression" as const,
       operator: "!" as Operator,
+      left: { type: "boolean" as const, value: true },
+      right: atomResult.result,
+    } as BinOpExpression,
+    atomResult.rest,
+  );
+};
+
+// --- Unary - operator ---
+// Desugared like `!`: -x → { op: "unary-", left: true, right: x }.
+// Runs after literalParser in baseAtom, so `-42` stays a number literal and
+// only `-<non-literal>` (a variable, a call, a parenthesized expression)
+// reaches here. `-x ** 2` is `(-x) ** 2`.
+const unaryMinusParser: Parser<Expression> = (input: string) => {
+  const minusResult = char("-")(input);
+  if (!minusResult.success) return minusResult;
+  const atomResult = unaryOperand(minusResult.rest);
+  if (!atomResult.success) return failure("expected expression after -", input);
+  return success(
+    {
+      type: "binOpExpression" as const,
+      operator: "unary-" as Operator,
       left: { type: "boolean" as const, value: true },
       right: atomResult.result,
     } as BinOpExpression,
@@ -3534,7 +3561,7 @@ function unaryKeywordParser(keyword: string): Parser<Expression> {
     }
     const wsResult = spaces(kwResult.rest);
     if (!wsResult.success) return failure(`expected expression after ${keyword}`, input);
-    const atomResult = atom(wsResult.rest);
+    const atomResult = unaryOperand(wsResult.rest);
     if (!atomResult.success) return failure(`expected expression after ${keyword}`, input);
     return success(
       {
@@ -3967,6 +3994,8 @@ const baseAtom: Parser<Expression> = or(
   lazy(() => undefinedAliasParser),
   lazy(() => valueAccessParser),
   lazy(() => literalParser),
+  // After literalParser so `-42` is a literal, not `-(42)`.
+  unaryMinusParser,
 );
 
 // Wrap atom to handle postfix ++ and -- operators.

--- a/packages/agency-lang/lib/typeChecker/synthesizer.ts
+++ b/packages/agency-lang/lib/typeChecker/synthesizer.ts
@@ -556,6 +556,7 @@ function synthBinOp(
   }
 
   if (BOOLEAN_OPS.has(op)) return BOOLEAN_T;
+  if (op === "unary-") return NUMBER_T;
   if (op === "+") {
     const leftType = synthType(expr.left, scope, ctx);
     const rightType = synthType(expr.right, scope, ctx);

--- a/packages/agency-lang/lib/types/binop.ts
+++ b/packages/agency-lang/lib/types/binop.ts
@@ -29,7 +29,7 @@ export type Operator =
   | "||"
   | "!"
   // Unary minus (`-x`). Distinct from binary `-` so consumers can tell
-  // `{ op: "unary-", left: true, right: x }` from `a - b`.
+  // `{ operator: "unary-", left: { type: "boolean", value: true }, right: x }` from `a - b`.
   | "unary-"
   | "typeof"
   | "void"

--- a/packages/agency-lang/lib/types/binop.ts
+++ b/packages/agency-lang/lib/types/binop.ts
@@ -28,6 +28,9 @@ export type Operator =
   | "&&"
   | "||"
   | "!"
+  // Unary minus (`-x`). Distinct from binary `-` so consumers can tell
+  // `{ op: "unary-", left: true, right: x }` from `a - b`.
+  | "unary-"
   | "typeof"
   | "void"
   | "++"
@@ -74,9 +77,13 @@ export const PRECEDENCE: Record<string, number> = {
   "++": 9,
   "--": 9,
   "!": 8,
+  "unary-": 8,
   typeof: 8,
   void: 8,
 };
+
+/** The prefix operators the parser desugars to `{ op, left: true, right }`. */
+export const PREFIX_OPS: Operator[] = ["!", "unary-", "typeof", "void"];
 
 export type BinOpExpression = BaseNode & {
   type: "binOpExpression";

--- a/packages/agency-lang/tests/agency/unary-minus.agency
+++ b/packages/agency-lang/tests/agency/unary-minus.agency
@@ -1,0 +1,45 @@
+// Unary minus on a non-literal (#933). `-42` was always a literal; `-x`,
+// `-f()`, and `-(a + b)` now parse too.
+def abs(n: number): number {
+  let x = n
+  if (x < 0) {
+    x = -x
+  }
+  return x
+}
+
+def negate(n: number): number {
+  return -n
+}
+
+node absOfNegative() {
+  return abs(-7)
+}
+
+node negateCall() {
+  const y = -negate(3)
+  return y
+}
+
+node negateGroup() {
+  const a = 2
+  const b = 3
+  return -(a + b)
+}
+
+node unaryBindsTighterThanPower() {
+  const x = 3
+  return -x ** 2
+}
+
+node binaryMinusStillWorks() {
+  const a = 10
+  const b = 4
+  return a - b - -b
+}
+
+node notOnGroup() {
+  const a = true
+  const b = false
+  return !(a && b)
+}

--- a/packages/agency-lang/tests/agency/unary-minus.test.json
+++ b/packages/agency-lang/tests/agency/unary-minus.test.json
@@ -1,0 +1,64 @@
+{
+  "tests": [
+    {
+      "nodeName": "absOfNegative",
+      "input": "",
+      "expectedOutput": "7",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "negateCall",
+      "input": "",
+      "expectedOutput": "3",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "negateGroup",
+      "input": "",
+      "expectedOutput": "-5",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "unaryBindsTighterThanPower",
+      "input": "",
+      "expectedOutput": "9",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "binaryMinusStillWorks",
+      "input": "",
+      "expectedOutput": "10",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "notOnGroup",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #933.

## The bug

`let y = -n`, `x = -x`, `return -x` all failed to parse with a message that never mentioned the minus sign. Only negative number literals (`-42`) worked. The coding agent writes `x = -x` unprompted and lost a whole eval to it.

## The fix

**Parser.** A `unaryMinusParser` next to `unaryNotParser`, desugared the same way the other prefix operators are:

```
-x   →  { type: "binOpExpression", operator: "unary-", left: true, right: x }
```

It uses a distinct operator name, `"unary-"`, so nothing downstream can confuse it with binary `a - b`. It sits after `literalParser` in `baseAtom`, so `-42` is still a number literal and only `-<non-literal>` reaches it.

While there: no prefix operator could take a parenthesized operand, because `parenParser` is a sibling of `atom` rather than part of it. `!(a && b)` failed to parse on main. All four prefix operators now share one `unaryOperand` parser (paren form first, then atom).

**Codegen.** `-x` compiles to `-x`. JS refuses a bare prefix operator before `**`, so `-x ** 2` compiles to `(-x) ** 2` (`needsParensLeft` treats any prefix operator as needing parens under `**`). A compound operand is parenthesized: `-(a + b)`.

**Formatter.** Prints `-x`, and keeps the parens on a compound operand, so `-(a + b)` does not become `-a + b`.

**Type checker.** `unary-` synthesizes `number`.

## Tests

- `tests/agency/unary-minus.agency`: `x = -x` inside an `if`, `return -n`, `-f()`, `-(a + b)`, `-x ** 2` (= 9), `a - b - -b`, `!(a && b)`. 6/6.
- Parser unit tests for `-x`, `-42` staying a literal, `-x ** 2` grouping, and parenthesized operands for `-` and `!`.
- Formatter pinned repro: `-(a + b)`, `-x ** 2`, `!(c && d)` round-trip structurally.
- Parser, backend, type checker and generator fixture suites: 4384 pass. Typecheck, structural lint and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8WgPvTTtUyQwJWrXGxAgh
