### PR TITLE
Weekly agent eval run uploaded to statelog

### DIFF
--- a/.github/workflows/agent-evals.yml
+++ b/.github/workflows/agent-evals.yml
@@ -1,14 +1,22 @@
 # Weekly eval run of the agency agent, uploaded to statelog so its accuracy
 # can be tracked over time (see packages/agency-lang/docs/dev/evals/eval-tracking.md).
 #
-# This spends real money: about $21 at three tests x three trials, plus the
-# grading judges. packages/agency-lang/agency.json caps it: maxBatchCostUsd
-# for the batch, maxCostUsd per run (worst case: batch cap + parallel x
-# per-run cap). It never fails on scores — a bad week is information for the
-# batch table, not an alarm. It fails only when a step could not run or the
-# upload was refused. The run directory is always saved as a workflow artifact
-# so a batch whose upload failed can be uploaded by hand: download it, then
-# `agency eval upload <dir>` from a linked checkout.
+# This spends real money. packages/agency-lang/agency.json caps it:
+# maxBatchCostUsd for the batch, maxCostUsd per run (worst case: batch cap +
+# parallel x per-run cap), plus the grading judges outside both. It never
+# fails on scores — a bad week is information for the batch table, not an
+# alarm. It fails only when a step could not run or the upload was refused.
+#
+# The agent runs with every interrupt approved, so it has a shell and the
+# network. Three things bound what that can reach:
+#   - it runs in the eval Docker image (evals/agency-agent/run-in-docker.sh),
+#     which passes in only the LLM key and mounts only the run directory;
+#   - each secret is set on the one step that needs it, never job-wide;
+#   - the LLM key is a dedicated one (AGENT_EVALS_OPENAI_API_KEY) with its own
+#     spend limit, so a leak costs at most that limit until it is rotated.
+# The run directory is saved as an artifact only when the upload failed (it
+# holds every trace, and artifacts on a public repo are public): download it,
+# then `agency eval upload <dir>` from a linked checkout.
 #
 # Trigger it manually (workflow_dispatch) to try a cheaper suite or fewer
 # trials without waiting for Sunday.
@@ -34,12 +42,9 @@ jobs:
     # Forks have neither the secrets nor a reason to spend the money.
     if: github.repository == 'egonSchiele/agency-lang'
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 180
     environment: ci-credentials
     env:
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      STATELOG_API_KEY: ${{ secrets.STATELOG_API_KEY }}
-      STATELOG_PROJECT_URL: ${{ secrets.STATELOG_PROJECT_URL }}
       TRIALS: ${{ inputs.trials || '3' }}
       SUITE: ${{ inputs.suite || 'evals/agency-agent' }}
     steps:
@@ -58,9 +63,13 @@ jobs:
         working-directory: packages/agency-lang
 
       - name: Check configuration
+        env:
+          AGENT_EVALS_OPENAI_API_KEY: ${{ secrets.AGENT_EVALS_OPENAI_API_KEY }}
+          STATELOG_API_KEY: ${{ secrets.STATELOG_API_KEY }}
+          STATELOG_PROJECT_URL: ${{ secrets.STATELOG_PROJECT_URL }}
         run: |
           missing=""
-          [ -n "$OPENAI_API_KEY" ] || missing="$missing OPENAI_API_KEY"
+          [ -n "$AGENT_EVALS_OPENAI_API_KEY" ] || missing="$missing AGENT_EVALS_OPENAI_API_KEY"
           [ -n "$STATELOG_API_KEY" ] || missing="$missing STATELOG_API_KEY"
           [ -n "$STATELOG_PROJECT_URL" ] || missing="$missing STATELOG_PROJECT_URL"
           if [ -n "$missing" ]; then
@@ -68,25 +77,37 @@ jobs:
             exit 1
           fi
 
+      # The image the agent runs in, built from this checkout so it tests the
+      # code at HEAD, not a published release.
+      - name: Build the eval image
+        working-directory: packages/agency-lang
+        run: make eval-image
+
       - name: Pick a run directory
         working-directory: packages/agency-lang
         run: echo "RUN_DIR=runs/weekly-$(date -u +%Y-%m-%d-%H%M%S)" >> "$GITHUB_ENV"
 
       - name: Link the statelog project
         working-directory: packages/agency-lang
+        env:
+          STATELOG_PROJECT_URL: ${{ secrets.STATELOG_PROJECT_URL }}
         run: node ./dist/scripts/agency.js remote link --url "$STATELOG_PROJECT_URL"
 
       # Flags here are checked against the CLI's registered options by
       # lib/cli/eval/workflowFlags.test.ts, so a rename fails `make test`
-      # instead of the Sunday run.
+      # instead of the Sunday run. The agent command is the suite's own
+      # wrapper (see evals/agency-agent/README.md); the wrapper forwards
+      # OPENAI_API_KEY into the container, and only that.
       # `eval run` exits 2 when some tests errored (they are run rows that
       # grade 0) and 1 when it could not run at all.
       - name: Run the suite
         working-directory: packages/agency-lang
+        env:
+          OPENAI_API_KEY: ${{ secrets.AGENT_EVALS_OPENAI_API_KEY }}
         run: |
           status=0
           node ./dist/scripts/agency.js eval run \
-            --agent-cmd "node $PWD/dist/scripts/agency.js agent --policy recommended -p -- {input}" \
+            --agent-cmd "$PWD/evals/agency-agent/run-in-docker.sh --brain coordinator --policy approve-all --max-tool-call-rounds 100 -p -- {input}" \
             --suite "$SUITE" \
             --trials "$TRIALS" \
             --parallel 2 \
@@ -97,10 +118,13 @@ jobs:
             exit "$status"
           fi
 
+      # The judge graders call the LLM; the key never reaches an agent here.
       # `eval grade` exits 2 when a must-pass gate failed (a score, which this
       # job records rather than fails on) and 1 when grading itself broke.
       - name: Grade
         working-directory: packages/agency-lang
+        env:
+          OPENAI_API_KEY: ${{ secrets.AGENT_EVALS_OPENAI_API_KEY }}
         run: |
           status=0
           node ./dist/scripts/agency.js eval grade "$RUN_DIR" || status=$?
@@ -111,11 +135,14 @@ jobs:
           fi
 
       - name: Upload to statelog
+        id: upload
         working-directory: packages/agency-lang
+        env:
+          STATELOG_API_KEY: ${{ secrets.STATELOG_API_KEY }}
         run: node ./dist/scripts/agency.js eval upload "$RUN_DIR"
 
-      - name: Save the run directory
-        if: always() && env.RUN_DIR != ''
+      - name: Save the run directory for a by-hand upload
+        if: failure() && steps.upload.outcome == 'failure'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: eval-runs

--- a/.github/workflows/agent-evals.yml
+++ b/.github/workflows/agent-evals.yml
@@ -1,10 +1,12 @@
 # Weekly eval run of the agency agent, uploaded to statelog so its accuracy
 # can be tracked over time (see packages/agency-lang/docs/dev/evals/eval-tracking.md).
 #
-# This spends real money (about $21 at three tests x three trials; the cap is
-# eval.limits.maxCostUsd in packages/agency-lang/agency.json). It never fails on
-# scores — a bad week is information for the batch table, not an alarm. It
-# fails only when a step could not run or the upload was refused. The run
+# This spends real money: about $21 at three tests x three trials, plus the
+# grading judges. eval.limits.maxCostUsd in packages/agency-lang/agency.json
+# caps each agent run separately (there is no batch-wide budget), so the worst
+# case is tests x trials x that cap. It never fails on scores — a bad week is
+# information for the batch table, not an alarm. It fails only when a step
+# could not run or the upload was refused. The run
 # directory is always saved as a workflow artifact so a batch whose upload
 # failed can be uploaded by hand: download it, then
 # `agency eval upload <dir>` from a linked checkout.
@@ -38,7 +40,7 @@ jobs:
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       STATELOG_API_KEY: ${{ secrets.STATELOG_API_KEY }}
-      STATELOG_PROJECT_URL: ${{ vars.STATELOG_PROJECT_URL }}
+      STATELOG_PROJECT_URL: ${{ secrets.STATELOG_PROJECT_URL }}
       TRIALS: ${{ inputs.trials || '3' }}
       SUITE: ${{ inputs.suite || 'evals/agency-agent' }}
     steps:
@@ -88,9 +90,18 @@ jobs:
             --parallel 2 \
             --out "$RUN_DIR"
 
+      # `eval grade` exits 2 when a must-pass gate failed (a score, which this
+      # job records rather than fails on) and 1 when grading itself broke.
       - name: Grade
         working-directory: packages/agency-lang
-        run: node ./dist/scripts/agency.js eval grade "$RUN_DIR"
+        run: |
+          status=0
+          node ./dist/scripts/agency.js eval grade "$RUN_DIR" || status=$?
+          if [ "$status" -eq 2 ]; then
+            echo "::warning::some runs failed a must-pass gate; uploading anyway"
+          elif [ "$status" -ne 0 ]; then
+            exit "$status"
+          fi
 
       - name: Upload to statelog
         working-directory: packages/agency-lang

--- a/.github/workflows/agent-evals.yml
+++ b/.github/workflows/agent-evals.yml
@@ -2,13 +2,12 @@
 # can be tracked over time (see packages/agency-lang/docs/dev/evals/eval-tracking.md).
 #
 # This spends real money: about $21 at three tests x three trials, plus the
-# grading judges. eval.limits.maxCostUsd in packages/agency-lang/agency.json
-# caps each agent run separately (there is no batch-wide budget), so the worst
-# case is tests x trials x that cap. It never fails on scores — a bad week is
-# information for the batch table, not an alarm. It fails only when a step
-# could not run or the upload was refused. The run
-# directory is always saved as a workflow artifact so a batch whose upload
-# failed can be uploaded by hand: download it, then
+# grading judges. packages/agency-lang/agency.json caps it: maxBatchCostUsd
+# for the batch, maxCostUsd per run (worst case: batch cap + parallel x
+# per-run cap). It never fails on scores — a bad week is information for the
+# batch table, not an alarm. It fails only when a step could not run or the
+# upload was refused. The run directory is always saved as a workflow artifact
+# so a batch whose upload failed can be uploaded by hand: download it, then
 # `agency eval upload <dir>` from a linked checkout.
 #
 # Trigger it manually (workflow_dispatch) to try a cheaper suite or fewer
@@ -80,15 +79,23 @@ jobs:
       # Flags here are checked against the CLI's registered options by
       # lib/cli/eval/workflowFlags.test.ts, so a rename fails `make test`
       # instead of the Sunday run.
+      # `eval run` exits 2 when some tests errored (they are run rows that
+      # grade 0) and 1 when it could not run at all.
       - name: Run the suite
         working-directory: packages/agency-lang
         run: |
+          status=0
           node ./dist/scripts/agency.js eval run \
             --agent-cmd "node $PWD/dist/scripts/agency.js agent --policy recommended -p -- {input}" \
             --suite "$SUITE" \
             --trials "$TRIALS" \
             --parallel 2 \
-            --out "$RUN_DIR"
+            --out "$RUN_DIR" || status=$?
+          if [ "$status" -eq 2 ]; then
+            echo "::warning::some tests errored; grading and uploading anyway"
+          elif [ "$status" -ne 0 ]; then
+            exit "$status"
+          fi
 
       # `eval grade` exits 2 when a must-pass gate failed (a score, which this
       # job records rather than fails on) and 1 when grading itself broke.

--- a/.github/workflows/agent-evals.yml
+++ b/.github/workflows/agent-evals.yml
@@ -1,0 +1,106 @@
+# Weekly eval run of the agency agent, uploaded to statelog so its accuracy
+# can be tracked over time (see packages/agency-lang/docs/dev/evals/eval-tracking.md).
+#
+# This spends real money (about $21 at three tests x three trials; the cap is
+# eval.limits.maxCostUsd in packages/agency-lang/agency.json). It never fails on
+# scores — a bad week is information for the batch table, not an alarm. It
+# fails only when a step could not run or the upload was refused. The run
+# directory is always saved as a workflow artifact so a batch whose upload
+# failed can be uploaded by hand: download it, then
+# `agency eval upload <dir>` from a linked checkout.
+#
+# Trigger it manually (workflow_dispatch) to try a cheaper suite or fewer
+# trials without waiting for Sunday.
+name: Agent evals (weekly)
+
+on:
+  schedule:
+    - cron: "0 3 * * 0"
+  workflow_dispatch:
+    inputs:
+      trials:
+        description: "Times to run every test"
+        default: "3"
+      suite:
+        description: "Suite directory, relative to packages/agency-lang"
+        default: "evals/agency-agent"
+
+permissions:
+  contents: read
+
+jobs:
+  evals:
+    # Forks have neither the secrets nor a reason to spend the money.
+    if: github.repository == 'egonSchiele/agency-lang'
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    environment: ci-credentials
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      STATELOG_API_KEY: ${{ secrets.STATELOG_API_KEY }}
+      STATELOG_PROJECT_URL: ${{ vars.STATELOG_PROJECT_URL }}
+      TRIALS: ${{ inputs.trials || '3' }}
+      SUITE: ${{ inputs.suite || 'evals/agency-agent' }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+        with:
+          run_install: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install
+      - run: make
+        working-directory: packages/agency-lang
+
+      - name: Check configuration
+        run: |
+          missing=""
+          [ -n "$OPENAI_API_KEY" ] || missing="$missing OPENAI_API_KEY"
+          [ -n "$STATELOG_API_KEY" ] || missing="$missing STATELOG_API_KEY"
+          [ -n "$STATELOG_PROJECT_URL" ] || missing="$missing STATELOG_PROJECT_URL"
+          if [ -n "$missing" ]; then
+            echo "::error::not configured:$missing"
+            exit 1
+          fi
+
+      - name: Pick a run directory
+        working-directory: packages/agency-lang
+        run: echo "RUN_DIR=runs/weekly-$(date -u +%Y-%m-%d-%H%M%S)" >> "$GITHUB_ENV"
+
+      - name: Link the statelog project
+        working-directory: packages/agency-lang
+        run: node ./dist/scripts/agency.js remote link --url "$STATELOG_PROJECT_URL"
+
+      # Flags here are checked against the CLI's registered options by
+      # lib/cli/eval/workflowFlags.test.ts, so a rename fails `make test`
+      # instead of the Sunday run.
+      - name: Run the suite
+        working-directory: packages/agency-lang
+        run: |
+          node ./dist/scripts/agency.js eval run \
+            --agent-cmd "node $PWD/dist/scripts/agency.js agent --policy recommended -p -- {input}" \
+            --suite "$SUITE" \
+            --trials "$TRIALS" \
+            --parallel 2 \
+            --out "$RUN_DIR"
+
+      - name: Grade
+        working-directory: packages/agency-lang
+        run: node ./dist/scripts/agency.js eval grade "$RUN_DIR"
+
+      - name: Upload to statelog
+        working-directory: packages/agency-lang
+        run: node ./dist/scripts/agency.js eval upload "$RUN_DIR"
+
+      - name: Save the run directory
+        if: always() && env.RUN_DIR != ''
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: eval-runs
+          path: packages/agency-lang/${{ env.RUN_DIR }}
+          retention-days: 14
+          if-no-files-found: ignore

--- a/packages/agency-lang/agency.json
+++ b/packages/agency-lang/agency.json
@@ -17,7 +17,7 @@
   "eval": {
     "limits": {
       "wallClockSec": 900,
-      "maxCostUsd": 25
+      "maxCostUsd": 5
     }
   },
   "doc": {

--- a/packages/agency-lang/agency.json
+++ b/packages/agency-lang/agency.json
@@ -17,7 +17,8 @@
   "eval": {
     "limits": {
       "wallClockSec": 900,
-      "maxCostUsd": 5
+      "maxCostUsd": 5,
+      "maxBatchCostUsd": 25
     }
   },
   "doc": {

--- a/packages/agency-lang/agency.json
+++ b/packages/agency-lang/agency.json
@@ -16,7 +16,8 @@
   },
   "eval": {
     "limits": {
-      "wallClockSec": 900
+      "wallClockSec": 900,
+      "maxCostUsd": 25
     }
   },
   "doc": {

--- a/packages/agency-lang/docs/dev/evals/eval-tracking.md
+++ b/packages/agency-lang/docs/dev/evals/eval-tracking.md
@@ -200,3 +200,17 @@ trace parser, and the annotation fold are not exported.
   `status`, `endedAt`, `eventCount`, `suiteSource`/`suiteSha`, and `score`,
   and silent runs, because statelog needs those and must not derive them
   itself.
+
+## The weekly CI run
+
+`.github/workflows/agent-evals.yml` runs `evals/agency-agent` with three
+trials every Sunday (03:00 UTC), grades it, and uploads it to the linked
+statelog project. `workflow_dispatch` takes `trials` and `suite` overrides for
+a cheap dry run. It needs the `OPENAI_API_KEY` and `STATELOG_API_KEY` secrets
+and the `STATELOG_PROJECT_URL` repository variable (a serve URL, as `remote
+link --url` takes). The cost cap is `eval.limits.maxCostUsd` in `agency.json`,
+not a workflow flag, so a local run of the suite is capped the same way; raise
+it as tests are added. The run directory is kept as a workflow artifact for 14
+days, so a batch whose upload failed can be uploaded by hand.
+`lib/cli/eval/workflowFlags.test.ts` checks every flag the workflow passes
+against the CLI's registered options.

--- a/packages/agency-lang/docs/dev/evals/eval-tracking.md
+++ b/packages/agency-lang/docs/dev/evals/eval-tracking.md
@@ -206,10 +206,20 @@ trace parser, and the annotation fold are not exported.
 `.github/workflows/agent-evals.yml` runs `evals/agency-agent` with three
 trials every Sunday (03:00 UTC), grades it, and uploads it to the linked
 statelog project. `workflow_dispatch` takes `trials` and `suite` overrides for
-a cheaper smoke run (it still calls the paid agent, grades, and uploads). It
-needs three secrets: `OPENAI_API_KEY`, `STATELOG_API_KEY`, and
-`STATELOG_PROJECT_URL` (a serve URL, as `remote link --url` takes; kept as a
-secret beside the key by the owner's choice, though it is not sensitive).
+a cheaper smoke run (it still calls the paid agent, grades, and uploads).
+
+The agent runs the way the suite's README says: inside the eval Docker image
+via `run-in-docker.sh`, with `--policy approve-all`, because the tests write
+and run code. That gives the agent a shell and the network, so the workflow
+bounds what a misbehaving or prompt-injected run can reach: the container
+sees only the LLM key and the run directory; every secret is set on the one
+step that needs it, never job-wide; and the LLM key is a dedicated
+`AGENT_EVALS_OPENAI_API_KEY` with its own spend limit, so a leak costs at
+most that limit until it is rotated. Secrets: `AGENT_EVALS_OPENAI_API_KEY`,
+`STATELOG_API_KEY`, and `STATELOG_PROJECT_URL` (a serve URL, as `remote link
+--url` takes; kept as a secret beside the key by the owner's choice). The run
+directory becomes a workflow artifact only when the upload failed, because it
+holds every trace and artifacts on a public repo are public.
 
 Cost: `eval.limits.maxBatchCostUsd` in `agency.json` caps the whole batch —
 once finished runs have spent that much, no further test starts — and
@@ -223,7 +233,5 @@ statelog shows it as incomplete.
 Scores never fail the job: `eval run` exits 2 when some tests errored and
 `eval grade` exits 2 when a must-pass gate failed; the workflow treats both as
 warnings and carries on to the upload. Any other non-zero exit (could not run,
-grading broke) fails the job. The run directory is kept as a workflow artifact
-for 14 days, so a batch whose upload failed can be uploaded by hand.
-`lib/cli/eval/workflowFlags.test.ts` checks every flag the workflow passes
-against the CLI's registered options.
+grading broke) fails the job. `lib/cli/eval/workflowFlags.test.ts` checks
+every flag the workflow passes against the CLI's registered options.

--- a/packages/agency-lang/docs/dev/evals/eval-tracking.md
+++ b/packages/agency-lang/docs/dev/evals/eval-tracking.md
@@ -207,19 +207,23 @@ trace parser, and the annotation fold are not exported.
 trials every Sunday (03:00 UTC), grades it, and uploads it to the linked
 statelog project. `workflow_dispatch` takes `trials` and `suite` overrides for
 a cheaper smoke run (it still calls the paid agent, grades, and uploads). It
-needs the `OPENAI_API_KEY`, `STATELOG_API_KEY`, and `STATELOG_PROJECT_URL`
-secrets (the last is a serve URL, as `remote link --url` takes).
+needs three secrets: `OPENAI_API_KEY`, `STATELOG_API_KEY`, and
+`STATELOG_PROJECT_URL` (a serve URL, as `remote link --url` takes; kept as a
+secret beside the key by the owner's choice, though it is not sensitive).
 
 Cost: `eval.limits.maxBatchCostUsd` in `agency.json` caps the whole batch —
 once finished runs have spent that much, no further test starts — and
 `maxCostUsd` caps each run on its own, so the worst case is the batch cap plus
 `--parallel` per-run caps (see `docs/site/cli/eval.md`). Grading judges are
 outside both. The caps apply to local runs of the suite too; set them from the
-batch table's real costs. A batch cut short by the cap uploads as incomplete.
+batch table's real costs. A batch cut short by the cap has an uneven trial
+grid: `eval grade` reports it as having no statistics (never throws), and
+statelog shows it as incomplete.
 
-Scores never fail the job: `eval grade` exits 2 when a must-pass gate failed,
-and the workflow treats that as a warning and uploads anyway; any other
-non-zero exit (grading broke) fails the job. The run directory is kept as a
-workflow artifact for 14 days, so a batch whose upload failed can be uploaded
-by hand. `lib/cli/eval/workflowFlags.test.ts` checks every flag the workflow
-passes against the CLI's registered options.
+Scores never fail the job: `eval run` exits 2 when some tests errored and
+`eval grade` exits 2 when a must-pass gate failed; the workflow treats both as
+warnings and carries on to the upload. Any other non-zero exit (could not run,
+grading broke) fails the job. The run directory is kept as a workflow artifact
+for 14 days, so a batch whose upload failed can be uploaded by hand.
+`lib/cli/eval/workflowFlags.test.ts` checks every flag the workflow passes
+against the CLI's registered options.

--- a/packages/agency-lang/docs/dev/evals/eval-tracking.md
+++ b/packages/agency-lang/docs/dev/evals/eval-tracking.md
@@ -206,11 +206,20 @@ trace parser, and the annotation fold are not exported.
 `.github/workflows/agent-evals.yml` runs `evals/agency-agent` with three
 trials every Sunday (03:00 UTC), grades it, and uploads it to the linked
 statelog project. `workflow_dispatch` takes `trials` and `suite` overrides for
-a cheap dry run. It needs the `OPENAI_API_KEY` and `STATELOG_API_KEY` secrets
-and the `STATELOG_PROJECT_URL` repository variable (a serve URL, as `remote
-link --url` takes). The cost cap is `eval.limits.maxCostUsd` in `agency.json`,
-not a workflow flag, so a local run of the suite is capped the same way; raise
-it as tests are added. The run directory is kept as a workflow artifact for 14
-days, so a batch whose upload failed can be uploaded by hand.
-`lib/cli/eval/workflowFlags.test.ts` checks every flag the workflow passes
-against the CLI's registered options.
+a cheaper smoke run (it still calls the paid agent, grades, and uploads). It
+needs the `OPENAI_API_KEY`, `STATELOG_API_KEY`, and `STATELOG_PROJECT_URL`
+secrets (the last is a serve URL, as `remote link --url` takes).
+
+Cost: `eval.limits.maxBatchCostUsd` in `agency.json` caps the whole batch —
+once finished runs have spent that much, no further test starts — and
+`maxCostUsd` caps each run on its own, so the worst case is the batch cap plus
+`--parallel` per-run caps (see `docs/site/cli/eval.md`). Grading judges are
+outside both. The caps apply to local runs of the suite too; set them from the
+batch table's real costs. A batch cut short by the cap uploads as incomplete.
+
+Scores never fail the job: `eval grade` exits 2 when a must-pass gate failed,
+and the workflow treats that as a warning and uploads anyway; any other
+non-zero exit (grading broke) fails the job. The run directory is kept as a
+workflow artifact for 14 days, so a batch whose upload failed can be uploaded
+by hand. `lib/cli/eval/workflowFlags.test.ts` checks every flag the workflow
+passes against the CLI's registered options.

--- a/packages/agency-lang/docs/site/cli/eval.md
+++ b/packages/agency-lang/docs/site/cli/eval.md
@@ -74,10 +74,12 @@ grade it with: agency eval grade runs/smoke
 Each run's agent process gets a wall-clock limit of 60 seconds unless `eval.limits.wallClockSec` in `agency.json` raises it:
 
 ```json
-{ "eval": { "limits": { "wallClockSec": 900, "maxCostUsd": 50 } } }
+{ "eval": { "limits": { "wallClockSec": 900, "maxCostUsd": 50, "maxBatchCostUsd": 100 } } }
 ```
 
 `maxCostUsd` is a per-run LLM spend ceiling, $50 by default. The harness watches each run's cost as it happens and kills the run when it passes the cap. Enforcement lags by one LLM call, because a call's cost is known only when it returns, so treat it as an accident stopper rather than an exact budget.
+
+`maxBatchCostUsd` caps one `eval run` invocation as a whole — every test and every trial — and has no default. Spend is summed as runs finish; once it crosses the cap no further test starts, the ones already running finish under their own `maxCostUsd`, and the run reports `batch cost cap exceeded`. So the worst case is `maxBatchCostUsd` plus `--parallel` times `maxCostUsd`. The tests that never started have no run directory, which a grade or an upload shows as an incomplete batch.
 
 ## Command agents
 

--- a/packages/agency-lang/docs/site/cli/eval.md
+++ b/packages/agency-lang/docs/site/cli/eval.md
@@ -62,7 +62,7 @@ Options:
 
 Agent configuration (strict types, tool-loop caps) comes from the `agency.json` beside the agent, not from eval flags.
 
-Every test runs whatever the others did: a test whose agent errored is a `run` row that grades 0, not a reason to stop. Running never grades. When the run finishes it prints the run directory and the grade command, and exits 1 if any test errored (the run directory is complete either way):
+Every test runs whatever the others did: a test whose agent errored is a `run` row that grades 0, not a reason to stop. Running never grades. When the run finishes it prints the run directory and the grade command, and exits 2 if any test errored (the run directory is complete either way; 1 means it could not run at all):
 
 ```
 Run completed: 3/3 tests ok
@@ -79,7 +79,7 @@ Each run's agent process gets a wall-clock limit of 60 seconds unless `eval.limi
 
 `maxCostUsd` is a per-run LLM spend ceiling, $50 by default. The harness watches each run's cost as it happens and kills the run when it passes the cap. Enforcement lags by one LLM call, because a call's cost is known only when it returns, so treat it as an accident stopper rather than an exact budget.
 
-`maxBatchCostUsd` caps one `eval run` invocation as a whole — every test and every trial — and has no default. Spend is summed as runs finish; once it crosses the cap no further test starts, the ones already running finish under their own `maxCostUsd`, and the run reports `batch cost cap exceeded`. So the worst case is `maxBatchCostUsd` plus `--parallel` times `maxCostUsd`. The tests that never started have no run directory, which a grade or an upload shows as an incomplete batch.
+`maxBatchCostUsd` caps one `eval run` invocation as a whole — every test and every trial — and has no default. Spend is summed as runs finish; once it crosses the cap no further test starts, the ones already running finish under their own `maxCostUsd`, and the run reports `batch cost cap exceeded`. So the worst case is `maxBatchCostUsd` plus `--parallel` times `maxCostUsd`. The tests that never started have no run directory, so the batch's trial grid is uneven: `eval grade` still grades every run that exists and reports the batch as having no statistics, and statelog shows it as incomplete.
 
 ## Command agents
 

--- a/packages/agency-lang/lib/cli/eval/formatGrade.test.ts
+++ b/packages/agency-lang/lib/cli/eval/formatGrade.test.ts
@@ -33,6 +33,7 @@ describe("formatGradeResult", () => {
       mean: 0.75,
       gatesPassed: true,
       batches: [],
+      incompleteBatches: [],
     };
     const lines = formatGradeResult(result).map(stripAnsi);
     expect(lines).toContain("mean 0.750 over 2 runs");
@@ -49,6 +50,7 @@ describe("formatGradeResult", () => {
       mean: 1,
       gatesPassed: true,
       batches: [],
+      incompleteBatches: [],
     };
     expect(formatGradeResult(result).map(stripAnsi)).toContain("grading cost: <$0.01");
   });
@@ -68,6 +70,7 @@ describe("formatGradeResult", () => {
       mean: 0.75,
       gatesPassed: true,
       batches: [],
+      incompleteBatches: [],
     };
     const lines = formatGradeResult(result).map(stripAnsi);
     expect(lines).toEqual([
@@ -87,6 +90,7 @@ describe("formatGradeResult", () => {
       mean: 1,
       gatesPassed: true,
       batches: [],
+      incompleteBatches: [],
     };
     const lines = formatGradeResult(result).map(stripAnsi);
     expect(lines).toEqual([
@@ -109,6 +113,7 @@ describe("formatGradeResult", () => {
       mean: 0.5,
       gatesPassed: false,
       batches: [],
+      incompleteBatches: [],
     };
     const lines = formatGradeResult(result).map(stripAnsi);
     expect(lines).toEqual([
@@ -130,6 +135,7 @@ describe("formatGradeResult with trial batches", () => {
       judgeCostUsd: 0,
       mean: 1,
       gatesPassed: true,
+      incompleteBatches: [],
       batches: [
         {
           batch: "b1",
@@ -194,6 +200,7 @@ describe("formatGradeResult with trial batches", () => {
       judgeCostUsd: 0,
       mean: 0,
       gatesPassed: true,
+      incompleteBatches: [],
       batches: [batch("b1", 1), batch("b2", 0)],
     };
     expect(formatGradeResult(result).map(stripAnsi)).toEqual([

--- a/packages/agency-lang/lib/cli/eval/formatGrade.ts
+++ b/packages/agency-lang/lib/cli/eval/formatGrade.ts
@@ -23,6 +23,10 @@ export function formatGradeResult(result: EvalGradeResult): string[] {
     ...result.runs.flatMap(formatRun),
     ...formatGroupSummary(result),
     ...result.batches.flatMap((batch) => formatBatch(batch, result.batches.length > 1)),
+    ...result.incompleteBatches.map(
+      (entry) =>
+        `${ttyColor.bold(`batch ${entry.batch ?? "(none)"}`)} has no statistics: ${entry.reason}`,
+    ),
   ];
 }
 

--- a/packages/agency-lang/lib/cli/eval/grade.test.ts
+++ b/packages/agency-lang/lib/cli/eval/grade.test.ts
@@ -263,6 +263,30 @@ describe("evalGrade", () => {
     ]);
   });
 
+  it("an uneven trial grid (a batch cut short) still grades every run and names the batch as incomplete", async () => {
+    const group = fs.mkdtempSync(path.join(process.cwd(), ".test-batch-uneven-"));
+    dirs.push(group);
+    const batch = path.basename(group);
+    for (const trial of [1, 2]) {
+      writeRunDirectory(
+        { test: lenTest("a"), output: "hello", batch, trial },
+        path.join(group, "a", String(trial)),
+      );
+    }
+    writeRunDirectory(
+      { test: lenTest("b"), output: "hello", batch, trial: 1 },
+      path.join(group, "b", "1"),
+    );
+
+    const result = await evalGrade([group], { config: {} });
+
+    expect(result.runs).toHaveLength(3);
+    expect(result.batches).toEqual([]);
+    expect(result.incompleteBatches).toEqual([
+      { batch, reason: expect.stringMatching(/incomplete trial grid/) },
+    ]);
+  });
+
   it("two selected batches that reuse test and trial ids are reported separately, never merged", async () => {
     const groups = ["one", "two"].map((name) => {
       const group = fs.mkdtempSync(path.join(process.cwd(), `.test-batch-${name}-`));

--- a/packages/agency-lang/lib/cli/eval/grade.ts
+++ b/packages/agency-lang/lib/cli/eval/grade.ts
@@ -1,7 +1,11 @@
 import * as fs from "fs";
 
 import type { AgencyConfig } from "@/config.js";
-import { batchStatisticsByBatch, type BatchStatistics } from "@/eval/batchStatistics.js";
+import {
+  batchStatisticsByBatchTolerant,
+  type BatchStatistics,
+  type IncompleteBatch,
+} from "@/eval/batchStatistics.js";
 import { gradeSuite } from "@/eval/grading/gradeSuite.js";
 import type { EvalRunGrading } from "@/eval/runTypes.js";
 import { findRunDirectories, uniqueRunDirectories } from "@/runDirectory/findRuns.js";
@@ -39,14 +43,18 @@ export type EvalGradeOptions = {
  *  after grading so the effective scores are the ones just written. A
  *  directory that is not a run (no trace, no run row) contributes nothing;
  *  batches of one trial are left out, the run blocks already say it all. */
-function trialBatches(runDirs: readonly string[]): BatchStatistics[] {
+function trialBatches(runDirs: readonly string[]): {
+  batches: BatchStatistics[];
+  incompleteBatches: IncompleteBatch[];
+} {
   const summaries = runDirs.flatMap((dir) => {
     const summary = summarizeRunDirectory(
       readRunDirectory(dir, { reportWarning: (message) => console.warn(message) }),
     );
     return summary === null ? [] : [summary];
   });
-  return batchStatisticsByBatch(summaries).filter((batch) => batch.trials > 1);
+  const { batches, incomplete } = batchStatisticsByBatchTolerant(summaries);
+  return { batches: batches.filter((batch) => batch.trials > 1), incompleteBatches: incomplete };
 }
 
 /** One graded run directory and the mean over them all. */
@@ -61,6 +69,9 @@ export type EvalGradeResult = {
   /** Trial statistics for each selected batch that ran more than one trial,
    *  in the order the batches were met. Unrelated batches never merge. */
   batches: BatchStatistics[];
+  /** Batches with no statistics — an uneven trial grid, say — and why. Their
+   *  runs are still graded above; only the batch-level numbers are missing. */
+  incompleteBatches: IncompleteBatch[];
 };
 
 /** The command's own preconditions, checked before anything loads: the two
@@ -127,7 +138,7 @@ export async function evalGrade(
     mean: runs.reduce((sum, run) => sum + run.grading.objective, 0) / runs.length,
     judgeCostUsd: graded.reduce((sum, entry) => sum + entry.judgeCostUsd, 0),
     gatesPassed: runs.every((run) => run.grading.gatesPassed),
-    batches: trialBatches(runDirs),
+    ...trialBatches(runDirs),
   };
 
   if (opts.out !== undefined) {

--- a/packages/agency-lang/lib/cli/eval/run.test.ts
+++ b/packages/agency-lang/lib/cli/eval/run.test.ts
@@ -16,7 +16,7 @@ import { readRunDirectory, runDirPaths } from "@/runDirectory/runDir.js";
 import { finishedTraceLines } from "@/runDirectory/testFixtures.js";
 
 import { evalGrade } from "./grade.js";
-import { evalRun, totalRunCostUsd, validateInputSelection } from "./run.js";
+import { evalRun, validateInputSelection } from "./run.js";
 
 /** A runner that behaves like a real child: a finished trace under the
  *  harness-minted trace id, recording the seeded code for file jobs. */
@@ -384,27 +384,6 @@ describe("eval run CLI", () => {
         validateGraders([new ExactMatch({})], { id: "a", goal: "g", input: "t" }),
       ).toThrow(/matchOn/);
     });
-  });
-
-  it("totalRunCostUsd sums trace costs across the run directories of a group", () => {
-    const group = fs.mkdtempSync(path.join(tmpDir, "group-"));
-    writeRunDirectory(
-      { test: { id: "a", input: "t" }, output: "x", costUsd: 0.25 },
-      path.join(group, "a"),
-    );
-    writeRunDirectory(
-      { test: { id: "b", input: "t" }, output: "y", costUsd: 0.5 },
-      path.join(group, "b"),
-    );
-    writeRunDirectory(
-      { test: { id: "c", input: "t" }, wroteStatelog: false, ended: "error" },
-      path.join(group, "c"),
-    );
-    expect(totalRunCostUsd(group)).toBeCloseTo(0.75);
-    expect(totalRunCostUsd(path.join(group, "a"))).toBeCloseTo(0.25);
-    // A run that never wrote a trace, and a group with no runs at all.
-    expect(totalRunCostUsd(path.join(group, "c"))).toBeUndefined();
-    expect(totalRunCostUsd(fs.mkdtempSync(path.join(tmpDir, "empty-")))).toBeUndefined();
   });
 
   describe("per-test graders", () => {

--- a/packages/agency-lang/lib/cli/eval/run.ts
+++ b/packages/agency-lang/lib/cli/eval/run.ts
@@ -124,27 +124,3 @@ export function loadSuite(args: {
   }
   return { tests: loadInputs(parsed.path, nanoid, loadOptions), identity: { source: parsed.path } };
 }
-
-/** Total LLM spend across the run directories under `groupDir`, summed from
- *  each trace's metrics. Traces of interrupted runs count too, so an
- *  interrupted run still reports what it cost. Undefined when no trace
- *  carried a cost (or the group holds no runs yet). */
-export function totalRunCostUsd(groupDir: string): number | undefined {
-  let total: number | undefined;
-  let runDirs: string[];
-  try {
-    runDirs = findRunDirectories([groupDir]);
-  } catch {
-    return undefined;
-  }
-  for (const dir of runDirs) {
-    const snapshot = readRunDirectory(dir, { reportWarning: () => {} });
-    for (const trace of snapshot.traces) {
-      const cost = evalRecordFor(trace, snapshot.dir).metrics.costUsdTotal;
-      if (typeof cost === "number" && Number.isFinite(cost)) {
-        total = (total ?? 0) + cost;
-      }
-    }
-  }
-  return total;
-}

--- a/packages/agency-lang/lib/cli/eval/workflowFlags.test.ts
+++ b/packages/agency-lang/lib/cli/eval/workflowFlags.test.ts
@@ -1,0 +1,63 @@
+import * as fs from "fs";
+import * as path from "path";
+
+import { describe, expect, it } from "vitest";
+
+import { createProgram } from "../../../scripts/agency.js";
+import type { Command } from "@/vendor/commander/index.js";
+
+// The weekly workflow calls the CLI by hand-written flags. A renamed flag
+// would otherwise surface as a failed Sunday run nobody watches; this checks
+// every flag in the workflow against the command's registered options.
+
+const WORKFLOW = path.resolve(__dirname, "../../../../../.github/workflows/agent-evals.yml");
+
+/** Every `agency <sub> <command> …` invocation in the workflow, unwrapped
+ *  across backslash continuations, as the words after `agency.js`. */
+function invocations(): string[][] {
+  const text = fs.readFileSync(WORKFLOW, "utf8").replace(/\\\n\s*/g, " ");
+  return [...text.matchAll(/agency\.js ([^\n]+)/g)].map((match) => match[1].trim().split(/\s+/));
+}
+
+function subcommand(program: Command, names: string[]): Command {
+  return names.reduce((command, name) => {
+    const found = command.commands.find((child) => child.name() === name);
+    if (found === undefined) throw new Error(`no command ${names.join(" ")}`);
+    return found;
+  }, program);
+}
+
+/** The `--flag`s of an invocation. Quoted values (the agent command) are
+ *  skipped: their own `--policy`/`-p` belong to `agency agent`. */
+function flagsOf(words: string[]): string[] {
+  const flags: string[] = [];
+  let inQuote = false;
+  for (const word of words) {
+    const quotes = (word.match(/"/g) ?? []).length;
+    if (!inQuote && /^--?[a-z]/.test(word)) flags.push(word);
+    if (quotes % 2 === 1) inQuote = !inQuote;
+  }
+  return flags;
+}
+
+describe("agent-evals.yml", () => {
+  const program = createProgram();
+  const found = invocations();
+
+  it("invokes eval run, eval grade, eval upload, and remote link", () => {
+    const heads = found.map((words) => words.slice(0, 2).join(" "));
+    expect(heads).toEqual(
+      expect.arrayContaining(["remote link", "eval run", "eval grade", "eval upload"]),
+    );
+  });
+
+  it("uses only flags the commands register", () => {
+    for (const words of found) {
+      const command = subcommand(program, words.slice(0, 2));
+      const known = command.options.flatMap((option) => [option.long, option.short]);
+      for (const flag of flagsOf(words.slice(2))) {
+        expect(known, `${words.slice(0, 2).join(" ")} ${flag}`).toContain(flag);
+      }
+    }
+  });
+});

--- a/packages/agency-lang/lib/config.ts
+++ b/packages/agency-lang/lib/config.ts
@@ -142,6 +142,7 @@ export interface AgencyConfig {
     limits?: {
       wallClockSec?: number; // max seconds per agent run (default 60)
       maxCostUsd?: number; // max LLM spend per agent run (default 50)
+      maxBatchCostUsd?: number; // max LLM spend per `eval run` invocation, all tests × trials (no default)
     };
 
     optimize?: {
@@ -513,6 +514,7 @@ export const AgencyConfigSchema = z
           .object({
             wallClockSec: z.number().int().positive(),
             maxCostUsd: z.number().positive(),
+            maxBatchCostUsd: z.number().positive(),
           })
           .partial()
           .optional(),

--- a/packages/agency-lang/lib/eval/batchStatistics.test.ts
+++ b/packages/agency-lang/lib/eval/batchStatistics.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from "vitest";
 
 import type { RunSummary } from "@/runDirectory/list.js";
 
-import { batchStatistics, batchStatisticsByBatch } from "./batchStatistics.js";
+import {
+  batchStatistics,
+  batchStatisticsByBatch,
+  batchStatisticsByBatchTolerant,
+} from "./batchStatistics.js";
 
 type Overrides = Partial<RunSummary>;
 
@@ -191,6 +195,23 @@ describe("batchStatisticsByBatch", () => {
     expect(groups.map((group) => [group.batch, group.accuracy])).toEqual([
       [null, 1],
       [null, 0],
+    ]);
+  });
+
+  it("tolerant variant reports an incomplete batch beside the others' statistics", () => {
+    const complete = [run({ batch: "x", testId: "a", trial: 1, score: 1 })];
+    const uneven = [
+      run({ batch: "y", testId: "a", trial: 1, score: 1 }),
+      run({ batch: "y", testId: "a", trial: 2, score: 0 }),
+      run({ batch: "y", testId: "b", trial: 1, score: 1 }),
+    ];
+    const { batches, incomplete } = batchStatisticsByBatchTolerant([...complete, ...uneven]);
+    expect(batches.map((batch) => batch.batch)).toEqual(["x"]);
+    expect(incomplete).toEqual([
+      {
+        batch: "y",
+        reason: expect.stringMatching(/incomplete trial grid: a has 2 trials, b has 1/),
+      },
     ]);
   });
 });

--- a/packages/agency-lang/lib/eval/batchStatistics.ts
+++ b/packages/agency-lang/lib/eval/batchStatistics.ts
@@ -36,6 +36,35 @@ export type BatchStatistics = {
 /** Split runs into batches by their batch id (a run without one is a batch
  *  of its own), in first-seen order, and compute each batch's statistics. */
 export function batchStatisticsByBatch(runs: readonly RunSummary[]): BatchStatistics[] {
+  return groupByBatch(runs).map((group) => batchStatistics(group.runs));
+}
+
+/** A batch that could not be scored as a whole (an uneven trial grid — a run
+ *  cut short by the batch cost cap or an interrupt — or mixed ids), with the
+ *  reason `batchStatistics` gave. */
+export type IncompleteBatch = { batch: string | null; reason: string };
+
+/** Like `batchStatisticsByBatch`, but a batch that `batchStatistics` refuses
+ *  is reported rather than thrown, so one incomplete batch never hides the
+ *  others' statistics. */
+export function batchStatisticsByBatchTolerant(runs: readonly RunSummary[]): {
+  batches: BatchStatistics[];
+  incomplete: IncompleteBatch[];
+} {
+  const batches: BatchStatistics[] = [];
+  const incomplete: IncompleteBatch[] = [];
+  for (const group of groupByBatch(runs)) {
+    try {
+      batches.push(batchStatistics(group.runs));
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      incomplete.push({ batch: group.batch, reason });
+    }
+  }
+  return { batches, incomplete };
+}
+
+function groupByBatch(runs: readonly RunSummary[]): { batch: string | null; runs: RunSummary[] }[] {
   const groups: { batch: string | null; runs: RunSummary[] }[] = [];
   for (const run of runs) {
     const group =
@@ -46,7 +75,7 @@ export function batchStatisticsByBatch(runs: readonly RunSummary[]): BatchStatis
       group.runs.push(run);
     }
   }
-  return groups.map((group) => batchStatistics(group.runs));
+  return groups;
 }
 
 /** Statistics for exactly one complete batch. Refuses an empty input, runs

--- a/packages/agency-lang/lib/eval/run/batchBudget.test.ts
+++ b/packages/agency-lang/lib/eval/run/batchBudget.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { batchCostCapFromConfig, makeBatchBudget } from "./batchBudget.js";
+
+describe("batchCostCapFromConfig", () => {
+  it("has no default and honors eval.limits.maxBatchCostUsd", () => {
+    expect(batchCostCapFromConfig({})).toBeUndefined();
+    expect(batchCostCapFromConfig({ eval: { limits: { maxBatchCostUsd: 25 } } })).toBe(25);
+    for (const bad of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(
+        batchCostCapFromConfig({ eval: { limits: { maxBatchCostUsd: bad } } }),
+      ).toBeUndefined();
+    }
+  });
+});
+
+describe("makeBatchBudget", () => {
+  it("reports the crossing once and stays exhausted", () => {
+    const budget = makeBatchBudget(5);
+    expect(budget.add(3)).toBe(false);
+    expect(budget.exhausted()).toBe(false);
+    expect(budget.add(3)).toBe(true);
+    expect(budget.exhausted()).toBe(true);
+    expect(budget.add(1)).toBe(false);
+    expect(budget.spentUsd()).toBe(7);
+    expect(budget.exceededMessage()).toContain("$7.00 spent, cap $5.00");
+  });
+
+  it("never exhausts without a cap", () => {
+    const budget = makeBatchBudget(undefined);
+    expect(budget.add(1_000)).toBe(false);
+    expect(budget.exhausted()).toBe(false);
+    expect(budget.spentUsd()).toBe(1_000);
+  });
+});

--- a/packages/agency-lang/lib/eval/run/batchBudget.ts
+++ b/packages/agency-lang/lib/eval/run/batchBudget.ts
@@ -1,0 +1,48 @@
+import type { AgencyConfig } from "@/config.js";
+import { makeStatelogCostTailer } from "./costTail.js";
+import * as fs from "fs";
+
+/** `eval.limits.maxBatchCostUsd`, or undefined when the config sets no
+ *  batch-wide cap. Unlike the per-run cap there is no default: a suite's
+ *  size is the user's, so is its budget. */
+export function batchCostCapFromConfig(config: AgencyConfig): number | undefined {
+  const cap = config.eval?.limits?.maxBatchCostUsd;
+  const valid = typeof cap === "number" && Number.isFinite(cap) && cap > 0;
+  return valid ? cap : undefined;
+}
+
+export type BatchBudget = {
+  /** Record one finished run's spend; true when this crossed the cap. */
+  add(costUsd: number): boolean;
+  exhausted(): boolean;
+  spentUsd(): number;
+  exceededMessage(): string;
+};
+
+/** Spend across one `eval run` invocation, summed from finished runs. The
+ *  suite stops STARTING runs once the cap is crossed; runs already in flight
+ *  finish under their own per-run cap, so the worst case is the batch cap
+ *  plus `parallel` per-run caps. */
+export function makeBatchBudget(capUsd: number | undefined): BatchBudget {
+  let spent = 0;
+  let exhausted = false;
+  return {
+    add(costUsd: number): boolean {
+      spent += costUsd;
+      if (capUsd === undefined || exhausted || spent <= capUsd) return false;
+      exhausted = true;
+      return true;
+    },
+    exhausted: () => exhausted,
+    spentUsd: () => spent,
+    exceededMessage: () =>
+      `batch cost cap exceeded: $${spent.toFixed(2)} spent, cap $${(capUsd ?? 0).toFixed(2)} ` +
+      `(eval.limits.maxBatchCostUsd raises it); no further tests will start`,
+  };
+}
+
+/** A finished run's LLM spend, read from its statelog; 0 when it left none. */
+export function runCostUsd(statelogPath: string | null): number {
+  if (statelogPath === null || !fs.existsSync(statelogPath)) return 0;
+  return makeStatelogCostTailer(statelogPath).poll();
+}

--- a/packages/agency-lang/lib/eval/run/runSuite.test.ts
+++ b/packages/agency-lang/lib/eval/run/runSuite.test.ts
@@ -631,6 +631,95 @@ describe("runSuite", () => {
     expect(withGoal.objective()).toBe(1);
   });
 
+  it("sequential: once the batch cost cap is crossed, no further test starts", async () => {
+    const runner = vi.fn(async (job: EvalRunnerJob) => {
+      fs.writeFileSync(
+        job.statelogPath,
+        finishedTraceLines(job.traceId, { output: "done", costUsd: 3 }).join("\n") + "\n",
+      );
+      return { ok: true as const };
+    });
+    const result = await runSuite(
+      {
+        agent: path.join(proj, "agent.agency"),
+        inputs: [
+          { id: "a", goal: "g", input: "t" },
+          { id: "b", goal: "g", input: "t" },
+          { id: "c", goal: "g", input: "t" },
+        ],
+        out: path.join(proj, "runs", "r-budget"),
+        config: { eval: { limits: { maxBatchCostUsd: 5 } } },
+        perRun: { pipeOutput: false },
+        progress: false,
+      },
+      { runner },
+    );
+    expect(runner).toHaveBeenCalledTimes(2);
+    expect(result.tests.map((test) => test.testId)).toEqual(["a", "b"]);
+    expect(result.costUsd).toBe(6);
+    expect(result.batchCostCapExceeded).toBe(true);
+    expect(fs.readdirSync(result.runDir).sort()).toEqual(["a", "b"]);
+  });
+
+  it("parallel: an exhausted batch budget stops scheduling; in-flight runs still record", async () => {
+    const runner = vi.fn(async (job: EvalRunnerJob) => {
+      await new Promise((r) => setTimeout(r, 20));
+      fs.writeFileSync(
+        job.statelogPath,
+        finishedTraceLines(job.traceId, { output: "done", costUsd: 4 }).join("\n") + "\n",
+      );
+      return { ok: true as const };
+    });
+    const result = await runSuite(
+      {
+        agent: path.join(proj, "agent.agency"),
+        inputs: [
+          { id: "a", goal: "g", input: "t" },
+          { id: "b", goal: "g", input: "t" },
+          { id: "c", goal: "g", input: "t" },
+          { id: "d", goal: "g", input: "t" },
+        ],
+        out: path.join(proj, "runs", "r-par-budget"),
+        config: { eval: { limits: { maxBatchCostUsd: 3 } } },
+        parallel: 2,
+        progress: false,
+      },
+      { runner },
+    );
+    // a and b start together; the first to finish crosses the cap ($4 > $3),
+    // the other is already in flight and records; c and d never start.
+    expect(runner).toHaveBeenCalledTimes(2);
+    expect(result.tests.map((test) => test.testId)).toEqual(["a", "b"]);
+    expect(result.batchCostCapExceeded).toBe(true);
+  });
+
+  it("without a batch cap, spend is reported and never stops the suite", async () => {
+    const runner = vi.fn(async (job: EvalRunnerJob) => {
+      fs.writeFileSync(
+        job.statelogPath,
+        finishedTraceLines(job.traceId, { output: "done", costUsd: 100 }).join("\n") + "\n",
+      );
+      return { ok: true as const };
+    });
+    const result = await runSuite(
+      {
+        agent: path.join(proj, "agent.agency"),
+        inputs: [
+          { id: "a", goal: "g", input: "t" },
+          { id: "b", goal: "g", input: "t" },
+        ],
+        out: path.join(proj, "runs", "r-no-budget"),
+        config: {},
+        perRun: { pipeOutput: false },
+        progress: false,
+      },
+      { runner },
+    );
+    expect(runner).toHaveBeenCalledTimes(2);
+    expect(result.costUsd).toBe(200);
+    expect(result.batchCostCapExceeded).toBe(false);
+  });
+
   it("a broken grading module fails before any agent runs", async () => {
     const modulePath = path.join(proj, "graders.ts");
     fs.writeFileSync(modulePath, "export const notDefault = 1;");

--- a/packages/agency-lang/lib/eval/run/runSuite.ts
+++ b/packages/agency-lang/lib/eval/run/runSuite.ts
@@ -10,6 +10,7 @@ import { ttyColor } from "@/utils/termcolors.js";
 import { makeStatelogCostTailer } from "./costTail.js";
 import { formatElapsed, startStatusBoard } from "./statusBoard.js";
 import type { AgencyConfig } from "@/config.js";
+import { batchCostCapFromConfig, makeBatchBudget, runCostUsd } from "./batchBudget.js";
 import type { SuiteRunResult, SuiteTestResult, Test } from "@/eval/runTypes.js";
 import type { RunOutcome, SuiteIdentity } from "@/runDirectory/annotations.js";
 import { recordedClosureHashes } from "@/runDirectory/attachCode.js";
@@ -137,6 +138,9 @@ export async function runSuite(
   };
   process.once("SIGINT", onSigint);
 
+  const budget = makeBatchBudget(batchCostCapFromConfig(config));
+  const shouldStop = () => interrupted || budget.exhausted();
+
   const parallel = Math.max(1, Math.floor(opts.parallel ?? 1));
   // `agent` is the target's label (an agent file path or the command line),
   // so a listing can say which agent a directory's runs came from.
@@ -193,6 +197,9 @@ export async function runSuite(
         },
         { runner: deps.runner },
       );
+      if (budget.add(runCostUsd(run.statelogPath)) && progress) {
+        console.warn(budget.exceededMessage());
+      }
       const assembled = `${stagingDir}.rundir`;
       fs.rmSync(assembled, { recursive: true, force: true });
       try {
@@ -245,7 +252,7 @@ export async function runSuite(
         trials,
         progress,
         pipeOutput: perRun.pipeOutput ?? true,
-        isInterrupted: () => interrupted,
+        shouldStop,
         executeTest,
       });
     } else {
@@ -255,7 +262,7 @@ export async function runSuite(
         trials,
         parallel,
         progress,
-        isInterrupted: () => interrupted,
+        shouldStop,
         executeTest,
       });
     }
@@ -270,6 +277,8 @@ export async function runSuite(
     tests: results,
     okCount: results.filter((result) => result.status === "success").length,
     errorCount: results.filter((result) => result.status === "error").length,
+    costUsd: budget.spentUsd(),
+    batchCostCapExceeded: budget.exhausted(),
   };
 }
 
@@ -444,17 +453,17 @@ function endedFrom(run: AgentRun): RunOutcome {
  * is never piped (n interleaved streams are noise — `eval logs <dir> -f` is
  * the drill-down); a status board shows each test's state, elapsed time, and
  * cost so far (tailed from its live statelog every second). An errored test
- * never stops the others (it is a `run` row that grades 0); an interrupt
- * stops SCHEDULING and in-flight runs settle normally (their forwarded
- * SIGINT kills their trees and they come back as error results). Results
- * keep input order.
+ * never stops the others (it is a `run` row that grades 0); an interrupt or
+ * an exhausted batch budget stops SCHEDULING and in-flight runs settle
+ * normally (on interrupt their forwarded SIGINT kills their trees and they
+ * come back as error results). Results keep input order.
  */
 async function runPool(args: {
   jobs: RunJob[];
   trials: number;
   parallel: number;
   progress: boolean;
-  isInterrupted: () => boolean;
+  shouldStop: () => boolean;
   executeTest: (
     job: RunJob,
     pipeOutput: boolean,
@@ -474,7 +483,7 @@ async function runPool(args: {
 
   const worker = async (): Promise<void> => {
     for (;;) {
-      if (args.isInterrupted()) return;
+      if (args.shouldStop()) return;
       const index = nextIndex++;
       if (index >= args.jobs.length) return;
       const job = args.jobs[index];
@@ -520,7 +529,7 @@ async function runSequential(args: {
   trials: number;
   progress: boolean;
   pipeOutput: boolean;
-  isInterrupted: () => boolean;
+  shouldStop: () => boolean;
   executeTest: (
     job: RunJob,
     pipeOutput: boolean,
@@ -551,7 +560,7 @@ async function runSequential(args: {
       console.error(`[${label}] ${status} in ${formatElapsed(Date.now() - startedAt)}`);
     }
     results.push(outcome);
-    if (args.isInterrupted()) break;
+    if (args.shouldStop()) break;
   }
   return results;
 }

--- a/packages/agency-lang/lib/eval/run/runSuite.ts
+++ b/packages/agency-lang/lib/eval/run/runSuite.ts
@@ -10,7 +10,12 @@ import { ttyColor } from "@/utils/termcolors.js";
 import { makeStatelogCostTailer } from "./costTail.js";
 import { formatElapsed, startStatusBoard } from "./statusBoard.js";
 import type { AgencyConfig } from "@/config.js";
-import { batchCostCapFromConfig, makeBatchBudget, runCostUsd } from "./batchBudget.js";
+import {
+  batchCostCapFromConfig,
+  makeBatchBudget,
+  runCostUsd,
+  type BatchBudget,
+} from "./batchBudget.js";
 import type { SuiteRunResult, SuiteTestResult, Test } from "@/eval/runTypes.js";
 import type { RunOutcome, SuiteIdentity } from "@/runDirectory/annotations.js";
 import { recordedClosureHashes } from "@/runDirectory/attachCode.js";
@@ -271,14 +276,24 @@ export async function runSuite(
     removeIfEmpty(stagingRoot);
   }
 
+  return suiteResult({ runDir: groupDir, agentLabel: target.label, results, budget });
+}
+
+function suiteResult(args: {
+  runDir: string;
+  agentLabel: string;
+  results: SuiteTestResult[];
+  budget: BatchBudget;
+}): SuiteRunResult {
+  const { results } = args;
   return {
-    runDir: groupDir,
-    agentLabel: target.label,
+    runDir: args.runDir,
+    agentLabel: args.agentLabel,
     tests: results,
     okCount: results.filter((result) => result.status === "success").length,
     errorCount: results.filter((result) => result.status === "error").length,
-    costUsd: budget.spentUsd(),
-    batchCostCapExceeded: budget.exhausted(),
+    costUsd: args.budget.spentUsd(),
+    batchCostCapExceeded: args.budget.exhausted(),
   };
 }
 

--- a/packages/agency-lang/lib/eval/runTypes.ts
+++ b/packages/agency-lang/lib/eval/runTypes.ts
@@ -101,6 +101,11 @@ export type SuiteRunResult = {
   tests: SuiteTestResult[];
   okCount: number;
   errorCount: number;
+  /** LLM spend summed from the finished runs' statelogs. */
+  costUsd: number;
+  /** True when `eval.limits.maxBatchCostUsd` was crossed: the tests after
+   *  the crossing never started, so `tests` is shorter than the suite. */
+  batchCostCapExceeded: boolean;
 };
 
 /** A run's score, as `eval grade` reports it. */

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -67,7 +67,7 @@ import {
 import { runGradeCommand } from "@/cli/eval/grade.js";
 import { resolveRunStatelog } from "@/cli/eval/logs.js";
 import { evalLs } from "@/cli/eval/ls.js";
-import { evalRun, totalRunCostUsd } from "@/cli/eval/run.js";
+import { evalRun } from "@/cli/eval/run.js";
 import { evalUpload, formatUploadResult } from "@/cli/eval/upload.js";
 import { ttyColor } from "@/utils/termcolors.js";
 import { evalOptimize } from "@/cli/eval/optimize.js";
@@ -901,10 +901,7 @@ export function createProgram(deps: CliDependencies = {}): Command {
             console.log(`  ${ttyColor.red(`${test.testId} error:`)} ${test.errorMessage ?? ""}`);
           }
         }
-        const costUsd = totalRunCostUsd(result.runDir);
-        if (costUsd !== undefined) {
-          console.log(`total LLM cost: $${costUsd.toFixed(2)}`);
-        }
+        console.log(`total LLM cost: $${result.costUsd.toFixed(2)}`);
         if (result.batchCostCapExceeded) {
           console.log(
             ttyColor.red("batch cost cap exceeded") +
@@ -913,10 +910,12 @@ export function createProgram(deps: CliDependencies = {}): Command {
         }
         console.log(`runs written under ${result.runDir}`);
         console.log(`grade it with: agency eval grade ${result.runDir}`);
-        // The run is complete and written; the exit code still reports that
-        // not every test ran to an end (a harness refusal or an agent crash).
+        // The run is complete and written; exit 2 still reports that not
+        // every test ran to an end (a harness refusal or an agent crash) —
+        // distinct from 1, which is "could not run at all", so a caller can
+        // grade and upload the directory anyway.
         if (result.errorCount > 0) {
-          process.exit(1);
+          process.exit(2);
         }
       },
     );

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -905,6 +905,12 @@ export function createProgram(deps: CliDependencies = {}): Command {
         if (costUsd !== undefined) {
           console.log(`total LLM cost: $${costUsd.toFixed(2)}`);
         }
+        if (result.batchCostCapExceeded) {
+          console.log(
+            ttyColor.red("batch cost cap exceeded") +
+              `: the remaining tests were not run (eval.limits.maxBatchCostUsd raises it)`,
+          );
+        }
         console.log(`runs written under ${result.runDir}`);
         console.log(`grade it with: agency eval grade ${result.runDir}`);
         // The run is complete and written; the exit code still reports that


### PR DESCRIPTION
PR 4 of the eval-tracking project (spec Part 3, `docs/superpowers/specs/2026-08-22-eval-tracking-pipeline-design.md`). Statelog's API (#54) and UI (#56) are merged and deployed.

## What

- `.github/workflows/agent-evals.yml` — Sundays 03:00 UTC, plus `workflow_dispatch` with `trials` (default 3) and `suite` (default `evals/agency-agent`). Steps: build → `make eval-image` → `remote link --url` → `eval run` with the suite's `run-in-docker.sh` wrapper (`--policy approve-all`, as the suite README prescribes) → `eval grade` → `eval upload`. Never fails on scores: `eval run` exit 2 (some tests errored) and `eval grade` exit 2 (a must-pass gate failed) are warnings and the upload still happens; any other non-zero exit fails the job. `timeout-minutes: 180`, fork-guarded, actions pinned by SHA.
- **Bounding an approve-all agent** — the container sees only the LLM key and the run directory; every secret is set on the one step that needs it, never job-wide; the LLM key is a dedicated `AGENT_EVALS_OPENAI_API_KEY` meant to carry its own spend limit; the run directory is saved as an artifact only when the upload failed (artifacts on a public repo are public).
- **Batch-wide budget** — new `eval.limits.maxBatchCostUsd`: `runSuite` sums each finished run's spend and stops starting tests once it is crossed (in-flight runs finish under `maxCostUsd`), so the worst case is batch cap + `--parallel` × per-run cap; judge costs are outside both. `agency.json` sets `maxBatchCostUsd: 25` and `maxCostUsd: 5`. `eval grade` tolerates the uneven trial grid a cut-short batch leaves (reports "has no statistics" instead of throwing); statelog already shows such a batch as incomplete.
- `eval run` exits 2 when some tests errored, 1 when it could not run; prints one cost total (`result.costUsd`).
- `lib/cli/eval/workflowFlags.test.ts` — checks every flag of each `agency.js …` invocation in the workflow against the command's registered options.
- Dev note section in `docs/dev/evals/eval-tracking.md`; `docs/site/cli/eval.md` documents the new cap and exit codes.

## Configuration

Three secrets in the `ci-credentials` environment: `AGENT_EVALS_OPENAI_API_KEY` (a dedicated OpenAI key with a hard monthly spend limit — new, must be created), `STATELOG_API_KEY`, and `STATELOG_PROJECT_URL` (a serve URL, `…/serve/:user/:project/:file`; kept as a secret by the owner's choice). Suggest a first `workflow_dispatch` with `suite=evals/smoke`, `trials=1` to check the wiring cheaply.

Not verified: an actual Actions run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YSdUvTQqBfWKBERTyspUHR

