### PR TITLE
Embed an optional HMAC integrity checksum in every checkpoint

### DIFF
--- a/packages/agency-lang/.claude/skills/agency-runtime-docs/SKILL.md
+++ b/packages/agency-lang/.claude/skills/agency-runtime-docs/SKILL.md
@@ -11,6 +11,7 @@ Paths are relative to `packages/agency-lang/`. Read the one that matches the tas
 - `docs/dev/runtime/interrupts.md` — How a program resumes in the middle of a block after an interrupt, using step counters.
 - `docs/dev/runtime/concurrent-interrupts.md` — What happens when several concurrent execution paths interrupt at the same time.
 - `docs/dev/runtime/runBatch.md` — The one primitive that owns concurrent-interrupt orchestration for forks, parallel blocks, tool calls, and subprocesses.
+- `docs/dev/runtime/checkpoint-integrity.md` — The optional HMAC checksum embedded in a checkpoint, and how a host verifies it.
 - `docs/dev/runtime/checkpointing.md` — Snapshotting execution state so a program can restore back to it later.
 - `docs/dev/runtime/rewind.md` — Replaying execution from a checkpoint, optionally with different values for its local variables.
 - `docs/dev/runtime/trace.md` — Execution traces: a checkpoint per step, written to a file the debugger can replay.

--- a/packages/agency-lang/CLAUDE.md
+++ b/packages/agency-lang/CLAUDE.md
@@ -234,6 +234,7 @@ Other process docs:
 - `docs/dev/runtime/async-context.md` — The async-context frame that carries runtime state, and how stdlib TypeScript helpers read it.
 - `docs/dev/runtime/async.md` — How async function calls work, and the problems the design solves.
 - `docs/dev/runtime/callback-hooks.md` — Registering callbacks for runtime events such as node, function, and tool lifecycle.
+- `docs/dev/runtime/checkpoint-integrity.md` — The optional HMAC checksum embedded in a checkpoint, and how a host verifies it.
 - `docs/dev/runtime/checkpointing.md` — Snapshotting execution state so a program can restore back to it later.
 - `docs/dev/runtime/concurrent-interrupts.md` — What happens when several concurrent execution paths interrupt at the same time.
 - `docs/dev/runtime/config.md` — Every `AgencyConfig` option, with types and defaults, and how config is resolved.

--- a/packages/agency-lang/docs/dev/runtime/checkpoint-integrity.md
+++ b/packages/agency-lang/docs/dev/runtime/checkpoint-integrity.md
@@ -1,60 +1,42 @@
 # Checkpoint integrity checksums
 
-A checkpoint is the serialized execution state of a paused program, and on the
-external resume path (HTTP `/resume`, a checkpoint loaded from disk) it comes
-back from a caller who could have edited it — changed a local, raised a budget,
-altered which environment variable a paused function is about to read. This
-feature gives a host a way to detect that: when a signing key is configured,
-every checkpoint carries an HMAC checksum of its own contents in a `signature`
-field, and the host can check it with one function call before resuming.
-
-## Embed, do not enforce
-
-The runtime signs but never refuses. No code path in agency-lang rejects a
-checkpoint because its signature is missing or wrong. That is deliberate:
-editing checkpoints is a supported feature — rewind replays with different
-values for a checkpoint's locals, the debugger edits state, `respondToInterrupts`
-accepts overrides — and trace mode writes a checkpoint per step that nobody
-signs a contract about. Enforcement is the host's policy, not the runtime's:
+On the external resume path (HTTP `/resume`, a checkpoint loaded from disk), a
+checkpoint comes back from a caller who could have edited it. When a signing
+key is configured, every checkpoint carries an HMAC checksum of its own
+contents in a `signature` field, and a host can check it with one call before
+resuming:
 
 ```ts
 import { verifyCheckpointChecksum } from "agency-lang";
 
-// On the resume leg, before calling respondToInterrupts:
 if (!verifyCheckpointChecksum(checkpoint)) {
   // refuse the resume — the checkpoint is not the one this host handed out
 }
 ```
 
 `verifyCheckpointChecksum` returns true only when the checkpoint carries a
-signature that validates under the configured key (compared in constant time).
-A missing signature returns false — so a caller cannot dodge verification by
-stripping the field (the downgrade guard). A host that has not opted in simply
-never calls verify.
+signature that validates under the configured key, compared in constant time.
+A missing signature returns false, so a caller cannot dodge verification by
+stripping the field.
 
-## Signing is automatic and opt-in
+## Embed, do not enforce
 
-`Checkpoint.fromStateStack` (`lib/runtime/state/checkpointStore.ts`) is the
-single chokepoint every checkpoint is created through — interrupt checkpoints,
-guard-trip checkpoints, trace snapshots, the stdlib `checkpoint()` builtin. Its
-last statement calls `signCheckpoint(checkpoint)`. With no key in the
-environment that call is a no-op and nothing about a run changes; with a key,
-every checkpoint comes out signed.
+The runtime signs but never refuses: editing checkpoints is a supported
+feature (rewind, the debugger, resume overrides), and trace mode writes a
+checkpoint per step. Enforcement is the host's policy — a host that has not
+opted in never calls verify.
 
-The legitimate edit paths re-sign, so an edited checkpoint stays
-self-consistent rather than carrying a stale signature:
+## Signing
 
-- `applyOverrides` (`lib/runtime/rewind.ts`) — rewind and resume-time local
-  overrides. This also runs on the served resume path with caller-supplied
-  overrides; that is fine because a host verifies *before* responding, and the
-  re-signed object is never returned to the caller.
-- `CheckpointStore.pin` — pinning sets `pinned`/`label`, which are signed
-  fields.
-- `Checkpoint.clone` — a clone usually changes `id`, which is signed.
+`Checkpoint.fromStateStack` is the single chokepoint every checkpoint is
+created through, and its last statement calls `signCheckpoint`. With no key in
+the environment that call is a no-op; with a key, every checkpoint comes out
+signed. The legitimate edit paths — `applyOverrides` (rewind and resume-time
+overrides), `CheckpointStore.pin`, `Checkpoint.clone` — re-sign, so an edited
+checkpoint stays self-consistent. Both functions also accept the plain parsed
+JSON form of a checkpoint, which is what the external resume path carries.
 
-Each re-signs only if the checkpoint was signed in the first place.
-
-## What exactly is signed
+## What is signed
 
 HMAC-SHA256, hex-encoded, over:
 
@@ -63,66 +45,42 @@ HMAC-SHA256, hex-encoded, over:
 ```
 
 `canonicalize` (`lib/utils/canonicalize.ts`) key-sorts objects at every depth,
-so a checkpoint that was serialized, stored, parsed, and re-serialized with
-different key order hashes identically. The checksum covers the **whole**
-checkpoint — never a hand-picked field list, which would rot the first time a
-field was added. New fields (for example the companion `moduleSourceHashes`
-code-fingerprint field) are covered automatically because they appear in
-`toJSON()`.
+so a checkpoint that was stored, parsed, and re-serialized with different key
+order hashes identically. The checksum covers the whole checkpoint, so new
+fields are covered automatically. There is no algorithm field; the algorithm
+is fixed in code, and the domain tag changes if it ever does.
 
-One consequence worth knowing: verification recomputes the canonical form from
-a checkpoint that came back through `Checkpoint.fromJSON`, i.e. through the zod
-schemas in `lib/runtime/state/schemas.ts`. zod strips unknown keys, so a
-`toJSON` field missing from its schema (the PR #977 drift class) no longer just
-drops data — it makes a valid, untampered checkpoint verify **false**. The
-rich-checkpoint round-trip test in `checkpointChecksum.test.ts` pins this; it
-is one more reason every new field on a checkpoint-tree `toJSON` must land in
-its schema in the same change.
-
-There is no algorithm field in the checkpoint. The algorithm is fixed in code
-(no caller-chosen algorithm means no algorithm-confusion attacks); if it ever
-changes, the domain tag changes with it.
+Verification recomputes the canonical form from a checkpoint that came
+through `Checkpoint.fromJSON`, i.e. through the zod schemas — so a `toJSON`
+field missing from its schema makes a valid checkpoint verify false. Every
+new field on a checkpoint-tree `toJSON` must land in its schema in the same
+change.
 
 ## The key
 
-- `AGENCY_CHECKPOINT_KEY` holds the signing key. Generate one with
-  `openssl rand -hex 32`.
-- The key must be at least 32 bytes. A present-but-short key throws
-  `CheckpointKeyTooShortError`; an unset key is not an error, it means signing
+- `AGENCY_CHECKPOINT_KEY`, at least 32 bytes (`openssl rand -hex 32`). A
+  short key throws `CheckpointKeyTooShortError`; an unset key means signing
   is off.
 - Rotation: move the retiring key into `AGENCY_CHECKPOINT_KEY_OLD`
-  (comma-separated list) and put the new key in `AGENCY_CHECKPOINT_KEY`.
-  Signing always uses the current key; verify accepts the current key first,
-  then each retired key, so outstanding checkpoints keep verifying. The old-key
-  list is verify-only.
-- The key is never logged, never sent to statelog, and neither signing nor
-  verification is exposed to Agency code — the key is a host concern, and
-  keeping it out of the language surface means untrusted agent code cannot mint
-  MACs over attacker-chosen content.
-- Subprocesses inherit the parent environment, so checkpoints created in a
-  subprocess segment sign under the same key.
+  (comma-separated, verify-only) and put the new key in
+  `AGENCY_CHECKPOINT_KEY`; outstanding checkpoints keep verifying.
+- The key is never logged or sent to statelog, and neither signing nor
+  verification is exposed to Agency code. Subprocesses inherit the parent
+  environment and sign under the same key.
 
 ## What this is not
 
-- **Not confidentiality.** The checkpoint is plaintext; the signature only
-  detects modification.
-- **Not freshness or binding.** An old, genuinely-signed checkpoint verifies
-  (replay), and a signed checkpoint from one program verifies when posted to
-  another program sharing the key. Binding a checkpoint to its invocation or
-  interrupt id is the host's job.
-- **Not a boundary against in-process code.** The key lives in the same
-  process as running agent code; HMAC defends the round trip to an external
-  caller, not against code already running where the key is.
-- **Verifiable only where the key is.** HMAC is symmetric: every verifier can
-  also sign. That fits the deployment shape here (a host verifying checkpoints
-  it handed out).
+- **Not confidentiality**: the checkpoint is plaintext.
+- **Not freshness or binding**: an old signed checkpoint verifies (replay),
+  and one program's checkpoint verifies against another sharing the key.
+  Binding to an invocation or interrupt id is the host's job.
+- **Not a boundary against in-process code**: the key lives in the process
+  that runs agent code; the checksum defends the round trip to an external
+  caller.
+- **Verifiable only where the key is**: HMAC is symmetric, so every verifier
+  can also sign.
 
-## Performance
-
-Signing costs one extra canonicalize + stringify + HMAC over the whole
-checkpoint at creation. For interrupt checkpoints that is noise. The known hot
-path is trace mode with a key set (a checkpoint per step over state that
-includes full thread history); trace already stringifies every checkpoint to
-disk, so signing roughly doubles that per-step serialization. If it ever shows
-up in a profile, the escape hatch is skipping signing for trace-store
-checkpoints — they never leave the machine.
+Signing costs one canonicalize + HMAC per checkpoint creation, only when a
+key is set. The known hot path is trace mode (a checkpoint per step); if that
+ever shows in a profile, skip signing for trace-store checkpoints — they
+never leave the machine.

--- a/packages/agency-lang/docs/dev/runtime/checkpoint-integrity.md
+++ b/packages/agency-lang/docs/dev/runtime/checkpoint-integrity.md
@@ -1,0 +1,128 @@
+# Checkpoint integrity checksums
+
+A checkpoint is the serialized execution state of a paused program, and on the
+external resume path (HTTP `/resume`, a checkpoint loaded from disk) it comes
+back from a caller who could have edited it — changed a local, raised a budget,
+altered which environment variable a paused function is about to read. This
+feature gives a host a way to detect that: when a signing key is configured,
+every checkpoint carries an HMAC checksum of its own contents in a `signature`
+field, and the host can check it with one function call before resuming.
+
+## Embed, do not enforce
+
+The runtime signs but never refuses. No code path in agency-lang rejects a
+checkpoint because its signature is missing or wrong. That is deliberate:
+editing checkpoints is a supported feature — rewind replays with different
+values for a checkpoint's locals, the debugger edits state, `respondToInterrupts`
+accepts overrides — and trace mode writes a checkpoint per step that nobody
+signs a contract about. Enforcement is the host's policy, not the runtime's:
+
+```ts
+import { verifyCheckpointChecksum } from "agency-lang";
+
+// On the resume leg, before calling respondToInterrupts:
+if (!verifyCheckpointChecksum(checkpoint)) {
+  // refuse the resume — the checkpoint is not the one this host handed out
+}
+```
+
+`verifyCheckpointChecksum` returns true only when the checkpoint carries a
+signature that validates under the configured key (compared in constant time).
+A missing signature returns false — so a caller cannot dodge verification by
+stripping the field (the downgrade guard). A host that has not opted in simply
+never calls verify.
+
+## Signing is automatic and opt-in
+
+`Checkpoint.fromStateStack` (`lib/runtime/state/checkpointStore.ts`) is the
+single chokepoint every checkpoint is created through — interrupt checkpoints,
+guard-trip checkpoints, trace snapshots, the stdlib `checkpoint()` builtin. Its
+last statement calls `signCheckpoint(checkpoint)`. With no key in the
+environment that call is a no-op and nothing about a run changes; with a key,
+every checkpoint comes out signed.
+
+The legitimate edit paths re-sign, so an edited checkpoint stays
+self-consistent rather than carrying a stale signature:
+
+- `applyOverrides` (`lib/runtime/rewind.ts`) — rewind and resume-time local
+  overrides. This also runs on the served resume path with caller-supplied
+  overrides; that is fine because a host verifies *before* responding, and the
+  re-signed object is never returned to the caller.
+- `CheckpointStore.pin` — pinning sets `pinned`/`label`, which are signed
+  fields.
+- `Checkpoint.clone` — a clone usually changes `id`, which is signed.
+
+Each re-signs only if the checkpoint was signed in the first place.
+
+## What exactly is signed
+
+HMAC-SHA256, hex-encoded, over:
+
+```
+"agency.checkpoint.v1" + "\n" + canonicalize(toJSON() minus the signature field)
+```
+
+`canonicalize` (`lib/utils/canonicalize.ts`) key-sorts objects at every depth,
+so a checkpoint that was serialized, stored, parsed, and re-serialized with
+different key order hashes identically. The checksum covers the **whole**
+checkpoint — never a hand-picked field list, which would rot the first time a
+field was added. New fields (for example the companion `moduleSourceHashes`
+code-fingerprint field) are covered automatically because they appear in
+`toJSON()`.
+
+One consequence worth knowing: verification recomputes the canonical form from
+a checkpoint that came back through `Checkpoint.fromJSON`, i.e. through the zod
+schemas in `lib/runtime/state/schemas.ts`. zod strips unknown keys, so a
+`toJSON` field missing from its schema (the PR #977 drift class) no longer just
+drops data — it makes a valid, untampered checkpoint verify **false**. The
+rich-checkpoint round-trip test in `checkpointChecksum.test.ts` pins this; it
+is one more reason every new field on a checkpoint-tree `toJSON` must land in
+its schema in the same change.
+
+There is no algorithm field in the checkpoint. The algorithm is fixed in code
+(no caller-chosen algorithm means no algorithm-confusion attacks); if it ever
+changes, the domain tag changes with it.
+
+## The key
+
+- `AGENCY_CHECKPOINT_KEY` holds the signing key. Generate one with
+  `openssl rand -hex 32`.
+- The key must be at least 32 bytes. A present-but-short key throws
+  `CheckpointKeyTooShortError`; an unset key is not an error, it means signing
+  is off.
+- Rotation: move the retiring key into `AGENCY_CHECKPOINT_KEY_OLD`
+  (comma-separated list) and put the new key in `AGENCY_CHECKPOINT_KEY`.
+  Signing always uses the current key; verify accepts the current key first,
+  then each retired key, so outstanding checkpoints keep verifying. The old-key
+  list is verify-only.
+- The key is never logged, never sent to statelog, and neither signing nor
+  verification is exposed to Agency code — the key is a host concern, and
+  keeping it out of the language surface means untrusted agent code cannot mint
+  MACs over attacker-chosen content.
+- Subprocesses inherit the parent environment, so checkpoints created in a
+  subprocess segment sign under the same key.
+
+## What this is not
+
+- **Not confidentiality.** The checkpoint is plaintext; the signature only
+  detects modification.
+- **Not freshness or binding.** An old, genuinely-signed checkpoint verifies
+  (replay), and a signed checkpoint from one program verifies when posted to
+  another program sharing the key. Binding a checkpoint to its invocation or
+  interrupt id is the host's job.
+- **Not a boundary against in-process code.** The key lives in the same
+  process as running agent code; HMAC defends the round trip to an external
+  caller, not against code already running where the key is.
+- **Verifiable only where the key is.** HMAC is symmetric: every verifier can
+  also sign. That fits the deployment shape here (a host verifying checkpoints
+  it handed out).
+
+## Performance
+
+Signing costs one extra canonicalize + stringify + HMAC over the whole
+checkpoint at creation. For interrupt checkpoints that is noise. The known hot
+path is trace mode with a key set (a checkpoint per step over state that
+includes full thread history); trace already stringifies every checkpoint to
+disk, so signing roughly doubles that per-step serialization. If it ever shows
+up in a profile, the escape hatch is skipping signing for trace-store
+checkpoints — they never leave the machine.

--- a/packages/agency-lang/docs/dev/runtime/checkpointing.md
+++ b/packages/agency-lang/docs/dev/runtime/checkpointing.md
@@ -281,3 +281,9 @@ checks is maintained by the interrupt dispatcher, is inherited by
 branch stacks, and is deliberately never serialized: since no pause can
 exist while it is non-empty, a deserialized stack correctly starts with
 it empty.
+
+## Integrity checksums
+
+When a signing key is configured, every checkpoint carries an embedded HMAC
+checksum a host can verify before resuming; the runtime itself never enforces
+it. See `docs/dev/runtime/checkpoint-integrity.md`.

--- a/packages/agency-lang/docs/site/guide/checkpointing.md
+++ b/packages/agency-lang/docs/site/guide/checkpointing.md
@@ -99,3 +99,24 @@ agency debugger foo.agency --checkpoint <checkpoint-file>
 ```
 
 Note that you have to additionally give the source file.
+## Verifying checkpoint integrity
+
+A checkpoint that leaves your process — returned over HTTP, stored on disk —
+can be edited before it comes back. If you set a signing key, Agency embeds a
+checksum in every checkpoint, and you can verify it before resuming:
+
+```bash
+export AGENCY_CHECKPOINT_KEY=$(openssl rand -hex 32)
+```
+
+```ts
+import { verifyCheckpointChecksum } from "agency-lang";
+
+if (!verifyCheckpointChecksum(checkpoint)) {
+  // this is not the checkpoint you handed out — refuse the resume
+}
+```
+
+With no key set, nothing is signed and nothing changes. Agency itself never
+rejects a checkpoint over its checksum — whether to require one is your call
+as the host.

--- a/packages/agency-lang/docs/site/guide/checkpointing.md
+++ b/packages/agency-lang/docs/site/guide/checkpointing.md
@@ -101,22 +101,20 @@ agency debugger foo.agency --checkpoint <checkpoint-file>
 Note that you have to additionally give the source file.
 ## Verifying checkpoint integrity
 
-A checkpoint that leaves your process — returned over HTTP, stored on disk —
-can be edited before it comes back. If you set a signing key, Agency embeds a
-checksum in every checkpoint, and you can verify it before resuming:
+You can verify that a checkpoint has not been tampered with. If you set the AGENCY_CHECKPOINT_KEY environment variable, Agency will embed a checksum into every checkpoint.
 
 ```bash
 export AGENCY_CHECKPOINT_KEY=$(openssl rand -hex 32)
 ```
 
+ You can verify the checkpoint like this:
+ 
 ```ts
 import { verifyCheckpointChecksum } from "agency-lang";
 
 if (!verifyCheckpointChecksum(checkpoint)) {
-  // this is not the checkpoint you handed out — refuse the resume
+  // oops! Someone has edited this checkpoint. Refuse to resume
 }
 ```
 
-With no key set, nothing is signed and nothing changes. Agency itself never
-rejects a checkpoint over its checksum — whether to require one is your call
-as the host.
+This is strictly opt-in: you opt in to add the signature by setting the env var, and you need to manually check whether a checkpoint has been tampered with.

--- a/packages/agency-lang/lib/runtime/checkpointChecksum.test.ts
+++ b/packages/agency-lang/lib/runtime/checkpointChecksum.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from "vitest";
-import { Checkpoint } from "./state/checkpointStore.js";
+import { Checkpoint, CheckpointStore } from "./state/checkpointStore.js";
 import {
   signCheckpoint,
   verifyCheckpointChecksum,
@@ -155,6 +155,20 @@ describe("checkpoint checksum", () => {
     expect(verifyCheckpointChecksum(checkpoint)).toBe(false);
   });
 
+  it("signs and verifies a PLAIN JSON checkpoint (the external resume shape)", () => {
+    // interrupt.checkpoint after an HTTP round trip is parsed JSON, not a
+    // Checkpoint instance; sign/verify must accept it (applyOverrides re-signs
+    // exactly this shape on the resume path).
+    process.env.AGENCY_CHECKPOINT_KEY = KEY;
+    const instance = makeCheckpoint();
+    signCheckpoint(instance);
+    const plain = JSON.parse(JSON.stringify(instance.toJSON()));
+    expect(verifyCheckpointChecksum(plain)).toBe(true);
+    plain.stack.stack[0].locals.x = 7;
+    signCheckpoint(plain);
+    expect(verifyCheckpointChecksum(plain)).toBe(true);
+  });
+
   it("an edited-then-resigned checkpoint verifies true", () => {
     process.env.AGENCY_CHECKPOINT_KEY = KEY;
     const checkpoint = makeCheckpoint();
@@ -162,5 +176,31 @@ describe("checkpoint checksum", () => {
     checkpoint.stack.stack[0].locals.x = 42; // simulate an override edit
     signCheckpoint(checkpoint); // re-sign
     expect(verifyCheckpointChecksum(checkpoint)).toBe(true);
+  });
+});
+
+describe("re-signing on the post-creation edit paths", () => {
+  afterEach(() => {
+    delete process.env.AGENCY_CHECKPOINT_KEY;
+  });
+
+  it("a pinned checkpoint still verifies (pin re-signs)", () => {
+    process.env.AGENCY_CHECKPOINT_KEY = KEY;
+    const store = new CheckpointStore();
+    const checkpoint = makeCheckpoint();
+    signCheckpoint(checkpoint);
+    store.add(checkpoint);
+    store.pin(checkpoint.id, "pinned-label");
+    expect(store.get(checkpoint.id)!.pinned).toBe(true);
+    expect(verifyCheckpointChecksum(store.get(checkpoint.id)!)).toBe(true);
+  });
+
+  it("a clone with a new id still verifies (clone re-signs)", () => {
+    process.env.AGENCY_CHECKPOINT_KEY = KEY;
+    const checkpoint = makeCheckpoint();
+    signCheckpoint(checkpoint);
+    const copy = checkpoint.clone({ id: 999 });
+    expect(copy.id).toBe(999);
+    expect(verifyCheckpointChecksum(copy)).toBe(true);
   });
 });

--- a/packages/agency-lang/lib/runtime/checkpointChecksum.test.ts
+++ b/packages/agency-lang/lib/runtime/checkpointChecksum.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { Checkpoint } from "./state/checkpointStore.js";
+import {
+  signCheckpoint,
+  verifyCheckpointChecksum,
+  CheckpointKeyTooShortError,
+} from "./checkpointChecksum.js";
+
+const KEY = "0123456789abcdef0123456789abcdef"; // 32 bytes
+const ROTATED_KEY = "ffffffffffffffffffffffffffffffff";
+
+function makeCheckpoint(): Checkpoint {
+  return new Checkpoint({
+    id: 1,
+    nodeId: "start",
+    moduleId: "mod.agency",
+    scopeName: "main",
+    stepPath: "0",
+    stack: {
+      stack: [{ args: {}, locals: { x: 1 }, threads: null, step: 0, scopeName: "main" }],
+      mode: "serialize",
+      other: {},
+      deserializeStackLength: 0,
+      nodesTraversed: [],
+    },
+    globals: { store: {}, initializedModules: [] },
+  });
+}
+
+/** A checkpoint carrying the fields PR #977 added to the schemas (guards,
+ *  cost, savedDraft, branches). The verify side goes through the zod schemas,
+ *  so any toJSON field missing from its schema would turn into a false
+ *  "tampered" verdict — this fixture pins the round trip. */
+function makeRichCheckpoint(): Checkpoint {
+  return new Checkpoint({
+    id: 2,
+    nodeId: "start",
+    moduleId: "mod.agency",
+    scopeName: "main",
+    stepPath: "0",
+    stack: {
+      stack: [
+        {
+          args: {},
+          locals: {},
+          threads: null,
+          step: 1,
+          scopeName: "main",
+          savedDraft: { value: "draft" },
+          branches: {
+            fork_1_0: {
+              stack: {
+                stack: [],
+                mode: "serialize",
+                other: {},
+                deserializeStackLength: 0,
+                nodesTraversed: [],
+              },
+              interruptId: "int-1",
+              result: { result: "done" },
+              activeStack: ["t1"],
+            },
+          },
+        },
+      ],
+      mode: "serialize",
+      other: {},
+      deserializeStackLength: 0,
+      nodesTraversed: [],
+      localCost: 2.25,
+      localTokens: 100,
+      guards: [{ kind: "cost", costLimit: 10, spent: 4, guardId: "g1", label: "budget" }],
+      inheritedGuardCount: 0,
+      inheritedTimeGuards: [{ kind: "time", timeLimit: 5000, elapsedMs: 1200, guardId: "g2" }],
+    },
+    globals: { store: {}, initializedModules: [] },
+  });
+}
+
+afterEach(() => {
+  delete process.env.AGENCY_CHECKPOINT_KEY;
+  delete process.env.AGENCY_CHECKPOINT_KEY_OLD;
+});
+
+describe("checkpoint checksum", () => {
+  it("signs then verifies true", () => {
+    process.env.AGENCY_CHECKPOINT_KEY = KEY;
+    const checkpoint = makeCheckpoint();
+    signCheckpoint(checkpoint);
+    expect(verifyCheckpointChecksum(checkpoint)).toBe(true);
+  });
+
+  it("verify is false when a local changed after signing", () => {
+    process.env.AGENCY_CHECKPOINT_KEY = KEY;
+    const checkpoint = makeCheckpoint();
+    signCheckpoint(checkpoint);
+    checkpoint.stack.stack[0].locals.x = 999;
+    expect(verifyCheckpointChecksum(checkpoint)).toBe(false);
+  });
+
+  it("verify is false under a different key", () => {
+    process.env.AGENCY_CHECKPOINT_KEY = KEY;
+    const checkpoint = makeCheckpoint();
+    signCheckpoint(checkpoint);
+    process.env.AGENCY_CHECKPOINT_KEY = ROTATED_KEY;
+    expect(verifyCheckpointChecksum(checkpoint)).toBe(false);
+  });
+
+  it("verify is false when the signature is stripped (downgrade guard)", () => {
+    process.env.AGENCY_CHECKPOINT_KEY = KEY;
+    const checkpoint = makeCheckpoint();
+    signCheckpoint(checkpoint);
+    checkpoint.signature = undefined;
+    expect(verifyCheckpointChecksum(checkpoint)).toBe(false);
+  });
+
+  it("key order does not matter (parse + re-stringify round trip verifies)", () => {
+    process.env.AGENCY_CHECKPOINT_KEY = KEY;
+    const checkpoint = makeCheckpoint();
+    signCheckpoint(checkpoint);
+    const revived = Checkpoint.fromJSON(JSON.parse(JSON.stringify(checkpoint.toJSON())))!;
+    expect(verifyCheckpointChecksum(revived)).toBe(true);
+  });
+
+  it("a RICH checkpoint survives the external zod round trip and still verifies", () => {
+    process.env.AGENCY_CHECKPOINT_KEY = KEY;
+    const checkpoint = makeRichCheckpoint();
+    signCheckpoint(checkpoint);
+    const revived = Checkpoint.fromJSON(JSON.parse(JSON.stringify(checkpoint.toJSON())))!;
+    expect(verifyCheckpointChecksum(revived)).toBe(true);
+  });
+
+  it("no key: signCheckpoint leaves signature absent and verify returns false, neither throws", () => {
+    const checkpoint = makeCheckpoint();
+    expect(() => signCheckpoint(checkpoint)).not.toThrow();
+    expect(checkpoint.signature).toBeUndefined();
+    expect(verifyCheckpointChecksum(checkpoint)).toBe(false);
+  });
+
+  it("a present but too-short key throws CheckpointKeyTooShortError", () => {
+    process.env.AGENCY_CHECKPOINT_KEY = "tooshort";
+    expect(() => signCheckpoint(makeCheckpoint())).toThrow(CheckpointKeyTooShortError);
+  });
+
+  it("a checkpoint signed under a retired key still verifies via AGENCY_CHECKPOINT_KEY_OLD", () => {
+    process.env.AGENCY_CHECKPOINT_KEY = KEY;
+    const checkpoint = makeCheckpoint();
+    signCheckpoint(checkpoint);
+    // Rotate: the signing key moves to _OLD, a new key takes its place.
+    process.env.AGENCY_CHECKPOINT_KEY = ROTATED_KEY;
+    process.env.AGENCY_CHECKPOINT_KEY_OLD = KEY;
+    expect(verifyCheckpointChecksum(checkpoint)).toBe(true);
+    // A key in neither var still fails.
+    process.env.AGENCY_CHECKPOINT_KEY_OLD = "00000000000000000000000000000000";
+    expect(verifyCheckpointChecksum(checkpoint)).toBe(false);
+  });
+
+  it("an edited-then-resigned checkpoint verifies true", () => {
+    process.env.AGENCY_CHECKPOINT_KEY = KEY;
+    const checkpoint = makeCheckpoint();
+    signCheckpoint(checkpoint);
+    checkpoint.stack.stack[0].locals.x = 42; // simulate an override edit
+    signCheckpoint(checkpoint); // re-sign
+    expect(verifyCheckpointChecksum(checkpoint)).toBe(true);
+  });
+});

--- a/packages/agency-lang/lib/runtime/checkpointChecksum.test.ts
+++ b/packages/agency-lang/lib/runtime/checkpointChecksum.test.ts
@@ -27,10 +27,9 @@ function makeCheckpoint(): Checkpoint {
   });
 }
 
-/** A checkpoint carrying the fields PR #977 added to the schemas (guards,
- *  cost, savedDraft, branches). The verify side goes through the zod schemas,
- *  so any toJSON field missing from its schema would turn into a false
- *  "tampered" verdict — this fixture pins the round trip. */
+/** Carries guards, cost, savedDraft, and branches: the verify side goes
+ *  through the zod schemas, so a toJSON field missing from its schema would
+ *  read as tampered. */
 function makeRichCheckpoint(): Checkpoint {
   return new Checkpoint({
     id: 2,
@@ -156,9 +155,7 @@ describe("checkpoint checksum", () => {
   });
 
   it("signs and verifies a PLAIN JSON checkpoint (the external resume shape)", () => {
-    // interrupt.checkpoint after an HTTP round trip is parsed JSON, not a
-    // Checkpoint instance; sign/verify must accept it (applyOverrides re-signs
-    // exactly this shape on the resume path).
+    // The external resume path carries parsed JSON, not a Checkpoint instance.
     process.env.AGENCY_CHECKPOINT_KEY = KEY;
     const instance = makeCheckpoint();
     signCheckpoint(instance);

--- a/packages/agency-lang/lib/runtime/checkpointChecksum.ts
+++ b/packages/agency-lang/lib/runtime/checkpointChecksum.ts
@@ -3,8 +3,7 @@ import { canonicalize } from "@/utils/canonicalize.js";
 import type { Checkpoint, CheckpointJSON } from "./state/checkpointStore.js";
 
 /** Both shapes a checkpoint travels as: the live class instance, and the
- *  plain parsed JSON the external resume path carries (`interrupt.checkpoint`
- *  after a round trip is not a Checkpoint instance). */
+ *  plain parsed JSON the external resume path carries. */
 export type SignableCheckpoint = Checkpoint | CheckpointJSON;
 
 const DOMAIN = "agency.checkpoint.v1";
@@ -49,9 +48,9 @@ function resolveOldKeys(): string[] {
   });
 }
 
-/** The plain-object form of a checkpoint, whichever shape it arrived in.
- *  Duck-typed on `toJSON` rather than `instanceof Checkpoint` so this module
- *  never imports the class value (checkpointStore imports this module). */
+/** The plain-object form, whichever shape it arrived in. Duck-typed on
+ *  `toJSON` so this module never imports the class value (checkpointStore
+ *  imports this module). */
 function checkpointJson(cp: SignableCheckpoint): Record<string, unknown> {
   const maybeInstance = cp as { toJSON?: () => CheckpointJSON };
   const json = typeof maybeInstance.toJSON === "function" ? maybeInstance.toJSON() : cp;

--- a/packages/agency-lang/lib/runtime/checkpointChecksum.ts
+++ b/packages/agency-lang/lib/runtime/checkpointChecksum.ts
@@ -1,6 +1,11 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 import { canonicalize } from "@/utils/canonicalize.js";
-import type { Checkpoint } from "./state/checkpointStore.js";
+import type { Checkpoint, CheckpointJSON } from "./state/checkpointStore.js";
+
+/** Both shapes a checkpoint travels as: the live class instance, and the
+ *  plain parsed JSON the external resume path carries (`interrupt.checkpoint`
+ *  after a round trip is not a Checkpoint instance). */
+export type SignableCheckpoint = Checkpoint | CheckpointJSON;
 
 const DOMAIN = "agency.checkpoint.v1";
 const KEY_ENV_VAR = "AGENCY_CHECKPOINT_KEY";
@@ -44,21 +49,30 @@ function resolveOldKeys(): string[] {
   });
 }
 
+/** The plain-object form of a checkpoint, whichever shape it arrived in.
+ *  Duck-typed on `toJSON` rather than `instanceof Checkpoint` so this module
+ *  never imports the class value (checkpointStore imports this module). */
+function checkpointJson(cp: SignableCheckpoint): Record<string, unknown> {
+  const maybeInstance = cp as { toJSON?: () => CheckpointJSON };
+  const json = typeof maybeInstance.toJSON === "function" ? maybeInstance.toJSON() : cp;
+  return { ...(json as Record<string, unknown>) };
+}
+
 /** The exact bytes the MAC is computed over: the whole checkpoint minus its
  *  own signature field, canonicalized (`canonicalize` key-sorts at every
  *  depth, so a parsed-and-reserialized checkpoint hashes identically
  *  regardless of key order), prefixed with a domain tag. */
-function canonicalString(cp: Checkpoint): string {
-  const json = { ...cp.toJSON() } as Record<string, unknown>;
+function canonicalString(cp: SignableCheckpoint): string {
+  const json = checkpointJson(cp);
   delete json.signature;
   return DOMAIN + "\n" + canonicalize(json);
 }
 
-function computeMac(cp: Checkpoint, key: string): string {
+function computeMac(cp: SignableCheckpoint, key: string): string {
   return createHmac("sha256", key).update(canonicalString(cp)).digest("hex");
 }
 
-function macMatches(cp: Checkpoint, signature: string, key: string): boolean {
+function macMatches(cp: SignableCheckpoint, signature: string, key: string): boolean {
   const expected = Buffer.from(computeMac(cp, key), "hex");
   const actual = Buffer.from(signature, "hex");
   if (expected.length !== actual.length) {
@@ -68,7 +82,7 @@ function macMatches(cp: Checkpoint, signature: string, key: string): boolean {
 }
 
 /** Embed a checksum in `cp.signature` when a key is configured; no-op otherwise. */
-export function signCheckpoint(cp: Checkpoint): void {
+export function signCheckpoint(cp: SignableCheckpoint): void {
   const key = resolveKey();
   if (key === null) {
     return;
@@ -80,7 +94,7 @@ export function signCheckpoint(cp: Checkpoint): void {
  *  the retired keys in AGENCY_CHECKPOINT_KEY_OLD, compared in constant time.
  *  False if the signature is absent, matches no key, or no key is configured —
  *  a stripped signature therefore reads as NOT verified (downgrade guard). */
-export function verifyCheckpointChecksum(cp: Checkpoint): boolean {
+export function verifyCheckpointChecksum(cp: SignableCheckpoint): boolean {
   const key = resolveKey();
   const signature = cp.signature;
   if (key === null || signature === undefined) {

--- a/packages/agency-lang/lib/runtime/checkpointChecksum.ts
+++ b/packages/agency-lang/lib/runtime/checkpointChecksum.ts
@@ -1,0 +1,93 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { canonicalize } from "@/utils/canonicalize.js";
+import type { Checkpoint } from "./state/checkpointStore.js";
+
+const DOMAIN = "agency.checkpoint.v1";
+const KEY_ENV_VAR = "AGENCY_CHECKPOINT_KEY";
+const OLD_KEYS_ENV_VAR = "AGENCY_CHECKPOINT_KEY_OLD";
+const MIN_KEY_BYTES = 32;
+
+/** Thrown only when a key is PRESENT but shorter than 32 bytes. An unset key
+ *  is not an error — it means signing is off. */
+export class CheckpointKeyTooShortError extends Error {
+  constructor(bytes: number) {
+    super(`Checkpoint key is ${bytes} bytes; at least ${MIN_KEY_BYTES} are required.`);
+    this.name = "CheckpointKeyTooShortError";
+  }
+}
+
+/** Read the signing key from the environment. null = not configured (signing off). */
+function resolveKey(): string | null {
+  const raw = process.env[KEY_ENV_VAR];
+  if (raw === undefined || raw === "") {
+    return null;
+  }
+  if (Buffer.byteLength(raw, "utf8") < MIN_KEY_BYTES) {
+    throw new CheckpointKeyTooShortError(Buffer.byteLength(raw, "utf8"));
+  }
+  return raw;
+}
+
+/** Retired keys accepted at verify time only: comma-separated, each subject to
+ *  the same minimum length. Rotation = move the old key here, sign with a new
+ *  one; outstanding checkpoints keep verifying. Nothing ever signs with these. */
+function resolveOldKeys(): string[] {
+  const raw = process.env[OLD_KEYS_ENV_VAR];
+  if (raw === undefined || raw === "") {
+    return [];
+  }
+  return raw.split(",").map((candidate) => {
+    if (Buffer.byteLength(candidate, "utf8") < MIN_KEY_BYTES) {
+      throw new CheckpointKeyTooShortError(Buffer.byteLength(candidate, "utf8"));
+    }
+    return candidate;
+  });
+}
+
+/** The exact bytes the MAC is computed over: the whole checkpoint minus its
+ *  own signature field, canonicalized (`canonicalize` key-sorts at every
+ *  depth, so a parsed-and-reserialized checkpoint hashes identically
+ *  regardless of key order), prefixed with a domain tag. */
+function canonicalString(cp: Checkpoint): string {
+  const json = { ...cp.toJSON() } as Record<string, unknown>;
+  delete json.signature;
+  return DOMAIN + "\n" + canonicalize(json);
+}
+
+function computeMac(cp: Checkpoint, key: string): string {
+  return createHmac("sha256", key).update(canonicalString(cp)).digest("hex");
+}
+
+function macMatches(cp: Checkpoint, signature: string, key: string): boolean {
+  const expected = Buffer.from(computeMac(cp, key), "hex");
+  const actual = Buffer.from(signature, "hex");
+  if (expected.length !== actual.length) {
+    return false;
+  }
+  return timingSafeEqual(expected, actual);
+}
+
+/** Embed a checksum in `cp.signature` when a key is configured; no-op otherwise. */
+export function signCheckpoint(cp: Checkpoint): void {
+  const key = resolveKey();
+  if (key === null) {
+    return;
+  }
+  cp.signature = computeMac(cp, key);
+}
+
+/** True iff `cp` carries a signature valid under the configured key or one of
+ *  the retired keys in AGENCY_CHECKPOINT_KEY_OLD, compared in constant time.
+ *  False if the signature is absent, matches no key, or no key is configured —
+ *  a stripped signature therefore reads as NOT verified (downgrade guard). */
+export function verifyCheckpointChecksum(cp: Checkpoint): boolean {
+  const key = resolveKey();
+  const signature = cp.signature;
+  if (key === null || signature === undefined) {
+    return false;
+  }
+  if (macMatches(cp, signature, key)) {
+    return true;
+  }
+  return resolveOldKeys().some((oldKey) => macMatches(cp, signature, oldKey));
+}

--- a/packages/agency-lang/lib/runtime/index.ts
+++ b/packages/agency-lang/lib/runtime/index.ts
@@ -124,6 +124,7 @@ export { _run } from "./ipc.js";
 
 export { CheckpointStore, RESULT_ENTRY_LABEL } from "./state/checkpointStore.js";
 export { Checkpoint } from "./state/checkpointStore.js";
+export { verifyCheckpointChecksum, CheckpointKeyTooShortError } from "./checkpointChecksum.js";
 
 export {
   setupNode,

--- a/packages/agency-lang/lib/runtime/rewind.ts
+++ b/packages/agency-lang/lib/runtime/rewind.ts
@@ -1,4 +1,5 @@
 import type { Checkpoint } from "./state/checkpointStore.js";
+import { signCheckpoint } from "./checkpointChecksum.js";
 import { throwIfNodeResultAborted } from "./abortBoundary.js";
 import { runInBootstrapFrame } from "./asyncContext.js";
 import { __initAllRegisteredCallbacks } from "./crossModuleInitRegistry.js";
@@ -14,6 +15,13 @@ export function applyOverrides(checkpoint: Checkpoint, overrides: Record<string,
   const frame = StateStack.lastFrameJSON(checkpoint.stack);
   for (const [key, value] of Object.entries(overrides)) {
     frame.locals[key] = value;
+  }
+  // A legitimate edit invalidates the embedded checksum, so re-sign. This also
+  // runs on the served resume path with caller-supplied overrides — fine,
+  // because a host verifies BEFORE responding, and the re-signed object is
+  // never returned to the caller.
+  if (checkpoint.signature !== undefined) {
+    signCheckpoint(checkpoint);
   }
 }
 

--- a/packages/agency-lang/lib/runtime/rewind.ts
+++ b/packages/agency-lang/lib/runtime/rewind.ts
@@ -16,10 +16,9 @@ export function applyOverrides(checkpoint: Checkpoint, overrides: Record<string,
   for (const [key, value] of Object.entries(overrides)) {
     frame.locals[key] = value;
   }
-  // A legitimate edit invalidates the embedded checksum, so re-sign. This also
-  // runs on the served resume path with caller-supplied overrides — fine,
-  // because a host verifies BEFORE responding, and the re-signed object is
-  // never returned to the caller.
+  // Re-sign after the edit. Also runs on the served resume path with caller
+  // overrides — safe: a host verifies before responding, and the re-signed
+  // object is never returned to the caller.
   if (checkpoint.signature !== undefined) {
     signCheckpoint(checkpoint);
   }

--- a/packages/agency-lang/lib/runtime/state/checkpointStore.test.ts
+++ b/packages/agency-lang/lib/runtime/state/checkpointStore.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import { Checkpoint, CheckpointStore } from "./checkpointStore.js";
+import { verifyCheckpointChecksum } from "../checkpointChecksum.js";
 import { type StateStackJSON, type StateJSON } from "./stateStack.js";
 import { type GlobalStoreJSON } from "./globalStore.js";
 import { CheckpointError } from "../errors.js";
@@ -718,5 +719,33 @@ describe("CheckpointStore", () => {
       // The JSON should only have 1 checkpoint
       expect(Object.keys(json.checkpoints)).toHaveLength(1);
     });
+  });
+});
+
+describe("checkpoint signing at creation", () => {
+  afterEach(() => {
+    delete process.env.AGENCY_CHECKPOINT_KEY;
+  });
+
+  it("signs a created checkpoint when a key is configured", () => {
+    process.env.AGENCY_CHECKPOINT_KEY = "0123456789abcdef0123456789abcdef";
+    const ctx = makeMockCtx();
+    const cp = Checkpoint.fromStateStack(ctx.stateStack, ctx, {
+      moduleId: "m",
+      scopeName: "main",
+      stepPath: "0",
+    });
+    expect(cp.signature).toBeDefined();
+    expect(verifyCheckpointChecksum(cp)).toBe(true);
+  });
+
+  it("does not sign when no key is configured", () => {
+    const ctx = makeMockCtx();
+    const cp = Checkpoint.fromStateStack(ctx.stateStack, ctx, {
+      moduleId: "m",
+      scopeName: "main",
+      stepPath: "0",
+    });
+    expect(cp.signature).toBeUndefined();
   });
 });

--- a/packages/agency-lang/lib/runtime/state/checkpointStore.ts
+++ b/packages/agency-lang/lib/runtime/state/checkpointStore.ts
@@ -189,7 +189,13 @@ export class Checkpoint implements SourceLocation {
   }
 
   clone(opts: Partial<CheckpointArgs> = {}): Checkpoint {
-    return Checkpoint.fromJSON({ ...this.toJSON(), ...opts })!;
+    const copy = Checkpoint.fromJSON({ ...this.toJSON(), ...opts })!;
+    // The copy carries the original signature but `opts` may have changed
+    // signed fields (typically `id`); re-sign so the copy verifies.
+    if (copy.signature !== undefined) {
+      signCheckpoint(copy);
+    }
+    return copy;
   }
 
   getLocation(): string {
@@ -370,6 +376,11 @@ export class CheckpointStore {
     if (!cp) return;
     cp.pinned = true;
     if (label !== undefined) cp.label = label;
+    // pinned/label are covered by the signature; re-sign the edited checkpoint
+    // so it stays self-consistent.
+    if (cp.signature !== undefined) {
+      signCheckpoint(cp);
+    }
   }
 
   get(id: number): Checkpoint | undefined {

--- a/packages/agency-lang/lib/runtime/state/checkpointStore.ts
+++ b/packages/agency-lang/lib/runtime/state/checkpointStore.ts
@@ -190,8 +190,7 @@ export class Checkpoint implements SourceLocation {
 
   clone(opts: Partial<CheckpointArgs> = {}): Checkpoint {
     const copy = Checkpoint.fromJSON({ ...this.toJSON(), ...opts })!;
-    // The copy carries the original signature but `opts` may have changed
-    // signed fields (typically `id`); re-sign so the copy verifies.
+    // `opts` may have changed signed fields (typically `id`); re-sign.
     if (copy.signature !== undefined) {
       signCheckpoint(copy);
     }
@@ -219,9 +218,7 @@ export class Checkpoint implements SourceLocation {
       nodeId,
       ...opts,
     });
-    // This is the single chokepoint every checkpoint (interrupt, guard,
-    // trace) is created through, so signing here covers them all. Keep this
-    // the last statement: the signature must cover every field set above.
+    // Keep this the last statement: the signature must cover every field.
     signCheckpoint(checkpoint);
     return checkpoint;
   }
@@ -376,8 +373,7 @@ export class CheckpointStore {
     if (!cp) return;
     cp.pinned = true;
     if (label !== undefined) cp.label = label;
-    // pinned/label are covered by the signature; re-sign the edited checkpoint
-    // so it stays self-consistent.
+    // pinned/label are signed fields; re-sign after the edit.
     if (cp.signature !== undefined) {
       signCheckpoint(cp);
     }

--- a/packages/agency-lang/lib/runtime/state/checkpointStore.ts
+++ b/packages/agency-lang/lib/runtime/state/checkpointStore.ts
@@ -1,4 +1,5 @@
 import { MessageJSON } from "smoltalk";
+import { signCheckpoint } from "../checkpointChecksum.js";
 import { CheckpointError } from "../errors.js";
 import { deepClone } from "../utils.js";
 import type { RuntimeContext } from "./context.js";
@@ -206,12 +207,17 @@ export class Checkpoint implements SourceLocation {
         "Cannot create checkpoint: no current node id in state stack. This error can happen if you call a function that throws an interrupt from the global namespace. Please use `const foo = funcName() with approve` syntax.",
       );
     }
-    return new Checkpoint({
+    const checkpoint = new Checkpoint({
       stack: stateStack.toJSON(),
       globals: ctx.globals.toJSON(),
       nodeId,
       ...opts,
     });
+    // This is the single chokepoint every checkpoint (interrupt, guard,
+    // trace) is created through, so signing here covers them all. Keep this
+    // the last statement: the signature must cover every field set above.
+    signCheckpoint(checkpoint);
+    return checkpoint;
   }
 
   static fromContext(

--- a/packages/agency-lang/lib/runtime/state/checkpointStore.ts
+++ b/packages/agency-lang/lib/runtime/state/checkpointStore.ts
@@ -36,6 +36,20 @@ export type CheckpointArgs = {
   stepPath?: string;
   label?: string | null;
   pinned?: boolean;
+  signature?: string;
+};
+
+export type CheckpointJSON = {
+  id: number;
+  stack: StateStackJSON;
+  globals: GlobalStoreJSON;
+  nodeId: string;
+  moduleId: string;
+  scopeName: string;
+  stepPath: string;
+  label: string | null;
+  pinned: boolean;
+  signature?: string;
 };
 
 export class Checkpoint implements SourceLocation {
@@ -48,6 +62,9 @@ export class Checkpoint implements SourceLocation {
   public stepPath: string;
   public label: string | null;
   public pinned: boolean;
+  /** HMAC checksum embedded at creation when a signing key is configured.
+   *  Absent on unsigned checkpoints. See lib/runtime/checkpointChecksum.ts. */
+  public signature?: string;
 
   constructor(args: CheckpointArgs) {
     this.id = args.id ?? globalCheckpointCounter++;
@@ -59,6 +76,7 @@ export class Checkpoint implements SourceLocation {
     this.stepPath = args.stepPath ?? "";
     this.label = args.label ?? null;
     this.pinned = args.pinned ?? false;
+    this.signature = args.signature;
   }
 
   getScopeKey(): string {
@@ -151,8 +169,8 @@ export class Checkpoint implements SourceLocation {
     return JSON.stringify(this.toJSON()) === JSON.stringify(other.toJSON());
   }
 
-  toJSON() {
-    return {
+  toJSON(): CheckpointJSON {
+    const json: CheckpointJSON = {
       id: this.id,
       stack: this.stack,
       globals: this.globals,
@@ -163,6 +181,10 @@ export class Checkpoint implements SourceLocation {
       label: this.label,
       pinned: this.pinned,
     };
+    if (this.signature !== undefined) {
+      json.signature = this.signature;
+    }
+    return json;
   }
 
   clone(opts: Partial<CheckpointArgs> = {}): Checkpoint {

--- a/packages/agency-lang/lib/runtime/state/schemas.test.ts
+++ b/packages/agency-lang/lib/runtime/state/schemas.test.ts
@@ -192,4 +192,28 @@ describe("Checkpoint.fromJSON round trip", () => {
     expect(costGuards[0].toJSON()).toMatchObject({ kind: "cost", spent: 4, costLimit: 10 });
     expect(restored.stack[0].savedDraft).toEqual({ value: "best-so-far" });
   });
+
+  it("keeps the signature field through Checkpoint.fromJSON", () => {
+    const original = {
+      id: 1,
+      nodeId: "start",
+      moduleId: "mod.agency",
+      scopeName: "main",
+      stepPath: "0",
+      label: null,
+      pinned: false,
+      signature: "deadbeef",
+      globals: { store: {}, initializedModules: [] },
+      stack: {
+        stack: [],
+        mode: "serialize",
+        other: {},
+        deserializeStackLength: 0,
+        nodesTraversed: [],
+      },
+    };
+    const revived = Checkpoint.fromJSON(JSON.parse(JSON.stringify(original)));
+    expect(revived).not.toBeNull();
+    expect(revived!.signature).toBe("deadbeef");
+  });
 });

--- a/packages/agency-lang/lib/runtime/state/schemas.ts
+++ b/packages/agency-lang/lib/runtime/state/schemas.ts
@@ -102,4 +102,5 @@ export const checkpointSchema = z.object({
   stepPath: z.string().optional().default(""),
   label: z.string().nullable().optional().default(null),
   pinned: z.boolean().optional().default(false),
+  signature: z.string().optional(),
 });


### PR DESCRIPTION
## What this does

Gives every checkpoint an optional, embedded HMAC checksum so a host can detect a tampered checkpoint on the external resume path, without the runtime enforcing anything.

The checkpoint is the serialized execution state of a paused program, and on the resume leg it comes back from a caller who could have edited it (changed a local, altered which env var a paused function reads). With a signing key configured, every checkpoint now carries an HMAC-SHA256 of its own contents in a `signature` field, and a host verifies with one call before resuming:

```ts
import { verifyCheckpointChecksum } from "agency-lang";
if (!verifyCheckpointChecksum(checkpoint)) {
  // refuse the resume
}
```

## Design points

- **Opt-in.** No `AGENCY_CHECKPOINT_KEY` in the environment means nothing is signed and nothing about a run changes. A present-but-short key (under 32 bytes) throws `CheckpointKeyTooShortError`.
- **Embed, do not enforce.** No runtime code path refuses a bad or missing signature (editing checkpoints is a supported feature: rewind, debugger, resume overrides). Verification is the host policy. A missing signature verifies false, so stripping the field does not dodge verification.
- **Whole-checkpoint coverage.** The MAC covers `toJSON()` minus the `signature` field, canonicalized with the existing `canonicalize` helper (key-sorted at every depth) under a fixed domain tag. No field allowlist to rot; the companion code-fingerprint field will be covered automatically.
- **Signing is automatic at the single creation chokepoint** (`Checkpoint.fromStateStack`), so interrupt, guard-trip, trace, and stdlib `checkpoint()` checkpoints are all covered. The legitimate edit paths re-sign: `applyOverrides` (rewind and resume overrides), `CheckpointStore.pin`, and `Checkpoint.clone`.
- **Rotation-ready.** Verify accepts the current key first, then retired keys from `AGENCY_CHECKPOINT_KEY_OLD` (comma-separated, verify-only), so rotating a key does not invalidate outstanding checkpoints.
- **Plain-JSON checkpoints sign and verify too.** On the external resume path, `interrupt.checkpoint` is parsed JSON rather than a `Checkpoint` instance; the module duck-types on `toJSON`. This was caught by running the interrupt-overrides agency-js test with a key set, and is pinned by a unit test.
- Signing and the key never touch Agency code or statelog; only `verifyCheckpointChecksum` is exported from the package surface.

## Tests

- `lib/runtime/checkpointChecksum.test.ts` (13 cases): sign/verify, tamper detection, wrong key, stripped-signature downgrade guard, key-order-independent round trip, a RICH checkpoint (guards, cost, savedDraft, branches) through the external zod round trip, no-key silence, short-key error, rotation via `_OLD`, re-sign after edit, pin and clone re-signing, and the plain-JSON shape.
- `schemas.test.ts`: `signature` survives `Checkpoint.fromJSON`.
- `checkpointStore.test.ts`: a created checkpoint is signed when a key is set, unsigned otherwise.
- Regression: `tests/agency-js/interrupts/interrupt-overrides` passes with and without a key configured.
- `pnpm run typecheck` (all three configs) and `pnpm run lint:structure` are green.

## Docs

`docs/dev/runtime/checkpoint-integrity.md` covers the embed-not-enforce rationale, the exact canonical form, key handling and rotation, the honest non-goals (no confidentiality, no freshness or binding, symmetric-key trust model), and the trace-mode performance note. Pointers added to `checkpointing.md`, the CLAUDE.md runtime index, and the `agency-runtime-docs` skill.

Plan: `docs/superpowers/plans/2026-08-30-checkpoint-integrity-checksum.md` (in the main checkout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G6gknY8UdagAQZABkRnJws
