### PR TITLE
Host-supplied root interrupt policy for served invocations (InvocationOptions.policy)

### DIFF
--- a/packages/agency-lang/docs/dev/hosting/how-hosted-serving-works.md
+++ b/packages/agency-lang/docs/dev/hosting/how-hosted-serving-works.md
@@ -308,7 +308,14 @@ An invalid policy shape throws before any execution context exists; the
 adapter logs the message and returns its generic error, so a host bug is
 loud in the host's log and opaque to the caller. An explicit policy replaces
 the `AGENCY_RUN_POLICY` environment policy for that run; it does not merge
-with it. End-to-end behaviour is pinned by `tests/agency-js/serve-policy`.
+with it, and an empty `{}` is a no-op that still disables the environment
+policy. End-to-end behaviour is pinned by `tests/agency-js/serve-policy`.
+
+One known gap: the module's top-level initialization code runs before the
+handler is installed, so a raise inside a top-level initializer is not yet
+governed by the policy. That ordering problem predates this feature (it
+applies to `agency run --policy` too) and is tracked as B1 on
+`docs/dev/security/roadmap.md` (#966).
 
 ## Where the trace goes
 

--- a/packages/agency-lang/docs/dev/hosting/how-hosted-serving-works.md
+++ b/packages/agency-lang/docs/dev/hosting/how-hosted-serving-works.md
@@ -217,7 +217,8 @@ is why the same statelog server can answer the next request from any
 machine, any time later.
 
 The client answers by sending the interrupt objects back, unchanged, with
-one decision per interrupt:
+one decision per interrupt. (Nothing verifies the echo — see "What a
+checkpoint contains, and who can change it" below for what that means.)
 
 ```
 POST /serve/u_123/my-project/greeter.agency/resume
@@ -264,6 +265,50 @@ the developer's program:
 Until checkpoints are signed with a server key (or stored server-side and
 referred to by id), the interrupt loop should stay between statelog and a
 client the developer trusts.
+
+## Root interrupt policy
+
+A host can attach a policy to any invocation — the same JSON rule format
+`agency run --policy` takes (`lib/runtime/policy.ts`) — as a fourth argument
+to the serve handler:
+
+```ts
+handler("POST", "/node/main", body, {
+  policy: { "std::env": [{ match: { name: "MY_SECRET" }, action: "approve" }, { action: "reject" }] },
+});
+```
+
+The runtime installs it as the **outermost handler** for that invocation, in
+the same bootstrap that serves nodes and functions (`initFreshExecCtx`,
+`lib/runtime/node.ts`), and installs it again on every `/resume`
+(`respondToInterruptsCore`, `lib/runtime/interrupts.ts`), because handlers
+are never part of a checkpoint. Per invocation on purpose: a host like
+statelog serves many projects through one handler, and the rule for
+"which env reads are fine" differs per project.
+
+What that buys, in chain terms (`docs/dev/runtime/interrupts.md`, "Handler
+verdicts"):
+
+- A policy `reject` settles the interrupt **at the raise**, before it ever
+  becomes an HTTP response — and it wins over the program's own
+  `handle { … } with approve`, because a reject beats any approve in the
+  chain merge. The program sees an ordinary denial: `env()` reads the
+  variable as unset, a `read()` gets a failure.
+- A policy `approve` settles the raise silently; the caller never sees it.
+- A policy `propagate` forces the interrupt out to the caller even when the
+  program would have approved it itself — "always ask", per effect.
+- Effects the policy does not mention behave exactly as with no policy.
+- An interrupt raised **during** a resume leg goes through the re-installed
+  policy the same way. The caller's answers to already-surfaced interrupts
+  are not policy-checked: they resolve by interrupt id, the decision for
+  them was made at their raise, and the echoed interrupt data is display
+  information the resumed program never reads.
+
+An invalid policy shape throws before any execution context exists; the
+adapter logs the message and returns its generic error, so a host bug is
+loud in the host's log and opaque to the caller. An explicit policy replaces
+the `AGENCY_RUN_POLICY` environment policy for that run; it does not merge
+with it. End-to-end behaviour is pinned by `tests/agency-js/serve-policy`.
 
 ## Where the trace goes
 

--- a/packages/agency-lang/docs/dev/runtime/interrupts.md
+++ b/packages/agency-lang/docs/dev/runtime/interrupts.md
@@ -242,6 +242,14 @@ The override is applied to the checkpoint state before execution resumes, so the
 
 ## Handler verdicts, merge, and registration-site scoping
 
+A serve host can put a policy at the root of this chain per invocation
+(`InvocationOptions.policy`); see the "Root interrupt policy" section of
+`docs/dev/hosting/how-hosted-serving-works.md`. It decides interrupts on the
+raise — including raises made during a resume leg, because the resume path
+re-installs it on the fresh execution context. Nothing about resume changes:
+the caller's answers to already-surfaced interrupts still resolve by id, as
+described above.
+
 Three pieces of the handler chain live in the runtime (added for the
 resumable-guards work; see `docs/superpowers/plans/2026-07-16-resumable-guards.md`):
 

--- a/packages/agency-lang/docs/dev/security/roadmap.md
+++ b/packages/agency-lang/docs/dev/security/roadmap.md
@@ -123,16 +123,28 @@ including `__initAllRegistered`; check the resume path in `interrupts.ts`
 for the same ordering; add an agency-js test that a top-level read is
 rejected.
 
-### B2. Resumed interrupts bypass the handler chain
+### B2. The resume leg: raise-time policy shipped; checkpoint integrity open
 
-Designed, not yet built:
-`docs/superpowers/specs/2026-08-29-serve-host-interrupt-policy-design.md`,
-section 3. A resume answers interrupts from `getInterruptResponse(id)`
-before the chain runs, so a root policy never sees them and a caller can
-approve their own `std::read`. The spec applies the policy to the response
-map before `setInterruptResponses`; a policy reject overrides a caller
-approve, a caller reject is always honoured. Build it as specified, and emit
-`resolvedBy: "policy"` on the lifecycle event.
+The host-supplied root policy
+(`docs/superpowers/specs/2026-08-29-serve-host-interrupt-policy-design.md`)
+is built: `InvocationOptions.policy` installs the outermost handler on the
+fresh run and again on every resume leg, so every **raise** — including one
+made during a resume — is decided by the host, over the program's own
+approving handlers (`tests/agency-js/serve-policy`).
+
+An earlier version of this item said a caller could "approve their own
+`std::read`" and asked for a policy re-check of the caller's responses on
+resume. That framing was wrong: the echoed interrupt data is display-only
+(the resumed program resolves responses by id and re-reads nothing from the
+interrupt object), and anything a policy would reject was already rejected
+at the raise. What actually remains open on the resume leg is **checkpoint
+integrity**: a stateless resume restores whatever checkpoint the caller
+sends, so the caller controls every local the resumed code runs with (the
+budget ceiling is already re-asserted by hand; nothing else is). The fixes
+are checkpoint signing with a server key, or host-side checkpoint storage
+with the caller holding only an id plus replay protection on that id — see
+"who can change it" in `docs/dev/hosting/how-hosted-serving-works.md`. Not
+filed yet.
 
 ### B3. The sandbox flags do not imply a policy (#970)
 
@@ -206,10 +218,11 @@ In order:
    an allowlisted environment carrying only that project's secrets, and the
    interrupt forwarding the child already does. Secrets then never touch
    the server's `process.env`, which ends the cross-tenant window.
-4. **Host-owned root policy** per invocation, from the serve-host policy
-   spec (B2): reject `std::write`, `std::rm`, `std::shell`, `std::run`, and
-   anything not on a short hosted allowlist; `std::env` approved only for
-   that project's secret names. Reject beats the deployer's `/resume`.
+4. **Host-owned root policy** per invocation (shipped in agency-lang, B2):
+   reject `std::write`, `std::rm`, `std::shell`, `std::run`, and anything
+   not on a short hosted allowlist; `std::env` approved only for that
+   project's secret names. The reject lands at the raise, so a refused
+   effect never reaches `/resume` at all.
 5. **Network.** Block link-local addresses (the metadata server) and
    internal services at the network layer, or route `std::http` through a
    broker with an egress allowlist.
@@ -236,7 +249,7 @@ is the place to start. No statelog issues are filed yet.
 | A2 review `JS_GLOBALS` | — | not filed |
 | A3 splice execution in non-build commands | — | not filed, known |
 | B1 top-level `with approve` before policy | #966 | open |
-| B2 resume bypasses chain | spec | designed |
+| B2 raise-time host policy / checkpoint integrity | spec | policy shipped; integrity open |
 | B3 sandbox flags imply no policy | #970 | open |
 | C1 `node_modules` shadowing | #967 | open |
 | C2 provider modules from tree config | #968 | open |

--- a/packages/agency-lang/docs/dev/security/roadmap.md
+++ b/packages/agency-lang/docs/dev/security/roadmap.md
@@ -118,6 +118,9 @@ No issue yet.
 runs global init and imported modules' top-level code, then installs the
 policy handler. A top-level `const x = read(...) with approve` therefore has
 only the author's approve in the chain and succeeds under `--reject '*'`.
+The per-invocation host policy (`InvocationOptions.policy`, B2) installs at
+the same bootstrap site, so it shares this gap: a hosted module's top-level
+initializer runs before the host policy exists.
 Fix: install the root policy handler and root budget before any user code,
 including `__initAllRegistered`; check the resume path in `interrupts.ts`
 for the same ordering; add an agency-js test that a top-level read is
@@ -132,13 +135,12 @@ fresh run and again on every resume leg, so every **raise** — including one
 made during a resume — is decided by the host, over the program's own
 approving handlers (`tests/agency-js/serve-policy`).
 
-An earlier version of this item said a caller could "approve their own
-`std::read`" and asked for a policy re-check of the caller's responses on
-resume. That framing was wrong: the echoed interrupt data is display-only
-(the resumed program resolves responses by id and re-reads nothing from the
-interrupt object), and anything a policy would reject was already rejected
-at the raise. What actually remains open on the resume leg is **checkpoint
-integrity**: a stateless resume restores whatever checkpoint the caller
+A policy re-check of the caller's responses on resume would add nothing:
+the echoed interrupt data is display-only (the resumed program resolves
+responses by id and re-reads nothing from the interrupt object), and
+anything a policy would reject was already rejected at the raise. What
+remains open on the resume leg is **checkpoint integrity**: a stateless
+resume restores whatever checkpoint the caller
 sends, so the caller controls every local the resumed code runs with (the
 budget ceiling is already re-asserted by hand; nothing else is). The fixes
 are checkpoint signing with a server key, or host-side checkpoint storage

--- a/packages/agency-lang/docs/superpowers/plans/2026-08-29-serve-host-interrupt-policy-plan-REVIEW.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-08-29-serve-host-interrupt-policy-plan-REVIEW.md
@@ -1,0 +1,98 @@
+# Review: plan for host-supplied interrupt policy
+
+Reviewer: Claude. Round 2, 2026-08-30, against the revised plan (the one whose
+"What changed after review" section cuts the resume response-rewrite).
+Round 1 of this review is superseded: its findings 1 and 2 argued about a
+resume decision point that does not exist (see CLAUDE.md, "How interrupts,
+handlers, policies, and effects work" — the decision happens at the raise;
+resume returns the stored answer by interrupt id). Findings 3-7 of round 1
+were absorbed into the revised plan.
+
+Verdict: the revised plan is correct on the interrupt model, and its scope is
+genuinely small. Every file:line it cites checks out on main at `0c1d5ff07`
+(re-verified 2026-08-30, after #975/#976 merged). One premise is wrong — the
+integration harness Phase 3 builds on does not do what the plan says — and
+one test is worth adding. Phases 0-2 can be executed as written.
+
+## Facts re-verified
+
+`InvocationOptions` (`invocationOptions.ts:13`), `resolveInvocation` with no
+validation (`:164`), `ServeHandler`'s 4th arg (`createServeHandler.ts:17`),
+the fresh-path resolves (`node.ts:290`, `:380`) and installs
+(`initFreshExecCtx` at `node.ts:126`, install `:202`, callers `:298`/`:413`),
+the resume resolve/install (`interrupts.ts:787`/`:805`), the chain precedence
+comment (`interrupts.ts:411`), and `makeRunPolicyHandler`'s
+approve/reject/propagate/abstain mapping (`runPolicyHandler.ts:27-36`). All
+accurate.
+
+One model-level check the revised plan gets right and round 1 never made:
+the root handler is installed before `restoreState` on resume, and the
+agent's own handlers re-push as the replay re-enters their `handle` blocks,
+so the policy stays outermost on a resumed leg exactly as on a fresh one.
+
+## 1. Phase 3's harness premise is false (blocking for Phase 3 only)
+
+The plan says `lib/serve/http/adapter.perInvocation.test.ts` "drives a
+compiled module through the HTTP adapter with `InvocationOptions`". It does
+not. That file's invokers are `vi.fn` spies (`adapter.perInvocation.test.ts:34`,
+`makeHandler`); it proves the adapter passes the options object through by
+identity and nothing more. No serve test anywhere compiles an Agency module:
+`createServeHandler.test.ts` uses a hand-written stand-in module (its own
+comment says so, line 7), and `perInvocation.integration.test.ts` drives the
+real serve core (`runExportedFunctionForServe`) with hand-built
+`AgencyFunction`s whose bodies cannot raise interrupts.
+
+(Round 1 listed this harness claim under "facts: all verified". It was never
+verified. Same mistake as the resume model: a name that sounded right.)
+
+So the Phase 3 cases — `env("A")`/`env("B")`, the handler-precedence test,
+the `/function` route, the resume-leg raise — have nowhere to run as written.
+Two ways to get them a home:
+
+- **An agency-js test (recommended).** `tests/agency-js/` already has the
+  exact pattern: compile a real `.agency` module and drive its exported
+  `respondToInterrupts`/`hasInterrupts` from JS
+  (`tests/agency-js/block-callback-tool-resume/test.js`). A new
+  `tests/agency-js/serve-policy/` fixture with an `env`-calling node and a
+  handler-wrapped variant covers every case, including the resume-leg raise
+  (two sequential interrupts: resume the first with approve under a policy
+  that rejects the second; the run must fail). No LLM calls needed. The
+  serve adapter itself stays covered by the existing identity-pass-through
+  spies, which is all the adapter does with the options.
+- **Teach the integration test to raise.** Extending
+  `perInvocation.integration.test.ts`'s hand-built functions to call the
+  runtime's interrupt entry point is possible but reimplements what the
+  compiler emits; the agency-js route tests the real generated code instead.
+
+Phase 3 should be rewritten around the agency-js fixture, and the "Facts"
+bullet corrected.
+
+## 2. Add the propagate-beats-approve case
+
+Verified in `runHandlerChain` (`interrupts.ts:371-399`): `hasPropagation` is
+checked before approvals, so one `propagate` verdict surfaces the interrupt
+even when another handler approved. `makeRunPolicyHandler` returns
+`{ type: "propagate" }` for an explicit propagate rule. Together that means a
+host policy can force "always ask me" for an effect *over the agent's own
+auto-approving handler* — for a host, arguably as valuable as the reject
+veto, and one line of policy JSON. Neither the spec's tests nor the plan's
+cover it. Add one case beside the security-critical reject-beats-approve
+test: agent wraps `env("B")` in an approving handler, policy says
+`propagate` for `std::env` → the interrupt surfaces.
+
+## 3. Small notes
+
+- Phase 0's "resume responses untouched, byte-identical" pin is now almost
+  vacuous — with the rewrite cut, no code in this change touches responses.
+  Keep the pin for `installRunPolicyHandler` being a no-op and
+  `resolvedBy:"user"`, but don't let the byte-identical clause suggest the
+  change goes anywhere near the response path.
+- The "interrupt RAISED during a resume leg" unit test the plan puts in
+  `interrupts.test.ts`: that file today tests leaf functions with stubs
+  (`stubCtx` at `:483`); a real raise-during-resume needs a compiled program
+  and belongs in the agency-js fixture from finding 1. Drop the unit
+  variant rather than building an exec-context rig for it.
+- The optional `resolvedBy:"policy"` note is correctly scoped: on the fresh
+  leg a policy decision flows through the ordinary handler events, so the
+  tag is a decision-site change in `makeRunPolicyHandler`'s caller path, not
+  a resume change. Fine to defer.

--- a/packages/agency-lang/docs/superpowers/plans/2026-08-29-serve-host-interrupt-policy-plan.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-08-29-serve-host-interrupt-policy-plan.md
@@ -1,0 +1,250 @@
+# Plan: host-supplied interrupt policy for served agents
+
+Spec: `../specs/2026-08-29-serve-host-interrupt-policy-design.md` (read first;
+revised twice — §3 no longer rewrites resume responses).
+Reviews: `../specs/…-REVIEW.md`, `../specs/…-REVIEW-2.md`,
+`./2026-08-29-serve-host-interrupt-policy-plan-REVIEW.md`.
+Companion: a host-side (statelog) PR in a separate repo; out of scope here.
+Branch: a fresh branch off `main`.
+
+## What changed after review (read this before the phases)
+
+The original plan had a Phase 3 that re-evaluated the policy against the
+caller's responses on `/resume`. That is **cut**. Two reasons, both confirmed
+in code:
+
+- The resumed program returns a response by interrupt id
+  (`agencyInterrupt.ts:158`) and never re-reads the interrupt's `effect`/`data`;
+  the effect runs off the *restored execution state* (`env` does
+  `return _env(name)` with `name` from the frame, `stdlib/system.agency`
+  `requestEnvRead`). So rewriting the echoed response/data changes nothing the
+  program acts on.
+- It was redundant: the policy already decides each interrupt on its **raise**
+  via the root handler (§2), when the data is the real in-memory value. Nothing
+  the policy would reject reaches the resume leg.
+
+The genuine resume-leg risk — a caller tampering the serialized checkpoint arg
+and replaying a host-approved interrupt id — is **checkpoint integrity**, not
+response-binding. It needs checkpoint signing and/or host-side checkpoint
+storage; both are separate roadmap items and out of scope. This plan delivers
+the raise-time enforcement (the fresh leg) that fixes the 0.17.0 break, and
+adds nothing to the resume answer path.
+
+## What "done" means
+
+| Scenario | Result |
+|---|---|
+| fresh run, `env("A")`, no handler, policy approves `name:"A"` else rejects | value returned; nothing surfaced |
+| fresh run, `env("B")`, same policy | `env` returns `null`; nothing surfaced. (Not a failed run: `env()` absorbs its own denial — `stdlib/system.agency` `env()` maps a rejected read to `null`, so a refused variable reads as unset. The run only fails for effects whose callers propagate the failure.) |
+| fresh run, `env("B")` wrapped in an approving handler (`handle { … } with approve`) | still `null`, not the value (root reject beats inner approve) — **the security-critical test** |
+| fresh run, `env("B")` wrapped in an approving handler, policy has an explicit `propagate` rule for `std::env` | interrupt surfaces anyway (a propagate verdict beats an approve in `runHandlerChain`, `interrupts.ts:399` — the host's "always ask me", even over an auto-approving agent) |
+| `/function` route, same `env` policy | governed identically (shared `initFreshExecCtx`) |
+| interrupt RAISED during a resume leg, policy rejects it | the raise is rejected there and then (root handler re-installed on resume); for an `env` read that means `null`, not the value |
+| invalid `policy` shape, any route | throws a plain `Error` ("invalid invocation policy: …") before any exec context; logged host-side, generic error to caller |
+| no `policy`, no `AGENCY_RUN_POLICY`, any route | byte-identical to today |
+
+The last row is the first invariant to pin.
+
+## Facts the plan relies on (verified 2026-08-30)
+
+- `InvocationOptions` is `{ config?, traceId? }` (`invocationOptions.ts:13`);
+  `ServeHandler`'s 4th arg is `invocation?: InvocationOptions`
+  (`createServeHandler.ts:16`) — no transport change.
+- `resolveInvocation` (`invocationOptions.ts:164`) does NO validation today;
+  returns `{ runId, contextOverride }`. Called on the fresh path
+  (`node.ts` `runNodeCore`) and resume (`interrupts.ts:787`), each before
+  `createExecutionContext`. The HTTP adapter turns a thrown setup error into a
+  logged, generic `TOOL_ERROR_MESSAGE` (`adapter.ts:132`).
+- `installRunPolicyHandler(execCtx)` (`runPolicyHandler.ts`) reads the env
+  policy via a private `loadEnvPolicy()`, is IPC-gated, pushes
+  `makeRunPolicyHandler(policy)` with `liveGuardIds: []`. `makeRunPolicyHandler`
+  maps approve/reject/explicit-propagate and abstains (`undefined`) when
+  `checkPolicyExplicit` is `null`.
+- Fresh-run install runs inside `initFreshExecCtx(execCtx, { initializeGlobals })`
+  (`node.ts:126`, install at `:202`, callers `:298` and `:413`) — the shared
+  bootstrap for served nodes AND functions. It receives no `resolved`;
+  `RuntimeContext` has no policy field.
+- Resume install at `interrupts.ts:805`; `resolved` is in scope from `:787`.
+- `chain precedence reject > propagate > approve` (`mergeChainOutcomes`,
+  `interrupts.ts:411,419`), regardless of nesting.
+- `env` from `std::system` raises `std::env` (`stdlib/system.agency`,
+  `effect std::env { name: string }`; `requestEnvRead`).
+- There is NO integration harness that drives a compiled module through the
+  serve path. `lib/serve/http/adapter.perInvocation.test.ts` is spies only (its
+  invokers are `vi.fn`; it proves the adapter passes `InvocationOptions`
+  through by identity, nothing more). `createServeHandler.test.ts` uses a
+  hand-written stand-in module, and `perInvocation.integration.test.ts` drives
+  the real serve core with hand-built functions that cannot raise interrupts.
+  The end-to-end policy tests therefore go in a new agency-js fixture
+  (Phase 3), following `tests/agency-js/block-callback-tool-resume/test.js`:
+  compile a real module, drive its exported `respondToInterrupts` from JS.
+
+## Phase 0 — the no-policy pin test
+
+With no `policy` and no `AGENCY_RUN_POLICY`, fresh and resume paths are
+unchanged: `installRunPolicyHandler` a no-op, `resolvedBy:"user"` on resume.
+Keep green through every phase. (Nothing in this change touches the resume
+response path at all, so there is no byte-identical-responses clause to pin —
+that was the cut Phase 3's concern.)
+
+Verify: `pnpm test:run lib/runtime/interrupts.test.ts lib/runtime/invocationOptions.test.ts lib/runtime/runPolicyHandler.test.ts > /tmp/p0.txt 2>&1`.
+
+## Phase 1 — `policy` on the invocation shape, validated
+
+1. `invocationOptions.ts`: add `policy?: Policy` to `InvocationOptions` and
+   `ResolvedInvocation` (import `Policy` from `./policy.js`).
+2. In `resolveInvocation`, when `request.options?.policy` is present, run
+   `validatePolicy(it)` and throw a plain
+   `Error("invalid invocation policy: " + error)` on `!success`; put the
+   validated policy on `ResolvedInvocation` for BOTH the fresh and resume
+   branches (the resume branch returns early — add `policy` there too).
+   Plain `Error`, not a class: nothing catches this by type (the adapter
+   maps every throw to the same generic message, `adapter.ts:132`), the env
+   channel's identical failure is a plain `Error` (`loadEnvPolicy`), and an
+   error class with no consumer is machinery without a user. Tests match on
+   the message prefix.
+
+Red first: `invocationOptions.test.ts` — `policy` round-trips for fresh and
+resume; an invalid shape throws with the "invalid invocation policy" prefix
+and names the schema problem; absent → `undefined`. Note in the test that
+the HTTP adapter surfaces this as a generic error to the caller
+(`adapter.ts:132`), so "done"'s "reported as a setup error" means host-log
+only.
+
+## Phase 2 — install the supplied policy (fresh + resume), no reorder
+
+1. `runPolicyHandler.ts`: give `installRunPolicyHandler` an optional
+   explicit-policy parameter with the env fallback in the BODY (a default
+   argument that reads the environment, validates, and can throw is
+   imperative work hidden in a signature — anti-patterns review), and keep
+   `loadEnvPolicy` PRIVATE:
+   ```ts
+   export function installRunPolicyHandler(
+     execCtx: { pushHandler: (h: HandlerFn, liveGuardIds: string[]) => void },
+     policy?: Policy,
+   ): void {
+     if (isIpcMode()) return;
+     const effective = policy ?? loadEnvPolicy();
+     if (!effective) return;
+     execCtx.pushHandler(makeRunPolicyHandler(effective), []);
+   }
+   ```
+   Call sites pass `resolved.policy` directly — no `?? loadEnvPolicy()`, no
+   export, no `?? undefined` conversion. (This refines the spec §2 sketch;
+   behaviour is identical.)
+2. Fresh path: add `policy?: Policy` to `initFreshExecCtx`'s opts; at its
+   install site pass `installRunPolicyHandler(execCtx, opts.policy)`. In the two
+   callers (`:298`, `:413`) pass `policy: resolved.policy` into the opts. One
+   change covers `/node/*` and `/function`. The narrow field is deliberate:
+   passing the whole `ResolvedInvocation` would leak invocation-resolution
+   shape into the bootstrap, which needs exactly one value.
+3. Resume path: `interrupts.ts:805` becomes
+   `installRunPolicyHandler(execCtx, resolved.policy)`. This governs interrupts
+   RAISED during the resume leg. Do NOT touch `buildResponseMap`, the
+   `interruptResolved` loop, or `setInterruptResponses` — the resume answer path
+   is unchanged (no reorder; the "sharp edge" of the old plan is gone).
+
+Red first: `runPolicyHandler.test.ts` — an explicit policy installs the
+handler; the **precedence** test uses disagreeing policies (env rejects effect
+X, explicit policy approves X, handler must return approve — a both-agree test
+would pass even if env leaked); IPC mode still skips; `undefined` → falls back
+to env; env-unset + no arg → no handler.
+
+## Phase 3 — end-to-end tests (new agency-js fixture)
+
+No existing serve test compiles a module (see Facts), so the end-to-end cases
+go in a new `tests/agency-js/serve-policy/`, modelled on
+`block-callback-tool-resume/test.js`: a real `.agency` module whose compiled
+exports (`invokeServed`-style entry plus `respondToInterrupts`) are driven
+from `test.js` with `InvocationOptions`. No LLM calls.
+
+Fixture module: a node calling `env("A")`/`env("B")` bare; a node wrapping
+`env("B")` in an approving `handle { … } with approve`; an exported function
+doing the same (for the `initFreshExecCtx`-covers-functions case); and a node
+raising two interrupts in sequence (for the resume-leg case).
+
+Cases (note: `env()` absorbs a denial and returns `null` — a policy reject on
+`std::env` never fails the run, it makes the variable read as unset):
+- `env("A")`/`env("B")` fresh-run (approve returns the value; reject returns
+  `null`, nothing surfaced).
+- **security-critical, mark it so a shrink pass cannot fold it away**: the
+  approving-handler node, policy rejects `std::env` → `null`, not the value.
+  This is the only test that proves a host reject beats the agent's own
+  handler.
+- the approving-handler node under a policy with an explicit `propagate` rule
+  for `std::env` → the interrupt surfaces (propagate beats approve,
+  `runHandlerChain` checks `hasPropagation` before approvals,
+  `interrupts.ts:399`).
+- the exported function under the same `env` policy, proving the shared
+  `initFreshExecCtx` install covers served functions.
+- the two-read node: surface the first read (no matching rule), resume it
+  with approve under a policy that rejects the second read's `name` → the
+  second read comes back `null` instead of surfacing (the root handler
+  re-installed on the resume exec context decides raises made during the
+  leg). Control: with no policy, the second read surfaces as a second
+  interrupt. This replaces the `interrupts.test.ts` unit variant — that file
+  tests leaf functions with stubs and has no exec-context rig.
+
+The adapter itself needs nothing new: the existing identity-pass-through
+spies in `adapter.perInvocation.test.ts` already cover all the adapter does
+with the options, and gain only a case asserting `policy` rides along
+untouched next to `traceId`/`config`.
+
+No hostile-caller resume test is written here, because the runtime cannot
+enforce it (see "What changed"); that guarantee is the host's, against its
+own stored checkpoints, and belongs to the checkpoint-integrity roadmap item.
+
+## Phase 4 — docs
+
+1. `docs/site/guide/policies.md` is hand-written and owner-owned — do NOT edit
+   it. List the needed "Serve hosts" additions (policy via `InvocationOptions`,
+   root precedence on the raise, that the resume answer path is not a policy
+   seam) in the PR description for the owner.
+2. Dev note: add a "Root interrupt policy" subsection to
+   `docs/dev/hosting/how-hosted-serving-works.md` (the two install sites, the
+   raise-time enforcement model, and the resume-integrity gap with a pointer to
+   the roadmap), and a cross-reference from `docs/dev/runtime/interrupts.md`.
+   While there, correct the line in `how-hosted-serving-works.md` that says the
+   caller returns the interrupt objects "unchanged" — the runtime does not
+   verify that.
+3. `docs/dev/security/roadmap.md`: add (or point at) the checkpoint-integrity
+   item — checkpoint signing (HMAC) and/or host-side checkpoint storage plus
+   interrupt-id replay protection — as the real resume-leg protection this spec
+   deliberately does not implement.
+4. Keep the CLAUDE.md doc index in step if a new dev doc is added.
+
+## Repo guards before any push (per standing feedback)
+
+- `pnpm run typecheck` (all three configs, not bare tsc).
+- `pnpm run fmt:ts`.
+- `pnpm run lint:structure`.
+- `pnpm test:run` for the touched `lib/runtime` and `lib/serve/http` files,
+  output saved to a file.
+- Do NOT run the full agency suite locally; CI runs it.
+- Anti-pattern audit of the diff against `docs/dev/contributing/anti-patterns.md`.
+
+## Risks and notes
+
+- **Scope is now genuinely small.** No reorder, no new response path, no codegen
+  change. The change is: a validated `policy` field, one new parameter on
+  `installRunPolicyHandler`, and threading it into `initFreshExecCtx` and the
+  resume install. The blast radius is the two install sites plus validation.
+- **CLI path unchanged.** Every new parameter defaults to the env-policy
+  behaviour; `agency run --policy` is byte-identical. The disagreeing-policy
+  precedence test pins that env is used only when no explicit policy is passed.
+- **The resume-integrity gap is real and named, not fixed.** Anyone reading the
+  security roadmap must not take this PR as closing hostile-caller resume. The
+  dev note and roadmap entry (Phase 4) are load-bearing for that reason — treat
+  them as part of "done", not optional polish.
+- **This plan survives "serve over run".** A separate spec
+  (`../specs/2026-08-30-serve-over-run-design.md`) explores running each
+  served invocation in a `std::agency.run` subprocess under an Agency
+  supervisor. Even there, the host still hands a per-invocation policy across
+  the TS boundary, so `InvocationOptions.policy` is the contract in both
+  worlds; only the install site would move (from `initFreshExecCtx` to a
+  `handle` block calling `std::policy.checkPolicy`). Do not wait for it.
+- **`resolvedBy:"policy"` is optional.** Tagging the root handler's decisions
+  `"policy"` (the enum already admits it, `statelogClient.ts:1119`) is a nice
+  observability touch but not required; if included, it is a one-line change at
+  the root handler's decision site, with a test that a policy-rejected raise
+  emits `resolvedBy:"policy"`.

--- a/packages/agency-lang/docs/superpowers/specs/2026-08-29-serve-host-interrupt-policy-design-REVIEW-2.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-08-29-serve-host-interrupt-policy-design-REVIEW-2.md
@@ -1,0 +1,138 @@
+# Review 2: Host-supplied interrupt policy for served agents
+
+Reviewer: Claude. Date: 2026-08-30.
+Spec: `2026-08-29-serve-host-interrupt-policy-design.md` (the revision after
+`-REVIEW.md`).
+
+Verdict: the revision resolved everything round 1 raised, and the fresh-run
+half (§1, §2, §4) is ready to build. The resume half (§3) has one problem the
+spec does not mention, and it is a security problem, so it needs a decision
+before implementation. Everything else below is small.
+
+## What I re-verified in code
+
+- `InvocationOptions` is `{ config?, traceId? }` and `resolveInvocation` does
+  no validation (`lib/runtime/invocationOptions.ts:13,164`). Correct.
+- `installRunPolicyHandler` reads the env policy privately and is called from
+  `initFreshExecCtx` (`lib/runtime/node.ts:202`) and the resume core
+  (`lib/runtime/interrupts.ts:805`). The fresh-path thread-through §2
+  describes is real: `initFreshExecCtx` takes only `{ initializeGlobals }`
+  (`node.ts:126`). Correct.
+- Resume order: `buildResponseMap` at `interrupts.ts:769`, `resolveInvocation`
+  at `:787`, the `interruptResolved` loop at `:829` reading `responses[i]`,
+  `setInterruptResponses` at `:855`. §3's ordering paragraph is right.
+- `resolvedBy` already admits `"policy"` (`lib/statelogClient.ts:1119`,
+  `lib/eval/types.ts:174`). No agency-lang enum change needed.
+- The interrupt site returns a cached response before consulting handlers
+  (`lib/runtime/agencyInterrupt.ts:158`). §3's premise holds.
+
+## 1. §3 evaluates the policy against data the caller wrote (security)
+
+On `/resume`, the `interrupts` array comes from the request body. The docs
+say the client sends the objects back "unchanged"
+(`docs/dev/hosting/how-hosted-serving-works.md:219`), but nothing checks that.
+`validateResumeBatch` (`interrupts.ts:658`) checks the shape only. The
+response map is keyed on `interruptId` (`interrupts.ts:679`), and the resumed
+program never re-derives `effect` or `data`: the site at
+`agencyInterrupt.ts:158` returns the cached response by id without looking at
+them.
+
+So §3's `checkPolicyExplicit(policy, interrupts[i])` reads `effect` and
+`data` as the caller claims them. A caller who is refused `std::env` for
+`DB_PASSWORD` resends the same `interruptId` with `data.name` changed to
+`"A"` (an allowed name) and `approve`. The policy sees `A`, keeps the
+approve, the id matches, and the program reads `DB_PASSWORD`.
+
+Worse, the checkpoint travels the same way: `intr.checkpoint =
+ctx.checkpoints.get(checkpointId)` is attached to the surfaced interrupt
+(`agencyInterrupt.ts:194`) and echoed back by the caller, and
+`respondToInterruptsCore` restores whatever arrives. The spec's own §3 says
+"a caller could approve their own `std::read`"; the deeper truth is that a
+caller controls the whole resumed state, so the runtime cannot enforce a
+policy on the resume leg against a hostile caller at all.
+
+This does not make §3 useless, but the spec must say what it protects
+against. Options, in order of preference:
+
+1. **State the trust boundary and move the matching to the host.** Statelog
+   already knows which interrupts it surfaced for a run. The honest design is:
+   statelog keeps the surfaced batch (or at least `interruptId → effect,
+   data`) server-side, matches its policy on the *stored* data, and rejects
+   any resume whose echoed interrupts differ. Agency-lang's §3 then becomes a
+   convenience for hosts that trust their callers, and the spec says so.
+2. **Have the runtime verify the echo.** A cheap partial check: the
+   checkpoint carries the persisted interrupt id in frame locals
+   (`agencyInterrupt.ts:150`), but not `effect`/`data`. Persisting those
+   next to the id, and refusing a resume whose body disagrees, closes the
+   `data` hole but not the forged-checkpoint hole. Only worth it if the host
+   cannot do option 1.
+3. Keep §3 as written and add a paragraph under "Non-goals" saying resume
+   enforcement assumes a caller who echoes faithfully, because a stateless
+   resume is caller-controlled state. Least work, and at least readers of the
+   security roadmap (`docs/dev/security/roadmap.md`) will not think this gap
+   is closed.
+
+Whichever is chosen, the "Why" section's promise that a host `reject`
+"wins regardless of what the resuming caller says" is only true for the
+fresh leg today. Reword it.
+
+## 2. §1: the error is not loud to the caller
+
+The spec says an invalid policy "should be loud". It is loud in the host's
+log only. Both `callNode` and `resumeInterrupts` route a thrown error through
+`errorResult` (`lib/serve/http/adapter.ts:132`), which logs the message and
+returns the generic `TOOL_ERROR_MESSAGE` so no server detail leaks. That is
+probably right for a host bug, but the spec should say "logged, generic
+error to the caller" instead of implying a distinct invocation-error
+response. There is no "existing setup-failure path" that reports it any
+differently.
+
+## 3. §2: the default parameter already gives the fallback
+
+With `policy: Policy | null = loadEnvPolicy()` as the signature, a caller
+passing `resolved.policy` (which is `undefined` when absent) triggers the
+default. So the call sites can pass `resolved.policy` directly; the
+`resolved.policy ?? loadEnvPolicy()` spelled out three times, and the
+"export `loadEnvPolicy`" the plan derives from it, are not needed. One
+subtlety to write down: `null` means "no policy, and do not read the env"
+while `undefined` means "fall back to the env". If that distinction is not
+wanted, make the parameter `Policy | undefined` and drop `null`.
+
+## 4. §3: the rewrite need not move `buildResponseMap`
+
+The spec asks for the rewrite to run before the emission loop, and the plan
+turns that into moving `buildResponseMap` below `resolveInvocation`. It does
+not have to move. `buildResponseMap` validates and builds an id-keyed map;
+the rewrite can run on the *map* after `resolveInvocation`, and the emission
+loop can read `responseMap[intr.interruptId].response` instead of
+`responses[i]`. That keeps validation first (a malformed batch still fails
+before the checkpoint lookup, as today) and removes the reorder the plan
+calls "the sharp edge". Suggest the spec name this shape.
+
+## 5. §3: the rewrite should carry the same IPC gate as the installer
+
+`respondToInterruptsCore` runs in IPC subprocesses too (the comment at
+`interrupts.ts:822`), and a subprocess inherits `AGENCY_RUN_POLICY`. The
+rewrite is idempotent (reject stays reject), so a second application in the
+child is harmless, but the spec's §2 says "the policy stays root-only". Say
+explicitly whether the rewrite is gated by `isIpcMode()` like the installer,
+or whether it is allowed to re-run because it is idempotent. Pick one; the
+plan currently claims a gate that the spec does not define.
+
+## 6. Small things
+
+- `checkPolicyExplicit` takes `{ effect, message, data, origin }`
+  (`policy.ts:38`). Confirm the surfaced `Interrupt` object carries `origin`
+  so the call type-checks without a cast; if it does not, a rule that globs
+  on origin would silently never match.
+- §4 says a policy-rejected interrupt "never appears in the `interrupts`
+  batch". True for the fresh leg. On the resume leg the interrupt was already
+  surfaced once, so a host reading `interruptResolved` sees it resolved by
+  policy; worth one sentence so §4 and §3 agree.
+- Testing section: the integration case "agent wraps `env("B")` in
+  `with handler(std::env) { approve }`" is the single test that proves the
+  security claim of the whole spec. Mark it as such so it does not get cut in
+  a shrink pass.
+- Docs: `docs/site/guide/policies.md` is hand-written and owner-owned. List
+  it under rollout as a note for the owner rather than a task for the
+  implementer.

--- a/packages/agency-lang/docs/superpowers/specs/2026-08-29-serve-host-interrupt-policy-design-REVIEW.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-08-29-serve-host-interrupt-policy-design-REVIEW.md
@@ -1,0 +1,122 @@
+# Review: Host-supplied interrupt policy for served agents
+
+Reviewer: Claude. Date: 2026-08-30.
+Spec: `2026-08-29-serve-host-interrupt-policy-design.md`.
+
+Verdict: a well-scoped, accurate spec that reuses the existing policy/handler
+machinery instead of adding a parallel mechanism, and the security property it
+depends on is real and already proven by the CLI `--policy` path. Every code
+claim I checked holds. Three things need attention before implementation: one
+real wiring gap on the fresh-run path the spec treats as trivial, one ordering
+precision issue in §3, and a simplification of the §3 rule. The rest are minor.
+
+## What I verified (all accurate)
+
+- CLI `--policy` installs `makeRunPolicyHandler` as the outermost handler on both
+  entry points (`node.ts` bootstrap, `respondToInterruptsCore` in
+  `interrupts.ts:805`); `mergeChainOutcomes` is `reject > propagate > approve >
+  noResponse` (`interrupts.ts:411,419`) regardless of nesting, so a root
+  `reject` is genuinely un-bypassable by an agent's own approving handler. The
+  central security claim holds.
+- `policy.ts` has the grammar, globs, and `checkPolicyExplicit` that returns
+  `null` when no rule matches — exactly what §3 needs to leave un-mentioned
+  effects to the caller.
+- `InvocationOptions` today is `{ config?, traceId? }`, and `ServeHandler`'s
+  fourth argument is already `invocation?: InvocationOptions`
+  (`createServeHandler.ts:16`). So "a host passes `policy` with no adapter
+  change" is true for the transport; the only real wiring is inside the runtime
+  (see the gap below).
+- §3's core premise is correct: on resume, a caller response bypasses the
+  handler chain. `agencyInterrupt.ts:158` reads `getInterruptResponse` first and
+  only falls through to `interruptWithHandlers` (line 166) when there is none.
+  So without §3 the root handler never sees a resumed interrupt — the gap is
+  real.
+- `interruptResolved` is emitted with `resolvedBy: "user"` for every resumed
+  interrupt (the loop in `respondToInterruptsCore`), so the open question is
+  well-posed.
+- The MCP path (`serve/mcp/interruptLoop.ts` `runWithPolicy`, used at
+  `mcp/adapter.ts:186`) is the post-hoc loop the non-goals describe; leaving it
+  alone is the right call.
+- `env` (from `std::system`) does raise `std::env` — `docs/site/stdlib/system.md`
+  declares `effect std::env` and lists it under "Throws", and
+  `splice/runGenerator.ts:51` records the change. Motivation confirmed.
+- `adapter.perInvocation.test.ts` exists and already drives a compiled module
+  through the HTTP adapter with `InvocationOptions`, so the named integration
+  target is real.
+
+## 1. The fresh-run install site does not have `resolved` in scope (wiring gap)
+
+§2 says "Both call sites pass `resolved.policy ?? loadEnvPolicy()`", implying the
+two are symmetric. They are not. The resume site
+(`respondToInterruptsCore`, `interrupts.ts:787`) does have `resolved` in scope.
+But the fresh-run install — `installRunPolicyHandler(execCtx)` — runs inside
+`initFreshExecCtx(execCtx, { initializeGlobals })` (`node.ts:126`, called from
+`runNodeCore` at `:298` and the served path at `:413`). `initFreshExecCtx`
+receives only `execCtx` and an opts bag; the `ResolvedInvocation` lives one
+frame up in the caller, and `RuntimeContext` carries no policy field. So on the
+fresh path the policy has to be threaded down — an extra `opts.policy` on
+`initFreshExecCtx` (both call sites already hold `resolved`), or stashed on
+`execCtx` at `createExecutionContext(resolved)` time.
+
+This is small, but the spec should name it, because as written it reads as a
+two-line change symmetric across both sites, and an implementer will hit the
+scope wall on the fresh path. Also worth stating: `initFreshExecCtx` is the
+shared bootstrap for BOTH served nodes and served functions (see the comment at
+`node.ts:115`), so threading it there covers `/function` as well — the data-flow
+diagram in §5 only draws `/node/*`, but the mechanism does (and must) cover the
+function route too. Add that route to the diagram or note it.
+
+## 2. §3's override must land before the `interruptResolved` loop, not just before `setInterruptResponses`
+
+§3 says apply the rewrite "before `setInterruptResponses`". But in
+`respondToInterruptsCore` the `interruptResolved` lifecycle events are emitted in
+a loop that reads `responses[i]` and runs BEFORE `setInterruptResponses`
+(`interrupts.ts:855`). If the rewrite is applied only immediately before
+`setInterruptResponses`, that loop still emits `outcome: "approved"` /
+`resolvedBy: "user"` for an interrupt the policy overrode to reject —
+inconsistent with the actual run outcome and with the whole point of the
+`resolvedBy: "policy"` open question. The override has to be computed before the
+emission loop (or the loop must read the rewritten responses). State the
+ordering precisely: rewrite first, then emit lifecycle events off the rewritten
+responses, then `setInterruptResponses`.
+
+On the open question itself: emit `resolvedBy: "policy"` for overridden
+interrupts. The spec's own reasoning ("seeing why a run was rejected is the
+point of hosting") is right, and finding #2 shows the emission loop is already
+the natural place to compute it — the cost is one enum value, and doing it
+correctly is not optional once #2 is fixed.
+
+## 3. The four-row table is really one rule
+
+On resume every interrupt in the batch has a paired caller response, so rows
+2-4 of §3's table all collapse to "keep the caller's response"; only a policy
+`reject` overrides. The effective rule is one line: **if the policy explicitly
+rejects, force reject; otherwise keep the caller's response.** A policy `approve`
+is inert on resume — the caller already answered — which is why "only the first
+row changes behaviour". Say it that way so an implementer doesn't write
+redundant approve-handling. (The table is fine as an exhaustive illustration;
+just add the one-line rule it reduces to.)
+
+## Minor
+
+- `InvalidInvocationPolicyError` is net-new (it does not exist today), and
+  `resolveInvocation` currently does no validation — it is a pure sync resolver
+  returning `{ runId, contextOverride }`. Adding a `validatePolicy` call and the
+  throw there is reasonable and the "before any execution context exists" claim
+  holds on both paths (`resolveInvocation` is called at `node.ts:290/380` and
+  `interrupts.ts:787`, each before `createExecutionContext`). Just flagging it is
+  new code, not a tweak to an existing validator.
+- `makeRunPolicyHandler` already maps an explicit `propagate` rule to
+  `{ type: "propagate" }`, consistent with §3 treating propagate/no-rule as
+  "caller's response". No change needed; noting the two paths agree.
+- `projectSecretsEndToEnd` lives in statelog, not this repo, so it is
+  unverifiable here. The rollout line reads as if it is agency-lang CI; clarify
+  it is the companion's test.
+
+## Ask before implementation
+
+1. Name the fresh-run threading in §2 (`initFreshExecCtx` gets the policy), and
+   note it also covers `/function`.
+2. Specify the §3 ordering (rewrite before the lifecycle-emission loop) and
+   commit to `resolvedBy: "policy"`.
+3. Add the one-line reduction of the §3 table.

--- a/packages/agency-lang/docs/superpowers/specs/2026-08-29-serve-host-interrupt-policy-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-08-29-serve-host-interrupt-policy-design.md
@@ -88,10 +88,13 @@ export type InvocationOptions = {
   config?: Partial<AgencyConfig>;
   traceId?: string;
   /** Root interrupt policy for this invocation, installed as the outermost
-   *  handler on the fresh run and on every resume leg. A `reject` here
-   *  beats any approval from the agent's own handlers or from the
-   *  resuming caller. Replaces (does not merge with) an AGENCY_RUN_POLICY
-   *  environment policy for this run. */
+   *  handler on the fresh run and re-installed on every resume leg. A
+   *  `reject` here beats any approval from the agent's own handlers, at the
+   *  raise. It does not re-judge the caller's answers to interrupts that
+   *  already surfaced (see §3 — there is nothing there to re-judge).
+   *  Replaces (does not merge with) an AGENCY_RUN_POLICY environment
+   *  policy for this run; note `{}` counts as a policy that abstains on
+   *  everything. */
   policy?: Policy;
 };
 ```
@@ -225,9 +228,12 @@ gap so the roadmap is not read as closing it.
 
 ### 4. What the host sees
 
-Nothing new in the response shape. A policy-rejected interrupt produces the
-same failed-run result an agent-handler rejection does today, with the
-existing "interrupt rejected" message (the policy does not attach a reason; a
+Nothing new in the response shape. A policy-rejected raise looks to the
+program exactly like an agent-handler rejection today: an ordinary denial at
+the raise site. Whether the run fails depends on the callsite — `env()`
+absorbs the denial and reads as unset; a callsite that propagates the
+failure fails the run with the existing "interrupt rejected" message (the
+policy does not attach a reason; a
 host that wants a per-effect explanation wraps it on its side, where it knows
 the project). An interrupt the policy settles on the raise never appears in
 the `interrupts` batch; interrupts it `propagate`s or does not mention behave

--- a/packages/agency-lang/docs/superpowers/specs/2026-08-29-serve-host-interrupt-policy-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-08-29-serve-host-interrupt-policy-design.md
@@ -1,0 +1,337 @@
+# Host-supplied interrupt policy for served agents
+
+Date: 2026-08-29. Status: design, revised twice
+(`-REVIEW.md`, then `-REVIEW-2.md` plus the owner's correction on the resume
+leg). The resume-response-binding section was cut — see "The resume leg"
+below.
+
+Terminology: **host** is the process serving other people's agents; statelog
+is the concrete host this is written for. The two words mean the same thing.
+
+Companion: a statelog spec (to be written against this one) that builds the
+per-project policy and scrubs statelog's own environment at boot.
+
+## Why
+
+A serve host runs other people's agents inside its own process. Today it has
+no say in which interrupts those agents may raise: an agent's own
+`with handler(...)` block can approve anything. The host only ever sees
+interrupts nobody downstream settled.
+
+That became a live problem in 0.17.0, where `env()` started raising
+`std::env`. A hosted agent calling `env("MY_SECRET")` now surfaces an
+unattended interrupt to the host, which cannot answer it (its serve path has
+no interrupt-handling seam), so the hosted-secrets feature broke. The same
+agent could instead wrap the call in an approving handler and read
+`DB_PASSWORD` out of the host's environment — the real gap.
+
+The host needs a **root policy** that:
+
+- decides an interrupt when it is *raised*, ahead of and overriding the
+  agent's own handlers (a host `reject` beats any inner `approve`), so a
+  refused read is settled before it ever surfaces;
+- can vary per invocation (the host's rule for `std::env` is "approve iff
+  `name` is one of *this project's* secrets");
+- governs interrupts raised on the fresh run and interrupts raised during a
+  resume leg alike;
+- costs nothing for hosts that don't use it.
+
+The enforcement point is the **raise**, not the caller's answer. That matters
+because a served resume is stateless: the caller sends back the checkpoint and
+interrupt objects, so everything about the resumed state is caller-controlled
+(see "The resume leg"). Deciding on the raise sidesteps that entirely — at the
+moment `interrupt std::env(...)` fires, the effect data is the real in-memory
+value, not something echoed by the caller.
+
+Almost all of this already exists for CLI runs: `agency run --policy`
+installs `makeRunPolicyHandler(policy)` as the outermost handler on both
+entry points (`lib/runtime/node.ts` bootstrap and `respondToInterruptsCore`
+in `lib/runtime/interrupts.ts`), and chain precedence is
+`reject > propagate > approve` regardless of nesting
+(`mergeChainOutcomes`). The policy grammar (`lib/runtime/policy.ts`) matches
+on interrupt data with globs, first match wins. What's missing is a way for
+a host to *supply* that policy other than the `AGENCY_RUN_POLICY`
+environment variable.
+
+## Non-goals
+
+- Changing the policy grammar. Statelog's needs (`std::env` by `name`,
+  later `std::read` by `dir`/`filename`) are expressible today.
+- A per-server static policy on `CreateServeHandlerOptions`. Statelog
+  caches one handler per module across projects, so the policy has to be
+  per invocation anyway; a host wanting a baseline merges it itself.
+- Making `env()` return host-supplied values instead of reading
+  `process.env`. Statelog keeps injecting secret values into the
+  environment for now; the policy is what stops reads of everything else.
+  Hiding the host's own variables is statelog's job (its companion spec).
+- Resume-leg integrity (checkpoint tampering and interrupt-id replay). This is
+  the real resume-leg risk and it is NOT what a policy fixes — see "The resume
+  leg". Closing it needs checkpoint signing (an HMAC the runtime writes on
+  creation and verifies on restore) and/or host-side checkpoint storage so the
+  caller only holds an interrupt id, plus replay protection on that id. Tracked
+  separately on `docs/dev/security/roadmap.md`; out of scope here.
+- Process isolation for served agents. Still the long-term answer; this
+  spec is the policy layer that isolation would also need.
+- Touching the MCP serve path (`lib/serve/mcp/interruptLoop.ts`), which has
+  its own post-hoc `runWithPolicy` loop over surfaced interrupts. That loop
+  cannot veto an agent's own handlers and re-enters the run once per
+  interrupt batch; the mechanism here is strictly stronger, and MCP can
+  migrate to it later if wanted.
+
+## Design
+
+### 1. `InvocationOptions.policy`
+
+```ts
+// lib/runtime/invocationOptions.ts
+export type InvocationOptions = {
+  config?: Partial<AgencyConfig>;
+  traceId?: string;
+  /** Root interrupt policy for this invocation, installed as the outermost
+   *  handler on the fresh run and on every resume leg. A `reject` here
+   *  beats any approval from the agent's own handlers or from the
+   *  resuming caller. Replaces (does not merge with) an AGENCY_RUN_POLICY
+   *  environment policy for this run. */
+  policy?: Policy;
+};
+```
+
+`ResolvedInvocation` gains `policy?: Policy`. `resolveInvocation` today does
+no validation — it is a pure resolver returning `{ runId, contextOverride }`
+— so this adds a `validatePolicy` call and a new `InvalidInvocationPolicyError`
+(a plain `Error` subclass carrying the schema message), thrown on failure.
+`resolveInvocation` is called on both the fresh path (`node.ts` `runNodeCore`)
+and the resume path (`respondToInterruptsCore` in `interrupts.ts`) before
+`createExecutionContext`, so the throw lands before any execution context
+exists. The HTTP adapter routes it through `errorResult` (`adapter.ts:132`),
+which logs the message host-side and returns the generic `TOOL_ERROR_MESSAGE`
+to the caller — no server detail leaks. That is the right handling for a host
+bug: loud in the host's log, opaque to the caller. There is no distinct
+invocation-error response shape.
+
+`ServeHandler`'s fourth argument is already `InvocationOptions`, so a host
+passes `policy` alongside `config`/`traceId` on both `/node/*` and
+`/resume` with no adapter change.
+
+### 2. Installing the handler
+
+`installRunPolicyHandler` gains an explicit-policy parameter whose default
+preserves the CLI behaviour (read the env policy):
+
+```ts
+export function installRunPolicyHandler(
+  execCtx: { pushHandler: (h: HandlerFn, liveGuardIds: string[]) => void },
+  policy: Policy | undefined = loadEnvPolicy() ?? undefined,
+): void {
+  if (isIpcMode()) return;
+  if (!policy) return;
+  execCtx.pushHandler(makeRunPolicyHandler(policy), []);
+}
+```
+
+The parameter is `Policy | undefined` on purpose: passing `resolved.policy`
+(which is `undefined` when the host supplied none) triggers the default and
+falls back to the env policy. So the call sites just pass `resolved.policy` —
+no `?? loadEnvPolicy()` spelled out, and `loadEnvPolicy` stays private. (There
+is no need for a `null` "policy present but empty, do not read env" meaning;
+if one is ever wanted, add it then.)
+
+The two call sites are not symmetric — the fresh path needs one
+thread-through:
+
+- **Resume** (`respondToInterruptsCore`, `interrupts.ts:805`): `resolved` is
+  already in scope, so this is a one-argument change:
+  `installRunPolicyHandler(execCtx, resolved.policy)`. This governs interrupts
+  raised *during* the resume leg (a fresh raise on a resumed run), exactly as
+  on a first run. It does not touch the caller's answers to already-surfaced
+  interrupts — those were decided on their original raise, and the resume leg
+  cannot re-decide them safely anyway (see "The resume leg").
+- **Fresh run**: the install runs inside `initFreshExecCtx(execCtx, opts)`
+  (`node.ts:202`), the shared bootstrap for served nodes *and* served
+  functions. That function takes only `{ initializeGlobals }` today — the
+  `ResolvedInvocation` lives one frame up in `runNodeCore` / the served path,
+  and `RuntimeContext` carries no policy field. So add `policy?: Policy` to
+  `initFreshExecCtx`'s opts and pass `resolved.policy` from each caller
+  (`:298`, `:413`). Because `initFreshExecCtx` is the single fresh-run
+  bootstrap, this one change covers `/node/*` and `/function` alike.
+
+`liveGuardIds: []` and the IPC gate are unchanged: the policy stays root-only
+and is never metered by user guards. Precedence with user handlers is the
+existing chain merge, so nothing in `interrupts.ts` dispatch changes.
+
+### 3. The resume leg: why there is nothing to bind, and what the real risk is
+
+An earlier draft of this spec added a step to re-check the policy against the
+caller's responses on `/resume`. That was wrong on two counts, both surfaced
+in review.
+
+**It checked data the resumed program never reads.** A resume returns a
+response by interrupt id — the generated site does
+`ctx.getInterruptResponse(id)` and returns it (`agencyInterrupt.ts:158`)
+without re-reading the interrupt's `effect` or `data`. The effect that
+actually runs uses the *restored execution state*, not the echoed interrupt
+object. Concretely, `env` is:
+
+```
+def requestEnvRead(name: string): string | null {
+  return interrupt std::env("...", { name: name })   // raise: {name} is live
+  return _env(name)                                   // on approve: reads process.env[name]
+}
+```
+
+On resume, `_env(name)` reads `process.env[name]` where `name` comes from the
+restored frame. The `interrupt.data.name` the caller echoes back is only the
+raise-time display/policy copy; rewriting it changes nothing.
+
+**It was redundant.** The policy already decided this interrupt on its
+*raise*, via the §2 root handler, when the effect data was the real in-memory
+value. If the policy rejects `std::env` for `DB_PASSWORD`, that rejection
+fires on the raise and the interrupt never surfaces. Nothing the policy would
+reject on resume survives to the resume leg to be re-rejected.
+
+So §2 is the whole enforcement: install the root handler on the fresh run and
+re-install it on the resume exec context so interrupts *raised during* the
+resume are governed too. There is no response-rewrite, no reorder of
+`respondToInterruptsCore`, and no new `resolvedBy` on the resume path.
+
+**The real resume-leg risk is checkpoint integrity, not response-binding.**
+A served resume is stateless: the caller sends back the checkpoint and
+interrupt objects, and `respondToInterruptsCore` restores whatever arrives
+(`interrupt.checkpoint ?? ctx.checkpoints.get(...)`; the checkpoint's own
+budget ceiling is already noted as caller-controllable). The concrete attack:
+an agent reads `env("FOO")` — a variable the project owns — the host approves
+it on the raise, and the checkpoint serializes the execution state including
+the argument `"FOO"`. Before resuming, the caller edits the checkpoint so the
+serialized argument reads `"DB_PASSWORD"`. Now they hold a checkpoint carrying
+a host approval that replays as a read of a variable the host never approved.
+Rewriting the interrupt's display `data` was never needed for this; editing
+the *checkpoint* is.
+
+No policy check on the resume leg can stop this, because the trusted copy of
+"what was approved" would live in the very checkpoint the caller controls.
+Closing it needs one of:
+
+- **Checkpoint signing** — the runtime writes an HMAC over the checkpoint on
+  creation and verifies it on restore, so a tampered checkpoint is refused.
+- **Host-side checkpoint storage** — the host keeps the checkpoint in its own
+  store and hands the caller only an interrupt id, so there is nothing to
+  tamper. This still needs replay protection on the id (a caller could resend
+  an older, already-approved id).
+
+Both are separate, larger security items on `docs/dev/security/roadmap.md`.
+This spec deliberately does not attempt them; it delivers the raise-time
+enforcement (§2) that fixes the 0.17.0 break, and names the resume-integrity
+gap so the roadmap is not read as closing it.
+
+### 4. What the host sees
+
+Nothing new in the response shape. A policy-rejected interrupt produces the
+same failed-run result an agent-handler rejection does today, with the
+existing "interrupt rejected" message (the policy does not attach a reason; a
+host that wants a per-effect explanation wraps it on its side, where it knows
+the project). An interrupt the policy settles on the raise never appears in
+the `interrupts` batch; interrupts it `propagate`s or does not mention behave
+exactly as before.
+
+Observability note (optional, not required for this spec): the root-policy
+handler's decisions currently emit `resolvedBy: "handler"` like any handler.
+A host may want them tagged `resolvedBy: "policy"` (the enum already admits
+it, `statelogClient.ts:1119`) so a run rejected by the host policy is
+distinguishable from one rejected by the agent's own handler. That is a
+one-line change at the root handler's decision site and can land here or
+later; it is not load-bearing.
+
+### 5. Data flow, end to end
+
+```
+host  ── ServeHandler(method, path, body, { policy, config, traceId })
+        │
+        ├─ /node/*      ┐  both fresh-run routes share initFreshExecCtx
+        ├─ /function/*  ┘
+        │             → resolveInvocation (validate policy)
+        │             → initFreshExecCtx(execCtx, { …, policy }):
+        │                 installRunPolicyHandler(execCtx, policy)  [outermost]
+        │             → run; agent handlers sit inside; chain merge: reject > propagate > approve
+        │             → unsettled interrupts surface to host as today
+        │
+        └─ /resume  → resolveInvocation (validate policy)
+                      → installRunPolicyHandler(execCtx, policy)   [outermost, again]
+                      → setInterruptResponses(caller responses, unchanged)
+                      → resume loop; interrupts RAISED during resume go through
+                        the root handler as on a fresh run; already-surfaced
+                        interrupts resolve by their caller response (decided on
+                        their original raise — see §3)
+```
+
+Note what the resume branch does NOT do: it does not re-evaluate the policy
+against the caller's responses. Enforcement happened on the raise (§2/§3).
+
+## Testing
+
+Unit (`lib/runtime`):
+
+- `invocationOptions.test.ts`: `policy` passes through `resolveInvocation`
+  for fresh and resume; an invalid policy throws a plain `Error` prefixed
+  "invalid invocation policy" naming the schema problem (a class would have
+  no consumer — the adapter maps every throw to the same generic message);
+  no policy → `undefined`.
+- `runPolicyHandler.test.ts`: an explicit policy installs the handler; the
+  explicit-vs-env precedence test uses **disagreeing** policies — env set to
+  reject an effect, explicit policy set to approve it, and the handler must
+  return approve (a test where both agree would pass even if the env leaked
+  through); IPC mode still skips.
+- resume-leg raise (in the agency-js fixture, not `interrupts.test.ts`, which
+  tests leaf functions with stubs): installing the root handler on the resume
+  exec context governs an interrupt **raised during** the resume leg (a fresh
+  raise on a resumed run) — a policy `reject` there settles the raise, so an
+  `env` read comes back `null` instead of surfacing; and the
+  no-policy resume path is byte-identical to today (caller responses untouched,
+  `resolvedBy: "user"`).
+
+Integration: a new agency-js fixture, `tests/agency-js/serve-policy/`, that
+compiles a real module and drives its serve entry points
+(`__invokeNodeForServe`, `__invokeFunctionForServe`,
+`__respondToInterruptsForServe`) with `InvocationOptions`. (The plan first
+pointed at `adapter.perInvocation.test.ts`, but that file is spies only — no
+serve test compiles a module; see the plan's Facts.) One behavioural note the
+cases below depend on: `env()` absorbs its own denial and returns `null`
+(`stdlib/system.agency`), so a policy reject on `std::env` never fails the
+run — the refused variable reads as unset, which is what a host wants.
+
+- agent calls `env("A")` with no handler; policy `{"std::env": [{match:{name:"A"}, action:"approve"}, {action:"reject"}]}`
+  → returns the value; `env("B")` → returns `null`, no interrupt surfaced.
+- **(security-critical — do not fold into the `env("B")` case in a shrink
+  pass)** agent wraps `env("B")` in an approving handler
+  (`handle { … } with approve`); same policy → still `null`, not the value.
+  This is the one test that proves a host `reject` beats the agent's own
+  approving handler; `env("B")` with no handler proves nothing about
+  precedence because there is no inner handler to beat.
+- the approving-handler node under a policy with an explicit `propagate` rule
+  → the interrupt surfaces anyway (a propagate verdict beats an approve in
+  the chain; the host's "always ask me" works even over an auto-approving
+  agent).
+- a served function (not just a node) with the same `env` policy, proving the
+  shared `initFreshExecCtx` install covers served functions too.
+- `traceId`/`config` behaviour unchanged when `policy` is present.
+
+Docs (see Rollout for who owns which): a "Serve hosts" section for the
+policies guide, and a note that `CreateServeHandler`'s fourth argument carries
+`policy`; a dev note under `docs/dev/hosting/how-hosted-serving-works.md`
+covering the root policy and the resume-integrity gap.
+
+## Rollout
+
+Single PR in agency-lang, no migration, no CLI change. Existing hosts that
+pass no `policy` are unaffected. The host's companion PR (a separate repo)
+then passes a per-project policy; once this agency-lang change is released,
+the host's own `projectSecretsEndToEnd` CI test goes green again via a
+`std::env` approve rule rather than any host-side auto-approval.
+
+`docs/site/guide/policies.md` is a hand-written, owner-owned page. The
+implementer does NOT edit it; the needed "Serve hosts" additions are listed
+in the PR description for the owner. The dev note
+(`docs/dev/hosting/how-hosted-serving-works.md`) and its
+`docs/dev/runtime/interrupts.md` cross-reference are the implementer's to
+write. While there, correct `how-hosted-serving-works.md` where it says the
+caller sends the interrupt objects back "unchanged": the runtime does not
+verify that (see §3, the resume-integrity gap).

--- a/packages/agency-lang/lib/runtime/interrupts.ts
+++ b/packages/agency-lang/lib/runtime/interrupts.ts
@@ -799,12 +799,10 @@ async function respondToInterruptsCore(
   let outcome: RawOutcome<RunNodeResult<any>>;
   try {
     // Re-install the root policy handler on the resumed exec context
-    // (handlers are never checkpointed): the caller's per-invocation policy
-    // when one was resolved, else the AGENCY_RUN_POLICY environment policy.
-    // Mirrors the runNode install, so a raise made DURING this resume leg is
-    // decided by the same root policy as on a fresh run. It does not touch
-    // the caller's answers to already-surfaced interrupts — those were
-    // decided on their original raise.
+    // (handlers are never checkpointed): the invocation's policy when one
+    // was resolved, else the AGENCY_RUN_POLICY environment policy. Mirrors
+    // the runNode install, so a raise made DURING this resume leg is decided
+    // by the same root policy as on a fresh run.
     installRunPolicyHandler(execCtx, resolved.policy);
     // A cross-process resume starts with an empty provider registry (registration
     // is process-global, not part of serialized checkpoint state), so re-register

--- a/packages/agency-lang/lib/runtime/interrupts.ts
+++ b/packages/agency-lang/lib/runtime/interrupts.ts
@@ -798,11 +798,14 @@ async function respondToInterruptsCore(
   let agentRunSpanId: ReturnType<typeof execCtx.statelogClient.startSpan> | undefined;
   let outcome: RawOutcome<RunNodeResult<any>>;
   try {
-    // Re-install the CLI-driven root policy handler on the resumed exec context
-    // (handlers are never checkpointed). Guarded no-op unless AGENCY_RUN_POLICY
-    // is set and this is the root process. Mirrors the runNode install so the
-    // policy survives a resumed leg.
-    installRunPolicyHandler(execCtx);
+    // Re-install the root policy handler on the resumed exec context
+    // (handlers are never checkpointed): the caller's per-invocation policy
+    // when one was resolved, else the AGENCY_RUN_POLICY environment policy.
+    // Mirrors the runNode install, so a raise made DURING this resume leg is
+    // decided by the same root policy as on a fresh run. It does not touch
+    // the caller's answers to already-surfaced interrupts — those were
+    // decided on their original raise.
+    installRunPolicyHandler(execCtx, resolved.policy);
     // A cross-process resume starts with an empty provider registry (registration
     // is process-global, not part of serialized checkpoint state), so re-register
     // before resuming. Idempotent in-process via loadProviderModules' guard.

--- a/packages/agency-lang/lib/runtime/invocationOptions.test.ts
+++ b/packages/agency-lang/lib/runtime/invocationOptions.test.ts
@@ -127,3 +127,34 @@ describe("resolveInvocation — config projection", () => {
     expect(resolved.contextOverride).toBeUndefined();
   });
 });
+
+describe("resolveInvocation — policy", () => {
+  const policy = { "std::env": [{ match: { name: "A" }, action: "approve" as const }] };
+
+  it("puts a valid policy on the resolved invocation for a fresh run", () => {
+    const resolved = resolveInvocation({ kind: "fresh", options: { policy } });
+    expect(resolved.policy).toBe(policy);
+  });
+
+  it("puts a valid policy on the resolved invocation for a resume", () => {
+    const resolved = resolveInvocation({ kind: "resume", runId: "run", options: { policy } });
+    expect(resolved.policy).toBe(policy);
+  });
+
+  it("resolves to no policy when none was supplied", () => {
+    expect(resolveInvocation({ kind: "fresh" }).policy).toBeUndefined();
+    expect(resolveInvocation({ kind: "resume", runId: "run" }).policy).toBeUndefined();
+  });
+
+  it("throws a prefixed error naming the schema problem on an invalid policy", () => {
+    const invalid = { "std::env": [{ action: "allow" }] } as never;
+    for (const request of [
+      { kind: "fresh" as const, options: { policy: invalid } },
+      { kind: "resume" as const, runId: "run", options: { policy: invalid } },
+    ]) {
+      expect(() => resolveInvocation(request)).toThrow(/^invalid invocation policy: /);
+      // The message names the schema problem, so a host log is actionable.
+      expect(() => resolveInvocation(request)).toThrow(/action/);
+    }
+  });
+});

--- a/packages/agency-lang/lib/runtime/invocationOptions.ts
+++ b/packages/agency-lang/lib/runtime/invocationOptions.ts
@@ -1,5 +1,7 @@
 import { nanoid } from "nanoid";
 import type { AgencyConfig } from "../config.js";
+import { validatePolicy } from "./policy.js";
+import type { Policy } from "./policy.js";
 
 /**
  * Per-invocation overrides a caller may attach to a single node, served
@@ -13,6 +15,12 @@ import type { AgencyConfig } from "../config.js";
 export type InvocationOptions = {
   config?: Partial<AgencyConfig>;
   traceId?: string;
+  /** Root interrupt policy for this invocation, installed as the outermost
+   *  handler on the fresh run and re-installed on every resume leg. A
+   *  `reject` here beats any approval from the program's own handlers
+   *  (chain precedence: reject > propagate > approve). Replaces — does not
+   *  merge with — an `AGENCY_RUN_POLICY` environment policy for this run. */
+  policy?: Policy;
 };
 
 /**
@@ -67,6 +75,8 @@ export type PerInvocationContextOverride = {
 export type ResolvedInvocation = {
   runId: string;
   contextOverride?: PerInvocationContextOverride;
+  /** The validated root policy for this invocation, when the caller sent one. */
+  policy?: Policy;
 };
 
 /**
@@ -163,9 +173,10 @@ function selectLogConfig(log: AgencyConfig["log"] | undefined): PerInvocationLog
  */
 export function resolveInvocation(request: InvocationRequest): ResolvedInvocation {
   const contextOverride = selectContextOverride(request.options?.config);
+  const policy = validateInvocationPolicy(request.options?.policy);
 
   if (request.kind === "resume") {
-    return { runId: request.runId, contextOverride };
+    return { runId: request.runId, contextOverride, policy };
   }
 
   const runId =
@@ -176,7 +187,25 @@ export function resolveInvocation(request: InvocationRequest): ResolvedInvocatio
   if (runId.length === 0) {
     throw new Error("traceId must not be empty");
   }
-  return { runId, contextOverride };
+  return { runId, contextOverride, policy };
+}
+
+/**
+ * Validate a caller-supplied root policy. An invalid one is a host bug, so it
+ * throws — before any execution context exists. The serve adapter logs the
+ * message host-side and returns its generic error to the caller. A plain
+ * `Error` with a fixed prefix, matching the env channel's identical failure
+ * (`loadEnvPolicy`); nothing catches this by type.
+ */
+function validateInvocationPolicy(policy: Policy | undefined): Policy | undefined {
+  if (policy === undefined) {
+    return undefined;
+  }
+  const valid = validatePolicy(policy);
+  if (!valid.success) {
+    throw new Error(`invalid invocation policy: ${valid.error}`);
+  }
+  return policy;
 }
 
 function emptyToUndefined(value: string | undefined): string | undefined {

--- a/packages/agency-lang/lib/runtime/invocationOptions.ts
+++ b/packages/agency-lang/lib/runtime/invocationOptions.ts
@@ -19,7 +19,11 @@ export type InvocationOptions = {
    *  handler on the fresh run and re-installed on every resume leg. A
    *  `reject` here beats any approval from the program's own handlers
    *  (chain precedence: reject > propagate > approve). Replaces — does not
-   *  merge with — an `AGENCY_RUN_POLICY` environment policy for this run. */
+   *  merge with — an `AGENCY_RUN_POLICY` environment policy for this run.
+   *  That makes an explicit empty policy `{}` a no-op that still disables
+   *  the environment policy: it has no rules, so the installed handler
+   *  abstains on every effect. To restrict everything, say so:
+   *  `{ "*": [{ action: "reject" }] }`. */
   policy?: Policy;
 };
 
@@ -191,11 +195,9 @@ export function resolveInvocation(request: InvocationRequest): ResolvedInvocatio
 }
 
 /**
- * Validate a caller-supplied root policy. An invalid one is a host bug, so it
- * throws — before any execution context exists. The serve adapter logs the
- * message host-side and returns its generic error to the caller. A plain
- * `Error` with a fixed prefix, matching the env channel's identical failure
- * (`loadEnvPolicy`); nothing catches this by type.
+ * Validate a caller-supplied root policy. An invalid one is a host bug, so
+ * it throws before any execution context exists; the serve adapter logs the
+ * message and returns its generic error to the caller.
  */
 function validateInvocationPolicy(policy: Policy | undefined): Policy | undefined {
   if (policy === undefined) {

--- a/packages/agency-lang/lib/runtime/node.ts
+++ b/packages/agency-lang/lib/runtime/node.ts
@@ -128,9 +128,7 @@ async function initFreshExecCtx(
   execCtx: RuntimeContext<GraphState>,
   opts: {
     initializeGlobals?: (ctx: RuntimeContext<GraphState>) => void | Promise<void>;
-    // The invocation's root policy (ResolvedInvocation.policy). A narrow
-    // field on purpose: the bootstrap needs exactly this one value, not the
-    // rest of the resolved invocation.
+    // The invocation's root policy (ResolvedInvocation.policy).
     policy?: Policy;
   },
 ): Promise<void> {

--- a/packages/agency-lang/lib/runtime/node.ts
+++ b/packages/agency-lang/lib/runtime/node.ts
@@ -17,6 +17,7 @@ import { getSubprocessRunInfo } from "./subprocessRunInfo.js";
 import { TRACE_ID_ENV } from "../config.js";
 import { resolveInvocation, type InvocationOptions } from "./invocationOptions.js";
 import { installRunPolicyHandler } from "./runPolicyHandler.js";
+import type { Policy } from "./policy.js";
 import { installRootBudget } from "./rootBudget.js";
 import { GraphState, RunNodeResult } from "./types.js";
 import { createReturnObject } from "./utils.js";
@@ -127,6 +128,10 @@ async function initFreshExecCtx(
   execCtx: RuntimeContext<GraphState>,
   opts: {
     initializeGlobals?: (ctx: RuntimeContext<GraphState>) => void | Promise<void>;
+    // The invocation's root policy (ResolvedInvocation.policy). A narrow
+    // field on purpose: the bootstrap needs exactly this one value, not the
+    // rest of the resolved invocation.
+    policy?: Policy;
   },
 ): Promise<void> {
   const { initializeGlobals } = opts;
@@ -199,7 +204,7 @@ async function initFreshExecCtx(
   // functions) inherit them. (Global-init and top-level-callback code above
   // runs before these exist; that's unchanged — runNode installed them here
   // too, just after initFreshExecCtx returned.)
-  installRunPolicyHandler(execCtx);
+  installRunPolicyHandler(execCtx, opts.policy);
   installRootBudget(execCtx.stateStack, execCtx.budget);
 }
 
@@ -295,7 +300,7 @@ async function runExportedFunctionCore({
   const execCtx = await ctx.createExecutionContext(resolved);
   let outcome: RawOutcome<unknown>;
   try {
-    await initFreshExecCtx(execCtx, { initializeGlobals });
+    await initFreshExecCtx(execCtx, { initializeGlobals, policy: resolved.policy });
     const threadStore = ThreadStore.withDefaultActive(execCtx.statelogClient);
     const value = await agencyStore.run(
       {
@@ -410,7 +415,7 @@ async function runNodeCore({
     // initFreshExecCtx (see there for the full ordering rationale, e.g. the
     // `node main() { route({ systemPrompt: foreignStatic }) }` foreign-static
     // case), so nodes and served functions are bootstrapped and capped identically.
-    await initFreshExecCtx(execCtx, { initializeGlobals });
+    await initFreshExecCtx(execCtx, { initializeGlobals, policy: resolved.policy });
     // Externally-passed callbacks are stored on ctx; hook execution merges them
     // with scoped/top-level callbacks at call time.
     if (callbacks) {

--- a/packages/agency-lang/lib/runtime/runPolicyHandler.test.ts
+++ b/packages/agency-lang/lib/runtime/runPolicyHandler.test.ts
@@ -222,3 +222,61 @@ describe("installRunPolicyHandler", () => {
     });
   });
 });
+
+describe("installRunPolicyHandler with an explicit policy", () => {
+  const grab = () => {
+    const pushed: unknown[] = [];
+    return { pushed, execCtx: { pushHandler: (h: unknown) => pushed.push(h) } };
+  };
+
+  it("installs the explicit policy with no env policy set", async () => {
+    await withEnv({ [AGENCY_RUN_POLICY]: undefined, AGENCY_IPC: undefined }, () => {
+      const { pushed, execCtx } = grab();
+      installRunPolicyHandler(execCtx, { "std::read": [{ action: "approve" }] });
+      expect(pushed).toHaveLength(1);
+    });
+  });
+
+  it("an explicit policy replaces a DISAGREEING env policy (env is not merged in)", async () => {
+    // The env policy rejects std::read; the explicit policy approves it. The
+    // installed handler must approve — this fails if the env policy leaks
+    // through. (Two agreeing policies would pass either way.)
+    const envRejectsRead = JSON.stringify({ "std::read": [{ action: "reject" }] });
+    await withEnv({ [AGENCY_RUN_POLICY]: envRejectsRead, AGENCY_IPC: undefined }, async () => {
+      const { pushed, execCtx } = grab();
+      installRunPolicyHandler(execCtx, { "std::read": [{ action: "approve" }] });
+      expect(pushed).toHaveLength(1);
+      const handler = pushed[0] as (i: unknown) => Promise<{ type: string } | undefined>;
+      const verdict = await handler(intr("std::read"));
+      expect(verdict?.type).toBe("approve");
+    });
+  });
+
+  it("falls back to the env policy when no explicit policy is passed", async () => {
+    const envRejectsRead = JSON.stringify({ "std::read": [{ action: "reject" }] });
+    await withEnv({ [AGENCY_RUN_POLICY]: envRejectsRead, AGENCY_IPC: undefined }, async () => {
+      const { pushed, execCtx } = grab();
+      installRunPolicyHandler(execCtx, undefined);
+      expect(pushed).toHaveLength(1);
+      const handler = pushed[0] as (i: unknown) => Promise<{ type: string } | undefined>;
+      const verdict = await handler(intr("std::read"));
+      expect(verdict?.type).toBe("reject");
+    });
+  });
+
+  it("is still a no-op in an IPC subprocess, explicit policy or not", async () => {
+    await withEnv({ [AGENCY_RUN_POLICY]: undefined, AGENCY_IPC: "1" }, () => {
+      const { pushed, execCtx } = grab();
+      installRunPolicyHandler(execCtx, { "std::read": [{ action: "approve" }] });
+      expect(pushed).toHaveLength(0);
+    });
+  });
+
+  it("stays a no-op with no explicit policy and no env policy (the pin)", async () => {
+    await withEnv({ [AGENCY_RUN_POLICY]: undefined, AGENCY_IPC: undefined }, () => {
+      const { pushed, execCtx } = grab();
+      installRunPolicyHandler(execCtx, undefined);
+      expect(pushed).toHaveLength(0);
+    });
+  });
+});

--- a/packages/agency-lang/lib/runtime/runPolicyHandler.ts
+++ b/packages/agency-lang/lib/runtime/runPolicyHandler.ts
@@ -63,10 +63,10 @@ export function hasRunPolicyMechanism(): boolean {
 }
 
 // Install the root policy handler on `execCtx` when the run carries a
-// policy: an explicit one (a serve host's `InvocationOptions.policy`,
+// policy: the explicit one (a serve host's `InvocationOptions.policy`,
 // validated by resolveInvocation) or, when none was passed, the
 // AGENCY_RUN_POLICY environment policy the CLI flags set. An explicit
-// policy replaces the env policy for the run; it never merges with it.
+// policy replaces the env policy for the run.
 // Skipped in IPC subprocesses: a std::agency::run child forwards its
 // interrupts up to the root process's handler chain, so the policy must
 // live at the root only. Called from BOTH the fresh-run entry (runNode)

--- a/packages/agency-lang/lib/runtime/runPolicyHandler.ts
+++ b/packages/agency-lang/lib/runtime/runPolicyHandler.ts
@@ -62,23 +62,30 @@ export function hasRunPolicyMechanism(): boolean {
   return loadEnvPolicy() !== null;
 }
 
-// Install the root policy handler on `execCtx` when the run was launched
-// with a policy. Skipped in IPC subprocesses: a std::agency::run child
-// forwards its interrupts up to the root process's handler chain, so the
-// policy must live at the root only. Called from BOTH the fresh-run entry
-// (runNode) and the resume entry (respondToInterrupts) so the never-
-// serialized root handler is re-installed on a resumed leg too.
-export function installRunPolicyHandler(execCtx: {
-  pushHandler: (h: HandlerFn, liveGuardIds: string[]) => void;
-}): void {
+// Install the root policy handler on `execCtx` when the run carries a
+// policy: an explicit one (a serve host's `InvocationOptions.policy`,
+// validated by resolveInvocation) or, when none was passed, the
+// AGENCY_RUN_POLICY environment policy the CLI flags set. An explicit
+// policy replaces the env policy for the run; it never merges with it.
+// Skipped in IPC subprocesses: a std::agency::run child forwards its
+// interrupts up to the root process's handler chain, so the policy must
+// live at the root only. Called from BOTH the fresh-run entry (runNode)
+// and the resume entry (respondToInterrupts) so the never-serialized root
+// handler is re-installed on a resumed leg too.
+export function installRunPolicyHandler(
+  execCtx: {
+    pushHandler: (h: HandlerFn, liveGuardIds: string[]) => void;
+  },
+  policy?: Policy,
+): void {
   if (isIpcMode()) return;
-  const policy = loadEnvPolicy();
-  if (!policy) return;
+  const effective = policy ?? loadEnvPolicy();
+  if (!effective) return;
   // liveGuardIds: [] — explicit: the --policy handler registers at run
   // start, before any guard exists, and it is the outermost supervisory
   // layer; a policy answering an interrupt is never metered or gated by
   // user guards.
-  execCtx.pushHandler(makeRunPolicyHandler(policy), []);
+  execCtx.pushHandler(makeRunPolicyHandler(effective), []);
 }
 
 // The CLI-driven run's user endpoint (`resolveCliInterrupts`) lives in

--- a/packages/agency-lang/lib/serve/http/adapter.perInvocation.test.ts
+++ b/packages/agency-lang/lib/serve/http/adapter.perInvocation.test.ts
@@ -86,6 +86,18 @@ describe("serve adapter forwards InvocationOptions unchanged", () => {
     await handler("POST", "/resume", validResumeBody(), invocation);
     expect((resumeSpy.mock.calls[0] as unknown[])[2]).toBe(invocation);
   });
+
+  it("a policy rides along untouched next to traceId/config", async () => {
+    // The adapter never reads or rewrites the policy; enforcement lives in
+    // the runtime (tests/agency-js/serve-policy covers it end to end).
+    const { handler, nodeSpy } = makeHandler();
+    const invocation: InvocationOptions = {
+      traceId: "abc",
+      policy: { "std::env": [{ action: "reject" }] },
+    };
+    await handler("POST", "/node/main", {}, invocation);
+    expect((nodeSpy.mock.calls[0] as unknown[])[1]).toBe(invocation);
+  });
 });
 
 describe("RouteResult.traceId presence", () => {

--- a/packages/agency-lang/tests/agency-js/serve-policy/agent.agency
+++ b/packages/agency-lang/tests/agency-js/serve-policy/agent.agency
@@ -1,0 +1,37 @@
+// Fixtures for the serve-host root policy (InvocationOptions.policy). Each
+// node reads environment variables the test sets; a policy decides the
+// std::env raises at the raise. Note env() absorbs a denial: a rejected read
+// returns null, it does not fail the run.
+import { env } from "std::system"
+
+// Bare read: nothing here settles the std::env raise, so without a policy it
+// surfaces; with one, the policy decides it.
+export node readVar(name: string) {
+  return env(name)
+}
+
+// The program tries to auto-approve its own env read. A host policy reject
+// must win anyway (chain precedence: reject > propagate > approve), and a
+// host policy propagate must surface the interrupt anyway.
+export node readVarApproved(name: string) {
+  handle {
+    return env(name)
+  } with approve
+}
+
+// Two reads in sequence. The first surfaces (the test's policy has no rule
+// for it); the second is raised DURING the resume leg, so it is decided by
+// the root policy re-installed on the resumed execution context.
+export node twoReads() {
+  const first = env("SERVE_POLICY_A")
+  const second = env("SERVE_POLICY_B")
+  return { first: first, second: second }
+}
+
+export def readVarFn(name: string): string | null {
+  """
+  Read one environment variable. Exists to prove served functions get the
+  root policy from the same bootstrap served nodes use.
+  """
+  return env(name)
+}

--- a/packages/agency-lang/tests/agency-js/serve-policy/agent.agency
+++ b/packages/agency-lang/tests/agency-js/serve-policy/agent.agency
@@ -3,6 +3,7 @@
 // std::env raises at the raise. Note env() absorbs a denial: a rejected read
 // returns null, it does not fail the run.
 import { env } from "std::system"
+import { runFile } from "std::agency"
 
 // Bare read: nothing here settles the std::env raise, so without a policy it
 // surfaces; with one, the policy decides it.
@@ -26,6 +27,18 @@ export node twoReads() {
   const first = env("SERVE_POLICY_A")
   const second = env("SERVE_POLICY_B")
   return { first: first, second: second }
+}
+
+// A subprocess read: the std::agency.run child has no policy of its own
+// (IPC mode); its std::env raise forwards to this process's handler chain,
+// where the host policy decides it. A regression in that forwarding would
+// let hosted code read the host's env through a subprocess.
+export node subprocessRead() {
+  const r = runFile(".", "child.agency", "main", {})
+  if (r is failure(err)) {
+    return "run failed: ${err}"
+  }
+  return r
 }
 
 export def readVarFn(name: string): string | null {

--- a/packages/agency-lang/tests/agency-js/serve-policy/child.agency
+++ b/packages/agency-lang/tests/agency-js/serve-policy/child.agency
@@ -1,0 +1,7 @@
+// Run by subprocessRead in agent.agency via runFile. The child installs no
+// policy (IPC mode); its std::env raise forwards to the parent's chain.
+import { env } from "std::system"
+
+export node main() {
+  return env("SERVE_POLICY_SECRET")
+}

--- a/packages/agency-lang/tests/agency-js/serve-policy/fixture.json
+++ b/packages/agency-lang/tests/agency-js/serve-policy/fixture.json
@@ -1,0 +1,22 @@
+{
+  "approved": "value-a",
+  "rejected": null,
+  "rejectedOverApprove": null,
+  "propagatedSurfaced": true,
+  "fnApproved": {
+    "status": "returned",
+    "value": "value-a"
+  },
+  "fnRejected": {
+    "status": "returned",
+    "value": null
+  },
+  "resumeLeg": {
+    "status": "returned",
+    "value": {
+      "first": "value-a",
+      "second": null
+    }
+  },
+  "controlSecondSurfaced": true
+}

--- a/packages/agency-lang/tests/agency-js/serve-policy/fixture.json
+++ b/packages/agency-lang/tests/agency-js/serve-policy/fixture.json
@@ -18,5 +18,9 @@
       "second": null
     }
   },
-  "controlSecondSurfaced": true
+  "controlSecondSurfaced": true,
+  "subprocessRead": {
+    "success": true,
+    "data": null
+  }
 }

--- a/packages/agency-lang/tests/agency-js/serve-policy/test.js
+++ b/packages/agency-lang/tests/agency-js/serve-policy/test.js
@@ -1,0 +1,118 @@
+// End-to-end for the serve-host root policy: a compiled module driven through
+// the serve entry points (__invokeNodeForServe / __invokeFunctionForServe /
+// __respondToInterruptsForServe) with InvocationOptions.policy. env() absorbs
+// a denial, so a policy reject shows up as null, never as a failed run.
+import {
+  readVarFn,
+  hasInterrupts,
+  approve,
+  __invokeNodeForServe,
+  __invokeFunctionForServe,
+  __respondToInterruptsForServe,
+} from "./agent.js";
+import { writeFileSync } from "fs";
+
+process.env.SERVE_POLICY_A = "value-a";
+process.env.SERVE_POLICY_B = "value-b";
+process.env.SERVE_POLICY_SECRET = "the-secret";
+
+// Approve reads of SERVE_POLICY_A by name; reject every other env read.
+const approveAOnly = {
+  "std::env": [{ match: { name: "SERVE_POLICY_A" }, action: "approve" }, { action: "reject" }],
+};
+
+function nodeData(outcome) {
+  if (outcome.status !== "returned") {
+    throw new Error(`expected a returned outcome, got: ${JSON.stringify(outcome.status)}`);
+  }
+  return outcome.value.data;
+}
+
+// 1. Policy approve: the read happens, nothing surfaces.
+const approved = nodeData(
+  await __invokeNodeForServe("readVar", { name: "SERVE_POLICY_A" }, { policy: approveAOnly }),
+);
+
+// 2. Policy reject: env() absorbs the denial; the variable reads as unset.
+const rejected = nodeData(
+  await __invokeNodeForServe("readVar", { name: "SERVE_POLICY_SECRET" }, { policy: approveAOnly }),
+);
+
+// 3. SECURITY-CRITICAL (do not fold into case 2): the program auto-approves
+// its own read, and the host policy reject must still win. Case 2 proves
+// nothing about precedence — there is no inner handler to beat.
+const rejectedOverApprove = nodeData(
+  await __invokeNodeForServe(
+    "readVarApproved",
+    { name: "SERVE_POLICY_SECRET" },
+    { policy: approveAOnly },
+  ),
+);
+
+// 4. A policy propagate rule surfaces the interrupt even over the program's
+// own approving handler: the host's "always ask me".
+const propagatePolicy = { "std::env": [{ action: "propagate" }] };
+const propagated = nodeData(
+  await __invokeNodeForServe(
+    "readVarApproved",
+    { name: "SERVE_POLICY_A" },
+    { policy: propagatePolicy },
+  ),
+);
+
+// 5. A served FUNCTION is governed by the same bootstrap install.
+const fnApproved = await __invokeFunctionForServe(
+  readVarFn,
+  { name: "SERVE_POLICY_A" },
+  { policy: approveAOnly },
+);
+const fnRejected = await __invokeFunctionForServe(
+  readVarFn,
+  { name: "SERVE_POLICY_SECRET" },
+  { policy: approveAOnly },
+);
+
+// 6. A raise made DURING a resume leg hits the re-installed root policy.
+// The policy has no rule for the first read, so it surfaces; the caller
+// approves it; the second read is then rejected at its raise and reads null.
+const rejectBOnly = {
+  "std::env": [{ match: { name: "SERVE_POLICY_B" }, action: "reject" }],
+};
+const paused = nodeData(await __invokeNodeForServe("twoReads", {}, { policy: rejectBOnly }));
+if (!hasInterrupts(paused)) {
+  throw new Error("expected the first read of twoReads to surface");
+}
+const resumed = await __respondToInterruptsForServe(paused, [approve()], {
+  invocation: { policy: rejectBOnly },
+});
+
+// 6b. Control: with no policy on either leg, the second read surfaces as a
+// second interrupt instead of reading null — proving 6's null came from the
+// re-installed policy, not from the effect itself.
+const controlPaused = nodeData(await __invokeNodeForServe("twoReads", {}, undefined));
+if (!hasInterrupts(controlPaused)) {
+  throw new Error("expected the first read of the control twoReads to surface");
+}
+const controlResumed = await __respondToInterruptsForServe(controlPaused, [approve()], {});
+const controlSecondSurfaced = hasInterrupts(controlResumed.value.data);
+
+writeFileSync(
+  "__result.json",
+  JSON.stringify(
+    {
+      approved,
+      rejected,
+      rejectedOverApprove,
+      propagatedSurfaced: hasInterrupts(propagated),
+      fnApproved: { status: fnApproved.status, value: fnApproved.value },
+      fnRejected: { status: fnRejected.status, value: fnRejected.value },
+      resumeLeg: {
+        status: resumed.status,
+        value: nodeData(resumed),
+      },
+      controlSecondSurfaced,
+    },
+    null,
+    2,
+  ),
+);

--- a/packages/agency-lang/tests/agency-js/serve-policy/test.js
+++ b/packages/agency-lang/tests/agency-js/serve-policy/test.js
@@ -96,6 +96,22 @@ if (!hasInterrupts(controlPaused)) {
 const controlResumed = await __respondToInterruptsForServe(controlPaused, [approve()], {});
 const controlSecondSurfaced = hasInterrupts(controlResumed.value.data);
 
+// 7. A subprocess read is governed by the same policy: the child's raise
+// forwards over IPC to this process's chain, where the host reject beats the
+// child-side silence. std::run must be approved so runFile itself proceeds.
+const subprocessPolicy = {
+  "std::run": [{ action: "approve" }],
+  "std::env": [{ action: "reject" }],
+};
+const subprocessResult = nodeData(
+  await __invokeNodeForServe("subprocessRead", {}, { policy: subprocessPolicy }),
+);
+// The Result carries token/message bookkeeping; only the read matters here.
+const subprocessRead = {
+  success: subprocessResult.success === true,
+  data: subprocessResult.value ? subprocessResult.value.data : subprocessResult,
+};
+
 writeFileSync(
   "__result.json",
   JSON.stringify(
@@ -111,6 +127,7 @@ writeFileSync(
         value: nodeData(resumed),
       },
       controlSecondSurfaced,
+      subprocessRead,
     },
     null,
     2,


### PR DESCRIPTION
## What

A serve host can attach a root interrupt policy to any invocation:

```ts
handler("POST", "/node/main", body, {
  policy: { "std::env": [{ match: { name: "MY_SECRET" }, action: "approve" }, { action: "reject" }] },
});
```

`resolveInvocation` validates it (invalid shape = a plain prefixed `Error` before any execution context; the adapter logs it and returns its generic error), and the runtime installs it as the **outermost handler** — in `initFreshExecCtx`, so one change covers `/node/*` and `/function`, and again in `respondToInterruptsCore`, so a raise made during a resume leg is governed too. An explicit policy replaces `AGENCY_RUN_POLICY` for the run. The resume answer path is untouched: decisions happen at the raise (see the CLAUDE.md interrupt-model section); caller responses still resolve by id.

Spec, plan, and reviews land under `docs/superpowers/` (the spec was revised twice; the earlier resume-response-rewrite design was cut as wrong).

## Why

Since 0.17.0, `env()` raises `std::env`, so a hosted agent reading an env variable surfaces an interrupt statelog cannot answer — and an agent could wrap the read in `handle { … } with approve` and read the host's own variables. With this change, statelog passes a per-project policy ("approve `std::env` iff `name` is one of this project's secrets") and a host reject beats the agent's own handlers (chain precedence `reject > propagate > approve`).

## Tests

- `tests/agency-js/serve-policy` — end to end through a compiled module's serve entry points (no existing serve test compiles a module; the adapter test file is spies only). Cases: approve returns the value; reject reads as `null` (`env()` absorbs its own denial); **reject beats the program's own approving handler** (the security-critical case); a `propagate` rule surfaces the interrupt over the program's approve ("always ask me"); a served function is governed identically; a raise during a resume leg is rejected by the re-installed policy, with a no-policy control where it surfaces instead.
- Unit: policy round-trip and validation in `invocationOptions.test.ts`; explicit-vs-env precedence with **disagreeing** policies, env fallback, IPC gate, and the no-policy pin in `runPolicyHandler.test.ts`; a pass-through case in `adapter.perInvocation.test.ts`.
- Guards run: `pnpm run typecheck` (3 configs), `pnpm run fmt:ts`, `pnpm run lint:structure`, the 5 touched vitest files (112 tests), and the agency-js fixture through the real runner. Full agency suite left to CI.

## Docs

- `docs/dev/hosting/how-hosted-serving-works.md`: new "Root interrupt policy" section; the "sent back unchanged" line now points at the checkpoint-integrity caveat.
- `docs/dev/runtime/interrupts.md`: cross-reference at the handler-verdicts section.
- `docs/dev/security/roadmap.md`: B2 rewritten — the old "caller can approve their own read" framing was wrong (echoed interrupt data is display-only); raise-time policy is shipped, and the open resume-leg item is checkpoint integrity (signing or host-side storage + replay protection).

## For the owner (docs/site, not edited here)

`docs/site/guide/policies.md` could use a short "Serve hosts" section: policy via `InvocationOptions`, installed at the root per invocation, decides at the raise (a reject on `std::env` reads as unset), `propagate` = always-ask, and the resume answer path is not a policy seam.

## Behavioral note found while testing

A policy reject on `std::env` does **not** fail the run: `env()` absorbs its own denial and returns `null`, so a refused variable reads as unset (`stdlib/system.agency`). The spec and plan were corrected to say so; for statelog this is the desired shape — secrets outside the project look like they were never set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvXaShvdNDAwbePbicHwb1
