### PR TITLE
Make `agency config` default to `config show`

### DIFF
--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -1829,7 +1829,7 @@ export function createProgram(deps: CliDependencies = {}): Command {
   const configCmd = program.command("config").description("Inspect Agency configuration");
 
   configCmd
-    .command("show")
+    .command("show", { isDefault: true })
     .description("Print the resolved, merged agency.json config as JSON")
     .option(
       "--show-secrets",


### PR DESCRIPTION
`agency config` has only one subcommand, `show`. Before this change, running bare `agency config` just printed the subcommand help. Now it defaults to `show` and prints the resolved, merged config as JSON.

This uses `{ isDefault: true }` on the `show` subcommand — the same pattern already used elsewhere in `scripts/agency.ts` for default subcommands (`list`, `run`). The `--show-secrets` flag still works through the default.

All three now behave the same:
- `agency config`
- `agency config show`
- `agency config --show-secrets` (passes through to the default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
