### PR TITLE
Bound eval upload concurrency; retry shed statelog requests

### DIFF
--- a/packages/agency-lang/lib/cli/eval/upload.ts
+++ b/packages/agency-lang/lib/cli/eval/upload.ts
@@ -12,6 +12,7 @@ import { findRunDirectories, uniqueRunDirectories } from "@/runDirectory/findRun
 import { summarizeRunDirectory, type RunSummary } from "@/runDirectory/list.js";
 import { readRunDirectory } from "@/runDirectory/runDir.js";
 import { agentNameProblem } from "@/statelog/agentName.js";
+import { mapInParallel } from "@/utils/parallelMap.js";
 import type { EventEnvelope } from "@/statelog/wireTypes.js";
 
 /**
@@ -56,6 +57,8 @@ export type EvalUploadResult = {
   batchUrl: string | null;
 };
 
+const UPLOAD_PARALLELISM = 6;
+
 export async function evalUpload(
   targets: string[],
   target: EvalUploadTarget,
@@ -65,8 +68,12 @@ export async function evalUpload(
     dependencies.client ?? createEvalUploadClient(target.origin, target.projectSlug, target.apiKey);
   const reportWarning = dependencies.reportWarning ?? ((message) => console.warn(message));
   const dirs = uniqueRunDirectories(findRunDirectories(targets));
-  // Runs are independent traces, so they upload at once; results keep input order.
-  const records = await Promise.all(dirs.map((dir) => uploadRun(dir, client, reportWarning)));
+  // Runs are independent traces, so they upload through a bounded pool —
+  // unbounded, a 69-run group is hundreds of concurrent requests and the
+  // host sheds them with 429s. Results keep input order.
+  const records = await mapInParallel(dirs, UPLOAD_PARALLELISM, (dir) =>
+    uploadRun(dir, client, reportWarning),
+  );
   return { runs: records.map((record) => record.outcome), batchUrl: batchUrlFor(records, target) };
 }
 

--- a/packages/agency-lang/lib/cli/statelog/statelogRequest.test.ts
+++ b/packages/agency-lang/lib/cli/statelog/statelogRequest.test.ts
@@ -206,9 +206,12 @@ describe("statelogRequest programmer-error boundary", () => {
         waits.push(ms);
         return Promise.resolve();
       };
+      const cancel = vi.fn().mockResolvedValue(undefined);
+      const shed = (): Response =>
+        ({ ...textResponse(429, "Rate exceeded"), body: { cancel } }) as unknown as Response;
       fetchMock
-        .mockResolvedValueOnce(textResponse(429, "Rate exceeded"))
-        .mockResolvedValueOnce(textResponse(429, "Rate exceeded"))
+        .mockResolvedValueOnce(shed())
+        .mockResolvedValueOnce(shed())
         .mockResolvedValueOnce(jsonResponse(200, { success: true, value: 7 }));
 
       const result = await request({ sleep });
@@ -216,6 +219,8 @@ describe("statelogRequest programmer-error boundary", () => {
       expect(result).toEqual({ ok: true, value: 7, status: 200 });
       expect(fetchMock).toHaveBeenCalledTimes(3);
       expect(waits).toEqual([RETRY_DELAYS_MS[0], RETRY_DELAYS_MS[1]]);
+      // Each shed response's unread body is cancelled before the retry.
+      expect(cancel).toHaveBeenCalledTimes(2);
     });
 
     it("gives up after the last delay and reports the 503 as an http failure", async () => {

--- a/packages/agency-lang/lib/cli/statelog/statelogRequest.test.ts
+++ b/packages/agency-lang/lib/cli/statelog/statelogRequest.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { statelogRequest } from "./statelogRequest.js";
+import { RETRY_DELAYS_MS, statelogRequest } from "./statelogRequest.js";
 import type { StatelogRequestOptions } from "./statelogRequest.js";
 
 function textResponse(status: number, rawBody: string): Response {
@@ -197,5 +197,41 @@ describe("statelogRequest programmer-error boundary", () => {
         },
       }),
     ).rejects.toThrow("sanitizer bug");
+  });
+
+  describe("retry on shed requests", () => {
+    it("retries a 429 with backoff and returns the eventual success", async () => {
+      const waits: number[] = [];
+      const sleep = (ms: number): Promise<void> => {
+        waits.push(ms);
+        return Promise.resolve();
+      };
+      fetchMock
+        .mockResolvedValueOnce(textResponse(429, "Rate exceeded"))
+        .mockResolvedValueOnce(textResponse(429, "Rate exceeded"))
+        .mockResolvedValueOnce(jsonResponse(200, { success: true, value: 7 }));
+
+      const result = await request({ sleep });
+
+      expect(result).toEqual({ ok: true, value: 7, status: 200 });
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      expect(waits).toEqual([RETRY_DELAYS_MS[0], RETRY_DELAYS_MS[1]]);
+    });
+
+    it("gives up after the last delay and reports the 503 as an http failure", async () => {
+      const sleep = (): Promise<void> => Promise.resolve();
+      fetchMock.mockResolvedValue(textResponse(503, "overloaded"));
+
+      const failure = await failureOf({ sleep });
+
+      expect(fetchMock).toHaveBeenCalledTimes(RETRY_DELAYS_MS.length + 1);
+      expect(failure).toMatchObject({ kind: "http", status: 503 });
+    });
+
+    it("never retries a non-retryable status", async () => {
+      fetchMock.mockResolvedValue(jsonResponse(500, { success: false, error: "boom" }));
+      await failureOf();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/agency-lang/lib/cli/statelog/statelogRequest.ts
+++ b/packages/agency-lang/lib/cli/statelog/statelogRequest.ts
@@ -39,7 +39,19 @@ export type StatelogRequestOptions = {
   contentType?: "when-body" | "always";
   /** Diagnostic-only redaction, forwarded to readJsonBody. */
   sanitizeDiagnostic?: (raw: string) => string;
+  /** Test seam for the retry backoff; default real timer. */
+  sleep?: (ms: number) => Promise<void>;
 };
+
+// A 429 or 503 means the server (or Cloud Run in front of it) shed the
+// request before handling it, so a retry cannot double-apply anything.
+// Waits are long enough that a burst of concurrent uploads spreads out.
+const RETRYABLE_STATUSES = new Set([429, 503]);
+export const RETRY_DELAYS_MS = [500, 2_000, 8_000];
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 export type StatelogRequestResult =
   { ok: true; value: unknown; status: number } | { ok: false; failure: StatelogFailure };
@@ -62,15 +74,22 @@ export async function statelogRequest(
     headers["Content-Type"] = "application/json";
   }
 
+  const sleep = options.sleep ?? defaultSleep;
   let response: Response;
-  try {
-    response = await fetch(options.url, {
-      method: options.method,
-      headers,
-      body: serializedBody,
-    });
-  } catch (error) {
-    return { ok: false, failure: { kind: "unreachable", cause: message(error) } };
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      response = await fetch(options.url, {
+        method: options.method,
+        headers,
+        body: serializedBody,
+      });
+    } catch (error) {
+      return { ok: false, failure: { kind: "unreachable", cause: message(error) } };
+    }
+    if (!RETRYABLE_STATUSES.has(response.status) || attempt >= RETRY_DELAYS_MS.length) {
+      break;
+    }
+    await sleep(RETRY_DELAYS_MS[attempt]);
   }
 
   const parsed = await readJsonBody(

--- a/packages/agency-lang/lib/cli/statelog/statelogRequest.ts
+++ b/packages/agency-lang/lib/cli/statelog/statelogRequest.ts
@@ -75,21 +75,25 @@ export async function statelogRequest(
   }
 
   const sleep = options.sleep ?? defaultSleep;
+  const fetchOnce = (): Promise<Response> =>
+    fetch(options.url, { method: options.method, headers, body: serializedBody });
+
+  // One retry per listed delay, then the last response stands.
   let response: Response;
-  for (let attempt = 0; ; attempt += 1) {
-    try {
-      response = await fetch(options.url, {
-        method: options.method,
-        headers,
-        body: serializedBody,
-      });
-    } catch (error) {
-      return { ok: false, failure: { kind: "unreachable", cause: message(error) } };
+  try {
+    response = await fetchOnce();
+    for (const delayMs of RETRY_DELAYS_MS) {
+      if (!RETRYABLE_STATUSES.has(response.status)) {
+        break;
+      }
+      // A shed response's body is never read; cancel it (best-effort) so its
+      // socket is released before the retry rather than held until GC.
+      await response.body?.cancel().catch(() => {});
+      await sleep(delayMs);
+      response = await fetchOnce();
     }
-    if (!RETRYABLE_STATUSES.has(response.status) || attempt >= RETRY_DELAYS_MS.length) {
-      break;
-    }
-    await sleep(RETRY_DELAYS_MS[attempt]);
+  } catch (error) {
+    return { ok: false, failure: { kind: "unreachable", cause: message(error) } };
   }
 
   const parsed = await readJsonBody(


### PR DESCRIPTION
Uploading a large run group (e.g. 69 runs) fired every run's requests at once — `Promise.all` over all directories, each with an upload-state GET, bulk POSTs, and annotation POSTs — and Cloud Run shed the burst with 429s.

- `evalUpload` uploads through `mapInParallel` with a pool of 6; results keep input order.
- `statelogRequest` retries 429/503 up to three times (0.5s / 2s / 8s). Those statuses mean the request was shed before handling, so a retry cannot double-apply anything; every other status and network errors are untouched. Applies to all sealed statelog clients.
- Tests: retry-until-success with the exact backoff sequence, give-up-after-last-delay, non-retryable statuses never retried.

Related: uploads of runs graded after 8/24 fail with `Unrecognized key: "graderFiles"` until a release containing #917 is published and statelog bumps to it — separate from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YSdUvTQqBfWKBERTyspUHR
