### PR TITLE
Keep thread labels and sessions when a checkpoint is loaded from JSON

### DIFF
--- a/packages/agency-lang/docs/dev/runtime/checkpointing.md
+++ b/packages/agency-lang/docs/dev/runtime/checkpointing.md
@@ -234,6 +234,14 @@ node main() {
 
 ### External persistence via getCheckpoint
 
+`restore()` accepts the parsed JSON directly; it revives it with
+`Checkpoint.fromJSON`, which validates against the zod schemas in
+`lib/runtime/state/schemas.ts`. zod strips any key a schema does not name, so
+every field `MessageThread.toJSON` and `ThreadStore.toJSON` write must be
+listed there. When a field is missing, a checkpoint read back from disk
+silently loses it: thread labels and the `sessions` map were dropped this way,
+so a resumed `thread(session: "main")` opened a fresh thread.
+
 ```agency
 node main() {
   const cp = checkpoint()

--- a/packages/agency-lang/docs/dev/runtime/checkpointing.md
+++ b/packages/agency-lang/docs/dev/runtime/checkpointing.md
@@ -234,13 +234,11 @@ node main() {
 
 ### External persistence via getCheckpoint
 
-`restore()` accepts the parsed JSON directly; it revives it with
+`restore()` accepts the parsed JSON directly and revives it with
 `Checkpoint.fromJSON`, which validates against the zod schemas in
-`lib/runtime/state/schemas.ts`. zod strips any key a schema does not name, so
-every field `MessageThread.toJSON` and `ThreadStore.toJSON` write must be
-listed there. When a field is missing, a checkpoint read back from disk
-silently loses it: thread labels and the `sessions` map were dropped this way,
-so a resumed `thread(session: "main")` opened a fresh thread.
+`lib/runtime/state/schemas.ts`. zod drops any key a schema does not name, so
+when adding a field to `MessageThread.toJSON` or `ThreadStore.toJSON`, add it
+to the schema too, or a checkpoint read back from a file will lose it.
 
 ```agency
 node main() {

--- a/packages/agency-lang/lib/runtime/checkpoint.test.ts
+++ b/packages/agency-lang/lib/runtime/checkpoint.test.ts
@@ -106,6 +106,25 @@ describe("getCheckpoint()", () => {
 });
 
 describe("restore()", () => {
+  it("accepts a checkpoint that was serialized to JSON and parsed back", async () => {
+    const ctx = makeMockCtx();
+    const id = await wrap(ctx, () => checkpoint());
+    const plain = JSON.parse(JSON.stringify(wrap(ctx, () => getCheckpoint(id))));
+
+    try {
+      wrap(ctx, () => restore(plain, {}));
+      expect.unreachable("restore() must throw RestoreSignal");
+    } catch (e) {
+      expect(e).toBeInstanceOf(RestoreSignal);
+      expect((e as RestoreSignal).checkpoint.id).toBe(id);
+    }
+  });
+
+  it("rejects an object that is not a checkpoint", () => {
+    const ctx = makeMockCtx();
+    expect(() => wrap(ctx, () => restore({ nope: true } as any, {}))).toThrow(CheckpointError);
+  });
+
   it("should throw RestoreSignal", async () => {
     const ctx = makeMockCtx();
     const id = await wrap(ctx, () => checkpoint());

--- a/packages/agency-lang/lib/runtime/checkpoint.test.ts
+++ b/packages/agency-lang/lib/runtime/checkpoint.test.ts
@@ -122,7 +122,7 @@ describe("restore()", () => {
 
   it("rejects an object that is not a checkpoint", () => {
     const ctx = makeMockCtx();
-    expect(() => wrap(ctx, () => restore({ nope: true } as any, {}))).toThrow(CheckpointError);
+    expect(() => wrap(ctx, () => restore({ nope: true }, {}))).toThrow(CheckpointError);
   });
 
   it("should throw RestoreSignal", async () => {

--- a/packages/agency-lang/lib/runtime/checkpoint.ts
+++ b/packages/agency-lang/lib/runtime/checkpoint.ts
@@ -30,7 +30,7 @@ export function getCheckpoint(checkpointId: number): Checkpoint {
 }
 
 export function restore(
-  checkpointIdOrCheckpoint: number | Checkpoint,
+  checkpointIdOrCheckpoint: number | Checkpoint | Record<string, unknown>,
   options: RestoreOptions,
 ): void {
   const { ctx } = getRuntimeContext();
@@ -43,7 +43,7 @@ export function restore(
       );
     cp = found;
   } else {
-    // A checkpoint read back from disk is plain JSON, not an instance.
+    // A checkpoint read back from a file is plain JSON, not an instance.
     const revived = Checkpoint.fromJSON(checkpointIdOrCheckpoint);
     if (!revived) throw new CheckpointError("Invalid checkpoint object passed to restore()");
     cp = revived;

--- a/packages/agency-lang/lib/runtime/checkpoint.ts
+++ b/packages/agency-lang/lib/runtime/checkpoint.ts
@@ -1,7 +1,7 @@
 import { CheckpointError, RestoreSignal } from "./errors.js";
 import type { RestoreOptions } from "./errors.js";
 import { getRuntimeContext } from "./asyncContext.js";
-import type { Checkpoint } from "./state/checkpointStore.js";
+import { Checkpoint } from "./state/checkpointStore.js";
 
 /**
  * Capture a checkpoint of the current execution state. The source
@@ -43,7 +43,10 @@ export function restore(
       );
     cp = found;
   } else {
-    cp = checkpointIdOrCheckpoint;
+    // A checkpoint read back from disk is plain JSON, not an instance.
+    const revived = Checkpoint.fromJSON(checkpointIdOrCheckpoint);
+    if (!revived) throw new CheckpointError("Invalid checkpoint object passed to restore()");
+    cp = revived;
   }
 
   const location = cp.getLocation();

--- a/packages/agency-lang/lib/runtime/index.ts
+++ b/packages/agency-lang/lib/runtime/index.ts
@@ -115,7 +115,7 @@ export { checkpoint, getCheckpoint, restore } from "./checkpoint.js";
 export { _run } from "./ipc.js";
 
 export { CheckpointStore, RESULT_ENTRY_LABEL } from "./state/checkpointStore.js";
-export type { Checkpoint } from "./state/checkpointStore.js";
+export { Checkpoint } from "./state/checkpointStore.js";
 
 export {
   setupNode,

--- a/packages/agency-lang/lib/runtime/state/checkpointStore.test.ts
+++ b/packages/agency-lang/lib/runtime/state/checkpointStore.test.ts
@@ -391,6 +391,37 @@ describe("Checkpoint", () => {
       expect(cp!.label).toBeNull();
       expect(cp!.pinned).toBe(false);
     });
+
+    it("keeps every thread field and the sessions map through a JSON round trip", () => {
+      // A checkpoint written to disk with JSON.stringify(getCheckpoint(id))
+      // and read back must reopen `thread(session: "main")` on the same
+      // thread. Before the schema named these fields, zod stripped them.
+      const threads = {
+        threads: {
+          "1": {
+            messages: [{ role: "user" as const, content: "hi" }],
+            messageLabels: ["greeting"],
+            parentId: null,
+            hidden: false,
+            label: "main",
+            summary: "a chat",
+            queuedMessages: [],
+            repairs: 2,
+          },
+        },
+        counter: 2,
+        activeStack: ["1"],
+        sessions: { main: "1" },
+      };
+      const plain = {
+        id: 4,
+        stack: makeStackJSON([{ args: {}, threads }]),
+        globals: makeGlobalsJSON(),
+        nodeId: "n1",
+      };
+      const cp = Checkpoint.fromJSON(JSON.parse(JSON.stringify(plain)));
+      expect(cp!.stack.stack[0].threads).toEqual(threads);
+    });
   });
 });
 

--- a/packages/agency-lang/lib/runtime/state/schemas.ts
+++ b/packages/agency-lang/lib/runtime/state/schemas.ts
@@ -1,8 +1,18 @@
 import { z } from "zod";
 
 // MessageThreadJSON
+// Every field MessageThread.toJSON writes. zod strips keys a schema does
+// not name, so a field missing here is silently dropped when a checkpoint
+// is loaded from JSON (a saved session lost its thread labels this way).
 export const messageThreadJSONSchema = z.object({
   messages: z.array(z.any()),
+  messageLabels: z.array(z.string().nullable()).optional(),
+  parentId: z.string().nullable().optional(),
+  hidden: z.boolean().optional(),
+  label: z.string().nullable().optional(),
+  summary: z.string().nullable().optional(),
+  queuedMessages: z.array(z.any()).optional(),
+  repairs: z.number().optional(),
 });
 
 // ThreadStoreJSON
@@ -10,6 +20,7 @@ export const threadStoreJSONSchema = z.object({
   threads: z.record(z.string(), messageThreadJSONSchema),
   counter: z.number(),
   activeStack: z.array(z.string()),
+  sessions: z.record(z.string(), z.string()).optional(),
 });
 
 // BranchStateJSON (forward-declared due to mutual recursion with StateStackJSON)

--- a/packages/agency-lang/lib/runtime/state/schemas.ts
+++ b/packages/agency-lang/lib/runtime/state/schemas.ts
@@ -2,8 +2,8 @@ import { z } from "zod";
 
 // MessageThreadJSON
 // Every field MessageThread.toJSON writes. zod strips keys a schema does
-// not name, so a field missing here is silently dropped when a checkpoint
-// is loaded from JSON (a saved session lost its thread labels this way).
+// not name, so a field missing here is dropped when a checkpoint is read
+// back from JSON.
 export const messageThreadJSONSchema = z.object({
   messages: z.array(z.any()),
   messageLabels: z.array(z.string().nullable()).optional(),
@@ -12,7 +12,7 @@ export const messageThreadJSONSchema = z.object({
   label: z.string().nullable().optional(),
   summary: z.string().nullable().optional(),
   queuedMessages: z.array(z.any()).optional(),
-  repairs: z.number().optional(),
+  repairs: z.number().int().nonnegative().optional(),
 });
 
 // ThreadStoreJSON


### PR DESCRIPTION
## What

A checkpoint saved to disk with `JSON.stringify(getCheckpoint(id))` and read back lost its thread metadata. `Checkpoint.fromJSON` validates with zod, and zod strips keys the schema does not name; the thread schema only named `messages`. So `label`, `summary`, `hidden`, `parentId`, `messageLabels`, `repairs`, and the store's `sessions` map were all dropped on load. In practice: after a resume, `thread(session: "main")` opened a new empty thread instead of continuing the saved conversation. Found while spiking save/resume for `agency agent`.

## Changes

- `lib/runtime/state/schemas.ts`: name every field `MessageThread.toJSON` and `ThreadStore.toJSON` write.
- `lib/runtime/checkpoint.ts`: `restore()` accepts the parsed JSON object and revives it with `Checkpoint.fromJSON` (it used to crash with `cp.getLocation is not a function`); a non-checkpoint object throws `CheckpointError`.
- `lib/runtime/index.ts`: export the `Checkpoint` class, not just its type.
- `docs/dev/runtime/checkpointing.md`: note that the schema must name every serialized field, and why.

## Tests

- `checkpointStore.test.ts`: a JSON round trip keeps every thread field and `sessions`. Fails on main (verified by stashing the schema change), passes here.
- `checkpoint.test.ts`: `restore()` on a parsed checkpoint throws `RestoreSignal` with the right id; a non-checkpoint object throws `CheckpointError`.

Ran the two test files, `pnpm run typecheck`, prettier, `lint:structure`, and `lib/sourceIsText.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012vPUGq5ALLFNRfJoy3ytfp
