### PR TITLE
Stop the checkpoint schema from dropping guards, cost, and drafts on reload

### DIFF
--- a/packages/agency-lang/docs/dev/runtime/checkpointing.md
+++ b/packages/agency-lang/docs/dev/runtime/checkpointing.md
@@ -237,8 +237,18 @@ node main() {
 `restore()` accepts the parsed JSON directly and revives it with
 `Checkpoint.fromJSON`, which validates against the zod schemas in
 `lib/runtime/state/schemas.ts`. zod drops any key a schema does not name, so
-when adding a field to `MessageThread.toJSON` or `ThreadStore.toJSON`, add it
-to the schema too, or a checkpoint read back from a file will lose it.
+every field written by a `toJSON` in the checkpoint tree must be named in the
+matching schema, or a checkpoint read back from a file will silently lose it.
+This applies to `StateStack.toJSON` (`localCost`, `guards`,
+`inheritedTimeGuards`, and so on), `State.toJSON` (`scopedCallbacks`,
+`savedDraft`), `BranchState` (`result`, `globalsJSON`, `activeStack`), the guard
+`toJSON` shapes, and `MessageThread.toJSON` / `ThreadStore.toJSON`. When you add
+a field to any of these, add it to its schema in the same change.
+`schemas.test.ts` pins this: it fails if a schema strips a field the
+deserializer reads back. Note this only bites the external path — the in-process
+resume deep-clones the live `Checkpoint` object, so it never loses these fields;
+only a checkpoint that is stringified and reparsed (HTTP `/resume`, a checkpoint
+loaded from disk) goes through the schema.
 
 ```agency
 node main() {

--- a/packages/agency-lang/docs/dev/runtime/checkpointing.md
+++ b/packages/agency-lang/docs/dev/runtime/checkpointing.md
@@ -237,18 +237,12 @@ node main() {
 `restore()` accepts the parsed JSON directly and revives it with
 `Checkpoint.fromJSON`, which validates against the zod schemas in
 `lib/runtime/state/schemas.ts`. zod drops any key a schema does not name, so
-every field written by a `toJSON` in the checkpoint tree must be named in the
-matching schema, or a checkpoint read back from a file will silently lose it.
-This applies to `StateStack.toJSON` (`localCost`, `guards`,
-`inheritedTimeGuards`, and so on), `State.toJSON` (`scopedCallbacks`,
-`savedDraft`), `BranchState` (`result`, `globalsJSON`, `activeStack`), the guard
-`toJSON` shapes, and `MessageThread.toJSON` / `ThreadStore.toJSON`. When you add
-a field to any of these, add it to its schema in the same change.
-`schemas.test.ts` pins this: it fails if a schema strips a field the
-deserializer reads back. Note this only bites the external path — the in-process
-resume deep-clones the live `Checkpoint` object, so it never loses these fields;
-only a checkpoint that is stringified and reparsed (HTTP `/resume`, a checkpoint
-loaded from disk) goes through the schema.
+every field a `toJSON` in the checkpoint tree writes must be named in the
+matching schema, or a checkpoint read back from JSON will lose it. Add the field
+to its schema in the same change you add it to `toJSON`. Only checkpoints that
+are stringified and reparsed hit the schema — the HTTP `/resume` round trip and
+checkpoints loaded from disk. In-process resume deep-clones the live
+`Checkpoint`, so it never touches the schema.
 
 ```agency
 node main() {

--- a/packages/agency-lang/lib/runtime/state/schemas.test.ts
+++ b/packages/agency-lang/lib/runtime/state/schemas.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect } from "vitest";
+import {
+  checkpointSchema,
+  stateStackJSONSchema,
+  stateJSONSchema,
+  branchStateJSONSchema,
+  guardJSONSchema,
+} from "./schemas.js";
+import { Checkpoint } from "./checkpointStore.js";
+import { StateStack, State } from "./stateStack.js";
+import { CostGuard } from "../guard.js";
+
+// These tests pin the fields the checkpoint schemas must NOT strip. zod
+// drops any key a schema does not name, so `Checkpoint.fromJSON` (the
+// external-resume entry point: HTTP /resume, checkpoints read off disk)
+// would silently lose guards, cost accounting, saved drafts, scoped
+// callbacks, and per-branch state if the schema fell out of sync with
+// `toJSON`. A plain `StateStack.fromJSON(toJSON())` never touches zod, so
+// every test here deliberately goes through the schema path.
+
+describe("guardJSONSchema", () => {
+  it("keeps every field of a cost guard", () => {
+    const json = {
+      kind: "cost",
+      costLimit: 5,
+      spent: 3,
+      guardId: "g1",
+      label: "budget",
+      scopeIds: ["s1"],
+      disarmed: true,
+      isRootBudget: true,
+    };
+    expect(guardJSONSchema.parse(json)).toEqual(json);
+  });
+
+  it("keeps every field of a time guard", () => {
+    const json = {
+      kind: "time",
+      timeLimit: 1000,
+      elapsedMs: 250,
+      grantedMs: 100,
+      guardId: "g2",
+      label: "clock",
+    };
+    expect(guardJSONSchema.parse(json)).toEqual(json);
+  });
+});
+
+describe("stateStackJSONSchema", () => {
+  it("keeps cost accounting and guard fields", () => {
+    const json = {
+      stack: [],
+      mode: "serialize",
+      other: {},
+      deserializeStackLength: 0,
+      nodesTraversed: [],
+      localCost: 1.5,
+      localTokens: 42,
+      seedCost: 0.5,
+      seedTokens: 10,
+      guards: [{ kind: "cost", costLimit: 5, spent: 3, guardId: "g1" }],
+      inheritedGuardCount: 2,
+      inheritedTimeGuards: [{ kind: "time", timeLimit: 1000, elapsedMs: 250, guardId: "g2" }],
+    };
+    expect(stateStackJSONSchema.parse(json)).toEqual(json);
+  });
+});
+
+describe("stateJSONSchema", () => {
+  it("keeps scopedCallbacks and savedDraft", () => {
+    const json = {
+      args: {},
+      locals: {},
+      threads: null,
+      step: 0,
+      scopeName: "main",
+      scopedCallbacks: [{ name: "cb", fn: null }],
+      savedDraft: { value: { best: "so far" } },
+    };
+    expect(stateJSONSchema.parse(json)).toEqual(json);
+  });
+});
+
+describe("branchStateJSONSchema", () => {
+  it("keeps result, globalsJSON, and activeStack", () => {
+    const json = {
+      stack: {
+        stack: [],
+        mode: "serialize",
+        other: {},
+        deserializeStackLength: 0,
+        nodesTraversed: [],
+      },
+      interruptId: "int-1",
+      result: { result: 99 },
+      globalsJSON: { store: { "mod.agency": { x: 1 } }, initializedModules: ["mod.agency"] },
+      activeStack: ["thread-1"],
+    };
+    expect(branchStateJSONSchema.parse(json)).toEqual(json);
+  });
+});
+
+describe("Checkpoint.fromJSON round trip", () => {
+  it("preserves guards, cost, savedDraft, and per-branch state through the schema", () => {
+    const original = {
+      id: 7,
+      nodeId: "start",
+      moduleId: "mod.agency",
+      scopeName: "main",
+      stepPath: "0",
+      label: null,
+      pinned: false,
+      globals: { store: {}, initializedModules: [] },
+      stack: {
+        mode: "serialize",
+        other: {},
+        deserializeStackLength: 0,
+        nodesTraversed: [],
+        localCost: 2.25,
+        localTokens: 100,
+        seedCost: 1.0,
+        seedTokens: 50,
+        guards: [{ kind: "cost", costLimit: 10, spent: 4, guardId: "g1", label: "budget" }],
+        inheritedGuardCount: 0,
+        inheritedTimeGuards: [{ kind: "time", timeLimit: 5000, elapsedMs: 1200, guardId: "g2" }],
+        stack: [
+          {
+            args: {},
+            locals: {},
+            threads: null,
+            step: 1,
+            scopeName: "main",
+            savedDraft: { value: "draft" },
+            branches: {
+              fork_1_0: {
+                stack: {
+                  stack: [],
+                  mode: "serialize",
+                  other: {},
+                  deserializeStackLength: 0,
+                  nodesTraversed: [],
+                },
+                interruptId: "int-1",
+                result: { result: "done" },
+                activeStack: ["t1"],
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    // Serialize the way an external store would, then revive.
+    const revived = Checkpoint.fromJSON(JSON.parse(JSON.stringify(original)));
+    expect(revived).not.toBeNull();
+
+    const stack = revived!.stack;
+    expect(stack.localCost).toBe(2.25);
+    expect(stack.localTokens).toBe(100);
+    expect(stack.seedCost).toBe(1.0);
+    expect(stack.seedTokens).toBe(50);
+    expect(stack.guards).toEqual(original.stack.guards);
+    expect(stack.inheritedTimeGuards).toEqual(original.stack.inheritedTimeGuards);
+
+    const frame = stack.stack[0];
+    expect(frame.savedDraft).toEqual({ value: "draft" });
+    const branch = frame.branches!["fork_1_0"];
+    expect(branch.result).toEqual({ result: "done" });
+    expect(branch.activeStack).toEqual(["t1"]);
+  });
+
+  it("survives a full toJSON -> Checkpoint.fromJSON -> StateStack.fromJSON with real guards", () => {
+    const stateStack = new StateStack([new State({ step: 1 })], "serialize");
+    const costGuard = new CostGuard(10, "budget");
+    costGuard.charge(4);
+    stateStack.pushGuard(costGuard);
+    stateStack.localCost = 4;
+    stateStack.stack[0].savedDraft = { value: "best-so-far" };
+
+    const cp = new Checkpoint({
+      id: 0,
+      stack: stateStack.toJSON(),
+      globals: { store: {}, initializedModules: [] },
+      nodeId: "start",
+    });
+
+    // The external path: stringify, parse, and re-validate through zod.
+    const revived = Checkpoint.fromJSON(JSON.parse(JSON.stringify(cp.toJSON())));
+    expect(revived).not.toBeNull();
+
+    const restored = StateStack.fromJSON(revived!.stack);
+    expect(restored.localCost).toBe(4);
+    const costGuards = restored.guards.filter((g) => g instanceof CostGuard) as CostGuard[];
+    expect(costGuards).toHaveLength(1);
+    // spent is private; read it back through the guard's own JSON shape.
+    expect(costGuards[0].toJSON()).toMatchObject({ kind: "cost", spent: 4, costLimit: 10 });
+    expect(restored.stack[0].savedDraft).toEqual({ value: "best-so-far" });
+  });
+});

--- a/packages/agency-lang/lib/runtime/state/schemas.test.ts
+++ b/packages/agency-lang/lib/runtime/state/schemas.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from "vitest";
 import {
-  checkpointSchema,
   stateStackJSONSchema,
   stateJSONSchema,
   branchStateJSONSchema,
@@ -10,13 +9,11 @@ import { Checkpoint } from "./checkpointStore.js";
 import { StateStack, State } from "./stateStack.js";
 import { CostGuard } from "../guard.js";
 
-// These tests pin the fields the checkpoint schemas must NOT strip. zod
-// drops any key a schema does not name, so `Checkpoint.fromJSON` (the
-// external-resume entry point: HTTP /resume, checkpoints read off disk)
-// would silently lose guards, cost accounting, saved drafts, scoped
-// callbacks, and per-branch state if the schema fell out of sync with
-// `toJSON`. A plain `StateStack.fromJSON(toJSON())` never touches zod, so
-// every test here deliberately goes through the schema path.
+// Only `Checkpoint.fromJSON` (the external-resume path) runs a checkpoint
+// through zod, and zod strips any key a schema does not name. A plain
+// `StateStack.fromJSON(toJSON())` skips zod entirely, so every test here goes
+// through the schema on purpose — that is the only path where a stripped field
+// shows up.
 
 describe("guardJSONSchema", () => {
   it("keeps every field of a cost guard", () => {
@@ -184,7 +181,6 @@ describe("Checkpoint.fromJSON round trip", () => {
       nodeId: "start",
     });
 
-    // The external path: stringify, parse, and re-validate through zod.
     const revived = Checkpoint.fromJSON(JSON.parse(JSON.stringify(cp.toJSON())));
     expect(revived).not.toBeNull();
 

--- a/packages/agency-lang/lib/runtime/state/schemas.ts
+++ b/packages/agency-lang/lib/runtime/state/schemas.ts
@@ -23,12 +23,35 @@ export const threadStoreJSONSchema = z.object({
   sessions: z.record(z.string(), z.string()).optional(),
 });
 
+// GuardJSON — every field CostGuard.toJSON / TimeGuard.toJSON write.
+// Discriminated on `kind`; the base fields are shared by both kinds.
+const guardJSONBase = {
+  guardId: z.string().optional(),
+  label: z.string().optional(),
+  scopeIds: z.array(z.string()).optional(),
+  disarmed: z.boolean().optional(),
+  isRootBudget: z.boolean().optional(),
+};
+export const guardJSONSchema = z.discriminatedUnion("kind", [
+  z.object({ ...guardJSONBase, kind: z.literal("cost"), costLimit: z.number(), spent: z.number() }),
+  z.object({
+    ...guardJSONBase,
+    kind: z.literal("time"),
+    timeLimit: z.number(),
+    elapsedMs: z.number(),
+    grantedMs: z.number().optional(),
+  }),
+]);
+
 // BranchStateJSON (forward-declared due to mutual recursion with StateStackJSON)
 export const branchStateJSONSchema: z.ZodType<any> = z.lazy(() =>
   z.object({
     stack: stateStackJSONSchema,
     interruptId: z.string().optional(),
     interruptData: z.any().optional(),
+    result: z.object({ result: z.any() }).optional(),
+    globalsJSON: globalStoreJSONSchema.optional(),
+    activeStack: z.array(z.string()).optional(),
   }),
 );
 
@@ -42,6 +65,8 @@ export const stateJSONSchema = z.object({
   // normalizes to null so the parsed shape satisfies StateJSON.
   scopeName: z.string().nullable().optional().default(null),
   branches: z.record(z.string(), branchStateJSONSchema).optional(),
+  scopedCallbacks: z.array(z.object({ name: z.string(), fn: z.any() })).optional(),
+  savedDraft: z.object({ value: z.any() }).optional(),
 });
 
 // StateStackJSON
@@ -51,6 +76,13 @@ export const stateStackJSONSchema = z.object({
   other: z.record(z.string(), z.any()),
   deserializeStackLength: z.number(),
   nodesTraversed: z.array(z.string()),
+  localCost: z.number().optional(),
+  localTokens: z.number().optional(),
+  seedCost: z.number().optional(),
+  seedTokens: z.number().optional(),
+  guards: z.array(guardJSONSchema).optional(),
+  inheritedGuardCount: z.number().optional(),
+  inheritedTimeGuards: z.array(guardJSONSchema).optional(),
 });
 
 // GlobalStoreJSON


### PR DESCRIPTION
## The bug

A checkpoint is validated against the zod schemas in `lib/runtime/state/schemas.ts` when it is read back from JSON (`Checkpoint.fromJSON`). zod strips any key a schema does not name. The schemas had drifted from the `toJSON` methods and were missing a set of load-bearing fields:

- **`StateStackJSON`**: `localCost`, `localTokens`, `seedCost`, `seedTokens`, `guards`, `inheritedGuardCount`, `inheritedTimeGuards`
- **`StateJSON`**: `scopedCallbacks`, `savedDraft`
- **`BranchStateJSON`**: `result`, `globalsJSON`, `activeStack`

`StateStack.fromJSON` / `State.fromJSON` read every one of these back, so a checkpoint that is stringified and reparsed lost its guards (cost/time budgets), cost and token accounting, saved drafts, scoped callbacks, and per-branch state.

## Blast radius

Only the **external** resume path is affected — the one where a checkpoint is serialized to JSON and reparsed: the HTTP `/resume` round trip when serving an agent, and any checkpoint written to disk and loaded back. The in-process resume path deep-clones the live `Checkpoint` object and never passes through the schema, so it was never losing these fields. The most serious consequence is a served agent losing its cost/time guards across a resume — the budget ceiling would silently reset.

## The fix

Add the missing fields to the three schemas, plus a new `guardJSONSchema` (a discriminated union on `kind` matching the `CostGuard` and `TimeGuard` JSON shapes). This is exactly the "keep the schema in step with `toJSON`" discipline the checkpointing dev doc already called out for thread fields.

## Tests

`lib/runtime/state/schemas.test.ts` (new) pins the round trip:

- Each schema keeps every previously-stripped field.
- A full `Checkpoint.fromJSON(JSON.parse(JSON.stringify(...)))` preserves guards, cost, `savedDraft`, and per-branch `result`/`activeStack`.
- An end-to-end `StateStack` with a real charged `CostGuard` survives `toJSON → Checkpoint.fromJSON → StateStack.fromJSON` with its `spent` intact.

I confirmed all 7 tests **fail** against the pre-fix schema and pass with the fix. The neighboring `checkpointStore.test.ts` and `stateStack.test.ts` (104 tests) still pass. `pnpm run typecheck` (all three configs), prettier, and `lint:structure` are green.

The checkpointing dev doc note is broadened to cover every `toJSON` in the checkpoint tree, not just the thread ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
