### PR TITLE
Grade every coding eval on whether the saved file is formatted

### DIFF
--- a/packages/agency-lang/docs/site/stdlib/agents/agency/coding.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/agency/coding.md
@@ -46,7 +46,7 @@ Return the Agency writer's tools: the bundled documentation, the source
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/coding.agency#L204))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/coding.agency#L206))
 
 ### agencyCodingAgent
 
@@ -105,4 +105,4 @@ Write an Agency program for the task. Iterates until the source parses,
 
 **Throws:** `std::guard`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/coding.agency#L356))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/coding.agency#L359))

--- a/packages/agency-lang/evals/agency-coding/README.md
+++ b/packages/agency-lang/evals/agency-coding/README.md
@@ -71,6 +71,12 @@ and a reference solution the judge can compare against. Such a test may
 have no harness at all. Only `files/` is seeded into the writer's working
 directory.
 
+Every test also carries `formatted` from `lib/formatted.ts`, at weight
+0.2: the saved file must match what the Agency formatter would produce
+from it. The writer has the stdlib `format` tool for this. A test that
+has only a harness gets a `graders.ts` holding just this grader; the
+harness graders are added alongside it.
+
 ## The tests
 
 Each `test.json` carries one tag, `easy`, `medium`, or `hard`, and nothing

--- a/packages/agency-lang/evals/agency-coding/concurrency-forms/graders.ts
+++ b/packages/agency-lang/evals/agency-coding/concurrency-forms/graders.ts
@@ -1,6 +1,8 @@
+import { formatted } from "../lib/formatted.js";
 import { idiomJudge } from "../lib/idiomJudge.js";
 
 export default [
+  formatted(),
   idiomJudge({
     name: "fork-race-parallel",
     standard: `

--- a/packages/agency-lang/evals/agency-coding/derived-tool-names/graders.ts
+++ b/packages/agency-lang/evals/agency-coding/derived-tool-names/graders.ts
@@ -1,6 +1,8 @@
+import { formatted } from "../lib/formatted.js";
 import { idiomJudge } from "../lib/idiomJudge.js";
 
 export default [
+  formatted(),
   idiomJudge({
     name: "renames-derived-tools",
     weight: 0.6,

--- a/packages/agency-lang/evals/agency-coding/destructive-markers/graders.ts
+++ b/packages/agency-lang/evals/agency-coding/destructive-markers/graders.ts
@@ -1,6 +1,8 @@
+import { formatted } from "../lib/formatted.js";
 import { idiomJudge } from "../lib/idiomJudge.js";
 
 export default [
+  formatted(),
   idiomJudge({
     name: "retry-markers",
     standard: `

--- a/packages/agency-lang/evals/agency-coding/docstrings-knows-how/graders.ts
+++ b/packages/agency-lang/evals/agency-coding/docstrings-knows-how/graders.ts
@@ -1,6 +1,8 @@
+import { formatted } from "../lib/formatted.js";
 import { idiomJudge } from "../lib/idiomJudge.js";
 
 export default [
+  formatted(),
   idiomJudge({
     name: "docstrings-knows-how",
     weight: 0.8,

--- a/packages/agency-lang/evals/agency-coding/docstrings-unasked/graders.ts
+++ b/packages/agency-lang/evals/agency-coding/docstrings-unasked/graders.ts
@@ -1,6 +1,8 @@
+import { formatted } from "../lib/formatted.js";
 import { idiomJudge } from "../lib/idiomJudge.js";
 
 export default [
+  formatted(),
   idiomJudge({
     name: "docstrings-unasked",
     standard: `

--- a/packages/agency-lang/evals/agency-coding/effect-payload-types/graders.ts
+++ b/packages/agency-lang/evals/agency-coding/effect-payload-types/graders.ts
@@ -1,6 +1,8 @@
+import { formatted } from "../lib/formatted.js";
 import { idiomJudge } from "../lib/idiomJudge.js";
 
 export default [
+  formatted(),
   idiomJudge({
     name: "declares-the-payload",
     weight: 0.6,

--- a/packages/agency-lang/evals/agency-coding/guards/graders.ts
+++ b/packages/agency-lang/evals/agency-coding/guards/graders.ts
@@ -1,6 +1,8 @@
+import { formatted } from "../lib/formatted.js";
 import { idiomJudge } from "../lib/idiomJudge.js";
 
 export default [
+  formatted(),
   idiomJudge({
     name: "time-guard-per-call",
     standard: `

--- a/packages/agency-lang/evals/agency-coding/handler-chain/graders.ts
+++ b/packages/agency-lang/evals/agency-coding/handler-chain/graders.ts
@@ -1,6 +1,8 @@
+import { formatted } from "../lib/formatted.js";
 import { idiomJudge } from "../lib/idiomJudge.js";
 
 export default [
+  formatted(),
   idiomJudge({
     name: "handler-syntax-and-chain",
     standard: `

--- a/packages/agency-lang/evals/agency-coding/interrupt-before-danger/graders.ts
+++ b/packages/agency-lang/evals/agency-coding/interrupt-before-danger/graders.ts
@@ -1,8 +1,10 @@
+import { formatted } from "../lib/formatted.js";
 // The holdout shows a rejected post sends nothing. This judge names the
 // idiom: a named interrupt, declared, decided by the caller.
 import { idiomJudge } from "../lib/idiomJudge.js";
 
 export default [
+  formatted(),
   idiomJudge({
     name: "named-interrupt-before-send",
     standard: `

--- a/packages/agency-lang/evals/agency-coding/lib/formatted.test.ts
+++ b/packages/agency-lang/evals/agency-coding/lib/formatted.test.ts
@@ -1,0 +1,34 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { describe, expect, it } from "vitest";
+
+import type { AgencyRunner } from "@/eval/grading/agencyRunner.js";
+import { loadedRun } from "@/eval/grading/testUtils.js";
+import { formatted } from "./formatted.js";
+
+async function gradeSource(source: string) {
+  const workdir = fs.mkdtempSync(path.join(os.tmpdir(), "formatted-"));
+  fs.writeFileSync(path.join(workdir, "solution.agency"), source);
+  const grader = formatted() as { run(input: unknown): Promise<{ score: { pass?: boolean } }> };
+  const grade = await grader.run({
+    test: { id: "t", input: { assignment: "", outFile: "solution.agency" } },
+    run: { ...loadedRun(""), workdir },
+    runAgency: {} as AgencyRunner,
+  });
+  return grade.score.pass;
+}
+
+describe("formatted", () => {
+  it("passes a file the formatter would leave alone", async () => {
+    expect(await gradeSource("export def f(x: number): number {\n  return x + 1\n}\n")).toBe(true);
+  });
+
+  it("fails a file the formatter would change", async () => {
+    expect(await gradeSource("export def f(x:number):number { return x+1 }\n")).toBe(false);
+  });
+
+  it("fails a file that does not parse", async () => {
+    expect(await gradeSource("def (")).toBe(false);
+  });
+});

--- a/packages/agency-lang/evals/agency-coding/lib/formatted.ts
+++ b/packages/agency-lang/evals/agency-coding/lib/formatted.ts
@@ -1,0 +1,27 @@
+// Every test carries this grader: the saved file must already be in the
+// layout the Agency formatter produces. It is a small share of the score,
+// enough to reward a writer that formats without outweighing correctness.
+import { binary, formatSource, grader, type Grader } from "agency-lang/eval";
+
+type CodingInput = { assignment: string; outFile: string };
+
+export function formatted(): Grader<CodingInput> {
+  return grader<CodingInput>(
+    ({ workdirFile, test }) => {
+      const outFile = test.input?.outFile ?? "";
+      const source = workdirFile(outFile);
+      if (source === "") {
+        return binary(false, `no ${outFile} was saved`);
+      }
+      const canonical = formatSource(source);
+      if (canonical === null) {
+        return binary(false, `${outFile} does not parse, so it cannot be formatted`);
+      }
+      if (canonical === source) {
+        return binary(true, `${outFile} is in the formatter's layout`);
+      }
+      return binary(false, `${outFile} is not formatted; running the formatter would change it`);
+    },
+    { name: "formatted", weight: 0.2 },
+  );
+}

--- a/packages/agency-lang/evals/agency-coding/loop-forms/graders.ts
+++ b/packages/agency-lang/evals/agency-coding/loop-forms/graders.ts
@@ -1,6 +1,8 @@
+import { formatted } from "../lib/formatted.js";
 import { idiomJudge } from "../lib/idiomJudge.js";
 
 export default [
+  formatted(),
   idiomJudge({
     name: "loop-form-fits-the-job",
     weight: 0.8,

--- a/packages/agency-lang/evals/agency-coding/module-basics/graders.ts
+++ b/packages/agency-lang/evals/agency-coding/module-basics/graders.ts
@@ -1,0 +1,3 @@
+import { formatted } from "../lib/formatted.js";
+
+export default [formatted()];

--- a/packages/agency-lang/evals/agency-coding/named-config-params/graders.ts
+++ b/packages/agency-lang/evals/agency-coding/named-config-params/graders.ts
@@ -1,8 +1,10 @@
+import { formatted } from "../lib/formatted.js";
 // The holdout scores behaviour. This judge says in words what the holdout
 // only shows as "Unknown named argument", so the optimizer learns why.
 import { idiomJudge } from "../lib/idiomJudge.js";
 
 export default [
+  formatted(),
   idiomJudge({
     name: "settings-are-named-parameters",
     standard: `

--- a/packages/agency-lang/evals/agency-coding/no-js-array-methods/graders.ts
+++ b/packages/agency-lang/evals/agency-coding/no-js-array-methods/graders.ts
@@ -1,6 +1,8 @@
+import { formatted } from "../lib/formatted.js";
 import { idiomJudge } from "../lib/idiomJudge.js";
 
 export default [
+  formatted(),
   idiomJudge({
     name: "no-js-array-methods",
     standard: `

--- a/packages/agency-lang/evals/agency-coding/program-shape/graders.ts
+++ b/packages/agency-lang/evals/agency-coding/program-shape/graders.ts
@@ -1,0 +1,3 @@
+import { formatted } from "../lib/formatted.js";
+
+export default [formatted()];

--- a/packages/agency-lang/evals/agency-coding/restrict-with-partial/graders.ts
+++ b/packages/agency-lang/evals/agency-coding/restrict-with-partial/graders.ts
@@ -1,9 +1,11 @@
+import { formatted } from "../lib/formatted.js";
 // The holdout proves .partial() can bind both parameters and that a dry
 // run leaves the files alone. This judge checks what the holdout cannot:
 // the default, and who approves the delete.
 import { idiomJudge } from "../lib/idiomJudge.js";
 
 export default [
+  formatted(),
   idiomJudge({
     name: "restrictable-by-partial",
     standard: `

--- a/packages/agency-lang/evals/agency-coding/result-handling/graders.ts
+++ b/packages/agency-lang/evals/agency-coding/result-handling/graders.ts
@@ -1,8 +1,10 @@
+import { formatted } from "../lib/formatted.js";
 // The holdout checks both branches and that the message survives. This
 // judge checks how the Result was read.
 import { idiomJudge } from "../lib/idiomJudge.js";
 
 export default [
+  formatted(),
   idiomJudge({
     name: "narrows-results",
     standard: `

--- a/packages/agency-lang/evals/agency-coding/reverse-digits/graders.ts
+++ b/packages/agency-lang/evals/agency-coding/reverse-digits/graders.ts
@@ -1,0 +1,3 @@
+import { formatted } from "../lib/formatted.js";
+
+export default [formatted()];

--- a/packages/agency-lang/evals/agency-coding/static-globals/graders.ts
+++ b/packages/agency-lang/evals/agency-coding/static-globals/graders.ts
@@ -1,6 +1,8 @@
+import { formatted } from "../lib/formatted.js";
 import { idiomJudge } from "../lib/idiomJudge.js";
 
 export default [
+  formatted(),
   idiomJudge({
     name: "static-for-fixed-values",
     standard: `

--- a/packages/agency-lang/evals/agency-coding/stdlib-knowledge/graders.ts
+++ b/packages/agency-lang/evals/agency-coding/stdlib-knowledge/graders.ts
@@ -1,6 +1,8 @@
+import { formatted } from "../lib/formatted.js";
 import { idiomJudge } from "../lib/idiomJudge.js";
 
 export default [
+  formatted(),
   idiomJudge({
     name: "uses-the-stdlib",
     standard: `

--- a/packages/agency-lang/evals/agency-coding/sum-multiples/graders.ts
+++ b/packages/agency-lang/evals/agency-coding/sum-multiples/graders.ts
@@ -1,0 +1,3 @@
+import { formatted } from "../lib/formatted.js";
+
+export default [formatted()];

--- a/packages/agency-lang/evals/agency-coding/uses-match/graders.ts
+++ b/packages/agency-lang/evals/agency-coding/uses-match/graders.ts
@@ -1,6 +1,8 @@
+import { formatted } from "../lib/formatted.js";
 import { idiomJudge } from "../lib/idiomJudge.js";
 
 export default [
+  formatted(),
   idiomJudge({
     name: "handler-uses-match",
     standard: `

--- a/packages/agency-lang/lib/eval/public.ts
+++ b/packages/agency-lang/lib/eval/public.ts
@@ -3,6 +3,7 @@
 export { grader, FunctionGrader, toGrader } from "./grading/functionGrader.js";
 export type { Grader, GraderFn, GraderContext } from "./grading/functionGrader.js";
 export { scalar, binary } from "./grading/grade.js";
+export { formatSource } from "../formatter.js";
 export { BaseGrader } from "./grading/baseGrader.js";
 export {
   ExactMatchGrader as ExactMatch,

--- a/packages/agency-lang/stdlib/agents/agency/coding.agency
+++ b/packages/agency-lang/stdlib/agents/agency/coding.agency
@@ -7,7 +7,7 @@
   agencyVerifierAgent on the result, and retry with its findings folded into
   the task.
 */
-import { compile, typecheck, parseAST } from "std::agency"
+import { compile, typecheck, parseAST, format } from "std::agency"
 import { agencyReviewAgent } from "std::agents/agency/review"
 import { renderFeedback, feedbackHasErrors } from "std::agents/lib/feedback"
 import {
@@ -188,7 +188,9 @@ relevant page with the docs tool before writing code. When a diagnostic code
 guessing at the fix.
 
 Typecheck your draft before returning it, and fix what it reports. An
-attempt you already know does not typecheck wastes a whole round.
+attempt you already know does not typecheck wastes a whole round. Then
+run the format tool on the draft and return the text it gives back, so
+the file is in the standard Agency layout.
 You cannot save files or run tests from here: the caller saves the code
 you return and runs any tests after that. Do not look for the file or try
 to run its tests; when the draft typechecks, return it.
@@ -213,6 +215,7 @@ export def buildTools(): any[] {
     ...agencyDocTools(),
     typecheck,
     parseAST,
+    format,
     ...readOnlyFileTools(),
     ...readOnlyGitTools(),
     fetch,


### PR DESCRIPTION
## What

Every test in `evals/agency-coding` now carries a `formatted` grader (weight 0.2, `evals/agency-coding/lib/formatted.ts`). It reads the saved file and passes only when the Agency formatter would leave it byte for byte unchanged. A missing or unparseable file fails.

The coding agent gets the stdlib `format` tool in `buildTools()` and one prompt line: format the draft before returning it. Without the tool the grader would only measure luck.

`formatSource` is exported from `agency-lang/eval` so grader code can reach the formatter.

## Why not the review suite

The reviewer writes no code, so there is nothing formatted to grade. If formatting should become a review rule, that is an idiom test with a deliberately unformatted input, not a suite-wide grader.

## Notes

- Module graders and harness graders are concatenated (`lib/eval/grading/gradeRun.ts:156`), so the four harness-only tests (`module-basics`, `program-shape`, `reverse-digits`, `sum-multiples`) get a `graders.ts` holding just `formatted()` and keep their harness.
- `formatted.test.ts` proves the grader passes canonical source and fails unformatted and unparseable source.
- `docs/site/stdlib/agents/agency/coding.md` is the `make` regenerated page (line numbers only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XWYYt9i5j2459ywyJPYj5b
