### PR TITLE
Document matching on interrupt effects in the match guide

### DIFF
--- a/packages/agency-lang/docs/site/guide/match-expressions.md
+++ b/packages/agency-lang/docs/site/guide/match-expressions.md
@@ -134,6 +134,44 @@ match (event) {
 }
 ```
 
+## Matching on interrupt effects
+
+Inside a handler, you can match an interrupt by its effect name:
+
+```ts
+handle {
+    writeReport()
+} with (intr) {
+    return match (intr) {
+        std::write => approve()
+        std::read  => approve()
+        _          => reject()
+    }
+}
+```
+
+The handler receives the interrupt as `intr`. Here you match on `intr` itself, the whole interrupt.
+
+An arm like `std::write` matches any interrupt whose effect is `std::write`. To also read the interrupt's payload, write the effect name with an object pattern:
+
+```ts
+match (intr) {
+    std::write({ data }) => inspect(data)
+    _                    => reject()
+}
+```
+
+The `{ data }` binds `data` to `intr.data`, which holds the interrupt's payload. You can destructure deeper. `std::write({ data: { dir } })` binds `dir` to `intr.data.dir`.
+
+An effect name always contains `::`. A bare name like `write` is a variable binding, not an effect. To match on a bare effect name, match on `intr.effect` against a string instead:
+
+```ts
+match (intr.effect) {
+    "write" => approve()
+    _       => reject()
+}
+```
+
 ## Guard clauses
 
 You can add a guard clause `if (…)` to any arm:


### PR DESCRIPTION
## Document matching on interrupt effects

Adds a "Matching on interrupt effects" section to `docs/site/guide/match-expressions.md`, covering the effect-pattern syntax shipped in #980.

The section shows, in order:

1. Naming an effect directly in a match arm inside a handler (`match (intr) { std::write => … }`).
2. Destructuring the interrupt's payload with an object pattern (`std::write({ data })` binds `data` to `intr.data`), including a deeper destructure.
3. The rule that effect names contain `::`, and the `match (intr.effect)` string form for matching a bare effect name.

Written to the guide's writing conventions (`docs/dev/contributing/general-writing-tips.md`): example first, one fact per sentence, the reader as the actor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
