### PR TITLE
Install the root policy handler and budget before any user code runs (#966)

### DIFF
--- a/packages/agency-lang/docs/dev/cli/test-cli-sandbox.md
+++ b/packages/agency-lang/docs/dev/cli/test-cli-sandbox.md
@@ -38,10 +38,12 @@ under each name it is given.
   "reject > propagate > approve > noResponse"; pinned by
   `tests/agency/connector-core.agency`), so an inline `with approve` in the
   tested code is a vote that loses.
-- Code that runs before the handler exists (static initializers, top-level
-  callbacks) cannot raise an interrupt at all: there is no node frame to
-  checkpoint, and the runtime throws "Cannot create checkpoint: no current
-  node id". An effectful initializer fails rather than runs.
+- Top-level code (static initializers, top-level callbacks) runs under the
+  same root handler: it installs before any user code, including global init
+  (#966, `initFreshExecCtx` in `lib/runtime/node.ts`). A top-level raise the
+  chain does not settle still fails rather than pausing — there is no node
+  frame to checkpoint, and the runtime throws "Cannot create checkpoint: no
+  current node id".
 - A `std::run` subprocess the tested code launches forwards its interrupts
   to this root chain and installs no policy of its own.
 - What is not covered: CPU inside the time limit, and reads of files the

--- a/packages/agency-lang/docs/dev/cli/test-cli-sandbox.md
+++ b/packages/agency-lang/docs/dev/cli/test-cli-sandbox.md
@@ -39,11 +39,11 @@ under each name it is given.
   `tests/agency/connector-core.agency`), so an inline `with approve` in the
   tested code is a vote that loses.
 - Top-level code (static initializers, top-level callbacks) runs under the
-  same root handler: it installs before any user code, including global init
-  (#966, `initFreshExecCtx` in `lib/runtime/node.ts`). A top-level raise the
-  chain does not settle still fails rather than pausing — there is no node
-  frame to checkpoint, and the runtime throws "Cannot create checkpoint: no
-  current node id".
+  same root handler, which installs before any user code (#966,
+  `initFreshExecCtx` in `lib/runtime/node.ts`). A top-level raise the chain
+  does not settle fails instead of pausing: there is no node frame to
+  checkpoint, and the runtime throws "Cannot create checkpoint: no current
+  node id".
 - A `std::run` subprocess the tested code launches forwards its interrupts
   to this root chain and installs no policy of its own.
 - What is not covered: CPU inside the time limit, and reads of files the

--- a/packages/agency-lang/docs/dev/language/with-approve.md
+++ b/packages/agency-lang/docs/dev/language/with-approve.md
@@ -49,7 +49,7 @@ async function __initializeGlobals(__ctx) {
 }
 ```
 
-The second `pushHandler` argument is the handler's live guard ids, and it is deliberately empty. These wrappers register during top-level init, before any guard can exist, so "hide every guard" is vacuously correct.
+The second `pushHandler` argument is the handler's live guard ids, and it is deliberately empty. The only guards that can exist during top-level init are the root budget guards, which install before any user code (`initFreshExecCtx`, `lib/runtime/node.ts`) — and those never raise an interrupt, so a wrapper handler hiding them changes nothing.
 
 `withHandler` deliberately needs no step id, which is why it works where `runner.handle()` cannot. The handler stack lives on the context, not on the runner. When the called function raises an interrupt through `interruptWithHandlers()`, the runtime walks `ctx.handlers`, finds the `approve` handler, and resolves the interrupt immediately. No state serialization, step counters, or runner machinery are involved.
 

--- a/packages/agency-lang/docs/dev/language/with-approve.md
+++ b/packages/agency-lang/docs/dev/language/with-approve.md
@@ -49,7 +49,7 @@ async function __initializeGlobals(__ctx) {
 }
 ```
 
-The second `pushHandler` argument is the handler's live guard ids, and it is deliberately empty. The only guards that can exist during top-level init are the root budget guards, which install before any user code (`initFreshExecCtx`, `lib/runtime/node.ts`) — and those never raise an interrupt, so a wrapper handler hiding them changes nothing.
+The second `pushHandler` argument is the handler's live guard ids, and it is deliberately empty. The only guards that can exist during top-level init are the root budget guards, which install before any user code (`initFreshExecCtx`, `lib/runtime/node.ts`). Those guards never raise an interrupt, so hiding them from the wrapper handler has no effect.
 
 `withHandler` deliberately needs no step id, which is why it works where `runner.handle()` cannot. The handler stack lives on the context, not on the runner. When the called function raises an interrupt through `interruptWithHandlers()`, the runtime walks `ctx.handlers`, finds the `approve` handler, and resolves the interrupt immediately. No state serialization, step counters, or runner machinery are involved.
 

--- a/packages/agency-lang/docs/dev/security/roadmap.md
+++ b/packages/agency-lang/docs/dev/security/roadmap.md
@@ -112,19 +112,23 @@ No issue yet.
 
 ## B. The runner's handler is outermost and always present
 
-### B1. Top-level `with approve` runs before the root policy exists (#966)
+### B1. Top-level `with approve` runs before the root policy exists (#966) — FIXED
 
 <https://github.com/egonSchiele/agency-lang/issues/966>. `lib/runtime/node.ts`
-runs global init and imported modules' top-level code, then installs the
-policy handler. A top-level `const x = read(...) with approve` therefore has
-only the author's approve in the chain and succeeds under `--reject '*'`.
-The per-invocation host policy (`InvocationOptions.policy`, B2) installs at
-the same bootstrap site, so it shares this gap: a hosted module's top-level
-initializer runs before the host policy exists.
-Fix: install the root policy handler and root budget before any user code,
-including `__initAllRegistered`; check the resume path in `interrupts.ts`
-for the same ordering; add an agency-js test that a top-level read is
-rejected.
+used to run global init and imported modules' top-level code, then install
+the policy handler. A top-level `const x = read(...) with approve` therefore
+had only the author's approve in the chain and succeeded under `--reject '*'`.
+The per-invocation host policy (`InvocationOptions.policy`, B2) installed at
+the same bootstrap site, so it shared the gap.
+Fixed: `initFreshExecCtx` installs the root policy handler and root budget
+first, before any user code, including `__initAllRegistered`. The resume path
+(`respondToInterrupts` in `interrupts.ts`) already installed the policy before
+top-level callback re-registration. A `std::agency` subprocess never had the
+gap: child global init consults the parent's chain over IPC like any other
+raise, so the parent's policy or handlers decide it
+(`tests/agency/subprocess/handler-reject-child-top-level.agency`).
+Test: `tests/agency-js/policy-top-level` pins both policy sources against a
+top-level `with approve`.
 
 ### B2. The resume leg: raise-time policy shipped; checkpoint integrity open
 
@@ -236,10 +240,11 @@ is the place to start. No statelog issues are filed yet.
 
 - Every codegen, import-template, and effectful-stdlib change gets a test
   that would fail if the boundary broke.
-- `docs/dev/cli/test-cli-sandbox.md` currently claims code before the
-  handler "cannot raise an interrupt at all" and that under `--agency-only`
-  "every effect the code can perform is an interrupt". Both are false until
-  A1 and B1 land; correct the doc when they do, and not before.
+- `docs/dev/cli/test-cli-sandbox.md` currently claims that under
+  `--agency-only` "every effect the code can perform is an interrupt". That
+  is false until A1 lands; correct the doc when it does, and not before.
+  (Its claim about code running before the root handler was corrected when
+  B1 was fixed.)
 - Before hosting strangers' code on the strength of the language, someone
   spends a day trying to break it with this list in hand.
 
@@ -250,7 +255,7 @@ is the place to start. No statelog issues are filed yet.
 | A1 JS globals reachable | #971 | open |
 | A2 review `JS_GLOBALS` | — | not filed |
 | A3 splice execution in non-build commands | — | not filed, known |
-| B1 top-level `with approve` before policy | #966 | open |
+| B1 top-level `with approve` before policy | #966 | fixed |
 | B2 raise-time host policy / checkpoint integrity | spec | policy shipped; integrity open |
 | B3 sandbox flags imply no policy | #970 | open |
 | C1 `node_modules` shadowing | #967 | open |

--- a/packages/agency-lang/docs/dev/security/roadmap.md
+++ b/packages/agency-lang/docs/dev/security/roadmap.md
@@ -32,7 +32,10 @@ The flag is not a full ban on generating code: `vm.runInThisContext` and
 `getBuiltinModule`, which layer 1 refuses by name, so there is no path today —
 but layer 3 should not assume the flag alone closes every route to new code.
 
-Layer 3 (freeze intrinsics) still open.
+Layer 3 (freeze intrinsics) still open. Feasibility is answered and the
+implementation is planned: `docs/superpowers/specs/2026-08-30-ses-feasibility-investigation.md`
+and `docs/superpowers/plans/2026-08-30-ses-layer3-plan.md` (`lockdown()` first,
+Compartment as a gated spike).
 
 <https://github.com/egonSchiele/agency-lang/issues/971>. An identifier the compiler does not know is emitted verbatim, so
 `process.env.HOME`, `process.getBuiltinModule("fs")`, `fetch(...)`,
@@ -129,6 +132,11 @@ raise, so the parent's policy or handlers decide it
 (`tests/agency/subprocess/handler-reject-child-top-level.agency`).
 Test: `tests/agency-js/policy-top-level` pins both policy sources against a
 top-level `with approve`.
+Residual: `rewindFrom` (`lib/runtime/rewind.ts`) installs neither the policy
+handler nor the root budget, yet runs user code (`__initAllRegisteredCallbacks`
+and the replay itself) — the same bypass class. Reachable only from the local
+debugger, not from a remote checkpoint. Tracked in
+<https://github.com/egonSchiele/agency-lang/issues/800>.
 
 ### B2. The resume leg: raise-time policy shipped; checkpoint integrity open
 
@@ -248,6 +256,75 @@ is the place to start. No statelog issues are filed yet.
 - Before hosting strangers' code on the strength of the language, someone
   spends a day trying to break it with this list in hand.
 
+## F. Making the safe posture the default
+
+The layers in A1 are gated behind `--agency-only`. That gate exists because
+the layers are only sound for pure Agency code: a program that imports
+TypeScript has handed full ambient authority to that TypeScript, and no
+check on the Agency side changes what the imported code can do. So "apply
+the layers everywhere" really means "apply them to every pure-Agency
+program", and the three layers answer that question differently. These are
+direction decisions, not holes; none blocks the untrusted-code work above.
+
+### F1. Refuse `eval` and `Function` in all Agency source, no flag
+
+No legitimate Agency program names `eval`, `Function`, or `new Function` —
+Agency has splices and templates for metaprogramming, and code built from
+strings defeats the language's own model (it is invisible to interrupts,
+policies, and the hoisting that makes resume safe). Make these specific
+names a hard compile error in every compile, trusted or not. The machinery
+exists (the A1 bind-check, and AG4004 before it); this is scoping a small
+subset of it to always-on. Cheap, independent of everything else, and it
+can ship first. No issue yet.
+
+### F2. The bind-check becomes the default, warning first
+
+A bare `fetch(...)` or `process.env.HOME` in Agency source is a problem for
+its own author, not only for a runner of untrusted code: the effect bypasses
+the interrupt system, so the author's own policies and `--reject` never see
+it, and the call is not hoisted the way stdlib calls are, so a checkpoint
+resume can replay it. Direct global access quietly breaks the semantics the
+user chose Agency for. So the bind-check is the language's correct default
+posture, with today's permissive mode as the opt-out rather than the
+reverse. Existing programs lean on verbatim-emitted identifiers, so the
+path is warning-by-default for a release or two, then error-by-default with
+an explicit opt-out flag. No issue yet.
+
+### F3. Derive the runtime hardening from program purity, and settle B3 with it
+
+Layer 2's Node flag and layer 3's `lockdown()` apply to the whole child
+process, including every npm dependency the user's imported TypeScript
+pulls in — and that ecosystem is not clean under them (ajv compiles
+validators with `new Function`; polyfills patch prototypes). The SES
+investigation verified the Agency runtime and its own dependencies are
+lockdown-clean; it says nothing about arbitrary interop JS. So neither can
+be turned on universally without breaking working programs, for a benefit
+that mostly evaporates once interop JS shares the process anyway.
+
+The compiler already knows whether a program is pure Agency. A pure program
+can get the flag, and (once A1 layer 3 ships and soaks) the lockdown
+preload, automatically — no flag needed — while `--agency-only` remains the
+explicit assertion you make about someone else's code. Hardening that
+switches off when a JS import is added must be visible: a compile-time
+note, not silence.
+
+Resolve this together with B3 (#970), because the two questions are halves
+of one decision: F1 always-on, F2 default-on with an opt-out, runtime
+hardening derived from purity, and `--agency-only` (or an `--untrusted`
+rename) meaning pure Agency **plus** a propagate-everything root policy.
+That leaves the flag meaning what a user reading it assumes it means: this
+code is not trusted.
+
+## G. Resource limits on the child (no issue yet)
+
+`goal.md` keeps "one plain Node child per run, with an allowlisted
+environment and resource limits" as the unit that can be limited and
+killed — it is what caps a `while (true) {}` and a compromised run. The
+environment half is C4; nothing on this roadmap defines the limits half.
+Decide what the child gets by default (a wall-clock timeout, a memory cap
+via `--max-old-space-size`, kill-on-parent-exit) and where a host like
+statelog sets them per invocation. File an issue alongside C4.
+
 ## Status
 
 | Item | Issue | State |
@@ -263,3 +340,7 @@ is the place to start. No statelog issues are filed yet.
 | C3 `llm()` redirect; `--agency-only` ignores config | #969 | open |
 | C4 child env allowlist | — | not filed |
 | D statelog hosted execution | statelog #11 (containment only) | open |
+| F1 refuse `eval`/`Function` everywhere | — | not filed |
+| F2 bind-check default-on (warning first) | — | not filed |
+| F3 hardening from purity; settle with B3 | #970 | open |
+| G child resource limits | — | not filed |

--- a/packages/agency-lang/lib/runtime/node.ts
+++ b/packages/agency-lang/lib/runtime/node.ts
@@ -112,17 +112,15 @@ export function setupFunction(): {
  *     under the checkpoint's limit rather than a re-asserted host one. That is
  *     a pre-existing gap, out of scope here (tracked separately).
  *
- * The root run-policy handler and root cost/time budget are installed here, at
- * the end of bootstrap, so EVERY fresh-run entry point (including a served
- * `/function/:name` call through runExportedFunction) is capped identically —
- * a served function must not run uncapped. Both installers are root-only
- * (no-op in IPC subprocesses, whose budgets the parent guard owns). They sit
- * after global init and top-level callback registration, so they are outermost
- * before the entry NODE/FUNCTION body runs and cannot be bypassed there; the
- * small amount of user code that global-init expressions and top-level
- * `callback(...)` blocks can run during bootstrap still runs before the guards
- * exist (unchanged from before this hoist — runNode installed them after
- * bootstrap too).
+ * The root run-policy handler and root cost/time budget are installed here,
+ * FIRST, before any user code runs, so EVERY fresh-run entry point (including
+ * a served `/function/:name` call through runExportedFunction) is capped
+ * identically — a served function must not run uncapped. Both installers are
+ * root-only (no-op in IPC subprocesses, whose budgets the parent guard owns).
+ * They must precede global init and top-level callback registration: those run
+ * user code, and installing the policy handler after them let a top-level
+ * `with approve` be the only handler in the chain — a full bypass of
+ * --reject and of a host's InvocationOptions.policy (#966).
  */
 async function initFreshExecCtx(
   execCtx: RuntimeContext<GraphState>,
@@ -133,6 +131,13 @@ async function initFreshExecCtx(
   },
 ): Promise<void> {
   const { initializeGlobals } = opts;
+
+  // Root policy handler (agency run --policy / --reject, or a serve host's
+  // InvocationOptions.policy) and root cost/time budget, installed before any
+  // user code so global-init expressions and top-level `callback(...)` blocks
+  // run under them (see the function comment; #966).
+  installRunPolicyHandler(execCtx, opts.policy);
+  installRootBudget(execCtx.stateStack, execCtx.budget);
 
   // initializeGlobals + callback registration both invoke Agency
   // code that goes through `__call` — and `__call` reads `ctx` /
@@ -192,18 +197,6 @@ async function initFreshExecCtx(
   // single topLevelCallbacks reset. Keep this in sync with the resume
   // (interrupts.ts) and rewind (rewind.ts) paths.
   await runInBootstrapFrame(execCtx, () => __initAllRegisteredCallbacks(execCtx));
-
-  // Install the CLI-driven root policy handler (agency run --policy) and the
-  // root cost/time budget (--max-cost / --max-time, via env / RuntimeContext).
-  // Both are root-only (isIpcMode gate inside each installer): no-op in IPC
-  // subprocesses. Installed at the end of bootstrap, so they are the outermost
-  // handler/guard before the entry node/function body runs and cannot be
-  // bypassed there — and so BOTH fresh-run entry points (nodes and served
-  // functions) inherit them. (Global-init and top-level-callback code above
-  // runs before these exist; that's unchanged — runNode installed them here
-  // too, just after initFreshExecCtx returned.)
-  installRunPolicyHandler(execCtx, opts.policy);
-  installRootBudget(execCtx.stateStack, execCtx.budget);
 }
 
 /**

--- a/packages/agency-lang/lib/runtime/node.ts
+++ b/packages/agency-lang/lib/runtime/node.ts
@@ -113,14 +113,14 @@ export function setupFunction(): {
  *     a pre-existing gap, out of scope here (tracked separately).
  *
  * The root run-policy handler and root cost/time budget are installed here,
- * FIRST, before any user code runs, so EVERY fresh-run entry point (including
- * a served `/function/:name` call through runExportedFunction) is capped
- * identically — a served function must not run uncapped. Both installers are
- * root-only (no-op in IPC subprocesses, whose budgets the parent guard owns).
- * They must precede global init and top-level callback registration: those run
- * user code, and installing the policy handler after them let a top-level
- * `with approve` be the only handler in the chain — a full bypass of
- * --reject and of a host's InvocationOptions.policy (#966).
+ * before anything else. Global-init expressions and top-level `callback(...)`
+ * registration run user code, and a raise from that code must already see the
+ * root policy in the chain. Installing the policy handler after them let a
+ * top-level `with approve` be the only handler in the chain, which bypassed
+ * --reject and a host's InvocationOptions.policy (#966). Both installers are
+ * root-only (no-op in IPC subprocesses, whose budgets the parent guard owns)
+ * and shared by both fresh-run entry points, so nodes and served functions
+ * are capped identically.
  */
 async function initFreshExecCtx(
   execCtx: RuntimeContext<GraphState>,
@@ -132,10 +132,7 @@ async function initFreshExecCtx(
 ): Promise<void> {
   const { initializeGlobals } = opts;
 
-  // Root policy handler (agency run --policy / --reject, or a serve host's
-  // InvocationOptions.policy) and root cost/time budget, installed before any
-  // user code so global-init expressions and top-level `callback(...)` blocks
-  // run under them (see the function comment; #966).
+  // Installed before any user code runs — see the function comment (#966).
   installRunPolicyHandler(execCtx, opts.policy);
   installRootBudget(execCtx.stateStack, execCtx.budget);
 
@@ -395,17 +392,13 @@ async function runNodeCore({
   // === Invocation started (context exists). A SINGLE lifecycle boundary covers
   // all remaining setup AND execution, so an already-aborted signal or a
   // bootstrap/setup failure still yields an outcome-with-usage and still runs
-  // cleanup. Handler/budget registration order (inside initFreshExecCtx) is
-  // unchanged. ===
+  // cleanup. ===
   const agentStartTime = performance.now();
   let agentRunSpanId: ReturnType<typeof execCtx.statelogClient.startSpan> | undefined;
   let outcome: RawOutcome<RunNodeResult<any>>;
   try {
-    // Cross-module init, this module's globals, top-level callbacks, then the
-    // root run-policy handler and root cost/time budget — all inside
-    // initFreshExecCtx (see there for the full ordering rationale, e.g. the
-    // `node main() { route({ systemPrompt: foreignStatic }) }` foreign-static
-    // case), so nodes and served functions are bootstrapped and capped identically.
+    // Bootstrapped and capped inside initFreshExecCtx; see its comment for
+    // the ordering (root policy and budget first, then init).
     await initFreshExecCtx(execCtx, { initializeGlobals, policy: resolved.policy });
     // Externally-passed callbacks are stored on ctx; hook execution merges them
     // with scoped/top-level callbacks at call time.

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -1829,7 +1829,7 @@ export function createProgram(deps: CliDependencies = {}): Command {
   const configCmd = program.command("config").description("Inspect Agency configuration");
 
   configCmd
-    .command("show", { isDefault: true })
+    .command("show")
     .description("Print the resolved, merged agency.json config as JSON")
     .option(
       "--show-secrets",

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -1829,7 +1829,7 @@ export function createProgram(deps: CliDependencies = {}): Command {
   const configCmd = program.command("config").description("Inspect Agency configuration");
 
   configCmd
-    .command("show")
+    .command("show", { isDefault: true })
     .description("Print the resolved, merged agency.json config as JSON")
     .option(
       "--show-secrets",

--- a/packages/agency-lang/tests/agency-js/policy-top-level/agent.agency
+++ b/packages/agency-lang/tests/agency-js/policy-top-level/agent.agency
@@ -1,12 +1,18 @@
 // Fixture for issue #966: top-level code must run under the root policy
-// handler. The program auto-approves its own top-level env read with
-// `with approve`; a root policy reject must win anyway, exactly as it
-// does for the same read inside a node. env() absorbs a denial, so a
-// rejected read shows up as null, never as a failed run.
+// handler. Two top-level reads, both decided during global init:
+//
+//  - `withApprove` auto-approves itself. A root policy reject or propagate
+//    must win anyway, exactly as it does inside a node.
+//  - `bare` has no handler of its own. A root policy approve must resolve
+//    it; with no policy it fails closed ("Cannot create checkpoint").
+//
+// env() absorbs a denial or a failed raise, so both reads show up as null
+// in those cases, never as a failed run.
 import { env } from "std::system"
 
-const topSecret = env("POLICY_TOP_LEVEL_SECRET") with approve
+const withApprove = env("POLICY_TOP_LEVEL_SECRET") with approve
+const bare = env("POLICY_TOP_LEVEL_BARE")
 
 export node readTop() {
-  return topSecret
+  return { withApprove: withApprove, bare: bare }
 }

--- a/packages/agency-lang/tests/agency-js/policy-top-level/agent.agency
+++ b/packages/agency-lang/tests/agency-js/policy-top-level/agent.agency
@@ -6,8 +6,8 @@
 //  - `bare` has no handler of its own. A root policy approve must resolve
 //    it; with no policy it fails closed ("Cannot create checkpoint").
 //
-// env() absorbs a denial or a failed raise, so both reads show up as null
-// in those cases, never as a failed run.
+// env() absorbs a denial and a failed raise, so both reads show up as
+// null in those cases and the run itself succeeds.
 import { env } from "std::system"
 
 const withApprove = env("POLICY_TOP_LEVEL_SECRET") with approve

--- a/packages/agency-lang/tests/agency-js/policy-top-level/agent.agency
+++ b/packages/agency-lang/tests/agency-js/policy-top-level/agent.agency
@@ -1,0 +1,12 @@
+// Fixture for issue #966: top-level code must run under the root policy
+// handler. The program auto-approves its own top-level env read with
+// `with approve`; a root policy reject must win anyway, exactly as it
+// does for the same read inside a node. env() absorbs a denial, so a
+// rejected read shows up as null, never as a failed run.
+import { env } from "std::system"
+
+const topSecret = env("POLICY_TOP_LEVEL_SECRET") with approve
+
+export node readTop() {
+  return topSecret
+}

--- a/packages/agency-lang/tests/agency-js/policy-top-level/fixture.json
+++ b/packages/agency-lang/tests/agency-js/policy-top-level/fixture.json
@@ -3,6 +3,7 @@
   "bareApprovedByPolicy": true,
   "propagateFailsClosed": true,
   "hostRejected": true,
+  "servedWithoutPolicy": true,
   "approvedWithoutPolicy": true,
   "bareFailsClosedWithoutPolicy": true
 }

--- a/packages/agency-lang/tests/agency-js/policy-top-level/fixture.json
+++ b/packages/agency-lang/tests/agency-js/policy-top-level/fixture.json
@@ -1,0 +1,5 @@
+{
+  "cliRejected": true,
+  "hostRejected": true,
+  "approvedWithoutPolicy": true
+}

--- a/packages/agency-lang/tests/agency-js/policy-top-level/fixture.json
+++ b/packages/agency-lang/tests/agency-js/policy-top-level/fixture.json
@@ -1,5 +1,8 @@
 {
   "cliRejected": true,
+  "bareApprovedByPolicy": true,
+  "propagateFailsClosed": true,
   "hostRejected": true,
-  "approvedWithoutPolicy": true
+  "approvedWithoutPolicy": true,
+  "bareFailsClosedWithoutPolicy": true
 }

--- a/packages/agency-lang/tests/agency-js/policy-top-level/test.js
+++ b/packages/agency-lang/tests/agency-js/policy-top-level/test.js
@@ -16,9 +16,9 @@ const rejectEnv = { "std::env": [{ action: "reject" }] };
 process.env.AGENCY_RUN_POLICY = s(rejectEnv);
 const cliRejected = (await readTop()).data.withApprove === null;
 
-// 2. Approve policy: a BARE top-level raise, which fails closed with no
-// policy (case 5), is resolved by the root policy — proving the handler is
-// genuinely in the chain during global init, not only able to reject.
+// 2. Approve policy: a bare top-level raise, which fails closed with no
+// policy (case 6), is resolved by the root policy. This is the positive
+// control showing the handler is in the chain during global init.
 process.env.AGENCY_RUN_POLICY = s({ "std::env": [{ action: "approve" }] });
 const bareApprovedByPolicy = (await readTop()).data.bare === "bare-secret";
 
@@ -35,9 +35,16 @@ const serveOutcome = await __invokeNodeForServe("readTop", {}, { policy: rejectE
 const hostRejected =
   serveOutcome.status === "returned" && serveOutcome.value.data.withApprove === null;
 
-// 5. No policy at all: the top-level auto-approve still resolves its own
-// read (regression guard for `with approve` in global scope), and the bare
-// raise still fails closed.
+// 5. Positive control for the serve leg: with no policy, the served read
+// returns the secret. Without this, case 4's null could come from the serve
+// leg failing env reads for an unrelated reason.
+const plainServe = await __invokeNodeForServe("readTop", {}, {});
+const servedWithoutPolicy =
+  plainServe.status === "returned" && plainServe.value.data.withApprove === "the-secret";
+
+// 6. No policy at all, direct call: the top-level auto-approve still
+// resolves its own read (regression guard for `with approve` in global
+// scope), and the bare raise still fails closed.
 const plain = (await readTop()).data;
 const approvedWithoutPolicy = plain.withApprove === "the-secret";
 const bareFailsClosedWithoutPolicy = plain.bare === null;
@@ -50,6 +57,7 @@ writeFileSync(
       bareApprovedByPolicy,
       propagateFailsClosed,
       hostRejected,
+      servedWithoutPolicy,
       approvedWithoutPolicy,
       bareFailsClosedWithoutPolicy,
     },

--- a/packages/agency-lang/tests/agency-js/policy-top-level/test.js
+++ b/packages/agency-lang/tests/agency-js/policy-top-level/test.js
@@ -1,0 +1,31 @@
+// Issue #966: a top-level `with approve` must not bypass the root policy.
+// Global init runs during bootstrap, so the root policy handler must already
+// be in the chain when the top-level raise happens. Covers both policy
+// sources: the AGENCY_RUN_POLICY environment policy (what the CLI's
+// --reject/--policy flags set) and a host's InvocationOptions.policy.
+import { readTop, __invokeNodeForServe } from "./agent.js";
+import { writeFileSync } from "fs";
+
+process.env.POLICY_TOP_LEVEL_SECRET = "the-secret";
+const rejectEnv = { "std::env": [{ action: "reject" }] };
+
+// 1. CLI surface: the env policy rejects the top-level read despite the
+// program's own `with approve`.
+process.env.AGENCY_RUN_POLICY = JSON.stringify(rejectEnv);
+const cliRes = await readTop();
+const cliRejected = cliRes.data === null;
+
+// 2. Host surface: InvocationOptions.policy rejects it the same way.
+delete process.env.AGENCY_RUN_POLICY;
+const serveOutcome = await __invokeNodeForServe("readTop", {}, { policy: rejectEnv });
+const hostRejected = serveOutcome.status === "returned" && serveOutcome.value.data === null;
+
+// 3. Regression guard: with no policy at all, the top-level auto-approve
+// still resolves the read.
+const plainRes = await readTop();
+const approvedWithoutPolicy = plainRes.data === "the-secret";
+
+writeFileSync(
+  "__result.json",
+  JSON.stringify({ cliRejected, hostRejected, approvedWithoutPolicy }, null, 2),
+);

--- a/packages/agency-lang/tests/agency-js/policy-top-level/test.js
+++ b/packages/agency-lang/tests/agency-js/policy-top-level/test.js
@@ -1,31 +1,59 @@
-// Issue #966: a top-level `with approve` must not bypass the root policy.
+// Issue #966: top-level raises must be decided by the root policy.
 // Global init runs during bootstrap, so the root policy handler must already
-// be in the chain when the top-level raise happens. Covers both policy
+// be in the chain when a top-level raise happens. Covers both policy
 // sources: the AGENCY_RUN_POLICY environment policy (what the CLI's
-// --reject/--policy flags set) and a host's InvocationOptions.policy.
+// --reject/--approve/--policy flags set) and a host's InvocationOptions.policy.
 import { readTop, __invokeNodeForServe } from "./agent.js";
 import { writeFileSync } from "fs";
 
 process.env.POLICY_TOP_LEVEL_SECRET = "the-secret";
+process.env.POLICY_TOP_LEVEL_BARE = "bare-secret";
+const s = (x) => JSON.stringify(x);
 const rejectEnv = { "std::env": [{ action: "reject" }] };
 
 // 1. CLI surface: the env policy rejects the top-level read despite the
 // program's own `with approve`.
-process.env.AGENCY_RUN_POLICY = JSON.stringify(rejectEnv);
-const cliRes = await readTop();
-const cliRejected = cliRes.data === null;
+process.env.AGENCY_RUN_POLICY = s(rejectEnv);
+const cliRejected = (await readTop()).data.withApprove === null;
 
-// 2. Host surface: InvocationOptions.policy rejects it the same way.
+// 2. Approve policy: a BARE top-level raise, which fails closed with no
+// policy (case 5), is resolved by the root policy — proving the handler is
+// genuinely in the chain during global init, not only able to reject.
+process.env.AGENCY_RUN_POLICY = s({ "std::env": [{ action: "approve" }] });
+const bareApprovedByPolicy = (await readTop()).data.bare === "bare-secret";
+
+// 3. Propagate policy: propagation beats the program's `with approve`, and
+// global init cannot pause to ask, so the read fails closed (env absorbs
+// the failure to null) instead of self-approving.
+process.env.AGENCY_RUN_POLICY = s({ "std::env": [{ action: "propagate" }] });
+const propagateFailsClosed = (await readTop()).data.withApprove === null;
+
+// 4. Host surface: InvocationOptions.policy rejects the same way the env
+// policy does in case 1.
 delete process.env.AGENCY_RUN_POLICY;
 const serveOutcome = await __invokeNodeForServe("readTop", {}, { policy: rejectEnv });
-const hostRejected = serveOutcome.status === "returned" && serveOutcome.value.data === null;
+const hostRejected =
+  serveOutcome.status === "returned" && serveOutcome.value.data.withApprove === null;
 
-// 3. Regression guard: with no policy at all, the top-level auto-approve
-// still resolves the read.
-const plainRes = await readTop();
-const approvedWithoutPolicy = plainRes.data === "the-secret";
+// 5. No policy at all: the top-level auto-approve still resolves its own
+// read (regression guard for `with approve` in global scope), and the bare
+// raise still fails closed.
+const plain = (await readTop()).data;
+const approvedWithoutPolicy = plain.withApprove === "the-secret";
+const bareFailsClosedWithoutPolicy = plain.bare === null;
 
 writeFileSync(
   "__result.json",
-  JSON.stringify({ cliRejected, hostRejected, approvedWithoutPolicy }, null, 2),
+  JSON.stringify(
+    {
+      cliRejected,
+      bareApprovedByPolicy,
+      propagateFailsClosed,
+      hostRejected,
+      approvedWithoutPolicy,
+      bareFailsClosedWithoutPolicy,
+    },
+    null,
+    2,
+  ),
 );

--- a/packages/agency-lang/tests/agency/subprocess/handler-reject-child-top-level.agency
+++ b/packages/agency-lang/tests/agency/subprocess/handler-reject-child-top-level.agency
@@ -1,10 +1,10 @@
 import { compile, run } from "std::agency"
 
-// The child auto-approves a TOP-LEVEL bash call. Child global init still
-// consults the parent's chain over IPC, so the parent's reject must win —
-// the subprocess counterpart of the #966 root-policy ordering fix. The
-// child hands back the raw result and the parent pins the exact rejection
-// message, so an unrelated bash failure cannot pass as a rejection.
+// The child auto-approves a top-level bash call. Child global init consults
+// the parent's chain over IPC, so the parent's reject must win (#966, the
+// subprocess side). The child hands back the raw result and the parent pins
+// the exact rejection message, so an unrelated bash failure cannot pass as
+// a rejection.
 node main() {
   const source = """
 import { bash } from "std::shell"

--- a/packages/agency-lang/tests/agency/subprocess/handler-reject-child-top-level.agency
+++ b/packages/agency-lang/tests/agency/subprocess/handler-reject-child-top-level.agency
@@ -1,0 +1,36 @@
+import { compile, run } from "std::agency"
+
+// The child auto-approves a TOP-LEVEL bash call. Child global init still
+// consults the parent's chain over IPC, so the parent's reject must win —
+// the subprocess counterpart of the #966 root-policy ordering fix.
+node main() {
+  const source = """
+import { bash } from "std::shell"
+
+const r = bash("echo child-top-level") with approve
+
+node main() {
+  if (isFailure(r)) {
+    return "top-level bash was rejected"
+  }
+  return "top-level bash succeeded"
+}
+"""
+  const compileResult = compile(source)
+  if (isFailure(compileResult)) {
+    return "compile failed: " + compileResult.error
+  }
+
+  handle {
+    const result = run(compiled: compileResult.value, node: "main", args: {})
+    if (isSuccess(result)) {
+      return result.value.data
+    }
+    return "run failed: " + result.error
+  } with (data) {
+    if (data.effect == "std::run") {
+      return approve()
+    }
+    return reject()
+  }
+}

--- a/packages/agency-lang/tests/agency/subprocess/handler-reject-child-top-level.agency
+++ b/packages/agency-lang/tests/agency/subprocess/handler-reject-child-top-level.agency
@@ -2,7 +2,9 @@ import { compile, run } from "std::agency"
 
 // The child auto-approves a TOP-LEVEL bash call. Child global init still
 // consults the parent's chain over IPC, so the parent's reject must win —
-// the subprocess counterpart of the #966 root-policy ordering fix.
+// the subprocess counterpart of the #966 root-policy ordering fix. The
+// child hands back the raw result and the parent pins the exact rejection
+// message, so an unrelated bash failure cannot pass as a rejection.
 node main() {
   const source = """
 import { bash } from "std::shell"
@@ -10,10 +12,7 @@ import { bash } from "std::shell"
 const r = bash("echo child-top-level") with approve
 
 node main() {
-  if (isFailure(r)) {
-    return "top-level bash was rejected"
-  }
-  return "top-level bash succeeded"
+  return r
 }
 """
   const compileResult = compile(source)
@@ -23,10 +22,14 @@ node main() {
 
   handle {
     const result = run(compiled: compileResult.value, node: "main", args: {})
-    if (isSuccess(result)) {
-      return result.value.data
+    if (isFailure(result)) {
+      return "run failed: " + result.error
     }
-    return "run failed: " + result.error
+    const childValue = result.value.data
+    if (childValue is failure(err)) {
+      return "top-level bash failed: ${err}"
+    }
+    return "top-level bash succeeded"
   } with (data) {
     if (data.effect == "std::run") {
       return approve()

--- a/packages/agency-lang/tests/agency/subprocess/handler-reject-child-top-level.test.json
+++ b/packages/agency-lang/tests/agency/subprocess/handler-reject-child-top-level.test.json
@@ -4,7 +4,7 @@
       "nodeName": "main",
       "description": "Parent handler rejects a subprocess interrupt raised by top-level `with approve` in the child's global init",
       "input": "",
-      "expectedOutput": "\"top-level bash was rejected\"",
+      "expectedOutput": "\"top-level bash failed: interrupt rejected\"",
       "evaluationCriteria": [{ "type": "exact" }]
     }
   ]

--- a/packages/agency-lang/tests/agency/subprocess/handler-reject-child-top-level.test.json
+++ b/packages/agency-lang/tests/agency/subprocess/handler-reject-child-top-level.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "Parent handler rejects a subprocess interrupt raised by top-level `with approve` in the child's global init",
+      "input": "",
+      "expectedOutput": "\"top-level bash was rejected\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #966.

## The bug

`initFreshExecCtx` (lib/runtime/node.ts) installed the root policy handler and the root cost/time budget at the end of bootstrap, after global init and top-level callback registration. So when top-level code raised an interrupt, the policy was not in the chain yet. A top-level `with approve` was then the only handler and won:

```
const prompt = read("./prompt.md") with approve   // succeeded under --reject '*'
```

This bypassed both policy sources, because they install at the same site:

1. **CLI flags** (`--reject` / `--approve` / `--policy`, via `AGENCY_RUN_POLICY`).
2. **A serve host** (`InvocationOptions.policy`, added in #978) -- a hosted module could read the host's environment from a top-level initializer before the host policy existed.

## The fix

Install both at the top of `initFreshExecCtx`, before `loadProviderModules` and `__initAllRegistered`, so all user code -- global-init expressions, imported modules' init, and top-level `callback(...)` registration -- runs under the root policy and budget. The steady-state chain is unchanged: the policy handler was already the outermost handler once the node body ran; it is now also present during bootstrap.

The resume path (`respondToInterrupts`) already installed the policy before top-level callback re-registration, so it needed no change. (`rewindFrom` installs neither; that is the pre-existing gap already noted in the `initFreshExecCtx` comment, tracked separately.)

One deliberate behavior change beyond the reject case: a policy `propagate` rule now also applies to a top-level `with approve`, and since global init cannot pause, the raise fails with the existing "Cannot create checkpoint" failure instead of self-approving -- failing closed, matching how an unhandled top-level raise already behaved.

## The subprocess path (investigated, no gap)

A `std::agency` `run()` child never had this hole. `gatherChainOutcome` consults the parent over IPC for every raise, including raises from the child's global init, and a parent reject beats the child's `with approve`. Verified empirically with both a parent in-code handler and parent CLI policy flags before writing any fix; pinned by the new `tests/agency/subprocess/handler-reject-child-top-level` test. (Note the child-side policy installer no-ops in IPC mode by design -- the policy lives at the root.)

## Tests

- `tests/agency-js/policy-top-level` -- a top-level `env(...) with approve` is rejected by the env policy (CLI surface) and by `InvocationOptions.policy` (host surface), and still self-approves when no policy is set. Failed before the fix on both surfaces.
- `tests/agency/subprocess/handler-reject-child-top-level` -- parent handler rejects a child top-level `with approve`.
- Ran: the policy/budget unit tests (runPolicyHandler, rootBudget, budgetExit, cliInterruptResolution, invocationOptions, adapter.perInvocation, budgetRun.spawn -- 88 passing), the policy agency-js tests (run-policy, run-policy-nested, serve-policy, cli-policy-handler x2, test-cli-policy, test-cli-agency-only, contained-filenames-policy), subprocess handler-approve/reject, `pnpm run typecheck`, `pnpm run fmt:ts`, `pnpm run lint:structure`.

Docs updated: `test-cli-sandbox.md` (its "cannot raise an interrupt at all" claim is now the corrected version the security roadmap asked for), `with-approve.md` (the empty `liveGuardIds` justification), `security/roadmap.md` (B1 marked fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HC9cryYEHEwWXscrBhPKjB
