### PR TITLE
Tell the agent what it is; frameless header tables

### DIFF
--- a/packages/agency-lang/docs/site/stdlib/ui/layout.md
+++ b/packages/agency-lang/docs/site/stdlib/ui/layout.md
@@ -85,7 +85,7 @@ export type Alignment = "start" | "center" | "end"
 ### BorderStyle
 
 ```ts
-export type BorderStyle = "rounded" | "heavy" | "double" | "light"
+export type BorderStyle = "rounded" | "heavy" | "double" | "light" | "none"
 ```
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/layout.agency#L55))
@@ -352,7 +352,9 @@ A bordered panel. Multiple children stack vertically inside it.
 
   @param title - Text shown in the top border (empty for none)
   @param titleColor - Color of the title text
-  @param borderStyle - The border character style
+  @param borderStyle - The border character style; "none" draws no
+    frame (padding and title still apply, the title as a plain first
+    line)
   @param borderColor - Color of the border
   @param padding - Cells of padding between the border and content
   @param width - Width as a column count, "X%" of the parent, or "full" for the whole terminal (root only)
@@ -405,4 +407,4 @@ Render a layout tree to a styled, multi-line string ready to print.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/layout.agency#L470))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/layout.agency#L472))

--- a/packages/agency-lang/docs/site/stdlib/ui/table.md
+++ b/packages/agency-lang/docs/site/stdlib/ui/table.md
@@ -144,6 +144,7 @@ table(
   footerDivider: boolean = true,
   rowDividers: boolean = false,
   columnDividers: boolean = true,
+  columnGap: number = 0,
   block: (TableBuilder) -> void = null,
 ): LayoutNode
 ```
@@ -154,7 +155,9 @@ Build a bordered table as a layout node. Pass the data form: `header`,
 
   @param title - Title shown in the top border
   @param titleColor - Color of the title text
-  @param borderStyle - Frame style
+  @param borderStyle - Frame style; "none" draws no outer frame, so the
+    cells render as plain aligned text (interior dividers still follow
+    their own flags)
   @param borderColor - Color of the border characters
   @param caption - Caption shown beneath the table
   @param cellPadding - Horizontal padding inside each cell, in cells
@@ -167,6 +170,9 @@ Build a bordered table as a layout node. Pass the data form: `header`,
   @param footerDivider - Draw a divider line above the footer
   @param rowDividers - Draw a divider between every body row
   @param columnDividers - Draw vertical dividers between columns
+  @param columnGap - Cells of blank space between adjacent columns when
+    columnDividers is false (the divider is the separator when it is on).
+    Keeps a gap even when a column grows past its minWidth.
 
 **Parameters:**
 
@@ -187,6 +193,7 @@ Build a bordered table as a layout node. Pass the data form: `header`,
 | footerDivider | `boolean` | true |
 | rowDividers | `boolean` | false |
 | columnDividers | `boolean` | true |
+| columnGap | `number` | 0 |
 | block | `(TableBuilder) => void` | null |
 
 **Returns:** [LayoutNode](layout.md#layoutnode)

--- a/packages/agency-lang/evals/agency-agent/README.md
+++ b/packages/agency-lang/evals/agency-agent/README.md
@@ -35,9 +35,12 @@ To compare brains, run twice with different `--brain` values and
 
 Three older tests predate this setup and run under the wrapper too: `fib`
 is an Agency coding task graded by its own harness, and `news` and
-`hollow-creek` are goal-judged questions. An unfiltered run covers all
-seven; to run only the terminal-bench-shaped tests, pass `--test` for
-each of the four below.
+`hollow-creek` are goal-judged questions. Two conversation tests,
+`identity` and `run-on-openrouter`, come from a real session where the
+agent could not say what it was or how to change its model: each asks
+the agent about itself and is goal-judged, with no workdir. An
+unfiltered run covers all nine; to run only the terminal-bench-shaped
+tests, pass `--test` for each of the four below.
 
 | test                | pattern from the benchmark                                                                    | must pass                                    |
 | ------------------- | --------------------------------------------------------------------------------------------- | -------------------------------------------- |

--- a/packages/agency-lang/evals/agency-agent/identity/test.json
+++ b/packages/agency-lang/evals/agency-agent/identity/test.json
@@ -1,0 +1,5 @@
+{
+  "description": "The agent knows what it is. Asked its name and model, it answers from its session facts instead of saying it cannot know.",
+  "input": "Hi, what is your name and what model are you currently running on? Anthropic?",
+  "goal": "identifies itself as the Agency agent and names the concrete model (and its provider) it is running on; does not claim it cannot know or verify which model it runs on"
+}

--- a/packages/agency-lang/evals/agency-agent/run-on-openrouter/test.json
+++ b/packages/agency-lang/evals/agency-agent/run-on-openrouter/test.json
@@ -1,0 +1,5 @@
+{
+  "description": "Asked to run on a specific OpenRouter model, the agent gives the restart recipe instead of refusing, and cites no files the user cannot open.",
+  "input": "How can I run you on the GLM 5.3 model on open router?",
+  "goal": "explains how to restart the agent on an OpenRouter model (agency agent --provider openrouter with --model, or the /model command) with an OPENROUTER_API_KEY, and does not tell the user to read repo-internal or agent-bundled file paths (such as docs/dev/... or docs/misc/...)"
+}

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -5,22 +5,17 @@ import { evalOutput, evalValue, setAgentName } from "std::statelog"
 import { cwd, env, isTTY, readStdin, setTitle } from "std::system"
 import { getCost } from "std::thread"
 import { setSlashPalette } from "std::ui/cli"
-import {
-  clearMessages,
-  pushMessage,
-  repl,
-  clearScreen,
- } from "std::ui/cli"
+import { clearMessages, pushMessage, repl, clearScreen } from "std::ui/cli"
 
 import { brainByName, allBrains, brainFlagHelp } from "./brains/registry.agency"
 import { agentNameFor } from "./lib/agentName.agency"
-import { mergedPalette } from "./lib/commandPalette.agency"
 import { parseAgentArgs } from "./lib/args.agency"
+import { mergedPalette } from "./lib/commandPalette.agency"
 import { getHeader } from "./lib/header.agency"
 import { maybeLoadMcp } from "./lib/mcp.agency"
 import { printPolicyHelp } from "./lib/policy.agency"
-import { chooseSession, startSession } from "./lib/resume.agency"
 import { installSessionHooks, startInteractive } from "./lib/repl.agency"
+import { chooseSession, startSession } from "./lib/resume.agency"
 import { pickModelsForAgent, maybeEnableMemory } from "./lib/session.agency"
 import { loadSettings } from "./lib/settings.agency"
 import { setDebug, setVerbose, setInteractive } from "./lib/trace.agency"
@@ -34,7 +29,6 @@ import {
  } from "./lib/turn.agency"
 import { formatTurnFailure } from "./lib/utils.agency"
 import { resolveMaxToolCallRounds, getCapabilities } from "./shared.agency"
-
 
 // UI mode select — one-line swap between the alt-screen TUI and the
 // line-mode REPL. Both modules expose the same `repl` / `pushMessage`
@@ -72,7 +66,7 @@ It means that agent starts with an initial prompt already there to respond to. *
 node main() {
   // Parse CLI flags first — `parseArgs` exits on --help / --version /
   // usage errors, before any handlers or the TUI are installed.
-  const args = parseAgentArgs(brainFlagHelp())
+  const args = parseAgentArgs()
 
   // NOTE: --trace / --log / --agent-home are declared here only for
   // --help and so parseArgs accepts them. runBundledAgent extracts them from
@@ -127,7 +121,11 @@ node main() {
   let startAgent = ""
   if (resolvedStartTarget == null) {
     const validTargets = ["main", ...brain.startTargets].join(", ")
-    print(color.red("Unknown --agent value: ${requestedStartTarget}. Valid for the ${brain.name} brain: ${validTargets}"))
+    print(
+      color.red(
+        "Unknown --agent value: ${requestedStartTarget}. Valid for the ${brain.name} brain: ${validTargets}",
+      ),
+    )
     process.exit(1)
     return
   } else {
@@ -174,7 +172,11 @@ node main() {
   // One-shot runs are not saved, so a resume flag on one is a mistake
   // rather than something to ignore.
   if (isOneShot && (args.flags.continue || args.flags.resume != null)) {
-    print(color.red("--continue and --resume need an interactive session; one-shot runs are not saved."))
+    print(
+      color.red(
+        "--continue and --resume need an interactive session; one-shot runs are not saved.",
+      ),
+    )
     process.exit(1)
   }
   // Everything above is process-level: model resolution feeds the memory
@@ -184,7 +186,10 @@ node main() {
   if (!isOneShot) {
     installSessionHooks()
     setSlashPalette(mergedPalette())
-    startSession(chooseSession(args.flags.continue, args.flags.resume ?? null), brain)
+    startSession(
+      chooseSession(args.flags.continue, args.flags.resume ?? null),
+      brain,
+    )
   }
 
   if (isOneShot) {

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -7,7 +7,7 @@ import { getCost } from "std::thread"
 import { setSlashPalette } from "std::ui/cli"
 import { clearMessages, pushMessage, repl, clearScreen } from "std::ui/cli"
 
-import { brainByName, allBrains, brainFlagHelp } from "./brains/registry.agency"
+import { brainByName, allBrains } from "./brains/registry.agency"
 import { agentNameFor } from "./lib/agentName.agency"
 import { parseAgentArgs } from "./lib/args.agency"
 import { mergedPalette } from "./lib/commandPalette.agency"

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/prompts/main-large.md
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/prompts/main-large.md
@@ -136,6 +136,13 @@ Pass the explorer a self-contained question with explicit scope
 not see your conversation. Be clear about the level of detail
 expected.
 
+## What you are
+
+Your identity, brain, and the models this session runs on are in the
+`<session_facts>` block appended below this prompt. When the user asks
+what you are, what your name is, or which model or provider you are
+running on, answer from that block — never say you cannot know.
+
 ## File references
 
 Only reference files that live in the user's own working directory.

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/prompts/main-large.md
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/prompts/main-large.md
@@ -83,7 +83,7 @@ Call the oracle:
   attempts — ask the oracle what's actually going on.
 - When the user proposes a plan or approach — ask the oracle
   whether the plan is sound, **before** you act on it. If the
-  oracle finds a flaw, surface that to the user *before* taking
+  oracle finds a flaw, surface that to the user _before_ taking
   any action.
 - Whenever you're tempted to guess about the codebase ("I think
   there's probably already a helper for X") — ask the oracle to
@@ -120,6 +120,7 @@ Call the explorer when the user asks:
   organizing the findings by theme.
 
 Do NOT use the explorer for:
+
 - Specific factual lookups ("what does function X return?") — use
   `codeAgent`.
 - Plan critique or bug diagnosis — use `oracleAgent`.
@@ -135,6 +136,13 @@ Pass the explorer a self-contained question with explicit scope
 not see your conversation. Be clear about the level of detail
 expected.
 
+## File references
+
+Only reference files that live in the user's own working directory.
+The user cannot open files that ship inside the agent or its source
+repository, such as docs in `docs/dev/...`, `docs/misc/...`, or stdlib
+sources, so never cite those as a path for the user to read.
+
 ## Style
 
 Never start a response by calling the user's question or idea good,
@@ -145,12 +153,13 @@ and respond directly. Don't pad replies with "happy to help",
 **Use ASCII diagrams when they clarify.** For control flow, state
 machines, pipelines, module relationships, or any "how do the parts
 fit together" answer, draw a small ASCII diagram in a fenced
-```text block. Boxes, arrows, and trees beat paragraphs for
+
+````text block. Boxes, arrows, and trees beat paragraphs for
 structural explanations:
 
 ```text
 parse → SymbolTable.build → preprocess → TypeScriptBuilder → printTs
-```
+````
 
 Keep diagrams small. Skip them where prose or code is clearer —
 diagrams earn their space by showing **relationships** or **flow**.
@@ -174,5 +183,6 @@ unless the user has clearly asked for an action ("do X", "fix Y",
 with them — don't sprint to implementation.
 
 ## Communicating with the user
+
 - Make sure the user is following what you're doing. Use the `whatIAmDoing` tool frequently to tell the user what you're doing.
 - Also use the `elapsedTime` tool frequently to check how much time has elapsed since you started the task. If the user gave you a time constraint to work within, make sure you finish the task within that time constraint. For simple tasks, make sure you don't spend too long researching things before giving an answer.

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/prompts/main-large.md
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/prompts/main-large.md
@@ -152,14 +152,13 @@ and respond directly. Don't pad replies with "happy to help",
 
 **Use ASCII diagrams when they clarify.** For control flow, state
 machines, pipelines, module relationships, or any "how do the parts
-fit together" answer, draw a small ASCII diagram in a fenced
-
-````text block. Boxes, arrows, and trees beat paragraphs for
-structural explanations:
+fit together" answer, draw a small ASCII diagram in a fenced text
+block. Boxes, arrows, and trees beat paragraphs for structural
+explanations:
 
 ```text
 parse → SymbolTable.build → preprocess → TypeScriptBuilder → printTs
-````
+```
 
 Keep diagrams small. Skip them where prose or code is clearer —
 diagrams earn their space by showing **relationships** or **flow**.

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/prompts/main-small.md
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/prompts/main-small.md
@@ -32,7 +32,10 @@ Routing rules:
 Style: plain, direct answers in Markdown. No preamble. Keep replies
 short unless the task demands detail.
 
-## Communicating with the user
+## File references
 
+Only reference files that live in the user's own working directory. Never cite agent-bundled or repository-internal paths such as `docs/dev/...` or `docs/misc/...`.
+
+## Communicating with the user
 - Make sure the user is following what you're doing. Use the `whatIAmDoing` tool frequently to tell the user what you're doing.
 - Also use the `elapsedTime` tool frequently to check how much time has elapsed since you started the task. If the user gave you a time constraint to work within, make sure you finish the task within that time constraint. For simple tasks, make sure you don't spend too long researching things before giving an answer.

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/prompts/main-small.md
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/prompts/main-small.md
@@ -2,6 +2,7 @@ You are the compact coordinator of an Agency-language assistant. Decide
 how to answer each user message.
 
 Tools (each runs in its own context; pass a self-contained message):
+
 - `codeAgent(userMsg)` — anything touching code or files: read, write,
   edit, run, typecheck. Also Agency syntax and CLI questions.
 - `researchAgent(userMsg)` — web search, URL fetches, external facts.
@@ -19,6 +20,7 @@ Tools (each runs in its own context; pass a self-contained message):
   image; do not route image work to codeAgent.
 
 Routing rules:
+
 - Simple chat, greetings, quick factual answers: reply directly, no
   tools.
 - Anything code- or file-related: codeAgent. Current/external info:
@@ -31,5 +33,6 @@ Style: plain, direct answers in Markdown. No preamble. Keep replies
 short unless the task demands detail.
 
 ## Communicating with the user
+
 - Make sure the user is following what you're doing. Use the `whatIAmDoing` tool frequently to tell the user what you're doing.
 - Also use the `elapsedTime` tool frequently to check how much time has elapsed since you started the task. If the user gave you a time constraint to work within, make sure you finish the task within that time constraint. For simple tasks, make sure you don't spend too long researching things before giving an answer.

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/prompts/main-small.md
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/prompts/main-small.md
@@ -32,6 +32,12 @@ Routing rules:
 Style: plain, direct answers in Markdown. No preamble. Keep replies
 short unless the task demands detail.
 
+## What you are
+
+The `<session_facts>` block below this prompt says what you are and
+which models this session runs on. Asked your name, model, or
+provider, answer from it — never say you cannot know.
+
 ## File references
 
 Only reference files that live in the user's own working directory. Never cite agent-bundled or repository-internal paths such as `docs/dev/...` or `docs/misc/...`.

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/tests/agentTurn.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/tests/agentTurn.agency
@@ -197,7 +197,8 @@ node reactSilentOnSameProvider(): boolean {
 }
 
 
-import { headerModelLines, getHeader } from "../../../lib/header.agency"
+import { getHeader } from "../../../lib/header.agency"
+import test { headerModelLines } from "../../../lib/header.agency"
 import { hostedModelInfo } from "std::llm"
 
 // The splash header lists the resolved main + reasoning models. The internal

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/tests/agentTurn.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/tests/agentTurn.agency
@@ -38,9 +38,11 @@ node respondsToAMessage(): string {
   return "${reply}|${threadHasSystemText("GROUNDING-MARKER-7f3a")}|${threadHasSystemText("Agency-language assistant")}"
 }
 
-node headerShowsBrain(): boolean {
+// The brain row moved behind --verbose; the default header renders
+// without it (and without any flag rows), but still renders.
+node headerOmitsBrainByDefault(): boolean {
   const header = getHeader("coordinator")
-  return header.includes("Brain") && header.includes("coordinator")
+  return !header.includes("Brain") && header.includes("Getting Started")
 }
 
 // End-to-end of the wired apply/read path (env-independent: empty settings, no

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/tests/agentTurn.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/tests/agentTurn.test.json
@@ -297,7 +297,7 @@
       ]
     },
     {
-      "nodeName": "headerShowsBrain",
+      "nodeName": "headerOmitsBrainByDefault",
       "input": "",
       "expectedOutput": "true",
       "evaluationCriteria": [

--- a/packages/agency-lang/lib/agents/agency-agent/brains/registry.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/registry.agency
@@ -18,12 +18,3 @@ export def brainByName(name: string): AgentBrain | null {
   }
   return null
 }
-
-/** The --brain flag description: each name with its one-line description. */
-export def brainFlagHelp(): string {
-  let lines: string[] = []
-  for (brain in allBrains()) {
-    lines.push("${brain.name}: ${brain.description}")
-  }
-  return "Which brain answers turns (default: coordinator). One of — ${lines.join("; ")}"
-}

--- a/packages/agency-lang/lib/agents/agency-agent/lib/args.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/args.agency
@@ -3,6 +3,7 @@ import { parseArgs } from "std::args"
 
 import { allBrains } from "./../brains/registry.agency"
 
+/** The --brain flag description: each name with its one-line description. */
 export def brainFlagHelp(): string {
   let lines: string[] = []
   for (brain in allBrains()) {

--- a/packages/agency-lang/lib/agents/agency-agent/lib/args.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/args.agency
@@ -13,7 +13,7 @@ export def brainFlagHelp(): string {
 }
 
 export def parseAgentArgs() {
-  return parseArgs(
+  const args = parseArgs(
     {
       programName: "agency agent",
       description: "Agency language assistant — interactive REPL by default; one-shot when piped or passed a query / --print.",
@@ -92,6 +92,11 @@ export def parseAgentArgs() {
           optional: true,
           description: "Run a local model (downloads if needed): a curated short name, an hf: URI, or a .gguf path. Run without a value for guided setup. Pins all slots to the local model; mutually exclusive with --model/--fastmodel/--slowmodel. Requires: npm i -g smoltalk-llama-cpp"
         },
+        "local-model": {
+          type: "string",
+          optional: true,
+          description: "Deprecated alias for --local."
+        },
         trace: {
           type: "string",
           optional: true,
@@ -121,4 +126,10 @@ export def parseAgentArgs() {
       }
     },
   )
+  // Deprecated alias: --local-model means --local. Normalize here so
+  // every consumer reads only flags.local.
+  if (args.flags["local"] == null && args.flags["local-model"] != null) {
+    args.flags["local"] = args.flags["local-model"]
+  }
+  return args
 }

--- a/packages/agency-lang/lib/agents/agency-agent/lib/args.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/args.agency
@@ -1,117 +1,123 @@
 import { getVersion } from "std::agency"
 import { parseArgs } from "std::args"
-export def parseAgentArgs(brainHelp: string) {
+
+import { allBrains } from "./../brains/registry.agency"
+
+export def brainFlagHelp(): string {
+  let lines: string[] = []
+  for (brain in allBrains()) {
+    lines.push("${brain.name}: ${brain.description}")
+  }
+  return "Which brain answers turns (default: coordinator). One of — ${lines.join("; ")}"
+}
+
+export def parseAgentArgs() {
   return parseArgs(
     {
-    programName: "agency agent",
-    description: "Agency language assistant — interactive REPL by default; one-shot when piped or passed a query / --print.",
-    version: getVersion(),
-    flags: {
-      print: {
-        type: "boolean",
-        short: "p",
-        description: "Run one-shot: print the reply to stdout and exit (no REPL)"
-      },
-      debug: {
-        type: "boolean",
-        description: "Log tool returns (toolName, result, timing). Same as AGENT_DEBUG=1"
-      },
-      verbose: {
-        type: "boolean",
-        description: "Echo tool-call starts to stdout in non-interactive mode"
-      },
-      model: {
-        type: "string",
-        description: "Model for all LLM calls (overrides provider auto-detection)"
-      },
-      fastmodel: {
-        type: "string",
-        description: "Model for ordinary work (default: per detected provider)"
-      },
-      slowmodel: {
-        type: "string",
-        description: "Model for deep reasoning, e.g. the oracle/explorer subagents"
-      },
-      provider: {
-        type: "string",
-        description: "Force the LLM provider. Given alone (openai/anthropic/google/openrouter) it selects that provider's default models and skips env auto-detection; pair it with --model for any other provider (e.g. litellm, openai-compat, or a custom/local model)"
-      },
-      interactive: {
-        type: "boolean",
-        short: "i",
-        description: "Run the given prompt as the first turn of an interactive session, then hand over the REPL (instead of one-shot)"
-      },
-      agent: {
-        type: "string",
-        description: "Route the starting prompt to a named subagent of the selected brain (default: the brain's main entry). The coordinator brain accepts: code, research, oracle, explorer, review"
-      },
-      brain: {
-        type: "string",
-        description: brainHelp
-      },
-      policy: {
-        type: "string",
-        optional: true,
-        description: "Approval policy for this run: a built-in name (minimal, recommended, with-writes, approve-all) or a path to a policy JSON file. with-writes auto-approves file writes and git changes scoped to the current directory and its children; approve-all approves EVERY interrupt with no scoping (sandbox use only). Overrides the saved policy without persisting it. Pass --policy with no value to list the built-in policies."
-      },
-      continue: {
-        type: "boolean",
-        description: "Resume the most recent saved session for this directory"
-      },
-      resume: {
-        type: "string",
-        optional: true,
-        description: "Resume a saved session by id, or pass --resume alone to pick one from a list"
-      },
-      "agent-home": {
-        type: "string",
-        description: "Directory to use instead of ~/.agency-agent for settings, policy, and history (equivalent to the AGENCY_AGENT_HOME env var; the flag wins when both are set)"
-      },
-      workdir: {
-        type: "string",
-        description: "Run the agent from this directory instead of the current one: file reads and writes, config discovery, and relative paths all resolve there"
-      },
-      config: {
-        type: "string",
-        description: "Path to an agency.json config file for this agent run (the agent is recompiled with it)"
-      },
-      local: {
-        type: "string",
-        optional: true,
-        description: "Run a local model (downloads if needed): a curated short name, an hf: URI, or a .gguf path. Run without a value for guided setup. Pins all slots to the local model; mutually exclusive with --model/--fastmodel/--slowmodel. Requires: npm i -g smoltalk-llama-cpp"
-      },
-      "local-model": {
-        type: "string",
-        optional: true,
-        description: "Deprecated alias for --local."
-      },
-      trace: {
-        type: "string",
-        optional: true,
-        description: "Write an execution trace to this file for debugging (bare --trace writes <runId>.agencytrace in the current directory)"
-      },
-      log: {
-        type: "string",
-        optional: true,
-        description: "Append structured statelog events (one JSON object per line) for debugging. Bare --log writes ./log.jsonl; --log <path> writes that file; --log stdout streams events to standard out."
-      },
-      "max-cost": {
-        type: "string",
-        description: "Abort if the agent's LLM spend exceeds this many dollars (0 = local models only; negative = no limit)"
-      },
-      "max-time": {
-        type: "string",
-        description: "Abort if the agent's working time exceeds this duration (e.g. 30m or 2d); waiting on a human is not counted; zero/negative = no limit"
-      },
-      "max-tool-call-rounds": {
-        type: "number",
-        description: "Max LLM tool-call rounds before a tool loop halts (default 10 interactive, 50 in one-shot/-p mode)"
-      },
-      "max-tool-result-chars": {
-        type: "number",
-        description: "Max chars of a single tool result fed back to the model (0 disables; default 100000)"
+      programName: "agency agent",
+      description: "Agency language assistant — interactive REPL by default; one-shot when piped or passed a query / --print.",
+      version: getVersion(),
+      flags: {
+        print: {
+          type: "boolean",
+          short: "p",
+          description: "Run one-shot: print the reply to stdout and exit (no REPL)"
+        },
+        debug: {
+          type: "boolean",
+          description: "Log tool returns (toolName, result, timing). Same as AGENT_DEBUG=1"
+        },
+        verbose: {
+          type: "boolean",
+          description: "Echo tool-call starts to stdout in non-interactive mode"
+        },
+        model: {
+          type: "string",
+          description: "Model for all LLM calls (overrides provider auto-detection)"
+        },
+        fastmodel: {
+          type: "string",
+          description: "Model for ordinary work (default: per detected provider)"
+        },
+        slowmodel: {
+          type: "string",
+          description: "Model for deep reasoning, e.g. the oracle/explorer subagents"
+        },
+        provider: {
+          type: "string",
+          description: "Force the LLM provider. Given alone (openai/anthropic/google/openrouter) it selects that provider's default models and skips env auto-detection; pair it with --model for any other provider (e.g. litellm, openai-compat, or a custom/local model)"
+        },
+        interactive: {
+          type: "boolean",
+          short: "i",
+          description: "Run the given prompt as the first turn of an interactive session, then hand over the REPL (instead of one-shot)"
+        },
+        agent: {
+          type: "string",
+          description: "Route the starting prompt to a named subagent of the selected brain (default: the brain's main entry). The coordinator brain accepts: code, research, oracle, explorer, review"
+        },
+        brain: {
+          type: "string",
+          description: brainFlagHelp()
+        },
+        policy: {
+          type: "string",
+          optional: true,
+          description: "Approval policy for this run: a built-in name (minimal, recommended, with-writes, approve-all) or a path to a policy JSON file. with-writes auto-approves file writes and git changes scoped to the current directory and its children; approve-all approves EVERY interrupt with no scoping (sandbox use only). Overrides the saved policy without persisting it. Pass --policy with no value to list the built-in policies."
+        },
+        continue: {
+          type: "boolean",
+          description: "Resume the most recent saved session for this directory"
+        },
+        resume: {
+          type: "string",
+          optional: true,
+          description: "Resume a saved session by id, or pass --resume alone to pick one from a list"
+        },
+        "agent-home": {
+          type: "string",
+          description: "Directory to use instead of ~/.agency-agent for settings, policy, and history (equivalent to the AGENCY_AGENT_HOME env var; the flag wins when both are set)"
+        },
+        workdir: {
+          type: "string",
+          description: "Run the agent from this directory instead of the current one: file reads and writes, config discovery, and relative paths all resolve there"
+        },
+        config: {
+          type: "string",
+          description: "Path to an agency.json config file for this agent run (the agent is recompiled with it)"
+        },
+        local: {
+          type: "string",
+          optional: true,
+          description: "Run a local model (downloads if needed): a curated short name, an hf: URI, or a .gguf path. Run without a value for guided setup. Pins all slots to the local model; mutually exclusive with --model/--fastmodel/--slowmodel. Requires: npm i -g smoltalk-llama-cpp"
+        },
+        trace: {
+          type: "string",
+          optional: true,
+          description: "Write an execution trace to this file for debugging (bare --trace writes <runId>.agencytrace in the current directory)"
+        },
+        log: {
+          type: "string",
+          optional: true,
+          description: "Append structured statelog events (one JSON object per line) for debugging. Bare --log writes ./log.jsonl; --log <path> writes that file; --log stdout streams events to standard out."
+        },
+        "max-cost": {
+          type: "string",
+          description: "Abort if the agent's LLM spend exceeds this many dollars (0 = local models only; negative = no limit)"
+        },
+        "max-time": {
+          type: "string",
+          description: "Abort if the agent's working time exceeds this duration (e.g. 30m or 2d); waiting on a human is not counted; zero/negative = no limit"
+        },
+        "max-tool-call-rounds": {
+          type: "number",
+          description: "Max LLM tool-call rounds before a tool loop halts (default 10 interactive, 50 in one-shot/-p mode)"
+        },
+        "max-tool-result-chars": {
+          type: "number",
+          description: "Max chars of a single tool result fed back to the model (0 disables; default 100000)"
+        }
       }
-    }
-  },
+    },
   )
 }

--- a/packages/agency-lang/lib/agents/agency-agent/lib/grounding.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/grounding.agency
@@ -13,9 +13,9 @@ import { Resolved } from "./models.agency"
 
 export def loadAgentsMd(dir: string): string {
   """
-  Read `AGENTS.md` from `dir` if it exists and return it wrapped in a
-  <project_context> block ready to splice into a system prompt. Returns
-  an empty string if there is no AGENTS.md or it cannot be read.
+  Read `AGENTS.md` from `dir` if it exists and return its raw contents;
+  the caller wraps them in a <project_context> block. Returns an empty
+  string if there is no AGENTS.md or it cannot be read.
   """
   if (!exists("AGENTS.md", dir)) {
     return ""
@@ -30,14 +30,16 @@ export def loadAgentsMd(dir: string): string {
 export def sessionFactsText(
   brainName: string,
   slots: Record<string, Resolved>,
-  args: Record<string, any>,
+  flags: Record<string, any>,
 ): string {
   """
   The identity block: what the agent is, which brain answers turns, and
   the models the run resolved to. Pure — the slots come in as a
   parameter — so tests can call it directly. The same resolved slots
   feed the splash header, so the model names here always match what the
-  user saw at startup.
+  user saw at startup. Takes only the CLI flags, never the positional
+  prompt: this block sits above the user-message boundary, and user
+  text serialized into it would be a prompt-injection vector.
   """
   let modelLines = []
   for (slot in ["main", "reasoning"]) {
@@ -55,7 +57,7 @@ export def sessionFactsText(
 
   The flags you were started with:
   <flags>
-  ${JSON.stringify(args, null, 2)}
+  ${JSON.stringify(flags, null, 2)}
   </flags>
   """
 }
@@ -70,7 +72,7 @@ export def groundingText(brainName: string): string {
   Current working directory: ${cwd()}
 
   <session_facts>
-  ${sessionFactsText(brainName, getResolvedSlots(), args)}
+  ${sessionFactsText(brainName, getResolvedSlots(), args.flags)}
   </session_facts>
 
   <project_context>

--- a/packages/agency-lang/lib/agents/agency-agent/lib/grounding.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/grounding.agency
@@ -1,10 +1,15 @@
 /** @module
-  @summary The per-run grounding a brain gets: date, working directory,
-  and the project AGENTS.md. Harness-owned; brains only read it.
+  @summary The per-run grounding a brain gets: what the agent is, the
+  models the run resolved to, date, working directory, and the project
+  AGENTS.md. Harness-owned; brains only read it.
 */
 import { today } from "std::date"
 import { exists } from "std::shell"
 import { cwd } from "std::system"
+
+import { demoteProvider, getResolvedSlots } from "../shared.agency"
+import { parseAgentArgs } from "./args.agency"
+import { Resolved } from "./models.agency"
 
 export def loadAgentsMd(dir: string): string {
   """
@@ -19,20 +24,57 @@ export def loadAgentsMd(dir: string): string {
   if (isFailure(result)) {
     return ""
   }
-  return """
+  return result.value
+}
 
-  <project_context>
-  ${result.value}
-  </project_context>
+export def sessionFactsText(
+  brainName: string,
+  slots: Record<string, Resolved>,
+  args: Record<string, any>,
+): string {
+  """
+  The identity block: what the agent is, which brain answers turns, and
+  the models the run resolved to. Pure — the slots come in as a
+  parameter — so tests can call it directly. The same resolved slots
+  feed the splash header, so the model names here always match what the
+  user saw at startup.
+  """
+  let modelLines = []
+  for (slot in ["main", "reasoning"]) {
+    const resolved = slots[slot]
+    if (resolved != null && resolved.model != "") {
+      modelLines.push(
+        "${slot} model: ${resolved.model} (provider: ${demoteProvider(resolved.provider)})",
+      )
+    }
+  }
+  return """
+  Your Name: Agency agent
+  Brain: ${brainName}
+  Models: ${modelLines.join("\n  ")}
+
+  The flags you were started with:
+  <flags>
+  ${JSON.stringify(args, null, 2)}
+  </flags>
   """
 }
 
-export def groundingText(): string {
+export def groundingText(brainName: string): string {
   const projectContext = loadAgentsMd(cwd()) with approve
+  const args = parseAgentArgs()
+
   return """
 
   Current date: ${today()}
   Current working directory: ${cwd()}
+
+  <session_facts>
+  ${sessionFactsText(brainName, getResolvedSlots(), args)}
+  </session_facts>
+
+  <project_context>
   ${projectContext}
+  </project_context>
   """
 }

--- a/packages/agency-lang/lib/agents/agency-agent/lib/header.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/header.agency
@@ -133,6 +133,9 @@ def extendedInfo(left, brainName: string) {
       t.row(color.cyan("Fast Model"), args.flags.fastmodel ?? "")
       t.row(color.cyan("Slow Model"), args.flags.slowmodel ?? "")
       t.row(color.cyan("Provider"), args.flags.provider ?? "")
+      t.row(color.cyan("Local Model"), args.flags.local ?? "")
+      t.row(color.cyan("Continue"), boolToString(args.flags.continue ?? false))
+      t.row(color.cyan("Resume"), args.flags.resume ?? "")
       t.row(color.cyan("Subagent"), args.flags.agent ?? "")
       t.row(color.cyan("Policy"), args.flags.policy ?? "")
       t.row(color.cyan("Agent Home"), args.flags["agent-home"] ?? "")
@@ -142,11 +145,11 @@ def extendedInfo(left, brainName: string) {
       t.row(color.cyan("Log"), args.flags.log ?? "")
       t.row(
         color.cyan("Max Tool Call Rounds"),
-        args.flags["max-tool-call-rounds"] ?? "",
+        "${args.flags["max-tool-call-rounds"] ?? ""}",
       )
       t.row(
         color.cyan("Max Tool Result Chars"),
-        args.flags["max-tool-result-chars"] ?? "",
+        "${args.flags["max-tool-result-chars"] ?? ""}",
       )
     }
   }

--- a/packages/agency-lang/lib/agents/agency-agent/lib/header.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/header.agency
@@ -1,10 +1,11 @@
 import { basename } from "std::path"
 import { box, render } from "std::ui/layout"
+import { table } from "std::ui/table"
 
 import { figs } from "../images/images.agency"
 import { demoteProvider, getResolvedSlots } from "../shared.agency"
+import { parseAgentArgs } from "./args.agency"
 import { Resolved } from "./models.agency"
-
 
 def sample(arr: any[]): any {
   return arr[Math.floor(Math.random() * arr.length)]
@@ -25,12 +26,10 @@ def slotModelLabel(resolved: Resolved | null): string {
   return "${modelName} (${demoteProvider(resolved.provider)})"
 }
 
-/** The model-slot lines for the splash header: one padded
-  "<label>  <model> (<provider>)" per resolved slot. Shows the main (chat /
-  coordinator) and reasoning (oracle / explorer) slots so the user can confirm,
-  at startup, which models the run resolved to from their env / flags. Skips a
-  slot that didn't resolve. Exported for the header test. */
-export def headerModelLines(slots: Record<string, Resolved>): string[] {
+// The model-slot lines for the splash header: one padded
+// "<label>  <model> (<provider>)" per resolved slot. Skips a slot that
+// didn't resolve. Tests reach it via `import test`.
+def headerModelLines(slots: Record<string, Resolved>): string[] {
   let lines: string[] = []
   const mainLabel = slotModelLabel(slots["main"])
   if (mainLabel != "") {
@@ -43,9 +42,12 @@ export def headerModelLines(slots: Record<string, Resolved>): string[] {
   return lines
 }
 
+def heading(col: any, text: string) {
+  col.text(text, bold: true, fgColor: "cyan")
+}
+
 export def getHeader(brainName: string): string {
   const fig = sample(figs)
-  const modelLines = headerModelLines(getResolvedSlots())
   const data = box(
     title: "Agency",
     padding: 1,
@@ -61,19 +63,10 @@ export def getHeader(brainName: string): string {
           "Interactions use your API key. All costs are estimates. Actual costs may be higher.",
           dim: true,
         )
-        if (modelLines.length > 0) {
-          left.hline()
-          left.text("Models", bold: true, fgColor: "cyan")
-          for (line in modelLines) {
-            left.text(line, dim: true)
-          }
-        }
         left.hline()
-        left.text("Brain", bold: true, fgColor: "cyan")
-        left.text(brainName, dim: true)
-        left.hline()
-        left.text("Getting Started", bold: true, fgColor: "cyan")
+        heading(left, "Getting Started")
         left.text("/help for commands · /exit to quit", dim: true)
+        extendedInfo(left, brainName: brainName)
       }
       r.vline()
       r.column(width: "30%", align: "center") as right {
@@ -82,4 +75,83 @@ export def getHeader(brainName: string): string {
     }
   }
   return render(data, color: true)
+}
+
+def boolToString(b: boolean): string {
+  if (b) {
+    return "true"
+  }
+  return "false"
+}
+
+def extendedInfo(left, brainName: string) {
+  const slots = getResolvedSlots()
+  const args = parseAgentArgs()
+  left.hline()
+  /*  if (modelLines.length > 0) {
+    heading(left, "Models")
+    for (line in modelLines) {
+      left.text(line, dim: true)
+    }
+  }
+ */
+  const mainModel = slotModelLabel(slots["main"])
+  const reasoningModel = slotModelLabel(slots["reasoning"])
+
+  const argsTable = table(
+    borderStyle: "none",
+    columnDividers: false,
+    cellPadding: 0,
+    columnGap: 1,
+    columns: [{
+      minWidth: 13
+    }, {}],
+  ) as t {
+    if (mainModel != "") {
+      t.row(color.cyan("Main Model"), mainModel)
+    }
+    if (reasoningModel != "") {
+      t.row(color.cyan("Reasoning Model"), reasoningModel)
+    }
+    if (args.flags["max-cost"] != null) {
+      t.row(color.cyan("Max Cost"), "$${args.flags["max-cost"]}")
+    }
+    if (args.flags["max-time"] != null) {
+      t.row(color.cyan("Max Time"), args.flags["max-time"])
+    }
+
+    if (args.flags.verbose) {
+      t.row(color.cyan("Brain"), brainName)
+      t.row(
+        color.cyan("Interactive"),
+        boolToString(args.flags.interactive ?? false),
+      )
+      t.row(color.cyan("Print"), boolToString(args.flags.print ?? false))
+      t.row(color.cyan("Debug"), boolToString(args.flags.debug ?? false))
+      t.row(color.cyan("Verbose"), boolToString(args.flags.verbose ?? false))
+      t.row(color.cyan("Model"), args.flags.model ?? "")
+      t.row(color.cyan("Fast Model"), args.flags.fastmodel ?? "")
+      t.row(color.cyan("Slow Model"), args.flags.slowmodel ?? "")
+      t.row(color.cyan("Provider"), args.flags.provider ?? "")
+      t.row(color.cyan("Subagent"), args.flags.agent ?? "")
+      t.row(color.cyan("Policy"), args.flags.policy ?? "")
+      t.row(color.cyan("Agent Home"), args.flags["agent-home"] ?? "")
+      t.row(color.cyan("Working Dir"), args.flags.workdir ?? "")
+      t.row(color.cyan("Config"), args.flags.config ?? "")
+      t.row(color.cyan("Trace"), args.flags.trace ?? "")
+      t.row(color.cyan("Log"), args.flags.log ?? "")
+      t.row(
+        color.cyan("Max Tool Call Rounds"),
+        args.flags["max-tool-call-rounds"] ?? "",
+      )
+      t.row(
+        color.cyan("Max Tool Result Chars"),
+        args.flags["max-tool-result-chars"] ?? "",
+      )
+    }
+  }
+  left.text(render(argsTable))
+
+  //  heading(left, "Brain")
+  //  left.text(brainName, dim: true)
 }

--- a/packages/agency-lang/lib/agents/agency-agent/lib/sessionTitle.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/sessionTitle.agency
@@ -77,6 +77,7 @@ export def titleFor(text: string): string {
 }
 
 def titleCall(text: string): string {
+  let out: Result<Titled> = failure("session title call did not run")
   thread(label: "sessionTitle", session: "sessionTitle") {
     const titled: Titled! = llm(
       """
@@ -91,7 +92,7 @@ def titleCall(text: string): string {
     )
     out = titled
   }
-  return match(titled) {
+  return match(out) {
     success(value) => cleanTitle(value.title)
     failure(reason) => ""
   }

--- a/packages/agency-lang/lib/agents/agency-agent/lib/sessionTitle.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/sessionTitle.agency
@@ -56,6 +56,9 @@ static const MAX_TITLE_CHARS = 80
 /** The model's title as one plain line: whitespace runs collapsed,
   control characters dropped, cut to MAX_TITLE_CHARS. */
 export def cleanTitle(raw: string): string {
+  if (raw == null) {
+    return ""
+  }
   const oneLine = raw.replace(re/[\x00-\x1f\x7f]+/g, " ").replace(re/\s+/g, " ").trim()
   return oneLine.slice(0, MAX_TITLE_CHARS)
 }
@@ -74,9 +77,8 @@ export def titleFor(text: string): string {
 }
 
 def titleCall(text: string): string {
-  let out: Titled = { title: "" }
   thread(label: "sessionTitle", session: "sessionTitle") {
-    const titled: Titled = llm(
+    const titled: Titled! = llm(
       """
       Write a title for this conversation, at most eight words, as a
       short noun phrase a person could pick out of a list. No quotes,
@@ -89,5 +91,8 @@ def titleCall(text: string): string {
     )
     out = titled
   }
-  return cleanTitle(out.title)
+  return match(titled) {
+    success(value) => cleanTitle(value.title)
+    failure(reason) => ""
+  }
 }

--- a/packages/agency-lang/lib/agents/agency-agent/lib/turn.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/turn.agency
@@ -86,10 +86,10 @@ export def resolveBrainName(flag: string | null, settings: Settings): string {
   return DEFAULT_BRAIN
 }
 
-def buildBrainContext(interactive: boolean): BrainContext {
+def buildBrainContext(interactive: boolean, brainName: string): BrainContext {
   return {
     interactive: interactive,
-    grounding: groundingText()
+    grounding: groundingText(brainName)
   }
 }
 
@@ -116,7 +116,7 @@ export def runSession(interactive: boolean, body: () -> void raises <*>) {
     throw(NO_BRAIN)
     return
   }
-  const context = buildBrainContext(interactive)
+  const context = buildBrainContext(interactive, brain.name)
   const handler = policyHandlerFor(interactive)
   handle {
     brain.init(context)

--- a/packages/agency-lang/lib/agents/agency-agent/tests/grounding.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/grounding.agency
@@ -1,0 +1,51 @@
+/*
+ * Tests for sessionFactsText: the identity block names the agent and its
+ * brain, lists the resolved models with the internal openai-responses
+ * provider demoted to the public name, and skips slots that did not
+ * resolve.
+ */
+import { sessionFactsText } from "../lib/grounding.agency"
+import { Resolved } from "../lib/models.agency"
+
+static const SLOTS: Record<string, Resolved> = {
+  main: {
+    model: "claude-sonnet-5",
+    provider: "anthropic",
+    via: "x"
+  },
+  reasoning: {
+    model: "gpt-5.6-sol",
+    provider: "openai-responses",
+    via: "x"
+  }
+}
+
+static const NO_ARGS: Record<string, any> = {}
+
+node namesTheAgentAndBrain(): boolean {
+  const text = sessionFactsText("coordinator", SLOTS, NO_ARGS)
+  const hasAgent = text.includes("Your Name: Agency agent")
+  const hasBrain = text.includes("Brain: coordinator")
+  return hasAgent && hasBrain
+}
+
+node listsModelsWithDemotedProvider(): boolean {
+  const text = sessionFactsText("coordinator", SLOTS, NO_ARGS)
+  const hasMain = text.includes("main model: claude-sonnet-5 (provider: anthropic)")
+  const hasReasoning = text.includes("reasoning model: gpt-5.6-sol (provider: openai)")
+  return hasMain && hasReasoning
+}
+
+node skipsUnresolvedSlots(): boolean {
+  const onlyMain: Record<string, Resolved> = {
+    main: {
+      model: "z-ai/glm-5.3",
+      provider: "openrouter",
+      via: "x"
+    }
+  }
+  const text = sessionFactsText("simple", onlyMain, NO_ARGS)
+  const hasMain = text.includes("main model: z-ai/glm-5.3 (provider: openrouter)")
+  const noReasoning = !text.includes("reasoning model:")
+  return hasMain && noReasoning
+}

--- a/packages/agency-lang/lib/agents/agency-agent/tests/grounding.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/grounding.test.json
@@ -1,0 +1,23 @@
+{
+  "sourceFile": "grounding.agency",
+  "tests": [
+    {
+      "nodeName": "namesTheAgentAndBrain",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "listsModelsWithDemotedProvider",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "skipsUnresolvedSlots",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/lib/agents/agency-agent/tests/registry.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/registry.agency
@@ -1,8 +1,5 @@
-import {
-  brainByName,
-  allBrains,
-  brainFlagHelp,
- } from "../brains/registry.agency"
+import { brainByName, allBrains } from "../brains/registry.agency"
+import { brainFlagHelp } from "../lib/args.agency"
 
 node knownBrainResolves(): string {
   const brain = brainByName("coordinator")

--- a/packages/agency-lang/lib/preprocessors/importResolver.test.ts
+++ b/packages/agency-lang/lib/preprocessors/importResolver.test.ts
@@ -441,6 +441,22 @@ describe("resolveImports", () => {
     }
   });
 
+  it("import test keeps testOnly on the rebuilt statement", () => {
+    // The typechecker runs over the preprocessed AST in the test harness;
+    // if the rebuild drops testOnly, a non-exported import trips AG4010.
+    const program: AgencyProgram = {
+      type: "agencyProgram",
+      nodes: [testImport(["helper"], "./utils.agency")],
+    };
+    const symbolTable = table({
+      "/project/utils.agency": { helper: fn("helper", { exported: false }) },
+    });
+    const result = resolveImports(program, symbolTable, "/project/main.agency", {
+      allowTestImports: true,
+    });
+    expect((result.nodes[0] as ImportStatement).testOnly).toBe(true);
+  });
+
   it("import test bypasses the export check for a non-exported type in test mode", () => {
     const program: AgencyProgram = {
       type: "agencyProgram",

--- a/packages/agency-lang/lib/preprocessors/importResolver.ts
+++ b/packages/agency-lang/lib/preprocessors/importResolver.ts
@@ -315,6 +315,11 @@ function resolveImportStatement(
       modulePath: node.modulePath,
       isAgencyImport: true,
     };
+    // Keep `testOnly` and `loc` from the source statement: the typechecker
+    // runs over this rebuilt AST in the test harness, and without them an
+    // `import test` of a non-exported symbol trips AG4010 with no location.
+    if (node.testOnly) importStmt.testOnly = true;
+    if (node.loc) importStmt.loc = node.loc;
     out.push(importStmt);
   }
 

--- a/packages/agency-lang/lib/stdlib/layout.test.ts
+++ b/packages/agency-lang/lib/stdlib/layout.test.ts
@@ -187,6 +187,15 @@ describe("resolveSizes", () => {
     expect(resolved.children[0].attrs.wrapWidth).toBe(28);
   });
 
+  test('box borderStyle "none" reserves no frame cells for its child', () => {
+    const tree = node("box", { width: 30, borderStyle: "none" }, [
+      node("text", { content: "the quick brown fox" }),
+    ]);
+    const resolved = _internal.resolveSizes(tree, { cols: 80, rows: 24 });
+    // Framed would be 28 (30 − 2 border cells); frameless keeps the full 30.
+    expect(resolved.children[0].attrs.wrapWidth).toBe(30);
+  });
+
   test("unsized container inherits constrained parent context", () => {
     const tree = node("box", { width: "full" }, [
       node("row", {}, [node("box", { width: "50%" }, []), node("box", { width: "50%" }, [])]),

--- a/packages/agency-lang/lib/stdlib/layout.test.ts
+++ b/packages/agency-lang/lib/stdlib/layout.test.ts
@@ -501,6 +501,20 @@ describe("bordered (no title)", () => {
       ["┌──┐", "│aa│", "│b │", "└──┘"].join("\n"),
     );
   });
+  test('borderStyle "none" draws no frame, keeps padding and target width', () => {
+    expect(bordered(Block.of("hi"), { borderStyle: "none" }).toString()).toBe("hi");
+    expect(bordered(Block.of("hi"), { borderStyle: "none", padding: 1 }).toString()).toBe(
+      "    \n hi \n    ",
+    );
+    const sized = bordered(Block.of("hi"), { borderStyle: "none", targetWidth: 6 });
+    expect(sized.width).toBe(6);
+    expect(sized.toString()).toBe("hi    ");
+  });
+
+  test('borderStyle "none" renders a title as a plain first line', () => {
+    expect(bordered(Block.of("hi"), { borderStyle: "none", title: "T" }).toString()).toBe("T \nhi");
+  });
+
   test("unknown borderStyle falls back to light + warns once", () => {
     const warns: string[] = [];
     const orig = console.warn;
@@ -1204,6 +1218,110 @@ describe("table — composeTable rendering", () => {
         body: [["1", "2"]],
       }),
     ).toBe("╭───╮\n" + "│A│B│\n" + "├─┼─┤\n" + "│1│2│\n" + "╰───╯");
+  });
+
+  test('borderStyle: "none" renders cells with no frame', () => {
+    expect(
+      renderTablePlain({
+        borderStyle: "none",
+        body: [
+          ["1", "2"],
+          ["3", "4"],
+        ],
+      }),
+    ).toBe(" 1 │ 2 \n" + " 3 │ 4 ");
+  });
+
+  test('borderStyle: "none" keeps interior dividers, drawn without end tees', () => {
+    expect(
+      renderTablePlain({
+        borderStyle: "none",
+        header: ["A", "B"],
+        body: [["1", "2"]],
+      }),
+    ).toBe(" A │ B \n" + "───┼───\n" + " 1 │ 2 ");
+  });
+
+  test("columnGap separates columns when dividers are off, even past minWidth", () => {
+    // The label column's content (15 cells) exceeds minWidth 13; without a
+    // gap the columns would run together.
+    expect(
+      renderTablePlain({
+        borderStyle: "none",
+        columnDividers: false,
+        cellPadding: 0,
+        columnGap: 1,
+        columns: [{ minWidth: 13 }, {}],
+        body: [
+          ["Brain", "coordinator"],
+          ["Reasoning Model", "claude-opus-4-8"],
+        ],
+      }),
+    ).toBe("Brain           coordinator    \n" + "Reasoning Model claude-opus-4-8");
+  });
+
+  test("columnGap also spaces the section divider line and framed rows", () => {
+    expect(
+      renderTablePlain({
+        columnDividers: false,
+        cellPadding: 0,
+        columnGap: 2,
+        header: ["A", "B"],
+        body: [["1", "2"]],
+      }),
+    ).toBe("╭────╮\n" + "│A  B│\n" + "├────┤\n" + "│1  2│\n" + "╰────╯");
+  });
+
+  test("columnGap is ignored while columnDividers is on", () => {
+    expect(
+      renderTablePlain({
+        columnGap: 3,
+        header: ["A", "B"],
+        body: [["1", "2"]],
+      }),
+    ).toBe("╭───────╮\n" + "│ A │ B │\n" + "├───┼───┤\n" + "│ 1 │ 2 │\n" + "╰───────╯");
+  });
+
+  test('borderStyle: "none" + columnDividers: false + cellPadding: 0 is bare aligned text', () => {
+    expect(
+      renderTablePlain({
+        borderStyle: "none",
+        columnDividers: false,
+        cellPadding: 0,
+        body: [
+          ["ID", "Alice"],
+          ["2", "B"],
+        ],
+      }),
+    ).toBe("IDAlice\n" + "2 B    ");
+  });
+
+  test('borderStyle: "none" title renders as its own row, no top edge', () => {
+    const out = renderTablePlain({
+      borderStyle: "none",
+      title: "T",
+      columnDividers: false,
+      body: [["1", "2"]],
+    });
+    expect(out).toBe("T     \n" + " 1  2 ");
+  });
+
+  test('borderStyle: "none" reserves no frame cells in width resolution', () => {
+    expect(_internal._tableChromeWidth(3, 1, true, false)).toBe(8);
+    // Fixed-width frameless table: every line pads to the full width,
+    // and the "full" column gets the 2 cells a frame would have taken.
+    // available = 20 - 0 border - 4 padding - 1 divider = 15; col0
+    // fixed=4, col1 "full" = 11.
+    const tree = tableNode({
+      borderStyle: "none",
+      width: 20,
+      columns: [{ width: 4 }, { width: "full" }],
+      body: [["a", "b"]],
+    });
+    const resolved = _internal.resolveSizes(tree, { cols: 80, rows: 24 });
+    expect(resolved.attrs.resolvedColumnWidths).toEqual([4, 11]);
+    const lines = renderTablePlain(resolved.attrs as Record<string, unknown>).split("\n");
+    expect(lines.map(_internal.visualWidth)).toEqual([20]);
   });
 
   test("borderStyle: heavy uses thick chars on outer border", () => {

--- a/packages/agency-lang/lib/stdlib/layout.test.ts
+++ b/packages/agency-lang/lib/stdlib/layout.test.ts
@@ -524,6 +524,18 @@ describe("bordered (no title)", () => {
     expect(bordered(Block.of("hi"), { borderStyle: "none", title: "T" }).toString()).toBe("T \nhi");
   });
 
+  test('borderStyle "none" wraps an over-wide title to the target width', () => {
+    const out = bordered(Block.of("hi"), {
+      borderStyle: "none",
+      title: "a very long title",
+      targetWidth: 6,
+    });
+    expect(out.width).toBe(6);
+    for (const line of out.lines) {
+      expect(_internal.visualWidth(line)).toBeLessThanOrEqual(6);
+    }
+  });
+
   test("unknown borderStyle falls back to light + warns once", () => {
     const warns: string[] = [];
     const orig = console.warn;
@@ -1313,6 +1325,20 @@ describe("table — composeTable rendering", () => {
       body: [["1", "2"]],
     });
     expect(out).toBe("T     \n" + " 1  2 ");
+  });
+
+  test('borderStyle: "none" wraps an over-wide title to a fixed table width', () => {
+    const tree = tableNode({
+      borderStyle: "none",
+      width: 10,
+      title: "a very long table title",
+      body: [["x", "y"]],
+    });
+    const resolved = _internal.resolveSizes(tree, { cols: 80, rows: 24 });
+    const lines = renderTablePlain(resolved.attrs as Record<string, unknown>).split("\n");
+    for (const line of lines) {
+      expect(_internal.visualWidth(line)).toBeLessThanOrEqual(10);
+    }
   });
 
   test('borderStyle: "none" reserves no frame cells in width resolution', () => {

--- a/packages/agency-lang/lib/stdlib/layout/border.ts
+++ b/packages/agency-lang/lib/stdlib/layout/border.ts
@@ -8,7 +8,11 @@
 import { Style, styledWrapper, visualWidth, wrapText } from "./ansi.js";
 import { Align, Block, above, pad, padLine, styled } from "./block.js";
 
-export type BorderStyle = "rounded" | "heavy" | "double" | "light";
+export type BorderStyle = "rounded" | "heavy" | "double" | "light" | "none";
+
+// Styles that actually draw a frame. `"none"` renders no frame at all,
+// so it has no entry in `BORDER_CHARS`.
+export type FramedBorderStyle = Exclude<BorderStyle, "none">;
 
 export type BorderChars = {
   // Corners + edges of the outer frame.
@@ -27,7 +31,7 @@ export type BorderChars = {
   rightTee: string;
 };
 
-export const BORDER_CHARS: Record<BorderStyle, BorderChars> = {
+export const BORDER_CHARS: Record<FramedBorderStyle, BorderChars> = {
   rounded: {
     tl: "╭",
     tr: "╮",
@@ -77,6 +81,7 @@ export const BORDER_CHARS: Record<BorderStyle, BorderChars> = {
 const warnedUnknownStyles = new Set<string>();
 export function resolveBorderStyle(s: string | undefined): BorderStyle {
   if (s == null || s === "") return "rounded";
+  if (s === "none") return "none";
   // `Object.hasOwn` (not `in`) so we don't traverse the prototype
   // chain — otherwise `"__proto__" in BORDER_CHARS` is truthy and
   // would hand back `Object.prototype` to the renderer, which crashes
@@ -104,6 +109,13 @@ export type BorderOpts = {
 // Number of cells a single `│`-style side border takes (one on each
 // side, so a framed box is `BORDER_CELLS` wider than its inner content).
 export const BORDER_CELLS = 2;
+
+// Horizontal cells the frame of `style` occupies: 0 for `"none"`,
+// `BORDER_CELLS` otherwise. Width math in box and table goes through
+// this so a frameless container is genuinely narrower.
+export function borderCells(style: BorderStyle): number {
+  return style === "none" ? 0 : BORDER_CELLS;
+}
 
 // Minimum inner width required to fit a title embedded in the top edge.
 // The top edge is `tl + h + " Title " + h*N + tr` — so we need at least
@@ -149,11 +161,22 @@ function withPaddingApplied(block: Block, padding: number): Block {
 }
 
 export function bordered(block: Block, opts: BorderOpts): Block {
-  const borderChars = BORDER_CHARS[resolveBorderStyle(opts.borderStyle)];
+  const style = resolveBorderStyle(opts.borderStyle);
   const padding = opts.padding ?? 0;
   const titleText = opts.title ?? "";
   const padded = withPaddingApplied(block, padding);
 
+  // Frameless: padding still applies, and a title becomes a plain
+  // styled first line instead of living in a top edge.
+  if (style === "none") {
+    const titleStyle: Style = opts.titleColor ? { fgColor: opts.titleColor } : {};
+    const titled =
+      titleText === "" ? padded : above(styled(Block.of(titleText), titleStyle), padded);
+    if (opts.targetWidth === undefined) return titled;
+    return pad(titled, opts.targetWidth, titled.height, "start", "start");
+  }
+
+  const borderChars = BORDER_CHARS[style];
   if (opts.targetWidth !== undefined) {
     const innerWidth = Math.max(0, opts.targetWidth - BORDER_CELLS);
     const titleStyle: Style = opts.titleColor ? { fgColor: opts.titleColor } : {};

--- a/packages/agency-lang/lib/stdlib/layout/border.ts
+++ b/packages/agency-lang/lib/stdlib/layout/border.ts
@@ -167,11 +167,14 @@ export function bordered(block: Block, opts: BorderOpts): Block {
   const padded = withPaddingApplied(block, padding);
 
   // Frameless: padding still applies, and a title becomes a plain
-  // styled first line instead of living in a top edge.
+  // styled first line instead of living in a top edge — wrapped to the
+  // target width, since nothing downstream shrinks an over-wide line.
   if (style === "none") {
     const titleStyle: Style = opts.titleColor ? { fgColor: opts.titleColor } : {};
+    const titleLines =
+      opts.targetWidth !== undefined ? wrapText(titleText, opts.targetWidth) : titleText;
     const titled =
-      titleText === "" ? padded : above(styled(Block.of(titleText), titleStyle), padded);
+      titleText === "" ? padded : above(styled(Block.of(titleLines), titleStyle), padded);
     if (opts.targetWidth === undefined) return titled;
     return pad(titled, opts.targetWidth, titled.height, "start", "start");
   }

--- a/packages/agency-lang/lib/stdlib/layout/box.ts
+++ b/packages/agency-lang/lib/stdlib/layout/box.ts
@@ -5,7 +5,7 @@
 // stack vertically inside the frame.
 
 import { Block } from "./block.js";
-import { BORDER_CELLS, BorderStyle, bordered } from "./border.js";
+import { BorderStyle, borderCells, bordered, resolveBorderStyle } from "./border.js";
 import { LayoutNode } from "./nodes.js";
 import { growToWidth, renderNode } from "./render.js";
 import {
@@ -40,7 +40,10 @@ export function composeBox(node: LayoutNode): Block {
 function sizeBox(node: LayoutNode, ctx: SizingContext): LayoutNode {
   const own = resolveOwnWidth(node, ctx);
   const padding = nonNegativeInteger(node.attrs.padding);
-  const chrome = BORDER_CELLS + 2 * padding;
+  // A frameless box ("none") reserves no side-border cells, so its
+  // children get the full width the frame would have taken.
+  const style = resolveBorderStyle(node.attrs.borderStyle as string | undefined);
+  const chrome = borderCells(style) + 2 * padding;
   const inner = innerWidthAfterChrome(own, chrome);
   // Box children either occupy the inner width directly (single child)
   // or are wrapped in an implicit column, which itself fills the inner

--- a/packages/agency-lang/lib/stdlib/layout/table.ts
+++ b/packages/agency-lang/lib/stdlib/layout/table.ts
@@ -16,7 +16,7 @@
 // both consume the same `ColumnLayout[]`, so a change to one stays in
 // sync with the other automatically.
 
-import { Style, styledWrapper, visualWidth } from "./ansi.js";
+import { Style, styledWrapper, visualWidth, wrapText } from "./ansi.js";
 import { Align, Block, above, beside, pad, padLine, styled } from "./block.js";
 import {
   BORDER_CELLS,
@@ -582,10 +582,14 @@ export function composeTable(node: LayoutNode): Block {
   // width; otherwise the table is free to grow to fit the title. With
   // no frame there is no top edge, so a title always renders as its own
   // row above the cells.
+  // In the resolved-width case the title wraps to innerWidth: nothing
+  // downstream shrinks an over-wide line, so an unwrapped title would
+  // push the table past its declared width.
+  const framelessTitle = resolved !== undefined ? wrapText(title, innerWidth) : title;
   const placement = !framed
     ? title === ""
       ? { kind: "top" as const, title: "" }
-      : { kind: "wrapped" as const, block: styled(Block.of(title), titleStyle) }
+      : { kind: "wrapped" as const, block: styled(Block.of(framelessTitle), titleStyle) }
     : resolved === undefined
       ? { kind: "top" as const, title }
       : placeTitle(title, innerWidth, titleStyle);

--- a/packages/agency-lang/lib/stdlib/layout/table.ts
+++ b/packages/agency-lang/lib/stdlib/layout/table.ts
@@ -220,10 +220,28 @@ export function _tableChromeWidth(
   columnCount: number,
   cellPadding: number,
   columnDividers: boolean,
+  framed: boolean = true,
+  columnGap: number = 0,
 ): number {
   const padding = columnCount * 2 * cellPadding;
-  const dividers = columnDividers ? Math.max(0, columnCount - 1) : 0;
-  return BORDER_CELLS + padding + dividers;
+  const separators = Math.max(0, columnCount - 1) * _separatorWidth(columnDividers, columnGap);
+  return (framed ? BORDER_CELLS : 0) + padding + separators;
+}
+
+function _isFramed(attrs: Record<string, unknown>): boolean {
+  return resolveBorderStyle((attrs.borderStyle as string | undefined) ?? "rounded") !== "none";
+}
+
+// Cells between adjacent columns: the 1-cell `│` divider when
+// columnDividers is on, else `columnGap` spaces. One home for the rule so
+// the chrome math, the row renderer, and the divider line stay in sync.
+function _separatorWidth(columnDividers: boolean, columnGap: number): number {
+  return columnDividers ? 1 : columnGap;
+}
+
+function clampColumnGap(raw: unknown): number {
+  const value = (raw as number | undefined) ?? 0;
+  return Math.max(0, Math.floor(Number.isFinite(value) ? value : 0));
 }
 
 type TableSections = {
@@ -246,7 +264,13 @@ export function _resolveTableWidths(
   const cellPadding = clampCellPadding(attrs.cellPadding);
   const columnDividers = (attrs.columnDividers as boolean | undefined) ?? true;
   const sections: TableSections = { header, body, footer };
-  const chrome = _tableChromeWidth(columnCount, cellPadding, columnDividers);
+  const chrome = _tableChromeWidth(
+    columnCount,
+    cellPadding,
+    columnDividers,
+    _isFramed(attrs),
+    clampColumnGap(attrs.columnGap),
+  );
   const available = resolvedWidth !== undefined ? Math.max(0, resolvedWidth - chrome) : undefined;
 
   const plan = planColumns(columns, columnCount, sections);
@@ -309,9 +333,13 @@ function annotateCellsWithWrap(
   };
 }
 
-function _innerTableWidth(layouts: ColumnLayout[], columnDividers: boolean): number {
+function _innerTableWidth(
+  layouts: ColumnLayout[],
+  columnDividers: boolean,
+  columnGap: number,
+): number {
   const cellsW = layouts.reduce((s, l) => s + l.width + 2 * l.cellPadding, 0);
-  return cellsW + (columnDividers ? Math.max(0, layouts.length - 1) : 0);
+  return cellsW + Math.max(0, layouts.length - 1) * _separatorWidth(columnDividers, columnGap);
 }
 
 // Pad a cell to its column's content width with the column's
@@ -331,17 +359,19 @@ function _composeRowBlock(
   cells: Block[],
   layouts: ColumnLayout[],
   columnDividers: boolean,
+  columnGap: number,
   dividerChar: string,
   wrapBorder: (s: string) => string,
 ): Block {
   const rowHeight = cells.reduce((m, b) => Math.max(m, b.height), 1);
   const paddedCells = cells.map((b, c) => _layoutCell(b, layouts[c], rowHeight));
-  if (!columnDividers || paddedCells.length <= 1) {
+  const separator = columnDividers ? wrapBorder(dividerChar) : " ".repeat(columnGap);
+  if (separator === "" || paddedCells.length <= 1) {
     return paddedCells.reduce(beside, Block.empty());
   }
-  const dividerBlock = Block.of(Array(rowHeight).fill(wrapBorder(dividerChar)));
+  const separatorBlock = Block.of(Array(rowHeight).fill(separator));
   return paddedCells.reduce<Block>(
-    (acc, cell, i) => (i === 0 ? cell : beside(beside(acc, dividerBlock), cell)),
+    (acc, cell, i) => (i === 0 ? cell : beside(beside(acc, separatorBlock), cell)),
     Block.empty(),
   );
 }
@@ -354,14 +384,18 @@ function _composeRowBlock(
 function _composeDividerLine(
   layouts: ColumnLayout[],
   columnDividers: boolean,
+  columnGap: number,
   innerWidth: number,
   ch: BorderChars,
   wrapBorder: (s: string) => string,
+  framed: boolean,
 ): Block {
   const runs = layouts.map((l) => ch.h.repeat(l.width + 2 * l.cellPadding));
-  const inner = columnDividers ? runs.join(ch.cross) : runs.join("");
+  const joiner = columnDividers ? ch.cross : ch.h.repeat(columnGap);
+  const inner = runs.join(joiner);
   const padding = ch.h.repeat(Math.max(0, innerWidth - visualWidth(inner)));
-  return Block.of(wrapBorder(ch.leftTee + inner + padding + ch.rightTee));
+  const line = framed ? ch.leftTee + inner + padding + ch.rightTee : inner + padding;
+  return Block.of(wrapBorder(line));
 }
 
 // Tags that act as explicit opt-outs of header auto-bold. Agency's
@@ -474,11 +508,16 @@ export function composeTable(node: LayoutNode): Block {
   const cellPadding = clampCellPadding(attrs.cellPadding);
   const columns = (attrs.columns as ColumnSpec[] | null) ?? [];
   const columnDividers = (attrs.columnDividers as boolean) ?? true;
+  const columnGap = clampColumnGap(attrs.columnGap);
   const headerDivider = (attrs.headerDivider as boolean) ?? true;
   const footerDivider = (attrs.footerDivider as boolean) ?? true;
   const rowDividers = (attrs.rowDividers as boolean) ?? false;
   const borderStyleKey = resolveBorderStyle((attrs.borderStyle as string | undefined) ?? "rounded");
-  const ch = BORDER_CHARS[borderStyleKey];
+  const framed = borderStyleKey !== "none";
+  // Interior dividers (header / row / column) are governed by their own
+  // flags, so a frameless table still honours them; they borrow the
+  // light chars since "none" has no chars of its own.
+  const ch = BORDER_CHARS[framed ? borderStyleKey : "light"];
   const borderColor = (attrs.borderColor as string | undefined) ?? "";
   const titleColor = (attrs.titleColor as string | undefined) ?? "";
   const title = (attrs.title as string | undefined) ?? "";
@@ -514,9 +553,10 @@ export function composeTable(node: LayoutNode): Block {
 
   // A wide title may grow innerWidth beyond the cell grid; dividers and
   // row wrappers both honour that final width so everything lines up.
-  const cellsWidth = _innerTableWidth(layouts, columnDividers);
-  const titleFloor = resolved === undefined && title !== "" ? minWidthForTitle(title) : 0;
-  const resolvedInner = resolved !== undefined ? Math.max(0, resolved - BORDER_CELLS) : 0;
+  const cellsWidth = _innerTableWidth(layouts, columnDividers, columnGap);
+  const titleFloor = framed && resolved === undefined && title !== "" ? minWidthForTitle(title) : 0;
+  const resolvedInner =
+    resolved !== undefined ? Math.max(0, resolved - (framed ? BORDER_CELLS : 0)) : 0;
   const innerWidth = Math.max(cellsWidth, titleFloor, resolvedInner);
 
   // Build flat declarative list of section parts, then render each
@@ -526,42 +566,46 @@ export function composeTable(node: LayoutNode): Block {
     footerDivider,
     rowDividers,
   });
+  // Frameless rows still pad out to `innerWidth` so a resolved width or
+  // a wide divider keeps every line the same length.
+  const wrapRow = (rowBlock: Block): Block =>
+    framed
+      ? _wrapRowSides(rowBlock, innerWidth, ch, wrapBorder)
+      : Block.of(rowBlock.lines.map((l) => padLine(l, innerWidth, "start")));
   const renderPart = (part: SectionPart): Block =>
     part.kind === "divider"
-      ? _composeDividerLine(layouts, columnDividers, innerWidth, ch, wrapBorder)
-      : _wrapRowSides(
-          _composeRowBlock(part.cells, layouts, columnDividers, ch.v, wrapBorder),
-          innerWidth,
-          ch,
-          wrapBorder,
-        );
+      ? _composeDividerLine(layouts, columnDividers, columnGap, innerWidth, ch, wrapBorder, framed)
+      : wrapRow(_composeRowBlock(part.cells, layouts, columnDividers, columnGap, ch.v, wrapBorder));
   // A title that doesn't fit on the top edge gets wrapped inside the
   // frame as its own section. Same rule the box renderer uses (via
   // `placeTitle` in border.ts) — but only when the table has a resolved
-  // width; otherwise the table is free to grow to fit the title.
-  const placement =
-    resolved === undefined
+  // width; otherwise the table is free to grow to fit the title. With
+  // no frame there is no top edge, so a title always renders as its own
+  // row above the cells.
+  const placement = !framed
+    ? title === ""
+      ? { kind: "top" as const, title: "" }
+      : { kind: "wrapped" as const, block: styled(Block.of(title), titleStyle) }
+    : resolved === undefined
       ? { kind: "top" as const, title }
       : placeTitle(title, innerWidth, titleStyle);
-  const titleRows =
-    placement.kind === "wrapped"
-      ? [_wrapRowSides(placement.block, innerWidth, ch, wrapBorder)]
-      : [];
+  const titleRows = placement.kind === "wrapped" ? [wrapRow(placement.block)] : [];
   const topTitle = placement.kind === "top" ? placement.title : "";
   const sectionBlocks = [...titleRows, ...sectionParts.map(renderPart)];
 
-  // Outer frame (top + bottom edges).
+  // Outer frame (top + bottom edges), skipped entirely for "none".
   const topEdge = Block.of(buildTopEdge(ch, innerWidth, wrapBorder, topTitle, titleStyle));
   const bottomEdge = Block.of(wrapBorder(ch.bl + ch.h.repeat(innerWidth) + ch.br));
-  const framed = [topEdge, ...sectionBlocks, bottomEdge].reduce(above, Block.empty());
+  const stacked = framed ? [topEdge, ...sectionBlocks, bottomEdge] : sectionBlocks;
+  const composed = stacked.reduce(above, Block.empty());
 
   // Optional caption below. Append directly via Block construction
   // (not `above`) — `_composeCaption` returns a trimmed-trailing-space
   // line, and routing it through `above` would re-pad it back out to
   // the framed width.
-  const captionBlock = _composeCaption(caption, framed.width);
+  const captionBlock = _composeCaption(caption, composed.width);
   const withCaption =
-    captionBlock === null ? framed : Block.of([...framed.lines, ...captionBlock.lines]);
+    captionBlock === null ? composed : Block.of([...composed.lines, ...captionBlock.lines]);
   return resolved !== undefined ? growToWidth(withCaption, resolved) : withCaption;
 }
 

--- a/packages/agency-lang/scripts/stage-agents.mjs
+++ b/packages/agency-lang/scripts/stage-agents.mjs
@@ -12,7 +12,8 @@
 //      module that imports symbols its source no longer defines (#498).
 //      Handwritten `.js` helpers (no `.agency` sibling) are still copied.
 //   2. delete dest files whose source counterpart is gone — a deleted
-//      foo.agency takes its compiled foo.js with it;
+//      foo.agency takes its compiled foo.js with it — and any
+//      previously staged file under a `tests/` directory (see isTestPath);
 //   3. never touch dest/docs/ (owned by the stage-agent-docs recipe) and
 //      never delete a compiled .js whose .agency source survives.
 // Orphan safety is double-covered: this sync deletes orphans, and publish
@@ -37,11 +38,22 @@ function walk(dir, out = []) {
   return out;
 }
 
+// Agent test files (any `tests/` directory) are never staged: they are only
+// compiled by `agency test`, which runs them from the SOURCE tree under the
+// test harness. Staging them made `make` compile them outside the harness,
+// where `import test` is rejected, and shipped test code in dist.
+function isTestPath(rel) {
+  return rel.split(path.sep).includes("tests");
+}
+
 export function syncAgents(srcDir, destDir) {
   fs.mkdirSync(destDir, { recursive: true });
   let copied = 0;
   for (const srcFile of walk(srcDir)) {
     const rel = path.relative(srcDir, srcFile);
+    if (isTestPath(rel)) {
+      continue;
+    }
     // Never stage a compiled `.js` whose `.agency` sibling lives in src:
     // it is stale build litter, and copying it would clobber the
     // compiler-owned dest output the incremental skip trusts (see rule 1).
@@ -57,6 +69,13 @@ export function syncAgents(srcDir, destDir) {
   for (const destFile of walk(destDir)) {
     const rel = path.relative(destDir, destFile);
     if (rel === "docs" || rel.startsWith(`docs${path.sep}`)) {
+      continue;
+    }
+    // Previously-staged test files (and their compiled outputs) are
+    // orphans under the no-tests rule, whether or not the source survives.
+    if (isTestPath(rel)) {
+      fs.unlinkSync(destFile);
+      deleted.push(rel);
       continue;
     }
     if (fs.existsSync(path.join(srcDir, rel))) {

--- a/packages/agency-lang/scripts/stage-agents.test.ts
+++ b/packages/agency-lang/scripts/stage-agents.test.ts
@@ -49,6 +49,29 @@ describe("syncAgents", () => {
     );
   });
 
+  test("never stages tests/ directories, and removes previously staged ones", () => {
+    // Tests are only compiled by `agency test` from the source tree; staging
+    // them made `make` compile them outside the harness, where `import test`
+    // is rejected.
+    const src = tree({
+      "agency-agent/agent.agency": "src",
+      "agency-agent/tests/turn.agency": "test-src",
+      "agency-agent/tests/turn.test.json": "{}",
+      "agency-agent/brains/coordinator/tests/agentTurn.agency": "test-src",
+    });
+    const dest = tree({
+      "agency-agent/tests/turn.agency": "previously-staged",
+      "agency-agent/tests/turn.js": "previously-compiled",
+    });
+    syncAgents(src, dest);
+    expect(fs.readFileSync(path.join(dest, "agency-agent/agent.agency"), "utf-8")).toBe("src");
+    // Files are removed; the emptied directory itself may linger, which the
+    // directory compile treats as nothing to do.
+    expect(fs.existsSync(path.join(dest, "agency-agent/tests/turn.agency"))).toBe(false);
+    expect(fs.existsSync(path.join(dest, "agency-agent/tests/turn.js"))).toBe(false);
+    expect(fs.existsSync(path.join(dest, "agency-agent/brains/coordinator/tests"))).toBe(false);
+  });
+
   test("still copies handwritten .js helpers that have no .agency sibling", () => {
     const src = tree({ "agency-agent/toolWiring.js": "handwritten" });
     const dest = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "agency-stage-")), "dest");

--- a/packages/agency-lang/stdlib/ui/layout.agency
+++ b/packages/agency-lang/stdlib/ui/layout.agency
@@ -52,7 +52,7 @@ export type LayoutBuilder = {
 
 export type Alignment = "start" | "center" | "end"
 
-export type BorderStyle = "rounded" | "heavy" | "double" | "light"
+export type BorderStyle = "rounded" | "heavy" | "double" | "light" | "none"
 
 export type Width = number | "full" | string
 
@@ -434,7 +434,9 @@ export def box(
 
   @param title - Text shown in the top border (empty for none)
   @param titleColor - Color of the title text
-  @param borderStyle - The border character style
+  @param borderStyle - The border character style; "none" draws no
+    frame (padding and title still apply, the title as a plain first
+    line)
   @param borderColor - Color of the border
   @param padding - Cells of padding between the border and content
   @param width - Width as a column count, "X%" of the parent, or "full" for the whole terminal (root only)

--- a/packages/agency-lang/stdlib/ui/table.agency
+++ b/packages/agency-lang/stdlib/ui/table.agency
@@ -130,6 +130,7 @@ export def table(
   footerDivider: boolean = true,
   rowDividers: boolean = false,
   columnDividers: boolean = true,
+  columnGap: number = 0,
   block: (TableBuilder) -> void = null,
 ): LayoutNode {
   """
@@ -139,7 +140,9 @@ export def table(
 
   @param title - Title shown in the top border
   @param titleColor - Color of the title text
-  @param borderStyle - Frame style
+  @param borderStyle - Frame style; "none" draws no outer frame, so the
+    cells render as plain aligned text (interior dividers still follow
+    their own flags)
   @param borderColor - Color of the border characters
   @param caption - Caption shown beneath the table
   @param cellPadding - Horizontal padding inside each cell, in cells
@@ -152,6 +155,9 @@ export def table(
   @param footerDivider - Draw a divider line above the footer
   @param rowDividers - Draw a divider between every body row
   @param columnDividers - Draw vertical dividers between columns
+  @param columnGap - Cells of blank space between adjacent columns when
+    columnDividers is false (the divider is the separator when it is on).
+    Keeps a gap even when a column grows past its minWidth.
   """
   const bodyArr: any[] = []
   if (body != null) {
@@ -189,7 +195,8 @@ export def table(
     headerDivider: headerDivider,
     footerDivider: footerDivider,
     rowDividers: rowDividers,
-    columnDividers: columnDividers
+    columnDividers: columnDividers,
+    columnGap: columnGap
   }
   if (width != null) {
     attrs.width = width

--- a/packages/agency-lang/tests/agency/layout/table-block-form.test.json
+++ b/packages/agency-lang/tests/agency/layout/table-block-form.test.json
@@ -3,7 +3,7 @@
     {
       "nodeName": "testBlockForm",
       "input": "",
-      "expectedOutput": "{\"type\":\"table\",\"attrs\":{\"title\":\"Employees\",\"titleColor\":\"\",\"borderStyle\":\"rounded\",\"borderColor\":\"\",\"caption\":\"All names are fictitious\",\"cellPadding\":1,\"columns\":[{\"align\":\"end\"},{\"align\":\"start\"},{\"align\":\"end\"}],\"header\":[\"ID\",\"Name\",\"Balance\"],\"body\":[[\"1\",\"Dave\",\"100\"],[\"2\",\"Alice\",{\"type\":\"text\",\"attrs\":{\"content\":\"-50\",\"fgColor\":\"red\",\"bgColor\":\"\",\"bold\":false,\"italic\":false,\"dim\":false,\"underline\":false,\"align\":\"start\"},\"children\":[]}]],\"footer\":[[\"\",\"Total\",\"50\"]],\"headerDivider\":true,\"footerDivider\":true,\"rowDividers\":false,\"columnDividers\":true},\"children\":[]}",
+      "expectedOutput": "{\"type\":\"table\",\"attrs\":{\"title\":\"Employees\",\"titleColor\":\"\",\"borderStyle\":\"rounded\",\"borderColor\":\"\",\"caption\":\"All names are fictitious\",\"cellPadding\":1,\"columns\":[{\"align\":\"end\"},{\"align\":\"start\"},{\"align\":\"end\"}],\"header\":[\"ID\",\"Name\",\"Balance\"],\"body\":[[\"1\",\"Dave\",\"100\"],[\"2\",\"Alice\",{\"type\":\"text\",\"attrs\":{\"content\":\"-50\",\"fgColor\":\"red\",\"bgColor\":\"\",\"bold\":false,\"italic\":false,\"dim\":false,\"underline\":false,\"align\":\"start\"},\"children\":[]}]],\"footer\":[[\"\",\"Total\",\"50\"]],\"headerDivider\":true,\"footerDivider\":true,\"rowDividers\":false,\"columnDividers\":true,\"columnGap\":0},\"children\":[]}",
       "evaluationCriteria": [{ "type": "exact" }]
     }
   ]

--- a/packages/agency-lang/tests/agency/layout/table-data-form.test.json
+++ b/packages/agency-lang/tests/agency/layout/table-data-form.test.json
@@ -3,7 +3,7 @@
     {
       "nodeName": "testDataForm",
       "input": "",
-      "expectedOutput": "{\"type\":\"table\",\"attrs\":{\"title\":\"Employees\",\"titleColor\":\"\",\"borderStyle\":\"rounded\",\"borderColor\":\"\",\"caption\":\"All names are fictitious\",\"cellPadding\":1,\"columns\":[{\"align\":\"end\"},{\"align\":\"start\"},{\"align\":\"end\"}],\"header\":[\"ID\",\"Name\",\"Balance\"],\"body\":[[\"1\",\"Dave\",\"100\"],[\"2\",\"Alice\",{\"type\":\"text\",\"attrs\":{\"content\":\"-50\",\"fgColor\":\"red\",\"bgColor\":\"\",\"bold\":false,\"italic\":false,\"dim\":false,\"underline\":false,\"align\":\"start\"},\"children\":[]}]],\"footer\":[[\"\",\"Total\",\"50\"]],\"headerDivider\":true,\"footerDivider\":true,\"rowDividers\":false,\"columnDividers\":true},\"children\":[]}",
+      "expectedOutput": "{\"type\":\"table\",\"attrs\":{\"title\":\"Employees\",\"titleColor\":\"\",\"borderStyle\":\"rounded\",\"borderColor\":\"\",\"caption\":\"All names are fictitious\",\"cellPadding\":1,\"columns\":[{\"align\":\"end\"},{\"align\":\"start\"},{\"align\":\"end\"}],\"header\":[\"ID\",\"Name\",\"Balance\"],\"body\":[[\"1\",\"Dave\",\"100\"],[\"2\",\"Alice\",{\"type\":\"text\",\"attrs\":{\"content\":\"-50\",\"fgColor\":\"red\",\"bgColor\":\"\",\"bold\":false,\"italic\":false,\"dim\":false,\"underline\":false,\"align\":\"start\"},\"children\":[]}]],\"footer\":[[\"\",\"Total\",\"50\"]],\"headerDivider\":true,\"footerDivider\":true,\"rowDividers\":false,\"columnDividers\":true,\"columnGap\":0},\"children\":[]}",
       "evaluationCriteria": [{ "type": "exact" }]
     }
   ]

--- a/packages/agency-lang/tests/agency/layout/width-sizing.test.json
+++ b/packages/agency-lang/tests/agency/layout/width-sizing.test.json
@@ -9,7 +9,7 @@
     {
       "nodeName": "testTableWidthAttr",
       "input": "",
-      "expectedOutput": "{\"type\":\"table\",\"attrs\":{\"title\":\"\",\"titleColor\":\"\",\"borderStyle\":\"rounded\",\"borderColor\":\"\",\"caption\":\"\",\"cellPadding\":1,\"columns\":null,\"header\":null,\"body\":[[\"x\"]],\"footer\":[],\"headerDivider\":true,\"footerDivider\":true,\"rowDividers\":false,\"columnDividers\":true,\"width\":24},\"children\":[]}",
+      "expectedOutput": "{\"type\":\"table\",\"attrs\":{\"title\":\"\",\"titleColor\":\"\",\"borderStyle\":\"rounded\",\"borderColor\":\"\",\"caption\":\"\",\"cellPadding\":1,\"columns\":null,\"header\":null,\"body\":[[\"x\"]],\"footer\":[],\"headerDivider\":true,\"footerDivider\":true,\"rowDividers\":false,\"columnDividers\":true,\"columnGap\":0,\"width\":24},\"children\":[]}",
       "evaluationCriteria": [{ "type": "exact" }]
     },
     {


### PR DESCRIPTION
Asked "what is your name and what model are you running on?", the agent said it could not know. Asked "how can I run you on GLM 5.3 on OpenRouter?", it refused and cited `docs/dev/...` paths the user cannot open. This PR fixes both, restyles the splash header, and adds the conversation as evals.

## The agent knows what it is

The harness-built grounding now carries a `session_facts` block: the agent's name, the brain answering turns, the resolved main/reasoning models (built from the same resolved slots the splash header shows, with the internal `openai-responses` provider demoted to `openai`), and the flags the run was started with. The coordinator prompts tell the model to answer identity and model questions from that block, and to never cite agent-bundled or repo-internal file paths - answer from the docs instead.

Two goal-judged eval tests in `evals/agency-agent/` reproduce the original conversation: `identity` (the name-and-model question) and `run-on-openrouter` (the GLM 5.3 question, which must give the `--provider openrouter --model <id>` recipe and cite no internal paths).

## Header: an aligned flags block, two new table options

The header now lists the models, budget caps, and (under `--verbose`) every startup flag as aligned label/value text. Two `std::ui/table` additions make that possible, both default-off so existing tables render unchanged:

- `borderStyle: "none"` draws no outer frame on a table or box: no edges, no side borders, and the width math reserves no frame cells. Interior dividers still follow their own flags; a title renders as a plain first row.
- `columnGap: N` puts N blank cells between adjacent columns when `columnDividers` is off. Without it, a cell that outgrew its `minWidth` rendered flush against the next column ("Reasoning Modelclaude-opus-4-8").

## Two things found along the way

- `importResolver` rebuilds each import statement and dropped its `testOnly` flag and `loc`, so the typecheck pass that `agency test` runs over the preprocessed AST reported a spurious no-location AG4010 for every `import test` of a non-exported symbol. The rebuilt statement now carries both through.
- `stage-agents.mjs` staged `lib/agents/**/tests/` into dist, where `make` compiled them outside the test harness - which rejects `import test` - and shipped test code in the published package. Staging now skips `tests/` directories and deletes previously staged ones; `agency test` keeps running them from the source tree. With that, `agentTurn.agency` reaches the now-unexported `headerModelLines` via `import test`.

## Tests

- `tests/grounding.agency`: the session-facts block names the agent, demotes the provider, skips unresolved slots.
- `layout.test.ts`: 10 new cases for `"none"` (table and box) and `columnGap`, including the exact header shape that ran together.
- `stage-agents.test.ts`: tests/ dirs are never staged and previously staged ones are removed.
- `importResolver.test.ts`: the rebuilt import keeps `testOnly`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HnpWia84urcJmjrhQGDDPx
