### PR TITLE
Print the transcript on resume; add /rename for agent sessions

### DIFF
--- a/packages/agency-lang/docs/dev/agents/agent-sessions.md
+++ b/packages/agency-lang/docs/dev/agents/agent-sessions.md
@@ -73,26 +73,21 @@ step in the checkpoint and come back from a restore as nothing.
 
 ### The transcript on resume
 
-A resumed run prints the saved conversation first, so the user can see
-what it was about (and some resumes are only for reading it). Nothing
-placed after `restore()` runs: it throws a signal, the runtime replays to
-the saved point, and that point is the `repl(...)` call, whose earlier
-steps are already complete. So the transcript is read from the checkpoint
-file, not from the restored threads: `_readTranscript` in
-`agentSessions.ts` parses the file with `Checkpoint.fromJSON`, finds the
-`main` thread on the saved stack (or the largest top-level thread for a
-brain that labels none), and returns its user and assistant messages.
-`showTranscript` in `repl.agency` draws them the way the turns were drawn
-when they ran, then `startSession` restores.
+A resumed run prints the saved conversation before it restores. It is
+read from the checkpoint file (`_readTranscript` in `agentSessions.ts`),
+not from the restored threads, because `restore()` replays to the saved
+point and runs nothing placed after it. The thread is the one the brain
+opens with `thread(session: ...)`; each brain names it in its
+`AgentBrain.session` field, and the title refresh reads the same thread.
+`showTranscript` in `transcript.agency` draws the messages with the same
+renderers the live turns use.
 
 ### `/rename`
 
-`/rename <title>` sets the record's title (cleaned with `cleanTitle`),
-pins it so the periodic title refresh leaves it alone, and marks the
-record dirty. `recordTurn` returns a save target for a dirty record even
-when no turn ran, so the same `_sessionOnSubmit` path writes both files
-after the command, and the checkpoint's copy of the record agrees with
-the record file. The pin is a `let` global, so it comes back on resume.
+`/rename <title>` sets the record's title, pins it so the periodic title
+refresh leaves it alone, and marks the record dirty. `recordTurn` returns
+a save target for a dirty record even when no turn ran, so the save that
+follows every REPL line writes it.
 
 Because the `let` globals come back from the saved run, `--model`,
 `--policy`, and similar flags passed on a resume are ignored; the session

--- a/packages/agency-lang/docs/dev/agents/agent-sessions.md
+++ b/packages/agency-lang/docs/dev/agents/agent-sessions.md
@@ -71,6 +71,29 @@ TypeScript module state (`installSessionHooks`, before the restore), not as
 an Agency value: a closure built by an Agency statement would be a completed
 step in the checkpoint and come back from a restore as nothing.
 
+### The transcript on resume
+
+A resumed run prints the saved conversation first, so the user can see
+what it was about (and some resumes are only for reading it). Nothing
+placed after `restore()` runs: it throws a signal, the runtime replays to
+the saved point, and that point is the `repl(...)` call, whose earlier
+steps are already complete. So the transcript is read from the checkpoint
+file, not from the restored threads: `_readTranscript` in
+`agentSessions.ts` parses the file with `Checkpoint.fromJSON`, finds the
+`main` thread on the saved stack (or the largest top-level thread for a
+brain that labels none), and returns its user and assistant messages.
+`showTranscript` in `repl.agency` draws them the way the turns were drawn
+when they ran, then `startSession` restores.
+
+### `/rename`
+
+`/rename <title>` sets the record's title (cleaned with `cleanTitle`),
+pins it so the periodic title refresh leaves it alone, and marks the
+record dirty. `recordTurn` returns a save target for a dirty record even
+when no turn ran, so the same `_sessionOnSubmit` path writes both files
+after the command, and the checkpoint's copy of the record agrees with
+the record file. The pin is a `let` global, so it comes back on resume.
+
 Because the `let` globals come back from the saved run, `--model`,
 `--policy`, and similar flags passed on a resume are ignored; the session
 continues as it was left.
@@ -81,5 +104,5 @@ file is read back (see `docs/dev/runtime/checkpointing.md`).
 
 ## Not in v1
 
-Naming and renaming, forking, `/resume` inside a session, saving one-shot
+Forking, `/resume` inside a session, saving one-shot
 (`-p`) runs, mid-turn crash recovery, and cleanup of old sessions.

--- a/packages/agency-lang/docs/site/stdlib/thread.md
+++ b/packages/agency-lang/docs/site/stdlib/thread.md
@@ -35,7 +35,7 @@ export type AttachmentSource =
   | { kind: "base64"; base64: string; mimeType: string }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L56))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L57))
 
 ### Attachment
 
@@ -46,7 +46,7 @@ export type Attachment =
   | null }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L65))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L66))
 
 ### MessageAttachment
 
@@ -59,7 +59,7 @@ export type MessageAttachment =
   | null }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L74))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L75))
 
 ### ModelCost
 
@@ -78,7 +78,7 @@ export type ModelCost = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L229))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L230))
 
 ### GuardFailureData
 
@@ -93,7 +93,7 @@ export type GuardFailureData = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L254))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L255))
 
 ### ThreadMessage
 
@@ -104,7 +104,7 @@ export type ThreadMessage = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L277))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L278))
 
 ### ThreadInfo
 
@@ -120,7 +120,7 @@ export type ThreadInfo = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L282))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L283))
 
 ## Functions
 
@@ -144,7 +144,7 @@ Add a system message to the current thread's message history.
 | msg | `string` |  |
 | label | `string` | "" |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L79))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L80))
 
 ### userMessage
 
@@ -166,7 +166,7 @@ Add a user message to the current thread's message history. Use this
 | msg | `string \| (string \| MessageAttachment)[]` |  |
 | label | `string` | "" |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L91))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L92))
 
 ### toolMessage
 
@@ -194,7 +194,7 @@ Add a synthetic tool call and its result to the current thread, as if the
 | result | `string` |  |
 | label | `string` | "" |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L103))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L104))
 
 ### image
 
@@ -223,7 +223,7 @@ Build an image attachment for a multimodal llm() call. The source is
 
 **Returns:** [Attachment](#attachment)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L124))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L125))
 
 ### file
 
@@ -254,7 +254,7 @@ Build a file (e.g. PDF) attachment for a multimodal llm() call.
 
 **Returns:** [Attachment](#attachment)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L140))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L141))
 
 ### audio
 
@@ -287,7 +287,7 @@ Build an audio attachment for a multimodal llm() call. Only usable in
 
 **Returns:** [MessageAttachment](#messageattachment)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L157))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L158))
 
 ### attachToReply
 
@@ -309,7 +309,7 @@ Queue an attachment to be shown to the model after the current tool
 |---|---|---|
 | attachment | [Attachment](#attachment) |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L176))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L177))
 
 ### assistantMessage
 
@@ -331,7 +331,7 @@ Add an assistant message to the current thread's message history.
 | msg | `string` |  |
 | label | `string` | "" |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L189))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L190))
 
 ### getCost
 
@@ -350,7 +350,7 @@ Inside a fork/race branch this includes the parent's accumulated cost
 
 **Returns:** `number`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L206))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L207))
 
 ### threadIsNew
 
@@ -363,7 +363,7 @@ True when the current message thread has no messages yet. Use it inside a
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L214))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L215))
 
 ### getTokens
 
@@ -375,7 +375,7 @@ Return the cumulative token count for the current execution branch.
 
 **Returns:** `number`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L222))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L223))
 
 ### getModelCosts
 
@@ -393,7 +393,7 @@ Unlike the per-branch cost/token accessors, this reads process-wide
 
 **Returns:** `ModelCost[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L245))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L246))
 
 ### listThreads
 
@@ -426,7 +426,26 @@ Summary sourcing: threads opened with `thread(summarize: true)` are
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L354))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L355))
+
+### sessionThreadId
+
+```ts
+sessionThreadId(name: string): string
+```
+
+Slug-form id of the thread that `thread(session: name)` resumes (e.g.
+  "t3"), or `""` when nothing has been opened under that name yet.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| name | `string` |  |
+
+**Returns:** `string`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L408))
 
 ### currentThreadId
 
@@ -441,7 +460,7 @@ Slug-form id of the active thread (e.g. "t3"), or `""` outside any
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L407))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L416))
 
 ### getThread
 
@@ -473,4 +492,4 @@ Read a slice of a thread's messages. Returns success holding `[]`
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L417))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L426))

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -18,7 +18,7 @@ import { getHeader } from "./lib/header.agency"
 import { maybeLoadMcp } from "./lib/mcp.agency"
 import { printPolicyHelp } from "./lib/policy.agency"
 import { chooseSession, startSession } from "./lib/resume.agency"
-import { installSessionHooks, startInteractive } from "./lib/repl.agency"
+import { installSessionHooks, showTranscript, startInteractive } from "./lib/repl.agency"
 import { pickModelsForAgent, maybeEnableMemory } from "./lib/session.agency"
 import { loadSettings } from "./lib/settings.agency"
 import { setDebug, setVerbose, setInteractive } from "./lib/trace.agency"
@@ -181,7 +181,11 @@ node main() {
   // those TypeScript-side effects and replaces only the Agency state.
   if (!isOneShot) {
     installSessionHooks()
-    startSession(chooseSession(args.flags.continue, args.flags.resume ?? null), brain.name)
+    startSession(
+      chooseSession(args.flags.continue, args.flags.resume ?? null),
+      brain.name,
+      showTranscript,
+    )
   }
 
   if (isOneShot) {

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -18,7 +18,7 @@ import { getHeader } from "./lib/header.agency"
 import { maybeLoadMcp } from "./lib/mcp.agency"
 import { printPolicyHelp } from "./lib/policy.agency"
 import { chooseSession, startSession } from "./lib/resume.agency"
-import { installSessionHooks, showTranscript, startInteractive } from "./lib/repl.agency"
+import { installSessionHooks, startInteractive } from "./lib/repl.agency"
 import { pickModelsForAgent, maybeEnableMemory } from "./lib/session.agency"
 import { loadSettings } from "./lib/settings.agency"
 import { setDebug, setVerbose, setInteractive } from "./lib/trace.agency"
@@ -181,11 +181,7 @@ node main() {
   // those TypeScript-side effects and replaces only the Agency state.
   if (!isOneShot) {
     installSessionHooks()
-    startSession(
-      chooseSession(args.flags.continue, args.flags.resume ?? null),
-      brain.name,
-      showTranscript,
-    )
+    startSession(chooseSession(args.flags.continue, args.flags.resume ?? null), brain)
   }
 
   if (isOneShot) {

--- a/packages/agency-lang/lib/agents/agency-agent/brains/brain.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/brain.agency
@@ -17,6 +17,9 @@ export type AgentBrain = {
   name: string;
   // One line, shown by --help next to the name.
   description: string;
+  // The `thread(session: ...)` name of the conversation with the user. The
+  // saved-session title and the transcript printed on resume read it.
+  session: string;
   // Valid --agent values. "" (the main entry) is always valid and not listed.
   startTargets: string[];
   // Called once, inside the policy handler, before any turn. Validate the

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/coordinator.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/coordinator.agency
@@ -122,6 +122,7 @@ def coordinatorRunTurn(
 export def coordinatorBrain(): AgentBrain {
   return {
     name: "coordinator",
+    session: "main",
     description: "One coordinator LLM that routes to code, research, oracle, explorer, review, writing, and rewrite subagents",
     startTargets: ["code", "research", "oracle", "explorer", "review", "writing", "rewrite"],
     init: coordinatorInit,

--- a/packages/agency-lang/lib/agents/agency-agent/brains/simple/simple.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/simple/simple.agency
@@ -35,6 +35,7 @@ def simpleRunTurn(
 export def simpleBrain(): AgentBrain {
   return {
     name: "simple",
+    session: "simple",
     description: "One tool-less LLM call per turn, in a single thread",
     startTargets: [],
     init: simpleInit,

--- a/packages/agency-lang/lib/agents/agency-agent/lib/commandPalette.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/commandPalette.agency
@@ -8,6 +8,7 @@ export def builtinPalette(): Record<string, string> {
     "/clear": "Clear the conversation transcript",
     "/clear-history": "Clear the input history (recall + saved file)",
     "/cost": "Show cumulative LLM cost and tokens",
+    "/rename": "Give this session a title: /rename <title>",
     "/model": "Switch the model (bare to pick, or slot=model)",
     "/models": "List / filter the hosted model catalog",
     "/local": "Switch to a local model",

--- a/packages/agency-lang/lib/agents/agency-agent/lib/repl.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/repl.agency
@@ -49,7 +49,13 @@ import { configureLocalModel, getResolvedSlots, currentProvider } from "../share
 
 import { _installSessionHooks, _sessionOnSubmit } from "agency-lang/stdlib-lib/agentSessions.js"
 
-import { markTurnDone, recordTurn, saveSeedTurn, sessionTitle } from "./resume.agency"
+import {
+  markTurnDone,
+  recordTurn,
+  renameSession,
+  saveSeedTurn,
+  sessionTitle,
+ } from "./resume.agency"
 import { runTurn } from "./turn.agency"
 import { parseModelSpec } from "./utils.agency"
 
@@ -237,7 +243,7 @@ def _runTurn(msg: string): boolean {
     }
     "/help" => {
       pushMessage(
-        "Commands: /exit, /clear, /clear-history, /cost, /model, /models, /local, /search, /settings, /mcp, /paste, /help",
+        "Commands: /exit, /clear, /clear-history, /cost, /model, /models, /local, /search, /settings, /mcp, /rename, /paste, /help",
       )
       return true
     }
@@ -252,7 +258,11 @@ def _runTurn(msg: string): boolean {
     "/model" => modelSlashCommand(trimmed)
     "/models" => modelsSlashCommand(trimmed)
     "/local" => localSlashCommand()
+    "/rename" => renameSlashCommand("")
     _ => {
+      if (trimmed.startsWith("/rename ")) {
+        return renameSlashCommand(trimmed.slice(8))
+      }
       if (trimmed.startsWith("/model ")) {
         return modelSlashCommand(trimmed)
       }
@@ -264,6 +274,23 @@ def _runTurn(msg: string): boolean {
   }
 }
 
+
+def renameSlashCommand(title: string): boolean {
+  pushMessage(renameSession(title))
+  return true
+}
+
+/** The saved conversation, drawn the way the turns were when they ran:
+  the user's lines dimmed after a `>`, the replies as markdown. */
+export def showTranscript(messages: any[]) {
+  for (m in messages) {
+    if (m.role == "user") {
+      pushMessage(color.dim("> ${m.content}"))
+    } else {
+      renderAgentResponse(success(m.content))
+    }
+  }
+}
 
 def renderUserTurn(trimmed: string, msg: string): boolean {
   const result = try runTurn("", msg)

--- a/packages/agency-lang/lib/agents/agency-agent/lib/repl.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/repl.agency
@@ -6,7 +6,6 @@
 import { localModelsSupported, listModelNames } from "std::agency/local"
 import { listHostedModels } from "std::llm"
 import { expandSlash } from "std::skills"
-import { highlight } from "std::syntax"
 import { getCost, getModelCosts } from "std::thread"
 import { chooseOption, ChoiceItem } from "std::ui"
 import {
@@ -56,6 +55,7 @@ import {
   saveSeedTurn,
   sessionTitle,
  } from "./resume.agency"
+import { renderReply, renderUserLine } from "./transcript.agency"
 import { runTurn } from "./turn.agency"
 import { parseModelSpec } from "./utils.agency"
 
@@ -280,18 +280,6 @@ def renameSlashCommand(title: string): boolean {
   return true
 }
 
-/** The saved conversation, drawn the way the turns were when they ran:
-  the user's lines dimmed after a `>`, the replies as markdown. */
-export def showTranscript(messages: any[]) {
-  for (m in messages) {
-    if (m.role == "user") {
-      pushMessage(color.dim("> ${m.content}"))
-    } else {
-      renderAgentResponse(success(m.content))
-    }
-  }
-}
-
 def renderUserTurn(trimmed: string, msg: string): boolean {
   const result = try runTurn("", msg)
   renderAgentResponse(result)
@@ -309,7 +297,7 @@ export def buildStatus(): { left: string; right: string; context: string } {
 }
 
 export def runSeedTurn(target: string, msg: string) {
-  pushMessage(color.dim("> ${msg}"))
+  renderUserLine(msg)
   const response = try runTurn(target, msg)
   renderAgentResponse(response)
   markTurnDone()
@@ -321,7 +309,7 @@ export def renderAgentResponse(
 ): void {
   if (response is success(reply)) {
     if (reply != "" && reply != null) {
-      pushMessage(highlight("${reply}\n", language: "markdown"))
+      renderReply(reply)
     } else {
       pushMessage(color.red("No reply generated."))
     }

--- a/packages/agency-lang/lib/agents/agency-agent/lib/resume.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/resume.agency
@@ -21,7 +21,9 @@ import {
   saveSession,
   sessionLabel,
  } from "./sessions.agency"
-import { cleanTitle, mainThreadText, shouldRefreshTitle, titleFor } from "./sessionTitle.agency"
+import { cleanTitle, conversationText, shouldRefreshTitle, titleFor } from "./sessionTitle.agency"
+import { showTranscript } from "./transcript.agency"
+import { AgentBrain } from "../brains/brain.agency"
 
 // The session this run writes to; null for one-shot runs, which are not
 // saved. A `let`, so a restore brings back the resumed session's own
@@ -32,10 +34,13 @@ let _current: SessionRecord | null = null
 // empty line is not recorded as a turn.
 let _turnDone = false
 
-// Set by `/rename`: the record changed without a turn, so the next save
-// must still happen, and the title is the user's now, never rewritten.
+// Set by `/rename`: the record changed without a turn, and the title is
+// the user's now.
 let _renamed = false
 let _titlePinned = false
+
+// The brain's conversation session, for the title and the transcript.
+let _conversation = ""
 
 /** Where to write after a turn: the session directory and its index row. */
 export type SaveTarget = {
@@ -57,12 +62,11 @@ export def markTurnDone() {
 }
 
 /** `/rename <title>`: give the session a title of the user's choosing.
-  Returns the line to show. The title is written with the next save,
-  which the REPL runs after this line whether or not a turn ran. */
+  Returns the line to show. The REPL saves after this line. */
 export def renameSession(title: string): string {
   const record = _current
   if (record == null) {
-    return "This run is not saved, so it cannot be renamed."
+    return "No session to rename."
   }
   const clean = cleanTitle(title)
   if (clean == "") {
@@ -136,21 +140,17 @@ def pickSession(): SessionRecord | null {
 
 /** Start this run's session. A new one gets a fresh record. A saved one
   is restored right here: the Agency execution state becomes the saved
-  one and the program continues from the saved point. `showTranscript`
-  prints the saved conversation first, because nothing written after
-  `restore` runs: it replays to the saved point, which is the REPL
-  waiting for a line. */
-export def startSession(
-  chosen: SessionRecord | null,
-  brain: string,
-  showTranscript: (messages: any[]) -> void,
-) {
+  one and the program continues from the saved point. The saved
+  conversation is printed before the restore, since nothing after
+  `restore` runs. */
+export def startSession(chosen: SessionRecord | null, brain: AgentBrain) {
+  _conversation = brain.session
   if (chosen == null) {
     const t = now()
     _current = {
       id: newSessionId(),
       cwd: cwd(),
-      brain: brain,
+      brain: brain.name,
       created: t,
       lastActive: t,
       turns: 0,
@@ -164,7 +164,7 @@ export def startSession(
     process.exit(1)
   }
   print(color.dim("Resuming: ${chosen.title}"))
-  showTranscript(_readTranscript(cp))
+  showTranscript(_readTranscript(cp, brain.session))
   restore(cp, {})
 }
 
@@ -191,7 +191,7 @@ export def recordTurn(userMsg: string): SaveTarget | null {
     // conversation so far.
     let source = userMsg
     if (record.turns > 1) {
-      source = mainThreadText()
+      source = conversationText(_conversation)
     }
     const title = titleFor(source)
     if (title != "") {

--- a/packages/agency-lang/lib/agents/agency-agent/lib/resume.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/resume.agency
@@ -8,6 +8,8 @@ import { now } from "std::date"
 import { cwd } from "std::system"
 import { chooseOption, ChoiceItem } from "std::ui"
 
+import { _readTranscript } from "agency-lang/stdlib-lib/agentSessions.js"
+
 import {
   SessionRecord,
   findSession,
@@ -19,7 +21,7 @@ import {
   saveSession,
   sessionLabel,
  } from "./sessions.agency"
-import { mainThreadText, shouldRefreshTitle, titleFor } from "./sessionTitle.agency"
+import { cleanTitle, mainThreadText, shouldRefreshTitle, titleFor } from "./sessionTitle.agency"
 
 // The session this run writes to; null for one-shot runs, which are not
 // saved. A `let`, so a restore brings back the resumed session's own
@@ -29,6 +31,11 @@ let _current: SessionRecord | null = null
 // Set by the REPL when a turn ran to completion, so a slash command or an
 // empty line is not recorded as a turn.
 let _turnDone = false
+
+// Set by `/rename`: the record changed without a turn, so the next save
+// must still happen, and the title is the user's now, never rewritten.
+let _renamed = false
+let _titlePinned = false
 
 /** Where to write after a turn: the session directory and its index row. */
 export type SaveTarget = {
@@ -47,6 +54,24 @@ export def sessionTitle(): string {
 
 export def markTurnDone() {
   _turnDone = true
+}
+
+/** `/rename <title>`: give the session a title of the user's choosing.
+  Returns the line to show. The title is written with the next save,
+  which the REPL runs after this line whether or not a turn ran. */
+export def renameSession(title: string): string {
+  const record = _current
+  if (record == null) {
+    return "This run is not saved, so it cannot be renamed."
+  }
+  const clean = cleanTitle(title)
+  if (clean == "") {
+    return "Usage: /rename <title>"
+  }
+  record.title = clean
+  _renamed = true
+  _titlePinned = true
+  return "Session renamed: ${clean}"
 }
 
 /** Which saved session, if any, this run continues. `resumeArg` is the
@@ -111,8 +136,15 @@ def pickSession(): SessionRecord | null {
 
 /** Start this run's session. A new one gets a fresh record. A saved one
   is restored right here: the Agency execution state becomes the saved
-  one and the program continues from the saved point. */
-export def startSession(chosen: SessionRecord | null, brain: string) {
+  one and the program continues from the saved point. `showTranscript`
+  prints the saved conversation first, because nothing written after
+  `restore` runs: it replays to the saved point, which is the REPL
+  waiting for a line. */
+export def startSession(
+  chosen: SessionRecord | null,
+  brain: string,
+  showTranscript: (messages: any[]) -> void,
+) {
   if (chosen == null) {
     const t = now()
     _current = {
@@ -132,20 +164,29 @@ export def startSession(chosen: SessionRecord | null, brain: string) {
     process.exit(1)
   }
   print(color.dim("Resuming: ${chosen.title}"))
+  showTranscript(_readTranscript(cp))
   restore(cp, {})
 }
 
 /** Record a completed turn: bump the count, refresh the title when due,
-  and say where the checkpoint should be written. Null when no turn ran. */
+  and say where the checkpoint should be written. Null when there is
+  nothing to save: no turn ran and no rename happened. */
 export def recordTurn(userMsg: string): SaveTarget | null {
   const record = _current
-  if (record == null || !_turnDone) {
+  if (record == null || (!_turnDone && !_renamed)) {
     return null
+  }
+  _renamed = false
+  if (!_turnDone) {
+    return {
+      dir: projectDir(),
+      record: record
+    }
   }
   _turnDone = false
   record.turns = record.turns + 1
   record.lastActive = now()
-  if (shouldRefreshTitle(record.turns)) {
+  if (!_titlePinned && shouldRefreshTitle(record.turns)) {
     // Turn 1 titles the first prompt; later refreshes summarize the
     // conversation so far.
     let source = userMsg

--- a/packages/agency-lang/lib/agents/agency-agent/lib/sessionTitle.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/sessionTitle.agency
@@ -1,9 +1,10 @@
 /** @module
   @summary The one-line title a saved session shows in the resume picker
   and the REPL footer. Written from the first prompt, then rewritten
-  every few turns as a summary of the conversation so far.
+  every few turns as a summary of the conversation so far, unless the
+  user set one with `/rename`.
 */
-import { getThread, listThreads } from "std::thread"
+import { getThread, listThreads, sessionThreadId } from "std::thread"
 
 // Rewrite the title on turn 1 and every TITLE_EVERY turns after that.
 export static const TITLE_EVERY = 5
@@ -20,24 +21,20 @@ type Titled = {
   title: string
 }
 
-/** The conversation thread as plain text, newest last, cut to the last
-  MAX_CONVERSATION_CHARS. The coordinator labels it `main`; any other
-  brain's is the top-level thread with the most messages. "" when there
-  is none. */
-export def mainThreadText(): string {
-  const threads = listThreads(false)
-  if (isFailure(threads)) {
+/** The conversation thread (the brain's `session`) as plain text,
+  newest last, cut to the last MAX_CONVERSATION_CHARS. "" when there is
+  none. */
+export def conversationText(session: string): string {
+  const id = sessionThreadId(session)
+  if (id == "") {
     return ""
   }
-  let mainThread = find(threads.value, \t -> t.label == "main")
-  if (mainThread == null) {
-    mainThread = largestThread(threads.value)
-  }
-  if (mainThread == null) {
+  const info = find(listThreads(false) catch [], \t -> t.id == id)
+  if (info == null) {
     return ""
   }
-  const offset = Math.max(0, mainThread.messageCount - MAX_MESSAGES)
-  const messages = getThread(mainThread.id, offset, MAX_MESSAGES)
+  const offset = Math.max(0, info.messageCount - MAX_MESSAGES)
+  const messages = getThread(id, offset, MAX_MESSAGES)
   if (isFailure(messages)) {
     return ""
   }
@@ -52,16 +49,6 @@ export def mainThreadText(): string {
     return text
   }
   return text.slice(text.length - MAX_CONVERSATION_CHARS)
-}
-
-def largestThread(threads: any[]): any {
-  let best: any = null
-  for (t in threads) {
-    if (t.parentId == null && t.messageCount > 0 && (best == null || t.messageCount > best.messageCount)) {
-      best = t
-    }
-  }
-  return best
 }
 
 static const MAX_TITLE_CHARS = 80

--- a/packages/agency-lang/lib/agents/agency-agent/lib/transcript.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/transcript.agency
@@ -1,0 +1,25 @@
+/** @module
+  @summary How a user line and a reply are drawn in the terminal, shared
+  by the live turns and the transcript a resumed session prints.
+*/
+import { highlight } from "std::syntax"
+import { pushMessage } from "std::ui/cli"
+
+export def renderUserLine(msg: string) {
+  pushMessage(color.dim("> ${msg}"))
+}
+
+export def renderReply(reply: string) {
+  pushMessage(highlight("${reply}\n", language: "markdown"))
+}
+
+/** The saved conversation, drawn the way the turns were when they ran. */
+export def showTranscript(messages: any[]) {
+  for (m in messages) {
+    if (m.role == "user") {
+      renderUserLine(m.content)
+    } else {
+      renderReply(m.content)
+    }
+  }
+}

--- a/packages/agency-lang/lib/agents/agency-agent/tests/stubBrains.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/stubBrains.agency
@@ -78,6 +78,7 @@ def recordingRunTurn(
 export def recordingBrain(): AgentBrain {
   return {
     name: "recording",
+    session: "recording",
     description: "test stub that records its arguments",
     startTargets: ["worker"],
     init: recordingInit,
@@ -117,6 +118,7 @@ def selfApprovingRunTurn(
 export def selfApprovingBrain(): AgentBrain {
   return {
     name: "self-approving",
+    session: "self-approving",
     description: "test stub that pre-approves its own interrupt",
     startTargets: [],
     init: selfApprovingInit,
@@ -135,6 +137,7 @@ def costlyRunTurn(
 export def costlyBrain(): AgentBrain {
   return {
     name: "costly",
+    session: "costly",
     description: "test stub that incurs deterministic LLM cost",
     startTargets: [],
     init: recordingInit,

--- a/packages/agency-lang/lib/stdlib/agentSessions.ts
+++ b/packages/agency-lang/lib/stdlib/agentSessions.ts
@@ -1,8 +1,10 @@
+import type { MessageJSON } from "smoltalk";
 import * as fs from "fs";
 import * as path from "path";
 import { __call } from "../runtime/call.js";
 import { checkpoint, getCheckpoint } from "../runtime/checkpoint.js";
 import { Checkpoint } from "../runtime/state/checkpointStore.js";
+import { _contentToString } from "./threads.js";
 
 /**
  * File I/O for the agency agent's saved sessions
@@ -105,56 +107,46 @@ export type TranscriptMessage = { role: "user" | "assistant"; content: string };
 
 type ThreadJSON = {
   messages: { role?: string; content?: unknown }[];
-  parentId?: string | null;
-  label?: string | null;
 };
 
 /**
- * The conversation of a saved session, as the user and the model said it:
- * the user and assistant messages of the `main` thread (or, for a brain
- * that labels none, the top-level thread with the most messages). Tool
- * calls and results are left out. Read from the checkpoint file before it
- * is restored, because a restore replays to the saved point and runs no
- * code of its own afterwards.
+ * The user and assistant messages of a saved session's conversation
+ * thread: the thread the brain opens with `thread(session: name)`. Tool
+ * calls and results are left out.
  */
-export function _readTranscript(checkpointJson: unknown): TranscriptMessage[] {
+export function _readTranscript(checkpointJson: unknown, session: string): TranscriptMessage[] {
   const cp = Checkpoint.fromJSON(checkpointJson);
-  if (!cp) return [];
-  const thread = mainThread(cp);
-  if (!thread) return [];
+  if (!cp) {
+    return [];
+  }
+  const thread = sessionThread(cp, session);
+  if (!thread) {
+    return [];
+  }
   const out: TranscriptMessage[] = [];
   for (const m of thread.messages) {
-    if (m.role !== "user" && m.role !== "assistant") continue;
-    const text = messageText(m.content);
-    if (text !== "") out.push({ role: m.role, content: text });
+    if (m.role !== "user" && m.role !== "assistant") {
+      continue;
+    }
+    const text = _contentToString(m.content as MessageJSON["content"]);
+    if (text !== "") {
+      out.push({ role: m.role, content: text });
+    }
   }
   return out;
 }
 
-// Every frame on the saved stack carries a thread store; the same thread
-// can appear in several, so take the fullest copy.
-function mainThread(cp: Checkpoint): ThreadJSON | null {
-  let labeled: ThreadJSON | null = null;
-  let largest: ThreadJSON | null = null;
+// Every frame on the saved stack carries the thread store; the outermost
+// frame's copy is the one the REPL was waiting in.
+function sessionThread(cp: Checkpoint, session: string): ThreadJSON | null {
   for (const frame of cp.stack.stack ?? []) {
-    const threads = (frame.threads?.threads ?? {}) as Record<string, ThreadJSON>;
-    for (const t of Object.values(threads)) {
-      if (t.label === "main") {
-        if (!labeled || t.messages.length > labeled.messages.length) labeled = t;
-      } else if (t.parentId == null) {
-        if (!largest || t.messages.length > largest.messages.length) largest = t;
-      }
+    const id = frame.threads?.sessions?.[session];
+    const thread = id == null ? null : frame.threads?.threads[id];
+    if (thread) {
+      return thread as ThreadJSON;
     }
   }
-  return labeled ?? largest;
-}
-
-function messageText(content: unknown): string {
-  if (typeof content === "string") return content;
-  if (Array.isArray(content)) {
-    return content.map((part) => (typeof part?.text === "string" ? part.text : "")).join("");
-  }
-  return "";
+  return null;
 }
 
 type SaveTarget = { dir: string; record: SessionRecord } | null;

--- a/packages/agency-lang/lib/stdlib/agentSessions.ts
+++ b/packages/agency-lang/lib/stdlib/agentSessions.ts
@@ -2,6 +2,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { __call } from "../runtime/call.js";
 import { checkpoint, getCheckpoint } from "../runtime/checkpoint.js";
+import { Checkpoint } from "../runtime/state/checkpointStore.js";
 
 /**
  * File I/O for the agency agent's saved sessions
@@ -98,6 +99,62 @@ export function _saveSession(dir: string, record: SessionRecord, checkpoint: unk
 /** The parsed checkpoint, or null when the file is missing or malformed. */
 export function _readCheckpointFile(dir: string, id: string): unknown {
   return readJson(checkpointFile(dir, id));
+}
+
+export type TranscriptMessage = { role: "user" | "assistant"; content: string };
+
+type ThreadJSON = {
+  messages: { role?: string; content?: unknown }[];
+  parentId?: string | null;
+  label?: string | null;
+};
+
+/**
+ * The conversation of a saved session, as the user and the model said it:
+ * the user and assistant messages of the `main` thread (or, for a brain
+ * that labels none, the top-level thread with the most messages). Tool
+ * calls and results are left out. Read from the checkpoint file before it
+ * is restored, because a restore replays to the saved point and runs no
+ * code of its own afterwards.
+ */
+export function _readTranscript(checkpointJson: unknown): TranscriptMessage[] {
+  const cp = Checkpoint.fromJSON(checkpointJson);
+  if (!cp) return [];
+  const thread = mainThread(cp);
+  if (!thread) return [];
+  const out: TranscriptMessage[] = [];
+  for (const m of thread.messages) {
+    if (m.role !== "user" && m.role !== "assistant") continue;
+    const text = messageText(m.content);
+    if (text !== "") out.push({ role: m.role, content: text });
+  }
+  return out;
+}
+
+// Every frame on the saved stack carries a thread store; the same thread
+// can appear in several, so take the fullest copy.
+function mainThread(cp: Checkpoint): ThreadJSON | null {
+  let labeled: ThreadJSON | null = null;
+  let largest: ThreadJSON | null = null;
+  for (const frame of cp.stack.stack ?? []) {
+    const threads = (frame.threads?.threads ?? {}) as Record<string, ThreadJSON>;
+    for (const t of Object.values(threads)) {
+      if (t.label === "main") {
+        if (!labeled || t.messages.length > labeled.messages.length) labeled = t;
+      } else if (t.parentId == null) {
+        if (!largest || t.messages.length > largest.messages.length) largest = t;
+      }
+    }
+  }
+  return labeled ?? largest;
+}
+
+function messageText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content.map((part) => (typeof part?.text === "string" ? part.text : "")).join("");
+  }
+  return "";
 }
 
 type SaveTarget = { dir: string; record: SessionRecord } | null;

--- a/packages/agency-lang/lib/stdlib/threads.ts
+++ b/packages/agency-lang/lib/stdlib/threads.ts
@@ -104,6 +104,17 @@ export function _getThread(
   }));
 }
 
+/** Slug form of the thread a session name maps to, or `""` when no
+ *  thread has been opened under that name. */
+export function _sessionThreadId(name: string): string {
+  const store = agency.thread.storeMaybe();
+  const rawId = store?.sessions[name];
+  if (rawId == null) {
+    return "";
+  }
+  return `t${rawId}`;
+}
+
 /** Slug form of the active thread, or `""` (Agency has no undefined). */
 export function _currentThreadId(): string {
   return agency.threads.current() ?? "";

--- a/packages/agency-lang/stdlib/thread.agency
+++ b/packages/agency-lang/stdlib/thread.agency
@@ -45,6 +45,7 @@ import {
   _getThread,
   _setThreadSummary,
   _currentThreadId,
+  _sessionThreadId,
 } from "agency-lang/stdlib-lib/threads.js"
 
 // The single source of truth for the attachment shape. `llm()`'s first-param
@@ -402,6 +403,14 @@ export def listThreads(lazySummarize: boolean = true): Result {
     })
   }
   return success(out)
+}
+
+export def sessionThreadId(name: string): string {
+  """
+  Slug-form id of the thread that `thread(session: name)` resumes (e.g.
+  "t3"), or `""` when nothing has been opened under that name yet.
+  """
+  return _sessionThreadId(name)
 }
 
 export def currentThreadId(): string {

--- a/packages/agency-lang/tests/agency-js/agent-session-resume/agent.agency
+++ b/packages/agency-lang/tests/agency-js/agent-session-resume/agent.agency
@@ -2,6 +2,7 @@ import {
   _installSessionHooks,
   _sessionOnSubmit,
   _readCheckpointFile,
+  _readTranscript,
  } from "agency-lang/stdlib-lib/agentSessions.js"
 import { getThread, listThreads, userMessage } from "std::thread"
 import { env } from "std::system"
@@ -53,8 +54,12 @@ node main() {
     restore(_readCheckpointFile("./sessions", "s1"), {})
   }
   fakeRepl(_sessionOnSubmit)
+  // The transcript is read from the file, the way a resume prints it
+  // before restoring.
+  const saved = _readTranscript(_readCheckpointFile("./sessions", "s1"))
   return {
     turns: turns,
-    messages: messages()
+    messages: messages(),
+    transcript: ["${m.role}: ${m.content}" for m in saved]
   }
 }

--- a/packages/agency-lang/tests/agency-js/agent-session-resume/agent.agency
+++ b/packages/agency-lang/tests/agency-js/agent-session-resume/agent.agency
@@ -4,7 +4,7 @@ import {
   _readCheckpointFile,
   _readTranscript,
  } from "agency-lang/stdlib-lib/agentSessions.js"
-import { getThread, listThreads, userMessage } from "std::thread"
+import { assistantMessage, getThread, listThreads, userMessage } from "std::thread"
 import { env } from "std::system"
 
 import { fakeRepl } from "./loop.js"
@@ -20,7 +20,14 @@ let turns = 0
 def turn(line: string): boolean {
   turns = turns + 1
   thread(label: "main", session: "main") {
-    userMessage("u${turns}: ${line}")
+    // The third line goes in as a content array, the way a prompt with
+    // attachments does.
+    if (turns == 3) {
+      userMessage(["u${turns}: ", line])
+    } else {
+      userMessage("u${turns}: ${line}")
+    }
+    assistantMessage("a${turns}")
   }
   return true
 }
@@ -56,7 +63,7 @@ node main() {
   fakeRepl(_sessionOnSubmit)
   // The transcript is read from the file, the way a resume prints it
   // before restoring.
-  const saved = _readTranscript(_readCheckpointFile("./sessions", "s1"))
+  const saved = _readTranscript(_readCheckpointFile("./sessions", "s1"), "main")
   return {
     turns: turns,
     messages: messages(),

--- a/packages/agency-lang/tests/agency-js/agent-session-resume/fixture.json
+++ b/packages/agency-lang/tests/agency-js/agent-session-resume/fixture.json
@@ -3,13 +3,19 @@
     "turns": 3,
     "messages": [
       "u1: hello",
+      "a1",
       "u2: world",
-      "u3: third"
+      "a2",
+      "u3:  third",
+      "a3"
     ],
     "transcript": [
       "user: u1: hello",
+      "assistant: a1",
       "user: u2: world",
-      "user: u3: third"
+      "assistant: a2",
+      "user: u3:  third",
+      "assistant: a3"
     ]
   }
 }

--- a/packages/agency-lang/tests/agency-js/agent-session-resume/fixture.json
+++ b/packages/agency-lang/tests/agency-js/agent-session-resume/fixture.json
@@ -1,6 +1,15 @@
 {
   "finalData": {
     "turns": 3,
-    "messages": ["u1: hello", "u2: world", "u3: third"]
+    "messages": [
+      "u1: hello",
+      "u2: world",
+      "u3: third"
+    ],
+    "transcript": [
+      "user: u1: hello",
+      "user: u2: world",
+      "user: u3: third"
+    ]
   }
 }

--- a/packages/agency-lang/tests/agency/agency-agent-sessions.agency
+++ b/packages/agency-lang/tests/agency/agency-agent-sessions.agency
@@ -11,34 +11,45 @@ import test {
  } from "../../lib/agents/agency-agent/lib/sessions.agency"
 import test { shouldRefreshTitle } from "../../lib/agents/agency-agent/lib/sessionTitle.agency"
 import test {
+  markTurnDone,
   recordTurn,
   renameSession,
   startSession,
  } from "../../lib/agents/agency-agent/lib/resume.agency"
-
-def noTranscript(messages: any[]) {
-}
+import { simpleBrain } from "../../lib/agents/agency-agent/brains/simple/simple.agency"
 
 // A rename with no turn still produces a save (the record carries the new
 // title, and the turn count is untouched); the save after it is a no-op.
+// Turn 1 would normally title the session with an LLM call; a renamed
+// session keeps its title instead.
 node renameFlow(): any {
-  startSession(null, "test", noTranscript)
+  startSession(null, simpleBrain())
   const empty = renameSession("   ")
   const renamed = renameSession("minnesota   news 8/29")
   const target = recordTurn("")
-  const again = recordTurn("")
   let title = ""
   let turns = -1
   if (target != null) {
     title = target.record.title
     turns = target.record.turns
   }
+  const again = recordTurn("")
+  markTurnDone()
+  const afterTurn = recordTurn("first prompt")
+  let titleAfterTurn = ""
+  let turnsAfterTurn = -1
+  if (afterTurn != null) {
+    titleAfterTurn = afterTurn.record.title
+    turnsAfterTurn = afterTurn.record.turns
+  }
   return {
     empty: empty,
     renamed: renamed,
     title: title,
     turns: turns,
-    again: again
+    again: again,
+    titleAfterTurn: titleAfterTurn,
+    turnsAfterTurn: turnsAfterTurn
   }
 }
 

--- a/packages/agency-lang/tests/agency/agency-agent-sessions.agency
+++ b/packages/agency-lang/tests/agency/agency-agent-sessions.agency
@@ -10,6 +10,37 @@ import test {
   SessionRecord,
  } from "../../lib/agents/agency-agent/lib/sessions.agency"
 import test { shouldRefreshTitle } from "../../lib/agents/agency-agent/lib/sessionTitle.agency"
+import test {
+  recordTurn,
+  renameSession,
+  startSession,
+ } from "../../lib/agents/agency-agent/lib/resume.agency"
+
+def noTranscript(messages: any[]) {
+}
+
+// A rename with no turn still produces a save (the record carries the new
+// title, and the turn count is untouched); the save after it is a no-op.
+node renameFlow(): any {
+  startSession(null, "test", noTranscript)
+  const empty = renameSession("   ")
+  const renamed = renameSession("minnesota   news 8/29")
+  const target = recordTurn("")
+  const again = recordTurn("")
+  let title = ""
+  let turns = -1
+  if (target != null) {
+    title = target.record.title
+    turns = target.record.turns
+  }
+  return {
+    empty: empty,
+    renamed: renamed,
+    title: title,
+    turns: turns,
+    again: again
+  }
+}
 
 node slug(): string {
   return cwdSlug("/Users/me/my proj_v2")

--- a/packages/agency-lang/tests/agency/agency-agent-sessions.test.json
+++ b/packages/agency-lang/tests/agency/agency-agent-sessions.test.json
@@ -65,6 +65,17 @@
           "type": "exact"
         }
       ]
+    },
+    {
+      "nodeName": "renameFlow",
+      "description": "/rename sets the title and forces a save",
+      "input": "",
+      "expectedOutput": "{\"empty\": \"Usage: /rename <title>\", \"renamed\": \"Session renamed: minnesota news 8/29\", \"title\": \"minnesota news 8/29\", \"turns\": 0, \"again\": null}",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/agency-agent-sessions.test.json
+++ b/packages/agency-lang/tests/agency/agency-agent-sessions.test.json
@@ -68,9 +68,9 @@
     },
     {
       "nodeName": "renameFlow",
-      "description": "/rename sets the title and forces a save",
+      "description": "/rename sets the title, forces a save, and survives the turn-1 refresh",
       "input": "",
-      "expectedOutput": "{\"empty\": \"Usage: /rename <title>\", \"renamed\": \"Session renamed: minnesota news 8/29\", \"title\": \"minnesota news 8/29\", \"turns\": 0, \"again\": null}",
+      "expectedOutput": "{\"empty\": \"Usage: /rename <title>\", \"renamed\": \"Session renamed: minnesota news 8/29\", \"title\": \"minnesota news 8/29\", \"turns\": 0, \"again\": null, \"titleAfterTurn\": \"minnesota news 8/29\", \"turnsAfterTurn\": 1}",
       "evaluationCriteria": [
         {
           "type": "exact"


### PR DESCRIPTION
Two changes to `agency agent` saved sessions (follow-up to #962).

## Print the transcript on resume

`--continue` / `--resume` now prints the saved conversation before restoring, so you can see what the session was about, or resume just to read it. User lines are dimmed after a `>`, replies are rendered as markdown: the same drawing as when the turns ran.

Why it reads the checkpoint file rather than the restored threads: `restore()` throws a signal and replays to the saved point (the REPL waiting for a line), so nothing placed after it, and no step before the `repl(...)` call, runs on resume. `_readTranscript` in `lib/stdlib/agentSessions.ts` parses the file with `Checkpoint.fromJSON`, picks the `main` thread on the saved stack (or the largest top-level thread for a brain that labels none), and returns its user and assistant messages. `showTranscript` in `repl.agency` draws them, then `startSession` restores.

## `/rename <title>`

Sets the session title (`/rename minnesota news 8/29`). The title is pinned so the periodic LLM refresh leaves it alone, and the record is marked dirty so the save that runs after every REPL line writes both files even though no turn ran. That keeps the checkpoint's copy of the record and the record file in agreement.

## Tests

- `tests/agency/agency-agent-sessions.agency`: `renameFlow` (usage on an empty title, cleaned title, save with turns untouched, no second save).
- `tests/agency-js/agent-session-resume`: the fixture now includes the transcript read back from the saved checkpoint file.

Dev doc: `docs/dev/agents/agent-sessions.md` gained sections for both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RGbtNzLmRXjpE47dPjmDkL
