### PR TITLE
Refuse JS-capability names under --agency-only (#971, layer 1)

### DIFF
--- a/packages/agency-lang/.claude/skills/agency-hosting-docs/SKILL.md
+++ b/packages/agency-lang/.claude/skills/agency-hosting-docs/SKILL.md
@@ -10,6 +10,7 @@ Paths are relative to `packages/agency-lang/`. Read the one that matches the tas
 - `docs/dev/hosting/statelog.md` — The observability system: what events are captured and where they are sent.
 - `docs/dev/hosting/statelog-clients.md` — The sealed per-route clients the CLI uses to talk to statelog, over one shared transport.
 - `docs/dev/hosting/hosted-agent-execution.md` — Deploying an agent to a hosted statelog instance and running it over HTTP.
+- `docs/dev/hosting/how-hosted-serving-works.md` — The plain walkthrough of serving: deploy, compile, the four routes, and how an interrupt becomes an HTTP round trip. Read before `hosted-agent-execution.md`.
 - `docs/dev/hosting/per-invocation-config.md` — Letting one invocation carry its own config override and trace id.
 - `docs/dev/hosting/invocation-usage-accounting.md` — How a hosted invocation reports its full cost and token breakdown, including across a subprocess.
 - `docs/dev/hosting/remote-secrets.md` — Managing a hosted project's secrets against a write-only store, and the rules that keep values out of argv and output.

--- a/packages/agency-lang/CLAUDE.md
+++ b/packages/agency-lang/CLAUDE.md
@@ -168,6 +168,11 @@ Other process docs:
 - `docs/dev/agents/why-agents-write-code.md` — The argument for letting an agent write and run programs instead of giving it more tools.
 - `docs/dev/agents/writing-rewrite-agent.md` — The rewrite agent over the writing reviewer: the passes loop, why a reviewer failure is not a clean pass, and how its eval suite shares the reviewer suite's files.
 
+### Security
+
+- `docs/dev/security/goal.md` — The goal of running untrusted Agency code with no operating-system sandbox, why the language design makes that possible, and what it demands of the compiler.
+- `docs/dev/security/roadmap.md` — Every gap between today's code and that goal, grouped by which part of the argument it breaks, with the GitHub issue for each.
+
 ### Standard library
 
 - `docs/dev/stdlib/adding-a-module-to-the-agency-stdlib.md` — The pattern for adding a stdlib module, including where files go and how docs are generated.
@@ -220,6 +225,7 @@ Other process docs:
 ### Hosting and statelog
 
 - `docs/dev/hosting/hosted-agent-execution.md` — Deploying an agent to a hosted statelog instance and running it over HTTP.
+- `docs/dev/hosting/how-hosted-serving-works.md` — The plain walkthrough of serving: deploy, compile, the four routes, and how an interrupt becomes an HTTP round trip. Read before `hosted-agent-execution.md`.
 - `docs/dev/hosting/invocation-usage-accounting.md` — How a hosted invocation reports its full cost and token breakdown, including across a subprocess.
 - `docs/dev/hosting/per-invocation-config.md` — Letting one invocation carry its own config override and trace id.
 - `docs/dev/hosting/remote-secrets.md` — Managing a hosted project's secrets against a write-only store, and the rules that keep values out of argv and output.

--- a/packages/agency-lang/CLAUDE.md
+++ b/packages/agency-lang/CLAUDE.md
@@ -138,6 +138,7 @@ Other process docs:
 
 ### Compiler and type checker
 
+- `docs/dev/compiler/agency-only-bound-names.md` — The `--agency-only` JS-globals bind-check: the sandbox allowlist, the four capability positions it refuses, and why it is defense in depth rather than the boundary.
 - `docs/dev/compiler/binop-parser.md` — How binary expressions parse, including the operator precedence and associativity table.
 - `docs/dev/compiler/codegen-als-accessors.md` — How generated code reads runtime values out of the active async-context frame.
 - `docs/dev/compiler/effect-propagation.md` — How the interrupt effects a function carries are computed and propagated through calls.

--- a/packages/agency-lang/docs/dev/cli/test-cli-sandbox.md
+++ b/packages/agency-lang/docs/dev/cli/test-cli-sandbox.md
@@ -17,8 +17,15 @@ under each name it is given.
 
 ## Why the two flags together are the safety argument
 
-- With `--agency-only`, every effect the code can perform is an interrupt.
-  There is no other way to touch the world from pure Agency.
+- With `--agency-only`, every effect the code can perform is an interrupt,
+  and the JS-globals bind-check refuses the compiled-to-JavaScript escapes
+  that would otherwise bypass interrupts entirely (`process`, `fetch`,
+  `eval`, `new Function`, the `.constructor` walk, tag arguments, default
+  values). See `docs/dev/compiler/agency-only-bound-names.md`. That check is
+  defense in depth, not the whole boundary: a runtime-computed property key
+  gets through it, so the backstop for code-from-strings is layer 2 in
+  `docs/dev/security/roadmap.md` (A1). There is no other way to touch the
+  world from pure Agency once those hold.
 - With `--reject '*'`, the root handler rejects each of those interrupts.
   The handler chain resolves reject over approve (`lib/runtime/interrupts.ts`,
   "reject > propagate > approve > noResponse"; pinned by

--- a/packages/agency-lang/docs/dev/cli/test-cli-sandbox.md
+++ b/packages/agency-lang/docs/dev/cli/test-cli-sandbox.md
@@ -17,6 +17,13 @@ under each name it is given.
 
 ## Why the two flags together are the safety argument
 
+> These flags reduce attack surface; they are **not yet a complete sandbox**.
+> The bind-check is defense in depth (a runtime-computed property key slips
+> past it), and the containment layers that close the remaining gaps are
+> tracked in `docs/dev/security/roadmap.md` (A1). Do not treat `--agency-only`
+> as sufficient to run fully untrusted code on its own yet.
+
+
 - With `--agency-only`, every effect the code can perform is an interrupt,
   and the JS-globals bind-check refuses the compiled-to-JavaScript escapes
   that would otherwise bypass interrupts entirely (`process`, `fetch`,

--- a/packages/agency-lang/docs/dev/compiler/agency-only-bound-names.md
+++ b/packages/agency-lang/docs/dev/compiler/agency-only-bound-names.md
@@ -1,0 +1,99 @@
+# Bound names under `--agency-only`
+
+Agency compiles to JavaScript, and an identifier the compiler does not know
+is emitted verbatim. So before this check, pure Agency code under
+`--agency-only` could name any JavaScript global — `process`, `fetch`,
+`eval`, `new Function` — and reach the host with no interrupt. This check
+refuses those names at compile time.
+
+It is **defense in depth and clearer errors, not the security boundary.** A
+runtime-computed property key (`m[a + b]`) defeats any syntactic check, so
+the real backstop for reaching `Function` and calling it with a string is
+disabling code generation from strings (roadmap A1 layer 2). The whole arc
+and its layers are in `docs/dev/security/roadmap.md` (item A1) and
+`docs/dev/security/goal.md`.
+
+## What it does
+
+When `typechecker.jsGlobals` is `"sandbox"` (set by `--agency-only` in
+`compileValidatedClosure.ts`, alongside `undefinedFunctions`/
+`undefinedVariables: "error"`), an unqualified name must resolve to an
+Agency declaration, an import, a builtin, or the reviewed allowlist
+`SANDBOX_JS_GLOBALS`. Anything else is a compile error.
+
+`SANDBOX_JS_GLOBALS` (`lib/typeChecker/resolveCall.ts`) is a **separate,
+reviewed** allowlist, not a filter over the interop registry `JS_GLOBALS`.
+Writing it out in full means a name added to `JS_GLOBALS` for interop never
+silently becomes allowed in the sandbox. It is not a subset: it adds
+constructor names (`Set`, `Map`, `RegExp`, `Intl`) that `new X()` resolves
+against but `JS_GLOBALS` never listed. An entry here is a promise the name
+cannot reach the host — review every addition against that.
+
+## The rule is shared; the positions differ
+
+Name resolution goes through the same `resolveCall` / `resolveVariable`
+(now registry-parametric, defaulting to `JS_GLOBALS` so non-sandbox
+behaviour is byte-identical). Four positions have to be checked, and they
+are covered by two walks that share that one rule:
+
+1. **Bare names, calls, namespace members, value-access bases** — the two
+   general passes (`undefinedFunctionDiagnostic`, `undefinedVariableDiagnostic`)
+   already walk scope bodies for these. Under the sandbox they select
+   `SANDBOX_JS_GLOBALS` and emit at error severity. `process.env.HOME` is
+   caught here via its base `process`.
+2. **`new` callees** (`new Function`/`Proxy`/`WebSocket`) — `checkSandboxNames`
+   (`lib/typeChecker/sandboxNameCheck.ts`). Sound and complete: the class
+   name is a grammar literal (no `new (x + y)()`), so the registry lookup
+   settles it. This is the layer that closes `new Proxy`/`new WebSocket`,
+   which the code-generation-from-strings flag does not.
+3. **The `constructor`/`prototype`/`__proto__` walk** — `checkSandboxNames`,
+   AG4011. Best-effort: spelled or string-literal-computed keys only; a
+   runtime-computed key gets through and is layer 2's job. The three names
+   are in a named constant `SANDBOX_FORBIDDEN_PROPERTIES`.
+4. **Declaration-hanging expressions** — `@validate`/`@jsonSchema` tag
+   arguments and array/object default parameter values. These sit outside
+   the scope bodies the general passes walk, so `checkSandboxNames` finds
+   them with `collectDeclHangingExpressions` and checks every name inside.
+
+## Coverage equals the traversal's reach
+
+The completeness of this check is exactly the set of positions the walks
+reach. `walkNodes` is a hand-written descent that has been caught missing
+positions before, which is why the arc found five escapes by hand (bare
+identifiers, `new` callees, the constructor walk, tag arguments, default
+values). Two design choices bound that risk:
+
+- **Positions 1–3** ride `walkNodes`, so a future AST node with an
+  expression slot `walkNodes` descends into is covered automatically.
+- **Position 4** does NOT use a `walkNodes` flag. Tags can hang on a type
+  property, which `walkNodes` does not reach at all, so
+  `collectDeclHangingExpressions` is a structural walk that finds every
+  `.tags` array and array/object `defaultValue` wherever it hangs — more
+  complete than a `walkNodes` extension would be. Each collected expression
+  is then descended with `walkNodes`, so the traversal of the expression
+  itself is still shared, not reimplemented.
+
+If a new capability position turns up, the fix is to feed it to the same
+resolver, not to write a second rule. The security guarantee still does not
+rest here — it rests on layer 2 and, ultimately, on removing ambient
+authority (roadmap).
+
+## Note on a pre-existing gap
+
+Template hygiene (AG8015) rides the same body walk and is likely blind to
+default parameter values too. That is a separate, pre-existing gap, noted
+here because a fix to either should consider both.
+
+## Files
+
+- `lib/typeChecker/resolveCall.ts` — `SANDBOX_JS_GLOBALS`, registry-param on
+  `resolveCall`/`lookupJsMember`/`isJsGlobalBase`.
+- `lib/typeChecker/resolveVariable.ts` — registry-param.
+- `lib/typeChecker/undefinedFunctionDiagnostic.ts`,
+  `undefinedVariableDiagnostic.ts` — registry + error severity under sandbox.
+- `lib/typeChecker/sandboxNameCheck.ts` — new-callee, forbidden-property, and
+  declaration-hanging-expression checks.
+- `lib/compiler/compileValidatedClosure.ts` — sets `jsGlobals: "sandbox"`.
+- Tests: `lib/typeChecker/sandboxRegistry.test.ts`,
+  `lib/compiler/compileSandboxed.test.ts` (bound-names describe),
+  `tests/agency-js/test-cli-agency-only`.

--- a/packages/agency-lang/docs/dev/compiler/agency-only-bound-names.md
+++ b/packages/agency-lang/docs/dev/compiler/agency-only-bound-names.md
@@ -51,9 +51,16 @@ are covered by two walks that share that one rule:
    runtime-computed key gets through and is layer 2's job. The three names
    are in a named constant `SANDBOX_FORBIDDEN_PROPERTIES`.
 4. **Declaration-hanging expressions** — `@validate`/`@jsonSchema` tag
-   arguments and array/object default parameter values. These sit outside
-   the scope bodies the general passes walk, so `checkSandboxNames` finds
-   them with `collectDeclHangingExpressions` and checks every name inside.
+   arguments and non-scalar default parameter values (arrays, objects, and
+   interpolated strings like `"${process.env.HOME}"`). These sit outside the
+   scope bodies the general passes walk, so `checkSandboxNames` finds them
+   with `collectDeclHangingExpressions` and checks every name inside. Each
+   carries the scope where it hangs: module-level bindings plus the owning
+   declaration's value parameters (type alias) or parameters (function/node),
+   so a top-level `const` or a value parameter used in a tag argument
+   resolves rather than being falsely refused. Tags are paired with their
+   owner via `tagsAbove`, because at type-check time the preprocessor has not
+   attached them yet (they are standalone nodes before the declaration).
 
 ## Coverage equals the traversal's reach
 

--- a/packages/agency-lang/docs/dev/hosting/how-hosted-serving-works.md
+++ b/packages/agency-lang/docs/dev/hosting/how-hosted-serving-works.md
@@ -1,0 +1,282 @@
+# How an Agency program is served through statelog
+
+This is a plain walkthrough of what happens between typing
+`agency remote deploy` and getting a JSON answer from a URL. It is the
+readable companion to `hosted-agent-execution.md`, which has the
+file-by-file detail. Read this one first.
+
+Two programs are involved:
+
+- **agency-lang** is the language. It includes the `agency` command line and
+  a small library, `agency-lang/serve`, that turns a compiled program into
+  something a web server can call.
+- **statelog** is a web app. It stores your uploaded program, runs it when a
+  request comes in, and records what happened.
+
+## Step 1: you write a program
+
+Nothing special is needed. Any node or function you `export` becomes
+callable over the web.
+
+```
+// greeter.agency
+export def greet(name: string): string {
+  return "Hello, " + name
+}
+
+export node summarize(text: string) {
+  const summary = llm("Summarize in one sentence: " + text)
+  return summary
+}
+```
+
+## Step 2: you deploy it
+
+```
+agency remote deploy greeter.agency
+```
+
+The command reads two settings from your `agency.json`: `log.host` (which
+statelog server) and `log.projectId` (which project on it). It reads your
+API key from the `STATELOG_API_KEY` environment variable. Then it sends the
+**source text** of `greeter.agency`, plus any `.agency` files it imports, to
+statelog's upload endpoint. It sends source, never compiled output.
+
+Statelog writes each file to disk under a folder for your user and project,
+compiles it once to check that it compiles, and records the file in its
+database. Then it prints the URLs you can call, with a ready-made `curl`
+for each:
+
+```
+curl -s -H "Authorization: Bearer $KEY" \
+  "https://statelog.example.com/serve/u_123/my-project/greeter.agency/list"
+
+curl -s -X POST "https://statelog.example.com/serve/u_123/my-project/greeter.agency/function/greet" \
+  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
+  -d '{"name":"…"}'
+```
+
+Every URL has the same shape:
+
+```
+/serve/<user id>/<project>/<file name>/<what to do>
+```
+
+and "what to do" is one of four things, described in step 4.
+
+## Step 3: statelog gets the program ready to run
+
+The first time a request arrives for a file (and again whenever the file
+changes), statelog does three things:
+
+1. **Compiles the source again.** Each compile stamps a fresh random id
+   into the output, and the serve library uses that id to find the
+   program's functions. So statelog cannot reuse the file it compiled at
+   upload time; it compiles now and keeps the id.
+2. **Writes the compiled JavaScript** next to the source, named after a
+   hash of its contents (`greeter.<hash>.js`). Two requests compiling the
+   same source produce the same file, so they cannot trip over each other.
+3. **Loads that JavaScript into the web server** with `import(...)` and asks
+   agency-lang for a *handler*.
+
+### Where the handler comes from
+
+agency-lang ships a small module for hosts, imported as `agency-lang/serve`
+(`lib/serve/public.ts`). Its main export is `createServeHandler`. Statelog
+calls it like this:
+
+```ts
+import { createServeHandler } from "agency-lang/serve";
+
+const handler = await createServeHandler("/uploads/u_123/my-project/greeter.<hash>.js", {
+  moduleId,            // the id stamped into the code by the compile in step 1
+  exportedNodeNames,   // ["summarize"]
+  version,             // the hash, so a changed file loads as new code
+});
+```
+
+Inside, `createServeHandler` (`lib/serve/createServeHandler.ts`):
+
+1. Imports the compiled file with `import("file:///...greeter.<hash>.js?v=<hash>")`.
+   The `?v=` part stops Node from handing back a stale cached module.
+2. Checks the file is really a compiled Agency program: it must export
+   `hasInterrupts` and `__respondToInterruptsForServe`, which the code
+   generator adds to every program. Anything else fails with a clear error.
+3. Collects what can be called: every `def` from the module's
+   `__toolRegistry` whose stamped id matches `moduleId`, plus the exported
+   nodes by name.
+4. Wraps those in a dispatcher (`lib/serve/http/adapter.ts`) and returns it.
+
+The dispatcher is the handler. It is a function with this shape:
+
+```ts
+(method, path, body, options) => Promise<{ status, body }>
+```
+
+You give it an HTTP method, a path like `/function/greet`, the request
+body, and some per-request options. It matches the path against the four
+routes in step 4, turns the body into named arguments, calls the matching
+compiled function or node, and turns the result into a status code and a
+JSON body. Statelog keeps one handler per file in memory and reuses it for
+every request. The handler holds no per-project settings; those arrive in
+`options` on each call.
+
+## Step 4: a request comes in
+
+Say a client calls:
+
+```
+POST /serve/u_123/my-project/greeter.agency/function/greet
+Authorization: Bearer sl_abc...
+Content-Type: application/json
+
+{"name": "Ada"}
+```
+
+Statelog, in order:
+
+1. **Checks the API key** and that it belongs to the project in the URL.
+2. **Loads the project's spending limit** (a maximum cost in dollars and a
+   maximum wall-clock time). If this cannot be loaded the request fails;
+   statelog never runs a program without knowing its limit.
+3. **Finds or builds the handler** for `greeter.agency` (step 3).
+4. **Puts the project's secrets into the environment.** Secrets you saved
+   with `agency remote secrets` are decrypted and set as environment
+   variables for the duration of this request, so the program's `env()`
+   calls can see them.
+5. **Calls the handler**, passing the per-request options: the spending
+   limit, and where to send the run's trace (this project's own page in
+   statelog, with this API key).
+6. **Records the cost** of the run against the project.
+7. **Sends the handler's answer back** as the HTTP response.
+
+The answer for a function is simple:
+
+```json
+{ "success": true, "value": "Hello, Ada" }
+```
+
+If the function returned a failure, you still get HTTP 200, with:
+
+```json
+{ "success": false, "error": "…a short message…" }
+```
+
+The full error is written to statelog's log; the client sees only a
+sanitized version.
+
+## The four things you can ask for
+
+| Path | Method | What it does |
+|---|---|---|
+| `/list` | GET | Describes the program: every exported function and node, its parameters, and which interrupt effects it can raise. |
+| `/function/<name>` | POST | Runs one function with the body as its named arguments. |
+| `/node/<name>` | POST | Runs one node the same way. Nodes can pause on an interrupt (next section). |
+| `/resume` | POST | Continues a node that paused. |
+
+## When the program asks a question: interrupts over HTTP
+
+Interrupts are how Agency code pauses to ask for permission or input
+(`docs/site/guide/interrupts.md`). On the command line, the pause shows up
+as a prompt in your terminal. Over the web there is no terminal, so the
+pause becomes a response.
+
+Suppose the node writes a file, which raises `std::write`:
+
+```
+export node saveNote(text: string) {
+  write("note.txt", text)
+  return "saved"
+}
+```
+
+Calling `/node/saveNote` does not return `"saved"`. It returns the question:
+
+```json
+{
+  "success": true,
+  "value": {
+    "interrupts": [
+      {
+        "effect": "std::write",
+        "message": "Are you sure you want to write this file?",
+        "data": { "dir": ".", "filename": "note.txt" },
+        "interruptId": "…",
+        "checkpoint": { "…a snapshot of the paused program…" }
+      }
+    ],
+    "state": "…the same array, as a JSON string…"
+  }
+}
+```
+
+Each interrupt object carries a **checkpoint**: a snapshot of the paused
+program, taken at the moment it asked. Statelog keeps nothing about this
+run in memory. Everything needed to continue travels in that object, which
+is why the same statelog server can answer the next request from any
+machine, any time later.
+
+The client answers by sending the interrupt objects back, unchanged, with
+one decision per interrupt:
+
+```
+POST /serve/u_123/my-project/greeter.agency/resume
+
+{
+  "interrupts": [ …the array from the last response, unchanged… ],
+  "responses": [ { "type": "approve" } ]
+}
+```
+
+(`state` is a convenience copy for clients that want to store the pause as
+one string; `/resume` reads `interrupts` and `responses` and ignores it.)
+
+The program picks up where it stopped, the file is written, and the
+response is now `{ "success": true, "value": "saved" }`. If the program
+pauses again, you get another `interrupts` response, so a client loops:
+call, answer, call, answer, until there is a final value. To refuse, send
+`{ "type": "reject" }` instead; the node stops with an "interrupt rejected"
+failure. To answer an interrupt that asked for a value (`const name = raise
+interrupt("Which file?")`), send `{ "type": "approve", "value": "note.txt" }`.
+
+### What a checkpoint contains, and who can change it
+
+A checkpoint is data only (`lib/runtime/state/checkpointStore.ts`): each
+frame's arguments and local variables, the module's globals, the LLM
+conversation so far, the name of the node to restart, and a step path
+saying where in that node to continue. There is no code in it. On resume
+the node name is looked up in the same compiled module the request is for,
+and everything that then runs is that module's own code.
+
+So the developer who deployed the program gains nothing by editing a
+checkpoint. Anything they could make it do, their program could already do,
+and the resume URL is tied to their project and file by the API key check.
+
+The picture is different for an **end user** who receives interrupts from
+the developer's program:
+
+- The checkpoint carries values out. A secret the program read into a
+  variable before pausing, or anything the LLM was told, is in the response.
+- The checkpoint is not signed. The values are checked for shape
+  (`lib/runtime/state/schemas.ts`), not for authenticity, so a caller can
+  change `{ amount: 5 }` to `{ amount: 5000 }` before approving.
+
+Until checkpoints are signed with a server key (or stored server-side and
+referred to by id), the interrupt loop should stay between statelog and a
+client the developer trusts.
+
+## Where the trace goes
+
+Every hosted run records a trace, the same kind `agency run --trace`
+produces, into statelog under the project the program belongs to. This is
+set per request (step 4, item 5), not baked into the compiled file, so one
+statelog server can host programs from many projects and keep their traces
+apart, and no API key ever sits inside a compiled `.js` file on disk.
+
+## What is not there yet
+
+The program runs **inside the statelog web server process**, compiled with
+no restrictions on what it may import. That is fine while everyone who can
+deploy is trusted by the server's owner, and today that is the rule. The
+work to change it, so that strangers' programs can be hosted, is in
+`docs/dev/security/roadmap.md`, section D.

--- a/packages/agency-lang/docs/dev/security/goal.md
+++ b/packages/agency-lang/docs/dev/security/goal.md
@@ -1,0 +1,108 @@
+# The goal: running untrusted Agency code without a sandbox
+
+Companion: `roadmap.md` in this directory lists every issue that stands
+between the current code and this goal.
+
+## What we want
+
+Someone hands you an Agency program you have never read. You run it. It
+cannot touch anything (a file, the network, an environment variable, a
+shell) unless it asks first, and you get to say no. That holds with no
+container, no virtual machine, and no operating-system sandbox around the
+process. The language enforces the rule.
+
+Concretely, this command line should be enough:
+
+```
+agency run --agency-only --reject '*' their-program.agency
+```
+
+and a host like statelog should be able to run an uploaded agent in a plain
+Node child process and give it only the effects that project is allowed.
+
+## Why we want this
+
+Every other language needs a sandbox to run code you do not trust, because
+every other language has *ambient authority*: any line of code can open a
+file or a socket, so the only way to stop it is to wrap the whole process.
+Sandboxes are slow to start, cost money to run, and add operational weight.
+
+Agency was designed differently. The only way for Agency code to affect the
+world is through the standard library, and every world-touching function in
+the standard library raises an interrupt before it acts. An interrupt is
+decided by the handler chain, and in that chain a reject from an outer
+handler beats an approve from an inner one (`mergeChainOutcomes` in
+`lib/runtime/interrupts.ts`: reject > propagate > approve). So whoever runs the
+program, and installs the outermost handler, has the last word over
+everything the program does.
+
+If that property holds all the way down, Agency does not need a sandbox.
+Hosted agents can then start in milliseconds, run in one process, and cost
+nothing extra to isolate.
+
+## What "holds all the way down" means
+
+The argument above has three parts, and each has to be true:
+
+1. **The only door is the standard library.** Pure Agency code has no other
+   way to reach the world. Today this is false. Agency compiles to
+   JavaScript, an unknown identifier is emitted as-is, and `process`,
+   `fetch`, `globalThis`, and `eval` are one bare name away (#971). Closing
+   this is most of the work.
+2. **Every door raises an interrupt first, with a truthful payload.** This is
+   a property of the standard library's TypeScript, kept true by review.
+   The standard library is the trusted computing base; keeping it small and
+   reviewed is the whole point of funnelling effects through it.
+3. **The runner's handler is outermost, and always in the chain.**
+   Today top-level code runs before the root policy handler is installed
+   (#966), and resumed interrupts are answered before the chain runs
+   (`docs/superpowers/specs/2026-08-29-serve-host-interrupt-policy-design.md`).
+
+There is a fourth condition that is not about the language at all: the
+process the code runs in must not hand it anything by accident. A
+`node_modules` directory, an `agency.json`, or the parent's environment
+beside the untrusted file are all ways code gets in without an `import`
+(#967, #968, #969).
+
+## What a language cannot buy, and what we keep
+
+Language-level security has a track record (Joe-E for Java, Caja and
+Hardened JavaScript for JavaScript, which MetaMask and Agoric use to run
+strangers' code in-process). All of them still needed one thing outside the
+language: a unit of execution that can be limited and killed.
+
+- A `while (true) {}` in a shared process stalls everyone on that event
+  loop. No capability rule fixes that; only a separate worker or child
+  process with resource limits does.
+- A bug in the trusted computing base (compiler, runtime, stdlib, Node
+  itself) is a full compromise of whatever shares the process. A process
+  boundary caps that to one run.
+
+So the goal is **no operating-system sandbox** and **one plain Node child
+process per untrusted run**, with an allowlisted environment and resource
+limits. A child process is a `fork()`. The machinery for it already exists (`std::agency.run`, `lib/runtime/ipc.ts`). We keep it for
+budgets and cancellation anyway.
+
+## What the goal demands of us
+
+The compiler becomes a security boundary. What that changes about how we
+work on it:
+
+- The rule "every free identifier is bound by Agency, or the compile fails"
+  has to be sound. A typechecker warning does not stop a run.
+- The list of JavaScript globals Agency code may use (`JS_GLOBALS` in
+  `lib/typeChecker/resolveCall.ts`) is an attack surface and is reviewed as
+  one. `Math` and `JSON` are fine; anything that reaches the host is not.
+- Changes to code generation, the import template
+  (`lib/templates/backends/typescriptGenerator/imports.mustache`), and the
+  stdlib's effectful functions need a test that would fail if the boundary
+  broke, not only a test that the feature works.
+- The invariant is written down (this document and `roadmap.md`) and
+  someone tries to break it before we rely on it for strangers' code.
+
+## Until then
+
+Until the roadmap is done, `--agency-only` reduces attack surface but is not
+a sandbox, and statelog's hosted execution is single-tenant and trusted:
+only people the server owner trusts may deploy. Say so wherever a user
+could believe otherwise.

--- a/packages/agency-lang/docs/dev/security/roadmap.md
+++ b/packages/agency-lang/docs/dev/security/roadmap.md
@@ -34,10 +34,12 @@ Fix, in three layers, cheapest first:
    `new WebSocket(...)` — the last two are not code-from-strings, so layer 2
    never covers them); the property names `constructor`, `prototype`,
    `__proto__` reached from a value (`x.constructor.constructor`), spelled or
-   as a string-literal computed key; and tag arguments (`@validate(...)`,
+   as a string-literal computed key; tag arguments (`@validate(...)`,
    `@jsonSchema({ ... })`), whose expressions are emitted verbatim and
-   executed at module load — reproduced writing a file under
-   `--agency-only --reject '*'`. Design:
+   executed at module load; and array/object default parameter values
+   (`def f(xs = [process.env.HOME])`) — all reproduced leaking under
+   `--agency-only --reject '*'`. The position list is by-hand and not proven
+   complete; the plan's final phase audits the generator. Design:
    `docs/superpowers/specs/2026-08-29-agency-only-bound-names-design.md`
    (revised after review).
 2. **`--disallow-code-generation-from-strings`** on the child Node process

--- a/packages/agency-lang/docs/dev/security/roadmap.md
+++ b/packages/agency-lang/docs/dev/security/roadmap.md
@@ -1,0 +1,203 @@
+# Roadmap: what has to change before untrusted Agency code is safe to run
+
+Read `goal.md` first; this document is the list of gaps between the code
+today and that goal. Each entry says what is wrong, how to see it, and what
+the fix looks like. Tick entries off here as they merge, and add new ones
+when a fresh hole is found. Every entry that has a GitHub issue links it.
+
+The entries are grouped by which part of the argument in `goal.md` they
+break. Within a group they are in the order to do them.
+
+## A. The only door is the standard library
+
+### A1. Pure Agency code can reach any JavaScript global (#971)
+
+<https://github.com/egonSchiele/agency-lang/issues/971>. An identifier the compiler does not know is emitted verbatim, so
+`process.env.HOME`, `process.getBuiltinModule("fs")`, `fetch(...)`,
+`eval("...")`, and `globalThis` all work from pure Agency, with no interrupt,
+under `--agency-only --reject '*'`. The typechecker's AG4004 is a warning,
+`run` ignores warnings, and it only inspects calls, so `process.env` gets no
+diagnostic at all.
+
+Fix, in three layers, cheapest first:
+
+1. **Bind-check under `--agency-only`.** Every free identifier must resolve
+   to an Agency declaration, an import, the `std::index` prelude, or a
+   short reviewed allowlist of pure intrinsics (`Math`, `JSON`, `Number`,
+   `String`, `Array`, `Object`, `Set`, `Map`, `Date`, `parseInt`, ...).
+   Anything else is a compile error, for value accesses as well as calls.
+   This also covers every name the import template puts in scope
+   (`readFileSync`, `writeFileSync`, `__process`, `path`, `os`, `z`,
+   `smoltalk`), since none of them is Agency-bound.
+2. **`--disallow-code-generation-from-strings`** on the child Node process
+   for `--agency-only` runs (`compiledOutputNodeArgs` in
+   `lib/cli/commands.ts`). Closes `eval`, `new Function`, and the
+   `"".constructor.constructor("return process")()` trick, which needs no
+   free identifier. Grep the runtime for `eval`/`new Function` first.
+3. **Confinement of the object graph.** After 1 and 2, the remaining
+   question is whether an Agency value can be walked to a capability:
+   `.constructor`, `__proto__`, `Object.getPrototypeOf`, or a runtime object
+   that leaks into user-visible values (a `Result`, interrupt `data`, a
+   function object like `read`). The known solution is Hardened JavaScript:
+   freeze the intrinsics (`ses` `lockdown()`) and load user modules into a
+   Compartment whose globals are the stdlib facade. This needs a design
+   note, whose first task is an audit of which runtime objects reach Agency
+   values.
+
+Tests to add: the programs in the issue are refused under `--agency-only`;
+a positive control (`Math.floor`, `JSON.parse`, `arr.push`) still compiles.
+
+### A2. Review the JavaScript interop allowlist
+
+`JS_GLOBALS` in `lib/typeChecker/resolveCall.ts` was built to avoid false
+positives in interop code. It was never reviewed as a security list. Once A1 makes it load-bearing, review
+every entry: keep pure value helpers, remove anything that can reach the
+host (`Function`, `eval`, `globalThis`, `Reflect`, `Proxy`, `process`,
+`fetch`, `require`, `import`, `setTimeout` if it can run strings). No issue
+yet; file one when A1 starts.
+
+### A3. Compile-time code execution via splices
+
+Known and documented (`docs/dev/language/splices.md`): `agency tc`, the
+language server, `ast`, `fmt`, `doc`, `preprocess`, and `interrupts` all run
+splice generators, and only `run`, `compile`, `typecheck`, and `test` offer
+`--refuse-splices`. The `recommended` policy approves
+`exec("agency tc ...")`, so untrusted code under that policy can reach a
+generator through the shell. The roadmap should decide
+whether `--refuse-splices` becomes the default for anything that is not an
+explicit build, and whether generators run through `compileSandboxed`.
+No issue yet.
+
+## B. The runner's handler is outermost and always present
+
+### B1. Top-level `with approve` runs before the root policy exists (#966)
+
+<https://github.com/egonSchiele/agency-lang/issues/966>. `lib/runtime/node.ts`
+runs global init and imported modules' top-level code, then installs the
+policy handler. A top-level `const x = read(...) with approve` therefore has
+only the author's approve in the chain and succeeds under `--reject '*'`.
+Fix: install the root policy handler and root budget before any user code,
+including `__initAllRegistered`; check the resume path in `interrupts.ts`
+for the same ordering; add an agency-js test that a top-level read is
+rejected.
+
+### B2. Resumed interrupts bypass the handler chain
+
+Designed, not yet built:
+`docs/superpowers/specs/2026-08-29-serve-host-interrupt-policy-design.md`,
+section 3. A resume answers interrupts from `getInterruptResponse(id)`
+before the chain runs, so a root policy never sees them and a caller can
+approve their own `std::read`. The spec applies the policy to the response
+map before `setInterruptResponses`; a policy reject overrides a caller
+approve, a caller reject is always honoured. Build it as specified, and emit
+`resolvedBy: "policy"` on the lifecycle event.
+
+### B3. The sandbox flags do not imply a policy (#970)
+
+<https://github.com/egonSchiele/agency-lang/issues/970>. `--agency-only`
+and `--refuse-splices` make effects visible as interrupts; neither blocks
+one. With no `--policy`/`--reject`, the author's own `with approve` is the
+only handler. Decide one of: `--agency-only` implies a propagate-everything
+root handler unless a policy is given; a single `--untrusted` flag that
+bundles the right set; or at least a warning and accurate help text.
+
+## C. Nothing reaches the process by accident
+
+### C1. `node_modules` beside the untrusted file shadows `agency-lang` (#967)
+
+<https://github.com/egonSchiele/agency-lang/issues/967>. Generated code
+imports `agency-lang/...` as bare specifiers; Node resolves them from the
+program's directory first, and the resolver shim
+(`lib/cli/runShim/resolver.mjs`) is only a fallback. A planted
+`node_modules/agency-lang/` runs arbitrary JS before any handler. Fix: the
+shim resolves `agency-lang` and `agency-lang/*` from the install root first,
+unconditionally. About five lines.
+
+### C2. `agency.json` in the untrusted tree loads provider modules (#968)
+
+<https://github.com/egonSchiele/agency-lang/issues/968>. Config is found by
+walking up from cwd; `client.providerModules` is a list of JS files loaded
+with a dynamic import at bootstrap. Fix: under `--agency-only`, never load
+provider modules named by a config discovered under the tree being run;
+longer term, find a pattern for provider modules that is not "a JS path in
+project config".
+
+### C3. `agency.json` in the untrusted tree redirects `llm()`; `--agency-only` ignores the runner's config (#969)
+
+<https://github.com/egonSchiele/agency-lang/issues/969>. `client.baseUrl.*`
+plus `defaultProvider` sends every prompt, and the key for that provider,
+wherever the tree's config says. Separately, `compileValidatedClosure.ts`
+never loads config at all, which is why `--agency-only` happens to be
+immune, and why it also ignores the runner's own `agency.json`. Fix: load
+the runner's config through the normal path, refuse the tree's explicitly.
+
+### C4. The child's environment (no issue yet)
+
+`withRootCarriers` (`lib/cli/childEnv.ts`) scrubs the four policy and
+budget variables from the child's environment and nothing else. A child
+running untrusted code should get an allowlist, not the parent's full
+environment minus four names; after A1 this matters less, but it is the
+right default and it is what statelog needs (see D). File an issue when C1
+to C3 are done.
+
+## D. Hosted execution (statelog)
+
+Statelog compiles uploads with plain `compileSource` and imports the result
+into the web server process (`src/backend/lib/agencyCompiler.ts`,
+`src/backend/lib/serveHost.ts`). Project secrets are injected into the real
+`process.env` for the invocation (`src/backend/lib/secrets/projectSecrets.ts`),
+and invocations run concurrently. With A1 open, any deployer can read the
+database URL, the secrets key, other tenants' in-flight secrets, and the
+Cloud Run metadata token. The upload route calls this "trusted single-tenant
+v1" (`upload.ts`, containment tracked as statelog #11).
+
+In order:
+
+1. **Say it in the product.** Until the items below ship, only people the
+   server owner trusts may deploy. That fact lives in a source comment
+   today.
+2. **Compile as untrusted.** `compileSandboxed` instead of `compileSource`
+   at upload and serve: no TS, no `pkg::`, no splices, imports contained to
+   the project directory (also closes statelog #11).
+3. **One child process per invocation**, using the `std::agency.run`
+   machinery (`lib/runtime/ipc.ts`): `--disallow-code-generation-from-strings`,
+   an allowlisted environment carrying only that project's secrets, and the
+   interrupt forwarding the child already does. Secrets then never touch
+   the server's `process.env`, which ends the cross-tenant window.
+4. **Host-owned root policy** per invocation, from the serve-host policy
+   spec (B2): reject `std::write`, `std::rm`, `std::shell`, `std::run`, and
+   anything not on a short hosted allowlist; `std::env` approved only for
+   that project's secret names. Reject beats the deployer's `/resume`.
+5. **Network.** Block link-local addresses (the metadata server) and
+   internal services at the network layer, or route `std::http` through a
+   broker with an egress allowlist.
+
+Each of these needs a statelog spec; the serve-host policy spec's companion
+is the place to start. No statelog issues are filed yet.
+
+## E. Keeping it true
+
+- Every codegen, import-template, and effectful-stdlib change gets a test
+  that would fail if the boundary broke.
+- `docs/dev/cli/test-cli-sandbox.md` currently claims code before the
+  handler "cannot raise an interrupt at all" and that under `--agency-only`
+  "every effect the code can perform is an interrupt". Both are false until
+  A1 and B1 land; correct the doc when they do, and not before.
+- Before hosting strangers' code on the strength of the language, someone
+  spends a day trying to break it with this list in hand.
+
+## Status
+
+| Item | Issue | State |
+|---|---|---|
+| A1 JS globals reachable | #971 | open |
+| A2 review `JS_GLOBALS` | — | not filed |
+| A3 splice execution in non-build commands | — | not filed, known |
+| B1 top-level `with approve` before policy | #966 | open |
+| B2 resume bypasses chain | spec | designed |
+| B3 sandbox flags imply no policy | #970 | open |
+| C1 `node_modules` shadowing | #967 | open |
+| C2 provider modules from tree config | #968 | open |
+| C3 `llm()` redirect; `--agency-only` ignores config | #969 | open |
+| C4 child env allowlist | — | not filed |
+| D statelog hosted execution | statelog #11 (containment only) | open |

--- a/packages/agency-lang/docs/dev/security/roadmap.md
+++ b/packages/agency-lang/docs/dev/security/roadmap.md
@@ -28,7 +28,15 @@ Fix, in three layers, cheapest first:
    Anything else is a compile error, for value accesses as well as calls.
    This also covers every name the import template puts in scope
    (`readFileSync`, `writeFileSync`, `__process`, `path`, `os`, `z`,
-   `smoltalk`), since none of them is Agency-bound.
+   `smoltalk`), since none of them is Agency-bound. Two positions a plain
+   bind-check misses, both found by review and both in scope for this layer:
+   the callee of a `new` expression (`new Function(...)`, `new Proxy(...)`,
+   `new WebSocket(...)` — the last two are not code-from-strings, so layer 2
+   never covers them), and the property names `constructor`, `prototype`,
+   `__proto__` reached from a value (`x.constructor.constructor`), spelled or
+   as a string-literal computed key. Design:
+   `docs/superpowers/specs/2026-08-29-agency-only-bound-names-design.md`
+   (revised after review).
 2. **`--disallow-code-generation-from-strings`** on the child Node process
    for `--agency-only` runs (`compiledOutputNodeArgs` in
    `lib/cli/commands.ts`). Closes `eval`, `new Function`, and the

--- a/packages/agency-lang/docs/dev/security/roadmap.md
+++ b/packages/agency-lang/docs/dev/security/roadmap.md
@@ -32,9 +32,12 @@ Fix, in three layers, cheapest first:
    bind-check misses, both found by review and both in scope for this layer:
    the callee of a `new` expression (`new Function(...)`, `new Proxy(...)`,
    `new WebSocket(...)` — the last two are not code-from-strings, so layer 2
-   never covers them), and the property names `constructor`, `prototype`,
+   never covers them); the property names `constructor`, `prototype`,
    `__proto__` reached from a value (`x.constructor.constructor`), spelled or
-   as a string-literal computed key. Design:
+   as a string-literal computed key; and tag arguments (`@validate(...)`,
+   `@jsonSchema({ ... })`), whose expressions are emitted verbatim and
+   executed at module load — reproduced writing a file under
+   `--agency-only --reject '*'`. Design:
    `docs/superpowers/specs/2026-08-29-agency-only-bound-names-design.md`
    (revised after review).
 2. **`--disallow-code-generation-from-strings`** on the child Node process

--- a/packages/agency-lang/docs/dev/security/roadmap.md
+++ b/packages/agency-lang/docs/dev/security/roadmap.md
@@ -42,9 +42,15 @@ Fix, in three layers, cheapest first:
    (revised after review).
 2. **`--disallow-code-generation-from-strings`** on the child Node process
    for `--agency-only` runs (`compiledOutputNodeArgs` in
-   `lib/cli/commands.ts`). Closes `eval`, `new Function`, and the
-   `"".constructor.constructor("return process")()` trick, which needs no
-   free identifier. Grep the runtime for `eval`/`new Function` first.
+   `lib/cli/commands.ts`). This is the REAL boundary for reaching `Function`
+   and calling it with a string — via `eval`, `new Function`, or any
+   constructor walk including `m[a + b]["constructor"]…` with a runtime-
+   computed key, which layer 1's syntactic property check cannot catch
+   (verified). So layer 2 ships WITH or immediately after layer 1; layer 1
+   alone must not be described as closing code-from-strings. Layer 1 still
+   carries what layer 2 cannot see: `new Proxy`/`new WebSocket` (not
+   code-from-strings; `className` is a literal, so soundly refused). Grep the
+   runtime for `eval`/`new Function` first.
 3. **Confinement of the object graph.** After 1 and 2, the remaining
    question is whether an Agency value can be walked to a capability:
    `.constructor`, `__proto__`, `Object.getPrototypeOf`, or a runtime object

--- a/packages/agency-lang/docs/dev/security/roadmap.md
+++ b/packages/agency-lang/docs/dev/security/roadmap.md
@@ -12,6 +12,12 @@ break. Within a group they are in the order to do them.
 
 ### A1. Pure Agency code can reach any JavaScript global (#971)
 
+**Layer 1 (the bind-check) DONE** — `jsGlobals: "sandbox"`, `SANDBOX_JS_GLOBALS`,
+and `checkSandboxNames` refuse free identifiers, `new` callees, the
+constructor/prototype walk (best-effort), tag arguments, and default values;
+see `docs/dev/compiler/agency-only-bound-names.md`. Layers 2 (disable
+code-generation-from-strings) and 3 (freeze intrinsics) still open.
+
 <https://github.com/egonSchiele/agency-lang/issues/971>. An identifier the compiler does not know is emitted verbatim, so
 `process.env.HOME`, `process.getBuiltinModule("fs")`, `fetch(...)`,
 `eval("...")`, and `globalThis` all work from pure Agency, with no interrupt,

--- a/packages/agency-lang/lib/compiler/compileSandboxed.test.ts
+++ b/packages/agency-lang/lib/compiler/compileSandboxed.test.ts
@@ -308,7 +308,9 @@ describe("compileAgencyOnly", () => {
 describe("bound names under --agency-only", () => {
   function compileOne(source: string) {
     // No local imports, so dir "" is fine; the closure is a single source.
-    return compileSandboxed({ entry: { source }, dir: "" });
+    // enforceJsGlobals is what `--agency-only` sets; the bound-names check is
+    // off for the trusted runtime fork path that shares compileSandboxed.
+    return compileSandboxed({ entry: { source }, dir: "", enforceJsGlobals: true });
   }
   function refused(source: string): string[] {
     const r = compileOne(source);

--- a/packages/agency-lang/lib/compiler/compileSandboxed.test.ts
+++ b/packages/agency-lang/lib/compiler/compileSandboxed.test.ts
@@ -350,6 +350,8 @@ describe("bound names under --agency-only", () => {
       'type Foo = {\n  @jsonSchema({ x: process })\n  value: number,\n}\nnode main() { print("hi") }',
     );
     refused('node main(xs = [process]) { print("hi") }');
+    // Interpolated string default: the interpolation reaches a host global.
+    refused('node main(x = "${process.env.HOME}") { print(x) }');
   });
 
   test("allows pure values, methods, and safe constructors", () => {
@@ -366,5 +368,13 @@ describe("bound names under --agency-only", () => {
       'def isPositive(n: number): Result<number> {\n  if (n > 0) { return success(n) }\n  return failure("no")\n}\n@validate(isPositive)\ntype Pos = number\nnode main() { let x: Pos = 5 }',
     );
     allowed("node main(xs = [1, 2]) { print(xs) }");
+    // A top-level const resolves inside a tag argument (module scope).
+    allowed(
+      'const MAXLEN = 5\n@jsonSchema({ maxLength: MAXLEN })\ndef f(x: string): string { return x }\nnode main() { print("hi") }',
+    );
+    // A type alias's value parameter resolves inside its own tag argument.
+    allowed(
+      '@jsonSchema({ minimum: low, maximum: high })\ntype Bounded(low: number, high: number) = number\nnode main() { print("hi") }',
+    );
   });
 });

--- a/packages/agency-lang/lib/compiler/compileSandboxed.test.ts
+++ b/packages/agency-lang/lib/compiler/compileSandboxed.test.ts
@@ -317,39 +317,54 @@ describe("bound names under --agency-only", () => {
   }
   function allowed(source: string): void {
     const r = compileOne(source);
-    expect(r.success, `expected to compile: ${source}\n${r.success ? "" : r.errors.join("\n")}`).toBe(true);
+    expect(
+      r.success,
+      `expected to compile: ${source}\n${r.success ? "" : r.errors.join("\n")}`,
+    ).toBe(true);
   }
 
   test("refuses host globals and code-from-strings", () => {
-    refused('node main() { print(process.env.HOME) }');
+    refused("node main() { print(process.env.HOME) }");
     refused('node main() { let m = process.getBuiltinModule("fs") }');
     refused('node main() { eval("print(1)") }');
     refused('node main() { fetch("http://x") }');
-    refused('node main() { print(globalThis) }');
+    refused("node main() { print(globalThis) }");
   });
 
   test("refuses new-expression capability constructors", () => {
     refused('node main() { let f = new Function("return 1") }');
-    refused('node main() { let p = new Proxy({}, {}) }');
+    refused("node main() { let p = new Proxy({}, {}) }");
     refused('node main() { let w = new WebSocket("ws://x") }');
-    refused('node main() { let x = new XMLHttpRequest() }');
+    refused("node main() { let x = new XMLHttpRequest() }");
   });
 
   test("refuses the constructor / prototype walk (literal spellings)", () => {
-    refused('def id(x) { return x }\nnode main() { let k = id("a")\n let f = k.constructor.constructor }');
+    refused(
+      'def id(x) { return x }\nnode main() { let k = id("a")\n let f = k.constructor.constructor }',
+    );
     refused('def id(x) { return x }\nnode main() { let k = id("a")\n let f = k["constructor"] }');
   });
 
   test("refuses capability names in tag arguments and default values", () => {
-    refused('type Foo = {\n  @jsonSchema({ x: process })\n  value: number,\n}\nnode main() { print("hi") }');
+    refused(
+      'type Foo = {\n  @jsonSchema({ x: process })\n  value: number,\n}\nnode main() { print("hi") }',
+    );
     refused('node main(xs = [process]) { print("hi") }');
   });
 
   test("allows pure values, methods, and safe constructors", () => {
-    allowed('node main() {\n  let xs = [3, 1, 2]\n  print(Math.floor(2.5))\n  print(JSON.stringify(xs))\n  print(xs.length)\n}');
-    allowed('node main() {\n  let s = new Set()\n  let m = new Map()\n  let d = new Date()\n  let r = new RegExp("a")\n  print("ok")\n}');
-    allowed('node main() {\n  let o = { a: 1 }\n  print(Object.keys(o))\n  let ks = "abc"\n  print(o[ks])\n}');
-    allowed('def isPositive(n: number): Result<number> {\n  if (n > 0) { return success(n) }\n  return failure("no")\n}\n@validate(isPositive)\ntype Pos = number\nnode main() { let x: Pos = 5 }');
-    allowed('node main(xs = [1, 2]) { print(xs) }');
+    allowed(
+      "node main() {\n  let xs = [3, 1, 2]\n  print(Math.floor(2.5))\n  print(JSON.stringify(xs))\n  print(xs.length)\n}",
+    );
+    allowed(
+      'node main() {\n  let s = new Set()\n  let m = new Map()\n  let d = new Date()\n  let r = new RegExp("a")\n  print("ok")\n}',
+    );
+    allowed(
+      'node main() {\n  let o = { a: 1 }\n  print(Object.keys(o))\n  let ks = "abc"\n  print(o[ks])\n}',
+    );
+    allowed(
+      'def isPositive(n: number): Result<number> {\n  if (n > 0) { return success(n) }\n  return failure("no")\n}\n@validate(isPositive)\ntype Pos = number\nnode main() { let x: Pos = 5 }',
+    );
+    allowed("node main(xs = [1, 2]) { print(xs) }");
   });
 });

--- a/packages/agency-lang/lib/compiler/compileSandboxed.test.ts
+++ b/packages/agency-lang/lib/compiler/compileSandboxed.test.ts
@@ -300,3 +300,56 @@ describe("compileAgencyOnly", () => {
     }
   });
 });
+
+// --- Bound-names under --agency-only (SANDBOX_JS_GLOBALS). See
+// docs/dev/security/roadmap.md A1. Each refused fixture names a capability;
+// none performs a side effect, so a regression that lets one compile still
+// cannot do harm when the test asserts only the compile result. ---
+describe("bound names under --agency-only", () => {
+  function compileOne(source: string) {
+    // No local imports, so dir "" is fine; the closure is a single source.
+    return compileSandboxed({ entry: { source }, dir: "" });
+  }
+  function refused(source: string): string[] {
+    const r = compileOne(source);
+    expect(r.success, `expected refusal for: ${source}`).toBe(false);
+    return r.success ? [] : r.errors;
+  }
+  function allowed(source: string): void {
+    const r = compileOne(source);
+    expect(r.success, `expected to compile: ${source}\n${r.success ? "" : r.errors.join("\n")}`).toBe(true);
+  }
+
+  test("refuses host globals and code-from-strings", () => {
+    refused('node main() { print(process.env.HOME) }');
+    refused('node main() { let m = process.getBuiltinModule("fs") }');
+    refused('node main() { eval("print(1)") }');
+    refused('node main() { fetch("http://x") }');
+    refused('node main() { print(globalThis) }');
+  });
+
+  test("refuses new-expression capability constructors", () => {
+    refused('node main() { let f = new Function("return 1") }');
+    refused('node main() { let p = new Proxy({}, {}) }');
+    refused('node main() { let w = new WebSocket("ws://x") }');
+    refused('node main() { let x = new XMLHttpRequest() }');
+  });
+
+  test("refuses the constructor / prototype walk (literal spellings)", () => {
+    refused('def id(x) { return x }\nnode main() { let k = id("a")\n let f = k.constructor.constructor }');
+    refused('def id(x) { return x }\nnode main() { let k = id("a")\n let f = k["constructor"] }');
+  });
+
+  test("refuses capability names in tag arguments and default values", () => {
+    refused('type Foo = {\n  @jsonSchema({ x: process })\n  value: number,\n}\nnode main() { print("hi") }');
+    refused('node main(xs = [process]) { print("hi") }');
+  });
+
+  test("allows pure values, methods, and safe constructors", () => {
+    allowed('node main() {\n  let xs = [3, 1, 2]\n  print(Math.floor(2.5))\n  print(JSON.stringify(xs))\n  print(xs.length)\n}');
+    allowed('node main() {\n  let s = new Set()\n  let m = new Map()\n  let d = new Date()\n  let r = new RegExp("a")\n  print("ok")\n}');
+    allowed('node main() {\n  let o = { a: 1 }\n  print(Object.keys(o))\n  let ks = "abc"\n  print(o[ks])\n}');
+    allowed('def isPositive(n: number): Result<number> {\n  if (n > 0) { return success(n) }\n  return failure("no")\n}\n@validate(isPositive)\ntype Pos = number\nnode main() { let x: Pos = 5 }');
+    allowed('node main(xs = [1, 2]) { print(xs) }');
+  });
+});

--- a/packages/agency-lang/lib/compiler/compileSandboxed.ts
+++ b/packages/agency-lang/lib/compiler/compileSandboxed.ts
@@ -16,12 +16,15 @@ export type CompileSandboxedArgs = {
   entry: ClosureEntry;
   /** Confinement boundary for local imports. "" = no local imports possible. */
   dir: string;
+  /** Enforce the reviewed JS-globals allowlist. Only `--agency-only` sets this;
+   *  the trusted runtime fork path leaves it off. See compileValidatedClosure. */
+  enforceJsGlobals?: boolean;
 };
 
 export function compileSandboxed(args: CompileSandboxedArgs): CompileResult {
   try {
     const closure = validateClosure({ entry: args.entry, dir: args.dir });
-    return compileValidatedClosure(closure);
+    return compileValidatedClosure(closure, { enforceJsGlobals: args.enforceJsGlobals });
   } catch (e) {
     if (e instanceof ClosureValidationError) {
       return { success: false, errors: e.violations };
@@ -38,7 +41,11 @@ export type AgencyOnlyCompile = { ok: true; scriptPath: string } | { ok: false; 
 export function compileAgencyOnly(sourceFile: string): AgencyOnlyCompile {
   const absolute = path.resolve(sourceFile);
   const dir = path.dirname(absolute);
-  const result = compileSandboxed({ entry: { file: path.basename(absolute) }, dir });
+  const result = compileSandboxed({
+    entry: { file: path.basename(absolute) },
+    dir,
+    enforceJsGlobals: true,
+  });
   if (!result.success) return { ok: false, errors: result.errors };
   for (const [relPath, code] of Object.entries(result.modules ?? {})) {
     fs.writeFileSync(path.join(dir, relPath), code);

--- a/packages/agency-lang/lib/compiler/compileValidatedClosure.ts
+++ b/packages/agency-lang/lib/compiler/compileValidatedClosure.ts
@@ -44,7 +44,17 @@ export function compileValidatedClosure(closure: ValidatedClosure): CompileResul
       return { success: false, errors: ["internal: validated closure has no entry module"] };
     }
     const sandboxOptions = {
-      typechecker: { enabled: true },
+      // jsGlobals:"sandbox" restricts unqualified names to the reviewed
+      // SANDBOX_JS_GLOBALS allowlist and turns every unresolved name into a
+      // hard error, so pure Agency code cannot reach a host global
+      // (process, fetch, eval, ...) with no interrupt. Defense in depth for
+      // running untrusted code; see docs/dev/security/goal.md.
+      typechecker: {
+        enabled: true,
+        jsGlobals: "sandbox" as const,
+        undefinedFunctions: "error" as const,
+        undefinedVariables: "error" as const,
+      },
       // Belt on top of validation: the mirror contains only validated
       // content, but keep the policy on so a regression fails closed.
       imports: { allowKinds: ["stdlib", "local"] as ImportKind[] },

--- a/packages/agency-lang/lib/compiler/compileValidatedClosure.ts
+++ b/packages/agency-lang/lib/compiler/compileValidatedClosure.ts
@@ -19,7 +19,18 @@ import { safeDeleteDirectoryWithin } from "../utils.js";
 
 const PRIVATE_DIRECTORY_MODE = 0o700;
 
-export function compileValidatedClosure(closure: ValidatedClosure): CompileResult {
+export type CompileValidatedClosureOptions = {
+  /** Enforce the reviewed JS-globals allowlist (jsGlobals:"sandbox"). Only the
+   *  `--agency-only` entry point sets this. The runtime fork path
+   *  (`std::agency.run`) shares this compile but is trusted-context code that
+   *  may name JS globals, so it leaves this off. */
+  enforceJsGlobals?: boolean;
+};
+
+export function compileValidatedClosure(
+  closure: ValidatedClosure,
+  options: CompileValidatedClosureOptions = {},
+): CompileResult {
   const data = openValidatedClosure(closure);
   const mirrorRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agency-sandbox-"));
   fs.chmodSync(mirrorRoot, PRIVATE_DIRECTORY_MODE);
@@ -43,18 +54,23 @@ export function compileValidatedClosure(closure: ValidatedClosure): CompileResul
     if (entryMirrorPath === "") {
       return { success: false, errors: ["internal: validated closure has no entry module"] };
     }
+    // Under `--agency-only`, jsGlobals:"sandbox" restricts unqualified names to
+    // the reviewed SANDBOX_JS_GLOBALS allowlist and every unresolved name
+    // becomes a hard error, so pure Agency code cannot reach a host global
+    // (process, fetch, eval, ...) with no interrupt. Defense in depth for
+    // running untrusted code; see docs/dev/security/goal.md. The trusted
+    // runtime fork path (`std::agency.run`) shares this compile but may name JS
+    // globals and relies on scope-visibility cases the undefined-name passes do
+    // not fully cover, so it leaves all of this off (matching prior behavior).
+    const jsGlobalsCheck = options.enforceJsGlobals
+      ? {
+          jsGlobals: "sandbox" as const,
+          undefinedFunctions: "error" as const,
+          undefinedVariables: "error" as const,
+        }
+      : {};
     const sandboxOptions = {
-      // jsGlobals:"sandbox" restricts unqualified names to the reviewed
-      // SANDBOX_JS_GLOBALS allowlist and turns every unresolved name into a
-      // hard error, so pure Agency code cannot reach a host global
-      // (process, fetch, eval, ...) with no interrupt. Defense in depth for
-      // running untrusted code; see docs/dev/security/goal.md.
-      typechecker: {
-        enabled: true,
-        jsGlobals: "sandbox" as const,
-        undefinedFunctions: "error" as const,
-        undefinedVariables: "error" as const,
-      },
+      typechecker: { enabled: true, ...jsGlobalsCheck },
       // Belt on top of validation: the mirror contains only validated
       // content, but keep the policy on so a regression fails closed.
       imports: { allowKinds: ["stdlib", "local"] as ImportKind[] },

--- a/packages/agency-lang/lib/config.ts
+++ b/packages/agency-lang/lib/config.ts
@@ -236,6 +236,15 @@ export interface AgencyConfig {
      */
     undefinedVariables?: "silent" | "warn" | "error";
     /**
+     * Which JavaScript globals an unqualified name may refer to.
+     * - "all" (default): the interop registry (JS_GLOBALS), so `process`,
+     *   `console`, etc. resolve — ordinary compilation.
+     * - "sandbox": the reviewed allowlist (SANDBOX_JS_GLOBALS) of globals
+     *   that cannot reach the host. Set by `--agency-only`; a name outside
+     *   the allowlist becomes an error.
+     */
+    jsGlobals?: "all" | "sandbox";
+    /**
      * Strictness of union member access. When a property exists on some but
      * not all members of an un-narrowed union (e.g. `r.value` on an
      * un-guarded `Result`), this governs the diagnostic:
@@ -570,6 +579,7 @@ export const AgencyConfigSchema = z
         strictTypes: z.boolean(),
         undefinedFunctions: z.enum(["silent", "warn", "error"]),
         undefinedVariables: z.enum(["silent", "warn", "error"]),
+        jsGlobals: z.enum(["all", "sandbox"]),
         strictMemberAccess: z.enum(["silent", "warn", "error"]),
         matchExhaustiveness: z.enum(["silent", "warn", "error"]),
         definiteReturns: z.enum(["silent", "warn", "error"]),

--- a/packages/agency-lang/lib/typeChecker/diagnosticExplanations.ts
+++ b/packages/agency-lang/lib/typeChecker/diagnosticExplanations.ts
@@ -303,6 +303,7 @@ node main() {
 
 **How to fix:** write the block without \`as\`, e.g. the keyword followed immediately by its \`{ ... }\` body.`,
 
+  sandboxForbiddenProperty: `Under \`--agency-only\` (\`typechecker.jsGlobals: "sandbox"\`), a program may not read \`constructor\`, \`prototype\`, or \`__proto__\` from a value, spelled or as a string-literal key. Those property names walk from any value to JavaScript's \`Function\` and the prototype chain, which is a way for pure Agency code to reach the host with no interrupt. This is a best-effort compile-time catch; the runtime backstop is code-generation-from-strings being disabled.`,
   undefinedVariable: `The type checker walks every scope — nodes, function bodies, blocks — and resolves each name to a declaration. This error means a name was used with no \`let\`, \`const\`, parameter, or import that introduces it in reach.
 
 **How to fix:** declare it before use (\`let x = …\` / \`const x = …\`), fix a typo in the name, or import it if it lives in another module. Agency has no implicit variables: a bare assignment like \`x = 5\` without a prior \`let\`/\`const\` is not a declaration.`,

--- a/packages/agency-lang/lib/typeChecker/diagnostics.ts
+++ b/packages/agency-lang/lib/typeChecker/diagnostics.ts
@@ -494,6 +494,12 @@ export const DIAGNOSTICS = {
     message:
       "`{keyword}` is a reserved block keyword. Write `{keyword} {{ ... }}` or `{keyword}(args) {{ ... }}` directly — the `as` keyword is not supported on {keyword} blocks (there's nothing to bind).",
   },
+  sandboxForbiddenProperty: {
+    code: "AG4011",
+    severity: "error",
+    message:
+      "'{name}' is not accessible under --agency-only. It reaches JavaScript's Function or prototype chain, which pure Agency code may not use.",
+  },
   undefinedVariable: {
     code: "AG4007",
     severity: "error",

--- a/packages/agency-lang/lib/typeChecker/index.ts
+++ b/packages/agency-lang/lib/typeChecker/index.ts
@@ -52,6 +52,7 @@ import * as path from "node:path";
 import { checkUndefinedFunctions } from "./undefinedFunctionDiagnostic.js";
 import { checkMissingImports } from "./missingImportDiagnostic.js";
 import { checkUndefinedVariables } from "./undefinedVariableDiagnostic.js";
+import { checkSandboxNames } from "./sandboxNameCheck.js";
 import { checkToolBlockBindings } from "./toolBlockBinding.js";
 import { RESERVED_FUNCTION_NAMES } from "./resolveCall.js";
 import { RESERVED_GENERIC_NAMES } from "./builtinGenerics.js";
@@ -364,6 +365,11 @@ export class TypeChecker {
 
     // Check for undefined variable references (config-controlled severity).
     checkUndefinedVariables(scopes, ctx);
+
+    // --agency-only: refuse the capability positions the two general passes
+    // do not reach (new-expression callees, the constructor/prototype walk,
+    // and names in tag arguments / default parameter values).
+    checkSandboxNames(ctx);
 
     // Tool-position binding validator: at every llm(...) call site
     // with a statically-known tools array, require every function-typed

--- a/packages/agency-lang/lib/typeChecker/resolveCall.ts
+++ b/packages/agency-lang/lib/typeChecker/resolveCall.ts
@@ -284,18 +284,92 @@ export const JS_GLOBALS: Record<string, JsRegistryEntry> = {
 };
 
 /**
- * Walk a namespace path through `JS_GLOBALS`. Returns the leaf entry if
- * the full chain resolves, otherwise null.
+ * Allowlist of JavaScript globals a program may reference under
+ * `--agency-only` (`typechecker.jsGlobals: "sandbox"`). An entry here is a
+ * PROMISE that the name cannot reach the host. Review every addition against
+ * that promise — this list is a reviewed security boundary, not a
+ * convenience registry like `JS_GLOBALS`.
+ *
+ * It is written out in full rather than filtered from `JS_GLOBALS`, so a
+ * name added to `JS_GLOBALS` for interop never silently becomes allowed
+ * here. It is NOT a subset of `JS_GLOBALS`: it adds constructor names
+ * (`Set`, `Map`, `RegExp`, `Intl`) that `new X()` resolves against but that
+ * `JS_GLOBALS` never listed.
+ *
+ * Deliberately EXCLUDED (each reaches or names the host): `process`,
+ * `console`, `Buffer`, `globalThis`, `eval`, `Function`, `fetch`, `Reflect`,
+ * `Proxy`, `Symbol`, `require`, `import`, `setTimeout`/`setInterval` (run
+ * code after the frame returns, outside the runtime's bookkeeping), and
+ * `Object.create`/`getPrototypeOf`/`setPrototypeOf`/`getOwnPropertyNames`
+ * (prototype and descriptor access).
+ */
+export const SANDBOX_JS_GLOBALS: Record<string, JsRegistryEntry> = {
+  // Pure conversions.
+  parseInt: JS_GLOBALS.parseInt,
+  parseFloat: JS_GLOBALS.parseFloat,
+  isNaN: JS_GLOBALS.isNaN,
+  isFinite: JS_GLOBALS.isFinite,
+  encodeURIComponent: JS_GLOBALS.encodeURIComponent,
+  decodeURIComponent: JS_GLOBALS.decodeURIComponent,
+  encodeURI: JS_GLOBALS.encodeURI,
+  decodeURI: JS_GLOBALS.decodeURI,
+  // Deep-copies plain data; throws on functions, so it yields no capability.
+  structuredClone: JS_GLOBALS.structuredClone,
+  Boolean: JS_GLOBALS.Boolean,
+  // Pure namespaces reused verbatim from JS_GLOBALS.
+  JSON: JS_GLOBALS.JSON,
+  Math: JS_GLOBALS.Math,
+  String: JS_GLOBALS.String,
+  Number: JS_GLOBALS.Number,
+  Promise: JS_GLOBALS.Promise,
+  Array: JS_GLOBALS.Array,
+  // Object minus the prototype/descriptor members (create, getPrototypeOf,
+  // setPrototypeOf, getOwnPropertyNames stay out).
+  Object: namespace({
+    keys: callable({ params: [ANY_T], returnType: stringArray }),
+    values: callable({ params: [ANY_T], returnType: anyArray }),
+    entries: callable({ params: [ANY_T], returnType: anyArray }),
+    fromEntries: callable({ params: [anyArray], returnType: ANY_T }),
+    assign: callable(),
+    freeze: callable({ params: [ANY_T], returnType: ANY_T }),
+  }),
+  // Constructors reached via `new X()`; also valid as value references.
+  Set: callable(),
+  Map: callable(),
+  RegExp: callable(),
+  Date: JS_GLOBALS.Date,
+  Error: JS_GLOBALS.Error,
+  TypeError: JS_GLOBALS.TypeError,
+  RangeError: JS_GLOBALS.RangeError,
+  // Formatting and collation only.
+  Intl: namespace({
+    NumberFormat: callable(),
+    DateTimeFormat: callable(),
+    Collator: callable(),
+    PluralRules: callable(),
+    RelativeTimeFormat: callable(),
+    ListFormat: callable(),
+    Segmenter: callable(),
+  }),
+};
+
+/**
+ * Walk a namespace path through a registry. Returns the leaf entry if
+ * the full chain resolves, otherwise null. Defaults to `JS_GLOBALS`;
+ * pass `SANDBOX_JS_GLOBALS` for the `--agency-only` allowlist.
  *
  * Examples:
  *   lookupJsMember(["JSON", "parse"])     → { kind: "callable", sig: undefined }
  *   lookupJsMember(["JSON", "banana"])    → null
  *   lookupJsMember(["NotAGlobal", "x"])   → null
  */
-export function lookupJsMember(path: string[]): JsRegistryEntry | null {
+export function lookupJsMember(
+  path: string[],
+  registry: Record<string, JsRegistryEntry> = JS_GLOBALS,
+): JsRegistryEntry | null {
   if (path.length === 0) return null;
-  if (!Object.prototype.hasOwnProperty.call(JS_GLOBALS, path[0])) return null;
-  let current: JsRegistryEntry | undefined = JS_GLOBALS[path[0]];
+  if (!Object.prototype.hasOwnProperty.call(registry, path[0])) return null;
+  let current: JsRegistryEntry | undefined = registry[path[0]];
   for (let i = 1; i < path.length; i++) {
     if (!current || current.kind !== "namespace") return null;
     if (!Object.prototype.hasOwnProperty.call(current.members, path[i])) {
@@ -315,6 +389,9 @@ type ResolveCallInput = {
   /** Names imported via `import { foo } from "./helpers.js"` (non-Agency). */
   jsImportedNames?: object;
   scopeHas: (name: string) => boolean;
+  /** JS-global registry to resolve against. Defaults to `JS_GLOBALS`; the
+   *  `--agency-only` sandbox passes `SANDBOX_JS_GLOBALS`. */
+  registry?: Record<string, JsRegistryEntry>;
 };
 
 /**
@@ -397,8 +474,12 @@ export type ShadowingInput = {
  * `JSON.parse(...)`) and avoid checking against `JS_GLOBALS` when the user
  * has their own `node JSON()` / `let JSON = …`.
  */
-export function isJsGlobalBase(name: string, input: ShadowingInput): boolean {
-  if (!has(JS_GLOBALS, name)) return false;
+export function isJsGlobalBase(
+  name: string,
+  input: ShadowingInput,
+  registry: Record<string, JsRegistryEntry> = JS_GLOBALS,
+): boolean {
+  if (!has(registry, name)) return false;
   if (input.scope.has(name)) return false;
   if (has(input.functionDefs, name)) return false;
   if (has(input.nodeDefs, name)) return false;
@@ -415,8 +496,9 @@ export function resolveCall(name: string, input: ResolveCallInput): CallResoluti
   if (input.jsImportedNames && has(input.jsImportedNames, name)) return { kind: "jsImported" };
   if (has(BUILTIN_FUNCTION_TYPES, name)) return { kind: "builtin" };
   if (input.scopeHas(name)) return { kind: "scopeBinding" };
-  if (has(JS_GLOBALS, name)) {
-    const jsEntry = JS_GLOBALS[name];
+  const registry = input.registry ?? JS_GLOBALS;
+  if (has(registry, name)) {
+    const jsEntry = registry[name];
     if (jsEntry.kind === "callable") return { kind: "jsGlobal" };
     // Some namespaces are also directly callable (e.g. `String(x)`).
     if (jsEntry.kind === "namespace" && jsEntry.callableSig) return { kind: "jsGlobal" };

--- a/packages/agency-lang/lib/typeChecker/resolveCall.ts
+++ b/packages/agency-lang/lib/typeChecker/resolveCall.ts
@@ -332,6 +332,7 @@ export const SANDBOX_JS_GLOBALS: Record<string, JsRegistryEntry> = {
     fromEntries: callable({ params: [anyArray], returnType: ANY_T }),
     assign: callable(),
     freeze: callable({ params: [ANY_T], returnType: ANY_T }),
+    hasOwn: callable({ params: [ANY_T, STRING_T], returnType: BOOLEAN_T }),
   }),
   // Constructors reached via `new X()`; also valid as value references.
   Set: callable(),

--- a/packages/agency-lang/lib/typeChecker/resolveVariable.ts
+++ b/packages/agency-lang/lib/typeChecker/resolveVariable.ts
@@ -2,7 +2,7 @@ import type { FunctionDefinition, GraphNodeDefinition } from "../types.js";
 import type { ImportedFunctionSignature } from "../compilationUnit.js";
 import { BUILTIN_FUNCTION_TYPES } from "./builtins.js";
 import { BUILTIN_VARIABLES } from "../config.js";
-import { JS_GLOBALS } from "./resolveCall.js";
+import { JS_GLOBALS, type JsRegistryEntry } from "./resolveCall.js";
 
 /**
  * Inputs for variable name resolution. Mirrors `ResolveCallInput` in
@@ -17,6 +17,9 @@ type ResolveVariableInput = {
   /** Names imported via `import { foo } from "./helpers.js"` (non-Agency). */
   jsImportedNames?: Record<string, true>;
   scopeHas: (name: string) => boolean;
+  /** JS-global registry to resolve against. Defaults to `JS_GLOBALS`; the
+   *  `--agency-only` sandbox passes `SANDBOX_JS_GLOBALS`. */
+  registry?: Record<string, JsRegistryEntry>;
 };
 
 /**
@@ -76,6 +79,6 @@ export function resolveVariable(name: string, input: ResolveVariableInput): Vari
   if (input.jsImportedNames && has(input.jsImportedNames, name)) return { kind: "jsImported" };
   if (has(BUILTIN_FUNCTION_TYPES, name)) return { kind: "builtin" };
   if (BUILTIN_VARIABLES.includes(name)) return { kind: "builtin" };
-  if (has(JS_GLOBALS, name)) return { kind: "jsGlobal" };
+  if (has(input.registry ?? JS_GLOBALS, name)) return { kind: "jsGlobal" };
   return { kind: "unresolved" };
 }

--- a/packages/agency-lang/lib/typeChecker/sandboxNameCheck.ts
+++ b/packages/agency-lang/lib/typeChecker/sandboxNameCheck.ts
@@ -129,9 +129,10 @@ function stringLiteralValue(node: AgencyNode): string | null {
 }
 
 /** A bare name or call inside a declaration-hanging expression. Resolved
- *  against SANDBOX_JS_GLOBALS with the program's defs/imports and no local
- *  scope (these expressions bind no locals of their own). A local `def`
- *  named in a `@validate(...)` still resolves via functionDefs. */
+ *  against SANDBOX_JS_GLOBALS with the program's defs/imports and `scopeNames`
+ *  — the module-level bindings plus the owning declaration's value parameters
+ *  / parameters — so a top-level `const`, a value parameter, or a local `def`
+ *  named in a tag argument all resolve. */
 function checkDeclExpressionName(
   node: AgencyNode,
   ctx: TypeCheckerContext,

--- a/packages/agency-lang/lib/typeChecker/sandboxNameCheck.ts
+++ b/packages/agency-lang/lib/typeChecker/sandboxNameCheck.ts
@@ -5,6 +5,7 @@ import type { ValueAccess } from "../types/access.js";
 import type { NewExpression } from "../types/newExpression.js";
 import type { StringLiteral } from "../types/literals.js";
 import { walkNodes } from "../utils/node.js";
+import { tagsAbove } from "../utils/tagsAbove.js";
 import { collectProgramShadowing } from "./shadowing.js";
 import { resolveCall, SANDBOX_JS_GLOBALS } from "./resolveCall.js";
 import { resolveVariable } from "./resolveVariable.js";
@@ -55,14 +56,31 @@ export function checkSandboxNames(ctx: TypeCheckerContext): void {
 
   // Positions the general passes do NOT reach (declaration-hanging
   // expressions): every name-bearing node is checked here, including bare
-  // names and calls, since nothing else looks at them.
-  for (const expr of collectDeclHangingExpressions(ctx.programNodes)) {
+  // names and calls, since nothing else looks at them. Each carries the
+  // names in scope where it hangs (module-level bindings plus the owning
+  // declaration's value parameters / function parameters), so a legitimate
+  // reference to a top-level `const` or a type alias's value parameter is not
+  // reported as undefined.
+  const moduleScope = moduleScopeNames(ctx.programNodes);
+  for (const { expr, scopeNames } of collectDeclHangingExpressions(ctx.programNodes, moduleScope)) {
     for (const { node } of walkNodes([expr])) {
       checkNewCallee(node, ctx);
       checkForbiddenProperty(node, ctx);
-      checkDeclExpressionName(node, ctx, importedNodeNames);
+      checkDeclExpressionName(node, ctx, importedNodeNames, scopeNames);
     }
   }
+}
+
+/** Names of top-level `const`/`let` declarations — the module scope a
+ *  declaration-hanging expression can reference. */
+function moduleScopeNames(nodes: AgencyNode[]): string[] {
+  const names: string[] = [];
+  for (const node of nodes) {
+    if (node.type === "assignment" && node.declKind && typeof node.variableName === "string") {
+      names.push(node.variableName);
+    }
+  }
+  return names;
 }
 
 /** Refuse `new X()` whose class name is not an allowlisted global. The class
@@ -118,6 +136,7 @@ function checkDeclExpressionName(
   node: AgencyNode,
   ctx: TypeCheckerContext,
   importedNodeNames: readonly string[],
+  scopeNames: readonly string[],
 ): void {
   if (node.type === "variableName") {
     const resolution = resolveVariable(node.value, {
@@ -126,7 +145,7 @@ function checkDeclExpressionName(
       importedFunctions: ctx.importedFunctions,
       importedNodeNames,
       jsImportedNames: ctx.jsImportedNames,
-      scopeHas: () => false,
+      scopeHas: (name) => scopeNames.includes(name),
       registry: SANDBOX_JS_GLOBALS,
     });
     if (resolution.kind === "unresolved") {
@@ -143,7 +162,7 @@ function checkDeclExpressionName(
       importedFunctions: ctx.importedFunctions,
       importedNodeNames,
       jsImportedNames: ctx.jsImportedNames,
-      scopeHas: () => false,
+      scopeHas: (name) => scopeNames.includes(name),
       registry: SANDBOX_JS_GLOBALS,
     });
     if (resolution.kind === "unresolved") {
@@ -164,37 +183,94 @@ function checkDeclExpressionName(
  * found. Each returned expression is then descended with `walkNodes`, so the
  * traversal of the expression itself is shared, not reimplemented.
  */
-function collectDeclHangingExpressions(nodes: AgencyNode[]): AgencyNode[] {
-  const found: AgencyNode[] = [];
-  const visit = (value: unknown): void => {
+type DeclHangingExpression = { expr: AgencyNode; scopeNames: string[] };
+
+function collectDeclHangingExpressions(
+  nodes: AgencyNode[],
+  moduleScope: string[],
+): DeclHangingExpression[] {
+  const found: DeclHangingExpression[] = [];
+
+  // (1) Statement-level tags. At type-check time the preprocessor has not
+  // attached them yet, so a `@tag(...)` is a standalone node before the
+  // declaration it annotates. `tagsAbove` pairs each with its owner at every
+  // body level, so a tag argument sees the owner's value parameters / params.
+  const handled = new Set<AgencyNode>();
+  for (const { node, tags } of tagsAbove(nodes)) {
+    const scopeNames =
+      (node ? ownerScope(node as unknown as Record<string, unknown>, moduleScope) : null) ??
+      moduleScope;
+    for (const tag of tags) {
+      handled.add(tag as unknown as AgencyNode);
+      for (const arg of tag.arguments) found.push({ expr: arg as AgencyNode, scopeNames });
+    }
+  }
+
+  // (2) Tags the pairing above cannot reach (attached to a type property,
+  // inside a type structure) and every non-scalar default parameter value.
+  // A structural walk finds them wherever they hang; the enclosing
+  // declaration's scope is threaded down so a value parameter still resolves.
+  const visit = (value: unknown, scopeNames: string[]): void => {
     if (Array.isArray(value)) {
-      for (const item of value) visit(item);
+      for (const item of value) visit(item, scopeNames);
       return;
     }
     if (value === null || typeof value !== "object") return;
     const record = value as Record<string, unknown>;
+    const childScope = ownerScope(record, moduleScope) ?? scopeNames;
 
-    if (record.type === "tag" && Array.isArray(record.arguments)) {
-      for (const arg of record.arguments) found.push(arg as AgencyNode);
-    }
-    // A parameter's array/object default holds arbitrary sub-expressions;
-    // a bare Literal default cannot.
     if (
-      record.defaultValue !== undefined &&
-      record.defaultValue !== null &&
-      typeof record.defaultValue === "object"
+      record.type === "tag" &&
+      !handled.has(record as unknown as AgencyNode) &&
+      Array.isArray(record.arguments)
     ) {
-      const dv = record.defaultValue as Record<string, unknown>;
-      if (dv.type === "agencyArray" || dv.type === "agencyObject") {
-        found.push(record.defaultValue as AgencyNode);
-      }
+      for (const arg of record.arguments)
+        found.push({ expr: arg as AgencyNode, scopeNames: childScope });
+    }
+    // Any non-scalar default holds sub-expressions — an array/object, or a
+    // string with an interpolation like `"${process.env.HOME}"`. A scalar
+    // literal has nothing to walk, so collecting it is harmless.
+    const dv = record.defaultValue;
+    if (dv !== undefined && dv !== null && typeof dv === "object" && "type" in dv) {
+      found.push({ expr: dv as AgencyNode, scopeNames: childScope });
     }
 
     for (const key of Object.keys(record)) {
       if (key === "loc") continue;
-      visit(record[key]);
+      visit(record[key], childScope);
     }
   };
-  visit(nodes);
+  visit(nodes, moduleScope);
   return found;
+}
+
+/** The names a declaration adds to the module scope for expressions that
+ *  hang off it: a type alias's value parameters, or a function / node's
+ *  parameters. `null` when the record introduces none (keep the inherited
+ *  scope); a concrete list becomes the scope for tags and defaults on it. */
+function ownerScope(record: Record<string, unknown>, moduleScope: string[]): string[] | null {
+  if (record.type === "typeAlias" && Array.isArray(record.valueParams)) {
+    return [...moduleScope, ...paramNames(record.valueParams)];
+  }
+  if (
+    (record.type === "function" || record.type === "graphNode") &&
+    Array.isArray(record.parameters)
+  ) {
+    return [...moduleScope, ...paramNames(record.parameters)];
+  }
+  return null;
+}
+
+function paramNames(params: unknown[]): string[] {
+  const names: string[] = [];
+  for (const param of params) {
+    if (
+      param !== null &&
+      typeof param === "object" &&
+      typeof (param as { name?: unknown }).name === "string"
+    ) {
+      names.push((param as { name: string }).name);
+    }
+  }
+  return names;
 }

--- a/packages/agency-lang/lib/typeChecker/sandboxNameCheck.ts
+++ b/packages/agency-lang/lib/typeChecker/sandboxNameCheck.ts
@@ -1,0 +1,200 @@
+import { diagnostic } from "./diagnostics.js";
+import type { TypeCheckerContext } from "./types.js";
+import type { AgencyNode } from "../types.js";
+import type { ValueAccess } from "../types/access.js";
+import type { NewExpression } from "../types/newExpression.js";
+import type { StringLiteral } from "../types/literals.js";
+import { walkNodes } from "../utils/node.js";
+import { collectProgramShadowing } from "./shadowing.js";
+import { resolveCall, SANDBOX_JS_GLOBALS } from "./resolveCall.js";
+import { resolveVariable } from "./resolveVariable.js";
+
+/**
+ * Property names that walk from any value toward JavaScript's `Function` or
+ * a prototype: `x.constructor.constructor` reaches `Function`, `__proto__`
+ * and `prototype` reach the prototype chain. Reviewed security list, like
+ * SANDBOX_JS_GLOBALS — review every addition.
+ *
+ * BEST-EFFORT: this catches the literal spellings only. A runtime-computed
+ * key (`m[a + b]`) reaches the same property and no syntactic check can see
+ * it. The real boundary for reaching Function and calling it with a string
+ * is the `--disallow-code-generation-from-strings` layer (see
+ * docs/dev/security/roadmap.md A1 layer 2); this is a clear compile-time
+ * error for the obvious case, not the guarantee.
+ */
+const SANDBOX_FORBIDDEN_PROPERTIES = ["constructor", "prototype", "__proto__"];
+
+/**
+ * The `--agency-only` (jsGlobals: "sandbox") name checks that the two
+ * general passes (undefinedFunctions / undefinedVariables) do not cover:
+ *
+ *   - `new` expression callees — `new Function(...)`, `new Proxy(...)`; the
+ *     class name is a grammar literal the general passes never resolve.
+ *   - forbidden property access on ANY value — `k.constructor`, which the
+ *     function pass skips because the base is not a JS global.
+ *   - names inside declaration-hanging expressions — `@validate(...)` /
+ *     `@jsonSchema({...})` tag arguments and array/object default parameter
+ *     values, which sit outside the scope bodies the general passes walk.
+ *
+ * The rule is shared: name resolution goes through the same
+ * `resolveCall`/`resolveVariable` against SANDBOX_JS_GLOBALS the general
+ * passes use. Only the set of positions differs.
+ */
+export function checkSandboxNames(ctx: TypeCheckerContext): void {
+  if (ctx.config.typechecker?.jsGlobals !== "sandbox") return;
+
+  const { importedNodeNames } = collectProgramShadowing(ctx.programNodes);
+
+  // Positions the general passes DO reach (bodies): only the new-callee and
+  // forbidden-property rules are added here — bare names and calls are
+  // already reported by the general passes.
+  for (const { node } of walkNodes(ctx.programNodes)) {
+    checkNewCallee(node, ctx);
+    checkForbiddenProperty(node, ctx);
+  }
+
+  // Positions the general passes do NOT reach (declaration-hanging
+  // expressions): every name-bearing node is checked here, including bare
+  // names and calls, since nothing else looks at them.
+  for (const expr of collectDeclHangingExpressions(ctx.programNodes)) {
+    for (const { node } of walkNodes([expr])) {
+      checkNewCallee(node, ctx);
+      checkForbiddenProperty(node, ctx);
+      checkDeclExpressionName(node, ctx, importedNodeNames);
+    }
+  }
+}
+
+/** Refuse `new X()` whose class name is not an allowlisted global. The class
+ *  name is a grammar literal (no `new (x + y)()`), so this is complete. */
+function checkNewCallee(node: AgencyNode, ctx: TypeCheckerContext): void {
+  if (node.type !== "newExpression") return;
+  const className = (node as NewExpression).className;
+  if (Object.prototype.hasOwnProperty.call(SANDBOX_JS_GLOBALS, className)) return;
+  ctx.errors.push(
+    diagnostic("undefinedFunction", { name: className }, node.loc ?? null, { severity: "error" }),
+  );
+}
+
+/** Refuse `.constructor` / `.prototype` / `.__proto__`, spelled or as a
+ *  string-literal computed key. A non-literal computed key is left alone
+ *  (best-effort; layer 2 is the boundary). */
+function checkForbiddenProperty(node: AgencyNode, ctx: TypeCheckerContext): void {
+  if (node.type !== "valueAccess") return;
+  for (const element of (node as ValueAccess).chain) {
+    const name = forbiddenPropertyName(element);
+    if (name === null) continue;
+    ctx.errors.push(
+      diagnostic("sandboxForbiddenProperty", { name }, node.loc ?? null, { severity: "error" }),
+    );
+  }
+}
+
+/** The forbidden property name a chain element names, or null. */
+function forbiddenPropertyName(element: ValueAccess["chain"][number]): string | null {
+  if (element.kind === "property" && SANDBOX_FORBIDDEN_PROPERTIES.includes(element.name)) {
+    return element.name;
+  }
+  if (element.kind === "index") {
+    const literal = stringLiteralValue(element.index);
+    if (literal !== null && SANDBOX_FORBIDDEN_PROPERTIES.includes(literal)) return literal;
+  }
+  return null;
+}
+
+/** The constant value of a single-text-segment string literal, or null. */
+function stringLiteralValue(node: AgencyNode): string | null {
+  if (node.type !== "string") return null;
+  const segments = (node as StringLiteral).segments;
+  if (segments.length !== 1 || segments[0].type !== "text") return null;
+  return segments[0].value;
+}
+
+/** A bare name or call inside a declaration-hanging expression. Resolved
+ *  against SANDBOX_JS_GLOBALS with the program's defs/imports and no local
+ *  scope (these expressions bind no locals of their own). A local `def`
+ *  named in a `@validate(...)` still resolves via functionDefs. */
+function checkDeclExpressionName(
+  node: AgencyNode,
+  ctx: TypeCheckerContext,
+  importedNodeNames: readonly string[],
+): void {
+  if (node.type === "variableName") {
+    const resolution = resolveVariable(node.value, {
+      functionDefs: ctx.functionDefs,
+      nodeDefs: ctx.nodeDefs,
+      importedFunctions: ctx.importedFunctions,
+      importedNodeNames,
+      jsImportedNames: ctx.jsImportedNames,
+      scopeHas: () => false,
+      registry: SANDBOX_JS_GLOBALS,
+    });
+    if (resolution.kind === "unresolved") {
+      ctx.errors.push(
+        diagnostic("undefinedVariable", { name: node.value }, node.loc ?? null, {
+          severity: "error",
+        }),
+      );
+    }
+  } else if (node.type === "functionCall" && typeof node.functionName === "string") {
+    const resolution = resolveCall(node.functionName, {
+      functionDefs: ctx.functionDefs,
+      nodeDefs: ctx.nodeDefs,
+      importedFunctions: ctx.importedFunctions,
+      importedNodeNames,
+      jsImportedNames: ctx.jsImportedNames,
+      scopeHas: () => false,
+      registry: SANDBOX_JS_GLOBALS,
+    });
+    if (resolution.kind === "unresolved") {
+      ctx.errors.push(
+        diagnostic("undefinedFunction", { name: node.functionName }, node.loc ?? null, {
+          severity: "error",
+        }),
+      );
+    }
+  }
+}
+
+/**
+ * Every expression that hangs off a declaration rather than sitting in an
+ * executable body: `@validate(...)` / `@jsonSchema(...)` tag arguments, and
+ * array/object default parameter values. Collected by a structural walk so
+ * a tag on a type property (which `walkNodes` does not reach) is still
+ * found. Each returned expression is then descended with `walkNodes`, so the
+ * traversal of the expression itself is shared, not reimplemented.
+ */
+function collectDeclHangingExpressions(nodes: AgencyNode[]): AgencyNode[] {
+  const found: AgencyNode[] = [];
+  const visit = (value: unknown): void => {
+    if (Array.isArray(value)) {
+      for (const item of value) visit(item);
+      return;
+    }
+    if (value === null || typeof value !== "object") return;
+    const record = value as Record<string, unknown>;
+
+    if (record.type === "tag" && Array.isArray(record.arguments)) {
+      for (const arg of record.arguments) found.push(arg as AgencyNode);
+    }
+    // A parameter's array/object default holds arbitrary sub-expressions;
+    // a bare Literal default cannot.
+    if (
+      record.defaultValue !== undefined &&
+      record.defaultValue !== null &&
+      typeof record.defaultValue === "object"
+    ) {
+      const dv = record.defaultValue as Record<string, unknown>;
+      if (dv.type === "agencyArray" || dv.type === "agencyObject") {
+        found.push(record.defaultValue as AgencyNode);
+      }
+    }
+
+    for (const key of Object.keys(record)) {
+      if (key === "loc") continue;
+      visit(record[key]);
+    }
+  };
+  visit(nodes);
+  return found;
+}

--- a/packages/agency-lang/lib/typeChecker/sandboxRegistry.test.ts
+++ b/packages/agency-lang/lib/typeChecker/sandboxRegistry.test.ts
@@ -1,7 +1,5 @@
 import { describe, it, expect } from "vitest";
-import {
-  resolveCall,
-} from "./resolveCall.js";
+import { resolveCall } from "./resolveCall.js";
 import { SANDBOX_JS_GLOBALS, JS_GLOBALS, lookupJsMember } from "./resolveCall.js";
 import { resolveVariable } from "./resolveVariable.js";
 
@@ -24,13 +22,39 @@ describe("SANDBOX_JS_GLOBALS as a resolver registry", () => {
   const sandbox = SANDBOX_JS_GLOBALS;
 
   it("refuses host-reaching globals under the sandbox registry", () => {
-    for (const name of ["process", "fetch", "eval", "Function", "Reflect", "Symbol", "setTimeout", "console", "globalThis", "Buffer"]) {
-      expect(resolveVariable(name, { ...emptyVarInput, registry: sandbox }).kind).toBe("unresolved");
+    for (const name of [
+      "process",
+      "fetch",
+      "eval",
+      "Function",
+      "Reflect",
+      "Symbol",
+      "setTimeout",
+      "console",
+      "globalThis",
+      "Buffer",
+    ]) {
+      expect(resolveVariable(name, { ...emptyVarInput, registry: sandbox }).kind).toBe(
+        "unresolved",
+      );
     }
   });
 
   it("allows pure globals under the sandbox registry", () => {
-    for (const name of ["Math", "JSON", "Object", "Set", "Map", "Date", "RegExp", "Intl", "structuredClone", "parseInt", "Boolean", "Promise"]) {
+    for (const name of [
+      "Math",
+      "JSON",
+      "Object",
+      "Set",
+      "Map",
+      "Date",
+      "RegExp",
+      "Intl",
+      "structuredClone",
+      "parseInt",
+      "Boolean",
+      "Promise",
+    ]) {
       expect(resolveVariable(name, { ...emptyVarInput, registry: sandbox }).kind).toBe("jsGlobal");
     }
   });

--- a/packages/agency-lang/lib/typeChecker/sandboxRegistry.test.ts
+++ b/packages/agency-lang/lib/typeChecker/sandboxRegistry.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolveCall,
+} from "./resolveCall.js";
+import { SANDBOX_JS_GLOBALS, JS_GLOBALS, lookupJsMember } from "./resolveCall.js";
+import { resolveVariable } from "./resolveVariable.js";
+
+const emptyInput = {
+  functionDefs: {},
+  nodeDefs: {},
+  importedFunctions: {},
+  importedNodeNames: [] as string[],
+  scopeHas: () => false,
+};
+const emptyVarInput = {
+  functionDefs: {},
+  nodeDefs: {},
+  importedFunctions: {},
+  importedNodeNames: [] as string[],
+  scopeHas: () => false,
+};
+
+describe("SANDBOX_JS_GLOBALS as a resolver registry", () => {
+  const sandbox = SANDBOX_JS_GLOBALS;
+
+  it("refuses host-reaching globals under the sandbox registry", () => {
+    for (const name of ["process", "fetch", "eval", "Function", "Reflect", "Symbol", "setTimeout", "console", "globalThis", "Buffer"]) {
+      expect(resolveVariable(name, { ...emptyVarInput, registry: sandbox }).kind).toBe("unresolved");
+    }
+  });
+
+  it("allows pure globals under the sandbox registry", () => {
+    for (const name of ["Math", "JSON", "Object", "Set", "Map", "Date", "RegExp", "Intl", "structuredClone", "parseInt", "Boolean", "Promise"]) {
+      expect(resolveVariable(name, { ...emptyVarInput, registry: sandbox }).kind).toBe("jsGlobal");
+    }
+  });
+
+  it("keeps default (JS_GLOBALS) behaviour when no registry is passed", () => {
+    expect(resolveVariable("process", emptyVarInput).kind).toBe("jsGlobal");
+    expect(resolveVariable("console", emptyVarInput).kind).toBe("jsGlobal");
+    expect(resolveCall("setTimeout", emptyInput).kind).toBe("jsGlobal");
+  });
+
+  it("member lookup: allows Object.keys, refuses Object.getPrototypeOf under sandbox", () => {
+    expect(lookupJsMember(["Object", "keys"], sandbox)).not.toBeNull();
+    expect(lookupJsMember(["Object", "getPrototypeOf"], sandbox)).toBeNull();
+    expect(lookupJsMember(["Math", "floor"], sandbox)).not.toBeNull();
+    // default registry still has getPrototypeOf
+    expect(lookupJsMember(["Object", "getPrototypeOf"])).not.toBeNull();
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/undefinedFunctionDiagnostic.ts
+++ b/packages/agency-lang/lib/typeChecker/undefinedFunctionDiagnostic.ts
@@ -6,7 +6,7 @@ import type { ValueAccess, AccessChainElement } from "../types/access.js";
 import { walkNodes } from "../utils/node.js";
 import { holeNames } from "../utils/holes.js";
 import { hasFunctionOrNodeAncestor, isResolvableBareCall } from "./nameReferences.js";
-import { resolveCall, lookupJsMember, isJsGlobalBase } from "./resolveCall.js";
+import { resolveCall, lookupJsMember, isJsGlobalBase, JS_GLOBALS, SANDBOX_JS_GLOBALS, type JsRegistryEntry } from "./resolveCall.js";
 import { collectProgramShadowing } from "./shadowing.js";
 
 /**
@@ -27,14 +27,21 @@ export function checkUndefinedFunctions(scopes: ScopeInfo[], ctx: TypeCheckerCon
   // importedFunctions via SymbolTable, JS_GLOBALS) are now accurate enough
   // that false positives are rare. Users can opt back into silence with
   // `{ typechecker: { undefinedFunctions: "silent" } }` in agency.json.
-  const mode = ctx.config.typechecker?.undefinedFunctions ?? "warn";
+  // --agency-only sets jsGlobals:"sandbox": resolve against the reviewed
+  // allowlist and make every unresolved name a hard error, whatever the
+  // undefinedFunctions setting says.
+  const sandbox = ctx.config.typechecker?.jsGlobals === "sandbox";
+  const registry = sandbox ? SANDBOX_JS_GLOBALS : JS_GLOBALS;
+  const mode = sandbox ? "error" : (ctx.config.typechecker?.undefinedFunctions ?? "warn");
   if (mode === "silent") return;
 
   // A file with holes is a template. AG8015 owns bare call names in it, so
-  // reporting them here too would double up. It does not look at JS
-  // namespace members — `nosuch` in `Math.nosuch()` is a method to it, not
-  // a lexical name — so the chain check below keeps running.
-  const isTemplateFile = holeNames(ctx.programNodes).length > 0;
+  // reporting them here too would double up (its own hole names must never
+  // be reported). Under the sandbox we still check non-hole names — a
+  // template compiled under --agency-only can name `process` too — so we
+  // skip only the hole names, not the whole file.
+  const holeNameSet = holeNames(ctx.programNodes);
+  const isTemplateFile = holeNameSet.length > 0;
 
   const shadowing = collectProgramShadowing(ctx.programNodes);
 
@@ -49,11 +56,13 @@ export function checkUndefinedFunctions(scopes: ScopeInfo[], ctx: TypeCheckerCon
         if (isTopLevel && hasFunctionOrNodeAncestor(ancestors)) continue;
 
         if (node.type === "functionCall") {
-          if (isTemplateFile) continue;
+          if (isTemplateFile && !sandbox) continue;
+          if (typeof node.functionName === "string" && holeNameSet.includes(node.functionName))
+            continue;
           if (!isResolvableBareCall(node, ancestors)) continue;
-          checkBareCall(node, info.scope, ctx, mode, shadowing.importedNodeNames);
+          checkBareCall(node, info.scope, ctx, mode, shadowing.importedNodeNames, registry);
         } else if (node.type === "valueAccess") {
-          checkAccessChain(node, info.scope, ctx, mode, shadowing);
+          checkAccessChain(node, info.scope, ctx, mode, shadowing, registry);
         }
       }
     });
@@ -80,6 +89,7 @@ function checkBareCall(
   ctx: TypeCheckerContext,
   mode: "warn" | "error",
   importedNodeNames: readonly string[],
+  registry: Record<string, JsRegistryEntry>,
 ): void {
   const resolution = resolveCall(call.functionName, {
     functionDefs: ctx.functionDefs,
@@ -88,6 +98,7 @@ function checkBareCall(
     importedNodeNames,
     jsImportedNames: ctx.jsImportedNames,
     scopeHas: (name) => scope.has(name),
+    registry,
   });
   if (resolution.kind !== "unresolved") return;
   const severity = mode === "warn" ? ("warning" as const) : ("error" as const);
@@ -110,6 +121,7 @@ function checkAccessChain(
   ctx: TypeCheckerContext,
   mode: "warn" | "error",
   shadowing: { importedNodeNames: readonly string[] },
+  registry: Record<string, JsRegistryEntry>,
 ): void {
   // Only handle <variableName>.<member>... chains where the base is a JS
   // namespace global. Everything else (objects in scope, computed lookups,
@@ -124,7 +136,7 @@ function checkAccessChain(
       importedFunctions: ctx.importedFunctions,
       importedNodeNames: shadowing.importedNodeNames,
       jsImportedNames: ctx.jsImportedNames,
-    })
+    }, registry)
   )
     return;
 
@@ -136,7 +148,7 @@ function checkAccessChain(
   const path = collectNamePath(expr.chain, baseName);
   if (path === null) return; // Computed/optional access — bail.
 
-  if (lookupJsMember(path) === null) {
+  if (lookupJsMember(path, registry) === null) {
     ctx.errors.push(
       diagnostic("undefinedFunction", { name: path.join(".") }, expr.loc ?? null, {
         severity: mode === "warn" ? "warning" : "error",

--- a/packages/agency-lang/lib/typeChecker/undefinedFunctionDiagnostic.ts
+++ b/packages/agency-lang/lib/typeChecker/undefinedFunctionDiagnostic.ts
@@ -6,7 +6,14 @@ import type { ValueAccess, AccessChainElement } from "../types/access.js";
 import { walkNodes } from "../utils/node.js";
 import { holeNames } from "../utils/holes.js";
 import { hasFunctionOrNodeAncestor, isResolvableBareCall } from "./nameReferences.js";
-import { resolveCall, lookupJsMember, isJsGlobalBase, JS_GLOBALS, SANDBOX_JS_GLOBALS, type JsRegistryEntry } from "./resolveCall.js";
+import {
+  resolveCall,
+  lookupJsMember,
+  isJsGlobalBase,
+  JS_GLOBALS,
+  SANDBOX_JS_GLOBALS,
+  type JsRegistryEntry,
+} from "./resolveCall.js";
 import { collectProgramShadowing } from "./shadowing.js";
 
 /**
@@ -129,14 +136,18 @@ function checkAccessChain(
   if (expr.base.type !== "variableName") return;
   const baseName = expr.base.value;
   if (
-    !isJsGlobalBase(baseName, {
-      scope,
-      functionDefs: ctx.functionDefs,
-      nodeDefs: ctx.nodeDefs,
-      importedFunctions: ctx.importedFunctions,
-      importedNodeNames: shadowing.importedNodeNames,
-      jsImportedNames: ctx.jsImportedNames,
-    }, registry)
+    !isJsGlobalBase(
+      baseName,
+      {
+        scope,
+        functionDefs: ctx.functionDefs,
+        nodeDefs: ctx.nodeDefs,
+        importedFunctions: ctx.importedFunctions,
+        importedNodeNames: shadowing.importedNodeNames,
+        jsImportedNames: ctx.jsImportedNames,
+      },
+      registry,
+    )
   )
     return;
 

--- a/packages/agency-lang/lib/typeChecker/undefinedVariableDiagnostic.ts
+++ b/packages/agency-lang/lib/typeChecker/undefinedVariableDiagnostic.ts
@@ -6,6 +6,7 @@ import type { WalkAncestor } from "../utils/node.js";
 import { walkNodes } from "../utils/node.js";
 import { holeNames } from "../utils/holes.js";
 import { resolveVariable } from "./resolveVariable.js";
+import { JS_GLOBALS, SANDBOX_JS_GLOBALS, type JsRegistryEntry } from "./resolveCall.js";
 import { hasFunctionOrNodeAncestor, isResolvableVariableReference } from "./nameReferences.js";
 import { collectProgramShadowing } from "./shadowing.js";
 
@@ -37,12 +38,19 @@ import { collectProgramShadowing } from "./shadowing.js";
  *     variable refs.
  */
 export function checkUndefinedVariables(scopes: ScopeInfo[], ctx: TypeCheckerContext): void {
-  const mode = ctx.config.typechecker?.undefinedVariables ?? "silent";
+  // --agency-only sets jsGlobals:"sandbox": resolve against the reviewed
+  // allowlist and force every unresolved name to a hard error.
+  const sandbox = ctx.config.typechecker?.jsGlobals === "sandbox";
+  const registry = sandbox ? SANDBOX_JS_GLOBALS : JS_GLOBALS;
+  const mode = sandbox ? "error" : (ctx.config.typechecker?.undefinedVariables ?? "silent");
   if (mode === "silent") return;
 
-  // A file with holes is a template. AG8015 owns every name in it, and
-  // reports what this pass would, so reporting here too would double up.
-  if (holeNames(ctx.programNodes).length > 0) return;
+  // A file with holes is a template. AG8015 owns every name in it, so outside
+  // the sandbox we defer to it entirely. Under the sandbox we still check
+  // non-hole names (a template compiled under --agency-only can name
+  // `process`), skipping only the hole names themselves.
+  const holeNameSet = holeNames(ctx.programNodes);
+  if (holeNameSet.length > 0 && !sandbox) return;
 
   const { importedNodeNames } = collectProgramShadowing(ctx.programNodes);
 
@@ -55,8 +63,9 @@ export function checkUndefinedVariables(scopes: ScopeInfo[], ctx: TypeCheckerCon
         // function/graphNode bodies during the top-level pass.
         if (isTopLevel && hasFunctionOrNodeAncestor(ancestors)) continue;
         if (node.type !== "variableName") continue;
+        if (holeNameSet.includes(node.value)) continue;
         if (isResolvableVariableReference(node, ancestors)) {
-          checkVariableRef(node, ancestors, info.scope, ctx, mode, importedNodeNames);
+          checkVariableRef(node, ancestors, info.scope, ctx, mode, importedNodeNames, registry);
         }
       }
     });
@@ -70,6 +79,7 @@ function checkVariableRef(
   ctx: TypeCheckerContext,
   mode: "warn" | "error",
   importedNodeNames: readonly string[],
+  registry: Record<string, JsRegistryEntry>,
 ): void {
   const resolution = resolveVariable(ref.value, {
     functionDefs: ctx.functionDefs,
@@ -78,6 +88,7 @@ function checkVariableRef(
     importedNodeNames,
     jsImportedNames: ctx.jsImportedNames,
     scopeHas: (name) => scope.has(name),
+    registry,
   });
   if (resolution.kind !== "unresolved") return;
   ctx.errors.push(

--- a/packages/agency-lang/tests/agency-js/test-cli-agency-only/bound-ctor.agency
+++ b/packages/agency-lang/tests/agency-js/test-cli-agency-only/bound-ctor.agency
@@ -1,0 +1,6 @@
+def id(x) { return x }
+node main() {
+  let k = id("a")
+  let f = k.constructor
+  print("x")
+}

--- a/packages/agency-lang/tests/agency-js/test-cli-agency-only/bound-default.agency
+++ b/packages/agency-lang/tests/agency-js/test-cli-agency-only/bound-default.agency
@@ -1,0 +1,1 @@
+node main(xs = [process]) { print("hi") }

--- a/packages/agency-lang/tests/agency-js/test-cli-agency-only/bound-globals.agency
+++ b/packages/agency-lang/tests/agency-js/test-cli-agency-only/bound-globals.agency
@@ -1,0 +1,1 @@
+node main() { print(process.env.HOME) }

--- a/packages/agency-lang/tests/agency-js/test-cli-agency-only/bound-good.agency
+++ b/packages/agency-lang/tests/agency-js/test-cli-agency-only/bound-good.agency
@@ -1,0 +1,17 @@
+def isPositive(n: number): Result<number> {
+  if (n > 0) { return success(n) }
+  return failure("no")
+}
+@validate(isPositive)
+type Pos = number
+
+node main() {
+  let xs = [3, 1, 2]
+  let s = new Set()
+  print(Math.floor(2.5))
+  print(JSON.stringify(xs))
+  let x: Pos = 5
+  let o = { a: 1 }
+  let key = "a"
+  print(o[key])
+}

--- a/packages/agency-lang/tests/agency-js/test-cli-agency-only/bound-good.agency
+++ b/packages/agency-lang/tests/agency-js/test-cli-agency-only/bound-good.agency
@@ -1,3 +1,6 @@
+const MAXLEN = 10
+
+@jsonSchema({ maxLength: MAXLEN })
 def isPositive(n: number): Result<number> {
   if (n > 0) { return success(n) }
   return failure("no")

--- a/packages/agency-lang/tests/agency-js/test-cli-agency-only/bound-new.agency
+++ b/packages/agency-lang/tests/agency-js/test-cli-agency-only/bound-new.agency
@@ -1,0 +1,1 @@
+node main() { let f = new Function("return 1") }

--- a/packages/agency-lang/tests/agency-js/test-cli-agency-only/bound-tag.agency
+++ b/packages/agency-lang/tests/agency-js/test-cli-agency-only/bound-tag.agency
@@ -1,0 +1,5 @@
+type Foo = {
+  @jsonSchema({ x: process })
+  value: number,
+}
+node main() { print("hi") }

--- a/packages/agency-lang/tests/agency-js/test-cli-agency-only/fixture.json
+++ b/packages/agency-lang/tests/agency-js/test-cli-agency-only/fixture.json
@@ -1,8 +1,55 @@
 {
-  "testControl": { "exitCode": 0 },
-  "testRestricted": { "exitCode": 1, "refused": true, "goodReported": true },
-  "runControl": { "exitCode": 0 },
-  "runRestricted": { "exitCode": 1, "refused": true },
-  "writeControl": { "exitCode": 0, "fileWritten": true },
-  "writeRestricted": { "exitCode": 0, "fileWritten": false }
+  "testControl": {
+    "exitCode": 0
+  },
+  "testRestricted": {
+    "exitCode": 1,
+    "refused": true,
+    "goodReported": true
+  },
+  "runControl": {
+    "exitCode": 0
+  },
+  "runRestricted": {
+    "exitCode": 1,
+    "refused": true
+  },
+  "writeControl": {
+    "exitCode": 0,
+    "fileWritten": true
+  },
+  "writeRestricted": {
+    "exitCode": 0,
+    "fileWritten": false
+  },
+  "boundRefused": [
+    {
+      "name": "bound-globals",
+      "exitCode": 1,
+      "refused": true
+    },
+    {
+      "name": "bound-new",
+      "exitCode": 1,
+      "refused": true
+    },
+    {
+      "name": "bound-ctor",
+      "exitCode": 1,
+      "refused": true
+    },
+    {
+      "name": "bound-tag",
+      "exitCode": 1,
+      "refused": true
+    },
+    {
+      "name": "bound-default",
+      "exitCode": 1,
+      "refused": true
+    }
+  ],
+  "boundGood": {
+    "exitCode": 0
+  }
 }

--- a/packages/agency-lang/tests/agency-js/test-cli-agency-only/test.js
+++ b/packages/agency-lang/tests/agency-js/test-cli-agency-only/test.js
@@ -34,6 +34,18 @@ const writeRestricted = agency(["run", "--agency-only", "--reject", "*", "writes
 const writeRestrictedFile = existsSync(resolve(here, "y.txt"));
 rmSync(resolve(here, "y.txt"), { force: true });
 
+// Bound names under --agency-only (SANDBOX_JS_GLOBALS). Each refused fixture
+// references a capability but performs no destructive action, so a regression
+// that let one compile still could not do harm when only the exit code is
+// asserted (anti-patterns.md: no catastrophic-on-failure tests).
+const boundRefused = ["bound-globals", "bound-new", "bound-ctor", "bound-tag", "bound-default"].map(
+  (name) => {
+    const r = agency(["run", "--agency-only", "--reject", "*", `${name}.agency`]);
+    return { name, exitCode: r.exitCode, refused: r.output.includes("compile refused") };
+  },
+);
+const boundGood = agency(["run", "--agency-only", "bound-good.agency"]);
+
 writeFileSync(
   "__result.json",
   JSON.stringify(
@@ -52,6 +64,8 @@ writeFileSync(
       },
       writeControl: { exitCode: writeControl.exitCode, fileWritten: writeControlFile },
       writeRestricted: { exitCode: writeRestricted.exitCode, fileWritten: writeRestrictedFile },
+      boundRefused,
+      boundGood: { exitCode: boundGood.exitCode },
     },
     null,
     2,


### PR DESCRIPTION
## What this does

Closes the biggest hole in `--agency-only` (#971): pure Agency code compiled
to JavaScript could name any host global — `process`, `fetch`, `eval`,
`new Function` — and reach the outside world with **no interrupt**, so no
policy or `--reject '*'` could stop it. This refuses those names at compile
time.

**This is defense in depth and clearer errors, not the security boundary.** A
runtime-computed property key (`m[a + b]`) defeats any syntactic check, so the
real backstop for code-from-strings is disabling code generation from strings
(roadmap A1 layer 2), and ultimately removing ambient authority (a process
boundary / SES — roadmap). This PR is layer 1.

## How

- `typechecker.jsGlobals: "all" | "sandbox"` (new config). `--agency-only`
  sets `"sandbox"` in `compileValidatedClosure`, which also forces
  `undefined{Functions,Variables}` to error. Default path is byte-identical.
- `SANDBOX_JS_GLOBALS`: a **separate reviewed allowlist** of globals that
  cannot reach the host (not a filter over the interop `JS_GLOBALS`). The four
  resolvers take the registry as a defaulted argument.
- The two general passes resolve against the allowlist under the sandbox,
  catching bare names, calls, namespace members, and value-access bases
  (`process.env`).
- `checkSandboxNames` (new pass) covers the four positions the general passes
  miss, each reproduced as an escape during design:
  - `new` callees (`new Function/Proxy/WebSocket`) — sound (className is a
    grammar literal); this is what closes `new Proxy`/`new WebSocket`, which
    layer 2 never covers.
  - the `constructor`/`prototype`/`__proto__` walk (AG4011) — best-effort,
    literal spellings only.
  - tag arguments (`@validate`/`@jsonSchema`) and array/object default
    parameter values — declaration-hanging expressions outside any scope body.

## Reviewing

- The rule is shared through one registry-parametric resolver; only the set of
  walked positions differs (see `docs/dev/compiler/agency-only-bound-names.md`).
- Coverage equals the traversal's reach — stated plainly in the dev note,
  because the arc found five escapes by hand. A future position is one resolver
  call from covered, and the security guarantee does not rest here.
- Tests: `lib/typeChecker/sandboxRegistry.test.ts` (registry, default path
  unchanged), `lib/compiler/compileSandboxed.test.ts` (all five escapes refused
  + positive controls), and `tests/agency-js/test-cli-agency-only` (end to end;
  refused fixtures use benign payloads so a regressed refusal cannot do harm).

## Also in this branch

The security-arc docs written earlier this session: `docs/dev/security/goal.md`
and `roadmap.md` (the whole no-OS-sandbox plan), and
`docs/dev/hosting/how-hosted-serving-works.md`. The design and plan (with three
rounds of review) live under `docs/superpowers/` (gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SwUwoL2LVZp8KmCS3GZHjS
