### PR TITLE
chore(schedule): bump egonSchiele/run-agency-action to v1.1.0

### DIFF
--- a/.github/workflows/constants-review.yml
+++ b/.github/workflows/constants-review.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.7
-      - uses: egonSchiele/run-agency-action@4768784aa7611fafee0801e01cdaea9f06d08dfb  # v1.0.3
+      - uses: egonSchiele/run-agency-action@bdae9e6bd4ac9cddbbebcef877c7d35ffe3cfa8c  # v1.1.0
         with:
           file: 'packages/agency-lang/agents/scheduled/constants-review.agency'
         env:

--- a/.github/workflows/docs-review.yml
+++ b/.github/workflows/docs-review.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.7
-      - uses: egonSchiele/run-agency-action@4768784aa7611fafee0801e01cdaea9f06d08dfb  # v1.0.3
+      - uses: egonSchiele/run-agency-action@bdae9e6bd4ac9cddbbebcef877c7d35ffe3cfa8c  # v1.1.0
         with:
           file: 'packages/agency-lang/agents/scheduled/docs-review.agency'
         env:

--- a/.github/workflows/stdlib-docs-links.yml
+++ b/.github/workflows/stdlib-docs-links.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.7
-      - uses: egonSchiele/run-agency-action@4768784aa7611fafee0801e01cdaea9f06d08dfb  # v1.0.3
+      - uses: egonSchiele/run-agency-action@bdae9e6bd4ac9cddbbebcef877c7d35ffe3cfa8c  # v1.1.0
         with:
           file: 'packages/agency-lang/agents/scheduled/stdlib-docs-links.agency'
         env:

--- a/packages/agency-lang/lib/cli/schedule/backends/__snapshots__/all-sha.yml
+++ b/packages/agency-lang/lib/cli/schedule/backends/__snapshots__/all-sha.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.7
-      - uses: egonSchiele/run-agency-action@4768784aa7611fafee0801e01cdaea9f06d08dfb  # v1.0.3
+      - uses: egonSchiele/run-agency-action@bdae9e6bd4ac9cddbbebcef877c7d35ffe3cfa8c  # v1.1.0
         with:
           file: 'agents/foo.agency'
         env:

--- a/packages/agency-lang/lib/cli/schedule/backends/__snapshots__/all-tag.yml
+++ b/packages/agency-lang/lib/cli/schedule/backends/__snapshots__/all-tag.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4.1.7
-      - uses: egonSchiele/run-agency-action@v1.0.3
+      - uses: egonSchiele/run-agency-action@v1.1.0
         with:
           file: 'agents/foo.agency'
         env:

--- a/packages/agency-lang/lib/cli/schedule/backends/__snapshots__/readonly-sha.yml
+++ b/packages/agency-lang/lib/cli/schedule/backends/__snapshots__/readonly-sha.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.7
-      - uses: egonSchiele/run-agency-action@4768784aa7611fafee0801e01cdaea9f06d08dfb  # v1.0.3
+      - uses: egonSchiele/run-agency-action@bdae9e6bd4ac9cddbbebcef877c7d35ffe3cfa8c  # v1.1.0
         with:
           file: 'agents/foo.agency'
         env:

--- a/packages/agency-lang/lib/cli/schedule/backends/__snapshots__/readonly-tag.yml
+++ b/packages/agency-lang/lib/cli/schedule/backends/__snapshots__/readonly-tag.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4.1.7
-      - uses: egonSchiele/run-agency-action@v1.0.3
+      - uses: egonSchiele/run-agency-action@v1.1.0
         with:
           file: 'agents/foo.agency'
         env:

--- a/packages/agency-lang/lib/cli/schedule/backends/__snapshots__/with-secrets-sha.yml
+++ b/packages/agency-lang/lib/cli/schedule/backends/__snapshots__/with-secrets-sha.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.7
-      - uses: egonSchiele/run-agency-action@4768784aa7611fafee0801e01cdaea9f06d08dfb  # v1.0.3
+      - uses: egonSchiele/run-agency-action@bdae9e6bd4ac9cddbbebcef877c7d35ffe3cfa8c  # v1.1.0
         with:
           file: 'agents/foo.agency'
         env:

--- a/packages/agency-lang/lib/cli/schedule/backends/__snapshots__/with-secrets-tag.yml
+++ b/packages/agency-lang/lib/cli/schedule/backends/__snapshots__/with-secrets-tag.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4.1.7
-      - uses: egonSchiele/run-agency-action@v1.0.3
+      - uses: egonSchiele/run-agency-action@v1.1.0
         with:
           file: 'agents/foo.agency'
         env:

--- a/packages/agency-lang/lib/cli/schedule/backends/__snapshots__/write-sha.yml
+++ b/packages/agency-lang/lib/cli/schedule/backends/__snapshots__/write-sha.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.7
-      - uses: egonSchiele/run-agency-action@4768784aa7611fafee0801e01cdaea9f06d08dfb  # v1.0.3
+      - uses: egonSchiele/run-agency-action@bdae9e6bd4ac9cddbbebcef877c7d35ffe3cfa8c  # v1.1.0
         with:
           file: 'agents/foo.agency'
         env:

--- a/packages/agency-lang/lib/cli/schedule/backends/__snapshots__/write-tag.yml
+++ b/packages/agency-lang/lib/cli/schedule/backends/__snapshots__/write-tag.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4.1.7
-      - uses: egonSchiele/run-agency-action@v1.0.3
+      - uses: egonSchiele/run-agency-action@v1.1.0
         with:
           file: 'agents/foo.agency'
         env:

--- a/packages/agency-lang/lib/cli/schedule/backends/pinnedActions.ts
+++ b/packages/agency-lang/lib/cli/schedule/backends/pinnedActions.ts
@@ -13,7 +13,7 @@ export const PINNED_ACTIONS: Record<string, PinnedAction> = {
     tag: "v4.1.7",
   },
   "egonSchiele/run-agency-action": {
-    sha: "4768784aa7611fafee0801e01cdaea9f06d08dfb",
-    tag: "v1.0.3",
+    sha: "bdae9e6bd4ac9cddbbebcef877c7d35ffe3cfa8c",
+    tag: "v1.1.0",
   },
 };

--- a/packages/agency-lang/makefile
+++ b/packages/agency-lang/makefile
@@ -165,7 +165,7 @@ test-log:
 # this list and pinnedActions.ts in the same commit.
 refresh-action-pins:
 	@echo "Look up these SHAs and update lib/cli/schedule/backends/pinnedActions.ts by hand:"
-	@for spec in actions/checkout@v4.1.7 egonSchiele/run-agency-action@v1.0.3; do \
+	@for spec in actions/checkout@v4.1.7 egonSchiele/run-agency-action@v1.1.0; do \
 	  repo=$${spec%@*}; tag=$${spec#*@}; \
 	  ref_obj=$$(gh api repos/$$repo/git/ref/tags/$$tag --jq '.object'); \
 	  type=$$(echo "$$ref_obj" | jq -r '.type'); \

--- a/packages/agency-lang/tests/integration/cli-main/fixtures/expected/nightly-cron.expected.yml
+++ b/packages/agency-lang/tests/integration/cli-main/fixtures/expected/nightly-cron.expected.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4.1.7
-      - uses: egonSchiele/run-agency-action@v1.0.3
+      - uses: egonSchiele/run-agency-action@v1.1.0
         with:
           file: 'agents/nightly.agency'
         env:

--- a/packages/agency-lang/tests/integration/cli-main/fixtures/expected/nightly-write.expected.yml
+++ b/packages/agency-lang/tests/integration/cli-main/fixtures/expected/nightly-write.expected.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4.1.7
-      - uses: egonSchiele/run-agency-action@v1.0.3
+      - uses: egonSchiele/run-agency-action@v1.1.0
         with:
           file: 'agents/nightly.agency'
         env:

--- a/packages/agency-lang/tests/integration/cli-main/fixtures/expected/nightly.expected.yml
+++ b/packages/agency-lang/tests/integration/cli-main/fixtures/expected/nightly.expected.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4.1.7
-      - uses: egonSchiele/run-agency-action@v1.0.3
+      - uses: egonSchiele/run-agency-action@v1.1.0
         with:
           file: 'agents/nightly.agency'
         env:


### PR DESCRIPTION
Bumps the pinned `egonSchiele/run-agency-action` from v1.0.3 to v1.1.0.

## Why this matters

v1.0.3's `bundled/package-lock.json` pins `agency-lang` **0.1.1**. That is the
version the action's `run.sh` installs with `npm ci`, so every scheduled agent
has been running against a two-year-old parser. It is why `stdlib-docs-links`,
`docs-review` and `constants-review` have failed **every** scheduled run going
back to at least 2026-07-20, always with a bare `Failed to parse Agency
program.` and no parser message.

v1.1.0's bundle pins `agency-lang` `^0.16.0`, resolved to 0.16.0 in its
lockfile.

## What changed

Follows `docs/dev/contributing/updating-pinned-actions.md`:

- `lib/cli/schedule/backends/pinnedActions.ts` — sha + tag
- `makefile` — the `refresh-action-pins` tag list
- `lib/cli/schedule/backends/__snapshots__/*.yml` — regenerated (8 files)
- `tests/integration/cli-main/fixtures/expected/*.yml` — 3 files
- `.github/workflows/{stdlib-docs-links,docs-review,constants-review}.yml` —
  the live pins

Left alone deliberately: the `v1.0.3` mentions in
`docs/superpowers/plans/2026-08-13-*` and `specs/2026-08-13-*` are a dated
record of what was true then, and the one in `updating-pinned-actions.md` is
illustrative sample output.

## Verification

- `make refresh-action-pins` independently resolves v1.1.0 to
  `bdae9e6bd4ac9cddbbebcef877c7d35ffe3cfa8c` via the GitHub API, matching the
  SHA in this diff.
- `pnpm run typecheck` clean; `pnpm test:run lib/cli/schedule` 180 passed.
- The snapshot diff is only the `uses:` line in all 8 files.
- Earlier today I reproduced the underlying failure directly: `agency-lang`
  0.16.0 compiles `agents/scheduled/stdlib-docs-links.agency` fine, and 0.1.1
  fails on it byte-identically to CI.

Note the snapshot test regenerates from the same constant it asserts against,
so it proves internal consistency, not that the SHA is right. The
`refresh-action-pins` lookup above is the check that could actually have
failed.

I have not dispatched a scheduled workflow to confirm end to end, since that
spends real API budget and pushes a branch. Happy to run one on this branch if
you want that before merging.

## Unrelated problem found in the same file

`pinnedActions.ts` pins `actions/checkout` to
`b4ffde65f46336ab88eb53be808477a3936bae11` with the comment `# v4.1.7`. That
SHA is really **v4.1.1**; v4.1.7 is `692973e3d937129bcbf40652eb9f2f61becf3332`.
So `make refresh-action-pins` reports a SHA that disagrees with the pinned one,
and the inline comment is exactly the kind of lie the doc warns about. Not
touched here to keep this diff to the bump you asked for. Say the word and I
will fix it separately, either by correcting the comment to v4.1.1 or by
moving the pin up to a current v4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017o4iNXjmbLUfDfBWdUsWft
