### PR TITLE
Build the slash palette when the REPL starts, not when the session was saved

### DIFF
--- a/packages/agency-lang/docs/site/stdlib/ui/cli.md
+++ b/packages/agency-lang/docs/site/stdlib/ui/cli.md
@@ -52,7 +52,7 @@ Line-mode REPL with the same call signature as the std::ui TUI repl,
   @param prompt - String shown before the input buffer (default "> ")
   @param historyFile - Path to a JSON history file; loaded at start and saved on exit. Empty string disables persistence.
   @param historyMax - Trim history to this many most-recent entries
-  @param paletteCommands - Map of /cmd -> description
+  @param paletteCommands - Map of /cmd -> description, or a function returning one (called when the REPL starts)
 
 * Line-mode sibling of the std::ui TUI repl. Current limitations:
  * `status` is accepted for signature parity but not yet rendered;

--- a/packages/agency-lang/lib/agents/agency-agent/lib/repl.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/repl.agency
@@ -335,7 +335,9 @@ export def startInteractive(seedTarget: string, seedPrompt: string) {
     prompt: "> ",
     historyFile: HISTORY_PATH,
     historyMax: 1000,
-    paletteCommands: mergedPalette(),
+    // The function, not its result: a resumed session replays this call
+    // with its saved arguments, and the palette must be the current one.
+    paletteCommands: mergedPalette,
   )
   print(color.cyan("\nGoodbye!"))
 }

--- a/packages/agency-lang/lib/stdlib/cli.palette.test.ts
+++ b/packages/agency-lang/lib/stdlib/cli.palette.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { resolvePalette } from "./cli.js";
+
+describe("resolvePalette", () => {
+  it("returns a map unchanged", async () => {
+    const map = { "/cost": "Show cost" };
+    expect(await resolvePalette(map)).toBe(map);
+  });
+
+  it("calls a function for the map, so it reflects the running code", async () => {
+    let calls = 0;
+    const build = () => {
+      calls += 1;
+      return { "/rename": "Rename" };
+    };
+    expect(await resolvePalette(build)).toEqual({ "/rename": "Rename" });
+    expect(calls).toBe(1);
+  });
+});

--- a/packages/agency-lang/lib/stdlib/cli.ts
+++ b/packages/agency-lang/lib/stdlib/cli.ts
@@ -3,6 +3,7 @@ import process from "process";
 import { readFileSync, writeFileSync, existsSync, mkdirSync, renameSync } from "fs";
 import { dirname } from "path";
 import { __call } from "../runtime/call.js";
+import { AgencyFunction } from "../runtime/agencyFunction.js";
 import { getRuntimeContext } from "../runtime/asyncContext.js";
 import { modifiers, RESET, styles } from "@/utils/termcolors.js";
 import { color, colors, bgColors } from "../utils/termcolors.js";
@@ -843,6 +844,17 @@ function startSpinner(useTTY: boolean): () => void {
  * inside the callback is swallowed — the footer is informational and
  * must never break a successful turn.
  */
+/** `paletteCommands` may be the map itself or a function that builds it.
+ *  A function is called when the REPL starts, so a resumed session shows
+ *  the commands of the code it is running rather than the map its
+ *  checkpoint saved. */
+export async function resolvePalette(paletteCommands: unknown): Promise<unknown> {
+  if (typeof paletteCommands === "function" || AgencyFunction.isAgencyFunction(paletteCommands)) {
+    return callBridgeFn(paletteCommands);
+  }
+  return paletteCommands;
+}
+
 /**
  * Convert the `paletteCommands` map the agent passes (e.g.
  * `{"/exit": "Exit", "/clear": "Clear", ...}`) into a stable
@@ -851,7 +863,9 @@ function startSpinner(useTTY: boolean): () => void {
  * inputs so callers don't have to null-check.
  */
 function paletteEntries(paletteCommands: unknown): [string, string][] {
-  if (!paletteCommands || typeof paletteCommands !== "object") return [];
+  if (!paletteCommands || typeof paletteCommands !== "object") {
+    return [];
+  }
   const out: [string, string][] = [];
   for (const [k, v] of Object.entries(paletteCommands as Record<string, unknown>)) {
     if (typeof k !== "string" || !k.startsWith("/")) continue;
@@ -1261,7 +1275,7 @@ export async function _runLineRepl(
   paletteCommands: unknown,
 ): Promise<void> {
   const { entries: initialHistory, expansions } = loadHistory(historyFile, historyMax);
-  const palette = paletteEntries(paletteCommands);
+  const palette = paletteEntries(await resolvePalette(paletteCommands));
   const rl = readline.createInterface({
     input: process.stdin,
     output: process.stdout,

--- a/packages/agency-lang/stdlib/ui/cli.agency
+++ b/packages/agency-lang/stdlib/ui/cli.agency
@@ -88,7 +88,7 @@ export def repl(
   @param prompt - String shown before the input buffer (default "> ")
   @param historyFile - Path to a JSON history file; loaded at start and saved on exit. Empty string disables persistence.
   @param historyMax - Trim history to this many most-recent entries
-  @param paletteCommands - Map of /cmd -> description
+  @param paletteCommands - Map of /cmd -> description, or a function returning one (called when the REPL starts)
   """
   // Publish the path to the execution-model global so `clearHistory()` can
   // resolve which file to clear from Agency state rather than a TS closure.


### PR DESCRIPTION
Follow-up to #964: `/rename` was missing from the slash palette in a resumed session.

**Cause.** `repl(...)` received `mergedPalette()` as a value. A resumed session replays that call with its saved arguments, so the palette was the map as it was when the session was saved. Your checkpoint from before #964 has `/cost` but no `/rename`.

**Fix.** `repl`'s `paletteCommands` now also accepts a function, which `_runLineRepl` calls when it starts. The agent passes `mergedPalette` itself. A checkpoint stores a function argument by name and revives it to the live function on restore, so a resumed session builds its palette from the code it is running (this also picks up new `.claude/commands` files).

Sessions saved before this change still carry the old map; they get the current palette after their first turn on the new build, once a new checkpoint is written.

Test: `lib/stdlib/cli.palette.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RGbtNzLmRXjpE47dPjmDkL
