### PR TITLE
Tell the model why a tool call was rejected, and stop retries of rejected calls

### DIFF
--- a/packages/agency-lang/.claude/skills/agency-agent-docs/SKILL.md
+++ b/packages/agency-lang/.claude/skills/agency-agent-docs/SKILL.md
@@ -11,7 +11,7 @@ Paths are relative to `packages/agency-lang/`. Read the one that matches the tas
 - `docs/dev/agents/agent-sessions.md` — Save and resume for `agency agent`: a checkpoint between turns, why it is taken from TypeScript after the turn's frames return, where the restore runs, and what a restore does not bring back.
 - `docs/dev/agents/agent-brains.md` — How `agency agent` splits into a harness and pluggable brains, and what each half owns.
 - `docs/dev/agents/approval-policies.md` — How approval policy rules match, and the matching rules that have caused surprises.
-- `docs/dev/agents/tool-loop-guards.md` — The two refusals that stop a model wasting rounds: a repeated call, and an argument that is really tool-call markup.
+- `docs/dev/agents/tool-loop-guards.md` — The three refusals that stop a model wasting rounds: a repeated call, an argument that is really tool-call markup, and a call identical to one already rejected.
 - `docs/dev/agents/reply-attachments.md` — How a tool hands images back to the model, given that most providers reject image parts in tool results.
 - `docs/dev/agents/promptRunner.md` — The small control-flow helper behind `runPrompt`.
 - `docs/dev/agents/why-agents-write-code.md` — The argument for letting an agent write and run programs instead of giving it more tools.

--- a/packages/agency-lang/.claude/skills/agency-agent-docs/SKILL.md
+++ b/packages/agency-lang/.claude/skills/agency-agent-docs/SKILL.md
@@ -13,6 +13,6 @@ Paths are relative to `packages/agency-lang/`. Read the one that matches the tas
 - `docs/dev/agents/approval-policies.md` — How approval policy rules match, and the matching rules that have caused surprises.
 - `docs/dev/agents/tool-loop-guards.md` — The three refusals that stop a model wasting rounds: a repeated call, an argument that is really tool-call markup, and a call identical to one already rejected.
 - `docs/dev/agents/reply-attachments.md` — How a tool hands images back to the model, given that most providers reject image parts in tool results.
-- `docs/dev/agents/promptRunner.md` — The small control-flow helper behind `runPrompt`.
+- `docs/dev/agents/promptRunner.md` — The control-flow helper behind `runPrompt`, and the rule that tool-loop decisions must be durable: made inside a step, persisted in `runnerState`.
 - `docs/dev/agents/why-agents-write-code.md` — The argument for letting an agent write and run programs instead of giving it more tools.
 - `docs/dev/agents/self-writing-agent.md` — Investigation notes from the experiment behind that argument.

--- a/packages/agency-lang/CLAUDE.md
+++ b/packages/agency-lang/CLAUDE.md
@@ -278,7 +278,7 @@ Other process docs:
 - `docs/dev/agents/promptRunner.md` — The small control-flow helper behind `runPrompt`.
 - `docs/dev/agents/reply-attachments.md` — How a tool hands images back to the model, given that most providers reject image parts in tool results.
 - `docs/dev/agents/self-writing-agent.md` — Investigation notes from the experiment behind that argument.
-- `docs/dev/agents/tool-loop-guards.md` — The two refusals that stop a model wasting rounds: a repeated call, and an argument that is really tool-call markup.
+- `docs/dev/agents/tool-loop-guards.md` — The three refusals that stop a model wasting rounds: a repeated call, an argument that is really tool-call markup, and a call identical to one already rejected.
 - `docs/dev/agents/why-agents-write-code.md` — The argument for letting an agent write and run programs instead of giving it more tools.
 - `docs/dev/agents/writing-rewrite-agent.md` — The rewrite agent over the writing reviewer: the passes loop, why a reviewer failure is not a clean pass, and how its eval suite shares the reviewer suite's files.
 

--- a/packages/agency-lang/CLAUDE.md
+++ b/packages/agency-lang/CLAUDE.md
@@ -275,7 +275,7 @@ Other process docs:
 - `docs/dev/agents/agent-brains.md` — How `agency agent` splits into a harness and pluggable brains, and what each half owns.
 - `docs/dev/agents/agent-sessions.md` — Save and resume for `agency agent`: a checkpoint between turns, why it is taken from TypeScript after the turn's frames return, where the restore runs, and what a restore does not bring back.
 - `docs/dev/agents/approval-policies.md` — How approval policy rules match, and the matching rules that have caused surprises.
-- `docs/dev/agents/promptRunner.md` — The small control-flow helper behind `runPrompt`.
+- `docs/dev/agents/promptRunner.md` — The control-flow helper behind `runPrompt`, and the rule that tool-loop decisions must be durable: made inside a step, persisted in `runnerState`.
 - `docs/dev/agents/reply-attachments.md` — How a tool hands images back to the model, given that most providers reject image parts in tool results.
 - `docs/dev/agents/self-writing-agent.md` — Investigation notes from the experiment behind that argument.
 - `docs/dev/agents/tool-loop-guards.md` — The three refusals that stop a model wasting rounds: a repeated call, an argument that is really tool-call markup, and a call identical to one already rejected.

--- a/packages/agency-lang/docs/dev/agents/promptRunner.md
+++ b/packages/agency-lang/docs/dev/agents/promptRunner.md
@@ -18,6 +18,58 @@ A `step()` body returns either `void` (happy path) or `Interrupt[]`. The body re
 
 The completed-keys list (`self.runnerState.completedSteps`) is **not** updated on bailout. On resume, the step body re-runs. If the user has responded to the interrupt, the tool's saved `__interruptId_N` matches the response and proceeds normally; the step then runs to completion and gets marked done.
 
+## Resume re-runs the code between steps
+
+`runPrompt` does not resume by jumping to the paused step. On resume it
+runs again from the top, and every completed step skips its body via
+`completedSteps`. The plain code BETWEEN the steps runs again for real:
+the round loop, the walk over the round's tool calls, and every inline
+`if`. That code must be deterministic. If it reads state that changed
+since the first pass, a replayed call can take a path it never took, and
+a step that never ran the first time will happily run now.
+
+This has bitten us. The tool loop once refused a call the user had just
+approved. Two calls to one tool ran in parallel; one was rejected for
+the fifth time, which pushed the tool into `removedTools`; the sibling
+paused on its interrupt, and the checkpoint carried the mutation. On
+resume, an inline `removedTools.includes(...)` check in front of the
+sibling was now true, so the sibling was refused and the approval
+discarded. The `removalRace` scenario in `tests/agency-js/tool-rejection`
+pins this.
+
+The rule for anything added to `runPrompt`:
+
+1. **Side effects go inside a step.** Anything that must happen exactly
+   once — pushing a tool message, firing a hook, bumping a counter —
+   belongs in a `step()` body, so a resume skips it.
+2. **Decisions that read mutable state also go inside a step, and the
+   answer goes into `self.runnerState`.** A step body's return value
+   does not survive a skip, so compute the decision once inside a step,
+   write it to `runnerState`, and have the code after the step read it
+   from there. `runnerState` lives on the frame and is serialized into
+   the checkpoint, so a resumed pass reads back exactly the answer the
+   first pass recorded.
+
+The tool loop keeps two records of this kind. Both are keyed by
+`round.<round>.tool.<slug>`, never by the slug alone: providers like
+Gemini return empty tool-call ids, so the same slug repeats across
+rounds.
+
+- `runnerState.gateVerdicts` — the refusal-gate verdict for each call
+  (removed, unhandled, tooManyRounds, markup, priorRejected, repeated,
+  or proceed), computed once in the call's `.gate` step. The gates read
+  `removedTools`, `rejectedCalls`, and `repeatStreak`, all of which
+  mutate as sibling branches complete.
+- `runnerState.invokeOutcomes` — how each invocation ended, recorded
+  inside the `.invoke` step. A completed non-success invocation already
+  answered the model, so a later pass returns instead of re-entering the
+  end and log steps. An interrupted invocation records nothing: its
+  invoke step must re-run on resume to consume the user's response.
+
+Deterministic reads need no record. Deriving `namedArgs` from
+`toolCall.arguments` inline is fine, because the checkpoint restores the
+same tool calls.
+
 ## `parallel` and merged interrupts
 
 ```ts
@@ -43,7 +95,7 @@ Inside a `branchFn`, use `b.step(...)`, which collects. Do not use `pr.step(...)
 
 ## `removedTools` / `toolErrorCounts` semantics
 
-`runPrompt`'s tool loop mutates two shared structures from inside concurrent branches: `removedTools` and `toolErrorCounts`. Both live on the frame (`self.removedTools`, `self.toolErrorCounts`) so they survive checkpoint and restore. The design accepts **eventual consistency**. A removal takes effect from the next LLM round, when the `.filter()` after the `pr.parallel` call drops the tool, never within the round where it happened. Within the round, a "gated start" check in each branch's first step still skips a tool already in `removedTools`. That check is best-effort, because the ordering between sibling pushes is undefined.
+`runPrompt`'s tool loop mutates two shared structures from inside concurrent branches: `removedTools` and `toolErrorCounts`. Both live on the frame (`self.removedTools`, `self.toolErrorCounts`) so they survive checkpoint and restore. The design accepts **eventual consistency**. A removal takes effect from the next LLM round, when the `.filter()` after the `pr.parallel` call drops the tool, never within the round where it happened. Within the round, the refusal-gate verdict (see "Resume re-runs the code between steps" above) still refuses a tool already in `removedTools`, but only when that call's `.gate` step runs after the sibling's push. That is best-effort, because the ordering between sibling branches is undefined.
 
 ## What `PromptRunner` deliberately is not
 

--- a/packages/agency-lang/docs/dev/agents/tool-loop-guards.md
+++ b/packages/agency-lang/docs/dev/agents/tool-loop-guards.md
@@ -78,31 +78,25 @@ naming the argument and asking for the call again without it.
 
 A rejected interrupt means a handler, policy, or user said no to a tool
 call. The tool loop tells rejections apart from failures by the
-`rejected` flag the interrupt codegen stamps on the halt failure
-(`lib/templates/backends/typescriptGenerator/interruptReturn.mustache`,
-`interruptAssignment.mustache` — both the handler-reject and the
-resume-reject branches, so an interactive `reject("reason")` carries its
-reason too). A TS tool that returns the raw `InterruptResponse` from
-`agency.interrupt` takes the same path.
+`rejected` flag the interrupt codegen stamps on the halt failure — both
+the handler-reject and the resume-reject template branches set it, so an
+interactive `reject("reason")` carries its reason too. A TS tool that
+returns the raw `InterruptResponse` from `agency.interrupt` takes the
+same path.
 
-A rejection is not a failure, so it gets its own treatment in
-`runInvokeStep` (`recordRejection` in `prompt.ts`):
+A rejection is not a tool error (`recordRejection` in `prompt.ts`):
 
-- The model sees `Tool call rejected: <reason>. Do not call this tool
-  with the same arguments again; the call will not be executed.` — the
-  rejecter's reason, not an error message. No `toolErrorCounts`
-  increment, no `toolError` statelog event (the handler chain already
-  emitted `interruptResolved`).
-- The call's `repeatKey` lands in `self.rejectedCalls`. An identical
-  retry is refused by the `priorRejected` gate before the start hook —
-  no invoke, no re-raised interrupt, no counter movement. Checked before
-  the repeat guard so the model hears "rejected", not "repeated".
-- `self.rejectionCounts[tool]` counts CONSECUTIVE rejections. At
-  `MAX_TOOL_REJECTIONS` (5) the tool joins `removedTools`. A successful
-  call of the tool resets its count to zero: a narrow policy reject rule
-  brushed against during otherwise-approved work never removes the tool,
-  while a model rephrasing a refused call with nothing approved in
-  between loses it quickly.
+- The model sees `Tool call rejected: <reason>` with a do-not-retry
+  instruction — the rejecter's reason, not an error message. No
+  `toolErrorCounts` increment, no `toolError` statelog event.
+- An identical retry (same `repeatKey`) is refused before the start
+  hook: no invoke, no re-raised interrupt. Checked before the repeat
+  guard so the model hears "rejected", not "repeated".
+- CONSECUTIVE rejections are counted per tool; at `MAX_TOOL_REJECTIONS`
+  (5) the tool joins `removedTools`. A successful call resets the count:
+  a narrow policy reject rule brushed against during otherwise-approved
+  work never removes the tool, while a model rephrasing a refused call
+  with nothing approved in between loses it quickly.
 
 Both records live on the runPrompt frame, so they survive checkpoint and
 resume within one `llm()` call and reset when the next one starts.

--- a/packages/agency-lang/docs/dev/agents/tool-loop-guards.md
+++ b/packages/agency-lang/docs/dev/agents/tool-loop-guards.md
@@ -104,14 +104,23 @@ A rejection is not a tool error (`recordRejection` in `prompt.ts`):
 Both records live on the runPrompt frame, so they survive checkpoint and
 resume within one `llm()` call and reset when the next one starts.
 
+The refusal gates decide from state that mutates as parallel siblings
+complete, so each call's verdict is computed exactly once, inside its
+own step, and persisted in `runnerState`. See "Resume re-runs the code
+between steps" in [`promptRunner.md`](promptRunner.md) for the rule and
+the incident behind it.
+
 ## Tests
 
 - Pure helpers: `lib/runtime/toolLoopGuards.test.ts` (`markupArgument`,
   `repeatKey`, `noteRepeat`).
 - Rejections: `tests/agency-js/tool-rejection` scripts a handler reject
   (reason + identical-retry gate), an interactive reject with a reason,
-  five consecutive rejections removing the tool, and an approval
-  resetting the count.
+  five consecutive rejections removing the tool, an approval resetting
+  the count, and the parallel replay scenarios: a rejection beside a
+  pausing sibling, empty-id providers across rounds, and a fifth
+  rejection landing beside a paused call whose approval must still be
+  honored (`removalRace`).
 - Real wiring: `tests/agency-js/repeated-tool-calls` scripts five
   identical calls and one garbled one through a fake client and checks
   the tool ran four times (the fourth call was refused and the count

--- a/packages/agency-lang/docs/dev/agents/tool-loop-guards.md
+++ b/packages/agency-lang/docs/dev/agents/tool-loop-guards.md
@@ -1,12 +1,15 @@
 # Tool-loop guards: repeated calls, markup arguments, and rejected calls
 
 Three refusals in `runPrompt`'s tool loop that stop a model from wasting
-rounds. The repeat and markup helpers live in
-`lib/runtime/toolLoopGuards.ts`; the rejection bookkeeping lives in
-`prompt.ts` itself. All three happen before the tool's
-`onToolCallStart` hook, so a refused call never runs, never fires hooks,
-and never counts toward `MAX_TOOL_FAILURES`. The model sees the refusal as
-an ordinary tool message, which is where it reads results.
+rounds: a repeated call, a markup argument, and a RETRY of an
+already-rejected call (the first rejected call runs normally up to its
+interrupt; only the identical retry is refused). The repeat and markup
+helpers live in `lib/runtime/toolLoopGuards.ts`; the rejection
+bookkeeping lives in `prompt.ts` itself. All three refusals happen
+before the tool's `onToolCallStart` hook, so a refused call never runs,
+never fires hooks, and never counts toward `MAX_TOOL_FAILURES`. The
+model sees the refusal as an ordinary tool message, which is where it
+reads results.
 
 ## Repeated calls
 

--- a/packages/agency-lang/docs/dev/agents/tool-loop-guards.md
+++ b/packages/agency-lang/docs/dev/agents/tool-loop-guards.md
@@ -1,8 +1,9 @@
-# Tool-loop guards: repeated calls and markup arguments
+# Tool-loop guards: repeated calls, markup arguments, and rejected calls
 
-Two refusals in `runPrompt`'s tool loop that stop a model from wasting
-rounds. The helpers live in `lib/runtime/toolLoopGuards.ts`; `prompt.ts`
-only calls them. Both happen before the tool's
+Three refusals in `runPrompt`'s tool loop that stop a model from wasting
+rounds. The repeat and markup helpers live in
+`lib/runtime/toolLoopGuards.ts`; the rejection bookkeeping lives in
+`prompt.ts` itself. All three happen before the tool's
 `onToolCallStart` hook, so a refused call never runs, never fires hooks,
 and never counts toward `MAX_TOOL_FAILURES`. The model sees the refusal as
 an ordinary tool message, which is where it reads results.
@@ -73,10 +74,47 @@ the middle of a document, is left alone. (One of the twelve,
 is not matched and fails the old way.) The refused call gets a message
 naming the argument and asking for the call again without it.
 
+## Rejected calls
+
+A rejected interrupt means a handler, policy, or user said no to a tool
+call. The tool loop tells rejections apart from failures by the
+`rejected` flag the interrupt codegen stamps on the halt failure
+(`lib/templates/backends/typescriptGenerator/interruptReturn.mustache`,
+`interruptAssignment.mustache` — both the handler-reject and the
+resume-reject branches, so an interactive `reject("reason")` carries its
+reason too). A TS tool that returns the raw `InterruptResponse` from
+`agency.interrupt` takes the same path.
+
+A rejection is not a failure, so it gets its own treatment in
+`runInvokeStep` (`recordRejection` in `prompt.ts`):
+
+- The model sees `Tool call rejected: <reason>. Do not call this tool
+  with the same arguments again; the call will not be executed.` — the
+  rejecter's reason, not an error message. No `toolErrorCounts`
+  increment, no `toolError` statelog event (the handler chain already
+  emitted `interruptResolved`).
+- The call's `repeatKey` lands in `self.rejectedCalls`. An identical
+  retry is refused by the `priorRejected` gate before the start hook —
+  no invoke, no re-raised interrupt, no counter movement. Checked before
+  the repeat guard so the model hears "rejected", not "repeated".
+- `self.rejectionCounts[tool]` counts CONSECUTIVE rejections. At
+  `MAX_TOOL_REJECTIONS` (5) the tool joins `removedTools`. A successful
+  call of the tool resets its count to zero: a narrow policy reject rule
+  brushed against during otherwise-approved work never removes the tool,
+  while a model rephrasing a refused call with nothing approved in
+  between loses it quickly.
+
+Both records live on the runPrompt frame, so they survive checkpoint and
+resume within one `llm()` call and reset when the next one starts.
+
 ## Tests
 
 - Pure helpers: `lib/runtime/toolLoopGuards.test.ts` (`markupArgument`,
   `repeatKey`, `noteRepeat`).
+- Rejections: `tests/agency-js/tool-rejection` scripts a handler reject
+  (reason + identical-retry gate), an interactive reject with a reason,
+  five consecutive rejections removing the tool, and an approval
+  resetting the count.
 - Real wiring: `tests/agency-js/repeated-tool-calls` scripts five
   identical calls and one garbled one through a fake client and checks
   the tool ran four times (the fourth call was refused and the count

--- a/packages/agency-lang/lib/runtime/prompt.test.ts
+++ b/packages/agency-lang/lib/runtime/prompt.test.ts
@@ -146,6 +146,15 @@ describe("stringifyToolResult", () => {
     // Does not throw; returns some string representation.
     expect(typeof stringifyToolResult(a)).toBe("string");
   });
+
+  it("falls back to String() on values JSON.stringify turns into undefined", () => {
+    // JSON.stringify returns undefined (without throwing) for these; a
+    // raw TS interrupt can reject with any value, and the capped
+    // rejection path reads .length off this result.
+    expect(typeof stringifyToolResult(Symbol("denied"))).toBe("string");
+    expect(typeof stringifyToolResult(() => {})).toBe("string");
+    expect(typeof stringifyToolResult(undefined)).toBe("string");
+  });
 });
 
 describe("capToolResultForLlm", () => {

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -1050,6 +1050,11 @@ export async function runPrompt(args: {
       handler: AgencyFunction;
       toolCall: smoltalk.ToolCallJSON;
       namedArgs: Record<string, any>;
+      /** repeatKey of this call, computed BEFORE invocation: the tool may
+       *  mutate nested argument objects (namedArgs is a shallow copy), and
+       *  a key digested after the fact would not match the model's retry
+       *  of the same call. */
+      callKey: string;
       branchKey: string;
       branchStack: StateStack;
     }): Promise<{
@@ -1057,7 +1062,7 @@ export async function runPrompt(args: {
       invokeOutcome: "success" | "failed" | "rejected" | "interrupted" | "crashed";
       interrupts?: any[];
     }> => {
-      const { handler, toolCall, namedArgs, branchKey, branchStack } = args;
+      const { handler, toolCall, namedArgs, callKey, branchKey, branchStack } = args;
       let toolResult: any;
       ctx.enterToolCall();
       try {
@@ -1154,7 +1159,6 @@ export async function runPrompt(args: {
       // emitted interruptResolved).
       const recordRejection = (reason: string): { toolResult: any; invokeOutcome: "rejected" } => {
         const capped = String(capToolResultForLlm(reason, toolResultCap));
-        const callKey = repeatKey(handler.name, namedArgs);
         if (!rejectedCalls.includes(callKey)) {
           rejectedCalls.push(callKey);
         }
@@ -1173,7 +1177,13 @@ export async function runPrompt(args: {
         return { toolResult, invokeOutcome: "rejected" };
       };
 
-      if (isFailure(toolResult) && toolResult.rejected) {
+      // Only a CLEAN rejection takes the rejection path. One stamped
+      // destructiveRan means the tool entered a destructive region before
+      // its gate — partial work may exist — so it falls through to the
+      // failure tiers, where the destructive tier removes the tool
+      // immediately. (Stdlib tools gate BEFORE their destructive regions,
+      // so their rejections are always clean.)
+      if (isFailure(toolResult) && toolResult.rejected && !toolResult.destructiveRan) {
         return recordRejection(toolErrorMessage(toolResult.error));
       }
 
@@ -1531,6 +1541,7 @@ export async function runPrompt(args: {
                     handler,
                     toolCall,
                     namedArgs,
+                    callKey,
                     branchKey,
                     branchStack,
                   });

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -1403,12 +1403,34 @@ export async function runPrompt(args: {
               // byte-for-byte unchanged.
               const callSlug = `${index}_${toolCall.id}`;
 
+              // Replay safety for the mutable refusal gates below (removed,
+              // priorRejected, repeated): their conditions read frame state
+              // that THIS invocation may have written before a sibling's
+              // interrupt was checkpointed (its own rejection recorded in
+              // rejectedCalls, its own fifth rejection in removedTools). An
+              // invocation that already ran must replay down its ORIGINAL
+              // path — a gate whose step never completed would push a second
+              // tool message for the same tool_call_id. `invokeOutcomes` is
+              // written inside the idempotent invoke step, never for the
+              // interrupted outcome (that step re-runs on resume by design).
+              self.runnerState.invokeOutcomes ??= {};
+              const priorOutcome: string | undefined = self.runnerState.invokeOutcomes[callSlug];
+              // A non-success invocation returned right after its invoke
+              // step, with its answer already in the thread — nothing left
+              // to do. A success falls through: its own steps no-op via
+              // completedSteps, and it must skip the gates (a same-round
+              // sibling's removal must not refuse a call that already ran).
+              if (priorOutcome !== undefined && priorOutcome !== "success") {
+                return;
+              }
+              const replayed = priorOutcome !== undefined;
+
               // Gated start (strategy B): a removed tool is refused by NAME,
               // before the handler lookup — the round-end filter drops
               // removed tools from toolFunctions, so a lookup-first path
               // would misreport a later call as "No handler found". Also
               // catches a removal by an earlier sibling in this round.
-              if (removedTools.includes(toolCall.name)) {
+              if (!replayed && removedTools.includes(toolCall.name)) {
                 await b.step(`round.${round}.tool.${callSlug}.removed`, async () =>
                   pushToolNotice(
                     `Error: Tool ${toolCall.name} has been removed from this conversation after repeated failures or rejections, and will not be executed.`,
@@ -1465,7 +1487,7 @@ export async function runPrompt(args: {
               // is refused outright: no invoke, no re-raised interrupt, no
               // counter movement. Before the repeat guard so the model hears
               // "rejected", not "repeated".
-              if (rejectedCalls.includes(callKey)) {
+              if (!replayed && rejectedCalls.includes(callKey)) {
                 await b.step(`round.${round}.tool.${callSlug}.priorRejected`, async () =>
                   pushToolNotice(
                     `This exact call to ${handler.name} was already rejected and will not be executed. Do not retry it.`,
@@ -1475,7 +1497,7 @@ export async function runPrompt(args: {
                 return;
               }
               const priorRuns = repeatsBefore(repeatStreak, callKey);
-              if (maxRepeatedToolCalls > 0 && priorRuns >= maxRepeatedToolCalls) {
+              if (!replayed && maxRepeatedToolCalls > 0 && priorRuns >= maxRepeatedToolCalls) {
                 await b.step(`round.${round}.tool.${callSlug}.repeated`, async () => {
                   resetRepeat(repeatStreak);
                   pushToolNotice(repeatedCallMessage(handler.name, priorRuns), toolCall);
@@ -1551,9 +1573,12 @@ export async function runPrompt(args: {
                     self.runnerState.toolTimings[callSlug] = performance.now() - toolCallStartTime;
                   }
                   // Inside the idempotent invoke step, so a resume does not
-                  // count the same run twice.
+                  // count the same run twice. The interrupted outcome is
+                  // never recorded: its invoke step re-runs on resume, and a
+                  // recorded outcome would short-circuit that re-run.
                   if (outcome.invokeOutcome !== "interrupted") {
                     noteRepeat(repeatStreak, callKey, stringifyToolResult(toolResult));
+                    self.runnerState.invokeOutcomes[callSlug] = outcome.invokeOutcome;
                   }
                   return outcome.interrupts;
                 });

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -198,6 +198,14 @@ const REJECTION_SUFFIX =
 const REJECTION_REMOVAL_SUFFIX =
   "This tool has been rejected too many times and can no longer be called.";
 
+/** The refusal-gate verdict for one tool invocation. Computed exactly
+ *  once, inside its own step, and persisted in runnerState: most gates
+ *  read frame state that mutates as sibling branches complete, so a
+ *  verdict recomputed on resume could differ from the one the call
+ *  originally acted on. */
+type GateVerdict =
+  "removed" | "unhandled" | "tooManyRounds" | "markup" | "priorRejected" | "repeated" | "proceed";
+
 type FailureTier = "destructive" | "neverStarted" | "idempotent" | "neutral";
 
 /** Classify a tool failure. Most-specific fact wins: a started destructive
@@ -1222,8 +1230,13 @@ export async function runPrompt(args: {
       }
 
       if (isRejected(toolResult)) {
+        // A structured reject value (e.g. reject({ code: "blocked" }))
+        // renders the same way a structured failure error does; only a
+        // reasonless rejection gets the generic message.
         return recordRejection(
-          typeof toolResult.value === "string" ? toolResult.value : "Tool call rejected by policy",
+          toolResult.value == null
+            ? "Tool call rejected by policy"
+            : toolErrorMessage(toolResult.value),
         );
       }
 
@@ -1262,6 +1275,71 @@ export async function runPrompt(args: {
     // answer the model this way.
     const pushToolNotice = (text: string, toolCall: smoltalk.ToolCallJSON): void => {
       messages.push(smoltalk.toolMessage(text, { tool_call_id: toolCall.id, name: toolCall.name }));
+    };
+
+    // The refusal-gate decision for one call, in refusal-priority order.
+    // Reads MUTABLE frame state (removedTools, rejectedCalls,
+    // repeatStreak), so callers must run it exactly once, inside the
+    // call's `.gate` step, and persist the verdict in runnerState.
+    const computeGateVerdict = (args: {
+      toolCall: smoltalk.ToolCallJSON;
+      handler: AgencyFunction | null;
+      markupArg: string | null;
+      callKey: string;
+    }): GateVerdict => {
+      const { toolCall, handler, markupArg, callKey } = args;
+      if (removedTools.includes(toolCall.name)) {
+        return "removed";
+      }
+      if (handler === null) {
+        return "unhandled";
+      }
+      if (self.toolCallRound >= effectiveMaxToolCallRounds) {
+        return "tooManyRounds";
+      }
+      if (markupArg !== null) {
+        return "markup";
+      }
+      if (rejectedCalls.includes(callKey)) {
+        // A call identical to one already rejected in this llm() call: no
+        // invoke, no re-raised interrupt, no counter movement. Checked
+        // before the repeat guard so the model hears "rejected", not
+        // "repeated".
+        return "priorRejected";
+      }
+      if (
+        maxRepeatedToolCalls > 0 &&
+        repeatsBefore(repeatStreak, callKey) >= maxRepeatedToolCalls
+      ) {
+        return "repeated";
+      }
+      return "proceed";
+    };
+
+    // The model-facing text for a refusal verdict.
+    const refusalMessage = (args: {
+      verdict: Exclude<GateVerdict, "proceed">;
+      toolCall: smoltalk.ToolCallJSON;
+      markupArg: string | null;
+      callKey: string;
+    }): string => {
+      const name = args.toolCall.name;
+      switch (args.verdict) {
+        case "removed":
+          return `Error: Tool ${name} has been removed from this conversation after repeated failures or rejections, and will not be executed.`;
+        case "unhandled":
+          return `Error: No handler found for tool call ${name}`;
+        case "tooManyRounds":
+          return `Error: Maximum number of tool call rounds (${effectiveMaxToolCallRounds}) exceeded. This tool call will not be executed.`;
+        case "markup":
+          // markupArg is non-null whenever the verdict says markup: both
+          // derive from the same replay-stable inputs.
+          return markupArgumentMessage(name, args.markupArg ?? "");
+        case "priorRejected":
+          return `This exact call to ${name} was already rejected and will not be executed. Do not retry it.`;
+        case "repeated":
+          return repeatedCallMessage(name, repeatsBefore(repeatStreak, args.callKey));
+      }
     };
 
     // Push the success ToolMessage for one invocation, with any reply-
@@ -1403,70 +1481,82 @@ export async function runPrompt(args: {
               // byte-for-byte unchanged.
               const callSlug = `${index}_${toolCall.id}`;
 
-              // Replay safety for the mutable refusal gates below (removed,
-              // priorRejected, repeated): their conditions read frame state
-              // that THIS invocation may have written before a sibling's
-              // interrupt was checkpointed (its own rejection recorded in
-              // rejectedCalls, its own fifth rejection in removedTools). An
-              // invocation that already ran must replay down its ORIGINAL
-              // path — a gate whose step never completed would push a second
-              // tool message for the same tool_call_id. `invokeOutcomes` is
-              // written inside the idempotent invoke step, never for the
-              // interrupted outcome (that step re-runs on resume by design).
+              // The refusal gates below (removed, priorRejected, repeated)
+              // decide from MUTABLE frame state: removedTools,
+              // rejectedCalls, and repeatStreak change as sibling branches
+              // and later rounds complete. Plain code between steps re-runs
+              // on resume, so an inline `if` on that state could steer a
+              // replayed call down a path it never took: a gate firing late
+              // would push a second tool message for the same tool_call_id,
+              // and a sibling's fifth rejection would refuse a paused call
+              // the user just approved. So the verdict is durable: computed
+              // once inside its own step, persisted in runnerState, and
+              // read back on every later pass. See
+              // docs/dev/agents/promptRunner.md.
+              self.runnerState.gateVerdicts ??= {};
               self.runnerState.invokeOutcomes ??= {};
               // Keyed by round + slug, NOT slug alone: the slug is unique
               // only within a round (providers like Gemini return empty
               // tool-call ids, so index-0 calls in every round share "0_"),
-              // and a cross-round collision would mistake a fresh call for
-              // a replay.
-              const outcomeKey = `round.${round}.tool.${callSlug}`;
-              const priorOutcome: string | undefined = self.runnerState.invokeOutcomes[outcomeKey];
-              // A non-success invocation returned right after its invoke
-              // step, with its answer already in the thread — nothing left
-              // to do. A success falls through: its own steps no-op via
-              // completedSteps, and it must skip the gates (a same-round
-              // sibling's removal must not refuse a call that already ran).
+              // and a cross-round collision would hand a fresh call a
+              // stale verdict.
+              const invocationKey = `round.${round}.tool.${callSlug}`;
+
+              // Resolved from the STABLE full list, not toolFunctions: on
+              // resume, runPrompt entry rebuilds toolFunctions without the
+              // names in removedTools, and a call that legitimately started
+              // before its tool was removed must still find its handler.
+              // Fresh calls to a removed tool never get here — the removed
+              // verdict refuses them first.
+              const handler = agencyFunctions.find((fn) => fn.name === toolCall.name) ?? null;
+              const namedArgs = handler
+                ? dropNullDefaultedArgs(toolCall.arguments, handler.params)
+                : {};
+              const markupArg = handler ? markupArgument(namedArgs, handler.params) : null;
+              const callKey = handler ? repeatKey(handler.name, namedArgs) : "";
+
+              await b.step(`${invocationKey}.gate`, async () => {
+                self.runnerState.gateVerdicts[invocationKey] = computeGateVerdict({
+                  toolCall,
+                  handler,
+                  markupArg,
+                  callKey,
+                });
+              });
+              const verdict: GateVerdict = self.runnerState.gateVerdicts[invocationKey];
+
+              // Recorded inside the invoke step. A completed non-success
+              // invocation (failed, rejected, crashed) already answered the
+              // model, so on replay there is nothing left to run. A success
+              // falls through: its remaining steps no-op via completedSteps.
+              // An interrupted invocation records nothing — its invoke step
+              // re-runs on resume to consume the user's response.
+              const priorOutcome: string | undefined =
+                self.runnerState.invokeOutcomes[invocationKey];
               if (priorOutcome !== undefined && priorOutcome !== "success") {
                 return;
               }
-              const replayed = priorOutcome !== undefined;
 
-              // Gated start (strategy B): a removed tool is refused by NAME,
-              // before the handler lookup — the round-end filter drops
-              // removed tools from toolFunctions, so a lookup-first path
-              // would misreport a later call as "No handler found". Also
-              // catches a removal by an earlier sibling in this round.
-              if (!replayed && removedTools.includes(toolCall.name)) {
-                await b.step(`round.${round}.tool.${callSlug}.removed`, async () =>
-                  pushToolNotice(
-                    `Error: Tool ${toolCall.name} has been removed from this conversation after repeated failures or rejections, and will not be executed.`,
-                    toolCall,
-                  ),
-                );
-                return;
-              }
-
-              const handler = toolFunctions.find((fn) => fn.name === toolCall.name);
-              if (!handler) {
-                await b.step(`round.${round}.tool.${callSlug}.unhandled`, async () => {
-                  console.error(
-                    `No handler found for tool call: ${toolCall.name}. This error will be sent back to the LLM.`,
-                  );
-                  pushToolNotice(
-                    `Error: No handler found for tool call ${toolCall.name}`,
-                    toolCall,
-                  );
+              // A refused call never reaches the tool: no start/end hooks,
+              // no failure count, one notice message in its own step (the
+              // step key matches the verdict, e.g. `.removed`).
+              if (verdict !== "proceed") {
+                await b.step(`${invocationKey}.${verdict}`, async () => {
+                  const notice = refusalMessage({ verdict, toolCall, markupArg, callKey });
+                  if (verdict === "unhandled") {
+                    console.error(
+                      `No handler found for tool call: ${toolCall.name}. This error will be sent back to the LLM.`,
+                    );
+                  }
+                  if (verdict === "repeated") {
+                    resetRepeat(repeatStreak);
+                  }
+                  pushToolNotice(notice, toolCall);
                 });
                 return;
               }
-
-              if (self.toolCallRound >= effectiveMaxToolCallRounds) {
-                await b.step(`round.${round}.tool.${callSlug}.tooManyRounds`, async () =>
-                  pushToolNotice(
-                    `Error: Maximum number of tool call rounds (${effectiveMaxToolCallRounds}) exceeded. This tool call will not be executed.`,
-                    toolCall,
-                  ),
-                );
+              if (handler === null) {
+                // Unreachable: a missing handler yields the "unhandled" verdict.
                 return;
               }
 
@@ -1476,40 +1566,6 @@ export async function runPrompt(args: {
               // uniformly by completedSteps inside b.step (start/invoke/end
               // each get marked done on success and skipped on resume).
               const branchStack = stack.getOrCreateBranch(branchKey).stack;
-              const namedArgs = dropNullDefaultedArgs(toolCall.arguments, handler.params);
-
-              // Two refusals that never reach the tool (so no start/end hooks
-              // and no failure count): an argument that is really tool-call
-              // markup, and a call the model keeps making with nothing changing.
-              const markupArg = markupArgument(namedArgs, handler.params);
-              if (markupArg !== null) {
-                await b.step(`round.${round}.tool.${callSlug}.markup`, async () =>
-                  pushToolNotice(markupArgumentMessage(handler.name, markupArg), toolCall),
-                );
-                return;
-              }
-              const callKey = repeatKey(handler.name, namedArgs);
-              // A call identical to one already rejected in this llm() call
-              // is refused outright: no invoke, no re-raised interrupt, no
-              // counter movement. Before the repeat guard so the model hears
-              // "rejected", not "repeated".
-              if (!replayed && rejectedCalls.includes(callKey)) {
-                await b.step(`round.${round}.tool.${callSlug}.priorRejected`, async () =>
-                  pushToolNotice(
-                    `This exact call to ${handler.name} was already rejected and will not be executed. Do not retry it.`,
-                    toolCall,
-                  ),
-                );
-                return;
-              }
-              const priorRuns = repeatsBefore(repeatStreak, callKey);
-              if (!replayed && maxRepeatedToolCalls > 0 && priorRuns >= maxRepeatedToolCalls) {
-                await b.step(`round.${round}.tool.${callSlug}.repeated`, async () => {
-                  resetRepeat(repeatStreak);
-                  pushToolNotice(repeatedCallMessage(handler.name, priorRuns), toolCall);
-                });
-                return;
-              }
 
               await b.step(`round.${round}.tool.${callSlug}.start`, async () => {
                 // Pass `branchStack` so scoped callbacks registered inside
@@ -1584,7 +1640,7 @@ export async function runPrompt(args: {
                   // recorded outcome would short-circuit that re-run.
                   if (outcome.invokeOutcome !== "interrupted") {
                     noteRepeat(repeatStreak, callKey, stringifyToolResult(toolResult));
-                    self.runnerState.invokeOutcomes[outcomeKey] = outcome.invokeOutcome;
+                    self.runnerState.invokeOutcomes[invocationKey] = outcome.invokeOutcome;
                   }
                   return outcome.interrupts;
                 });

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -186,6 +186,20 @@ function toolErrorMessage(error: any): string {
  *  breaker against retry spirals), or immediately on the destructive tier. */
 const MAX_TOOL_FAILURES = 5;
 
+/** A rejected tool call is not a failure: a handler, policy, or user said
+ *  no. Rejections get their own counter with the same limit — but only
+ *  CONSECUTIVE rejections count. An approved (successful) call of the tool
+ *  resets its count, so a narrow reject rule brushed against during
+ *  otherwise-approved work never removes the tool, while a model that
+ *  keeps rephrasing a refused call (nothing approved in between) loses the
+ *  tool quickly. */
+const MAX_TOOL_REJECTIONS = 5;
+
+const REJECTION_SUFFIX =
+  "Do not call this tool with the same arguments again; the call will not be executed.";
+const REJECTION_REMOVAL_SUFFIX =
+  "This tool has been rejected too many times and can no longer be called.";
+
 type FailureTier = "destructive" | "neverStarted" | "idempotent" | "neutral";
 
 /** Classify a tool failure. Most-specific fact wins: a started destructive
@@ -260,6 +274,9 @@ export const _internal = {
   failureTier,
   TIER_SUFFIX,
   MAX_TOOL_FAILURES,
+  MAX_TOOL_REJECTIONS,
+  REJECTION_SUFFIX,
+  REJECTION_REMOVAL_SUFFIX,
   armCallTimeout,
   runWithRetry,
   dropNullDefaultedArgs,
@@ -650,6 +667,8 @@ export async function runPrompt(args: {
     self.__initialized = true;
     self.removedTools = args.removedTools || [];
     self.toolErrorCounts = {};
+    self.rejectedCalls = [];
+    self.rejectionCounts = {};
     self.repeatStreak = freshRepeatStreak();
     self.toolCallRound = 0;
     self.validationAttempt = 0;
@@ -659,6 +678,17 @@ export async function runPrompt(args: {
 
   const removedTools: string[] = self.removedTools;
   const toolErrorCounts: Record<string, number> = self.toolErrorCounts;
+  // Back-compat for checkpoints taken before the rejection counters
+  // existed: a resumed frame passes the __initialized guard above with
+  // these slots absent.
+  self.rejectedCalls ??= [];
+  self.rejectionCounts ??= {};
+  /** repeatKeys of calls rejected in THIS llm() call. An identical retry
+   *  is refused before it can re-raise the interrupt. */
+  const rejectedCalls: string[] = self.rejectedCalls;
+  /** Consecutive rejections per tool (reset by an approved call). At
+   *  MAX_TOOL_REJECTIONS the tool joins removedTools. */
+  const rejectionCounts: Record<string, number> = self.rejectionCounts;
   const repeatStreak: RepeatStreak = self.repeatStreak;
   // The calling function's locals, for decision 8. Read from `args` (not the
   // frame) because it belongs to the CALLER, not to runPrompt's own frame.
@@ -1117,6 +1147,37 @@ export async function runPrompt(args: {
         markDestructiveWork({ locals: destructiveSink });
       }
 
+      // A rejection — a handler, policy, or user said no — arrives either
+      // as a Failure the interrupt codegen marked `rejected` (compiled
+      // Agency tools) or as a raw InterruptResponse a TS tool returned
+      // (agency.interrupt). Both take this path: push the rejecter's
+      // reason, remember the exact call so an identical retry is refused
+      // (see the priorRejected gate), and count toward the consecutive-
+      // rejection removal. Deliberately no toolErrorCounts increment and
+      // no toolError statelog event — the chain already emitted
+      // interruptResolved, and a rejection does not mean the tool is
+      // broken.
+      const recordRejection = (reason: string): { toolResult: any; invokeOutcome: "rejected" } => {
+        const capped = String(capToolResultForLlm(reason, toolResultCap));
+        const callKey = repeatKey(handler.name, namedArgs);
+        if (!rejectedCalls.includes(callKey)) rejectedCalls.push(callKey);
+        rejectionCounts[handler.name] = (rejectionCounts[handler.name] || 0) + 1;
+        const removed = rejectionCounts[handler.name] >= MAX_TOOL_REJECTIONS;
+        if (removed) removedTools.push(handler.name);
+        messages.push(
+          smoltalk.toolMessage(
+            `Tool call rejected: ${capped}. ${removed ? REJECTION_REMOVAL_SUFFIX : REJECTION_SUFFIX}`,
+            { tool_call_id: toolCall.id, name: toolCall.name },
+          ),
+        );
+        stack.deleteBranch(branchKey);
+        return { toolResult, invokeOutcome: "rejected" };
+      };
+
+      if (isFailure(toolResult) && toolResult.rejected) {
+        return recordRejection(toolErrorMessage(toolResult.error));
+      }
+
       if (isFailure(toolResult)) {
         const errorMessage = toolErrorMessage(toolResult.error);
         // Cap only what the LLM sees; statelog keeps the full message.
@@ -1152,16 +1213,9 @@ export async function runPrompt(args: {
       }
 
       if (isRejected(toolResult)) {
-        const message =
-          typeof toolResult.value === "string" ? toolResult.value : "Tool call rejected by policy";
-        messages.push(
-          smoltalk.toolMessage(capToolResultForLlm(message, toolResultCap), {
-            tool_call_id: toolCall.id,
-            name: toolCall.name,
-          }),
+        return recordRejection(
+          typeof toolResult.value === "string" ? toolResult.value : "Tool call rejected by policy",
         );
-        stack.deleteBranch(branchKey);
-        return { toolResult, invokeOutcome: "rejected" };
       }
 
       if (hasInterrupts(toolResult)) {
@@ -1186,9 +1240,19 @@ export async function runPrompt(args: {
       // Nullish, NOT ||: legitimate falsy returns (false, 0, "") must
       // reach the model and the branch cache as-is.
       toolResult = toolResult ?? `${handler.name} ran successfully but did not return a value`;
+      // An approved call is evidence the tool is not blanket-refused:
+      // only CONSECUTIVE rejections remove it.
+      rejectionCounts[handler.name] = 0;
       stack.setResultOnBranch(branchKey, toolResult);
       pushSuccessToolMessage({ toolResult, toolCall, handler, branchStack });
       return { toolResult, invokeOutcome: "success" };
+    };
+
+    // Push a plain notice ToolMessage for one call — the refusal gates
+    // (unhandled, round cap, removed, markup, repeat, prior rejection) all
+    // answer the model this way.
+    const pushToolNotice = (text: string, toolCall: smoltalk.ToolCallJSON): void => {
+      messages.push(smoltalk.toolMessage(text, { tool_call_id: toolCall.id, name: toolCall.name }));
     };
 
     // Push the success ToolMessage for one invocation, with any reply-
@@ -1333,25 +1397,21 @@ export async function runPrompt(args: {
                   console.error(
                     `No handler found for tool call: ${toolCall.name}. This error will be sent back to the LLM.`,
                   );
-                  messages.push(
-                    smoltalk.toolMessage(`Error: No handler found for tool call ${toolCall.name}`, {
-                      tool_call_id: toolCall.id,
-                      name: toolCall.name,
-                    }),
+                  pushToolNotice(
+                    `Error: No handler found for tool call ${toolCall.name}`,
+                    toolCall,
                   );
                 });
                 return;
               }
 
               if (self.toolCallRound >= effectiveMaxToolCallRounds) {
-                await b.step(`round.${round}.tool.${callSlug}.tooManyRounds`, async () => {
-                  messages.push(
-                    smoltalk.toolMessage(
-                      `Error: Maximum number of tool call rounds (${effectiveMaxToolCallRounds}) exceeded. This tool call will not be executed.`,
-                      { tool_call_id: toolCall.id, name: toolCall.name },
-                    ),
-                  );
-                });
+                await b.step(`round.${round}.tool.${callSlug}.tooManyRounds`, async () =>
+                  pushToolNotice(
+                    `Error: Maximum number of tool call rounds (${effectiveMaxToolCallRounds}) exceeded. This tool call will not be executed.`,
+                    toolCall,
+                  ),
+                );
                 return;
               }
 
@@ -1360,14 +1420,12 @@ export async function runPrompt(args: {
               // sibling in this round that pushed first), skip with a
               // notice toolMessage.
               if (removedTools.includes(handler.name)) {
-                await b.step(`round.${round}.tool.${callSlug}.removed`, async () => {
-                  messages.push(
-                    smoltalk.toolMessage(
-                      `Error: Handler for tool call ${handler.name} has been removed already due to previous errors, and will not be executed.`,
-                      { tool_call_id: toolCall.id, name: toolCall.name },
-                    ),
-                  );
-                });
+                await b.step(`round.${round}.tool.${callSlug}.removed`, async () =>
+                  pushToolNotice(
+                    `Error: Handler for tool call ${handler.name} has been removed already due to previous errors, and will not be executed.`,
+                    toolCall,
+                  ),
+                );
                 return;
               }
 
@@ -1384,27 +1442,30 @@ export async function runPrompt(args: {
               // markup, and a call the model keeps making with nothing changing.
               const markupArg = markupArgument(namedArgs, handler.params);
               if (markupArg !== null) {
-                await b.step(`round.${round}.tool.${callSlug}.markup`, async () => {
-                  messages.push(
-                    smoltalk.toolMessage(markupArgumentMessage(handler.name, markupArg), {
-                      tool_call_id: toolCall.id,
-                      name: toolCall.name,
-                    }),
-                  );
-                });
+                await b.step(`round.${round}.tool.${callSlug}.markup`, async () =>
+                  pushToolNotice(markupArgumentMessage(handler.name, markupArg), toolCall),
+                );
                 return;
               }
               const callKey = repeatKey(handler.name, namedArgs);
+              // A call identical to one already rejected in this llm() call
+              // is refused outright: no invoke, no re-raised interrupt, no
+              // counter movement. Before the repeat guard so the model hears
+              // "rejected", not "repeated".
+              if (rejectedCalls.includes(callKey)) {
+                await b.step(`round.${round}.tool.${callSlug}.priorRejected`, async () =>
+                  pushToolNotice(
+                    `This exact call to ${handler.name} was already rejected and will not be executed. Do not retry it.`,
+                    toolCall,
+                  ),
+                );
+                return;
+              }
               const priorRuns = repeatsBefore(repeatStreak, callKey);
               if (maxRepeatedToolCalls > 0 && priorRuns >= maxRepeatedToolCalls) {
                 await b.step(`round.${round}.tool.${callSlug}.repeated`, async () => {
                   resetRepeat(repeatStreak);
-                  messages.push(
-                    smoltalk.toolMessage(repeatedCallMessage(handler.name, priorRuns), {
-                      tool_call_id: toolCall.id,
-                      name: toolCall.name,
-                    }),
-                  );
+                  pushToolNotice(repeatedCallMessage(handler.name, priorRuns), toolCall);
                 });
                 return;
               }

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -186,13 +186,11 @@ function toolErrorMessage(error: any): string {
  *  breaker against retry spirals), or immediately on the destructive tier. */
 const MAX_TOOL_FAILURES = 5;
 
-/** A rejected tool call is not a failure: a handler, policy, or user said
- *  no. Rejections get their own counter with the same limit — but only
- *  CONSECUTIVE rejections count. An approved (successful) call of the tool
- *  resets its count, so a narrow reject rule brushed against during
- *  otherwise-approved work never removes the tool, while a model that
- *  keeps rephrasing a refused call (nothing approved in between) loses the
- *  tool quickly. */
+/** Consecutive rejections that remove a tool. Only consecutive: a
+ *  successful call resets the count, so a narrow reject rule brushed
+ *  against during otherwise-approved work never removes the tool, while
+ *  a model rephrasing a refused call with nothing approved in between
+ *  loses it quickly. */
 const MAX_TOOL_REJECTIONS = 5;
 
 const REJECTION_SUFFIX =
@@ -678,11 +676,12 @@ export async function runPrompt(args: {
 
   const removedTools: string[] = self.removedTools;
   const toolErrorCounts: Record<string, number> = self.toolErrorCounts;
-  // Back-compat for checkpoints taken before the rejection counters
-  // existed: a resumed frame passes the __initialized guard above with
-  // these slots absent.
+  // Rebuilt on every entry: a checkpoint taken before these slots existed
+  // restores without them, and a restore revives plain-prototype objects.
+  // Null-prototype because tool names are author-chosen and may collide
+  // with Object.prototype keys (a def named `constructor`).
   self.rejectedCalls ??= [];
-  self.rejectionCounts ??= {};
+  self.rejectionCounts = Object.assign(Object.create(null), self.rejectionCounts);
   /** repeatKeys of calls rejected in THIS llm() call. An identical retry
    *  is refused before it can re-raise the interrupt. */
   const rejectedCalls: string[] = self.rejectedCalls;
@@ -1149,21 +1148,21 @@ export async function runPrompt(args: {
 
       // A rejection — a handler, policy, or user said no — arrives either
       // as a Failure the interrupt codegen marked `rejected` (compiled
-      // Agency tools) or as a raw InterruptResponse a TS tool returned
-      // (agency.interrupt). Both take this path: push the rejecter's
-      // reason, remember the exact call so an identical retry is refused
-      // (see the priorRejected gate), and count toward the consecutive-
-      // rejection removal. Deliberately no toolErrorCounts increment and
-      // no toolError statelog event — the chain already emitted
-      // interruptResolved, and a rejection does not mean the tool is
-      // broken.
+      // Agency tools) or as a raw InterruptResponse returned by a TS tool
+      // (agency.interrupt). It is not a tool error: no toolErrorCounts
+      // increment, no toolError statelog event (the handler chain already
+      // emitted interruptResolved).
       const recordRejection = (reason: string): { toolResult: any; invokeOutcome: "rejected" } => {
         const capped = String(capToolResultForLlm(reason, toolResultCap));
         const callKey = repeatKey(handler.name, namedArgs);
-        if (!rejectedCalls.includes(callKey)) rejectedCalls.push(callKey);
+        if (!rejectedCalls.includes(callKey)) {
+          rejectedCalls.push(callKey);
+        }
         rejectionCounts[handler.name] = (rejectionCounts[handler.name] || 0) + 1;
         const removed = rejectionCounts[handler.name] >= MAX_TOOL_REJECTIONS;
-        if (removed) removedTools.push(handler.name);
+        if (removed) {
+          removedTools.push(handler.name);
+        }
         messages.push(
           smoltalk.toolMessage(
             `Tool call rejected: ${capped}. ${removed ? REJECTION_REMOVAL_SUFFIX : REJECTION_SUFFIX}`,
@@ -1357,7 +1356,10 @@ export async function runPrompt(args: {
         // `removedTools` and `toolErrorCounts` use eventually-consistent
         // semantics across branches (strategy B in the plan): same-round
         // removal is best-effort and removals always take effect from the
-        // NEXT round (the .filter() after this parallel call).
+        // NEXT round (the .filter() after this parallel call). The
+        // rejection counters share these semantics: outcomes apply in
+        // branch-completion order, so a same-round mix of rejections and
+        // approvals of ONE tool near the removal limit is best-effort too.
         // An all-intrinsic round has nothing to dispatch: keep the
         // empty values result instead of running runBatch over zero
         // children.
@@ -1391,6 +1393,21 @@ export async function runPrompt(args: {
               // byte-for-byte unchanged.
               const callSlug = `${index}_${toolCall.id}`;
 
+              // Gated start (strategy B): a removed tool is refused by NAME,
+              // before the handler lookup — the round-end filter drops
+              // removed tools from toolFunctions, so a lookup-first path
+              // would misreport a later call as "No handler found". Also
+              // catches a removal by an earlier sibling in this round.
+              if (removedTools.includes(toolCall.name)) {
+                await b.step(`round.${round}.tool.${callSlug}.removed`, async () =>
+                  pushToolNotice(
+                    `Error: Tool ${toolCall.name} has been removed from this conversation after repeated failures or rejections, and will not be executed.`,
+                    toolCall,
+                  ),
+                );
+                return;
+              }
+
               const handler = toolFunctions.find((fn) => fn.name === toolCall.name);
               if (!handler) {
                 await b.step(`round.${round}.tool.${callSlug}.unhandled`, async () => {
@@ -1409,20 +1426,6 @@ export async function runPrompt(args: {
                 await b.step(`round.${round}.tool.${callSlug}.tooManyRounds`, async () =>
                   pushToolNotice(
                     `Error: Maximum number of tool call rounds (${effectiveMaxToolCallRounds}) exceeded. This tool call will not be executed.`,
-                    toolCall,
-                  ),
-                );
-                return;
-              }
-
-              // Gated start (strategy B): if the tool is already in
-              // removedTools (either from a prior round or from an earlier
-              // sibling in this round that pushed first), skip with a
-              // notice toolMessage.
-              if (removedTools.includes(handler.name)) {
-                await b.step(`round.${round}.tool.${callSlug}.removed`, async () =>
-                  pushToolNotice(
-                    `Error: Handler for tool call ${handler.name} has been removed already due to previous errors, and will not be executed.`,
                     toolCall,
                   ),
                 );

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -1414,7 +1414,13 @@ export async function runPrompt(args: {
               // written inside the idempotent invoke step, never for the
               // interrupted outcome (that step re-runs on resume by design).
               self.runnerState.invokeOutcomes ??= {};
-              const priorOutcome: string | undefined = self.runnerState.invokeOutcomes[callSlug];
+              // Keyed by round + slug, NOT slug alone: the slug is unique
+              // only within a round (providers like Gemini return empty
+              // tool-call ids, so index-0 calls in every round share "0_"),
+              // and a cross-round collision would mistake a fresh call for
+              // a replay.
+              const outcomeKey = `round.${round}.tool.${callSlug}`;
+              const priorOutcome: string | undefined = self.runnerState.invokeOutcomes[outcomeKey];
               // A non-success invocation returned right after its invoke
               // step, with its answer already in the thread — nothing left
               // to do. A success falls through: its own steps no-op via
@@ -1578,7 +1584,7 @@ export async function runPrompt(args: {
                   // recorded outcome would short-circuit that re-run.
                   if (outcome.invokeOutcome !== "interrupted") {
                     noteRepeat(repeatStreak, callKey, stringifyToolResult(toolResult));
-                    self.runnerState.invokeOutcomes[callSlug] = outcome.invokeOutcome;
+                    self.runnerState.invokeOutcomes[outcomeKey] = outcome.invokeOutcome;
                   }
                   return outcome.interrupts;
                 });

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -154,7 +154,10 @@ const DEFAULT_TOOL_RESULT_CHARS = 100_000;
 function stringifyToolResult(result: any): string {
   if (typeof result === "string") return result;
   try {
-    return JSON.stringify(result);
+    const json = JSON.stringify(result);
+    // JSON.stringify returns undefined WITHOUT throwing for symbols,
+    // functions, and undefined itself; callers read .length off this.
+    return json === undefined ? String(result) : json;
   } catch {
     return String(result);
   }

--- a/packages/agency-lang/lib/runtime/result.test.ts
+++ b/packages/agency-lang/lib/runtime/result.test.ts
@@ -197,6 +197,7 @@ describe("failure", () => {
       checkpoint: null,
       neverStarted: false,
       destructiveRan: false,
+      rejected: false,
       functionName: null,
       args: null,
       skippedFunctions: [],
@@ -212,16 +213,23 @@ describe("failure", () => {
       checkpoint: null,
       neverStarted: false,
       destructiveRan: false,
+      rejected: false,
       functionName: null,
       args: null,
       skippedFunctions: [],
     });
   });
 
-  it("births neverStarted and destructiveRan false", () => {
+  it("births neverStarted, destructiveRan, and rejected false", () => {
     const f = failure("boom");
     expect(f.neverStarted).toBe(false);
     expect(f.destructiveRan).toBe(false);
+    expect(f.rejected).toBe(false);
+  });
+
+  it("honors an explicit rejected opt", () => {
+    const f = failure("no tools for you", { rejected: true });
+    expect(f.rejected).toBe(true);
   });
 
   it("honors explicit neverStarted and destructiveRan opts", () => {

--- a/packages/agency-lang/lib/runtime/result.ts
+++ b/packages/agency-lang/lib/runtime/result.ts
@@ -64,6 +64,11 @@ export type FailureOpts = {
   /** Execution entered a destructive region — a `destructive def` body (which
    *  commits at entry) or a `destructive { }` region. */
   destructiveRan?: boolean;
+  /** This failure is a rejected interrupt: a handler, policy, or user
+   *  said no. Its only producers are the interrupt codegen templates
+   *  (interruptReturn/interruptAssignment). The tool loop reads it to
+   *  tell "you may not do this" apart from "the tool broke". */
+  rejected?: boolean;
   functionName?: string;
   args?: Record<string, any>;
   /** The guard ids this `try` boundary OWNS. A `guardTrip` cause is
@@ -93,6 +98,9 @@ export type ResultFailure = {
    *  region entry) — when this failure was produced. Birth default false;
    *  boundaries OR the activation's flag in via stampFailureBoundary. */
   destructiveRan: boolean;
+  /** This failure is a rejected interrupt (see FailureOpts.rejected).
+   *  Birth default false; set only by the interrupt codegen templates. */
+  rejected: boolean;
   functionName: string | null;
   args: Record<string, any> | null;
   skippedFunctions: SkippedFunction[];
@@ -114,6 +122,7 @@ export function failure(error: any, opts?: FailureOpts): ResultFailure {
     // sole producer sets it explicitly.
     neverStarted: opts?.neverStarted ?? false,
     destructiveRan: opts?.destructiveRan ?? false,
+    rejected: opts?.rejected ?? false,
     functionName: opts?.functionName ?? null,
     args: opts?.args ?? null,
     skippedFunctions: [],

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/interruptAssignment.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/interruptAssignment.mustache
@@ -8,12 +8,12 @@ if (__response) {
       {{{assignApprove}}};
     }
   } else if (__response.type === "reject") {
-    // reject for tool calls handled separately
+    // rejected, halt
     {{#nodeContext}}
-    runner.halt({ messages: __threads(), data: failure("interrupt rejected") });
+    runner.halt({ messages: __threads(), data: failure(__response.value ?? "interrupt rejected", { rejected: true }) });
     {{/nodeContext}}
     {{^nodeContext}}
-    runner.halt(failure("interrupt rejected", { checkpoint: getRuntimeContext().ctx.getResultCheckpoint() }));
+    runner.halt(failure(__response.value ?? "interrupt rejected", { rejected: true, checkpoint: getRuntimeContext().ctx.getResultCheckpoint() }));
     {{/nodeContext}}
     return;
   }
@@ -22,10 +22,10 @@ if (__response) {
   const __handlerResult = await interruptWithHandlers({{{effect}}}, {{{message}}}, {{{data}}}, {{{origin}}}, __ctx, __stateStack(), { expectsValue: true });
   if (isRejected(__handlerResult)) {
     {{#nodeContext}}
-    runner.halt({ messages: __threads(), data: failure(__handlerResult.value ?? "interrupt rejected") });
+    runner.halt({ messages: __threads(), data: failure(__handlerResult.value ?? "interrupt rejected", { rejected: true }) });
     {{/nodeContext}}
     {{^nodeContext}}
-    runner.halt(failure(__handlerResult.value ?? "interrupt rejected", { checkpoint: getRuntimeContext().ctx.checkpoints.get(__resultCheckpointId) }));
+    runner.halt(failure(__handlerResult.value ?? "interrupt rejected", { rejected: true, checkpoint: getRuntimeContext().ctx.checkpoints.get(__resultCheckpointId) }));
     {{/nodeContext}}
     return;
   }

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/interruptAssignment.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/interruptAssignment.ts
@@ -13,12 +13,12 @@ if (__response) {
       {{{assignApprove}}};
     }
   } else if (__response.type === "reject") {
-    // reject for tool calls handled separately
+    // rejected, halt
     {{#nodeContext}}
-    runner.halt({ messages: __threads(), data: failure("interrupt rejected") });
+    runner.halt({ messages: __threads(), data: failure(__response.value ?? "interrupt rejected", { rejected: true }) });
     {{/nodeContext}}
     {{^nodeContext}}
-    runner.halt(failure("interrupt rejected", { checkpoint: getRuntimeContext().ctx.getResultCheckpoint() }));
+    runner.halt(failure(__response.value ?? "interrupt rejected", { rejected: true, checkpoint: getRuntimeContext().ctx.getResultCheckpoint() }));
     {{/nodeContext}}
     return;
   }
@@ -27,10 +27,10 @@ if (__response) {
   const __handlerResult = await interruptWithHandlers({{{effect}}}, {{{message}}}, {{{data}}}, {{{origin}}}, __ctx, __stateStack(), { expectsValue: true });
   if (isRejected(__handlerResult)) {
     {{#nodeContext}}
-    runner.halt({ messages: __threads(), data: failure(__handlerResult.value ?? "interrupt rejected") });
+    runner.halt({ messages: __threads(), data: failure(__handlerResult.value ?? "interrupt rejected", { rejected: true }) });
     {{/nodeContext}}
     {{^nodeContext}}
-    runner.halt(failure(__handlerResult.value ?? "interrupt rejected", { checkpoint: getRuntimeContext().ctx.checkpoints.get(__resultCheckpointId) }));
+    runner.halt(failure(__handlerResult.value ?? "interrupt rejected", { rejected: true, checkpoint: getRuntimeContext().ctx.checkpoints.get(__resultCheckpointId) }));
     {{/nodeContext}}
     return;
   }

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/interruptReturn.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/interruptReturn.mustache
@@ -6,10 +6,10 @@ if (__response) {
   } else if (__response.type === "reject") {
     // rejected, halt
     {{#nodeContext}}
-    runner.halt({ messages: __threads(), data: failure("interrupt rejected") });
+    runner.halt({ messages: __threads(), data: failure(__response.value ?? "interrupt rejected", { rejected: true }) });
     {{/nodeContext}}
     {{^nodeContext}}
-    runner.halt(failure("interrupt rejected", { checkpoint: getRuntimeContext().ctx.getResultCheckpoint() }));
+    runner.halt(failure(__response.value ?? "interrupt rejected", { rejected: true, checkpoint: getRuntimeContext().ctx.getResultCheckpoint() }));
     {{/nodeContext}}
     return;
   }
@@ -18,10 +18,10 @@ if (__response) {
   const __handlerResult = await interruptWithHandlers({{{effect}}}, {{{message}}}, {{{data}}}, {{{origin}}}, __ctx, __stateStack());
   if (isRejected(__handlerResult)) {
     {{#nodeContext}}
-    runner.halt({ messages: __threads(), data: failure(__handlerResult.value ?? "interrupt rejected") });
+    runner.halt({ messages: __threads(), data: failure(__handlerResult.value ?? "interrupt rejected", { rejected: true }) });
     {{/nodeContext}}
     {{^nodeContext}}
-    runner.halt(failure(__handlerResult.value ?? "interrupt rejected", { checkpoint: getRuntimeContext().ctx.checkpoints.get(__resultCheckpointId) }));
+    runner.halt(failure(__handlerResult.value ?? "interrupt rejected", { rejected: true, checkpoint: getRuntimeContext().ctx.checkpoints.get(__resultCheckpointId) }));
     {{/nodeContext}}
     return;
   }

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/interruptReturn.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/interruptReturn.ts
@@ -11,10 +11,10 @@ if (__response) {
   } else if (__response.type === "reject") {
     // rejected, halt
     {{#nodeContext}}
-    runner.halt({ messages: __threads(), data: failure("interrupt rejected") });
+    runner.halt({ messages: __threads(), data: failure(__response.value ?? "interrupt rejected", { rejected: true }) });
     {{/nodeContext}}
     {{^nodeContext}}
-    runner.halt(failure("interrupt rejected", { checkpoint: getRuntimeContext().ctx.getResultCheckpoint() }));
+    runner.halt(failure(__response.value ?? "interrupt rejected", { rejected: true, checkpoint: getRuntimeContext().ctx.getResultCheckpoint() }));
     {{/nodeContext}}
     return;
   }
@@ -23,10 +23,10 @@ if (__response) {
   const __handlerResult = await interruptWithHandlers({{{effect}}}, {{{message}}}, {{{data}}}, {{{origin}}}, __ctx, __stateStack());
   if (isRejected(__handlerResult)) {
     {{#nodeContext}}
-    runner.halt({ messages: __threads(), data: failure(__handlerResult.value ?? "interrupt rejected") });
+    runner.halt({ messages: __threads(), data: failure(__handlerResult.value ?? "interrupt rejected", { rejected: true }) });
     {{/nodeContext}}
     {{^nodeContext}}
-    runner.halt(failure(__handlerResult.value ?? "interrupt rejected", { checkpoint: getRuntimeContext().ctx.checkpoints.get(__resultCheckpointId) }));
+    runner.halt(failure(__handlerResult.value ?? "interrupt rejected", { rejected: true, checkpoint: getRuntimeContext().ctx.checkpoints.get(__resultCheckpointId) }));
     {{/nodeContext}}
     return;
   }

--- a/packages/agency-lang/lib/typeChecker/resultUnion.ts
+++ b/packages/agency-lang/lib/typeChecker/resultUnion.ts
@@ -35,6 +35,7 @@ export function resultToObjectUnion(
           // Tool-failure classification (lib/runtime/result.ts).
           { key: "neverStarted", value: BOOLEAN_T },
           { key: "destructiveRan", value: BOOLEAN_T },
+          { key: "rejected", value: BOOLEAN_T },
           // runtime is `string | null` (result.ts); under nullish unification
           // the one nothing-value is `null`, so the surface type is `string | null`.
           {

--- a/packages/agency-lang/lib/typeChecker/strictMemberAccess.test.ts
+++ b/packages/agency-lang/lib/typeChecker/strictMemberAccess.test.ts
@@ -295,6 +295,24 @@ node main() {
   });
 });
 
+describe("rejected member on a narrowed failure", () => {
+  it("allows rejected on a narrowed failure", () => {
+    const { errors } = check(`
+def f(): Result { return failure("x") }
+def g(): string {
+  const r = f()
+  if (isFailure(r)) {
+    if (r.rejected) {
+      return "rejected"
+    }
+    return "failed"
+  }
+  return "ok"
+}`);
+    expect(errors).toEqual([]);
+  });
+});
+
 describe("skippedFunctions member on a narrowed failure", () => {
   it("allows skippedFunctions on a narrowed failure", () => {
     const { errors } = check(`

--- a/packages/agency-lang/lib/typeChecker/synthesizer.ts
+++ b/packages/agency-lang/lib/typeChecker/synthesizer.ts
@@ -114,6 +114,7 @@ const RESULT_FIELDS = new Set<string>([
   "args",
   "neverStarted",
   "destructiveRan",
+  "rejected",
   "success",
   "skippedFunctions",
 ]);

--- a/packages/agency-lang/tests/agency-js/interrupts/interrupt-overrides/fixture.json
+++ b/packages/agency-lang/tests/agency-js/interrupts/interrupt-overrides/fixture.json
@@ -10,6 +10,7 @@
     "checkpoint": null,
     "neverStarted": false,
     "destructiveRan": false,
+    "rejected": true,
     "functionName": null,
     "args": null,
     "skippedFunctions": []

--- a/packages/agency-lang/tests/agency-js/tool-rejection/agent.agency
+++ b/packages/agency-lang/tests/agency-js/tool-rejection/agent.agency
@@ -59,6 +59,20 @@ node parallelRejectAndPause() {
   return out
 }
 
+// Providers like Gemini return empty tool-call ids, so the index-0 call
+// of EVERY round shares one slug. A rejection in round 1 must not make
+// round 2's fresh call look like a replay: both calls must run and both
+// rejection messages must reach the model.
+node emptyIdRounds() {
+  let out = ""
+  handle {
+    out = llm("Use guardedTool twice.", { tools: [guardedTool] })
+  } with (intr) {
+    return reject("denied ${intr.message}")
+  }
+  return out
+}
+
 // A destructive def commits destructiveRan at body entry, so a rejection
 // of its gate is NOT a clean rejection: it takes the destructive failure
 // tier (immediate removal), not the rejection path.

--- a/packages/agency-lang/tests/agency-js/tool-rejection/agent.agency
+++ b/packages/agency-lang/tests/agency-js/tool-rejection/agent.agency
@@ -1,0 +1,53 @@
+// A tool that raises an interrupt before doing its work. The interrupt
+// message carries the id so a handler can approve some calls and reject
+// others.
+def guardedTool(id: string): string {
+  const _ok = interrupt("run ${id}")
+  return "ran ${id}"
+}
+
+// Every interrupt is rejected with a reason. The reason must reach the
+// model as the tool result, and an identical retry must be refused
+// without raising another interrupt.
+node handlerRejects() {
+  let out = ""
+  handle {
+    out = llm("Use guardedTool.", { tools: [guardedTool] })
+  } with (intr) {
+    return reject("no tools for you")
+  }
+  return out
+}
+
+// No handler: the interrupt pauses the run, and the test rejects it
+// interactively with a reason that must reach the model after resume.
+node interactiveReject() {
+  return llm("Use guardedTool.", { tools: [guardedTool] })
+}
+
+// Five consecutive rejections (different args each time, so the
+// identical-call gate never fires) remove the tool.
+node fiveRejectionsRemove() {
+  let out = ""
+  handle {
+    out = llm("Use guardedTool.", { tools: [guardedTool] })
+  } with (intr) {
+    return reject("denied")
+  }
+  return out
+}
+
+// An approved call resets the consecutive-rejection count: four
+// rejections, an approval, then more calls — the tool must survive.
+node approvalResets() {
+  let out = ""
+  handle {
+    out = llm("Use guardedTool.", { tools: [guardedTool] })
+  } with (intr) {
+    if (intr.message == "run ok" || intr.message == "run ok2") {
+      return approve()
+    }
+    return reject("denied ${intr.message}")
+  }
+  return out
+}

--- a/packages/agency-lang/tests/agency-js/tool-rejection/agent.agency
+++ b/packages/agency-lang/tests/agency-js/tool-rejection/agent.agency
@@ -37,6 +37,24 @@ node fiveRejectionsRemove() {
   return out
 }
 
+// A destructive def commits destructiveRan at body entry, so a rejection
+// of its gate is NOT a clean rejection: it takes the destructive failure
+// tier (immediate removal), not the rejection path.
+destructive def destructiveGated(id: string): string {
+  const _ok = interrupt("run ${id}")
+  return "ran ${id}"
+}
+
+node destructiveReject() {
+  let out = ""
+  handle {
+    out = llm("Use destructiveGated.", { tools: [destructiveGated] })
+  } with (intr) {
+    return reject("stop")
+  }
+  return out
+}
+
 // An approved call resets the consecutive-rejection count: four
 // rejections, an approval, then more calls — the tool must survive.
 node approvalResets() {

--- a/packages/agency-lang/tests/agency-js/tool-rejection/agent.agency
+++ b/packages/agency-lang/tests/agency-js/tool-rejection/agent.agency
@@ -37,6 +37,28 @@ node fiveRejectionsRemove() {
   return out
 }
 
+// Replay safety: one tool of a parallel round is rejected while its
+// sibling pauses on an interrupt. The rejected branch's message and
+// bookkeeping are in the checkpoint; the resume replay must not push a
+// second tool message for it.
+def pauseMe(id: string): string {
+  const _ok = interrupt("pause ${id}")
+  return "ran ${id}"
+}
+
+node parallelRejectAndPause() {
+  let out = ""
+  handle {
+    out = llm("Use both tools.", { tools: [guardedTool, pauseMe] })
+  } with (intr) {
+    if (intr.message == "run pr1") {
+      return reject("no guardedTool")
+    }
+    return pass()
+  }
+  return out
+}
+
 // A destructive def commits destructiveRan at body entry, so a rejection
 // of its gate is NOT a clean rejection: it takes the destructive failure
 // tier (immediate removal), not the rejection path.

--- a/packages/agency-lang/tests/agency-js/tool-rejection/agent.agency
+++ b/packages/agency-lang/tests/agency-js/tool-rejection/agent.agency
@@ -91,6 +91,25 @@ node destructiveReject() {
   return out
 }
 
+// The removal race: guardedTool has four consecutive rejections when a
+// parallel round makes two more calls. The handler rejects one (the
+// fifth strike, which removes the tool) and passes the other to the
+// user, pausing the run. The paused call started before the removal,
+// and removal takes effect only from the next round — so the user's
+// approval must still be honored on resume.
+node removalRace() {
+  let out = ""
+  handle {
+    out = llm("Use guardedTool.", { tools: [guardedTool] })
+  } with (intr) {
+    if (intr.message == "run keep") {
+      return pass()
+    }
+    return reject("denied ${intr.message}")
+  }
+  return out
+}
+
 // An approved call resets the consecutive-rejection count: four
 // rejections, an approval, then more calls — the tool must survive.
 node approvalResets() {

--- a/packages/agency-lang/tests/agency-js/tool-rejection/fixture.json
+++ b/packages/agency-lang/tests/agency-js/tool-rejection/fixture.json
@@ -17,8 +17,14 @@
     "toolStarts": 5,
     "removalSeen": true
   },
-  "approvalResets": {
+  "destructiveReject": {
     "result": "s4 done",
+    "toolStarts": 1,
+    "destructiveTierSeen": true,
+    "rejectionPathSeen": false
+  },
+  "approvalResets": {
+    "result": "s5 done",
     "toolStarts": 7,
     "removalSeen": false
   }

--- a/packages/agency-lang/tests/agency-js/tool-rejection/fixture.json
+++ b/packages/agency-lang/tests/agency-js/tool-rejection/fixture.json
@@ -1,0 +1,25 @@
+{
+  "handlerRejects": {
+    "result": "s1 done",
+    "toolStarts": 1,
+    "reasonSeen": true,
+    "noRetrySuffixSeen": true,
+    "identicalRetryRefused": true,
+    "framedAsError": false
+  },
+  "interactiveReject": {
+    "pausedWithInterrupt": true,
+    "result": "s2 done",
+    "reasonSeen": true
+  },
+  "fiveRejectionsRemove": {
+    "result": "s3 done",
+    "toolStarts": 5,
+    "removalSeen": true
+  },
+  "approvalResets": {
+    "result": "s4 done",
+    "toolStarts": 7,
+    "removalSeen": false
+  }
+}

--- a/packages/agency-lang/tests/agency-js/tool-rejection/fixture.json
+++ b/packages/agency-lang/tests/agency-js/tool-rejection/fixture.json
@@ -33,5 +33,11 @@
     "result": "s6 done",
     "toolMessagesInFinalRequest": 2,
     "rejectionMessages": 1
+  },
+  "emptyIdRounds": {
+    "result": "s7 done",
+    "toolStarts": 2,
+    "toolMessagesInFinalRequest": 2,
+    "rejectionMessages": 2
   }
 }

--- a/packages/agency-lang/tests/agency-js/tool-rejection/fixture.json
+++ b/packages/agency-lang/tests/agency-js/tool-rejection/fixture.json
@@ -27,5 +27,11 @@
     "result": "s5 done",
     "toolStarts": 7,
     "removalSeen": false
+  },
+  "parallelRejectAndPause": {
+    "pausedWithInterrupt": true,
+    "result": "s6 done",
+    "toolMessagesInFinalRequest": 2,
+    "rejectionMessages": 1
   }
 }

--- a/packages/agency-lang/tests/agency-js/tool-rejection/fixture.json
+++ b/packages/agency-lang/tests/agency-js/tool-rejection/fixture.json
@@ -39,5 +39,11 @@
     "toolStarts": 2,
     "toolMessagesInFinalRequest": 2,
     "rejectionMessages": 2
+  },
+  "removalRace": {
+    "pausedWithInterrupt": true,
+    "result": "s8 done",
+    "approvedCallRan": true,
+    "removalSeen": true
   }
 }

--- a/packages/agency-lang/tests/agency-js/tool-rejection/llmMocks.json
+++ b/packages/agency-lang/tests/agency-js/tool-rejection/llmMocks.json
@@ -14,6 +14,10 @@
   { "toolCall": { "name": "guardedTool", "args": { "id": "r6" } } },
   { "return": "s3 done" },
 
+  { "toolCall": { "name": "destructiveGated", "args": { "id": "d1" } } },
+  { "toolCall": { "name": "destructiveGated", "args": { "id": "d2" } } },
+  { "return": "s4 done" },
+
   { "toolCall": { "name": "guardedTool", "args": { "id": "x1" } } },
   { "toolCall": { "name": "guardedTool", "args": { "id": "x2" } } },
   { "toolCall": { "name": "guardedTool", "args": { "id": "x3" } } },
@@ -21,5 +25,5 @@
   { "toolCall": { "name": "guardedTool", "args": { "id": "ok" } } },
   { "toolCall": { "name": "guardedTool", "args": { "id": "x5" } } },
   { "toolCall": { "name": "guardedTool", "args": { "id": "ok2" } } },
-  { "return": "s4 done" }
+  { "return": "s5 done" }
 ]

--- a/packages/agency-lang/tests/agency-js/tool-rejection/llmMocks.json
+++ b/packages/agency-lang/tests/agency-js/tool-rejection/llmMocks.json
@@ -35,5 +35,17 @@
   { "return": "s6 done" },
   { "toolCalls": [{ "name": "guardedTool", "args": { "id": "e1" }, "id": "" }] },
   { "toolCalls": [{ "name": "guardedTool", "args": { "id": "e2" }, "id": "" }] },
-  { "return": "s7 done" }
+  { "return": "s7 done" },
+
+  { "toolCall": { "name": "guardedTool", "args": { "id": "m1" } } },
+  { "toolCall": { "name": "guardedTool", "args": { "id": "m2" } } },
+  { "toolCall": { "name": "guardedTool", "args": { "id": "m3" } } },
+  { "toolCall": { "name": "guardedTool", "args": { "id": "m4" } } },
+  {
+    "toolCalls": [
+      { "name": "guardedTool", "args": { "id": "m5" } },
+      { "name": "guardedTool", "args": { "id": "keep" } }
+    ]
+  },
+  { "return": "s8 done" }
 ]

--- a/packages/agency-lang/tests/agency-js/tool-rejection/llmMocks.json
+++ b/packages/agency-lang/tests/agency-js/tool-rejection/llmMocks.json
@@ -1,0 +1,25 @@
+[
+  { "toolCall": { "name": "guardedTool", "args": { "id": "a" } } },
+  { "toolCall": { "name": "guardedTool", "args": { "id": "a" } } },
+  { "return": "s1 done" },
+
+  { "toolCall": { "name": "guardedTool", "args": { "id": "b" } } },
+  { "return": "s2 done" },
+
+  { "toolCall": { "name": "guardedTool", "args": { "id": "r1" } } },
+  { "toolCall": { "name": "guardedTool", "args": { "id": "r2" } } },
+  { "toolCall": { "name": "guardedTool", "args": { "id": "r3" } } },
+  { "toolCall": { "name": "guardedTool", "args": { "id": "r4" } } },
+  { "toolCall": { "name": "guardedTool", "args": { "id": "r5" } } },
+  { "toolCall": { "name": "guardedTool", "args": { "id": "r6" } } },
+  { "return": "s3 done" },
+
+  { "toolCall": { "name": "guardedTool", "args": { "id": "x1" } } },
+  { "toolCall": { "name": "guardedTool", "args": { "id": "x2" } } },
+  { "toolCall": { "name": "guardedTool", "args": { "id": "x3" } } },
+  { "toolCall": { "name": "guardedTool", "args": { "id": "x4" } } },
+  { "toolCall": { "name": "guardedTool", "args": { "id": "ok" } } },
+  { "toolCall": { "name": "guardedTool", "args": { "id": "x5" } } },
+  { "toolCall": { "name": "guardedTool", "args": { "id": "ok2" } } },
+  { "return": "s4 done" }
+]

--- a/packages/agency-lang/tests/agency-js/tool-rejection/llmMocks.json
+++ b/packages/agency-lang/tests/agency-js/tool-rejection/llmMocks.json
@@ -25,5 +25,12 @@
   { "toolCall": { "name": "guardedTool", "args": { "id": "ok" } } },
   { "toolCall": { "name": "guardedTool", "args": { "id": "x5" } } },
   { "toolCall": { "name": "guardedTool", "args": { "id": "ok2" } } },
-  { "return": "s5 done" }
+  { "return": "s5 done" },
+  {
+    "toolCalls": [
+      { "name": "guardedTool", "args": { "id": "pr1" } },
+      { "name": "pauseMe", "args": { "id": "pp1" } }
+    ]
+  },
+  { "return": "s6 done" }
 ]

--- a/packages/agency-lang/tests/agency-js/tool-rejection/llmMocks.json
+++ b/packages/agency-lang/tests/agency-js/tool-rejection/llmMocks.json
@@ -32,5 +32,8 @@
       { "name": "pauseMe", "args": { "id": "pp1" } }
     ]
   },
-  { "return": "s6 done" }
+  { "return": "s6 done" },
+  { "toolCalls": [{ "name": "guardedTool", "args": { "id": "e1" }, "id": "" }] },
+  { "toolCalls": [{ "name": "guardedTool", "args": { "id": "e2" }, "id": "" }] },
+  { "return": "s7 done" }
 ]

--- a/packages/agency-lang/tests/agency-js/tool-rejection/test.js
+++ b/packages/agency-lang/tests/agency-js/tool-rejection/test.js
@@ -5,6 +5,7 @@ import {
   destructiveReject,
   approvalResets,
   parallelRejectAndPause,
+  emptyIdRounds,
   respondToInterrupts,
   approve,
   reject,
@@ -133,6 +134,24 @@ const results = {};
     result: resumed.data,
     toolMessagesInFinalRequest: toolContents.length,
     rejectionMessages: toolContents.filter((c) => c.includes("Tool call rejected: no guardedTool"))
+      .length,
+  };
+}
+
+// Empty-id providers: round 1's call (slug "0_") is rejected; round 2's
+// fresh call shares the slug and must NOT be mistaken for a replay —
+// both calls run, both rejection messages reach the final request.
+{
+  const { state, callbacks } = makeCapture();
+  const result = await emptyIdRounds({ callbacks });
+  const toolContents = state.lastMessages
+    .filter((m) => m.role === "tool")
+    .map((m) => (typeof m.content === "string" ? m.content : JSON.stringify(m.content)));
+  results.emptyIdRounds = {
+    result: result.data,
+    toolStarts: state.toolStarts,
+    toolMessagesInFinalRequest: toolContents.length,
+    rejectionMessages: toolContents.filter((c) => c.startsWith("Tool call rejected: denied"))
       .length,
   };
 }

--- a/packages/agency-lang/tests/agency-js/tool-rejection/test.js
+++ b/packages/agency-lang/tests/agency-js/tool-rejection/test.js
@@ -4,7 +4,9 @@ import {
   fiveRejectionsRemove,
   destructiveReject,
   approvalResets,
+  parallelRejectAndPause,
   respondToInterrupts,
+  approve,
   reject,
 } from "./agent.js";
 import { writeFileSync } from "fs";
@@ -12,9 +14,10 @@ import { writeFileSync } from "fs";
 // Capture every tool-role message the model sees, via onLLMCallStart:
 // each round's request carries the tool results of the previous round.
 const makeCapture = () => {
-  const state = { toolMessages: [], toolStarts: 0 };
+  const state = { toolMessages: [], toolStarts: 0, lastMessages: [] };
   const callbacks = {
     onLLMCallStart: ({ messages }) => {
+      state.lastMessages = messages;
       for (const m of messages) {
         if (m.role === "tool") {
           const text = typeof m.content === "string" ? m.content : JSON.stringify(m.content);
@@ -106,6 +109,31 @@ const results = {};
     result: result.data,
     toolStarts: state.toolStarts,
     removalSeen: seen(state, "rejected too many times"),
+  };
+}
+
+// Replay safety: guardedTool is rejected while its parallel sibling
+// pauses. On resume, the rejected branch's message is already in the
+// checkpointed thread — the replay must not push a second one. The
+// final request must hold exactly TWO tool messages (one rejection,
+// one success), counted WITH duplicates via lastMessages.
+{
+  const { state, callbacks } = makeCapture();
+  const paused = await parallelRejectAndPause({ callbacks });
+  const pausedWithInterrupt =
+    Array.isArray(paused.data) && paused.data[0]?.type === "interrupt";
+  const resumed = await respondToInterrupts(paused.data, [approve()], {
+    metadata: { callbacks },
+  });
+  const toolContents = state.lastMessages
+    .filter((m) => m.role === "tool")
+    .map((m) => (typeof m.content === "string" ? m.content : JSON.stringify(m.content)));
+  results.parallelRejectAndPause = {
+    pausedWithInterrupt,
+    result: resumed.data,
+    toolMessagesInFinalRequest: toolContents.length,
+    rejectionMessages: toolContents.filter((c) => c.includes("Tool call rejected: no guardedTool"))
+      .length,
   };
 }
 

--- a/packages/agency-lang/tests/agency-js/tool-rejection/test.js
+++ b/packages/agency-lang/tests/agency-js/tool-rejection/test.js
@@ -2,6 +2,7 @@ import {
   handlerRejects,
   interactiveReject,
   fiveRejectionsRemove,
+  destructiveReject,
   approvalResets,
   respondToInterrupts,
   reject,
@@ -77,6 +78,20 @@ const results = {};
     result: result.data,
     toolStarts: state.toolStarts,
     removalSeen: seen(state, "rejected too many times"),
+  };
+}
+
+// A destructive def commits destructiveRan at entry, so its rejected gate
+// is not a clean rejection: the destructive failure tier removes the tool
+// immediately, and the second scripted call never starts.
+{
+  const { state, callbacks } = makeCapture();
+  const result = await destructiveReject({ callbacks });
+  results.destructiveReject = {
+    result: result.data,
+    toolStarts: state.toolStarts,
+    destructiveTierSeen: seen(state, "Verify state manually"),
+    rejectionPathSeen: seen(state, "Tool call rejected:"),
   };
 }
 

--- a/packages/agency-lang/tests/agency-js/tool-rejection/test.js
+++ b/packages/agency-lang/tests/agency-js/tool-rejection/test.js
@@ -1,0 +1,97 @@
+import {
+  handlerRejects,
+  interactiveReject,
+  fiveRejectionsRemove,
+  approvalResets,
+  respondToInterrupts,
+  reject,
+} from "./agent.js";
+import { writeFileSync } from "fs";
+
+// Capture every tool-role message the model sees, via onLLMCallStart:
+// each round's request carries the tool results of the previous round.
+const makeCapture = () => {
+  const state = { toolMessages: [], toolStarts: 0 };
+  const callbacks = {
+    onLLMCallStart: ({ messages }) => {
+      for (const m of messages) {
+        if (m.role === "tool") {
+          const text = typeof m.content === "string" ? m.content : JSON.stringify(m.content);
+          if (!state.toolMessages.includes(text)) state.toolMessages.push(text);
+        }
+      }
+    },
+    onToolCallStart: () => {
+      state.toolStarts += 1;
+    },
+  };
+  return { state, callbacks };
+};
+
+const seen = (state, substring) => state.toolMessages.some((m) => m.includes(substring));
+
+const results = {};
+
+// Handler rejects with a reason. The model must see the reason (not a
+// generic error), the no-retry instruction, and — on the scripted
+// identical retry — the already-rejected refusal, with the tool invoked
+// only once.
+{
+  const { state, callbacks } = makeCapture();
+  const result = await handlerRejects({ callbacks });
+  results.handlerRejects = {
+    result: result.data,
+    toolStarts: state.toolStarts,
+    reasonSeen: seen(state, "Tool call rejected: no tools for you"),
+    noRetrySuffixSeen: seen(state, "Do not call this tool with the same arguments again"),
+    identicalRetryRefused: seen(state, "was already rejected and will not be executed"),
+    framedAsError: seen(state, "Error:"),
+  };
+}
+
+// No handler: the run pauses, the test rejects interactively with a
+// reason. After resume the model must see that reason.
+{
+  const { state, callbacks } = makeCapture();
+  const paused = await interactiveReject({ callbacks });
+  const pausedWithInterrupt =
+    Array.isArray(paused.data) && paused.data[0]?.type === "interrupt";
+  const resumed = await respondToInterrupts(
+    paused.data,
+    [reject("b is forbidden today")],
+    { metadata: { callbacks } },
+  );
+  results.interactiveReject = {
+    pausedWithInterrupt,
+    result: resumed.data,
+    reasonSeen: seen(state, "Tool call rejected: b is forbidden today"),
+  };
+}
+
+// Five consecutive rejections remove the tool: the fifth rejection's
+// message says so, and the sixth scripted call never starts.
+{
+  const { state, callbacks } = makeCapture();
+  const result = await fiveRejectionsRemove({ callbacks });
+  results.fiveRejectionsRemove = {
+    result: result.data,
+    toolStarts: state.toolStarts,
+    removalSeen: seen(state, "rejected too many times"),
+  };
+}
+
+// An approved call resets the count: four rejections, an approval, one
+// more rejection, then another approved call. Without the reset, the
+// post-approval rejection would be the fifth strike and the final call
+// would never start (toolStarts 6, not 7).
+{
+  const { state, callbacks } = makeCapture();
+  const result = await approvalResets({ callbacks });
+  results.approvalResets = {
+    result: result.data,
+    toolStarts: state.toolStarts,
+    removalSeen: seen(state, "rejected too many times"),
+  };
+}
+
+writeFileSync("__result.json", JSON.stringify(results, null, 2));

--- a/packages/agency-lang/tests/agency-js/tool-rejection/test.js
+++ b/packages/agency-lang/tests/agency-js/tool-rejection/test.js
@@ -6,6 +6,7 @@ import {
   approvalResets,
   parallelRejectAndPause,
   emptyIdRounds,
+  removalRace,
   respondToInterrupts,
   approve,
   reject,
@@ -153,6 +154,27 @@ const results = {};
     toolMessagesInFinalRequest: toolContents.length,
     rejectionMessages: toolContents.filter((c) => c.startsWith("Tool call rejected: denied"))
       .length,
+  };
+}
+
+// The removal race: the fifth consecutive rejection lands in the same
+// parallel round as a sibling call that pauses for the user. The
+// sibling started before the removal, so the approval must be honored
+// on resume — the call runs and "ran keep" reaches the model, instead
+// of a removal refusal that silently ignores the approval.
+{
+  const { state, callbacks } = makeCapture();
+  const paused = await removalRace({ callbacks });
+  const pausedWithInterrupt =
+    Array.isArray(paused.data) && paused.data[0]?.type === "interrupt";
+  const resumed = await respondToInterrupts(paused.data, [approve()], {
+    metadata: { callbacks },
+  });
+  results.removalRace = {
+    pausedWithInterrupt,
+    result: resumed.data,
+    approvedCallRan: seen(state, "ran keep"),
+    removalSeen: seen(state, "rejected too many times"),
   };
 }
 

--- a/packages/agency-lang/tests/agency/dynamic-functions/runtime-arg-errors.test.json
+++ b/packages/agency-lang/tests/agency/dynamic-functions/runtime-arg-errors.test.json
@@ -3,7 +3,7 @@
     {
       "nodeName": "testUnknownArg",
       "input": "",
-      "expectedOutput": "{\"__type\":\"resultType\",\"success\":false,\"error\":\"Unknown named argument 'z' in call to 'add'\",\"checkpoint\":null,\"neverStarted\":false,\"destructiveRan\":false,\"functionName\":\"testUnknownArg\",\"args\":null,\"skippedFunctions\":[]}",
+      "expectedOutput": "{\"__type\":\"resultType\",\"success\":false,\"error\":\"Unknown named argument 'z' in call to 'add'\",\"checkpoint\":null,\"neverStarted\":false,\"destructiveRan\":false,\"rejected\":false,\"functionName\":\"testUnknownArg\",\"args\":null,\"skippedFunctions\":[]}",
       "evaluationCriteria": [
         {
           "type": "exact"
@@ -13,7 +13,7 @@
     {
       "nodeName": "testMissingRequired",
       "input": "",
-      "expectedOutput": "{\"__type\":\"resultType\",\"success\":false,\"error\":\"Missing required argument 'b' in call to 'add'\",\"checkpoint\":null,\"neverStarted\":false,\"destructiveRan\":false,\"functionName\":\"testMissingRequired\",\"args\":null,\"skippedFunctions\":[]}",
+      "expectedOutput": "{\"__type\":\"resultType\",\"success\":false,\"error\":\"Missing required argument 'b' in call to 'add'\",\"checkpoint\":null,\"neverStarted\":false,\"destructiveRan\":false,\"rejected\":false,\"functionName\":\"testMissingRequired\",\"args\":null,\"skippedFunctions\":[]}",
       "evaluationCriteria": [
         {
           "type": "exact"
@@ -23,7 +23,7 @@
     {
       "nodeName": "testConflict",
       "input": "",
-      "expectedOutput": "{\"__type\":\"resultType\",\"success\":false,\"error\":\"Named argument 'a' conflicts with positional argument at position 1 in call to 'add'\",\"checkpoint\":null,\"neverStarted\":false,\"destructiveRan\":false,\"functionName\":\"testConflict\",\"args\":null,\"skippedFunctions\":[]}",
+      "expectedOutput": "{\"__type\":\"resultType\",\"success\":false,\"error\":\"Named argument 'a' conflicts with positional argument at position 1 in call to 'add'\",\"checkpoint\":null,\"neverStarted\":false,\"destructiveRan\":false,\"rejected\":false,\"functionName\":\"testConflict\",\"args\":null,\"skippedFunctions\":[]}",
       "evaluationCriteria": [
         {
           "type": "exact"

--- a/packages/agency-lang/tests/agency/interrupts/interruptAssignmentReject.test.json
+++ b/packages/agency-lang/tests/agency/interrupts/interruptAssignmentReject.test.json
@@ -4,7 +4,7 @@
       "nodeName": "foo",
       "description": "Test that rejecting an interrupt assigned to a variable returns null",
       "input": "",
-      "expectedOutput": "{\"__type\":\"resultType\",\"success\":false,\"error\":\"interrupt rejected\",\"checkpoint\":null,\"neverStarted\":false,\"destructiveRan\":false,\"functionName\":null,\"args\":null,\"skippedFunctions\":[]}",
+      "expectedOutput": "{\"__type\":\"resultType\",\"success\":false,\"error\":\"interrupt rejected\",\"checkpoint\":null,\"neverStarted\":false,\"destructiveRan\":false,\"rejected\":true,\"functionName\":null,\"args\":null,\"skippedFunctions\":[]}",
       "evaluationCriteria": [
         {
           "type": "exact"

--- a/packages/agency-lang/tests/agency/result/pipe-inline-block.test.json
+++ b/packages/agency-lang/tests/agency/result/pipe-inline-block.test.json
@@ -3,7 +3,7 @@
     {
       "nodeName": "main",
       "input": "",
-      "expectedOutput": "{\"r1\":{\"__type\":\"resultType\",\"success\":true,\"value\":[10,20,30]},\"r2\":{\"__type\":\"resultType\",\"success\":true,\"value\":[4,6,8]},\"r3\":{\"__type\":\"resultType\",\"success\":false,\"error\":\"nope\",\"checkpoint\":null,\"neverStarted\":false,\"destructiveRan\":false,\"functionName\":null,\"args\":null,\"skippedFunctions\":[]}}",
+      "expectedOutput": "{\"r1\":{\"__type\":\"resultType\",\"success\":true,\"value\":[10,20,30]},\"r2\":{\"__type\":\"resultType\",\"success\":true,\"value\":[4,6,8]},\"r3\":{\"__type\":\"resultType\",\"success\":false,\"error\":\"nope\",\"checkpoint\":null,\"neverStarted\":false,\"destructiveRan\":false,\"rejected\":false,\"functionName\":null,\"args\":null,\"skippedFunctions\":[]}}",
       "evaluationCriteria": [
         {
           "type": "exact"

--- a/packages/agency-lang/tests/agency/result/pipe-operator.test.json
+++ b/packages/agency-lang/tests/agency/result/pipe-operator.test.json
@@ -3,7 +3,7 @@
     {
       "nodeName": "main",
       "input": "",
-      "expectedOutput": "{\"r1\":{\"__type\":\"resultType\",\"success\":true,\"value\":10},\"r2\":{\"__type\":\"resultType\",\"success\":true,\"value\":50},\"r3\":{\"__type\":\"resultType\",\"success\":true,\"value\":60},\"r4\":{\"__type\":\"resultType\",\"success\":false,\"error\":\"nope\",\"checkpoint\":null,\"neverStarted\":false,\"destructiveRan\":false,\"functionName\":null,\"args\":null,\"skippedFunctions\":[]}}",
+      "expectedOutput": "{\"r1\":{\"__type\":\"resultType\",\"success\":true,\"value\":10},\"r2\":{\"__type\":\"resultType\",\"success\":true,\"value\":50},\"r3\":{\"__type\":\"resultType\",\"success\":true,\"value\":60},\"r4\":{\"__type\":\"resultType\",\"success\":false,\"error\":\"nope\",\"checkpoint\":null,\"neverStarted\":false,\"destructiveRan\":false,\"rejected\":false,\"functionName\":null,\"args\":null,\"skippedFunctions\":[]}}",
       "evaluationCriteria": [
         {
           "type": "exact"

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
@@ -267,7 +267,7 @@ if (__response) {
     // rejected, halt
     
     
-    runner.halt(failure("interrupt rejected", { checkpoint: getRuntimeContext().ctx.getResultCheckpoint() }));
+    runner.halt(failure(__response.value ?? "interrupt rejected", { rejected: true, checkpoint: getRuntimeContext().ctx.getResultCheckpoint() }));
     
     return;
   }
@@ -277,7 +277,7 @@ if (__response) {
   if (isRejected(__handlerResult)) {
     
     
-    runner.halt(failure(__handlerResult.value ?? "interrupt rejected", { checkpoint: getRuntimeContext().ctx.checkpoints.get(__resultCheckpointId) }));
+    runner.halt(failure(__handlerResult.value ?? "interrupt rejected", { rejected: true, checkpoint: getRuntimeContext().ctx.checkpoints.get(__resultCheckpointId) }));
     
     return;
   }

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
@@ -231,9 +231,9 @@ if (__response) {
       __stack.locals.name = true;;
     }
   } else if (__response.type === "reject") {
-    // reject for tool calls handled separately
+    // rejected, halt
     
-    runner.halt({ messages: __threads(), data: failure("interrupt rejected") });
+    runner.halt({ messages: __threads(), data: failure(__response.value ?? "interrupt rejected", { rejected: true }) });
     
     
     return;
@@ -243,7 +243,7 @@ if (__response) {
   const __handlerResult = await interruptWithHandlers("unknown", `What is your name?`, {}, "./interrupt-assignment.agency", __ctx, __stateStack(), { expectsValue: true });
   if (isRejected(__handlerResult)) {
     
-    runner.halt({ messages: __threads(), data: failure(__handlerResult.value ?? "interrupt rejected") });
+    runner.halt({ messages: __threads(), data: failure(__handlerResult.value ?? "interrupt rejected", { rejected: true }) });
     
     
     return;

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
@@ -267,7 +267,7 @@ if (__response) {
     // rejected, halt
     
     
-    runner.halt(failure("interrupt rejected", { checkpoint: getRuntimeContext().ctx.getResultCheckpoint() }));
+    runner.halt(failure(__response.value ?? "interrupt rejected", { rejected: true, checkpoint: getRuntimeContext().ctx.getResultCheckpoint() }));
     
     return;
   }
@@ -277,7 +277,7 @@ if (__response) {
   if (isRejected(__handlerResult)) {
     
     
-    runner.halt(failure(__handlerResult.value ?? "interrupt rejected", { checkpoint: getRuntimeContext().ctx.checkpoints.get(__resultCheckpointId) }));
+    runner.halt(failure(__handlerResult.value ?? "interrupt rejected", { rejected: true, checkpoint: getRuntimeContext().ctx.checkpoints.get(__resultCheckpointId) }));
     
     return;
   }

--- a/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
@@ -254,7 +254,7 @@ if (__response) {
     // rejected, halt
     
     
-    runner.halt(failure("interrupt rejected", { checkpoint: getRuntimeContext().ctx.getResultCheckpoint() }));
+    runner.halt(failure(__response.value ?? "interrupt rejected", { rejected: true, checkpoint: getRuntimeContext().ctx.getResultCheckpoint() }));
     
     return;
   }
@@ -264,7 +264,7 @@ if (__response) {
   if (isRejected(__handlerResult)) {
     
     
-    runner.halt(failure(__handlerResult.value ?? "interrupt rejected", { checkpoint: getRuntimeContext().ctx.checkpoints.get(__resultCheckpointId) }));
+    runner.halt(failure(__handlerResult.value ?? "interrupt rejected", { rejected: true, checkpoint: getRuntimeContext().ctx.checkpoints.get(__resultCheckpointId) }));
     
     return;
   }


### PR DESCRIPTION
Two fixes to how the tool loop handles a rejected interrupt, plus a retry-spiral guard.

## The rejection reason now always reaches the model

A handler or policy `reject("reason")` already forwarded its reason to the model. An interactive reject via `respondToInterrupts` did not: the resume branch of both interrupt templates hard-coded `failure("interrupt rejected")`, so the model saw a generic message no matter what the user wrote. Both templates now halt with the response's value.

Both reject branches also stamp the failure with a new `rejected` flag (on `ResultFailure`), which is what lets the tool loop tell "you may not do this" apart from "the tool broke". A TS tool that returns the raw `InterruptResponse` from `agency.interrupt` takes the same path.

## Rejections are not errors, and cannot be retried

- The model now sees `Tool call rejected: <reason>` with a do-not-retry instruction, instead of `Error: <reason>. The call failed. You may call this tool again.`
- A call identical to one already rejected (same tool, same `repeatKey`) is refused before the start hook: no invoke, no re-raised interrupt, no counter movement.
- Rejections no longer count toward `toolErrorCounts`. They get their own counter: five CONSECUTIVE rejections remove the tool, and a successful call resets the count. So a narrow policy reject rule brushed against during otherwise-approved work never removes the tool, while a model that keeps rephrasing a refused call (the "do it some other way in bash" pattern) with nothing approved in between loses the tool quickly.

Both records live on the runPrompt frame, so they survive checkpoint/resume within one `llm()` call and reset when the next `llm()` call starts.

## Other changes

- Extracted `pushToolNotice` for the six refusal-gate messages in the tool-call branch (also keeps the branch arrow inside the lint budget).
- Documented the new refusal in `docs/dev/agents/tool-loop-guards.md` and updated the index lines.
- `tests/agency-js/interrupts/interrupt-overrides/fixture.json` picks up the new `rejected: true` field on a serialized rejection failure.

## Testing

New `tests/agency-js/tool-rejection` (deterministic LLM, no API key) covers: the handler-reject reason and no-retry suffix reaching the model, the identical-retry gate (tool invoked once), the interactive-reject reason reaching the model after resume, five consecutive rejections removing the tool (sixth scripted call never starts), and an approval resetting the count (post-approval calls still run; without the reset the final call would never start).

Also ran the prompt/result/generator vitest files, the tool-tiers / max-tool-call-rounds / parallel-tools / repeated-tool-calls / cli-policy-handler / interrupts agency-js suites, `pnpm run typecheck`, `pnpm run lint:structure`, and `pnpm run fmt:ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dbwHKw3XSb4JQfpR9gQMt
