### PR TITLE
Disable code-generation-from-strings for --agency-only runs (layer 2)

### DIFF
--- a/packages/agency-lang/docs/dev/security/roadmap.md
+++ b/packages/agency-lang/docs/dev/security/roadmap.md
@@ -15,8 +15,19 @@ break. Within a group they are in the order to do them.
 **Layer 1 (the bind-check) DONE** — `jsGlobals: "sandbox"`, `SANDBOX_JS_GLOBALS`,
 and `checkSandboxNames` refuse free identifiers, `new` callees, the
 constructor/prototype walk (best-effort), tag arguments, and default values;
-see `docs/dev/compiler/agency-only-bound-names.md`. Layers 2 (disable
-code-generation-from-strings) and 3 (freeze intrinsics) still open.
+see `docs/dev/compiler/agency-only-bound-names.md`.
+
+**Layer 2 (disable code-generation-from-strings) DONE** — `agency run
+--agency-only` spawns the child Node process with
+`--disallow-code-generation-from-strings` (`sandboxRuntimeNodeArgs` in
+`lib/cli/commands.ts`). This is the runtime backstop for the constructor walk
+layer 1 catches only best-effort: a runtime-computed key that reaches
+`Function` (`m[a + b]["constructor"](...)`) now throws `EvalError`. Verified a
+benign agency-only program still runs under the flag. Not yet applied across
+forks (`std::agency.run` children) or to the `agency test --agency-only`
+grader path — those ride with #974 (make enforcement transitive across forks).
+
+Layer 3 (freeze intrinsics) still open.
 
 <https://github.com/egonSchiele/agency-lang/issues/971>. An identifier the compiler does not know is emitted verbatim, so
 `process.env.HOME`, `process.getBuiltinModule("fs")`, `fetch(...)`,
@@ -49,7 +60,7 @@ Fix, in three layers, cheapest first:
    `docs/superpowers/specs/2026-08-29-agency-only-bound-names-design.md`
    (revised after review).
 2. **`--disallow-code-generation-from-strings`** on the child Node process
-   for `--agency-only` runs (`compiledOutputNodeArgs` in
+   for `--agency-only` runs (shipped — `sandboxRuntimeNodeArgs` in
    `lib/cli/commands.ts`). This is the REAL boundary for reaching `Function`
    and calling it with a string — via `eval`, `new Function`, or any
    constructor walk including `m[a + b]["constructor"]…` with a runtime-

--- a/packages/agency-lang/docs/dev/security/roadmap.md
+++ b/packages/agency-lang/docs/dev/security/roadmap.md
@@ -17,15 +17,20 @@ and `checkSandboxNames` refuse free identifiers, `new` callees, the
 constructor/prototype walk (best-effort), tag arguments, and default values;
 see `docs/dev/compiler/agency-only-bound-names.md`.
 
-**Layer 2 (disable code-generation-from-strings) DONE** — `agency run
---agency-only` spawns the child Node process with
+**Layer 2 (disable code-generation-from-strings) — shipped for `agency run`.**
+`agency run --agency-only` spawns the child Node process with
 `--disallow-code-generation-from-strings` (`sandboxRuntimeNodeArgs` in
-`lib/cli/commands.ts`). This is the runtime backstop for the constructor walk
-layer 1 catches only best-effort: a runtime-computed key that reaches
-`Function` (`m[a + b]["constructor"](...)`) now throws `EvalError`. Verified a
-benign agency-only program still runs under the flag. Not yet applied across
-forks (`std::agency.run` children) or to the `agency test --agency-only`
-grader path — those ride with #974 (make enforcement transitive across forks).
+`lib/cli/commands.ts`), so `eval`, the `Function` constructor, and a
+constructor walk through a runtime-computed key (`m[a + b]` where `a + b` is
+`"constructor"`, which layer 1's syntactic check cannot see) all throw
+`EvalError`. Forks (`std::agency.run` children, whose `execArgv` is set
+explicitly in `buildForkOptions`, `lib/runtime/ipc.ts`) and the `agency test
+--agency-only` grader path do not carry the flag yet; both follow in #974.
+
+The flag is not a full ban on generating code: `vm.runInThisContext` and
+`vm.Script` still run under it. Reaching `vm` needs `require` or
+`getBuiltinModule`, which layer 1 refuses by name, so there is no path today —
+but layer 3 should not assume the flag alone closes every route to new code.
 
 Layer 3 (freeze intrinsics) still open.
 
@@ -60,8 +65,9 @@ Fix, in three layers, cheapest first:
    `docs/superpowers/specs/2026-08-29-agency-only-bound-names-design.md`
    (revised after review).
 2. **`--disallow-code-generation-from-strings`** on the child Node process
-   for `--agency-only` runs (shipped — `sandboxRuntimeNodeArgs` in
-   `lib/cli/commands.ts`). This is the REAL boundary for reaching `Function`
+   for `--agency-only` runs (shipped for `agency run`; forks and `agency test`
+   in #974 — `sandboxRuntimeNodeArgs` in `lib/cli/commands.ts`). This is the
+   REAL boundary for reaching `Function`
    and calling it with a string — via `eval`, `new Function`, or any
    constructor walk including `m[a + b]["constructor"]…` with a runtime-
    computed key, which layer 1's syntactic property check cannot catch

--- a/packages/agency-lang/lib/cli/commands.ts
+++ b/packages/agency-lang/lib/cli/commands.ts
@@ -49,6 +49,16 @@ export function compiledOutputNodeArgs(): string[] {
   return [`--import=${compiledOutputRegisterUrl()}`];
 }
 
+/** Extra V8 flags for running UNTRUSTED compiled output (`--agency-only`).
+ *  `--disallow-code-generation-from-strings` makes `eval` and the `Function`
+ *  constructor throw at runtime, closing the one route the compile-time
+ *  bind-check cannot see: a runtime-computed property key that reaches
+ *  `Function` (`m[a + b]["constructor"](...)`). Layer 2 of the JS-globals
+ *  containment; see docs/dev/security/roadmap.md A1. Empty for trusted runs. */
+export function sandboxRuntimeNodeArgs(agencyOnly: boolean): string[] {
+  return agencyOnly ? ["--disallow-code-generation-from-strings"] : [];
+}
+
 // Returns true if `agency-lang` resolves from a file inside the given
 // directory using Node's standard CommonJS resolver. If true, the user
 // can run `node compiled.js` from that location and it will succeed —
@@ -314,11 +324,20 @@ export function run(
   // Use process.execPath so the child runs under the same Node as the CLI,
   // and pass our resolver shim so the compiled output's `import "agency-lang"`
   // succeeds even when the CLI is installed globally.
-  const nodeProcess = spawn(process.execPath, [...compiledOutputNodeArgs(), output, ...nodeArgs], {
-    stdio: "inherit",
-    shell: false,
-    env,
-  });
+  const nodeProcess = spawn(
+    process.execPath,
+    [
+      ...compiledOutputNodeArgs(),
+      ...sandboxRuntimeNodeArgs(compileMode.agencyOnly),
+      output,
+      ...nodeArgs,
+    ],
+    {
+      stdio: "inherit",
+      shell: false,
+      env,
+    },
+  );
 
   nodeProcess.on("error", (error) => {
     console.error(`Failed to run ${output}:`, error);

--- a/packages/agency-lang/lib/cli/commands.ts
+++ b/packages/agency-lang/lib/cli/commands.ts
@@ -51,10 +51,10 @@ export function compiledOutputNodeArgs(): string[] {
 
 /** Extra V8 flags for running UNTRUSTED compiled output (`--agency-only`).
  *  `--disallow-code-generation-from-strings` makes `eval` and the `Function`
- *  constructor throw at runtime, closing the one route the compile-time
- *  bind-check cannot see: a runtime-computed property key that reaches
- *  `Function` (`m[a + b]["constructor"](...)`). Layer 2 of the JS-globals
- *  containment; see docs/dev/security/roadmap.md A1. Empty for trusted runs. */
+ *  constructor throw, closing the route the compile-time bind-check cannot
+ *  see: a property key built at runtime that reaches `Function`, as in
+ *  `m[a + b]` where `a + b` is `"constructor"`. Layer 2; see
+ *  docs/dev/security/roadmap.md A1. Empty for trusted runs. */
 export function sandboxRuntimeNodeArgs(agencyOnly: boolean): string[] {
   return agencyOnly ? ["--disallow-code-generation-from-strings"] : [];
 }

--- a/packages/agency-lang/lib/cli/run.spawn.test.ts
+++ b/packages/agency-lang/lib/cli/run.spawn.test.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "url";
 import {
   compileWarning,
   compiledOutputNodeArgs,
+  sandboxRuntimeNodeArgs,
   compiledOutputRegisterUrl,
   runChildOverrides,
 } from "./commands.js";
@@ -99,5 +100,14 @@ describe("runChildOverrides", () => {
     expect(merged.log?.logFile).toBe("harness.jsonl");
     expect(merged.observability).toBeUndefined();
     expect(merged.log?.code?.entry).toBe("main.agency");
+  });
+});
+
+describe("sandboxRuntimeNodeArgs", () => {
+  it("disables code-generation-from-strings for --agency-only (untrusted) runs", () => {
+    expect(sandboxRuntimeNodeArgs(true)).toEqual(["--disallow-code-generation-from-strings"]);
+  });
+  it("adds no runtime flags for a trusted run", () => {
+    expect(sandboxRuntimeNodeArgs(false)).toEqual([]);
   });
 });

--- a/packages/agency-lang/lib/cli/run.spawn.test.ts
+++ b/packages/agency-lang/lib/cli/run.spawn.test.ts
@@ -6,7 +6,6 @@ import { fileURLToPath } from "url";
 import {
   compileWarning,
   compiledOutputNodeArgs,
-  sandboxRuntimeNodeArgs,
   compiledOutputRegisterUrl,
   runChildOverrides,
 } from "./commands.js";
@@ -100,14 +99,5 @@ describe("runChildOverrides", () => {
     expect(merged.log?.logFile).toBe("harness.jsonl");
     expect(merged.observability).toBeUndefined();
     expect(merged.log?.code?.entry).toBe("main.agency");
-  });
-});
-
-describe("sandboxRuntimeNodeArgs", () => {
-  it("disables code-generation-from-strings for --agency-only (untrusted) runs", () => {
-    expect(sandboxRuntimeNodeArgs(true)).toEqual(["--disallow-code-generation-from-strings"]);
-  });
-  it("adds no runtime flags for a trusted run", () => {
-    expect(sandboxRuntimeNodeArgs(false)).toEqual([]);
   });
 });

--- a/packages/agency-lang/tests/agency-js/test-cli-agency-only/codegen-walk.agency
+++ b/packages/agency-lang/tests/agency-js/test-cli-agency-only/codegen-walk.agency
@@ -1,0 +1,12 @@
+// Reaches JavaScript's Function through a property key built at runtime, so
+// the compile-time bind-check (layer 1) cannot see it: `key` is "constructor"
+// only after the concatenation runs. Layer 2 (the child Node flag
+// --disallow-code-generation-from-strings) makes the Function call throw at
+// runtime. Reads no real secret; the point is that the call is refused.
+node main() {
+  const key = "cons" + "tructor"
+  const obj = {}
+  const FunctionCtor = obj[key][key]
+  const leak = FunctionCtor("return 1 + 1")
+  return leak()
+}

--- a/packages/agency-lang/tests/agency-js/test-cli-agency-only/fixture.json
+++ b/packages/agency-lang/tests/agency-js/test-cli-agency-only/fixture.json
@@ -51,5 +51,9 @@
   ],
   "boundGood": {
     "exitCode": 0
+  },
+  "codegenWalk": {
+    "compiled": true,
+    "blocked": true
   }
 }

--- a/packages/agency-lang/tests/agency-js/test-cli-agency-only/test.js
+++ b/packages/agency-lang/tests/agency-js/test-cli-agency-only/test.js
@@ -1,7 +1,7 @@
 // --agency-only on `agency test` and `agency run`: a closure that is not pure
 // Agency is refused, as a file failure in the test runner (the suite goes on
 // and the exit code is 1) and as exit 1 in run. Positive controls first.
-import { execFileSync } from "child_process";
+import { spawnSync } from "child_process";
 import { existsSync, rmSync, writeFileSync } from "fs";
 import { dirname, resolve } from "path";
 import { fileURLToPath } from "url";
@@ -11,13 +11,12 @@ const cli = resolve(here, "../../../dist/scripts/agency.js");
 // eslint-disable-next-line no-control-regex
 const stripAnsi = (text) => text.replace(/\x1b\[[0-9;]*m/g, "");
 
+// spawnSync (not execFileSync) so both streams and the exit code come back
+// even when the child exits 0: codegen-walk.agency logs its EvalError to
+// stderr and exits 0, so a stdout-only capture would miss it.
 function agency(args) {
-  try {
-    const out = execFileSync(process.execPath, [cli, ...args], { cwd: here, stdio: "pipe" });
-    return { exitCode: 0, output: stripAnsi(out.toString()) };
-  } catch (e) {
-    return { exitCode: e.status ?? 1, output: stripAnsi(`${e.stdout ?? ""}${e.stderr ?? ""}`) };
-  }
+  const r = spawnSync(process.execPath, [cli, ...args], { cwd: here, encoding: "utf8" });
+  return { exitCode: r.status ?? 1, output: stripAnsi(`${r.stdout ?? ""}${r.stderr ?? ""}`) };
 }
 
 const testControl = agency(["test", "run", "bad.test.json"]);
@@ -46,6 +45,14 @@ const boundRefused = ["bound-globals", "bound-new", "bound-ctor", "bound-tag", "
 );
 const boundGood = agency(["run", "--agency-only", "bound-good.agency"]);
 
+// Layer 2: --agency-only runs the child Node process with
+// --disallow-code-generation-from-strings. codegen-walk.agency reaches
+// Function through a runtime-computed key, which layer 1 cannot see, so it
+// COMPILES; the flag makes the call throw EvalError at runtime. This is the
+// one check that fails if the flag falls off the spawn args: without it the
+// Function call succeeds and no EvalError is printed.
+const codegenWalk = agency(["run", "--agency-only", "--reject", "*", "codegen-walk.agency"]);
+
 writeFileSync(
   "__result.json",
   JSON.stringify(
@@ -66,6 +73,10 @@ writeFileSync(
       writeRestricted: { exitCode: writeRestricted.exitCode, fileWritten: writeRestrictedFile },
       boundRefused,
       boundGood: { exitCode: boundGood.exitCode },
+      codegenWalk: {
+        compiled: !codegenWalk.output.includes("compile refused"),
+        blocked: codegenWalk.output.includes("EvalError"),
+      },
     },
     null,
     2,


### PR DESCRIPTION
## What

`agency run --agency-only` now spawns the child Node process with `--disallow-code-generation-from-strings`. This is **layer 2** of the JS-globals containment for untrusted Agency code (#971); layer 1 (the compile-time bind-check) shipped in #973.

## Why

Layer 1 refuses `.constructor` / `prototype` / `__proto__` only when they are spelled out or written as a string-literal computed key. A **runtime-computed** key that reaches `Function` slips past any syntactic check:

```agency
node main() {
  const key = "cons" + "tructor"
  const F = ({})[key][key]              // ({}).constructor.constructor === Function
  return F("return process.env.HOME")() // Function(body) — reads a host global
}
```

`--disallow-code-generation-from-strings` makes `eval` and the `Function` constructor throw `EvalError` at runtime, closing this route. It also backstops `eval` / `new Function` themselves (layer 1 already refuses those by name; this catches the computed forms).

## Regression guards (in CI)

- `codegen-walk.agency` in `tests/agency-js/test-cli-agency-only/` runs the computed-key escape under `--agency-only` and asserts `EvalError` appears — this fails if the flag falls off the spawn args.
- `bound-good.agency` in the same harness runs a benign program under `run --agency-only`, so the "a normal program still runs under the flag" check runs in CI too.

## Verified end-to-end through the CLI

- The escape above is **refused** under `--agency-only` (crashes with `EvalError: Code generation from strings disallowed`).
- A benign agency-only program still **runs** under the flag — the startup imports (`agency-lang`, `smoltalk`, `zod`) do not use code-generation-from-strings.
- A non-`--agency-only` run is **unaffected** (the flag is scoped to untrusted runs via `sandboxRuntimeNodeArgs(agencyOnly)`).

## Scope / follow-ups

- Applied to the `agency run --agency-only` entry only. **Not** yet applied across forks (`std::agency.run` children) or the `agency test --agency-only` grader path; both ride with #974 (make enforcement transitive across forks — carrier + the `fork ... as` scope fix).
- Layer 3 (freeze intrinsics / SES) remains open; see `docs/dev/security/roadmap.md` A1.

Related: #971 (the hole), #973 (layer 1), #974 (fork transitivity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SwUwoL2LVZp8KmCS3GZHjS

