### PR TITLE
Accept capability set names in --approve and --reject

### DIFF
--- a/packages/agency-lang/docs/dev/agents/approval-policies.md
+++ b/packages/agency-lang/docs/dev/agents/approval-policies.md
@@ -16,15 +16,23 @@ surprised us more than once.
   when that fails too.
 - Built-ins like `with-writes` are constructed at launch with the process
   cwd baked into their dir rules.
-- `--approve <effects>` / `--reject <effects>` (both `agency run` and
-  `agency agent`) take comma- or whitespace-separated effect names and
-  overlay blanket rules ahead of whatever base the run resolved — the
-  saved file, a built-in, or a `--policy` path — with reject rules ahead
-  of approve rules, so under first-match-wins the flags outrank the base
-  and a reject outranks an approve for the same effect. On the agent the
-  overlay is session-only; the saved policy file is never written. Both
-  commands build the overlay with `policyOverlayFromFlags`
-  (`lib/runtime/policyFlags.ts`).
+- `--approve <effects>` / `--reject <effects>` (`agency run`,
+  `agency test`, and `agency agent`) take comma- or whitespace-separated
+  effect names and overlay blanket rules ahead of whatever base the run
+  resolved — the saved file, a built-in, or a `--policy` path — with
+  reject rules ahead of approve rules, so under first-match-wins the
+  flags outrank the base and a reject outranks an approve for the same
+  effect. A bare name that exactly matches a built-in capability set
+  from `std::capabilities` (e.g. `FileRead`) expands to the set's member
+  effects; any other bare name stays a plain effect name, since bare
+  effect declarations are legal and the bare `interrupt("msg")` form
+  raises the effect named `unknown`. A user effect whose bare name
+  shadows a set is unreachable from the flags — namespace user effects.
+  On the agent the overlay is session-only; the saved policy file is
+  never written. Every command builds the overlay with
+  `policyOverlayFromFlags` (`lib/runtime/policyFlags.ts`); the set table
+  is parsed from `stdlib/capabilities.agency`
+  (`lib/runtime/effectSets.ts`).
 
 In a non-interactive run (`-p`), an effect no rule decides is
 auto-rejected with an explanatory message (`stdlib/policy.agency`) — there

--- a/packages/agency-lang/docs/dev/agents/approval-policies.md
+++ b/packages/agency-lang/docs/dev/agents/approval-policies.md
@@ -17,7 +17,8 @@ surprised us more than once.
 - Built-ins like `with-writes` are constructed at launch with the process
   cwd baked into their dir rules.
 - `--approve <effects>` / `--reject <effects>` (`agency run`,
-  `agency test`, and `agency agent`) take comma- or whitespace-separated
+  `agency test`, `agency remote call`, and
+  `agency agent`) take comma- or whitespace-separated
   effect names and overlay blanket rules ahead of whatever base the run
   resolved — the saved file, a built-in, or a `--policy` path — with
   reject rules ahead of approve rules, so under first-match-wins the

--- a/packages/agency-lang/lib/agents/agency-agent/lib/args.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/args.agency
@@ -68,11 +68,11 @@ export def parseAgentArgs() {
         },
         approve: {
           type: "string",
-          description: "Comma-separated interrupt effects to auto-approve for this run (e.g. std::write,std::git::commit), ahead of the active policy's own rules. Session-only; never saved."
+          description: "Comma-separated interrupt effects or capability set names to auto-approve for this run (e.g. std::write,std::git::commit or FileRead), ahead of the active policy's own rules. Session-only; never saved."
         },
         reject: {
           type: "string",
-          description: "Comma-separated interrupt effects to auto-reject for this run. A reject outranks an approve for the same effect. Session-only; never saved."
+          description: "Comma-separated interrupt effects or capability set names to auto-reject for this run. A reject outranks an approve for the same effect. Session-only; never saved."
         },
         continue: {
           type: "boolean",

--- a/packages/agency-lang/lib/agents/agency-agent/lib/policy.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/policy.agency
@@ -112,10 +112,18 @@ export def getPolicyForAgent(
   }
 
   // --approve / --reject overlay: session-only, never written to the
-  // saved policy.
+  // saved policy. The overlay can throw (set expansion parses the
+  // shipped stdlib/capabilities.agency and refuses a broken install);
+  // surface that like a --policy error instead of letting it propagate.
   if ((approveArg != "" || rejectArg != "") && basePolicy != null) {
-    sessionPolicy = _policyOverlayFromFlags(approveArg, rejectArg, basePolicy)
-    policyFile = SESSION_POLICY_PATH
+    const overlaid = try _policyOverlayFromFlags(approveArg, rejectArg, basePolicy)
+    if (overlaid is failure(f)) {
+      print(color.red("Failed to apply --approve/--reject: ${f}"))
+      process.exit(1)
+    } else {
+      sessionPolicy = overlaid.value
+      policyFile = SESSION_POLICY_PATH
+    }
   }
 
   return {

--- a/packages/agency-lang/lib/agents/agency-agent/tests/policyFlags.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/policyFlags.agency
@@ -58,6 +58,24 @@ node rejectOutranksApprove(): string {
   return decide(sessionPolicy, "myapp::both")
 }
 
+// A capability-set name in --approve expands to its member effects;
+// effects outside the set stay undecided.
+node setExpansion(): string[] {
+  const { sessionPolicy } = getPolicyForAgent(STUB, "FileRead", "", false)
+  return [
+    decide(sessionPolicy, "std::read"),
+    decide(sessionPolicy, "std::grep"),
+    decide(sessionPolicy, "std::write"),
+  ]
+}
+
+// A bare name matching no set still makes a working blanket rule (bare
+// effect names are legal in declarations).
+node bareNamePassthrough(): string {
+  const { sessionPolicy } = getPolicyForAgent(STUB, "confirm", "", false)
+  return decide(sessionPolicy, "confirm")
+}
+
 // Flags also overlay onto a built-in --policy, and the built-in's own
 // rules survive underneath.
 node flagsOverlayOntoBuiltin(): string[] {

--- a/packages/agency-lang/lib/agents/agency-agent/tests/policyFlags.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/policyFlags.test.json
@@ -19,6 +19,18 @@
       "evaluationCriteria": [{ "type": "exact" }]
     },
     {
+      "nodeName": "setExpansion",
+      "input": "",
+      "expectedOutput": "[\"approve\",\"approve\",\"propagate\"]",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "bareNamePassthrough",
+      "input": "",
+      "expectedOutput": "\"approve\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
       "nodeName": "flagsOverlayOntoBuiltin",
       "input": "",
       "expectedOutput": "[\"session-path\",\"approve\",\"approve\"]",

--- a/packages/agency-lang/lib/runtime/effectSets.test.ts
+++ b/packages/agency-lang/lib/runtime/effectSets.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { builtinEffectSets } from "./effectSets.js";
+import { builtinEffectSets, parseEffectSets } from "./effectSets.js";
 
 // These parse the REAL shipped stdlib/capabilities.agency, so they double
 // as drift tests: an edit to that file the walker misreads fails here.
@@ -56,5 +56,28 @@ describe("builtinEffectSets", () => {
   it("is safe against prototype-colliding lookups", () => {
     expect(sets["toString"]).toBeUndefined();
     expect(sets["__proto__"]).toBeUndefined();
+  });
+});
+
+describe("parseEffectSets", () => {
+  it("pairs a doc comment with the declaration that follows it", () => {
+    const sets = parseEffectSets(
+      `/** Everything filesystem. */\nexport effectSet Fs = <std::read, std::write>\n`,
+      "test",
+    );
+    expect(sets["Fs"].doc).toBe("Everything filesystem.");
+    expect(sets["Fs"].members).toEqual(["std::read", "std::write"]);
+  });
+
+  it("refuses a set declared as <*> (no enumerable members)", () => {
+    expect(() => parseEffectSets(`export effectSet Anything = <*>\n`, "test")).toThrow(
+      "cannot be expanded",
+    );
+  });
+
+  it("refuses a reference to an undeclared set", () => {
+    expect(() => parseEffectSets(`export effectSet A = <Missing>\n`, "test")).toThrow(
+      "unknown set 'Missing'",
+    );
   });
 });

--- a/packages/agency-lang/lib/runtime/effectSets.test.ts
+++ b/packages/agency-lang/lib/runtime/effectSets.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { builtinEffectSets } from "./effectSets.js";
+
+// These parse the REAL shipped stdlib/capabilities.agency, so they double
+// as drift tests: an edit to that file the walker misreads fails here.
+describe("builtinEffectSets", () => {
+  const sets = builtinEffectSets();
+
+  it("reads FileRead's exact members", () => {
+    expect(sets["FileRead"].members).toEqual([
+      "std::read",
+      "std::readBinary",
+      "std::ls",
+      "std::glob",
+      "std::grep",
+    ]);
+  });
+
+  it("flattens a nested set to the union of its parts", () => {
+    expect(sets["FileSystem"].members).toEqual([
+      ...sets["FileRead"].members,
+      ...sets["FileWrite"].members,
+    ]);
+    expect(sets["Notes"].members).toEqual([
+      ...sets["NotesRead"].members,
+      ...sets["NotesWrite"].members,
+    ]);
+  });
+
+  it("records the composition of a nested set", () => {
+    expect(sets["FileSystem"].composedOf).toEqual(["FileRead", "FileWrite"]);
+    expect(sets["FileRead"].composedOf).toEqual([]);
+  });
+
+  it("every member of every set is a namespaced effect name", () => {
+    for (const set of Object.values(sets)) {
+      expect(set.members.length).toBeGreaterThan(0);
+      for (const member of set.members) {
+        expect(member).toContain("::");
+      }
+    }
+  });
+
+  it("every set carries a doc line", () => {
+    for (const set of Object.values(sets)) {
+      expect(set.doc.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("includes the known set names", () => {
+    for (const name of ["FileRead", "FileWrite", "FileSystem", "Shell", "Network", "Secrets"]) {
+      expect(sets[name]).toBeDefined();
+    }
+  });
+
+  it("is safe against prototype-colliding lookups", () => {
+    expect(sets["toString"]).toBeUndefined();
+    expect(sets["__proto__"]).toBeUndefined();
+  });
+});

--- a/packages/agency-lang/lib/runtime/effectSets.ts
+++ b/packages/agency-lang/lib/runtime/effectSets.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "fs";
 import path from "path";
 import { parseAgency } from "../parser.js";
 import { getPackageRoot } from "../importPaths.js";
+import type { AgencyMultiLineComment, TypeAlias, UnionType, VariableType } from "../types.js";
 
 /** One built-in capability set from `stdlib/capabilities.agency`. */
 export type EffectSetInfo = {
@@ -30,34 +31,50 @@ let cache: Record<string, EffectSetInfo> | null = null;
  */
 export function builtinEffectSets(): Record<string, EffectSetInfo> {
   if (cache === null) {
-    cache = load();
+    const file = path.join(getPackageRoot(), "stdlib", "capabilities.agency");
+    cache = parseEffectSets(readFileSync(file, "utf-8"), file);
   }
   return cache;
 }
 
-function load(): Record<string, EffectSetInfo> {
-  const file = path.join(getPackageRoot(), "stdlib", "capabilities.agency");
-  const source = readFileSync(file, "utf-8");
+type RawSet = { name: string; doc: string; items: VariableType[] };
+
+/** Build the set table from Agency source. Exported for tests; production
+ *  use goes through `builtinEffectSets`. */
+export function parseEffectSets(source: string, origin: string): Record<string, EffectSetInfo> {
   const parsed = parseAgency(source);
   if (!parsed.success) {
-    throw new Error(`stdlib capabilities file failed to parse (${file}): ${parsed.message}`);
+    throw new Error(`stdlib capabilities file failed to parse (${origin}): ${parsed.message}`);
   }
 
   // Doc comments are standalone nodes after a bare parse (attachment to
   // the following declaration is the preprocessor's job, which we don't
   // run) — pair each doc comment with the effectSet declaration that
   // follows it.
-  type RawSet = { name: string; doc: string; items: any[] };
   const raw: RawSet[] = [];
   let pendingDoc = "";
-  for (const node of parsed.result.nodes as any[]) {
+  for (const node of parsed.result.nodes) {
     if (node.type === "multiLineComment") {
-      pendingDoc = node.isDoc && !node.isModuleDoc ? cleanDoc(node.content) : "";
+      const comment = node as AgencyMultiLineComment;
+      pendingDoc = comment.isDoc && !comment.isModuleDoc ? cleanDoc(comment.content) : "";
       continue;
     }
-    if (node.type === "typeAlias" && node.isEffectSet) {
-      const items = node.aliasedType?.types ?? [];
-      raw.push({ name: node.aliasName, doc: pendingDoc, items });
+    if (node.type === "typeAlias" && (node as TypeAlias).isEffectSet) {
+      const alias = node as TypeAlias;
+      // Only the `<a, b>` literal form is a member list. `<*>` parses to
+      // the `any` primitive; a set declared that way has no enumerable
+      // members and cannot be expanded, so refuse it at the source.
+      if (alias.aliasedType.type !== "unionType" || !alias.aliasedType.isEffectSet) {
+        throw new Error(
+          `effect set '${alias.aliasName}' in ${origin} is not a member list (<a, b>); ` +
+            `'${alias.aliasedType.type}' cannot be expanded`,
+        );
+      }
+      raw.push({
+        name: alias.aliasName,
+        doc: pendingDoc,
+        items: (alias.aliasedType as UnionType).types,
+      });
     }
     pendingDoc = "";
   }
@@ -72,7 +89,7 @@ function load(): Record<string, EffectSetInfo> {
     result[set.name] = {
       name: set.name,
       doc: set.doc,
-      members: resolveMembers(set, byName, []),
+      members: resolveMembers(set, byName, [], origin),
       composedOf: set.items
         .filter((item) => item.type === "typeAliasVariable")
         .map((item) => item.aliasName),
@@ -83,12 +100,13 @@ function load(): Record<string, EffectSetInfo> {
 
 /** Flatten one set's items to effect names, resolving nested sets. */
 function resolveMembers(
-  set: { name: string; items: any[] },
-  byName: Record<string, { name: string; items: any[] }>,
+  set: RawSet,
+  byName: Record<string, RawSet>,
   seen: string[],
+  origin: string,
 ): string[] {
   if (seen.includes(set.name)) {
-    throw new Error(`effect set cycle involving '${set.name}' in stdlib/capabilities.agency`);
+    throw new Error(`effect set cycle involving '${set.name}' in ${origin}`);
   }
   const members: string[] = [];
   for (const item of set.items) {
@@ -98,15 +116,15 @@ function resolveMembers(
     } else if (item.type === "typeAliasVariable") {
       // A bare label: a reference to another set in this file.
       const target = byName[item.aliasName];
-      if (!target) {
+      if (target === undefined) {
         throw new Error(
-          `effect set '${set.name}' references unknown set '${item.aliasName}' in stdlib/capabilities.agency`,
+          `effect set '${set.name}' references unknown set '${item.aliasName}' in ${origin}`,
         );
       }
-      members.push(...resolveMembers(target, byName, [...seen, set.name]));
+      members.push(...resolveMembers(target, byName, [...seen, set.name], origin));
     } else {
       throw new Error(
-        `effect set '${set.name}' has a member of unexpected shape '${item.type}' in stdlib/capabilities.agency`,
+        `effect set '${set.name}' has a member of unexpected shape '${item.type}' in ${origin}`,
       );
     }
   }

--- a/packages/agency-lang/lib/runtime/effectSets.ts
+++ b/packages/agency-lang/lib/runtime/effectSets.ts
@@ -1,0 +1,125 @@
+import { readFileSync } from "fs";
+import path from "path";
+import { parseAgency } from "../parser.js";
+import { getPackageRoot } from "../importPaths.js";
+
+/** One built-in capability set from `stdlib/capabilities.agency`. */
+export type EffectSetInfo = {
+  name: string;
+  /** The declaration's doc comment, whitespace-trimmed. */
+  doc: string;
+  /** Effect names only; nested sets resolved to their members. */
+  members: string[];
+  /** The other sets this one was declared from, e.g. FileSystem's
+   *  ["FileRead", "FileWrite"]. Empty for a set declared from effects. */
+  composedOf: string[];
+};
+
+// Parsed once per process. Derived from a shipped file that cannot change
+// mid-process — the same footing as the always-scope registry
+// (alwaysScope.ts), not per-run mutable state.
+let cache: Record<string, EffectSetInfo> | null = null;
+
+/**
+ * The built-in capability sets, keyed by name (null-prototype record —
+ * callers look up CLI-supplied names). Parses `stdlib/capabilities.agency`
+ * from the install on first use: the doc comments live only in the source,
+ * so the source is the single definition discovery and flag expansion
+ * share. Throws when the shipped file is missing or fails to parse — a
+ * broken install should be loud, never an empty table.
+ */
+export function builtinEffectSets(): Record<string, EffectSetInfo> {
+  if (cache === null) {
+    cache = load();
+  }
+  return cache;
+}
+
+function load(): Record<string, EffectSetInfo> {
+  const file = path.join(getPackageRoot(), "stdlib", "capabilities.agency");
+  const source = readFileSync(file, "utf-8");
+  const parsed = parseAgency(source);
+  if (!parsed.success) {
+    throw new Error(`stdlib capabilities file failed to parse (${file}): ${parsed.message}`);
+  }
+
+  // Doc comments are standalone nodes after a bare parse (attachment to
+  // the following declaration is the preprocessor's job, which we don't
+  // run) — pair each doc comment with the effectSet declaration that
+  // follows it.
+  type RawSet = { name: string; doc: string; items: any[] };
+  const raw: RawSet[] = [];
+  let pendingDoc = "";
+  for (const node of parsed.result.nodes as any[]) {
+    if (node.type === "multiLineComment") {
+      pendingDoc = node.isDoc && !node.isModuleDoc ? cleanDoc(node.content) : "";
+      continue;
+    }
+    if (node.type === "typeAlias" && node.isEffectSet) {
+      const items = node.aliasedType?.types ?? [];
+      raw.push({ name: node.aliasName, doc: pendingDoc, items });
+    }
+    pendingDoc = "";
+  }
+
+  const byName: Record<string, RawSet> = Object.create(null);
+  for (const set of raw) {
+    byName[set.name] = set;
+  }
+
+  const result: Record<string, EffectSetInfo> = Object.create(null);
+  for (const set of raw) {
+    result[set.name] = {
+      name: set.name,
+      doc: set.doc,
+      members: resolveMembers(set, byName, []),
+      composedOf: set.items
+        .filter((item) => item.type === "typeAliasVariable")
+        .map((item) => item.aliasName),
+    };
+  }
+  return result;
+}
+
+/** Flatten one set's items to effect names, resolving nested sets. */
+function resolveMembers(
+  set: { name: string; items: any[] },
+  byName: Record<string, { name: string; items: any[] }>,
+  seen: string[],
+): string[] {
+  if (seen.includes(set.name)) {
+    throw new Error(`effect set cycle involving '${set.name}' in stdlib/capabilities.agency`);
+  }
+  const members: string[] = [];
+  for (const item of set.items) {
+    if (item.type === "stringLiteralType") {
+      // A namespaced label: a plain effect name.
+      members.push(item.value);
+    } else if (item.type === "typeAliasVariable") {
+      // A bare label: a reference to another set in this file.
+      const target = byName[item.aliasName];
+      if (!target) {
+        throw new Error(
+          `effect set '${set.name}' references unknown set '${item.aliasName}' in stdlib/capabilities.agency`,
+        );
+      }
+      members.push(...resolveMembers(target, byName, [...seen, set.name]));
+    } else {
+      throw new Error(
+        `effect set '${set.name}' has a member of unexpected shape '${item.type}' in stdlib/capabilities.agency`,
+      );
+    }
+  }
+  // A member can arrive twice through overlapping nested sets.
+  return members.filter((m, i) => members.indexOf(m) === i);
+}
+
+/** Strip comment markup: leading/trailing whitespace and the per-line
+ *  ` * ` continuation prefix. */
+function cleanDoc(content: string): string {
+  return content
+    .split("\n")
+    .map((line) => line.replace(/^\s*\*?\s?/, "").trimEnd())
+    .join("\n")
+    .trim();
+}

--- a/packages/agency-lang/lib/runtime/policyFlags.test.ts
+++ b/packages/agency-lang/lib/runtime/policyFlags.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { policyOverlayFromFlags, splitEffects } from "./policyFlags.js";
 import type { Policy } from "./policy.js";
 
@@ -49,5 +49,60 @@ describe("policyOverlayFromFlags", () => {
   it("returns an equal policy when both flags are empty", () => {
     const base: Policy = { "std::read": [{ action: "approve" }] };
     expect(policyOverlayFromFlags(undefined, "", base)).toEqual(base);
+  });
+});
+
+describe("effect sets in flag values", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("a set name expands to one blanket rule per member effect", () => {
+    const out = policyOverlayFromFlags("FileRead", undefined, {});
+    for (const effect of ["std::read", "std::readBinary", "std::ls", "std::glob", "std::grep"]) {
+      expect(out[effect]).toEqual([{ action: "approve" }]);
+    }
+    expect(out["FileRead"]).toBeUndefined();
+  });
+
+  it("an effect rejected alongside its approving set gets reject first", () => {
+    const out = policyOverlayFromFlags("FileSystem", "std::remove", {});
+    expect(out["std::remove"]).toEqual([{ action: "reject" }, { action: "approve" }]);
+    expect(out["std::write"]).toEqual([{ action: "approve" }]);
+  });
+
+  it("overlapping sets collapse to one rule per effect", () => {
+    const out = policyOverlayFromFlags("FileRead,FileSystem", undefined, {});
+    expect(out["std::read"]).toEqual([{ action: "approve" }]);
+  });
+
+  it("a bare name matching no set passes through as an effect name", () => {
+    // Both are legal invocations today: bare effect declarations
+    // (`effect confirm { ... }`) and the bare interrupt form, whose
+    // effect is named "unknown".
+    const out = policyOverlayFromFlags("confirm", "unknown", {});
+    expect(out["confirm"]).toEqual([{ action: "approve" }]);
+    expect(out["unknown"]).toEqual([{ action: "reject" }]);
+  });
+
+  it("warns on stderr for a near-miss of a set name, and still passes it through", () => {
+    const warn = vi.spyOn(console, "error").mockImplementation(() => {});
+    const out = policyOverlayFromFlags("FileReed", undefined, {});
+    expect(out["FileReed"]).toEqual([{ action: "approve" }]);
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0][0]).toContain("FileRead");
+  });
+
+  it("warns on a case-only mismatch of a set name", () => {
+    const warn = vi.spyOn(console, "error").mockImplementation(() => {});
+    const out = policyOverlayFromFlags(undefined, "fileread", {});
+    expect(out["fileread"]).toEqual([{ action: "reject" }]);
+    expect(warn.mock.calls[0][0]).toContain("FileRead");
+  });
+
+  it("does not warn on an unrelated bare name", () => {
+    const warn = vi.spyOn(console, "error").mockImplementation(() => {});
+    policyOverlayFromFlags("confirm", undefined, {});
+    expect(warn).not.toHaveBeenCalled();
   });
 });

--- a/packages/agency-lang/lib/runtime/policyFlags.ts
+++ b/packages/agency-lang/lib/runtime/policyFlags.ts
@@ -1,4 +1,5 @@
 import type { Policy, PolicyRule } from "./policy.js";
+import { builtinEffectSets } from "./effectSets.js";
 
 /** Split a flag's effect list on commas and/or whitespace, so
  *  `--approve "std::read, std::ls"`, `--approve std::read,std::ls`, and
@@ -21,13 +22,70 @@ export function splitEffects(list: string | undefined): string[] {
  *  statements.
  *
  *  Shared by `agency run` (via `resolveRunPolicy`) and the agent's flags. */
+/** Expand any built-in capability-set names in a flag's effect list to
+ *  their member effects. A name with `::` is always a plain effect. A
+ *  bare name that matches no set passes through as an effect name — bare
+ *  effect declarations are legal, and the bare `interrupt("msg")` form
+ *  raises the effect named "unknown", so an unmatched bare name must
+ *  keep working; a near-miss of a set name gets a stderr warning. */
+function expandSetNames(names: string[], flag: string): string[] {
+  if (names.every((name) => name.includes("::"))) {
+    return names;
+  }
+  const sets = builtinEffectSets();
+  const expanded: string[] = [];
+  for (const name of names) {
+    if (name.includes("::")) {
+      expanded.push(name);
+      continue;
+    }
+    const set = sets[name];
+    if (set !== undefined) {
+      expanded.push(...set.members);
+      continue;
+    }
+    const near = nearMissSetName(name, Object.keys(sets));
+    if (near !== null) {
+      console.error(
+        `Warning: "${name}" in ${flag} matches no built-in effect set. Did you mean ${near}? It was kept as a plain effect name.`,
+      );
+    }
+    expanded.push(name);
+  }
+  return expanded;
+}
+
+/** A set name this one probably meant: a case-only mismatch, or one edit
+ *  (insert, delete, or replace) away. */
+function nearMissSetName(name: string, setNames: string[]): string | null {
+  const exact = setNames.find((s) => s.toLowerCase() === name.toLowerCase());
+  if (exact !== undefined) {
+    return exact;
+  }
+  return setNames.find((s) => withinOneEdit(name.toLowerCase(), s.toLowerCase())) ?? null;
+}
+
+function withinOneEdit(a: string, b: string): boolean {
+  if (Math.abs(a.length - b.length) > 1) {
+    return false;
+  }
+  let i = 0;
+  while (i < a.length && i < b.length && a[i] === b[i]) {
+    i += 1;
+  }
+  // Skip one edit at the first mismatch; the remainders must match.
+  const restA = a.length > b.length ? a.slice(i + 1) : a.slice(a.length === b.length ? i + 1 : i);
+  const restB = b.length > a.length ? b.slice(i + 1) : b.slice(a.length === b.length ? i + 1 : i);
+  return restA === restB;
+}
+
 export function policyOverlayFromFlags(
   approve: string | undefined,
   reject: string | undefined,
   base: Policy,
 ): Policy {
-  const approved = splitEffects(approve);
-  const rejected = splitEffects(reject);
+  const approved = expandSetNames(splitEffects(approve), "--approve");
+  const rejected = expandSetNames(splitEffects(reject), "--reject");
   // Null-prototype: effect names come straight from a CLI flag, and on a
   // plain object a name like "toString" would read an inherited function
   // out of `policy[effect]` below, and "__proto__" would be a prototype

--- a/packages/agency-lang/lib/runtime/policyFlags.ts
+++ b/packages/agency-lang/lib/runtime/policyFlags.ts
@@ -11,17 +11,6 @@ export function splitEffects(list: string | undefined): string[] {
   return list.split(/[\s,]+/).filter((s) => s.length > 0);
 }
 
-/** Overlay blanket rules from `--approve` / `--reject` flag values onto a
- *  base policy. Returns a new policy; `base` is not mutated.
- *
- *  Each affected effect's rule list is built in one construction so
- *  precedence is visible in the literal, not implied by statement order:
- *  reject rule, then approve rule, then the base's own rules.
- *  Reject-ahead-of-approve is how overlap resolves to reject under
- *  checkPolicy's first-match-wins — and you cannot break it by reordering
- *  statements.
- *
- *  Shared by `agency run` (via `resolveRunPolicy`) and the agent's flags. */
 /** Expand any built-in capability-set names in a flag's effect list to
  *  their member effects. A name with `::` is always a plain effect. A
  *  bare name that matches no set passes through as an effect name — bare
@@ -79,6 +68,19 @@ function withinOneEdit(a: string, b: string): boolean {
   return restA === restB;
 }
 
+/** Overlay blanket rules from `--approve` / `--reject` flag values onto a
+ *  base policy. Returns a new policy; `base` is not mutated. A flag value
+ *  holds effect names and capability-set names; sets expand to their
+ *  member effects (see expandSetNames).
+ *
+ *  Each affected effect's rule list is built in one construction so
+ *  precedence is visible in the literal, not implied by statement order:
+ *  reject rule, then approve rule, then the base's own rules.
+ *  Reject-ahead-of-approve is how overlap resolves to reject under
+ *  checkPolicy's first-match-wins — and you cannot break it by reordering
+ *  statements.
+ *
+ *  Shared by `agency run` (via `resolveRunPolicy`) and the agent's flags. */
 export function policyOverlayFromFlags(
   approve: string | undefined,
   reject: string | undefined,

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -438,8 +438,14 @@ export function createProgram(deps: CliDependencies = {}): Command {
           "--policy <name|path>",
           "Interrupt policy: a built-in (recommended|minimal|with-writes|approve-all) or a policy JSON file",
         )
-        .option("--approve <effects>", "Comma-separated interrupt effects to auto-approve")
-        .option("--reject <effects>", "Comma-separated interrupt effects to auto-reject")
+        .option(
+          "--approve <effects>",
+          "Comma-separated interrupt effects or capability set names (e.g. FileRead) to auto-approve",
+        )
+        .option(
+          "--reject <effects>",
+          "Comma-separated interrupt effects or capability set names to auto-reject",
+        )
         .option(
           "-i, --interactive",
           "Prompt on interrupts that surface unhandled (default: reject them)",
@@ -561,8 +567,14 @@ export function createProgram(deps: CliDependencies = {}): Command {
     .option("--function", "call a function instead of a node")
     .option("-i, --interactive", "prompt on surfaced interrupts (else report and exit)")
     .option("--policy <name|path>", "interrupt policy: a built-in or a policy JSON file")
-    .option("--approve <effects>", "comma-separated interrupt effects to auto-approve")
-    .option("--reject <effects>", "comma-separated interrupt effects to auto-reject")
+    .option(
+      "--approve <effects>",
+      "comma-separated interrupt effects or capability set names (e.g. FileRead) to auto-approve",
+    )
+    .option(
+      "--reject <effects>",
+      "comma-separated interrupt effects or capability set names to auto-reject",
+    )
     .option("--host <url>", "statelog host (overrides agency.json log.host)")
     .option("--project <slug>", "project slug (overrides agency.json log.projectId)")
     .option("--api-key-env <name>", "env var to read the API key from (default: STATELOG_API_KEY)")
@@ -1228,11 +1240,11 @@ export function createProgram(deps: CliDependencies = {}): Command {
     )
     .option(
       "--approve <effects>",
-      "Comma-separated interrupt effects to auto-approve in every test case",
+      "Comma-separated interrupt effects or capability set names (e.g. FileRead) to auto-approve in every test case",
     )
     .option(
       "--reject <effects>",
-      "Comma-separated interrupt effects to auto-reject in every test case ('*' rejects every effect)",
+      "Comma-separated interrupt effects or capability set names to auto-reject in every test case ('*' rejects every effect)",
     )
     .option(
       "--max-cost <dollars>",


### PR DESCRIPTION
PR 1 of 2 from the effect-sets spec (`2026-08-31-effect-sets-in-flags-spec.md`, reviewed in its sibling `-REVIEW` file): `--approve` and `--reject` accept capability set names alongside effect names, everywhere the flags exist.

```bash
agency agent --approve FileRead --reject Shell
agency run --approve FileRead,Network foo.agency
```

## How it works

A bare name that exactly matches a built-in set from `std::capabilities` expands to the set's member effects, each getting the blanket rule at that position. Expansion happens inside `policyOverlayFromFlags`, so `agency run`, `agency test`, and the agent gain it at the one shared point. The compiled policy contains only plain effect names — serialization, `checkPolicy`, and the session-policy file are untouched, and a printed policy shows exactly which effects were granted.

**Compatibility, per the spec review:** any other bare name passes through as a plain effect name, exactly as today. Bare effect declarations are legal (`effect confirm { ... }` + `--approve confirm`), and the bare `interrupt("msg")` form raises the effect named `unknown`, so `--reject unknown` is meaningful — neither may start failing. A near-miss of a set name (case-only or one edit away) gets a stderr warning and still passes through. A user effect whose bare name shadows a set is unreachable from the flags; the documented answer is to namespace user effects.

**Membership** comes from a new `lib/runtime/effectSets.ts` that parses `stdlib/capabilities.agency` from the install on first use (lazy — runs with no bare names never read it), pairs each declaration with its doc comment (attachment is normally the preprocessor's job, so the walker does its own pairing), resolves nested sets transitively, and throws loudly if the shipped file fails to parse. The parse was chosen over walking the compiled zod unions or a build-time manifest: the doc comments the upcoming discovery command needs live only in the source, and the declaration stays the single definition. The once-per-process cache is derived from a shipped file, the same footing as the always-scope registry.

The agent's overlay call now catches a failure from the JS import and exits with the message in red, matching its `--policy` error handling.

## Testing

- `lib/runtime/effectSets.test.ts` parses the real shipped file: FileRead's exact members, FileSystem/Notes transitive flattening, composition, every member namespaced, every doc non-empty. These double as drift tests for edits to `capabilities.agency`.
- `lib/runtime/policyFlags.test.ts`: set expansion, an effect rejected alongside its approving set, overlapping-set dedup, the `confirm`/`unknown` passthrough cases, near-miss and case-only warnings, no warning on unrelated names.
- `lib/agents/agency-agent/tests/policyFlags.agency`: `setExpansion` and `bareNamePassthrough` scenarios (6/6 pass, no LLM).
- Also ran the turn agent test, existing runPolicy/policyFlags vitest files, `pnpm run typecheck`, `pnpm run lint:structure`, `pnpm run fmt:ts` after a full `make`.

## Docs

Flag help on `run`, `test`, `remote call`, and the agent mentions set names (the `see: agency effects` pointer waits for PR 2, which adds the command). The `--approve`/`--reject` bullet in `docs/dev/agents/approval-policies.md` documents the expansion, the passthrough rule, and the shadowing case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qh4zR96LWmg3kyGbCti4XR
