### PR TITLE
Effect patterns in match (#926, PR 2 of 3)

### DIFF
--- a/packages/agency-lang/.claude/skills/agency-language-docs/SKILL.md
+++ b/packages/agency-lang/.claude/skills/agency-language-docs/SKILL.md
@@ -9,6 +9,7 @@ Paths are relative to `packages/agency-lang/`. Read the one that matches the tas
 
 - `docs/dev/language/agency-function.md` — The wrapper codegen emits around every Agency `def`. Covers tool metadata, argument resolution, and block arguments.
 - `docs/dev/language/closures-and-lambdas.md` — Why Agency has blocks and first-class functions but no lambdas, and what makes adding them hard.
+- `docs/dev/language/effect-patterns.md` — Naming an interrupt effect in a `match` arm and destructuring its payload, how it lowers, and its limits.
 - `docs/dev/language/lambda-sketch.md` — A design sketch for lambdas. Nothing here is implemented.
 - `docs/dev/language/match-expression-positions.md` — Where a `match` may appear as a value, and why each such position has to be wired up by hand.
 - `docs/dev/language/null-and-undefined.md` — Why Agency has exactly one nothing-value, `null`, and treats `undefined` as another spelling of it.

--- a/packages/agency-lang/CLAUDE.md
+++ b/packages/agency-lang/CLAUDE.md
@@ -215,6 +215,7 @@ Other process docs:
 
 - `docs/dev/language/agency-function.md` — The wrapper codegen emits around every Agency `def`. Covers tool metadata, argument resolution, and block arguments.
 - `docs/dev/language/closures-and-lambdas.md` — Why Agency has blocks and first-class functions but no lambdas, and what makes adding them hard.
+- `docs/dev/language/effect-patterns.md` — Naming an interrupt effect in a `match` arm and destructuring its payload, how it lowers, and its limits.
 - `docs/dev/language/lambda-sketch.md` — A design sketch for lambdas. Nothing here is implemented.
 - `docs/dev/language/match-expression-positions.md` — Where a `match` may appear as a value, and why each such position has to be wired up by hand.
 - `docs/dev/language/null-and-undefined.md` — Why Agency has exactly one nothing-value, `null`, and treats `undefined` as another spelling of it.

--- a/packages/agency-lang/docs/dev/language/effect-patterns.md
+++ b/packages/agency-lang/docs/dev/language/effect-patterns.md
@@ -1,0 +1,104 @@
+# Effect patterns in `match`
+
+An effect pattern lets a `match` arm name an interrupt effect directly and
+optionally destructure its payload, instead of comparing `intr.effect` against
+a string by hand. Inside a handler:
+
+```
+handle {
+  a = act(dir: ".")
+} with (intr) {
+  return match (intr) {
+    app::write({ data }) if data.dir == "/tmp" => return approve()
+    app::write => return reject()
+    _ => return reject()
+  }
+}
+```
+
+Before this feature the same handler was written with `match(intr.effect)` and
+string arms, pulling the payload out by hand with `const data = intr.data`.
+
+## What it is
+
+An `effectPattern` is a new `MatchPattern` variant (`lib/types/pattern.ts`),
+modeled on `resultPattern` (`success(s)` / `failure(e)`). It has two forms:
+
+- `app::write` — matches any interrupt whose effect is `app::write`, binds
+  nothing.
+- `app::write({ data })` — the same match, plus an object-pattern binding over
+  the whole interrupt. `{ data }` binds `data = intr.data`.
+
+Match on the whole interrupt, written `match(intr)`. The older form matched on
+`intr.effect`; an effect pattern matches the interrupt itself so the binding can
+reach its other fields. Those fields are `effect`, `message`, `data`, and
+`origin`, so `app::write({ data })` binds the payload (which lives under
+`intr.data`), and a deep destructure like `app::write({ data: { dir } })` binds
+`dir = intr.data.dir`.
+
+Like `resultPattern`, an effect pattern lives only in `MatchPattern` — legal in
+a match arm and after `is` (`intr is app::write`, `if (intr is app::write({ data }))`),
+never in `let`/`const`/`for`. It is kept out of `BindingPattern`.
+
+## How it lowers
+
+The pattern lowers (`lib/lowering/patternLowering.ts`) to existing nodes — no
+new runtime helper. `app::write({ data })` becomes:
+
+1. a shape check on the scrutinee (`intr != null && intr is object`),
+2. an equality `intr.effect == "app::write"`, and
+3. the object binding's own checks and bindings against the same source.
+
+The shape check goes first so the `.effect` read is guarded: a null or
+non-object scrutinee fails the arm rather than throwing. This keeps the lowered
+condition a total function of the value, the invariant
+`patternGuards.tripwire.test.ts` enforces across the whole corpus.
+
+The binding is an ordinary `objectMatchPatternParser` object pattern, so it
+carries full object-pattern semantics: value matchers add checks
+(`app::write({ data: "x" })` also tests `intr.data == "x"`) and deep
+destructures work (`app::write({ data: { dir } })`).
+
+## The sites it touches
+
+Every place that switches on `resultPattern` gains a parallel `effectPattern`
+case. Grepping `effectPattern` across `lib/` is the checklist: the type and the
+`MatchPattern` union (`lib/types/pattern.ts`), the parser and its two wiring
+sites (`lib/parsers/parsers.ts` — `_matchPatternBase` and `_isRhsParser`, both
+before the binder / type parsers), lowering (`extractBindings`, `collectChecks`,
+`walkPattern`, the arm-value type list), the formatter
+(`lib/backends/agencyGenerator.ts`), and the per-node registries
+(`lib/utils/topLevel.ts`, `lib/utils/identifierSlots.ts`).
+
+## Limitations
+
+- **Only namespaced effect names.** The parser intercepts a `::`-containing
+  name (`namespaceIdentifier`). A bare `foo` in case position stays a
+  `variableName` binder, as before — a `::` name can never be a
+  variable, so there is no ambiguity. Effects are not required to be
+  namespaced, so a **bare-named effect** (`deploy`) has no effect-pattern
+  spelling. Handle it with `match(intr.effect)` and string arms. Do not reach
+  for a quoted `"deploy"` arm under `match(intr)`: that compares the whole
+  interrupt object to a string and never matches.
+
+- **Duplicate effect arms are first-wins**, like duplicate literal arms — the
+  first matching arm runs. The #926 `on`-clause handler alias instead rejects a
+  duplicate effect at parse time, because that alias is generated code where a
+  duplicate is almost certainly a bug. A `match` is ordinary code, where
+  first-wins is the language-wide rule.
+
+- **A non-interrupt scrutinee** (`match(5) { std::read => ... }`) surfaces as a
+  member-access diagnostic on the lowered `.effect` read — phrased on generated
+  code, so it names `.effect` rather than the arm the author wrote. This is the
+  same class of edge as the type-pattern edges, and a known v1 limitation.
+
+- **Open set: always needs `_`.** Effect names are open, so an effect pattern
+  never makes a match exhaustive. The exhaustiveness checker treats an
+  interrupt scrutinee as open/unsupported — it stays silent rather than guess a
+  missing case, and an effect-pattern arm never counts as a catch-all.
+
+## Not covered here
+
+This is the parser/lowering side. The user-facing guide page under
+`docs/site/guide/` is the owner's to write; nothing in this PR edits
+`docs/site/**`.

--- a/packages/agency-lang/docs/dev/language/effect-patterns.md
+++ b/packages/agency-lang/docs/dev/language/effect-patterns.md
@@ -92,10 +92,24 @@ before the binder / type parsers), lowering (`extractBindings`, `collectChecks`,
   code, so it names `.effect` rather than the arm the author wrote. This is the
   same class of edge as the type-pattern edges, and a known v1 limitation.
 
-- **Open set: always needs `_`.** Effect names are open, so an effect pattern
-  never makes a match exhaustive. The exhaustiveness checker treats an
-  interrupt scrutinee as open/unsupported — it stays silent rather than guess a
-  missing case, and an effect-pattern arm never counts as a catch-all.
+## Exhaustiveness
+
+An effect pattern pins the `effect` discriminant, so it behaves like the
+`{ effect: "app::read" }` object pattern it is sugar for
+(`matchExhaustiveness.ts`, `armDiscriminantValue`). What that means depends on
+the scrutinee's type:
+
+- Over a real inline handler param, which is re-typed to a discriminated union
+  keyed on `effect` (`handlerParamTyping.ts`), effect-pattern arms discriminate
+  the union: covering every effect makes the match exhaustive with no `_`, and
+  a missing effect is reported by name.
+- Over an open scrutinee (an `intr: any`, or a param the handler-typing pass
+  did not narrow), the match is open/unsupported territory — the checker stays
+  silent and requires nothing. Include a `_` there so an expression match does
+  not fall through to `undefined`.
+
+An effect-pattern arm never counts as a catch-all; only `_` and a bare binder
+do.
 
 ## Not covered here
 

--- a/packages/agency-lang/docs/dev/language/effect-patterns.md
+++ b/packages/agency-lang/docs/dev/language/effect-patterns.md
@@ -6,10 +6,10 @@ a string by hand. Inside a handler:
 
 ```
 handle {
-  a = act(dir: ".")
+  let a = act(dir: ".")
 } with (intr) {
   return match (intr) {
-    app::write({ data }) if data.dir == "/tmp" => return approve()
+    app::write({ data }) if (data.dir == "/tmp") => return approve()
     app::write => return reject()
     _ => return reject()
   }
@@ -47,7 +47,9 @@ new runtime helper. `app::write({ data })` becomes:
 
 1. a shape check on the scrutinee (`intr != null && intr is object`),
 2. an equality `intr.effect == "app::write"`, and
-3. the object binding's own checks and bindings against the same source.
+3. the object binding's per-property checks and bindings against the same
+   source (the shape check on the source is not repeated for the binding —
+   step 1 already emitted it).
 
 The shape check goes first so the `.effect` read is guarded: a null or
 non-object scrutinee fails the arm rather than throwing. This keeps the lowered
@@ -103,10 +105,15 @@ the scrutinee's type:
   keyed on `effect` (`handlerParamTyping.ts`), effect-pattern arms discriminate
   the union: covering every effect makes the match exhaustive with no `_`, and
   a missing effect is reported by name. A bound arm only covers its member when
-  the binding is irrefutable — bare (`app::read`) or pure binders
+  the binding is irrefutable — bare (`app::read`) or top-level pure binders
   (`app::read({ data })`). A value-matching binding
   (`app::read({ data: { path: "p" } })`) matches only some interrupts of that
-  effect, so it does not cover the member and a `_` is still required.
+  effect, so it does not cover the member and a `_` is still required. So does
+  a nested destructure (`app::read({ data: { dir } })`), even with only binders
+  inside: it lowers to a shape check on `intr.data` that a null or missing
+  payload fails at runtime. The object-pattern spelling follows the same rule —
+  `{ effect: "app::read", data: { path: "p" } }` pins the discriminant but does
+  not cover the member either.
 - Over an open scrutinee (an `intr: any`, or a param the handler-typing pass
   did not narrow), the match is open/unsupported territory — the checker stays
   silent and requires nothing. Include a `_` there so an expression match does

--- a/packages/agency-lang/docs/dev/language/effect-patterns.md
+++ b/packages/agency-lang/docs/dev/language/effect-patterns.md
@@ -102,7 +102,11 @@ the scrutinee's type:
 - Over a real inline handler param, which is re-typed to a discriminated union
   keyed on `effect` (`handlerParamTyping.ts`), effect-pattern arms discriminate
   the union: covering every effect makes the match exhaustive with no `_`, and
-  a missing effect is reported by name.
+  a missing effect is reported by name. A bound arm only covers its member when
+  the binding is irrefutable — bare (`app::read`) or pure binders
+  (`app::read({ data })`). A value-matching binding
+  (`app::read({ data: { path: "p" } })`) matches only some interrupts of that
+  effect, so it does not cover the member and a `_` is still required.
 - Over an open scrutinee (an `intr: any`, or a param the handler-typing pass
   did not narrow), the match is open/unsupported territory — the checker stays
   silent and requires nothing. Include a `_` there so an expression match does

--- a/packages/agency-lang/lib/backends/agencyGenerator.matchBlock.test.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.matchBlock.test.ts
@@ -194,3 +194,22 @@ def describe(value: any): string {
     expect(formatSource(src)).toContain("is string =>");
   });
 });
+
+describe("effect pattern formatting", () => {
+  it("round-trips bare and bound effect patterns", () => {
+    const src = `node main() {
+  match(intr) {
+    std::read => 1
+    std::write({ data }) => 2
+    _ => 0
+  }
+}
+`;
+    const first = formatSource(src)!;
+    // Idempotent: formatting the formatted output changes nothing.
+    expect(formatSource(first)).toBe(first);
+    // Both spellings survive: bare name and name with an object binding.
+    expect(first).toContain("std::read => 1");
+    expect(first).toContain("std::write({ data }) => 2");
+  });
+});

--- a/packages/agency-lang/lib/backends/agencyGenerator.matchBlock.test.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.matchBlock.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { formatSource } from "../formatter.js";
+import { parseAgency } from "../parser.js";
 
 describe("agencyGenerator - match block arm printing", () => {
   it.each([
@@ -211,5 +212,12 @@ describe("effect pattern formatting", () => {
     // Both spellings survive: bare name and name with an object binding.
     expect(first).toContain("std::read => 1");
     expect(first).toContain("std::write({ data }) => 2");
+    // Print -> reparse identity: the formatted output parses to the same AST as
+    // the source, so no arm silently changed shape on the way through.
+    const original = parseAgency(src, {}, false);
+    const reparsed = parseAgency(first, {}, false);
+    expect(original.success && reparsed.success).toBe(true);
+    if (!original.success || !reparsed.success) return;
+    expect(reparsed.result.nodes).toEqualWithoutLoc(original.result.nodes);
   });
 });

--- a/packages/agency-lang/lib/backends/agencyGenerator.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.ts
@@ -83,6 +83,7 @@ import { NewExpression } from "@/types/newExpression.js";
 import {
   ArrayPattern,
   BindingPattern,
+  EffectPattern,
   MatchPattern,
   ObjectPattern,
   ObjectPatternProperty,
@@ -589,6 +590,7 @@ export class AgencyGenerator {
       case "restPattern":
       case "wildcardPattern":
       case "resultPattern":
+      case "effectPattern":
         return this.formatPattern(node);
       case "isExpression":
         return `${this.processNode(node.expression).trim()} is ${this.formatIsRhs(node.pattern)}`;
@@ -1008,6 +1010,10 @@ export class AgencyGenerator {
       case "resultPattern": {
         const rp = pattern as ResultPattern;
         return rp.binding === null ? rp.kind : `${rp.kind}(${rp.binding})`;
+      }
+      case "effectPattern": {
+        const ep = pattern as EffectPattern;
+        return ep.binding === null ? ep.effect : `${ep.effect}(${this.formatPattern(ep.binding)})`;
       }
       case "typePattern": {
         // A test-only type pattern (no binder) has THREE spellings, one per

--- a/packages/agency-lang/lib/lowering/patternGuards.tripwire.test.ts
+++ b/packages/agency-lang/lib/lowering/patternGuards.tripwire.test.ts
@@ -51,6 +51,7 @@ const PATTERN_KINDS = [
   "wildcardPattern",
   "variableName",
   "resultPattern",
+  "effectPattern",
   "typePattern",
   "number",
   "unitLiteral",
@@ -75,6 +76,9 @@ void _kindListIsExhaustive;
 const KNOWN_UNCOVERED_KINDS: Record<string, string> = {
   unitLiteral: "no stdlib/fixture match arm matches on a unit literal (30s, $5)",
   multiLineString: 'no match arm matches on a """..."""  literal',
+  // Removed in the effect-pattern execution-test task, which adds a corpus
+  // program that matches on one (the staleness guard forces the deletion).
+  effectPattern: "no corpus match arm matches on an effect pattern yet",
 };
 
 // ---------------------------------------------------------------------------
@@ -346,6 +350,7 @@ const MUST_NOT_SURVIVE = [
   "objectPatternProperty",
   "objectPatternShorthand",
   "resultPattern",
+  "effectPattern",
   "typePattern",
   "isExpression",
 ];

--- a/packages/agency-lang/lib/lowering/patternGuards.tripwire.test.ts
+++ b/packages/agency-lang/lib/lowering/patternGuards.tripwire.test.ts
@@ -76,9 +76,6 @@ void _kindListIsExhaustive;
 const KNOWN_UNCOVERED_KINDS: Record<string, string> = {
   unitLiteral: "no stdlib/fixture match arm matches on a unit literal (30s, $5)",
   multiLineString: 'no match arm matches on a """..."""  literal',
-  // Removed in the effect-pattern execution-test task, which adds a corpus
-  // program that matches on one (the staleness guard forces the deletion).
-  effectPattern: "no corpus match arm matches on an effect pattern yet",
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/agency-lang/lib/lowering/patternLowering.test.ts
+++ b/packages/agency-lang/lib/lowering/patternLowering.test.ts
@@ -730,6 +730,78 @@ describe("result patterns", () => {
   });
 });
 
+describe("effect patterns", () => {
+  /** Every binOp in an expression tree, so a test can find the effect-equality
+   *  conjunct without depending on where it sits in the `&&` chain. */
+  function binOps(expr: unknown): BinOpExpression[] {
+    const out: BinOpExpression[] = [];
+    const visit = (v: unknown): void => {
+      if (!v || typeof v !== "object") return;
+      if (Array.isArray(v)) {
+        v.forEach(visit);
+        return;
+      }
+      const rec = v as Record<string, unknown>;
+      if (rec.type === "binOpExpression") out.push(rec as unknown as BinOpExpression);
+      for (const key of Object.keys(rec)) if (key !== "loc") visit(rec[key]);
+    };
+    visit(expr);
+    return out;
+  }
+
+  /** The `source.effect == "<effect>"` conjunct a lowered effect pattern emits. */
+  function effectEqualityFor(condition: unknown): BinOpExpression | undefined {
+    return binOps(condition).find((b) => {
+      if (b.operator !== "==") return false;
+      const left = b.left as ValueAccess;
+      return (
+        left.type === "valueAccess" &&
+        left.chain.length === 1 &&
+        left.chain[0].kind === "property" &&
+        left.chain[0].name === "effect"
+      );
+    });
+  }
+
+  it("lowers a bare `std::read` arm to an `intr.effect == \"std::read\"` check", () => {
+    const lowered = lower(
+      `let intr = { effect: "std::read" }\nmatch (intr) {\n  std::read => print("r")\n  _ => print("none")\n}`,
+    );
+    // [intr assignment, scrutinee assignment, ifElse]
+    expect(lowered).toHaveLength(3);
+    const ifNode = lowered[2] as IfElse;
+    expect(ifNode.type).toBe("ifElse");
+    const eq = effectEqualityFor(ifNode.condition);
+    expect(eq).toBeDefined();
+    expect(eq!.right).toMatchObject({
+      type: "string",
+      segments: [{ type: "text", value: "std::read" }],
+    });
+    // The bare effect arm binds nothing.
+    expect(ifNode.thenBody[0]?.type).not.toBe("assignment");
+  });
+
+  it("lowers `std::read({ data })` to the effect check plus `const data = intr.data`", () => {
+    const lowered = lower(
+      `let intr = { effect: "std::read", data: 1 }\nmatch (intr) {\n  std::read({ data }) => print(data)\n  _ => print("none")\n}`,
+    );
+    expect(lowered).toHaveLength(3);
+    const ifNode = lowered[2] as IfElse;
+    // The effect gate is present.
+    expect(effectEqualityFor(ifNode.condition)).toBeDefined();
+    // The object binding reads `.data` off the SAME scrutinee (the interrupt).
+    const dataBind = ifNode.thenBody[0] as Assignment;
+    expect(dataBind.variableName).toBe("data");
+    expect(dataBind.declKind).toBe("const");
+    const access = dataBind.value as ValueAccess;
+    expect(access.chain).toEqual([{ kind: "property", name: "data" }]);
+  });
+
+  // `is`-position effect patterns (`intr is std::read({ data })`, and the
+  // pure-boolean rejection) are tested in the parser suite once `_isRhsParser`
+  // is wired — see lib/parsers/effectPattern.test.ts.
+});
+
 describe("match metadata preservation (matchSource)", () => {
   function findTaggedAssignment(nodes: AgencyNode[]): Assignment | undefined {
     const hit = walkNodesArray(nodes).find(

--- a/packages/agency-lang/lib/lowering/patternLowering.test.ts
+++ b/packages/agency-lang/lib/lowering/patternLowering.test.ts
@@ -810,9 +810,31 @@ describe("effect patterns", () => {
     expect((dataBind.value as ValueAccess).chain).toEqual([{ kind: "property", name: "data" }]);
   });
 
+  it("lowers a bare `is` effect pattern as a pure boolean without throwing", () => {
+    // Positive control for the rejection below: the bare form binds nothing, so
+    // a pure-boolean `is` is legal and must lower cleanly. If the binder walk
+    // ever over-rejected, this would go red.
+    const lowered = lower(`let intr = { effect: "std::read" }\nlet x = intr is std::read`);
+    expect(lowered).toHaveLength(2);
+    const xAssign = lowered[1] as Assignment;
+    expect(xAssign.variableName).toBe("x");
+    expect(effectEqualityFor(xAssign.value)).toBeDefined();
+  });
+
   it("rejects a binding in a pure-boolean `is` context", () => {
     expect(() =>
       lower(`let intr = { effect: "std::read" }\nlet x = intr is std::read({ data })`),
+    ).toThrow(PatternLoweringError);
+  });
+
+  it("rejects a binding effect pattern in a match-arm guard (a pure-boolean context)", () => {
+    // A match-arm guard is pure-boolean even though it is spelled with `if`, so
+    // a binding effect pattern inside it has nowhere to bind. Top-level match
+    // avoids a pre-existing parser bug with guards nested in a node body.
+    expect(() =>
+      lowerProgram(
+        `let intr = { effect: "std::write" }\nmatch (intr) {\n  x if (x is std::write({ data })) => "yes"\n  _ => "no"\n}`,
+      ),
     ).toThrow(PatternLoweringError);
   });
 });

--- a/packages/agency-lang/lib/lowering/patternLowering.test.ts
+++ b/packages/agency-lang/lib/lowering/patternLowering.test.ts
@@ -797,9 +797,24 @@ describe("effect patterns", () => {
     expect(access.chain).toEqual([{ kind: "property", name: "data" }]);
   });
 
-  // `is`-position effect patterns (`intr is std::read({ data })`, and the
-  // pure-boolean rejection) are tested in the parser suite once `_isRhsParser`
-  // is wired — see lib/parsers/effectPattern.test.ts.
+  it("binds through `if (intr is std::read({ data }))`", () => {
+    const lowered = lower(
+      `let intr = { effect: "std::read", data: 1 }\nif (intr is std::read({ data })) {\n  print(data)\n}`,
+    );
+    expect(lowered).toHaveLength(2);
+    const ifNode = lowered[1] as IfElse;
+    expect(ifNode.type).toBe("ifElse");
+    expect(effectEqualityFor(ifNode.condition)).toBeDefined();
+    const dataBind = ifNode.thenBody[0] as Assignment;
+    expect(dataBind.variableName).toBe("data");
+    expect((dataBind.value as ValueAccess).chain).toEqual([{ kind: "property", name: "data" }]);
+  });
+
+  it("rejects a binding in a pure-boolean `is` context", () => {
+    expect(() =>
+      lower(`let intr = { effect: "std::read" }\nlet x = intr is std::read({ data })`),
+    ).toThrow(PatternLoweringError);
+  });
 });
 
 describe("match metadata preservation (matchSource)", () => {

--- a/packages/agency-lang/lib/lowering/patternLowering.test.ts
+++ b/packages/agency-lang/lib/lowering/patternLowering.test.ts
@@ -763,7 +763,7 @@ describe("effect patterns", () => {
     });
   }
 
-  it("lowers a bare `std::read` arm to an `intr.effect == \"std::read\"` check", () => {
+  it('lowers a bare `std::read` arm to an `intr.effect == "std::read"` check', () => {
     const lowered = lower(
       `let intr = { effect: "std::read" }\nmatch (intr) {\n  std::read => print("r")\n  _ => print("none")\n}`,
     );

--- a/packages/agency-lang/lib/lowering/patternLowering.test.ts
+++ b/packages/agency-lang/lib/lowering/patternLowering.test.ts
@@ -734,19 +734,9 @@ describe("effect patterns", () => {
   /** Every binOp in an expression tree, so a test can find the effect-equality
    *  conjunct without depending on where it sits in the `&&` chain. */
   function binOps(expr: unknown): BinOpExpression[] {
-    const out: BinOpExpression[] = [];
-    const visit = (v: unknown): void => {
-      if (!v || typeof v !== "object") return;
-      if (Array.isArray(v)) {
-        v.forEach(visit);
-        return;
-      }
-      const rec = v as Record<string, unknown>;
-      if (rec.type === "binOpExpression") out.push(rec as unknown as BinOpExpression);
-      for (const key of Object.keys(rec)) if (key !== "loc") visit(rec[key]);
-    };
-    visit(expr);
-    return out;
+    return walkNodesArray([expr as AgencyNode])
+      .filter(({ node }) => node.type === "binOpExpression")
+      .map(({ node }) => node as unknown as BinOpExpression);
   }
 
   /** The `source.effect == "<effect>"` conjunct a lowered effect pattern emits. */
@@ -795,6 +785,18 @@ describe("effect patterns", () => {
     expect(dataBind.declKind).toBe("const");
     const access = dataBind.value as ValueAccess;
     expect(access.chain).toEqual([{ kind: "property", name: "data" }]);
+  });
+
+  it("emits the scrutinee shape check once, not again for the binding", () => {
+    // The effectPattern case emits `scrutinee != null && scrutinee is object`
+    // before the effect gate; the binding's checks are collected per property
+    // so that check is not duplicated. One `!=` conjunct means one shape check.
+    const lowered = lower(
+      `let intr = { effect: "std::read", data: 1 }\nmatch (intr) {\n  std::read({ data }) => print(data)\n  _ => print("none")\n}`,
+    );
+    const ifNode = lowered[2] as IfElse;
+    const nullChecks = binOps(ifNode.condition).filter((b) => b.operator === "!=");
+    expect(nullChecks).toHaveLength(1);
   });
 
   it("binds through `if (intr is std::read({ data }))`", () => {

--- a/packages/agency-lang/lib/lowering/patternLowering.ts
+++ b/packages/agency-lang/lib/lowering/patternLowering.ts
@@ -439,6 +439,7 @@ class PatternLowerer {
           (c.caseValue.type === "objectPattern" ||
             c.caseValue.type === "arrayPattern" ||
             c.caseValue.type === "resultPattern" ||
+            c.caseValue.type === "effectPattern" ||
             c.caseValue.type === "typePattern")) ||
           c.guard !== undefined),
     );
@@ -1177,6 +1178,12 @@ class PatternLowerer {
         const field = pattern.kind === "success" ? "value" : "error";
         return [makeAssign(pattern.binding, fieldAccess(source, field, loc), declKind, loc)];
       }
+      case "effectPattern":
+        // The binding is an object pattern over the SAME source — the whole
+        // interrupt — so `std::read({ data })` binds `data = intr.data`.
+        return pattern.binding === null
+          ? []
+          : this.extractBindings(pattern.binding, source, declKind, loc);
       case "typePattern":
         // The type test contributes no bindings of its own; the inner
         // pattern binds from the SAME source — the original value, never a
@@ -1319,6 +1326,28 @@ function collectChecks(pattern: MatchPattern, source: Expression, checks: Expres
     case "resultPattern":
       checks.push(resultCheckCall(pattern.kind, source, pattern.loc));
       break;
+    case "effectPattern": {
+      // Shape check FIRST, then `source.effect == "<effect>"`. The scrutinee is
+      // the whole interrupt; the shape check guards the `.effect` read the same
+      // way an object pattern guards its field reads (a null or non-object
+      // scrutinee fails the arm rather than throwing on `.effect`).
+      checks.push(...shapeCheck(source, OBJECT_HINT, pattern.loc));
+      checks.push(
+        makeBinOp(
+          fieldAccess(source, "effect", pattern.loc),
+          "==",
+          stringLit(pattern.effect, pattern.loc),
+          pattern.loc,
+        ),
+      );
+      // The binding is an object pattern over the SAME source, so any value
+      // matchers inside it (`std::read({ data: "x" })`) run under the effect
+      // gate, and its own shape check keeps its field reads safe.
+      if (pattern.binding !== null) {
+        collectChecks(pattern.binding, source, checks);
+      }
+      break;
+    }
     case "typePattern": {
       // The runtime type test itself, compiled away by the builder (coarse
       // check or schema validation). Inner-pattern checks run after it.
@@ -1422,6 +1451,11 @@ function walkPattern(
       walkPattern(pattern.value as MatchPattern, visit);
     } else if (pattern.type === "typePattern" && pattern.pattern !== null) {
       walkPattern(pattern.pattern, visit);
+    } else if (pattern.type === "effectPattern" && pattern.binding !== null) {
+      // Descend into the object binding so its binders are seen by
+      // assertNoBindersInBoolIs (a pure-boolean `is std::read({ data })` has
+      // nowhere to bind `data`) and by binder collection.
+      walkPattern(pattern.binding, visit);
     }
   }
 }

--- a/packages/agency-lang/lib/lowering/patternLowering.ts
+++ b/packages/agency-lang/lib/lowering/patternLowering.ts
@@ -37,6 +37,7 @@ import type {
   BindingPattern,
   IsExpression,
   MatchPattern,
+  ObjectPattern,
   ObjectPatternProperty,
   ObjectPatternShorthand,
   ResultPattern,
@@ -1262,16 +1263,7 @@ function collectChecks(pattern: MatchPattern, source: Expression, checks: Expres
       // `{ length: 2 }` no longer matches an array — `[a, b]` is the spelling
       // for that. One definition of `object`, not two.
       checks.push(...shapeCheck(source, OBJECT_HINT, pattern.loc));
-      for (const prop of pattern.properties) {
-        if (prop.type === "objectPatternProperty") {
-          collectChecks(
-            prop.value as MatchPattern,
-            fieldAccess(source, prop.key, pattern.loc),
-            checks,
-          );
-        }
-        // shorthand and rest do not produce checks (binders only)
-      }
+      collectObjectPropertyChecks(pattern, source, checks);
       break;
     case "arrayPattern": {
       // Shape check FIRST, for the same reason — and because `.length` alone
@@ -1342,9 +1334,11 @@ function collectChecks(pattern: MatchPattern, source: Expression, checks: Expres
       );
       // The binding is an object pattern over the SAME source, so any value
       // matchers inside it (`std::read({ data: "x" })`) run under the effect
-      // gate, and its own shape check keeps its field reads safe.
+      // gate. Only its property checks are collected — the shape check on
+      // `source` was already emitted above, so going through the objectPattern
+      // case would duplicate it in every bound arm's condition.
       if (pattern.binding !== null) {
-        collectChecks(pattern.binding, source, checks);
+        collectObjectPropertyChecks(pattern.binding, source, checks);
       }
       break;
     }
@@ -1366,6 +1360,21 @@ function collectChecks(pattern: MatchPattern, source: Expression, checks: Expres
       // Literal — equality check
       checks.push(makeBinOp(cloneExpr(source), "==", pattern as Expression, pattern.loc));
       break;
+    }
+  }
+}
+
+/** The per-property checks of an object pattern, WITHOUT the shape check on
+ *  `source` itself — the caller has already emitted it. Shorthand and rest
+ *  properties are binders and produce no checks. */
+function collectObjectPropertyChecks(
+  pattern: ObjectPattern,
+  source: Expression,
+  checks: Expression[],
+): void {
+  for (const prop of pattern.properties) {
+    if (prop.type === "objectPatternProperty") {
+      collectChecks(prop.value as MatchPattern, fieldAccess(source, prop.key, pattern.loc), checks);
     }
   }
 }

--- a/packages/agency-lang/lib/parsers/effectPattern.test.ts
+++ b/packages/agency-lang/lib/parsers/effectPattern.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { matchPatternParser } from "./parsers.js";
+import { parseAgency } from "@/parser.js";
+import type { EffectPattern } from "../types/pattern.js";
+import { normalizeCode } from "@/index.js";
+
+/** Parse a whole program and return its error message. The committed
+ *  failure `parseError` raises escapes a direct sub-parser call, so a
+ *  committed-error assertion has to go through the top-level parser. */
+function parseFailureMessage(src: string): string {
+  const parsed = parseAgency(src, {}, false);
+  if (parsed.success) throw new Error(`expected a failed parse for:\n${src}`);
+  return parsed.message ?? "";
+}
+
+describe("effectPatternParser (via matchPatternParser)", () => {
+  it("parses a bare namespaced effect name", () => {
+    const result = matchPatternParser(normalizeCode("std::read"));
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.result).toEqualWithoutLoc({
+      type: "effectPattern",
+      effect: "std::read",
+      binding: null,
+    });
+  });
+
+  it("parses an effect name with an object binding", () => {
+    const result = matchPatternParser(normalizeCode("std::read({ data })"));
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const pattern = result.result as EffectPattern;
+    expect(pattern.type).toBe("effectPattern");
+    expect(pattern.effect).toBe("std::read");
+    expect(pattern.binding?.type).toBe("objectPattern");
+  });
+
+  it("leaves a bare identifier as a variableName binder, not an effect pattern", () => {
+    const result = matchPatternParser(normalizeCode("foo"));
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect((result.result as { type: string }).type).toBe("variableName");
+  });
+
+  it("rejects a positional binding with a committed, specific error", () => {
+    // `std::read(data)` — positional, no braces — is the model's observed
+    // guess. It must NOT soft-fail through to variableNameParser; the commit in
+    // effectPatternParser makes it a committed failure naming the object-pattern
+    // requirement.
+    const message = parseFailureMessage(
+      "node main() {\n  match (intr) {\n    std::read(data) => { return approve() }\n    _ => { return reject() }\n  }\n}",
+    );
+    expect(message).toContain("object pattern");
+    expect(message).toContain("std::read({ data })");
+  });
+});

--- a/packages/agency-lang/lib/parsers/effectPattern.test.ts
+++ b/packages/agency-lang/lib/parsers/effectPattern.test.ts
@@ -35,6 +35,18 @@ describe("effectPatternParser (via matchPatternParser)", () => {
     expect(pattern.binding?.type).toBe("objectPattern");
   });
 
+  it("parses the binding form with a space before the parens", () => {
+    // `std::read ({ data })` must be the binding form, not a bare pattern with
+    // ` ({ data })` left unconsumed to die downstream with a generic error.
+    const result = matchPatternParser(normalizeCode("std::read ({ data })"));
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const pattern = result.result as EffectPattern;
+    expect(pattern.type).toBe("effectPattern");
+    expect(pattern.effect).toBe("std::read");
+    expect(pattern.binding?.type).toBe("objectPattern");
+  });
+
   it("leaves a bare identifier as a variableName binder, not an effect pattern", () => {
     const result = matchPatternParser(normalizeCode("foo"));
     expect(result.success).toBe(true);

--- a/packages/agency-lang/lib/parsers/effectPattern.test.ts
+++ b/packages/agency-lang/lib/parsers/effectPattern.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { matchPatternParser } from "./parsers.js";
+import { matchPatternParser, exprParser } from "./parsers.js";
 import { parseAgency } from "@/parser.js";
 import type { EffectPattern } from "../types/pattern.js";
 import { normalizeCode } from "@/index.js";
@@ -52,5 +52,27 @@ describe("effectPatternParser (via matchPatternParser)", () => {
     );
     expect(message).toContain("object pattern");
     expect(message).toContain("std::read({ data })");
+  });
+});
+
+describe("effect patterns after `is`", () => {
+  it("parses `intr is std::read` as a bare effect pattern", () => {
+    const result = exprParser("intr is std::read");
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.result).toMatchObject({
+      type: "isExpression",
+      pattern: { type: "effectPattern", effect: "std::read", binding: null },
+    });
+  });
+
+  it("parses `intr is std::read({ data })` with an object binding", () => {
+    const result = exprParser("intr is std::read({ data })");
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.result).toMatchObject({
+      type: "isExpression",
+      pattern: { type: "effectPattern", effect: "std::read", binding: { type: "objectPattern" } },
+    });
   });
 });

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -7340,6 +7340,11 @@ const _isRhsParser = (input: string): ParserResult<MatchPattern> => {
     booleanParser,
     unitLiteralParser,
     resultPatternParser,
+    // effectPatternParser MUST come before typePatternParser: after `is`, a
+    // bare identifier is a type reference, and typePatternParser would take
+    // `std` as a type name and strand `::read`. Safe unconditionally — the type
+    // grammar has no `::`, so an effect pattern can never shadow a type.
+    effectPatternParser,
     numberParser,
     _stringParser,
     typePatternParser,

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -4279,11 +4279,15 @@ export const gotoStatementParser: Parser<GotoStatement> = label(
 
 // Namespace identifier: two or more segments separated by "::"
 // e.g. "std::read", "myapp::deploy", "std::http::fetch"
+// The combinator is hoisted rather than rebuilt per call: effectPatternParser
+// puts this on the match-pattern and `is` hot paths, where a per-call build
+// would be paid on every bare-binder arm.
+const _namespaceIdentifierParser: Parser<string> = map(
+  sepBy1(str("::"), many1WithJoin(varNameChar)),
+  (segments) => segments.join("::"),
+);
 const namespaceIdentifier: Parser<string> = (input: string) => {
-  const parser = map(sepBy1(str("::"), many1WithJoin(varNameChar)), (segments) =>
-    segments.join("::"),
-  );
-  const result = parser(input);
+  const result = _namespaceIdentifierParser(input);
   if (!result.success) return result;
   if (!result.result.includes("::")) {
     return failure("expected interrupt effect with ::, e.g. std::read or myapp::deploy", input);
@@ -7269,16 +7273,39 @@ export const resultPatternParser: Parser<ResultPattern> = withLoc(
 // and `_isRhsParser` BEFORE `variableNameParser` / `typePatternParser`. Only a
 // `::`-containing name is intercepted here; a bare `foo` stays a binder / type
 // reference because `namespaceIdentifier` soft-fails on it.
+// The character set of varNameChar as a regex, for cheap lookahead scans that
+// must not pay for a combinator run.
+const VAR_NAME_CHAR_RE = /[A-Za-z0-9_]/;
+
 export const effectPatternParser: Parser<EffectPattern> = withLoc(
   (input: string): ParserResult<EffectPattern> => {
     // Namespaced name only. A soft failure here lets the outer `or` fall
-    // through to variableNameParser (a bare identifier is a binder).
+    // through to variableNameParser (a bare identifier is a binder). Gated by
+    // a raw character scan for `<ident>::` first: this parser sits ahead of
+    // the bare-binder path in two hot or-chains (match patterns and `is`
+    // right-hand sides), so the common no-`::` case must cost a scan, not a
+    // namespaceIdentifier run.
+    let gate = 0;
+    while (gate < input.length && VAR_NAME_CHAR_RE.test(input[gate])) gate++;
+    if (gate === 0 || input[gate] !== ":" || input[gate + 1] !== ":") {
+      return failure(
+        "expected interrupt effect with ::, e.g. std::read or myapp::deploy",
+        input,
+      ) as ParserResult<EffectPattern>;
+    }
     const name = namespaceIdentifier(input);
     if (!name.success) return name as ParserResult<EffectPattern>;
     const effect = name.result;
 
-    // Bare form: no `(` after the name.
-    if (name.rest[0] !== "(") {
+    // Bare form: no `(` after the name. Spaces before a `(` still mean the
+    // binding form — `std::read ({ data })` must not silently take the bare
+    // branch, leave ` ({ data })` unconsumed, and die downstream with a
+    // generic error instead of the committed diagnostic below. Newlines are
+    // not skipped: arms are newline-separated, so a `(` on the next line is
+    // the next arm's problem, not this pattern's.
+    let afterName = 0;
+    while (name.rest[afterName] === " " || name.rest[afterName] === "\t") afterName++;
+    if (name.rest[afterName] !== "(") {
       return success({ type: "effectPattern", effect, binding: null }, name.rest);
     }
 
@@ -7298,7 +7325,7 @@ export const effectPatternParser: Parser<EffectPattern> = withLoc(
       ),
       optionalSpacesOrNewline,
       char(")"),
-    )(name.rest);
+    )(name.rest.slice(afterName));
     if (!bindingResult.success) return bindingResult as ParserResult<EffectPattern>;
     // The capture is present whenever parseError returned success — a missing
     // one would be a loud crash here, not a silent downgrade to the bare

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -187,6 +187,7 @@ import { StaticStatement } from "@/types/staticStatement.js";
 import {
   ArrayPattern,
   BindingPattern,
+  EffectPattern,
   IsExpression,
   MatchPattern,
   ObjectPattern,
@@ -7261,6 +7262,52 @@ export const resultPatternParser: Parser<ResultPattern> = withLoc(
   },
 );
 
+// Effect patterns: `std::read`, `std::read({ data })`. Mirrors
+// resultPatternParser, but the constructor is a namespaced effect name and the
+// optional binding is an object pattern over the whole interrupt (the
+// scrutinee), not a single identifier. Must be placed in `_matchPatternBase`
+// and `_isRhsParser` BEFORE `variableNameParser` / `typePatternParser`. Only a
+// `::`-containing name is intercepted here; a bare `foo` stays a binder / type
+// reference because `namespaceIdentifier` soft-fails on it.
+export const effectPatternParser: Parser<EffectPattern> = withLoc(
+  (input: string): ParserResult<EffectPattern> => {
+    // Namespaced name only. A soft failure here lets the outer `or` fall
+    // through to variableNameParser (a bare identifier is a binder).
+    const name = namespaceIdentifier(input);
+    if (!name.success) return name as ParserResult<EffectPattern>;
+    const effect = name.result;
+
+    // Bare form: no `(` after the name.
+    if (name.rest[0] !== "(") {
+      return success({ type: "effectPattern", effect, binding: null }, name.rest);
+    }
+
+    // Committed to the effect-pattern form: once we see `<effect>(`, the
+    // binding MUST be an object pattern. `parseError` bypasses the surrounding
+    // `or` — without it, `std::read(data)` (a positional binding, the mistake
+    // this alias exists to catch) would soft-fail, fall through to
+    // variableNameParser, and die later with an error naming nothing the
+    // author wrote. Mirrors resultPatternParser's commit above.
+    const bindingResult = parseError(
+      `an effect pattern binding must be an object pattern, e.g. \`${effect}({ data })\``,
+      char("("),
+      optionalSpacesOrNewline,
+      capture(lazy(() => objectMatchPatternParser), "binding"),
+      optionalSpacesOrNewline,
+      char(")"),
+    )(name.rest);
+    if (!bindingResult.success) return bindingResult as ParserResult<EffectPattern>;
+    return success(
+      {
+        type: "effectPattern",
+        effect,
+        binding: (bindingResult.result.binding as ObjectPattern) ?? null,
+      },
+      bindingResult.rest,
+    );
+  },
+) as Parser<EffectPattern>;
+
 // A type in pattern position: `is string`, `is Person`, `is number[]`, and
 // the match-arm suffix `pattern: Type`. Parses one non-union,
 // non-intersection type — bare inline unions and intersections are
@@ -7318,6 +7365,10 @@ const _matchPatternBase = (input: string): ParserResult<MatchPattern> => {
     // resultPatternParser MUST come before variableNameParser so `success` /
     // `failure` are intercepted before they'd parse as bare identifiers.
     resultPatternParser,
+    // effectPatternParser matches a `::`-containing name (`std::read`), which a
+    // bare identifier can never be, so it must run before variableNameParser
+    // to intercept the effect name before it'd parse as a binder.
+    effectPatternParser,
     variableNameParser,
     numberParser,
     _stringParser,

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -7300,11 +7300,14 @@ export const effectPatternParser: Parser<EffectPattern> = withLoc(
       char(")"),
     )(name.rest);
     if (!bindingResult.success) return bindingResult as ParserResult<EffectPattern>;
+    // The capture is present whenever parseError returned success — a missing
+    // one would be a loud crash here, not a silent downgrade to the bare
+    // pattern (which would drop the binding and its value-matcher checks).
     return success(
       {
         type: "effectPattern",
         effect,
-        binding: (bindingResult.result.binding as ObjectPattern) ?? null,
+        binding: bindingResult.result.binding as ObjectPattern,
       },
       bindingResult.rest,
     );

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -7292,7 +7292,10 @@ export const effectPatternParser: Parser<EffectPattern> = withLoc(
       `an effect pattern binding must be an object pattern, e.g. \`${effect}({ data })\``,
       char("("),
       optionalSpacesOrNewline,
-      capture(lazy(() => objectMatchPatternParser), "binding"),
+      capture(
+        lazy(() => objectMatchPatternParser),
+        "binding",
+      ),
       optionalSpacesOrNewline,
       char(")"),
     )(name.rest);

--- a/packages/agency-lang/lib/typeChecker/matchExhaustiveness.test.ts
+++ b/packages/agency-lang/lib/typeChecker/matchExhaustiveness.test.ts
@@ -380,6 +380,50 @@ node h(): string {
     );
     expect(errs.some((e) => /not exhaustive/i.test(e))).toBe(false);
   });
+
+  it("error: pure-binder bindings still cover their member (exhaustive, no `_`)", () => {
+    const errs = check(
+      `${HANDLER_PRELUDE}
+node h(): string {
+  handle {
+    let a: string = rd()
+    let b: string = wr()
+  } with (intr) {
+    return match (intr) {
+      app::read({ data }) => reject()
+      app::write({ data }) => reject()
+    }
+  }
+  return "done"
+}`,
+      ERROR,
+    );
+    expect(errs.some((e) => /not exhaustive/i.test(e))).toBe(false);
+  });
+
+  it("error: a refutable value-matcher binding does NOT cover its member", () => {
+    // `app::read({ data: { path: "p" } })` matches only one payload, so it
+    // cannot stand in for the whole app::read member. Without a `_`, an
+    // app::read with another path falls through — the checker must still report
+    // app::read missing.
+    const errs = check(
+      `${HANDLER_PRELUDE}
+node h(): string {
+  handle {
+    let a: string = rd()
+    let b: string = wr()
+  } with (intr) {
+    return match (intr) {
+      app::read({ data: { path: "p" } }) => reject()
+      app::write => reject()
+    }
+  }
+  return "done"
+}`,
+      ERROR,
+    );
+    expect(errs.some((e) => /not exhaustive/i.test(e) && /app::read/.test(e))).toBe(true);
+  });
 });
 
 describe("match exhaustiveness — coverage edge cases & structural", () => {

--- a/packages/agency-lang/lib/typeChecker/matchExhaustiveness.test.ts
+++ b/packages/agency-lang/lib/typeChecker/matchExhaustiveness.test.ts
@@ -270,11 +270,9 @@ def f(x: boolean): number {
     expect(errs.some((e) => /not exhaustive/i.test(e) && /false/.test(e))).toBe(true);
   });
 
-  // Effect names are an open set — an effect pattern can never make a match
-  // exhaustive. The scrutinee (an interrupt) is open/unsupported territory, so
-  // the checker stays silent rather than guessing a missing case. No code was
-  // added for this in matchExhaustiveness.ts; these pin the fall-through.
-  it("error config: match over effect patterns is open — never reported, never crashes", () => {
+  it("error config: match over effect patterns on an open (any) scrutinee is not reported", () => {
+    // An `any` scrutinee is open/unsupported territory, so the checker stays
+    // silent whether or not `_` is present.
     const errs = check(
       `
 def f(intr: any): number {
@@ -302,6 +300,85 @@ def f(x: boolean): number {
       ERROR,
     );
     expect(errs.some((e) => /not exhaustive/i.test(e) && /false/.test(e))).toBe(true);
+  });
+});
+
+// A real inline handler param is re-typed to a discriminated union keyed on
+// `effect` (handlerParamTyping.ts), so effect-pattern arms discriminate it just
+// like `{ effect: "app::read" }` object arms would. These pin that: covering
+// every effect makes the match exhaustive with no `_`, and a missing effect is
+// reported by name.
+describe("match exhaustiveness — effect patterns over a handler union", () => {
+  const HANDLER_PRELUDE = `
+effect app::read { path: string }
+effect app::write { dir: string }
+def rd(): string raises <app::read> {
+  raise app::read("r", { path: "p" })
+  return "r"
+}
+def wr(): string raises <app::write> {
+  raise app::write("w", { dir: "d" })
+  return "w"
+}
+`;
+
+  it("error: covering every effect is exhaustive with no `_`", () => {
+    const errs = check(
+      `${HANDLER_PRELUDE}
+node h(): string {
+  handle {
+    let a: string = rd()
+    let b: string = wr()
+  } with (intr) {
+    return match (intr) {
+      app::read => reject()
+      app::write => reject()
+    }
+  }
+  return "done"
+}`,
+      ERROR,
+    );
+    expect(errs.some((e) => /not exhaustive/i.test(e))).toBe(false);
+  });
+
+  it("error: a missing effect is reported by name", () => {
+    const errs = check(
+      `${HANDLER_PRELUDE}
+node h(): string {
+  handle {
+    let a: string = rd()
+    let b: string = wr()
+  } with (intr) {
+    return match (intr) {
+      app::read => reject()
+    }
+  }
+  return "done"
+}`,
+      ERROR,
+    );
+    expect(errs.some((e) => /not exhaustive/i.test(e) && /app::write/.test(e))).toBe(true);
+  });
+
+  it("error: a `_` catch-all clears it (open-set style)", () => {
+    const errs = check(
+      `${HANDLER_PRELUDE}
+node h(): string {
+  handle {
+    let a: string = rd()
+    let b: string = wr()
+  } with (intr) {
+    return match (intr) {
+      app::read => reject()
+      _ => reject()
+    }
+  }
+  return "done"
+}`,
+      ERROR,
+    );
+    expect(errs.some((e) => /not exhaustive/i.test(e))).toBe(false);
   });
 });
 

--- a/packages/agency-lang/lib/typeChecker/matchExhaustiveness.test.ts
+++ b/packages/agency-lang/lib/typeChecker/matchExhaustiveness.test.ts
@@ -269,6 +269,40 @@ def f(x: boolean): number {
     );
     expect(errs.some((e) => /not exhaustive/i.test(e) && /false/.test(e))).toBe(true);
   });
+
+  // Effect names are an open set — an effect pattern can never make a match
+  // exhaustive. The scrutinee (an interrupt) is open/unsupported territory, so
+  // the checker stays silent rather than guessing a missing case. No code was
+  // added for this in matchExhaustiveness.ts; these pin the fall-through.
+  it("error config: match over effect patterns is open — never reported, never crashes", () => {
+    const errs = check(
+      `
+def f(intr: any): number {
+  return match (intr) {
+    std::read => 1
+    std::write => 2
+  }
+}`,
+      ERROR,
+    );
+    expect(errs.some((e) => /not exhaustive/i.test(e))).toBe(false);
+  });
+
+  it("error config: an effect-pattern arm is not a catch-all (missing case still reported)", () => {
+    // On a boolean scrutinee, `true` plus an effect-pattern arm must still
+    // leave `false` missing — the effect arm covers nothing and clears nothing.
+    const errs = check(
+      `
+def f(x: boolean): number {
+  return match (x) {
+    std::read => 1
+    true => 2
+  }
+}`,
+      ERROR,
+    );
+    expect(errs.some((e) => /not exhaustive/i.test(e) && /false/.test(e))).toBe(true);
+  });
 });
 
 describe("match exhaustiveness — coverage edge cases & structural", () => {

--- a/packages/agency-lang/lib/typeChecker/matchExhaustiveness.test.ts
+++ b/packages/agency-lang/lib/typeChecker/matchExhaustiveness.test.ts
@@ -424,6 +424,54 @@ node h(): string {
     );
     expect(errs.some((e) => /not exhaustive/i.test(e) && /app::read/.test(e))).toBe(true);
   });
+
+  it("error: a nested all-binder destructure does NOT cover its member", () => {
+    // `app::read({ data: { path } })` has only binders inside, but the nested
+    // destructure lowers to a shape check on `intr.data` — a null or missing
+    // payload fails it at runtime, so the arm matches only SOME app::read
+    // interrupts. Counting it as coverage would let an expression match fall
+    // through to `undefined` in a handler.
+    const errs = check(
+      `${HANDLER_PRELUDE}
+node h(): string {
+  handle {
+    let a: string = rd()
+    let b: string = wr()
+  } with (intr) {
+    return match (intr) {
+      app::read({ data: { path } }) => reject()
+      app::write => reject()
+    }
+  }
+  return "done"
+}`,
+      ERROR,
+    );
+    expect(errs.some((e) => /not exhaustive/i.test(e) && /app::read/.test(e))).toBe(true);
+  });
+
+  it("error: the object-pattern spelling with a refutable sibling does NOT cover its member", () => {
+    // `{ effect: "app::read", data: { path: "p" } }` pins the discriminant but
+    // also value-matches the payload, so it matches only some app::read
+    // interrupts — the same refutability rule as the effect-pattern spelling.
+    const errs = check(
+      `${HANDLER_PRELUDE}
+node h(): string {
+  handle {
+    let a: string = rd()
+    let b: string = wr()
+  } with (intr) {
+    return match (intr) {
+      { effect: "app::read", data: { path: "p" } } => reject()
+      app::write => reject()
+    }
+  }
+  return "done"
+}`,
+      ERROR,
+    );
+    expect(errs.some((e) => /not exhaustive/i.test(e) && /app::read/.test(e))).toBe(true);
+  });
 });
 
 describe("match exhaustiveness — coverage edge cases & structural", () => {

--- a/packages/agency-lang/lib/typeChecker/matchExhaustiveness.ts
+++ b/packages/agency-lang/lib/typeChecker/matchExhaustiveness.ts
@@ -60,6 +60,26 @@ function objectPatternDiscriminantValue(
 }
 
 /**
+ * True when an effect-pattern object binding adds no refutable check, so the arm
+ * matches EVERY interrupt of its effect and can stand in for the whole union
+ * member. Every property must be a binder (shorthand, rename, rest, wildcard) or
+ * a nested all-binder object pattern. A value matcher (`{ data: "p" }`), an
+ * array pattern (a length check), a result pattern, or a nested type test all
+ * make the arm match only SOME interrupts of that effect, so it cannot cover the
+ * member. (Nested type tests also mark the whole arm guarded via
+ * hasNestedTypeTest, which drops it from coverage independently.)
+ */
+function isIrrefutableEffectBinding(binding: ObjectPattern | null): boolean {
+  if (binding === null) return true;
+  return binding.properties.every((p) => {
+    if (p.type === "objectPatternShorthand" || p.type === "restPattern") return true;
+    const v = p.value; // objectPatternProperty
+    if (v.type === "objectPattern") return isIrrefutableEffectBinding(v);
+    return v.type === "variableName" || v.type === "wildcardPattern" || v.type === "restPattern";
+  });
+}
+
+/**
  * The discriminant value an un-guarded arm pins, whether it is written as an
  * object pattern (`{ effect: "app::read" }`) or an effect pattern
  * (`app::read` / `app::read({ data })`). An effect pattern is sugar for the
@@ -67,10 +87,15 @@ function objectPatternDiscriminantValue(
  * discriminant and no other. A handler param is a discriminated union keyed on
  * `effect` (handlerParamTyping.ts), so this is what lets effect-pattern arms
  * count toward covering that union — without it every effect reads as missing.
+ * A bound effect pattern only counts when its binding is irrefutable: a
+ * value-matching binding matches some interrupts of the effect, not all, so it
+ * cannot stand in for the member (an expression match over it would fall through
+ * to `undefined`).
  */
 function armDiscriminantValue(cv: CaseValue, prop: string): string | number | boolean | null {
   if (cv !== "_" && cv.type === "effectPattern") {
-    return prop === "effect" ? cv.effect : null;
+    if (prop !== "effect") return null;
+    return isIrrefutableEffectBinding(cv.binding) ? cv.effect : null;
   }
   return objectPatternDiscriminantValue(cv, prop);
 }

--- a/packages/agency-lang/lib/typeChecker/matchExhaustiveness.ts
+++ b/packages/agency-lang/lib/typeChecker/matchExhaustiveness.ts
@@ -60,23 +60,44 @@ function objectPatternDiscriminantValue(
 }
 
 /**
+ * True when an object-pattern property adds no refutable check: a binder
+ * (shorthand, rename, rest, wildcard). Everything else can fail at runtime on a
+ * value whose discriminant matched — a value matcher (`{ data: "p" }`), an
+ * array pattern (a length check), a result pattern, a nested type test, and
+ * also a nested object destructure (`{ data: { dir } }`): the lowering emits a
+ * shape check on the field (`x.data != null && x.data is object`), which a null
+ * or missing payload fails even when every nested property is a binder.
+ */
+function isIrrefutableProperty(p: ObjectPattern["properties"][number]): boolean {
+  if (p.type === "objectPatternShorthand" || p.type === "restPattern") return true;
+  const v = p.value; // objectPatternProperty
+  return v.type === "variableName" || v.type === "wildcardPattern" || v.type === "restPattern";
+}
+
+/**
  * True when an effect-pattern object binding adds no refutable check, so the arm
  * matches EVERY interrupt of its effect and can stand in for the whole union
- * member. Every property must be a binder (shorthand, rename, rest, wildcard) or
- * a nested all-binder object pattern. A value matcher (`{ data: "p" }`), an
- * array pattern (a length check), a result pattern, or a nested type test all
- * make the arm match only SOME interrupts of that effect, so it cannot cover the
- * member. (Nested type tests also mark the whole arm guarded via
- * hasNestedTypeTest, which drops it from coverage independently.)
+ * member. A refutable property makes the arm match only SOME interrupts of that
+ * effect, so it cannot cover the member. (Nested type tests also mark the whole
+ * arm guarded via hasNestedTypeTest, which drops it from coverage
+ * independently.)
  */
 function isIrrefutableEffectBinding(binding: ObjectPattern | null): boolean {
   if (binding === null) return true;
-  return binding.properties.every((p) => {
-    if (p.type === "objectPatternShorthand" || p.type === "restPattern") return true;
-    const v = p.value; // objectPatternProperty
-    if (v.type === "objectPattern") return isIrrefutableEffectBinding(v);
-    return v.type === "variableName" || v.type === "wildcardPattern" || v.type === "restPattern";
-  });
+  return binding.properties.every(isIrrefutableProperty);
+}
+
+/**
+ * True when an objectPattern arm's checks beyond the discriminant pin are all
+ * binders, so matching the member's tag guarantees the arm matches. A sibling
+ * value matcher (`{ effect: "app::read", data: { path: "p" } }`) matches only
+ * some values of the member, so the arm cannot stand in for it — the same rule
+ * isIrrefutableEffectBinding applies to the sugar spelling.
+ */
+function objectPatternCoversMember(cv: ObjectPattern, prop: string): boolean {
+  return cv.properties.every(
+    (p) => (p.type === "objectPatternProperty" && p.key === prop) || isIrrefutableProperty(p),
+  );
 }
 
 /**
@@ -87,17 +108,20 @@ function isIrrefutableEffectBinding(binding: ObjectPattern | null): boolean {
  * discriminant and no other. A handler param is a discriminated union keyed on
  * `effect` (handlerParamTyping.ts), so this is what lets effect-pattern arms
  * count toward covering that union — without it every effect reads as missing.
- * A bound effect pattern only counts when its binding is irrefutable: a
- * value-matching binding matches some interrupts of the effect, not all, so it
- * cannot stand in for the member (an expression match over it would fall through
- * to `undefined`).
+ * Either spelling only counts when the rest of the pattern is irrefutable: a
+ * value-matching binding (or a sibling value matcher next to the pin) matches
+ * some values of the member, not all, so it cannot stand in for the member (an
+ * expression match over it would fall through to `undefined`).
  */
 function armDiscriminantValue(cv: CaseValue, prop: string): string | number | boolean | null {
-  if (cv !== "_" && cv.type === "effectPattern") {
+  if (cv === "_") return null;
+  if (cv.type === "effectPattern") {
     if (prop !== "effect") return null;
     return isIrrefutableEffectBinding(cv.binding) ? cv.effect : null;
   }
-  return objectPatternDiscriminantValue(cv, prop);
+  const pinned = objectPatternDiscriminantValue(cv, prop);
+  if (pinned === null) return null;
+  return objectPatternCoversMember(cv as ObjectPattern, prop) ? pinned : null;
 }
 
 /**

--- a/packages/agency-lang/lib/typeChecker/matchExhaustiveness.ts
+++ b/packages/agency-lang/lib/typeChecker/matchExhaustiveness.ts
@@ -60,6 +60,22 @@ function objectPatternDiscriminantValue(
 }
 
 /**
+ * The discriminant value an un-guarded arm pins, whether it is written as an
+ * object pattern (`{ effect: "app::read" }`) or an effect pattern
+ * (`app::read` / `app::read({ data })`). An effect pattern is sugar for the
+ * object pattern that pins `effect` to the name, so it pins the `effect`
+ * discriminant and no other. A handler param is a discriminated union keyed on
+ * `effect` (handlerParamTyping.ts), so this is what lets effect-pattern arms
+ * count toward covering that union — without it every effect reads as missing.
+ */
+function armDiscriminantValue(cv: CaseValue, prop: string): string | number | boolean | null {
+  if (cv !== "_" && cv.type === "effectPattern") {
+    return prop === "effect" ? cv.effect : null;
+  }
+  return objectPatternDiscriminantValue(cv, prop);
+}
+
+/**
  * True when a pattern contains a type test somewhere INSIDE it — an element or
  * property carrying a `: Type` suffix.
  *
@@ -192,7 +208,7 @@ function coveredMemberKeys(arms: NormalizedArm[], prop: string): Set<string> {
   const covered = new Set<string>();
   for (const arm of arms) {
     if (arm.guarded) continue;
-    const pinnedValue = objectPatternDiscriminantValue(arm.caseValue, prop);
+    const pinnedValue = armDiscriminantValue(arm.caseValue, prop);
     if (pinnedValue !== null) covered.add(discriminatedMemberKey(prop, pinnedValue));
   }
   return covered;

--- a/packages/agency-lang/lib/types.ts
+++ b/packages/agency-lang/lib/types.ts
@@ -41,6 +41,7 @@ import { Splice } from "./types/splice.js";
 import {
   ArrayPattern,
   BindingPattern,
+  EffectPattern,
   IsExpression,
   ObjectPattern,
   RestPattern,
@@ -374,6 +375,7 @@ export type AgencyNode =
   | RestPattern
   | WildcardPattern
   | ResultPattern
+  | EffectPattern
   | TypePattern
   | Hole
   | CodeLiteral

--- a/packages/agency-lang/lib/types/pattern.ts
+++ b/packages/agency-lang/lib/types/pattern.ts
@@ -6,9 +6,10 @@ import type { Expression, VariableType } from "../types.js";
 export type ObjectPatternProperty = {
   type: "objectPatternProperty";
   key: string;
-  // ResultPattern and TypePattern are only valid in match-position use; the
-  // parser does not produce either in binding-position contexts.
-  value: BindingPattern | Literal | ResultPattern | TypePattern;
+  // ResultPattern, EffectPattern, and TypePattern are only valid in
+  // match-position use; the parser does not produce them in binding-position
+  // contexts.
+  value: BindingPattern | Literal | ResultPattern | EffectPattern | TypePattern;
 };
 
 export type ObjectPatternShorthand = {
@@ -25,10 +26,17 @@ export type ObjectPattern = BaseNode & {
 
 export type ArrayPattern = BaseNode & {
   type: "arrayPattern";
-  // ResultPattern and TypePattern are only valid in match-position use; the
-  // parser does not produce either in binding-position contexts.
+  // ResultPattern, EffectPattern, and TypePattern are only valid in
+  // match-position use; the parser does not produce them in binding-position
+  // contexts.
   elements: (
-    BindingPattern | Literal | WildcardPattern | RestPattern | ResultPattern | TypePattern
+    | BindingPattern
+    | Literal
+    | WildcardPattern
+    | RestPattern
+    | ResultPattern
+    | EffectPattern
+    | TypePattern
   )[];
   /** Comments between elements. */
   elementTrivia?: ListTrivia[];
@@ -53,6 +61,21 @@ export type ResultPattern = BaseNode & {
   type: "resultPattern";
   kind: "success" | "failure";
   binding: string | null; // null = bare form (no parens), string = binding identifier
+};
+
+// An interrupt effect in match position: `std::read` matches any interrupt
+// whose effect is `std::read`, and `std::read({ data })` also destructures the
+// interrupt's fields. The scrutinee is the whole interrupt (`match(intr)`), so
+// the binding is an object pattern over `intr`, not a single identifier.
+//
+// Like ResultPattern, this lives only in MatchPattern (match arms and after
+// `is`), never in BindingPattern, so it is illegal in let/const/for.
+export type EffectPattern = BaseNode & {
+  type: "effectPattern";
+  // The namespaced effect name, e.g. "std::read".
+  effect: string;
+  // null = bare `std::read`; an object pattern = `std::read({ data })`.
+  binding: ObjectPattern | null;
 };
 
 // A runtime type test in pattern position. Two spellings share this node:
@@ -88,7 +111,7 @@ export type BindingPattern =
 
 // A match pattern: binders OR literal value matchers.
 // Used in match arm LHS and after `is`.
-export type MatchPattern = BindingPattern | Literal | ResultPattern | TypePattern;
+export type MatchPattern = BindingPattern | Literal | ResultPattern | TypePattern | EffectPattern;
 
 // Convenience union when context doesn't matter
 export type Pattern = MatchPattern;

--- a/packages/agency-lang/lib/utils/identifierSlots.ts
+++ b/packages/agency-lang/lib/utils/identifierSlots.ts
@@ -223,6 +223,7 @@ const REGISTRY: { [K in AgencyNode["type"]]: SlotExtractor<K> } = {
   restPattern: none,
   wildcardPattern: none,
   resultPattern: none,
+  effectPattern: none,
   typePattern: none,
 };
 

--- a/packages/agency-lang/lib/utils/topLevel.ts
+++ b/packages/agency-lang/lib/utils/topLevel.ts
@@ -102,6 +102,7 @@ const LEGAL_AT_TOP_LEVEL: Record<AgencyNode["type"], boolean> = {
   restPattern: false,
   wildcardPattern: false,
   resultPattern: false,
+  effectPattern: false,
   typePattern: false,
 
   // Templates. Both ARE legal top-level Agency, and both are handled by a

--- a/packages/agency-lang/tests/agency/effect-pattern-match.agency
+++ b/packages/agency-lang/tests/agency/effect-pattern-match.agency
@@ -1,0 +1,76 @@
+// Effect patterns in `match` (#926) must reach the SAME verdicts as the
+// string-compare `match(intr.effect) { "app::write" => ... }` form: naming the
+// effect and destructuring its data may not turn a reject into an approve.
+// Both nodes run the same program under the two spellings and must agree.
+
+effect app::write { dir: string }
+
+// Raises app::write, then (only if approved) returns success. A rejected
+// interrupt makes this function return a failure instead.
+def act(dir: string): Result<string> raises <app::write> {
+  raise app::write("writing", { dir: dir })
+  return success(dir)
+}
+
+def tag(r: Result<string>): string {
+  return match (r) {
+    success(s) => "ok"
+    failure(e) => "no"
+  }
+}
+
+// The effect-pattern form: match the whole interrupt, bind `data = intr.data`.
+node effectPattern(): string {
+  let a: Result<string> = failure("unset")
+  handle {
+    a = act(dir: ".")
+  } with (intr) {
+    return match (intr) {
+      app::write({ data }) => {
+        if (data.dir == ".") { return approve() } else { return reject() }
+      }
+      _ => return reject()
+    }
+  }
+  let b: Result<string> = failure("unset")
+  handle {
+    b = act(dir: "/etc")
+  } with (intr) {
+    return match (intr) {
+      app::write({ data }) => {
+        if (data.dir == ".") { return approve() } else { return reject() }
+      }
+      _ => return reject()
+    }
+  }
+  return "${tag(a)} ${tag(b)}"
+}
+
+// The string-compare form of the same two handlers — must agree.
+node canonical(): string {
+  let a: Result<string> = failure("unset")
+  handle {
+    a = act(dir: ".")
+  } with (intr) {
+    return match (intr.effect) {
+      "app::write" => {
+        const data = intr.data
+        if (data.dir == ".") { return approve() } else { return reject() }
+      }
+      _ => return reject()
+    }
+  }
+  let b: Result<string> = failure("unset")
+  handle {
+    b = act(dir: "/etc")
+  } with (intr) {
+    return match (intr.effect) {
+      "app::write" => {
+        const data = intr.data
+        if (data.dir == ".") { return approve() } else { return reject() }
+      }
+      _ => return reject()
+    }
+  }
+  return "${tag(a)} ${tag(b)}"
+}

--- a/packages/agency-lang/tests/agency/effect-pattern-match.test.json
+++ b/packages/agency-lang/tests/agency/effect-pattern-match.test.json
@@ -1,0 +1,18 @@
+{
+  "tests": [
+    {
+      "nodeName": "effectPattern",
+      "description": "The effect-pattern handler approves \".\" and rejects \"/etc\"",
+      "input": "",
+      "expectedOutput": "\"ok no\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "canonical",
+      "description": "The string-compare handler reaches the same verdicts the effect-pattern form does",
+      "input": "",
+      "expectedOutput": "\"ok no\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}


### PR DESCRIPTION
## Effect patterns in `match` (#926, PR 2 of 3)

Lets a `match` arm name an interrupt effect directly and optionally destructure its payload, instead of comparing `intr.effect` against a string by hand. Inside a handler:

```
handle {
  a = act(dir: ".")
} with (intr) {
  return match (intr) {
    app::write({ data }) if data.dir == "/tmp" => return approve()
    app::write => return reject()
    _ => return reject()
  }
}
```

The `on`-clause handler alias from PR 1 (#979) desugars to this string-compare form today; this PR gives `match` a first-class spelling for it.

### Design

A new `effectPattern` variant of `MatchPattern`, modeled end-to-end on `resultPattern` (`success(s)` / `failure(e)`). Two forms:

- `app::write` — matches any interrupt whose effect is `app::write`.
- `app::write({ data })` — the same, plus an object-pattern binding over the whole interrupt, so `{ data }` binds `data = intr.data`.

The scrutinee is the whole interrupt (`match(intr)`), so the binding reaches its `effect` / `message` / `data` / `origin` fields; deep destructures like `app::write({ data: { dir } })` work because the binding is an ordinary object pattern. It lowers to a shape check, an `intr.effect == "app::write"` equality, and the object binding's own checks and bindings — no new runtime helper. Like `resultPattern`, it lives only in `MatchPattern` (match arm and after `is`), never in `let`/`const`/`for`.

### Behavior

- **Namespaced-only.** The parser intercepts a `::`-containing name; a bare `foo` stays a binder. A positional binding `std::read(data)` (the mistake this arc absorbs) commits to a specific error naming the object-pattern form.
- **Shape check first**, so the `.effect` read is guarded — a null or non-object scrutinee fails the arm rather than throwing. The whole-corpus `patternGuards` tripwire confirms the lowered condition reads no unguarded value.
- **Exhaustiveness.** An effect pattern pins the `effect` discriminant, so it behaves like the `{ effect: "app::read" }` object pattern it is sugar for. Over a real inline handler param (a closed discriminated union keyed on `effect`), covering every effect is exhaustive with no `_`, and a missing effect is reported by name — but a bound arm only covers its member when the binding is irrefutable (bare or pure binders); a value-matching binding still needs a `_`. Over an open (`any`) scrutinee the match stays open. An effect arm never counts as a catch-all. (This corrects the earlier "never makes a match exhaustive / no code change" framing, after review found the discriminated-union case.)
- **Limitations** documented in the dev note: bare-named effects have no spelling here (use `match(intr.effect)`); duplicate arms are first-wins; a non-interrupt scrutinee surfaces a member-access diagnostic on generated code.

### Verification

- `pnpm run typecheck` (3 configs), `pnpm run fmt:ts`, `pnpm run lint:structure` — all green.
- `pnpm test:run lib/parsers lib/lowering lib/backends lib/typeChecker` — 4545 pass, including the whole-corpus round-trip identity and the `patternGuards` tripwire now exercising an effect pattern.
- Execution test (no LLM): the effect-pattern handler and a string-compare handler both approve `.` and reject `/etc` (`"ok no"`).

### Notes for the owner

- This is a user-facing feature, so a `docs/site/guide/` page is warranted; guide pages are yours to write, so this PR only adds the `docs/dev` note.
- One open item flagged in the plan review, resolved as document-the-limit for v1: bare-named effects. If you want a dead-arm warning for a string-literal arm on an interrupt scrutinee, that is a separate general typechecker diagnostic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
