### PR TITLE
Pin the fork-stress test to the deterministic LLM provider

### DIFF
--- a/packages/agency-lang/docs/misc/TESTING.md
+++ b/packages/agency-lang/docs/misc/TESTING.md
@@ -281,6 +281,12 @@ Keys are matched against the module making the `llm()` call: the exact module id
 
 The post-merge workflow ([`.github/workflows/test-with-llm.yml`](../../.github/workflows/test-with-llm.yml)) re-runs the same suites against the real OpenAI provider after a PR lands on `main`.
 
+`llmMocks` only apply in deterministic mode. The post-merge run does not set that mode, so a
+real model chooses the tool calls there. A fixture whose `interruptHandlers` list has one entry
+per expected interrupt runs out of handlers when the model makes an extra tool call, and the
+case fails with `Unexpected interrupt #N`. Add `"useTestLLMProvider": true` to a case that must
+stay deterministic in both workflows.
+
 ### Deterministic fetch mode
 
 Independently of the LLM deterministic mode, you can mock HTTP responses. A `fetchMocks` array in a `.test.json` (file-level and/or per test case), or a `fetchMocks.json` file in an agency-js test directory, replaces **every** `fetch` in the agent subprocess — agency `fetch()`/`fetchJSON()`/`fetchMarkdown()`, internal stdlib TS, and interop TS — with canned responses. Any fetch that matches no entry throws and fails the test, so tests never hit the real network.

--- a/packages/agency-lang/docs/misc/TESTING.md
+++ b/packages/agency-lang/docs/misc/TESTING.md
@@ -281,12 +281,6 @@ Keys are matched against the module making the `llm()` call: the exact module id
 
 The post-merge workflow ([`.github/workflows/test-with-llm.yml`](../../.github/workflows/test-with-llm.yml)) re-runs the same suites against the real OpenAI provider after a PR lands on `main`.
 
-`llmMocks` only apply in deterministic mode. The post-merge run does not set that mode, so a
-real model chooses the tool calls there. A fixture whose `interruptHandlers` list has one entry
-per expected interrupt runs out of handlers when the model makes an extra tool call, and the
-case fails with `Unexpected interrupt #N`. Add `"useTestLLMProvider": true` to a case that must
-stay deterministic in both workflows.
-
 ### Deterministic fetch mode
 
 Independently of the LLM deterministic mode, you can mock HTTP responses. A `fetchMocks` array in a `.test.json` (file-level and/or per test case), or a `fetchMocks.json` file in an agency-js test directory, replaces **every** `fetch` in the agent subprocess — agency `fetch()`/`fetchJSON()`/`fetchMarkdown()`, internal stdlib TS, and interop TS — with canned responses. Any fetch that matches no entry throws and fails the test, so tests never hit the real network.

--- a/packages/agency-lang/tests/agency/fork/fork-stress.test.json
+++ b/packages/agency-lang/tests/agency/fork/fork-stress.test.json
@@ -2,10 +2,11 @@
   "tests": [
     {
       "nodeName": "main",
-      "description": "Stress test: for loop × (handler + LLM call + fork-tool + race-with-abort + conditional interrupt) × 2 rounds. Round 1 approves the 'important' interrupt; round 2 rejects it. Mix of success and failure across branches gets flattened to uniform strings via the extract() helper for exact matching.",
+      "description": "Stress test: for loop × (handler + LLM call + fork-tool + race-with-abort + conditional interrupt) × 2 rounds. Round 1 approves the 'important' interrupt; round 2 rejects it. Mix of success and failure across branches gets flattened to uniform strings via the extract() helper for exact matching. Pinned to the deterministic provider with useTestLLMProvider: the interruptHandlers list has one entry per round, so a real model that calls cleanup an extra time runs the list out and the case fails with \"Unexpected interrupt #3\". The post-merge real-LLM workflow ignores llmMocks unless a case sets that flag.",
       "input": "",
       "expectedOutput": "[\"deleted: safe (fast: safe)\",\"deleted: important (fast: important)\",\"deleted: safe2 (fast: safe2)\",\"deleted: safe (fast: safe)\",\"FAILED: interrupt rejected\",\"deleted: safe2 (fast: safe2)\"]",
       "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
       "interruptHandlers": [
         { "action": "approve", "expectedMessage": "really delete 'important'?" },
         { "action": "reject", "expectedMessage": "really delete 'important'?" }

--- a/packages/agency-lang/tests/agency/fork/fork-stress.test.json
+++ b/packages/agency-lang/tests/agency/fork/fork-stress.test.json
@@ -2,7 +2,7 @@
   "tests": [
     {
       "nodeName": "main",
-      "description": "Stress test: for loop × (handler + LLM call + fork-tool + race-with-abort + conditional interrupt) × 2 rounds. Round 1 approves the 'important' interrupt; round 2 rejects it. Mix of success and failure across branches gets flattened to uniform strings via the extract() helper for exact matching. Pinned to the deterministic provider with useTestLLMProvider: the interruptHandlers list has one entry per round, so a real model that calls cleanup an extra time runs the list out and the case fails with \"Unexpected interrupt #3\". The post-merge real-LLM workflow ignores llmMocks unless a case sets that flag.",
+      "description": "Stress test: for loop × (handler + LLM call + fork-tool + race-with-abort + conditional interrupt) × 2 rounds. Round 1 approves the 'important' interrupt; round 2 rejects it. Mix of success and failure across branches gets flattened to uniform strings via the extract() helper for exact matching.",
       "input": "",
       "expectedOutput": "[\"deleted: safe (fast: safe)\",\"deleted: important (fast: important)\",\"deleted: safe2 (fast: safe2)\",\"deleted: safe (fast: safe)\",\"FAILED: interrupt rejected\",\"deleted: safe2 (fast: safe2)\"]",
       "evaluationCriteria": [{ "type": "exact" }],


### PR DESCRIPTION
`tests/agency/fork/fork-stress.test.json` has failed the post-merge real-LLM
workflow on three of the last four pushes to main, most recently in
[run 33135552225](https://github.com/egonSchiele/agency-lang/actions/runs/33135552225):

```
Error: Unexpected interrupt #3: "really delete 'important'?". No handler provided.
    at runEvaluation (tests/agency/fork/fork-stress.evaluate.js:20:15)
```

## Why

`test-with-llm.yml` deliberately leaves `AGENCY_USE_TEST_LLM_PROVIDER` unset,
and `executeNodeAsync` only puts `llmMocks` into the subprocess environment in
deterministic mode (`lib/cli/util.ts:368-373`). On main the fixture's four
mocks were therefore dropped and a real model chose the tool calls, while
`interruptHandlers` stayed a fixed two-entry list. When the model called
`cleanup` a third time the list ran out and the case died. All three retries
hit it.

## The change

One line: `"useTestLLMProvider": true` on the case, so the mocks apply in both
workflows.

## Verification

With `OPENAI_API_KEY` unset, so the run cannot reach a model:

```
1/1 tests passed   (3.52s, was 34.38s in CI)
```

To check the mocks actually drive the run rather than passing by accident, I
changed one entry of the second `return` mock to a wrong string and re-ran:
`0/1 tests passed`, exact match failed.

I left `"retry": 2` in place. The test still races a `sleep` against an abort,
so a timing flake remains possible and the retry still earns its keep.

## Not fixed here

Two sibling fixtures fail the same workflow for the same reason and are
untouched: `tests/agency/threads/subthreads.test.json` (exact-match misses)
and `tests/agency/threads/thread-three-levels-deep.test.json` (LLM judge
43-57/70).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017o4iNXjmbLUfDfBWdUsWft
