### PR TITLE
eval upload: per-run progress output and the batch-first statelog link

### DIFF
--- a/packages/agency-lang/docs/dev/evals/eval-tracking.md
+++ b/packages/agency-lang/docs/dev/evals/eval-tracking.md
@@ -143,11 +143,10 @@ next one still uploads. Running the command twice is safe: events skip,
 annotations upsert.
 
 Runs upload through a bounded pool, and each one prints its line as it
-finishes (`reportProgress` in `EvalUploadDependencies`), so a long upload
-shows progress instead of staying silent until the end. The result names
+finishes (`reportProgress` in `EvalUploadDependencies`). The result names
 the statelog batch page (`/projects/evals/batch?id=<slug>&batch=<batch>`)
 only when every uploaded run shares one batch id; statelog keys the page
-by project and batch alone, so no agent name is needed.
+by project and batch alone.
 
 The client, `lib/cli/statelog/evalUploadClient.ts`, is the seventh sealed
 statelog client (`docs/dev/hosting/statelog-clients.md`).
@@ -157,12 +156,11 @@ statelog client (`docs/dev/hosting/statelog-clients.md`).
 `setAgentName` (`std::statelog`) names the agent a trace belongs to.
 Statelog treats the name as a filterable label on a batch, not a URL key:
 its evals pages are keyed by project and batch, and a batch whose runs
-carry no name simply shows no agent. The name is still validated
-(`lib/statelog/agentName.ts`: letters, digits, `.`, `_`, `-`, and `/`
-between segments; at most 200 characters; no empty, `.`, or `..` segment)
-because it appears in the `?agent=` filter and must stay a single clean
-token. An invalid name throws at the call site, inside or outside an
-Agency frame. The agency agent names itself `agency-agent/<brain>`
+carry no name shows no agent. The rule in `lib/statelog/agentName.ts` —
+letters, digits, `.`, `_`, `-`, and `/` between segments; at most 200
+characters; no empty, `.`, or `..` segment — keeps a name one clean token
+that stays intact wherever a URL carries it. An invalid name throws at
+the call site, inside or outside an Agency frame. The agency agent names itself `agency-agent/<brain>`
 (`lib/agents/agency-agent/lib/agentName.agency`) right after it picks its
 brain, so runs group per brain.
 

--- a/packages/agency-lang/docs/dev/evals/eval-tracking.md
+++ b/packages/agency-lang/docs/dev/evals/eval-tracking.md
@@ -142,23 +142,27 @@ a trace it cannot complete. A failure on one directory is reported and the
 next one still uploads. Running the command twice is safe: events skip,
 annotations upsert.
 
-The result names the statelog batch page only when every uploaded run
-shares one batch id and one agent name, and that name passes
-`agentNameProblem`. An older trace may carry a name from before validation;
-`..` would be folded out of the URL, so no link is better than a wrong one.
+Runs upload through a bounded pool, and each one prints its line as it
+finishes (`reportProgress` in `EvalUploadDependencies`), so a long upload
+shows progress instead of staying silent until the end. The result names
+the statelog batch page (`/projects/evals/batch?id=<slug>&batch=<batch>`)
+only when every uploaded run shares one batch id; statelog keys the page
+by project and batch alone, so no agent name is needed.
 
 The client, `lib/cli/statelog/evalUploadClient.ts`, is the seventh sealed
 statelog client (`docs/dev/hosting/statelog-clients.md`).
 
-## Agent names are URL segments
+## Agent names are labels
 
-`setAgentName` (`std::statelog`) names the agent a trace belongs to, and
-statelog puts that name in a path: `/evals/agents/<name>/batches/<batch>`.
-So the rule in `lib/statelog/agentName.ts` is: letters, digits, `.`, `_`,
-`-`, and `/` between segments; at most 200 characters; no empty, `.`, or
-`..` segment (a URL parser folds those away even when percent-encoded). An
-invalid name throws at the call site, inside or outside an Agency frame.
-The agency agent names itself `agency-agent/<brain>`
+`setAgentName` (`std::statelog`) names the agent a trace belongs to.
+Statelog treats the name as a filterable label on a batch, not a URL key:
+its evals pages are keyed by project and batch, and a batch whose runs
+carry no name simply shows no agent. The name is still validated
+(`lib/statelog/agentName.ts`: letters, digits, `.`, `_`, `-`, and `/`
+between segments; at most 200 characters; no empty, `.`, or `..` segment)
+because it appears in the `?agent=` filter and must stay a single clean
+token. An invalid name throws at the call site, inside or outside an
+Agency frame. The agency agent names itself `agency-agent/<brain>`
 (`lib/agents/agency-agent/lib/agentName.agency`) right after it picks its
 brain, so runs group per brain.
 

--- a/packages/agency-lang/lib/cli/eval/upload.test.ts
+++ b/packages/agency-lang/lib/cli/eval/upload.test.ts
@@ -211,7 +211,7 @@ describe("evalUpload", () => {
     expect(annotations[0].map((row) => row.kind).sort()).toEqual(["run", "score"]);
   });
 
-  it("names the batch page only when every uploaded run shares one batch and one valid agent name", async () => {
+  it("names the batch page only when every uploaded run shares one batch", async () => {
     const group = tempDir("group-");
     for (const [testId, traceId] of [
       ["a", "ta"],
@@ -225,9 +225,7 @@ describe("evalUpload", () => {
       );
     }
     const shared = await evalUpload([group], target, { client: fakeClient({}).client });
-    expect(shared.batchUrl).toBe(
-      "https://h/projects/proj/evals/agents/agency-agent%2Fcoordinator/batches/b%201",
-    );
+    expect(shared.batchUrl).toBe("https://h/projects/evals/batch?id=proj&batch=b+1");
 
     // Different batches: no page shows exactly these runs.
     const other = writeRunDirectory({
@@ -240,20 +238,37 @@ describe("evalUpload", () => {
     expect(mixed.batchUrl).toBeNull();
   });
 
-  it("an agent name that would not survive a URL gets no batch page", async () => {
+  it("names the batch page for runs with no agent name at all", async () => {
     const dir = writeRunDirectory({
-      traceId: "dots",
+      traceId: "unnamed",
       test: { id: "a", input: "t" },
       batch: "b1",
       trial: 1,
     });
-    fs.appendFileSync(
-      path.join(dir, "statelog.jsonl"),
-      statelogLine("dots", "agentName", { name: ".." }) + "\n",
-    );
     const result = await evalUpload([dir], target, { client: fakeClient({}).client });
     expect(result.runs[0].status).toBe("uploaded");
-    expect(result.batchUrl).toBeNull();
+    expect(result.batchUrl).toBe("https://h/projects/evals/batch?id=proj&batch=b1");
+  });
+
+  it("reports one progress line as each run finishes", async () => {
+    const group = tempDir("group-");
+    writeRunDirectory(
+      { traceId: "pa", test: { id: "a", input: "t" }, output: "x" },
+      path.join(group, "a"),
+    );
+    writeRunDirectory(
+      { traceId: "pb", test: { id: "b", input: "t" }, output: "x" },
+      path.join(group, "b"),
+    );
+    const lines: string[] = [];
+    const result = await evalUpload([group], target, {
+      client: fakeClient({}).client,
+      reportProgress: (line) => lines.push(line),
+    });
+    expect(lines.length).toBe(2);
+    expect(lines.toSorted()).toEqual(
+      result.runs.map((run) => `${run.dir}: uploaded 3 events, 1 annotations`).toSorted(),
+    );
   });
 });
 
@@ -281,7 +296,7 @@ describe("formatUploadResult", () => {
           },
           { dir: "/runs/b1/d", traceId: null, status: "failed", error: "could not reach h" },
         ],
-        batchUrl: "https://h/projects/p/evals/agents/x/batches/b1",
+        batchUrl: "https://h/projects/evals/batch?id=p&batch=b1",
       },
       "/elsewhere",
     );
@@ -291,7 +306,7 @@ describe("formatUploadResult", () => {
       "/runs/b1/c: resumed at event 500: 3 events, 1 annotations",
       "/runs/b1/d: failed: could not reach h",
       "1 uploaded · 1 present · 1 resumed · 1 failed",
-      "batch: https://h/projects/p/evals/agents/x/batches/b1",
+      "batch: https://h/projects/evals/batch?id=p&batch=b1",
     ]);
   });
 });

--- a/packages/agency-lang/lib/cli/eval/upload.ts
+++ b/packages/agency-lang/lib/cli/eval/upload.ts
@@ -27,8 +27,7 @@ export type EvalUploadTarget = { origin: string; projectSlug: string; apiKey: st
 export type EvalUploadDependencies = {
   client?: EvalUploadClient;
   reportWarning?: (message: string) => void;
-  /** Called with one formatted line as each run finishes, so a long upload
-   *  shows progress instead of staying silent until the end. */
+  /** Called with one formatted line as each run finishes. */
   reportProgress?: (line: string) => void;
 };
 
@@ -249,8 +248,7 @@ function messageOf(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-/** One run's outcome as the line the CLI prints, both as progress while
- *  uploads run and in tests over the collected result. */
+/** One run's outcome as the line the CLI prints. */
 export function formatRunLine(run: UploadRunOutcome, cwd: string = process.cwd()): string {
   return `${shownDir(run.dir, cwd)}: ${describeOutcome(run)}`;
 }

--- a/packages/agency-lang/lib/cli/eval/upload.ts
+++ b/packages/agency-lang/lib/cli/eval/upload.ts
@@ -11,7 +11,6 @@ import type { Annotation } from "@/runDirectory/annotations.js";
 import { findRunDirectories, uniqueRunDirectories } from "@/runDirectory/findRuns.js";
 import { summarizeRunDirectory, type RunSummary } from "@/runDirectory/list.js";
 import { readRunDirectory } from "@/runDirectory/runDir.js";
-import { agentNameProblem } from "@/statelog/agentName.js";
 import { mapInParallel } from "@/utils/parallelMap.js";
 import type { EventEnvelope } from "@/statelog/wireTypes.js";
 
@@ -28,6 +27,9 @@ export type EvalUploadTarget = { origin: string; projectSlug: string; apiKey: st
 export type EvalUploadDependencies = {
   client?: EvalUploadClient;
   reportWarning?: (message: string) => void;
+  /** Called with one formatted line as each run finishes, so a long upload
+   *  shows progress instead of staying silent until the end. */
+  reportProgress?: (line: string) => void;
 };
 
 export type UploadRunOutcome =
@@ -53,7 +55,7 @@ export type UploadRunOutcome =
 export type EvalUploadResult = {
   runs: UploadRunOutcome[];
   /** The batch page on statelog, when every uploaded run belongs to one
-   *  batch of one (valid) agent name; null otherwise. */
+   *  batch; null otherwise. */
   batchUrl: string | null;
 };
 
@@ -71,9 +73,11 @@ export async function evalUpload(
   // Runs are independent traces, so they upload through a bounded pool —
   // unbounded, a 69-run group is hundreds of concurrent requests and the
   // host sheds them with 429s. Results keep input order.
-  const records = await mapInParallel(dirs, UPLOAD_PARALLELISM, (dir) =>
-    uploadRun(dir, client, reportWarning),
-  );
+  const records = await mapInParallel(dirs, UPLOAD_PARALLELISM, async (dir) => {
+    const record = await uploadRun(dir, client, reportWarning);
+    dependencies.reportProgress?.(formatRunLine(record.outcome));
+    return record;
+  });
   return { runs: records.map((record) => record.outcome), batchUrl: batchUrlFor(records, target) };
 }
 
@@ -222,9 +226,8 @@ function chunked<T>(items: readonly T[], size: number): T[][] {
 }
 
 /** The batch page, only when it would show exactly these runs: every run
- *  that made it shares one batch id and one agent name, and that name is
- *  valid (an older trace may predate validation; a `..` would not survive
- *  the URL unchanged, so no URL is better than a misleading one). */
+ *  that made it shares one batch id. Statelog keys the page by project and
+ *  batch alone; agent names are labels there, not part of the URL. */
 function batchUrlFor(records: readonly RunRecord[], target: EvalUploadTarget): string | null {
   const summaries = records.flatMap((record) =>
     record.outcome.status === "failed" || record.summary === null ? [] : [record.summary],
@@ -232,43 +235,45 @@ function batchUrlFor(records: readonly RunRecord[], target: EvalUploadTarget): s
   if (summaries.length === 0) {
     return null;
   }
-  const [first] = summaries;
-  const batch = first.batch;
-  const agent = first.agentName;
-  if (batch === null || agent === null || agentNameProblem(agent) !== null) {
+  const batch = summaries[0].batch;
+  if (batch === null || summaries.some((summary) => summary.batch !== batch)) {
     return null;
   }
-  const shared = summaries.every(
-    (summary) => summary.batch === batch && summary.agentName === agent,
-  );
-  if (!shared) {
-    return null;
-  }
-  const route = ["projects", target.projectSlug, "evals", "agents", agent, "batches", batch]
-    .map(encodeURIComponent)
-    .join("/");
-  return new URL(`/${route}`, target.origin).toString();
+  const url = new URL("/projects/evals/batch", target.origin);
+  url.searchParams.set("id", target.projectSlug);
+  url.searchParams.set("batch", batch);
+  return url.toString();
 }
 
 function messageOf(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-/** One line per run, a count line, and the batch page when there is one. */
-export function formatUploadResult(
-  result: EvalUploadResult,
-  cwd: string = process.cwd(),
-): string[] {
-  const lines = result.runs.map((run) => `${shownDir(run.dir, cwd)}: ${describeOutcome(run)}`);
+/** One run's outcome as the line the CLI prints, both as progress while
+ *  uploads run and in tests over the collected result. */
+export function formatRunLine(run: UploadRunOutcome, cwd: string = process.cwd()): string {
+  return `${shownDir(run.dir, cwd)}: ${describeOutcome(run)}`;
+}
+
+/** The closing lines: a count line, and the batch page when there is one. */
+export function formatUploadSummary(result: EvalUploadResult): string[] {
   const counts = ["uploaded", "present", "resumed", "failed"].flatMap((status) => {
     const count = result.runs.filter((run) => run.status === status).length;
     return count === 0 ? [] : [`${count} ${status}`];
   });
-  lines.push(counts.join(" · "));
+  const lines = [counts.join(" · ")];
   if (result.batchUrl !== null) {
     lines.push(`batch: ${result.batchUrl}`);
   }
   return lines;
+}
+
+/** Every output line at once: per-run lines, then the summary. */
+export function formatUploadResult(
+  result: EvalUploadResult,
+  cwd: string = process.cwd(),
+): string[] {
+  return [...result.runs.map((run) => formatRunLine(run, cwd)), ...formatUploadSummary(result)];
 }
 
 function describeOutcome(run: UploadRunOutcome): string {

--- a/packages/agency-lang/lib/statelog/agentName.ts
+++ b/packages/agency-lang/lib/statelog/agentName.ts
@@ -1,11 +1,11 @@
 /**
  * The rule for an agent's statelog name (`std::statelog` `setAgentName`).
- * Statelog uses the name as a filterable label on eval batches and in a
- * `?agent=` query parameter, so it has to stay one clean token: no
- * whitespace, no characters a URL would encode, and no `.` or `..` segment,
- * which a URL parser folds away even after `encodeURIComponent`. Slashes are
- * allowed so a family can nest its variants, as in
- * `agency-agent/coordinator`.
+ * Statelog shows the name as a label on eval batches and filters by it, so
+ * it must be one clean token: only the characters in `AGENT_NAME_PATTERN`,
+ * and no empty, `.`, or `..` segment. The segment ban keeps a name safe to
+ * place in a URL path, where a parser folds dot segments away even when
+ * they are percent-encoded. Slashes are allowed so a family can nest its
+ * variants, as in `agency-agent/coordinator`.
  */
 export const AGENT_NAME_MAX_LENGTH = 200;
 

--- a/packages/agency-lang/lib/statelog/agentName.ts
+++ b/packages/agency-lang/lib/statelog/agentName.ts
@@ -1,11 +1,11 @@
 /**
  * The rule for an agent's statelog name (`std::statelog` `setAgentName`).
- * The name becomes one path segment of a statelog URL
- * (`/evals/agents/<name>/batches/<batch>`), so it has to survive that trip
- * unchanged: no whitespace, no characters a URL would encode, and no `.` or
- * `..` segment, which a URL parser folds away (`agents/../batches` loses the
- * `agents` segment even after `encodeURIComponent`). Slashes are allowed so a
- * family can nest its variants, as in `agency-agent/coordinator`.
+ * Statelog uses the name as a filterable label on eval batches and in a
+ * `?agent=` query parameter, so it has to stay one clean token: no
+ * whitespace, no characters a URL would encode, and no `.` or `..` segment,
+ * which a URL parser folds away even after `encodeURIComponent`. Slashes are
+ * allowed so a family can nest its variants, as in
+ * `agency-agent/coordinator`.
  */
 export const AGENT_NAME_MAX_LENGTH = 200;
 

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -1023,8 +1023,6 @@ export function createProgram(deps: CliDependencies = {}): Command {
       // The project in agency.json is the only target: no host or key flags here,
       // agency.json and $STATELOG_API_KEY own that.
       const target = resolveProjectTarget(getConfigContext(), {});
-      // Each run prints as it finishes; a 69-run upload takes minutes and
-      // must not sit silent until the end.
       const result = await evalUpload(paths, target, {
         reportProgress: (line) => console.log(line),
       }).catch(failProjectCommand);

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -67,7 +67,7 @@ import { runGradeCommand } from "@/cli/eval/grade.js";
 import { resolveRunStatelog } from "@/cli/eval/logs.js";
 import { evalLs } from "@/cli/eval/ls.js";
 import { evalRun } from "@/cli/eval/run.js";
-import { evalUpload, formatUploadResult } from "@/cli/eval/upload.js";
+import { evalUpload, formatUploadSummary } from "@/cli/eval/upload.js";
 import { ttyColor } from "@/utils/termcolors.js";
 import { evalOptimize } from "@/cli/eval/optimize.js";
 import { renderDiagnosticText, renderDiagnosticList } from "@/cli/explain.js";
@@ -1023,8 +1023,12 @@ export function createProgram(deps: CliDependencies = {}): Command {
       // The project in agency.json is the only target: no host or key flags here,
       // agency.json and $STATELOG_API_KEY own that.
       const target = resolveProjectTarget(getConfigContext(), {});
-      const result = await evalUpload(paths, target).catch(failProjectCommand);
-      for (const line of formatUploadResult(result)) console.log(line);
+      // Each run prints as it finishes; a 69-run upload takes minutes and
+      // must not sit silent until the end.
+      const result = await evalUpload(paths, target, {
+        reportProgress: (line) => console.log(line),
+      }).catch(failProjectCommand);
+      for (const line of formatUploadSummary(result)) console.log(line);
       if (result.runs.some((run) => run.status === "failed")) {
         process.exitCode = 1;
       }

--- a/packages/agency-lang/stdlib/agents/writing/rewrite.agency
+++ b/packages/agency-lang/stdlib/agents/writing/rewrite.agency
@@ -19,7 +19,7 @@ import {
   writingReviewAgent,
   WritingReviewEvalInput,
  } from "std::agents/writing/review"
-import { evalValue } from "std::statelog"
+import { evalValue, setAgentName } from "std::statelog"
 
 static const rewritePrompt = """You rewrite prose to apply a reviewer's findings. You get the text, the task it was written for, and the findings. Return the rewritten text and nothing else: no preamble, no notes, no list of what you changed.
 
@@ -161,6 +161,7 @@ export def writingRewriteAgent(
   `docsOnlyHandler`, so a budget trip comes back as text rather than an
   interrupt escaping the entry point. */
 node evalMain(input: WritingReviewEvalInput): string {
+  setAgentName("writing-rewrite")
   evalValue(input)
   const source = read(input.sourceFile) with approve
   if (source is failure(readErr)) {


### PR DESCRIPTION
## What this fixes

Two `agency eval upload` problems from today's debugging session:

1. **No progress output.** The command collected every run's outcome and printed everything only at the end, so a 69-run upload sat silent for minutes. `EvalUploadDependencies` now carries a `reportProgress` callback, and the CLI prints each run's line the moment that run finishes. The count line and batch link still print last, via the new `formatUploadSummary`; `formatUploadResult` remains as the all-at-once composition for tests and API callers.

2. **The batch link almost never printed, and pointed at an agent-keyed page.** The link required every uploaded run to share one valid agent name — runs that never called `setAgentName` (like the writing-rewrite suite's) got no link and were invisible on statelog's old agent-keyed evals page. Statelog now keys its evals pages by project and batch alone (statelog PR 66, "Make batches the top-level unit of the evals pages"), so the link becomes `/projects/evals/batch?id=<slug>&batch=<batch>` and prints whenever the runs share one batch id, named agent or not.

Also:

- `evalMain` in `stdlib/agents/writing/rewrite.agency` now calls `setAgentName("writing-rewrite")`, so rewrite batches carry an agent label for filtering on the evals page. (Existing uploaded traces keep their null name; the summary is computed at upload time.)
- `docs/dev/evals/eval-tracking.md` and the `agentName.ts` header now describe agent names as filter labels rather than URL path segments; the validation rule itself is unchanged.

## Pairing

Merge alongside statelog PR 66 — the link this prints only exists once that deploys. The old link only printed when every run shared a valid agent name, so nothing depends on the old URL shape.

## Testing

- `lib/cli/eval/upload.test.ts` updated: the batch-link tests use the new URL, a new test covers the link for unnamed runs, and a new test asserts one progress line per run. All green, plus `agentName.test.ts`.
- `pnpm run typecheck` (all three configs), `pnpm run fmt:ts`, and `pnpm run lint:structure` clean.
- `make` rebuilt cleanly after the stdlib change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016HL3NJzBcspTuWRp88rga3
