### PR TITLE
Review agent: stop reporting guesses as errors; complete the agency-true fact card

### DIFF
--- a/packages/agency-lang/docs/site/stdlib/agents/agency/review.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/agency/review.md
@@ -30,7 +30,7 @@ Convert a typecheck report into findings: one error item per error,
 
 **Returns:** `Feedback[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/review.agency#L117))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/review.agency#L128))
 
 ### buildTools
 
@@ -43,7 +43,7 @@ Return the Agency reviewer's lookup tools: the bundled language
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/review.agency#L132))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/review.agency#L143))
 
 ### agencyReviewAgent
 
@@ -96,4 +96,4 @@ Review Agency source code and return findings. Always includes parse and
 
 **Throws:** `std::guard`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/review.agency#L191))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/review.agency#L202))

--- a/packages/agency-lang/evals/agency-review/lib/agencyFacts.ts
+++ b/packages/agency-lang/evals/agency-review/lib/agencyFacts.ts
@@ -36,9 +36,28 @@ like JS/TS, but its idioms differ, and reviews must judge it as Agency:
   { ... }". A "return" inside a block returns the block's value for that
   item; it does not return from the enclosing function.
 - Declarations use let/const (bare assignment without a declaration is an
-  error); types are postfix ("x: number"); string interpolation is
-  "\${...}"; entry points are "node main() { ... }"; blocks always use
-  braces, and if/while/for require parentheses around the condition.
+  error); types are postfix ("x: number"); entry points are "node main()
+  { ... }"; blocks always use braces, and if/while/for require
+  parentheses around the condition.
+- String interpolation is "\${...}" and works inside ordinary
+  double-quoted strings; a finding that says a double-quoted string will
+  not interpolate is false.
+- Record types are written "Record<string, number>", the same as in
+  TypeScript, and "Record<Status, number>" with a union key type is valid.
+- "static const" initializes a value once and shares it across every run
+  of the program. It is for fixed tables and configuration; mutating a
+  static value (pushing to a static array) is a real bug. A plain
+  module-level "let" or "const" is per-run state.
+- A "raises <...>" clause is optional. A function with no clause may raise
+  anything, so a missing clause is never an error; a clause only narrows
+  what the function is allowed to raise. Calling a function that has no
+  effects needs no clause and no handler.
+- Concurrency forms: "fork(xs) as x { ... }" runs the block for every
+  item at once and returns every result in input order; "race(xs) as x
+  { ... }" returns the first result to settle and cancels the rest, and
+  returns null for an empty list without throwing; "parallel { a() b()
+  }" runs a fixed set of calls at once. None of these throws on an empty
+  list.
 
 Performance, robustness, and idiom suggestions (memoization, iteration
 instead of deep recursion, clearer naming) are legitimate ADVISORY

--- a/packages/agency-lang/stdlib/agents/agency/review.agency
+++ b/packages/agency-lang/stdlib/agents/agency/review.agency
@@ -55,6 +55,13 @@ Facts about Agency:
   it for state the program changes.
 - Declarations use `let` or `const`. Types are postfix. Entry points are
   `node main()`. Every block has braces. Every condition has parentheses.
+- String interpolation `\${...}` works inside ordinary double-quoted
+  strings.
+- A `raises` clause is optional. A function without one may raise
+  anything, so a missing clause is not an error. Calling a function that
+  has no effects needs no clause and no handler.
+- `race` over an empty list returns null; `fork` over an empty list
+  returns an empty array. Neither throws.
 
 How to review:
 1. Work out what the task requires: the exported names and signatures,
@@ -65,7 +72,11 @@ How to review:
    for the boundary cases: empty input, one element, duplicates, zero.
 3. Set error=true only for a finding where the code fails the task: a
    wrong result, a missing requirement, a missing export the task needs,
-   or one of the rules below. Everything else is advisory.
+   or one of the rules below. Everything else is advisory. A requirement
+   the task does not state is not a requirement: do not report a guess
+   about what a function "probably" does, what a caller "likely" needs,
+   or what the task "implies", as an error. If you cannot show the wrong
+   result from the code and the task, the finding is advisory.
 4. Before flagging a syntax or API mistake, verify the claim with the
    Agency documentation tools you have. If the code and the docs do not
    support a finding, do not report it as an error.


### PR DESCRIPTION
## What

Two fixes from reading the low tests in the review agent's 3-trial baseline (`runs/review-baseline-2`, suite mean 0.84).

**The reviewer stated guesses as errors.** On `concurrency-clean` (0.35) both error findings were speculation: a function needs a `raises` clause because its callees "likely mutate external state", and `race(names)` on an empty list "is likely invalid or will throw". On `comments-not-docstrings` one trial invented a requirement the task never stated. On `static-history` it added a false error that `"${...}"` in double quotes does not interpolate. The prompt in `stdlib/agents/agency/review.agency` now says a requirement the task does not state is not one, and that a finding without a shown wrong result is advisory. Three facts added: double-quoted strings interpolate; a `raises` clause is optional and a missing one is never an error; `race` on an empty list returns null and `fork` returns an empty array (verified by running it).

**The `agency-true` judge's fact card was incomplete.** It failed correct findings because `AGENCY_FACTS` (`evals/agency-review/lib/agencyFacts.ts`) said nothing about `static`, `Record<K, V>` types, the `raises` clause, or the concurrency forms, scoring 0.19, 0.37, and 0.44 on three of the four low tests. Those facts are on the card now, each checked against `docs/site/guide` or run.

## Numbers

Single trial on the three tests that motivated this, before → after: `concurrency-clean` 0.35 → 0.87 (`no-false-positive` fail → pass, `agency-true` 0.19 → 1.0), `static-history` 0.73 → 0.95, `comments-not-docstrings` 0.68 → 0.88. A 3-trial run of the whole suite is the real measure; the previous one is 0.84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XWYYt9i5j2459ywyJPYj5b
