### PR TITLE
Learned skills and a wired-in toolbox for the agency agent

### DIFF
--- a/packages/agency-lang/.claude/skills/agency-agent-docs/SKILL.md
+++ b/packages/agency-lang/.claude/skills/agency-agent-docs/SKILL.md
@@ -13,6 +13,7 @@ Paths are relative to `packages/agency-lang/`. Read the one that matches the tas
 - `docs/dev/agents/approval-policies.md` — How approval policy rules match, and the matching rules that have caused surprises.
 - `docs/dev/agents/tool-loop-guards.md` — The three refusals that stop a model wasting rounds: a repeated call, an argument that is really tool-call markup, and a call identical to one already rejected.
 - `docs/dev/agents/reply-attachments.md` — How a tool hands images back to the model, given that most providers reject image parts in tool results.
+- `docs/dev/agents/learned-skills-and-toolbox.md` — Skills the user teaches a subagent and tools the agent writes for one: the home-directory storage, the session catalogs, the review interrupts, and the widened default read scope.
 - `docs/dev/agents/promptRunner.md` — The control-flow helper behind `runPrompt`, and the rule that tool-loop decisions must be durable: made inside a step, persisted in `runnerState`.
 - `docs/dev/agents/why-agents-write-code.md` — The argument for letting an agent write and run programs instead of giving it more tools.
 - `docs/dev/agents/self-writing-agent.md` — Investigation notes from the experiment behind that argument.

--- a/packages/agency-lang/CLAUDE.md
+++ b/packages/agency-lang/CLAUDE.md
@@ -277,6 +277,7 @@ Other process docs:
 - `docs/dev/agents/agent-brains.md` — How `agency agent` splits into a harness and pluggable brains, and what each half owns.
 - `docs/dev/agents/agent-sessions.md` — Save and resume for `agency agent`: a checkpoint between turns, why it is taken from TypeScript after the turn's frames return, where the restore runs, and what a restore does not bring back.
 - `docs/dev/agents/approval-policies.md` — How approval policy rules match, and the matching rules that have caused surprises.
+- `docs/dev/agents/learned-skills-and-toolbox.md` — Skills the user teaches a subagent and tools the agent writes for one: the home-directory storage, the session catalogs, the review interrupts, and the widened default read scope.
 - `docs/dev/agents/promptRunner.md` — The control-flow helper behind `runPrompt`, and the rule that tool-loop decisions must be durable: made inside a step, persisted in `runnerState`.
 - `docs/dev/agents/reply-attachments.md` — How a tool hands images back to the model, given that most providers reject image parts in tool results.
 - `docs/dev/agents/self-writing-agent.md` — Investigation notes from the experiment behind that argument.

--- a/packages/agency-lang/docs/dev/agents/agent-brains.md
+++ b/packages/agency-lang/docs/dev/agents/agent-brains.md
@@ -120,18 +120,25 @@ the handler is installed, not from the type.
 
 There is a corollary about module statics. `registry.agency` imports every
 brain, and Agency initializes the whole import closure at startup
-(`docs/dev/compiler/init-topsort.md`), so every registered brain's top-level statics
-run whether or not that brain was selected. Two consequences:
+(`docs/dev/compiler/init-topsort.md`), so every registered brain's top-level
+statics run whether or not that brain was selected. Keep them free of
+side effects beyond the bundled reads (the coordinator's system prompts,
+the code subagent's skill files); `init` only validates that those reads
+succeeded, takes the grounding, and does other policy-neutral setup.
 
-1. Brain statics must do nothing effectful, with one exception: bundled
-   file reads (the coordinator's system prompts, the code subagent's skill
-   files) stay `static const ... with approve`, exactly as before the split.
-2. Those reads must *not* move into `init`. `init` runs inside the policy
-   handler, and an inner `with approve` cannot get past an outer policy, so
-   a read there would prompt the user under `--policy minimal` (which has no
-   `std::read` rule) or fail in a non-interactive run. `init` only validates
-   that the static reads succeeded, takes the grounding, and does other
-   policy-neutral setup.
+A historical note, because an earlier version of this doc said otherwise:
+statics running before the policy handler was a security hole, not a
+pattern — it was fixed by installing the root policy handler before any
+user code runs (#966, #987). Statics are policy-governed like all code.
+Every tool that touches the filesystem raises an interrupt; the
+concession for directory-of-files tools (`skillsDir`, the docs tools) is
+ONE scan interrupt up front whose approval covers the reads that follow,
+never zero interrupts and never one per file. Session-lived mutable
+state belongs in a module global (a top-level `let`), not a static — the
+CLI agent is one long-lived run, so a global lives for the session and
+can be updated in place; the learned catalogs
+(`docs/dev/agents/learned-skills-and-toolbox.md`) are the worked
+example.
 
 ## Adding a brain
 

--- a/packages/agency-lang/docs/dev/agents/approval-policies.md
+++ b/packages/agency-lang/docs/dev/agents/approval-policies.md
@@ -62,6 +62,12 @@ The read-only file effects (`std::read`, `std::readBinary`, `std::ls`,
   interrupts, and reading them back (including `runTool`'s per-run scan of
   a tool's directory) would otherwise prompt on every use and auto-reject
   headless. A stricter custom policy overrides it like any other rule.
+  One write rides along: `runTool` records a use count in the tool's
+  `meta.json` after every run, so `recommended` (and `with-writes`,
+  which would otherwise clobber the entry) approve exactly that file
+  under `<agent-home>/tools/**`; every other write still prompts. The
+  shared scope reaches every `recommended` run, not only the agent —
+  the built-in policy descriptions disclose it.
 
 All three rules are placeholders, not paths. `.` expands to the process cwd,
 `<agency>` to the directory the agency package is installed in

--- a/packages/agency-lang/docs/dev/agents/approval-policies.md
+++ b/packages/agency-lang/docs/dev/agents/approval-policies.md
@@ -54,12 +54,21 @@ The read-only file effects (`std::read`, `std::readBinary`, `std::ls`,
   `{<agency>/stdlib/**,<agency>/dist/**}`. The docs tools (`agencyGuide`,
   `agencyStdlib`, ...) are `read` partially applied to
   `stdlib/docs/<section>`, and the bundled skills are read the same way, so
-  without this rule those tools return rejections in a headless run.
+  without this rule those tools return rejections in a headless run;
+- the agent home's learned directories, written as
+  `{<agent-home>/skills/**,<agent-home>/tools/**}`. This is a deliberate
+  widening of the default scope: the directories hold skills the user
+  taught the agent and tools it wrote, both saved only through review
+  interrupts, and reading them back (including `runTool`'s per-run scan of
+  a tool's directory) would otherwise prompt on every use and auto-reject
+  headless. A stricter custom policy overrides it like any other rule.
 
-Both rules are placeholders, not paths. `.` expands to the process cwd and
+All three rules are placeholders, not paths. `.` expands to the process cwd,
 `<agency>` to the directory the agency package is installed in
 (`AGENCY_INSTALL_DIR_PLACEHOLDER`, `expandAgencyInstallDir`,
-`getPackageRoot`), each at match time. The copy the agent saves to
+`getPackageRoot`), and `<agent-home>` to `AGENCY_AGENT_HOME` or
+`~/.agency-agent` (`AGENT_HOME_PLACEHOLDER`, `expandAgentHomeDir`; an empty
+env var counts as unset), each at match time. The copy the agent saves to
 `~/.agency-agent/policy.json` therefore pins neither the directory it was
 first run in nor the install path of one version. After an upgrade moves the
 package, the same rule still matches. A root that cannot be found (a bundled build

--- a/packages/agency-lang/docs/dev/agents/approval-policies.md
+++ b/packages/agency-lang/docs/dev/agents/approval-policies.md
@@ -62,12 +62,16 @@ The read-only file effects (`std::read`, `std::readBinary`, `std::ls`,
   interrupts, and reading them back (including `runTool`'s per-run scan of
   a tool's directory) would otherwise prompt on every use and auto-reject
   headless. A stricter custom policy overrides it like any other rule.
-  One write rides along: `runTool` records a use count in the tool's
-  `meta.json` after every run, so `recommended` (and `with-writes`,
-  which would otherwise clobber the entry) approve exactly that file
-  under `<agent-home>/tools/**`; every other write still prompts. The
-  shared scope reaches every `recommended` run, not only the agent —
-  the built-in policy descriptions disclose it.
+  `recommended` also approves `std::toolbox::recordUse` under
+  `<agent-home>/tools/**` — the effect `runTool` raises before updating
+  a tool's `meta.json` use count. It is a dedicated effect rather than
+  a `std::write` rule on that filename because a filename glob cannot
+  tell the stdlib's own bookkeeping apart from any program writing
+  arbitrary content into a tool's `meta.json` (whose `purpose` text
+  `listTools` then trusts); approving the effect approves only the
+  constrained mutation the stdlib composes. Writes are not widened at
+  all. The shared scope reaches every `recommended` run, not only the
+  agent — the built-in policy descriptions disclose it.
 
 All three rules are placeholders, not paths. `.` expands to the process cwd,
 `<agency>` to the directory the agency package is installed in

--- a/packages/agency-lang/docs/dev/agents/learned-skills-and-toolbox.md
+++ b/packages/agency-lang/docs/dev/agents/learned-skills-and-toolbox.md
@@ -50,12 +50,18 @@ when something is saved (`docs/site/guide/global-vs-static.md`).
 
 Loading is lazy and interrupt-bounded: the skills catalog loads with
 ONE `std::skills::skillsDir` interrupt covering the whole skills root
-(`scanSkillsSubdirs` in `stdlib/skills.agency`); the toolbox catalog
-loads with one `listTools` scan per agent directory that exists —
-absent directories are skipped with a plain `exists` check that raises
-nothing. Saving updates the catalog in place (`recordLearnedSkill`,
-`recordLearnedTool`), which is why `writeSkill` returns the complete
-entry: nothing ever rescans after a save, so no second interrupt.
+(`scanSkillsSubdirs` in `stdlib/skills.agency`, which takes the subagent
+names as a parameter — the record's keys are caller data, never
+directory names read off the disk — and scans each subdirectory with
+its own file cap); the toolbox catalog loads with one `listTools` scan
+per agent directory that exists. A missing root loads as an empty
+catalog with no interrupt, and a rejected scan caches an empty catalog
+rather than the Failure value. Saving updates the catalog in place
+(`recordLearnedSkill`, `recordLearnedTool`), which is why `writeSkill`
+returns the complete entry: nothing rescans after a save. The record
+functions skip an entry the catalog already holds — when the save was
+the session's first learned action, the lazy load runs after the file
+hit disk and has already picked it up.
 
 Each subagent invocation calls `learnedExtrasFor(<wrapper name>)`
 inside the wrapper function body — never at module top level — and
@@ -101,11 +107,30 @@ review interrupts; a stricter custom policy overrides the rule like any
 other. `docs/dev/agents/approval-policies.md` documents the
 placeholder.
 
-Writes are NOT widened: saving a skill or publishing a tool raises the
+One narrow write rides along: `runTool` records a use count in the
+tool's `meta.json` after every run, and `recommended`/`with-writes`
+approve exactly that file under the agent-home toolboxes so a
+successful learned-tool run cannot end in a rejected metadata write.
+Other writes are NOT widened: saving a skill or publishing a tool raises the
 ordinary write interrupts on top of the review gate, and under
 with-writes (cwd-scoped) a home-directory write surfaces for explicit
 approval. For "the agent is permanently teaching itself something,"
 that double visibility is intended.
+
+The scope rules live in the shared `readScopeRules()`, so a non-agent
+`agency run --policy recommended` script gets them too; the built-in
+policy descriptions disclose it. Layering them agent-side was
+considered and rejected: the policy handler flushes its whole
+in-memory policy to the user's `policy.json` on an "always" decision,
+so a session-layered rule would either leak into the saved file or
+force every default session's always-decisions onto the session-only
+path.
+
+Interactively, the review interrupts answer with approve (a bare
+approve counts as accept) or reject; the revise verdict is a
+structured answer only a handler or policy can give today. The
+coordinator still round-trips revisions by relaying the user's words
+and calling the tool again with a fresh draft.
 
 ## The user surface
 

--- a/packages/agency-lang/docs/dev/agents/learned-skills-and-toolbox.md
+++ b/packages/agency-lang/docs/dev/agents/learned-skills-and-toolbox.md
@@ -45,23 +45,34 @@ overlay served through a second tool, `learned_skills_<agent>`.
 
 Session state sits in two module globals — a top-level `let`, not a
 `static const`. The CLI agent is one long-lived run, so a global lives
-for the whole session and, unlike a static, can be updated in place
+for the whole session and, unlike a static, can be dropped mid-session
 when something is saved (`docs/site/guide/global-vs-static.md`).
 
 Loading is lazy and interrupt-bounded: the skills catalog loads with
 ONE `std::skills::skillsDir` interrupt covering the whole skills root
 (`scanSkillsSubdirs` in `stdlib/skills.agency`, which takes the subagent
-names as a parameter — the record's keys are caller data, never
-directory names read off the disk — and scans each subdirectory with
-its own file cap); the toolbox catalog loads with one `listTools` scan
-per agent directory that exists. A missing root loads as an empty
-catalog with no interrupt, and a rejected scan caches an empty catalog
-rather than the Failure value. Saving updates the catalog in place
-(`recordLearnedSkill`, `recordLearnedTool`), which is why `writeSkill`
-returns the complete entry: nothing rescans after a save. The record
-functions skip an entry the catalog already holds — when the save was
-the session's first learned action, the lazy load runs after the file
-hit disk and has already picked it up.
+names as a parameter — each validated as a bare path segment, so a
+compound or `..` name can never carry the root's approval outside the
+root — and scans each subdirectory with its own file cap); the toolbox
+catalog loads with one `listTools` scan per agent directory that
+exists. A missing root loads as an empty catalog with no interrupt, and
+a rejected scan caches an empty catalog rather than the Failure value.
+
+The catalogs are only a cache of the disk, never a second copy of the
+truth: a save calls `invalidateLearned()` (both globals to null), and
+the next access rescans. An earlier design updated the catalogs in
+place after a save; it saved one scan interrupt per save and bought a
+whole class of cache-coherence bugs (a stale entry surviving a
+delete-and-reteach, duplicate entries, a record pushed into a copy the
+cache never held), so it was replaced. Saves are rare and
+user-directed, and the same policy scope that approved the first scan
+approves the rescan.
+
+Learned tools with an over-long name (one whose `learned_` prefix would
+break the 64-character provider cap — possible only for a directory
+dropped in by hand, since `writeToolFor` refuses such names) stay
+visible in the inventory but are never offered to the model: one bad
+name would fail every LLM call the target makes.
 
 Each subagent invocation calls `learnedExtrasFor(<wrapper name>)`
 inside the wrapper function body — never at module top level — and
@@ -80,10 +91,17 @@ built-in.
 
 `writeSkill(dir, name, description, body)` lives in `std::skills` so
 user-written agents get the same primitive. It composes the frontmatter
-itself (a raw-content parameter would let a description extend the
-frontmatter), validates the name against kebab-case rather than
-rewriting it, refuses duplicates before raising anything, then shows
-the complete file in a `std::skills::reviewSkill` interrupt. The
+through tarsec's `stringifyFrontmatter` (the encode half of the parser
+`std::markdown` wraps, added in tarsec 0.5.4 for exactly this: a
+hand-rolled encoder against a grammar it does not own kept producing
+silent read-back corruption — flow syntax, quote escapes, bare-numeric
+coercion). The serializer round-trips every value it accepts and throws
+on the rare one it cannot hold, which `writeSkill` surfaces as a clean
+failure. A raw-content parameter was rejected because a description
+could then extend the frontmatter. It validates the name against
+kebab-case rather than rewriting it, refuses duplicates before raising
+anything, then shows the complete file in a
+`std::skills::reviewSkill` interrupt. The
 handler answers accept (or bare `approve()`), revise-with-feedback —
 returned to the caller so the coordinator redrafts and tries again — or
 reject, which fails the call. Only an accepted draft touches disk, via
@@ -107,15 +125,20 @@ review interrupts; a stricter custom policy overrides the rule like any
 other. `docs/dev/agents/approval-policies.md` documents the
 placeholder.
 
-One narrow write rides along: `runTool` records a use count in the
-tool's `meta.json` after every run, and `recommended`/`with-writes`
-approve exactly that file under the agent-home toolboxes so a
-successful learned-tool run cannot end in a rejected metadata write.
-Other writes are NOT widened: saving a skill or publishing a tool raises the
-ordinary write interrupts on top of the review gate, and under
-with-writes (cwd-scoped) a home-directory write surfaces for explicit
-approval. For "the agent is permanently teaching itself something,"
-that double visibility is intended.
+`runTool`'s use-count bookkeeping has its own effect,
+`std::toolbox::recordUse`, approved under `recommended` for the
+agent-home toolboxes. A `std::write` rule scoped to `meta.json` was
+tried first and reverted: a dir+filename glob cannot tell the stdlib's
+own bookkeeping apart from ANY program writing arbitrary content into a
+tool's `meta.json`, whose `purpose`/`request` text `listTools` then
+trusts — so the rule was a content-injection hole. The dedicated effect
+approves only the mutation the stdlib composes, and it is best-effort:
+a declined `recordUse` never fails a run that succeeded. Writes are NOT
+widened: saving a skill or publishing a tool raises the ordinary write
+interrupts on top of the review gate, and under with-writes
+(cwd-scoped) a home-directory write surfaces for explicit approval. For
+"the agent is permanently teaching itself something," that double
+visibility is intended.
 
 The scope rules live in the shared `readScopeRules()`, so a non-agent
 `agency run --policy recommended` script gets them too; the built-in

--- a/packages/agency-lang/docs/dev/agents/learned-skills-and-toolbox.md
+++ b/packages/agency-lang/docs/dev/agents/learned-skills-and-toolbox.md
@@ -1,0 +1,122 @@
+# Learned skills and the wired-in toolbox
+
+The agency agent can be taught. The user tells the coordinator to save a
+skill for a named subagent, or to have a tool written into that
+subagent's toolbox; a review interrupt shows the complete artifact
+before anything lands on disk; and the target subagent carries the
+result from its next invocation on — in the same session, and in every
+later one. This note records how the pieces fit and the decisions
+behind them. The spec is
+`2026-08-31-learned-skills-and-toolbox-spec.md` at the package root
+while the arc is in flight.
+
+## What "learned" means here
+
+Two kinds of artifact, both user-directed (the agent never decides on
+its own to save something):
+
+- A **skill** is reference prose: a flat-layout markdown file with
+  `name` and `description` frontmatter, the same format the bundled
+  skills use. The target agent's skills tool lists it and reads it on
+  demand. Skills never become slash commands — a slash command is
+  user-invoked, a skill is model-invoked.
+- A **tool** is executable: a `std::toolbox` tool directory produced by
+  the `writeTool` pipeline (drafting agent, review agent, sandbox
+  compile and typecheck, generated tests for pure tools, review
+  interrupt, staged publish).
+
+## Storage
+
+Everything lives under the agent home, namespaced by the coordinator's
+wrapper names (`code`, `research`, `explorer`, `oracle`, `review`,
+`writing`, `rewrite`):
+
+```
+<agent home>/
+  skills/<subagent>/<skill-name>.md
+  tools/<subagent>/<tool-name>/...
+```
+
+Global only: project-scoped directories were deliberately deferred. The
+bundled skills stay immutable in the package; learned skills are an
+overlay served through a second tool, `learned_skills_<agent>`.
+
+## The catalogs (`lib/agents/agency-agent/lib/learned.agency`)
+
+Session state sits in two module globals — a top-level `let`, not a
+`static const`. The CLI agent is one long-lived run, so a global lives
+for the whole session and, unlike a static, can be updated in place
+when something is saved (`docs/site/guide/global-vs-static.md`).
+
+Loading is lazy and interrupt-bounded: the skills catalog loads with
+ONE `std::skills::skillsDir` interrupt covering the whole skills root
+(`scanSkillsSubdirs` in `stdlib/skills.agency`); the toolbox catalog
+loads with one `listTools` scan per agent directory that exists —
+absent directories are skipped with a plain `exists` check that raises
+nothing. Saving updates the catalog in place (`recordLearnedSkill`,
+`recordLearnedTool`), which is why `writeSkill` returns the complete
+entry: nothing ever rescans after a save, so no second interrupt.
+
+Each subagent invocation calls `learnedExtrasFor(<wrapper name>)`
+inside the wrapper function body — never at module top level — and
+passes the result through the stdlib agents' `extraTools` parameter
+(the code subagent appends to its local tool list instead). Building
+per invocation is what makes a skill saved this turn live on the
+target's next call.
+
+Learned tools are renamed `learned_<name>` before the model sees them.
+That prefix is the whole collision story: no built-in tool starts with
+`learned_` (a test pins this for the code agent's list), so a learned
+tool can never shadow or trip the provider's unique-name rule against a
+built-in.
+
+## The write paths
+
+`writeSkill(dir, name, description, body)` lives in `std::skills` so
+user-written agents get the same primitive. It composes the frontmatter
+itself (a raw-content parameter would let a description extend the
+frontmatter), validates the name against kebab-case rather than
+rewriting it, refuses duplicates before raising anything, then shows
+the complete file in a `std::skills::reviewSkill` interrupt. The
+handler answers accept (or bare `approve()`), revise-with-feedback —
+returned to the caller so the coordinator redrafts and tries again — or
+reject, which fails the call. Only an accepted draft touches disk, via
+ordinary `std::mkdir`/`std::write`.
+
+`writeToolFor(target, ...)` on the coordinator is a thin wrapper over
+`writeTool` rooted at `<agent home>/tools/<target>`; the pipeline and
+its own review interrupt are used as-is.
+
+## Policy
+
+The built-in read scope covers
+`{<agent-home>/skills/**,<agent-home>/tools/**}`
+(`readScopeRules` in `lib/runtime/builtinPolicies.ts`, the
+`<agent-home>` placeholder in `lib/runtime/policy.ts`). This is a
+deliberate widening, stated as a trade: without it, every learned-skill
+read, catalog scan, and `runTool` call (which rescans its tool
+directory) would prompt on every use and auto-reject headless. The
+directories are the agent's own home and are written only through
+review interrupts; a stricter custom policy overrides the rule like any
+other. `docs/dev/agents/approval-policies.md` documents the
+placeholder.
+
+Writes are NOT widened: saving a skill or publishing a tool raises the
+ordinary write interrupts on top of the review gate, and under
+with-writes (cwd-scoped) a home-directory write surfaces for explicit
+approval. For "the agent is permanently teaching itself something,"
+that double visibility is intended.
+
+## The user surface
+
+`/skills` and `/toolbox` (`lib/agents/agency-agent/lib/learnedView.agency`)
+render the inventory grouped by subagent, with a one-line hint when
+nothing has been learned. There is no dedicated remove flow: deleting a
+learned artifact is an ordinary file operation, picked up at the next
+session's scan.
+
+## Deferred on purpose
+
+Project-scoped directories; the coordinator as a learning target;
+promoting a learned skill to a slash command; agent-initiated learning;
+migrating the bundled skills tools off statics.

--- a/packages/agency-lang/docs/dev/stdlib/toolbox.md
+++ b/packages/agency-lang/docs/dev/stdlib/toolbox.md
@@ -156,10 +156,13 @@ stops the tool before it has side effects. It then runs `main` through
 `runFile`, with `wallClock` set to the tool's own `maxTime` plus
 headroom, so the guard trips before the subprocess is killed. `runFile`
 clamps `wallClock` to an hour, so `writeTool` refuses a `maxTime` above
-an hour minus that headroom. It then rewrites `meta.json` with
-one more use and the time. If that write fails, the returned failure
-carries the tool's result in its message, since the tool has already
-run. Otherwise it returns the node's own `Result`.
+an hour minus that headroom. It then rewrites `meta.json` with one more
+use and the time, behind its own `std::toolbox::recordUse` interrupt
+(the write itself uses the interrupt-free `_write`, covered by that
+approval — the same pattern as a scan's reads). The bookkeeping is
+best-effort: the tool has already run, so a declined interrupt or a
+failed write never turns a successful run into a failure; the count
+simply stays unrecorded. It returns the node's own `Result`.
 
 ## Model calls and mocks
 

--- a/packages/agency-lang/docs/site/stdlib/agents/writing/rewrite.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/writing/rewrite.md
@@ -28,6 +28,7 @@ writingRewriteAgent(
   maxTime: number = 10m,
   model: string = "",
   provider: string = "",
+  extraTools: any[] = [],
 ): Result<string>
 ```
 
@@ -46,6 +47,7 @@ Review prose and return it rewritten with the findings applied. If
   @param maxTime - Hard wall-clock cap for all rounds together
   @param model - Model override, or "" for the ambient model
   @param provider - Provider for the model override
+  @param extraTools - Extra tools to offer the LLM, appended to the built-in set
 
 * Rewrites a piece of text according to the findings of a writing review.
  *
@@ -74,9 +76,10 @@ Review prose and return it rewritten with the findings applied. If
 | maxTime | `number` | 10m |
 | model | `string` | "" |
 | provider | `string` | "" |
+| extraTools | `any[]` | [] |
 
 **Returns:** `Result<string>`
 
 **Throws:** `std::guard`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/writing/rewrite.agency#L85))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/writing/rewrite.agency#L86))

--- a/packages/agency-lang/docs/site/stdlib/skills.md
+++ b/packages/agency-lang/docs/site/stdlib/skills.md
@@ -48,7 +48,7 @@ export type SkillReview =
   | { verdict: "revise"; feedback: string }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L334))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L333))
 
 ### WriteSkillOutcome
 
@@ -56,7 +56,7 @@ export type SkillReview =
 export type WriteSkillOutcome = { saved: SkillEntry } | { revise: string }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L338))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L337))
 
 ## Effects
 
@@ -119,7 +119,7 @@ effect std::skills::reviewSkill {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L326))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L325))
 
 ## Functions
 
@@ -174,32 +174,36 @@ Build a skills tool for an LLM over a directory of skills.
 
 **Throws:** `std::skills::skillsDir`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L264))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L274))
 
 ### scanSkillsSubdirs
 
 ```ts
-scanSkillsSubdirs(root: string): Record<string, SkillEntry[]>
+scanSkillsSubdirs(root: string, subdirs: string[]): Record<string, SkillEntry[]>
 ```
 
-Scan a directory whose immediate subdirectories each hold one agent's
+Scan named subdirectories of a root, each holding one agent's
   flat-layout skills. Raises one `std::skills::skillsDir` interrupt for
-  the root; its approval covers the reads. A missing root or a subdir
-  with no markdown files yields no entry for it.
+  the root; its approval covers the reads. Each subdirectory gets its
+  own MAX_SKILL_FILES scan; one with no markdown files (or that does not
+  exist) yields no entry. Taking the names as a parameter keeps the
+  record's keys caller-chosen data, never something read off the disk.
 
-  @param root - The directory holding one subdirectory per agent
+  @param root - The directory holding the subdirectories
+  @param subdirs - The subdirectory names to scan
 
 **Parameters:**
 
 | Name | Type | Default |
 |---|---|---|
 | root | `string` |  |
+| subdirs | `string[]` |  |
 
 **Returns:** `Record<string, SkillEntry[]>`
 
 **Throws:** `std::skills::skillsDir`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L284))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L294))
 
 ### writeSkill
 
@@ -237,7 +241,7 @@ Save a skill file into a skills directory, after the user reviews it.
 
 **Throws:** `std::skills::reviewSkill`, `std::mkdir`, `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L368))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L367))
 
 ### docsSkill
 
@@ -262,7 +266,7 @@ Build a docs tool for an LLM over the packaged Agency documentation.
 |---|---|---|
 | section | `\| "guide" \| "cli" \| "diagnostics" \| "stdlib" \| "agent"` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L424))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L430))
 
 ### bundledDocsDir
 
@@ -275,7 +279,7 @@ The directory holding the Agency docs that ship inside the package. A
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L445))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L451))
 
 ### agentSkill
 
@@ -295,7 +299,7 @@ Build a skills tool over the skills shipped for one agent. The returned
 |---|---|---|
 | agent | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L453))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L459))
 
 ### commandsDir
 
@@ -348,7 +352,7 @@ Discover .md files under `dir` and parse each as a slash-command
 
 **Throws:** `std::skills::commandsDir`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L541))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L547))
 
 ### expandSlash
 
@@ -387,4 +391,4 @@ Expand a /command in `msg` into its command body. Returns the rendered
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L596))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L602))

--- a/packages/agency-lang/docs/site/stdlib/skills.md
+++ b/packages/agency-lang/docs/site/stdlib/skills.md
@@ -48,7 +48,7 @@ export type SkillReview =
   | { verdict: "revise"; feedback: string }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L333))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L345))
 
 ### WriteSkillOutcome
 
@@ -56,7 +56,7 @@ export type SkillReview =
 export type WriteSkillOutcome = { saved: SkillEntry } | { revise: string }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L337))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L349))
 
 ## Effects
 
@@ -95,7 +95,7 @@ effect std::skills::skillsDir {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L192))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L194))
 
 ### std::skills::commandsDir
 
@@ -106,7 +106,7 @@ effect std::skills::commandsDir {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L197))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L199))
 
 ### std::skills::reviewSkill
 
@@ -119,7 +119,17 @@ effect std::skills::reviewSkill {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L325))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L337))
+
+## Constants
+
+### MAX_TOOL_NAME_LEN
+
+```ts
+export static const MAX_TOOL_NAME_LEN = 64
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L103))
 
 ## Functions
 
@@ -146,7 +156,7 @@ Build the skills tool for `dir` from already-scanned entries. Pure: no
 | entries | `SkillEntry[]` |  |
 | name | `string` | "" |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L201))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L203))
 
 ### skillsDir
 
@@ -174,7 +184,7 @@ Build a skills tool for an LLM over a directory of skills.
 
 **Throws:** `std::skills::skillsDir`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L274))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L276))
 
 ### scanSkillsSubdirs
 
@@ -203,7 +213,7 @@ Scan named subdirectories of a root, each holding one agent's
 
 **Throws:** `std::skills::skillsDir`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L294))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L296))
 
 ### writeSkill
 
@@ -241,7 +251,7 @@ Save a skill file into a skills directory, after the user reviews it.
 
 **Throws:** `std::skills::reviewSkill`, `std::mkdir`, `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L367))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L379))
 
 ### docsSkill
 
@@ -266,7 +276,7 @@ Build a docs tool for an LLM over the packaged Agency documentation.
 |---|---|---|
 | section | `\| "guide" \| "cli" \| "diagnostics" \| "stdlib" \| "agent"` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L430))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L441))
 
 ### bundledDocsDir
 
@@ -279,7 +289,7 @@ The directory holding the Agency docs that ship inside the package. A
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L451))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L462))
 
 ### agentSkill
 
@@ -299,7 +309,7 @@ Build a skills tool over the skills shipped for one agent. The returned
 |---|---|---|
 | agent | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L459))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L470))
 
 ### commandsDir
 
@@ -352,7 +362,7 @@ Discover .md files under `dir` and parse each as a slash-command
 
 **Throws:** `std::skills::commandsDir`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L547))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L558))
 
 ### expandSlash
 
@@ -391,4 +401,4 @@ Expand a /command in `msg` into its command body. Returns the rendered
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L602))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L613))

--- a/packages/agency-lang/docs/site/stdlib/skills.md
+++ b/packages/agency-lang/docs/site/stdlib/skills.md
@@ -21,6 +21,43 @@ Give an LLM access to a directory of skills, and support Claude-Code-style
   }
   ```
 
+## Types
+
+### SkillEntry
+
+```ts
+export type SkillEntry = {
+  name: string;
+  description: string;
+  location: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L39))
+
+### SkillReview
+
+The value a handler passes to approve() for std::skills::reviewSkill.
+  A bare approve() counts as accept.
+
+```ts
+/** The value a handler passes to approve() for std::skills::reviewSkill.
+  A bare approve() counts as accept. */
+export type SkillReview =
+  | { verdict: "accept" }
+  | { verdict: "revise"; feedback: string }
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L334))
+
+### WriteSkillOutcome
+
+```ts
+export type WriteSkillOutcome = { saved: SkillEntry } | { revise: string }
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L338))
+
 ## Effects
 
 ### std::skills::skillsDir
@@ -58,7 +95,7 @@ effect std::skills::skillsDir {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L187))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L192))
 
 ### std::skills::commandsDir
 
@@ -69,9 +106,47 @@ effect std::skills::commandsDir {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L192))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L197))
+
+### std::skills::reviewSkill
+
+```ts
+@alwaysUnder(dir)
+effect std::skills::reviewSkill {
+  dir: string;
+  name: string;
+  content: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L326))
 
 ## Functions
+
+### skillsToolFromEntries
+
+```ts
+skillsToolFromEntries(dir: string, entries: SkillEntry[], name: string = "")
+```
+
+Build the skills tool for `dir` from already-scanned entries. Pure: no
+  reads, no interrupts. Callers that already hold a directory's entries
+  (a catalog updated after a save) use this to rebuild the tool without
+  rescanning.
+
+  @param dir - The directory the tool will read skills from
+  @param entries - The skills to list in the tool description
+  @param name - Optional explicit tool name. Sanitized to alphanumerics/underscores and capped at 64 characters; defaults to a name derived from `dir`.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| dir | `string` |  |
+| entries | `SkillEntry[]` |  |
+| name | `string` | "" |
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L201))
 
 ### skillsDir
 
@@ -99,7 +174,70 @@ Build a skills tool for an LLM over a directory of skills.
 
 **Throws:** `std::skills::skillsDir`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L240))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L264))
+
+### scanSkillsSubdirs
+
+```ts
+scanSkillsSubdirs(root: string): Record<string, SkillEntry[]>
+```
+
+Scan a directory whose immediate subdirectories each hold one agent's
+  flat-layout skills. Raises one `std::skills::skillsDir` interrupt for
+  the root; its approval covers the reads. A missing root or a subdir
+  with no markdown files yields no entry for it.
+
+  @param root - The directory holding one subdirectory per agent
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| root | `string` |  |
+
+**Returns:** `Record<string, SkillEntry[]>`
+
+**Throws:** `std::skills::skillsDir`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L284))
+
+### writeSkill
+
+```ts
+writeSkill(
+  dir: string,
+  name: string,
+  description: string,
+  body: string,
+): Result<WriteSkillOutcome>
+```
+
+Save a skill file into a skills directory, after the user reviews it.
+  Composes the flat-layout markdown (frontmatter with name and
+  description, then the body), raises a `std::skills::reviewSkill`
+  interrupt showing the complete file, and only writes on acceptance. A
+  "revise" review returns the feedback instead of writing, so the caller
+  can redraft. A rejected interrupt fails the call.
+
+  @param dir - The skills directory to write into
+  @param name - The skill's name; also its filename. Lowercase letters, digits, and hyphens.
+  @param description - One line telling the reading agent when to use the skill
+  @param body - The skill's markdown body
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| dir | `string` |  |
+| name | `string` |  |
+| description | `string` |  |
+| body | `string` |  |
+
+**Returns:** `Result<WriteSkillOutcome>`
+
+**Throws:** `std::skills::reviewSkill`, `std::mkdir`, `std::write`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L368))
 
 ### docsSkill
 
@@ -124,7 +262,7 @@ Build a docs tool for an LLM over the packaged Agency documentation.
 |---|---|---|
 | section | `\| "guide" \| "cli" \| "diagnostics" \| "stdlib" \| "agent"` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L260))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L424))
 
 ### bundledDocsDir
 
@@ -137,7 +275,7 @@ The directory holding the Agency docs that ship inside the package. A
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L281))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L445))
 
 ### agentSkill
 
@@ -157,7 +295,7 @@ Build a skills tool over the skills shipped for one agent. The returned
 |---|---|---|
 | agent | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L289))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L453))
 
 ### commandsDir
 
@@ -210,7 +348,7 @@ Discover .md files under `dir` and parse each as a slash-command
 
 **Throws:** `std::skills::commandsDir`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L377))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L541))
 
 ### expandSlash
 
@@ -249,4 +387,4 @@ Expand a /command in `msg` into its command body. Returns the rendered
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L432))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L596))

--- a/packages/agency-lang/docs/site/stdlib/toolbox.md
+++ b/packages/agency-lang/docs/site/stdlib/toolbox.md
@@ -76,7 +76,7 @@ export type ModuleFacts = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L125))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L138))
 
 ### ToolMeta
 
@@ -95,7 +95,7 @@ export type ToolMeta = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L132))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L145))
 
 ### ToolEntry
 
@@ -114,7 +114,7 @@ export type ToolEntry = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L144))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L157))
 
 ### WriteToolReview
 
@@ -129,7 +129,7 @@ export type WriteToolReview =
   | { verdict: "revise"; feedback: string }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L154))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L167))
 
 ## Effects
 
@@ -142,7 +142,19 @@ effect std::toolbox::scan {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L112))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L113))
+
+### std::toolbox::recordUse
+
+```ts
+@alwaysUnder(dir)
+effect std::toolbox::recordUse {
+  dir: string;
+  name: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L124))
 
 ### std::toolbox::review
 
@@ -156,7 +168,7 @@ effect std::toolbox::review {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L116))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L129))
 
 ## Functions
 
@@ -184,7 +196,7 @@ List the tools in a toolbox directory. Raises a `std::toolbox::scan`
 
 **Throws:** `std::toolbox::scan`, `std::ls`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L317))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L330))
 
 ### writeTool
 
@@ -236,7 +248,7 @@ Write a reusable tool into a toolbox directory. The coding agent drafts
 
 **Throws:** `std::mkdir`, `std::remove`, `std::toolbox::review`, `std::toolbox::scan`, `std::write`, `std::move`, `std::read`, `std::guard`, `std::run`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L844))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L857))
 
 ### runTool
 
@@ -249,8 +261,10 @@ runTool(
 ```
 
 Run a saved tool's `main` node in a subprocess and return what it
-  returned. The tool's meta.json records one more use and the time; it
-  does not record the result.
+  returned. The tool's meta.json records one more use and the time,
+  best-effort behind a `std::toolbox::recordUse` interrupt: a declined
+  or failed record never fails a run that succeeded. It does not record
+  the result.
 
   @param name - The tool's name under dir
   @param request - The tool's input, a value of its Request type
@@ -266,6 +280,6 @@ Run a saved tool's `main` node in a subprocess and return what it
 
 **Returns:** `Result<Json>`
 
-**Throws:** `std::toolbox::scan`, `std::run`, `std::guard`, `std::write`
+**Throws:** `std::toolbox::scan`, `std::run`, `std::guard`, `std::toolbox::recordUse`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L933))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L952))

--- a/packages/agency-lang/evals/agency-agent/README.md
+++ b/packages/agency-lang/evals/agency-agent/README.md
@@ -38,8 +38,11 @@ is an Agency coding task graded by its own harness, and `news` and
 `hollow-creek` are goal-judged questions. Two conversation tests,
 `identity` and `run-on-openrouter`, come from a real session where the
 agent could not say what it was or how to change its model: each asks
-the agent about itself and is goal-judged, with no workdir. An
-unfiltered run covers all nine; to run only the terminal-bench-shaped
+the agent about itself and is goal-judged, with no workdir. A third
+conversation test, `learned-skill`, teaches the explorer subagent a
+skill mid-session and checks the explorer uses it; it depends on the
+approve-all policy covering the review interrupt and the home write. An
+unfiltered run covers all ten; to run only the terminal-bench-shaped
 tests, pass `--test` for each of the four below.
 
 | test                | pattern from the benchmark                                                                    | must pass                                    |

--- a/packages/agency-lang/evals/agency-agent/learned-skill/test.json
+++ b/packages/agency-lang/evals/agency-agent/learned-skill/test.json
@@ -1,0 +1,5 @@
+{
+  "description": "The agent can learn a skill for a named subagent and use it in the same session. Relies on the suite's approve-all policy: the review interrupt and the home-directory write must be auto-approved in a headless run.",
+  "input": "Teach the explorer agent this skill, then use the explorer to answer: what should you do first in an unfamiliar repo? Skill: when dropped into a repo you have not seen, read the README and the directory layout first and produce a short orientation before answering anything else.",
+  "goal": "saves a skill targeted at the explorer subagent after review, and the explorer's answer reflects the taught content (read the README and layout first, produce an orientation); the reply confirms the skill was saved"
+}

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/coordinator.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/coordinator.agency
@@ -10,6 +10,7 @@ import { setMemoryId } from "std::memory"
 import { Attachment, systemMessage } from "std::thread"
 
 import { generateImageFile } from "../../lib/images.agency"
+import { learnSkill, writeToolFor } from "./learn.agency"
 import { getMcpTools } from "../../lib/mcp.agency"
 import { getCapabilities } from "../../shared.agency"
 import { AgentBrain, BrainContext } from "../brain.agency"
@@ -40,6 +41,8 @@ static const mainAgentTools = [
   writingAgent,
   rewriteAgent,
   generateImageFile,
+  learnSkill,
+  writeToolFor,
 ]
 
 def coordinatorInit(context: BrainContext) {

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/learn.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/learn.agency
@@ -2,29 +2,23 @@
   @summary The coordinator's two learning tools: teach a subagent a
   skill (learnSkill) or have a tool written into its toolbox
   (writeToolFor). Both validate the target, route the save through the
-  stdlib review pipelines, and record the result in the session
-  catalogs so the target's next invocation carries it.
+  stdlib review pipelines, and invalidate the session catalogs so the
+  target's next invocation rescans and carries the result.
 */
 import { writeSkill } from "std::skills"
 import { writeTool } from "std::toolbox"
 
 import {
   LEARN_TARGETS,
+  invalidateLearned,
   learnedSkillsRoot,
   learnedToolsRoot,
-  recordLearnedSkill,
-  recordLearnedTool,
+  maxLearnedToolName,
  } from "../../lib/learned.agency"
 
 def unknownTarget(target: string): string {
   return "Unknown target '${target}'. Valid targets: ${LEARN_TARGETS.join(", ")}."
 }
-
-// Providers cap tool names at 64 characters, and a learned tool is
-// advertised as `learned_<name>`, so the name itself gets what the
-// prefix leaves. Enforced here, where the prefix is known, rather than
-// in std::toolbox, which has no prefix.
-static const MAX_LEARNED_TOOL_NAME = 56
 
 export def learnSkill(
   target: string,
@@ -58,7 +52,7 @@ export def learnSkill(
   if (value.revise != undefined) {
     return "The user asked for a revision: ${value.revise}. Redraft the skill with that feedback and call learnSkill again."
   }
-  recordLearnedSkill(target, value.saved)
+  invalidateLearned()
   return "Saved. The ${target} agent has the '${value.saved.name}' skill from its next invocation. /skills lists it."
 }
 
@@ -82,13 +76,13 @@ export def writeToolFor(
   if (!LEARN_TARGETS.includes(target)) {
     return unknownTarget(target)
   }
-  if (name.length > MAX_LEARNED_TOOL_NAME) {
-    return "Not saved: the name must be at most ${MAX_LEARNED_TOOL_NAME} characters, because the tool is advertised as learned_${name} and providers cap tool names at 64."
+  if (name.length > maxLearnedToolName()) {
+    return "Not saved: the name must be at most ${maxLearnedToolName()} characters, because the tool is advertised as learned_${name} and providers cap tool names at 64."
   }
   const written = writeTool(name, purpose, request, dir: "${learnedToolsRoot()}/${target}")
   if (written is failure(reason)) {
     return "Not saved: ${reason}"
   }
-  recordLearnedTool(target, written.value)
+  invalidateLearned()
   return "Saved. The ${target} agent can call it as learned_${written.value.name} from its next invocation. /toolbox lists it."
 }

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/learn.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/learn.agency
@@ -20,6 +20,12 @@ def unknownTarget(target: string): string {
   return "Unknown target '${target}'. Valid targets: ${LEARN_TARGETS.join(", ")}."
 }
 
+// Providers cap tool names at 64 characters, and a learned tool is
+// advertised as `learned_<name>`, so the name itself gets what the
+// prefix leaves. Enforced here, where the prefix is known, rather than
+// in std::toolbox, which has no prefix.
+static const MAX_LEARNED_TOOL_NAME = 56
+
 export def learnSkill(
   target: string,
   name: string,
@@ -75,6 +81,9 @@ export def writeToolFor(
   """
   if (!LEARN_TARGETS.includes(target)) {
     return unknownTarget(target)
+  }
+  if (name.length > MAX_LEARNED_TOOL_NAME) {
+    return "Not saved: the name must be at most ${MAX_LEARNED_TOOL_NAME} characters, because the tool is advertised as learned_${name} and providers cap tool names at 64."
   }
   const written = writeTool(name, purpose, request, dir: "${learnedToolsRoot()}/${target}")
   if (written is failure(reason)) {

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/learn.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/learn.agency
@@ -1,0 +1,85 @@
+/** @module
+  @summary The coordinator's two learning tools: teach a subagent a
+  skill (learnSkill) or have a tool written into its toolbox
+  (writeToolFor). Both validate the target, route the save through the
+  stdlib review pipelines, and record the result in the session
+  catalogs so the target's next invocation carries it.
+*/
+import { writeSkill } from "std::skills"
+import { writeTool } from "std::toolbox"
+
+import {
+  LEARN_TARGETS,
+  learnedSkillsRoot,
+  learnedToolsRoot,
+  recordLearnedSkill,
+  recordLearnedTool,
+ } from "../../lib/learned.agency"
+
+def unknownTarget(target: string): string {
+  return "Unknown target '${target}'. Valid targets: ${LEARN_TARGETS.join(", ")}."
+}
+
+export def learnSkill(
+  target: string,
+  name: string,
+  description: string,
+  body: string,
+): string {
+  """
+  Teach one subagent a skill it keeps permanently. Draft the skill from
+  what the user asked for, written for the target agent as the reader:
+  `description` is one line telling that agent when to reach for the
+  skill; `body` is the skill itself in markdown. The user reviews the
+  complete file before anything is saved and may accept, ask for a
+  revision (redraft with their feedback and call this again), or
+  reject.
+
+  @param target - Which subagent keeps the skill: code, research, explorer, oracle, review, writing, or rewrite
+  @param name - A short kebab-case skill name (lowercase letters, digits, hyphens)
+  @param description - One line telling the target agent when to use the skill
+  @param body - The skill content, markdown
+  """
+  if (!LEARN_TARGETS.includes(target)) {
+    return unknownTarget(target)
+  }
+  const dir = "${learnedSkillsRoot()}/${target}"
+  const outcome = writeSkill(dir, name, description, body)
+  if (outcome is failure(reason)) {
+    return "Not saved: ${reason}"
+  }
+  const value = outcome.value
+  if (value.revise != undefined) {
+    return "The user asked for a revision: ${value.revise}. Redraft the skill with that feedback and call learnSkill again."
+  }
+  recordLearnedSkill(target, value.saved)
+  return "Saved. The ${target} agent has the '${value.saved.name}' skill from its next invocation. /skills lists it."
+}
+
+export def writeToolFor(
+  target: string,
+  name: string,
+  purpose: string,
+  request: string,
+): string {
+  """
+  Have a reusable tool written into one subagent's toolbox. A coding
+  agent drafts the implementation against the request type, the draft is
+  reviewed, typechecked, and tested, and the user accepts, revises, or
+  rejects it before anything is saved. Takes several model calls.
+
+  @param target - Which subagent gets the tool: code, research, explorer, oracle, review, writing, or rewrite
+  @param name - The tool's name, e.g. hnTopStories
+  @param purpose - What the tool should do, in plain language
+  @param request - The tool's input type as Agency type text, e.g. { topics: string[]; maxItems: number }
+  """
+  if (!LEARN_TARGETS.includes(target)) {
+    return unknownTarget(target)
+  }
+  const written = writeTool(name, purpose, request, dir: "${learnedToolsRoot()}/${target}")
+  if (written is failure(reason)) {
+    return "Not saved: ${reason}"
+  }
+  recordLearnedTool(target, written.value)
+  return "Saved. The ${target} agent can call it as learned_${written.value.name} from its next invocation. /toolbox lists it."
+}

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/prompts/main-large.md
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/prompts/main-large.md
@@ -136,6 +136,16 @@ Pass the explorer a self-contained question with explicit scope
 not see your conversation. Be clear about the level of detail
 expected.
 
+## Learning
+
+You can teach a subagent something it keeps permanently. `learnSkill`
+saves a skill (reference prose the target agent reads on demand);
+`writeToolFor` has a reusable tool written into the target agent's
+toolbox. Always pass an explicit `target`. If the reply says the user
+asked for a revision, redraft with their feedback and call the tool
+again. Never claim a skill or tool was saved unless the reply said so.
+`/skills` and `/toolbox` list what has been learned.
+
 ## What you are
 
 Your identity, brain, and the models this session runs on are in the

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/prompts/main-small.md
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/prompts/main-small.md
@@ -32,6 +32,13 @@ Routing rules:
 Style: plain, direct answers in Markdown. No preamble. Keep replies
 short unless the task demands detail.
 
+## Learning
+
+`learnSkill(target, name, description, body)` teaches a subagent a
+skill; `writeToolFor(target, name, purpose, request)` writes it a tool.
+The user reviews before anything is saved; on a revision reply, redraft
+and call again. Never claim a save the reply did not confirm.
+
 ## What you are
 
 The `<session_facts>` block below this prompt says what you are and

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/subagents/code.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/subagents/code.agency
@@ -27,6 +27,7 @@ import { exec } from "std::shell"
 import { supervise } from "std::supervise"
 import { systemMessage } from "std::thread"
 
+import { learnedExtrasFor } from "../../../lib/learned.agency"
 import { withWebSearch, getSearchBackend } from "../../../lib/search.agency"
 import { getSlowModel, getSlowProvider } from "../../../shared.agency"
 import { oracleAgent } from "./oracle.agency"
@@ -267,6 +268,7 @@ Deliverable: ONLY the Agency module source that will be saved as ${target}. The 
     context: context,
     maxCost: ESCALATE_MAX_COST,
     maxTime: ESCALATE_MAX_TIME,
+    extraTools: learnedExtrasFor("code"),
   )
 }
 
@@ -520,7 +522,7 @@ def converse(
   originalUserMsg: string,
   agencyTask: boolean,
 ): string {
-  const tools = [...codeTools]
+  const tools = [...codeTools, ...learnedExtrasFor("code")]
   tools.push(escalate.partial(task: userMsg))
   let message = userMsg
   let attemptsLeft = 3

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/subagents/explorer.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/subagents/explorer.agency
@@ -12,6 +12,7 @@
  */
 import { explorerAgent as stdExplorerAgent } from "std::agents/explorer"
 
+import { learnedExtrasFor } from "../../../lib/learned.agency"
 import { getSlowModel, getSlowProvider } from "../../../shared.agency"
 
 export def explorerAgent(userMsg: string): string {
@@ -47,6 +48,7 @@ export def explorerAgent(userMsg: string): string {
     model: getSlowModel(),
     provider: getSlowProvider(),
     session: "explorer",
+    extraTools: learnedExtrasFor("explorer"),
   )
   if (isFailure(result)) {
     return "The explorer could not finish: ${result.error}"

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/subagents/oracle.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/subagents/oracle.agency
@@ -12,6 +12,7 @@
  */
 import { oracleAgent as stdOracleAgent } from "std::agents/oracle"
 
+import { learnedExtrasFor } from "../../../lib/learned.agency"
 import { getSlowModel, getSlowProvider } from "../../../shared.agency"
 
 export def oracleAgent(userMsg: string): string {
@@ -42,6 +43,7 @@ export def oracleAgent(userMsg: string): string {
     model: getSlowModel(),
     provider: getSlowProvider(),
     session: "oracle",
+    extraTools: learnedExtrasFor("oracle"),
   )
   if (isFailure(result)) {
     return "The oracle could not finish: ${result.error}"

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/subagents/research.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/subagents/research.agency
@@ -19,6 +19,8 @@ import { agencyResearcherAgent } from "std::agents/agency/researcher"
 import { researcherAgent } from "std::agents/researcher"
 import { memoryTools, planningTools } from "std::agents/lib/toolkits"
 import { setMemoryId } from "std::memory"
+
+import { learnedExtrasFor } from "../../../lib/learned.agency"
 import { highlight } from "std::syntax"
 
 export static const researchTools: any[] = [
@@ -55,14 +57,14 @@ export def researchAgent(userMsg: string, agencyTopic: boolean = false): string 
       question: userMsg,
       context: replStyle,
       session: "research",
-      extraTools: researchTools,
+      extraTools: [...researchTools, ...learnedExtrasFor("research")],
     )
   } else {
     result = researcherAgent(
       task: userMsg,
       context: replStyle,
       session: "research",
-      extraTools: researchTools,
+      extraTools: [...researchTools, ...learnedExtrasFor("research")],
     )
   }
   if (isFailure(result)) {

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/subagents/review.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/subagents/review.agency
@@ -1,6 +1,8 @@
 import { agencyReviewAgent } from "std::agents/agency/review"
 import { reviewAgent as generalReviewAgent } from "std::agents/review"
 import { Feedback, mergeFeedback, renderFeedback } from "std::agents/lib/feedback"
+
+import { learnedExtrasFor } from "../../../lib/learned.agency"
 import { setMemoryId } from "std::memory"
 import { gitStatus, gitIsRepo } from "std::git"
 import { filter, map } from "std::array"
@@ -25,7 +27,7 @@ export def reviewAgent(userMsg: string, agencyTask: boolean = false): string {
     language, where that reviewer has nothing useful to say.
   """
   if (!agencyTask) {
-    const general = generalReviewAgent(work: userMsg, task: "Review this code.")
+    const general = generalReviewAgent(work: userMsg, task: "Review this code.", extraTools: learnedExtrasFor("review"))
     return renderFeedback(general)
   }
   return renderFeedback(review(userMsg))
@@ -42,7 +44,7 @@ export def review(userMsg: string): Result<Feedback[]> {
     let feedback: Result<Feedback[]> = success([])
 
     for (codeSnippet in snippets) {
-      feedback = mergeFeedback(feedback, agencyReviewAgent(codeSnippet.code))
+      feedback = mergeFeedback(feedback, agencyReviewAgent(codeSnippet.code, extraTools: learnedExtrasFor("review")))
     }
   }
   return feedback
@@ -90,7 +92,7 @@ export def reviewFiles(paths: string[]): Result<Feedback[]> raises <std::read> {
   for (path in paths) {
     const sourceResult = read(filename: path, useAgentCwd: true)
     if (sourceResult is success(source)) {
-      feedback = mergeFeedback(feedback, agencyReviewAgent(source))
+      feedback = mergeFeedback(feedback, agencyReviewAgent(source, extraTools: learnedExtrasFor("review")))
     }
   }
   return feedback

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/subagents/review.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/subagents/review.agency
@@ -43,8 +43,9 @@ export def review(userMsg: string): Result<Feedback[]> {
 
     let feedback: Result<Feedback[]> = success([])
 
+    const extras = learnedExtrasFor("review")
     for (codeSnippet in snippets) {
-      feedback = mergeFeedback(feedback, agencyReviewAgent(codeSnippet.code, extraTools: learnedExtrasFor("review")))
+      feedback = mergeFeedback(feedback, agencyReviewAgent(codeSnippet.code, extraTools: extras))
     }
   }
   return feedback
@@ -87,12 +88,15 @@ export def changedAgencyFiles(): string[] raises <std::git::status> {
   each file against the agent cwd; an unreadable path (e.g. a file `git status`
   lists as deleted) is skipped, so a stale path can never crash the review. No
   `task` is passed, so this is deterministic parse+typecheck with no LLM call. */
-export def reviewFiles(paths: string[]): Result<Feedback[]> raises <std::read> {
+export def reviewFiles(paths: string[]): Result<Feedback[]> raises <std::read, std::skills::skillsDir, std::toolbox::scan, std::ls, std::guard> {
+  // Hoisted: the extras cannot change mid-loop, and rebuilding them per
+  // file re-renders the skills tool and rewraps every learned tool.
+  const extras = learnedExtrasFor("review")
   let feedback: Result<Feedback[]> = success([])
   for (path in paths) {
     const sourceResult = read(filename: path, useAgentCwd: true)
     if (sourceResult is success(source)) {
-      feedback = mergeFeedback(feedback, agencyReviewAgent(source, extraTools: learnedExtrasFor("review")))
+      feedback = mergeFeedback(feedback, agencyReviewAgent(source, extraTools: extras))
     }
   }
   return feedback
@@ -102,6 +106,6 @@ export def reviewFiles(paths: string[]): Result<Feedback[]> raises <std::read> {
   agent changed this run (found via std::git), never the chat reply. Returns
   success([]) when no .agency files changed — the common case for Python / C /
   shell tasks — so `feedbackHasErrors` is false and the loop reaches `verify`. */
-export def reviewWrittenFiles(): Result<Feedback[]> raises <std::git::status, std::read> {
+export def reviewWrittenFiles(): Result<Feedback[]> raises <std::git::status, std::read, std::skills::skillsDir, std::toolbox::scan, std::ls, std::guard> {
   return reviewFiles(changedAgencyFiles())
 }

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/subagents/rewrite.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/subagents/rewrite.agency
@@ -1,4 +1,6 @@
 import { writingRewriteAgent } from "std::agents/writing/rewrite"
+
+import { learnedExtrasFor } from "../../../lib/learned.agency"
 import { setMemoryId } from "std::memory"
 
 // The rewrite lives in std::agents/writing/rewrite. This wrapper only
@@ -31,7 +33,7 @@ export def rewriteAgent(userMsg: string): string {
   thread(label: "rewrite", summarize: true, session: "rewrite") {
     setMemoryId("rewrite")
     const request = splitRequest(userMsg)
-    const rewritten = writingRewriteAgent(text: request.text, task: request.task)
+    const rewritten = writingRewriteAgent(text: request.text, task: request.task, extraTools: learnedExtrasFor("rewrite"))
     reply = match(rewritten) {
       success(value) => value
       failure(err) => "rewrite failed: ${err}"

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/subagents/writing.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/subagents/writing.agency
@@ -1,5 +1,7 @@
 import { writingReviewAgent } from "std::agents/writing/review"
 import { renderFeedback } from "std::agents/lib/feedback"
+
+import { learnedExtrasFor } from "../../../lib/learned.agency"
 import { setMemoryId } from "std::memory"
 
 // The review itself lives in std::agents/writing/review. That reviewer
@@ -18,7 +20,7 @@ export def writingAgent(userMsg: string): string {
   let reply = ""
   thread(label: "writing", summarize: true, session: "writing") {
     setMemoryId("writing")
-    reply = renderFeedback(writingReviewAgent(text: userMsg))
+    reply = renderFeedback(writingReviewAgent(text: userMsg, extraTools: learnedExtrasFor("writing")))
   }
   return reply
 }

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/tests/learn.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/tests/learn.agency
@@ -1,0 +1,102 @@
+/*
+ * learnSkill / writeToolFor: target validation raises nothing; an
+ * accepted skill lands in the session catalog; a revision flows back as
+ * text. Roots are repointed at a sandbox under test-output FIRST and
+ * verified, so a failing test can never touch the real ~/.agency-agent
+ * (the issue #469 rule).
+ */
+import { map } from "std::array"
+import { remove } from "std::fs"
+
+import test { _setLearnedRoot } from "../../../lib/learned.agency"
+import {
+  learnedSkillsRoot,
+  learnedSkillsToolFor,
+ } from "../../../lib/learned.agency"
+import { learnSkill, writeToolFor } from "../learn.agency"
+import { codeTools } from "../subagents/code.agency"
+
+def sandboxRoot(node: string): string {
+  return "${__dirname}/test-output/learn/${node}"
+}
+
+// Repoint at a fresh sandbox and verify the repoint took.
+def sandboxed(node: string): boolean {
+  const root = sandboxRoot(node)
+  remove(root) with approve
+  _setLearnedRoot(root)
+  return learnedSkillsRoot() == "${root}/skills"
+}
+
+node unknownTargetListsValidNames(): boolean {
+  if (!sandboxed("unknown-target")) {
+    return false
+  }
+  let interrupts = 0
+  let skillReply = ""
+  let toolReply = ""
+  handle {
+    skillReply = learnSkill("nope", "a-skill", "desc", "body")
+    toolReply = writeToolFor("nope", "aTool", "purpose", "{ n: number }")
+  } with (intr) {
+    interrupts = interrupts + 1
+    return approve()
+  }
+  return interrupts == 0
+      && skillReply.includes("Unknown target 'nope'")
+      && skillReply.includes("explorer")
+      && toolReply.includes("Unknown target 'nope'")
+}
+
+node acceptedSkillUpdatesCatalog(): boolean {
+  if (!sandboxed("accepted")) {
+    return false
+  }
+  let reply = ""
+  let description = ""
+  handle {
+    reply = learnSkill("explorer", "repo-orientation", "Orient in an unfamiliar repo", "Read the README first.")
+    const tool = learnedSkillsToolFor("explorer")
+    if (tool != null) {
+      description = tool.description
+    }
+  } with (intr) {
+    if (intr.effect == "std::skills::reviewSkill") {
+      return approve({ verdict: "accept" })
+    }
+    return approve()
+  }
+  return reply.includes("Saved.")
+      && reply.includes("repo-orientation")
+      && description.includes("<name>repo-orientation</name>")
+}
+
+node reviseFlowsBackAsText(): boolean {
+  if (!sandboxed("revise")) {
+    return false
+  }
+  let reply = ""
+  let tool: any = "unset"
+  handle {
+    reply = learnSkill("explorer", "revised", "Will be revised", "Body.")
+    tool = learnedSkillsToolFor("explorer")
+  } with (intr) {
+    if (intr.effect == "std::skills::reviewSkill") {
+      return approve({ verdict: "revise", feedback: "make it shorter" })
+    }
+    return approve()
+  }
+  return reply.includes("make it shorter") && reply.includes("call learnSkill again") && tool == null
+}
+
+// The collision-freedom premise: no built-in code tool is named with the
+// learned_ prefix, so a learned_<name> rename can never shadow one.
+node noBuiltinCodeToolUsesLearnedPrefix(): boolean {
+  const names = map(codeTools, \tool -> "${tool.name}")
+  for (name in names) {
+    if (name.startsWith("learned_")) {
+      return false
+    }
+  }
+  return names.length > 0
+}

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/tests/learn.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/tests/learn.test.json
@@ -1,0 +1,9 @@
+{
+  "sourceFile": "learn.agency",
+  "tests": [
+    { "nodeName": "unknownTargetListsValidNames", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "acceptedSkillUpdatesCatalog", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "reviseFlowsBackAsText", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "noBuiltinCodeToolUsesLearnedPrefix", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] }
+  ]
+}

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/tests/learnedWiring.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/tests/learnedWiring.agency
@@ -1,0 +1,47 @@
+/*
+ * The learnedExtrasFor contract each wrapper wires in: an agent with a
+ * learned skill gets exactly one skills tool; an agent with nothing
+ * gets an empty list. Roots repointed at the committed fixture FIRST
+ * and verified (the issue #469 rule). A full subagent turn needs an
+ * LLM, so the eval suite covers end to end; this pins the seam.
+ */
+import test { _setLearnedRoot } from "../../../lib/learned.agency"
+import {
+  learnedSkillsRoot,
+  learnedExtrasFor,
+ } from "../../../lib/learned.agency"
+
+def fixtureRoot(): string {
+  return "${__dirname}/../../../tests/learned-fixture"
+}
+
+def sandboxed(): boolean {
+  _setLearnedRoot(fixtureRoot())
+  return learnedSkillsRoot() == "${fixtureRoot()}/skills"
+}
+
+node explorerGetsItsSkillsTool(): boolean {
+  if (!sandboxed()) {
+    return false
+  }
+  let extras: any[] = []
+  handle {
+    extras = learnedExtrasFor("explorer")
+  } with approve
+  if (extras.length != 1) {
+    return false
+  }
+  return extras[0].name == "learned_skills_explorer"
+      && extras[0].description.includes("<name>repo-orientation</name>")
+}
+
+node codeGetsNothingFromThisFixture(): boolean {
+  if (!sandboxed()) {
+    return false
+  }
+  let extras: any[] = ["unset"]
+  handle {
+    extras = learnedExtrasFor("code")
+  } with approve
+  return extras.length == 0
+}

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/tests/learnedWiring.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/tests/learnedWiring.test.json
@@ -1,0 +1,7 @@
+{
+  "sourceFile": "learnedWiring.agency",
+  "tests": [
+    { "nodeName": "explorerGetsItsSkillsTool", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "codeGetsNothingFromThisFixture", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] }
+  ]
+}

--- a/packages/agency-lang/lib/agents/agency-agent/lib/commandPalette.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/commandPalette.agency
@@ -14,6 +14,8 @@ export def builtinPalette(): Record<string, string> {
     "/local": "Switch to a local model",
     "/search": "Choose the web search backend (hosted / Tavily / Brave / off)",
     "/settings": "View and change capability settings for the current model",
+    "/skills": "List skills the agent has learned, by subagent",
+    "/toolbox": "List tools the agent has written, by subagent",
     "/mcp": "List configured MCP servers and their tools",
     "/paste": "Multi-line paste mode (Ctrl+D submits, Ctrl+C cancels)",
     "/help": "Show available slash commands"

--- a/packages/agency-lang/lib/agents/agency-agent/lib/learned.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/learned.agency
@@ -2,13 +2,16 @@
   @summary The session catalogs of learned content: skills the user
   taught a subagent and tools the agent wrote for one. Loaded lazily
   (one scan interrupt for the skills root; one toolbox scan per agent
-  directory that exists), held in module globals so a save this turn is
-  visible to the target subagent's next invocation without a rescan.
+  directory that exists) and held in module globals. A save calls
+  `invalidateLearned()`, so the next access rescans and picks it up —
+  the disk is the single source of truth, and the catalogs are only a
+  cache of it.
 */
 import { filter, map } from "std::array"
 import { keys } from "std::object"
 import { exists } from "std::shell"
 import {
+  MAX_TOOL_NAME_LEN,
   SkillEntry,
   scanSkillsSubdirs,
   skillsToolFromEntries,
@@ -31,7 +34,7 @@ export static const LEARN_TARGETS = [
 ]
 
 // Session-lived catalogs. Globals, not statics: the CLI agent is one
-// long-lived run, and a save must update these in place.
+// long-lived run, and a save must be able to invalidate these mid-session.
 let _skillEntries: Record<string, SkillEntry[]> | null = null
 let _toolEntries: Record<string, ToolEntry[]> | null = null
 // Test seam: repoints both roots at a sandbox. The production root is
@@ -40,11 +43,6 @@ let _rootOverride: string | null = null
 
 def _setLearnedRoot(root: string) {
   _rootOverride = root
-  _skillEntries = null
-  _toolEntries = null
-}
-
-def _resetLearned() {
   _skillEntries = null
   _toolEntries = null
 }
@@ -110,8 +108,8 @@ def loadToolEntries(): Record<string, ToolEntry[]> {
 export def learnedSkillsToolFor(agent: string): any | null {
   """
   The skills tool over one subagent's learned skills, or null when it
-  has none. Built from the session catalog, so a skill recorded this
-  turn appears without rescanning the directory.
+  has none. Built from the session catalog; a save this turn
+  invalidated the catalog, so the next build here rescans and lists it.
   """
   const entries = loadSkillEntries()[agent]
   if (entries == undefined || entries.length == 0) {
@@ -120,25 +118,41 @@ export def learnedSkillsToolFor(agent: string): any | null {
   return skillsToolFromEntries("${learnedSkillsRoot()}/${agent}", entries, "learned_skills_${agent}")
 }
 
-// One catalog entry as an LLM-callable tool. The `learned_` prefix is
-// what makes collision with a target's built-in tools impossible.
+// The prefix every learned tool is advertised under. It is what makes
+// collision with a target's built-in tools impossible: no built-in
+// tool's name starts with it.
+export static const LEARNED_TOOL_PREFIX = "learned_"
+
+export def maxLearnedToolName(): number {
+  """
+  The longest name a learned tool can have: the provider cap, minus the
+  learned_ prefix the tool is advertised under. Derived so the three
+  numbers (provider cap, prefix length, this cap) cannot drift apart.
+  """
+  return MAX_TOOL_NAME_LEN - LEARNED_TOOL_PREFIX.length
+}
+
+// One catalog entry as an LLM-callable tool.
 def learnedToolFromEntry(agent: string, entry: ToolEntry): any {
   const description = "${entry.meta.purpose}\n\nRequest type: ${entry.meta.request}"
   const dir = "${learnedToolsRoot()}/${agent}"
-  return runTool.partial(name: entry.name, dir: dir).describe(description).rename("learned_${entry.name}")
+  return runTool.partial(name: entry.name, dir: dir).describe(description).rename("${LEARNED_TOOL_PREFIX}${entry.name}")
 }
 
 export def learnedToolsFor(agent: string): any[] {
   """
   The LLM-callable tools from one subagent's learned toolbox, each
-  renamed `learned_<name>`. Broken entries stay in the inventory but are
-  never offered to the model.
+  renamed `learned_<name>`. Broken entries, and entries whose prefixed
+  name would exceed the provider cap (a tool dropped into the directory
+  by hand — writeToolFor refuses such names at write time), stay in the
+  inventory but are never offered to the model: one bad name would fail
+  every LLM call the target makes.
   """
   const entries = loadToolEntries()[agent]
   if (entries == undefined) {
     return []
   }
-  const usable = filter(entries, \entry -> entry.broken == undefined)
+  const usable = filter(entries, \entry -> entry.broken == undefined && entry.name.length <= maxLearnedToolName())
   return map(usable, \entry -> learnedToolFromEntry(agent, entry))
 }
 
@@ -152,42 +166,19 @@ export def learnedExtrasFor(agent: string): any[] {
   return [...skillsTools, ...learnedToolsFor(agent)]
 }
 
-export def recordLearnedSkill(agent: string, entry: SkillEntry) {
+export def invalidateLearned() {
   """
-  Add a just-saved skill to the session catalog, so the target agent's
-  next invocation lists it without a rescan. A no-op when the catalog
-  already holds the entry: when the save was the session's first learned
-  action, the lazy load above scans AFTER the file hit disk and has
-  already picked it up.
+  Drop both session catalogs, so the next access rescans the learned
+  directories. Called after every save. Rescanning instead of patching
+  the catalogs in place keeps the disk the single source of truth —
+  updating a cached record cannot drift from what a scan would see
+  (a stale entry surviving a delete-and-reteach, a duplicate, a push
+  into a copy the cache never held). Saves are rare and user-directed,
+  so the extra scan interrupt is cheap, and the same policy scope that
+  approved the first scan approves this one.
   """
-  const entries = loadSkillEntries()
-  if (entries[agent] == undefined) {
-    entries[agent] = []
-  }
-  const existing = filter(entries[agent], \known -> known.location == entry.location)
-  if (existing.length > 0) {
-    return
-  }
-  entries[agent].push(entry)
-}
-
-export def recordLearnedTool(agent: string, entry: ToolEntry) {
-  """
-  Add a just-written tool to the session catalog, so the target agent's
-  next invocation carries it without a rescan. A no-op when the catalog
-  already holds the name — a duplicate would produce two tools named
-  learned_<name> and trip the unique-tool-name check on the target's
-  next LLM call.
-  """
-  const entries = loadToolEntries()
-  if (entries[agent] == undefined) {
-    entries[agent] = []
-  }
-  const existing = filter(entries[agent], \known -> known.name == entry.name)
-  if (existing.length > 0) {
-    return
-  }
-  entries[agent].push(entry)
+  _skillEntries = null
+  _toolEntries = null
 }
 
 export type LearnedForAgent = {

--- a/packages/agency-lang/lib/agents/agency-agent/lib/learned.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/learned.agency
@@ -70,7 +70,19 @@ def loadSkillEntries(): Record<string, SkillEntry[]> {
   if (loaded != null) {
     return loaded
   }
-  const scanned = scanSkillsSubdirs(learnedSkillsRoot())
+  // No skills root yet (nothing ever learned): no scan, no interrupt.
+  if (!exists(learnedSkillsRoot())) {
+    _skillEntries = {}
+    return {}
+  }
+  const scanned: any = scanSkillsSubdirs(learnedSkillsRoot(), LEARN_TARGETS)
+  // A rejected scan interrupt surfaces here as a Failure value. Cache an
+  // empty catalog instead: caching the Failure would make every later
+  // lookup read fields off it and a record push silently vanish.
+  if (scanned is failure) {
+    _skillEntries = {}
+    return {}
+  }
   _skillEntries = scanned
   return scanned
 }
@@ -143,11 +155,18 @@ export def learnedExtrasFor(agent: string): any[] {
 export def recordLearnedSkill(agent: string, entry: SkillEntry) {
   """
   Add a just-saved skill to the session catalog, so the target agent's
-  next invocation lists it without a rescan.
+  next invocation lists it without a rescan. A no-op when the catalog
+  already holds the entry: when the save was the session's first learned
+  action, the lazy load above scans AFTER the file hit disk and has
+  already picked it up.
   """
   const entries = loadSkillEntries()
   if (entries[agent] == undefined) {
     entries[agent] = []
+  }
+  const existing = filter(entries[agent], \known -> known.location == entry.location)
+  if (existing.length > 0) {
+    return
   }
   entries[agent].push(entry)
 }
@@ -155,11 +174,18 @@ export def recordLearnedSkill(agent: string, entry: SkillEntry) {
 export def recordLearnedTool(agent: string, entry: ToolEntry) {
   """
   Add a just-written tool to the session catalog, so the target agent's
-  next invocation carries it without a rescan.
+  next invocation carries it without a rescan. A no-op when the catalog
+  already holds the name — a duplicate would produce two tools named
+  learned_<name> and trip the unique-tool-name check on the target's
+  next LLM call.
   """
   const entries = loadToolEntries()
   if (entries[agent] == undefined) {
     entries[agent] = []
+  }
+  const existing = filter(entries[agent], \known -> known.name == entry.name)
+  if (existing.length > 0) {
+    return
   }
   entries[agent].push(entry)
 }

--- a/packages/agency-lang/lib/agents/agency-agent/lib/learned.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/learned.agency
@@ -1,0 +1,194 @@
+/** @module
+  @summary The session catalogs of learned content: skills the user
+  taught a subagent and tools the agent wrote for one. Loaded lazily
+  (one scan interrupt for the skills root; one toolbox scan per agent
+  directory that exists), held in module globals so a save this turn is
+  visible to the target subagent's next invocation without a rescan.
+*/
+import { filter, map } from "std::array"
+import { keys } from "std::object"
+import { exists } from "std::shell"
+import {
+  SkillEntry,
+  scanSkillsSubdirs,
+  skillsToolFromEntries,
+ } from "std::skills"
+import { ToolEntry, listTools, runTool } from "std::toolbox"
+
+import { AGENCY_AGENT_DIR } from "../shared.agency"
+
+// Every subagent a skill or tool can be learned for. These are the
+// coordinator's wrapper names (the directory names under the learned
+// roots), not the stdlib agents' names.
+export static const LEARN_TARGETS = [
+  "code",
+  "research",
+  "explorer",
+  "oracle",
+  "review",
+  "writing",
+  "rewrite",
+]
+
+// Session-lived catalogs. Globals, not statics: the CLI agent is one
+// long-lived run, and a save must update these in place.
+let _skillEntries: Record<string, SkillEntry[]> | null = null
+let _toolEntries: Record<string, ToolEntry[]> | null = null
+// Test seam: repoints both roots at a sandbox. The production root is
+// the AGENCY_AGENT_DIR static, resolved once at startup.
+let _rootOverride: string | null = null
+
+def _setLearnedRoot(root: string) {
+  _rootOverride = root
+  _skillEntries = null
+  _toolEntries = null
+}
+
+def _resetLearned() {
+  _skillEntries = null
+  _toolEntries = null
+}
+
+def learnedRoot(): string {
+  const override = _rootOverride
+  if (override != null) {
+    return override
+  }
+  return AGENCY_AGENT_DIR
+}
+
+export def learnedSkillsRoot(): string {
+  return "${learnedRoot()}/skills"
+}
+
+export def learnedToolsRoot(): string {
+  return "${learnedRoot()}/tools"
+}
+
+def loadSkillEntries(): Record<string, SkillEntry[]> {
+  const loaded = _skillEntries
+  if (loaded != null) {
+    return loaded
+  }
+  const scanned = scanSkillsSubdirs(learnedSkillsRoot())
+  _skillEntries = scanned
+  return scanned
+}
+
+def loadToolEntries(): Record<string, ToolEntry[]> {
+  const loaded = _toolEntries
+  if (loaded != null) {
+    return loaded
+  }
+  let scanned: Record<string, ToolEntry[]> = {}
+  for (agent in LEARN_TARGETS) {
+    const dir = "${learnedToolsRoot()}/${agent}"
+    if (!exists(dir)) {
+      continue
+    }
+    const listed = listTools(dir)
+    if (listed is success(entries)) {
+      scanned[agent] = entries
+    }
+  }
+  _toolEntries = scanned
+  return scanned
+}
+
+export def learnedSkillsToolFor(agent: string): any | null {
+  """
+  The skills tool over one subagent's learned skills, or null when it
+  has none. Built from the session catalog, so a skill recorded this
+  turn appears without rescanning the directory.
+  """
+  const entries = loadSkillEntries()[agent]
+  if (entries == undefined || entries.length == 0) {
+    return null
+  }
+  return skillsToolFromEntries("${learnedSkillsRoot()}/${agent}", entries, "learned_skills_${agent}")
+}
+
+// One catalog entry as an LLM-callable tool. The `learned_` prefix is
+// what makes collision with a target's built-in tools impossible.
+def learnedToolFromEntry(agent: string, entry: ToolEntry): any {
+  const description = "${entry.meta.purpose}\n\nRequest type: ${entry.meta.request}"
+  const dir = "${learnedToolsRoot()}/${agent}"
+  return runTool.partial(name: entry.name, dir: dir).describe(description).rename("learned_${entry.name}")
+}
+
+export def learnedToolsFor(agent: string): any[] {
+  """
+  The LLM-callable tools from one subagent's learned toolbox, each
+  renamed `learned_<name>`. Broken entries stay in the inventory but are
+  never offered to the model.
+  """
+  const entries = loadToolEntries()[agent]
+  if (entries == undefined) {
+    return []
+  }
+  const usable = filter(entries, \entry -> entry.broken == undefined)
+  return map(usable, \entry -> learnedToolFromEntry(agent, entry))
+}
+
+export def learnedExtrasFor(agent: string): any[] {
+  """
+  The learned additions to one subagent's tool list: its learned-skills
+  tool (when it has skills) followed by its learned tools.
+  """
+  const skillsTool = learnedSkillsToolFor(agent)
+  const skillsTools = if skillsTool == null then [] else [skillsTool]
+  return [...skillsTools, ...learnedToolsFor(agent)]
+}
+
+export def recordLearnedSkill(agent: string, entry: SkillEntry) {
+  """
+  Add a just-saved skill to the session catalog, so the target agent's
+  next invocation lists it without a rescan.
+  """
+  const entries = loadSkillEntries()
+  if (entries[agent] == undefined) {
+    entries[agent] = []
+  }
+  entries[agent].push(entry)
+}
+
+export def recordLearnedTool(agent: string, entry: ToolEntry) {
+  """
+  Add a just-written tool to the session catalog, so the target agent's
+  next invocation carries it without a rescan.
+  """
+  const entries = loadToolEntries()
+  if (entries[agent] == undefined) {
+    entries[agent] = []
+  }
+  entries[agent].push(entry)
+}
+
+export type LearnedForAgent = {
+  skills: SkillEntry[];
+  tools: ToolEntry[]
+}
+
+export type LearnedInventory = Record<string, LearnedForAgent>
+
+export def learnedInventory(): LearnedInventory {
+  """
+  Everything the agent has learned, grouped by subagent. Agents with
+  nothing are omitted.
+  """
+  const skills = loadSkillEntries()
+  const tools = loadToolEntries()
+  let out: LearnedInventory = {}
+  for (agent in LEARN_TARGETS) {
+    const agentSkills = skills[agent] ?? []
+    const agentTools = tools[agent] ?? []
+    if (agentSkills.length == 0 && agentTools.length == 0) {
+      continue
+    }
+    out[agent] = {
+      skills: agentSkills,
+      tools: agentTools
+    }
+  }
+  return out
+}

--- a/packages/agency-lang/lib/agents/agency-agent/lib/learnedView.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/learnedView.agency
@@ -5,7 +5,12 @@
 */
 import { keys } from "std::object"
 
-import { LearnedInventory, learnedInventory } from "./learned.agency"
+import {
+  LEARNED_TOOL_PREFIX,
+  LearnedInventory,
+  learnedInventory,
+  maxLearnedToolName,
+ } from "./learned.agency"
 
 def skillsSection(agent: string, inventory: LearnedInventory): string {
   const entry = inventory[agent]
@@ -26,11 +31,13 @@ def toolsSection(agent: string, inventory: LearnedInventory): string {
   }
   let lines = ["${agent}:"]
   for (tool in entry.tools) {
-    let broken = ""
+    let note = ""
     if (tool.broken != undefined) {
-      broken = " (broken: ${tool.broken})"
+      note = " (broken: ${tool.broken})"
+    } else if (tool.name.length > maxLearnedToolName()) {
+      note = " (name too long to offer; rename the tool directory)"
     }
-    lines.push("  learned_${tool.name} — ${tool.meta.purpose}${broken}")
+    lines.push("  ${LEARNED_TOOL_PREFIX}${tool.name} — ${tool.meta.purpose}${note}")
   }
   return lines.join("\n")
 }

--- a/packages/agency-lang/lib/agents/agency-agent/lib/learnedView.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/learnedView.agency
@@ -1,0 +1,78 @@
+/** @module
+  @summary Renders the /skills and /toolbox listings: everything the
+  agent has learned, grouped by subagent. Pure formatting over
+  learnedInventory(); repl.agency stays a dispatcher.
+*/
+import { keys } from "std::object"
+
+import { LearnedInventory, learnedInventory } from "./learned.agency"
+
+def skillsSection(agent: string, inventory: LearnedInventory): string {
+  const entry = inventory[agent]
+  if (entry == undefined || entry.skills.length == 0) {
+    return ""
+  }
+  let lines = ["${agent}:"]
+  for (skill in entry.skills) {
+    lines.push("  ${skill.name} — ${skill.description}")
+  }
+  return lines.join("\n")
+}
+
+def toolsSection(agent: string, inventory: LearnedInventory): string {
+  const entry = inventory[agent]
+  if (entry == undefined || entry.tools.length == 0) {
+    return ""
+  }
+  let lines = ["${agent}:"]
+  for (tool in entry.tools) {
+    let broken = ""
+    if (tool.broken != undefined) {
+      broken = " (broken: ${tool.broken})"
+    }
+    lines.push("  learned_${tool.name} — ${tool.meta.purpose}${broken}")
+  }
+  return lines.join("\n")
+}
+
+def renderSections(
+  inventory: LearnedInventory,
+  section: (string, LearnedInventory) -> string,
+  emptyHint: string,
+): string {
+  let sections: string[] = []
+  for (agent in keys(inventory)) {
+    const rendered = section(agent, inventory)
+    if (rendered != "") {
+      sections.push(rendered)
+    }
+  }
+  if (sections.length == 0) {
+    return emptyHint
+  }
+  return sections.join("\n")
+}
+
+export def skillsView(): string {
+  """
+  The /skills listing: learned skills grouped by subagent, or a hint
+  when nothing has been learned yet.
+  """
+  return renderSections(
+    learnedInventory(),
+    skillsSection,
+    "No learned skills yet. Ask me to learn one for a subagent.",
+  )
+}
+
+export def toolboxView(): string {
+  """
+  The /toolbox listing: learned tools grouped by subagent, or a hint
+  when none have been written yet.
+  """
+  return renderSections(
+    learnedInventory(),
+    toolsSection,
+    "No learned tools yet. Ask me to write one for a subagent.",
+  )
+}

--- a/packages/agency-lang/lib/agents/agency-agent/lib/repl.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/repl.agency
@@ -17,6 +17,7 @@ import {
 
 import { showCapabilities, editCapabilities } from "./capabilitiesUi.agency"
 import { HISTORY_PATH } from "./config.agency"
+import { skillsView, toolboxView } from "./learnedView.agency"
 import { mcpSlashCommand } from "./mcp.agency"
 import { filterHostedModels } from "./modelFilters.agency"
 import { diffResolved, Ctx } from "./resolution.agency"
@@ -242,13 +243,21 @@ def _runTurn(msg: string): boolean {
     }
     "/help" => {
       pushMessage(
-        "Commands: /exit, /clear, /clear-history, /cost, /model, /models, /local, /search, /settings, /mcp, /rename, /paste, /help",
+        "Commands: /exit, /clear, /clear-history, /cost, /model, /models, /local, /search, /settings, /skills, /toolbox, /mcp, /rename, /paste, /help",
       )
       return true
     }
     "/settings" => {
       showCapabilities()
       editCapabilities()
+      return true
+    }
+    "/skills" => {
+      pushMessage(skillsView())
+      return true
+    }
+    "/toolbox" => {
+      pushMessage(toolboxView())
       return true
     }
     "/mcp" => mcpSlashCommand()

--- a/packages/agency-lang/lib/agents/agency-agent/tests/learned-fixture/skills/explorer/one.md
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/learned-fixture/skills/explorer/one.md
@@ -1,0 +1,6 @@
+---
+name: repo-orientation
+description: Orient in an unfamiliar repo
+---
+
+Read the README and layout first.

--- a/packages/agency-lang/lib/agents/agency-agent/tests/learned-fixture/tools/research/a-tool-name-far-too-long-to-advertise-behind-the-learned-prefix/impl.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/learned-fixture/tools/research/a-tool-name-far-too-long-to-advertise-behind-the-learned-prefix/impl.agency
@@ -1,0 +1,7 @@
+import { Json } from "std::validation"
+
+export type Request = { maxItems: number }
+
+export def run(request: Request): Json {
+  return request.maxItems
+}

--- a/packages/agency-lang/lib/agents/agency-agent/tests/learned-fixture/tools/research/hnTop/impl.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/learned-fixture/tools/research/hnTop/impl.agency
@@ -1,0 +1,7 @@
+import { Json } from "std::validation"
+
+export type Request = { maxItems: number }
+
+export def run(request: Request): Json {
+  return request.maxItems
+}

--- a/packages/agency-lang/lib/agents/agency-agent/tests/learned-fixture/tools/research/hnTop/meta.json
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/learned-fixture/tools/research/hnTop/meta.json
@@ -1,0 +1,7 @@
+{
+  "purpose": "Fetch top stories",
+  "request": "{ maxItems: number }",
+  "createdAt": "2026-09-01T00:00:00Z",
+  "version": 1,
+  "uses": 0
+}

--- a/packages/agency-lang/lib/agents/agency-agent/tests/learned.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/learned.agency
@@ -1,22 +1,18 @@
 /*
  * The learned catalogs: lazy load with one skills-root scan interrupt,
- * in-place updates without a rescan, and per-agent tools/extras. Every
+ * invalidate-and-rescan after a save, and per-agent tools/extras. Every
  * node repoints the roots at the committed fixture FIRST and verifies
  * the repoint took, so a failing test can never touch the real
  * ~/.agency-agent (the issue #469 rule).
  */
-import test {
-  _setLearnedRoot,
-  _resetLearned,
- } from "../lib/learned.agency"
+import test { _setLearnedRoot } from "../lib/learned.agency"
 import {
+  invalidateLearned,
   learnedSkillsRoot,
   learnedSkillsToolFor,
   learnedToolsFor,
   learnedExtrasFor,
   learnedInventory,
-  recordLearnedSkill,
-  recordLearnedTool,
  } from "../lib/learned.agency"
 
 def fixtureRoot(): string {
@@ -50,7 +46,10 @@ node lazyLoadRaisesOneScanInterrupt(): boolean {
   return scans == 1 && first != null && second != null
 }
 
-node recordSkillVisibleWithoutRescan(): boolean {
+// The post-save path: a save calls invalidateLearned(), and the next
+// access rescans the directory (a second scan interrupt) instead of
+// serving the stale catalog.
+node invalidateForcesRescan(): boolean {
   if (!sandboxed()) {
     return false
   }
@@ -58,7 +57,7 @@ node recordSkillVisibleWithoutRescan(): boolean {
   let description = ""
   handle {
     learnedSkillsToolFor("explorer")
-    recordLearnedSkill("explorer", { name: "x", description: "d", location: "x.md" })
+    invalidateLearned()
     const tool = learnedSkillsToolFor("explorer")
     if (tool != null) {
       description = tool.description
@@ -69,7 +68,7 @@ node recordSkillVisibleWithoutRescan(): boolean {
     }
     return approve()
   }
-  return scans == 1 && description.includes("<name>x</name>") && description.includes("<name>repo-orientation</name>")
+  return scans == 2 && description.includes("<name>repo-orientation</name>")
 }
 
 node unknownAgentYieldsNullAndEmpty(): boolean {
@@ -85,22 +84,17 @@ node unknownAgentYieldsNullAndEmpty(): boolean {
   return skillsTool == null && tools.length == 0
 }
 
-node learnedToolNamePrefixed(): boolean {
+// Two properties off the real on-disk fixture toolbox: a healthy tool
+// (listTools gives it `broken: null`, which must pass the not-broken
+// filter) is offered as learned_<name>, and the committed tool whose
+// 63-character directory name would overflow the provider cap behind
+// the learned_ prefix is never offered.
+node learnedToolNamePrefixedAndOverlongExcluded(): boolean {
   if (!sandboxed()) {
     return false
   }
-  const entry: any = {
-    name: "hnTop",
-    dir: "${fixtureRoot()}/tools/research/hnTop",
-    module: {},
-    meta: {
-      purpose: "Fetch top stories",
-      request: "{ maxItems: number }"
-    }
-  }
   let names = ""
   handle {
-    recordLearnedTool("research", entry)
     const tools = learnedToolsFor("research")
     for (tool in tools) {
       names = "${names}${tool.name},"
@@ -118,10 +112,13 @@ node inventoryGroupsByAgent(): boolean {
     inventory = learnedInventory()
   } with approve
   const explorer = inventory["explorer"]
-  if (explorer == undefined) {
+  const research = inventory["research"]
+  if (explorer == undefined || research == undefined) {
     return false
   }
-  return explorer.skills.length == 1 && explorer.tools.length == 0 && inventory["code"] == undefined
+  // The overlong-named tool stays visible in the inventory (so /toolbox
+  // can show what is on disk) even though it is never offered as a tool.
+  return explorer.skills.length == 1 && explorer.tools.length == 0 && research.tools.length == 2 && inventory["code"] == undefined
 }
 
 node extrasForExplorerHasSkillsTool(): boolean {
@@ -147,22 +144,4 @@ node extrasForCodeEmpty(): boolean {
     extras = learnedExtrasFor("code")
   } with approve
   return extras.length == 0
-}
-
-// The first-learned-action ordering: the file is on disk before the
-// catalog ever loads, so the lazy scan already contains it and the
-// record must not add a second copy.
-node recordAfterLazyLoadDoesNotDuplicate(): boolean {
-  if (!sandboxed()) {
-    return false
-  }
-  let count = 0
-  handle {
-    recordLearnedSkill("explorer", { name: "repo-orientation", description: "Orient in an unfamiliar repo", location: "one.md" })
-    const tool = learnedSkillsToolFor("explorer")
-    if (tool != null) {
-      count = tool.description.split("<name>repo-orientation</name>").length - 1
-    }
-  } with approve
-  return count == 1
 }

--- a/packages/agency-lang/lib/agents/agency-agent/tests/learned.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/learned.agency
@@ -1,0 +1,150 @@
+/*
+ * The learned catalogs: lazy load with one skills-root scan interrupt,
+ * in-place updates without a rescan, and per-agent tools/extras. Every
+ * node repoints the roots at the committed fixture FIRST and verifies
+ * the repoint took, so a failing test can never touch the real
+ * ~/.agency-agent (the issue #469 rule).
+ */
+import test {
+  _setLearnedRoot,
+  _resetLearned,
+ } from "../lib/learned.agency"
+import {
+  learnedSkillsRoot,
+  learnedSkillsToolFor,
+  learnedToolsFor,
+  learnedExtrasFor,
+  learnedInventory,
+  recordLearnedSkill,
+  recordLearnedTool,
+ } from "../lib/learned.agency"
+
+def fixtureRoot(): string {
+  return "${__dirname}/learned-fixture"
+}
+
+// Repoint at the fixture and verify the repoint took. Returns false if
+// the sandbox is not in effect; every node checks this before anything
+// else.
+def sandboxed(): boolean {
+  _setLearnedRoot(fixtureRoot())
+  return learnedSkillsRoot() == "${fixtureRoot()}/skills"
+}
+
+node lazyLoadRaisesOneScanInterrupt(): boolean {
+  if (!sandboxed()) {
+    return false
+  }
+  let scans = 0
+  let first: any = null
+  let second: any = null
+  handle {
+    first = learnedSkillsToolFor("explorer")
+    second = learnedSkillsToolFor("explorer")
+  } with (intr) {
+    if (intr.effect == "std::skills::skillsDir") {
+      scans = scans + 1
+    }
+    return approve()
+  }
+  return scans == 1 && first != null && second != null
+}
+
+node recordSkillVisibleWithoutRescan(): boolean {
+  if (!sandboxed()) {
+    return false
+  }
+  let scans = 0
+  let description = ""
+  handle {
+    learnedSkillsToolFor("explorer")
+    recordLearnedSkill("explorer", { name: "x", description: "d", location: "x.md" })
+    const tool = learnedSkillsToolFor("explorer")
+    if (tool != null) {
+      description = tool.description
+    }
+  } with (intr) {
+    if (intr.effect == "std::skills::skillsDir") {
+      scans = scans + 1
+    }
+    return approve()
+  }
+  return scans == 1 && description.includes("<name>x</name>") && description.includes("<name>repo-orientation</name>")
+}
+
+node unknownAgentYieldsNullAndEmpty(): boolean {
+  if (!sandboxed()) {
+    return false
+  }
+  let skillsTool: any = "unset"
+  let tools: any[] = ["unset"]
+  handle {
+    skillsTool = learnedSkillsToolFor("nope")
+    tools = learnedToolsFor("nope")
+  } with approve
+  return skillsTool == null && tools.length == 0
+}
+
+node learnedToolNamePrefixed(): boolean {
+  if (!sandboxed()) {
+    return false
+  }
+  const entry: any = {
+    name: "hnTop",
+    dir: "${fixtureRoot()}/tools/research/hnTop",
+    module: {},
+    meta: {
+      purpose: "Fetch top stories",
+      request: "{ maxItems: number }"
+    }
+  }
+  let names = ""
+  handle {
+    recordLearnedTool("research", entry)
+    const tools = learnedToolsFor("research")
+    for (tool in tools) {
+      names = "${names}${tool.name},"
+    }
+  } with approve
+  return names == "learned_hnTop,"
+}
+
+node inventoryGroupsByAgent(): boolean {
+  if (!sandboxed()) {
+    return false
+  }
+  let inventory: any = null
+  handle {
+    inventory = learnedInventory()
+  } with approve
+  const explorer = inventory["explorer"]
+  if (explorer == undefined) {
+    return false
+  }
+  return explorer.skills.length == 1 && explorer.tools.length == 0 && inventory["code"] == undefined
+}
+
+node extrasForExplorerHasSkillsTool(): boolean {
+  if (!sandboxed()) {
+    return false
+  }
+  let extras: any[] = []
+  handle {
+    extras = learnedExtrasFor("explorer")
+  } with approve
+  if (extras.length != 1) {
+    return false
+  }
+  return extras[0].description.includes("<name>repo-orientation</name>")
+}
+
+node extrasForCodeEmpty(): boolean {
+  if (!sandboxed()) {
+    return false
+  }
+  let extras: any[] = ["unset"]
+  handle {
+    extras = learnedExtrasFor("code")
+  } with approve
+  return extras.length == 0
+}

--- a/packages/agency-lang/lib/agents/agency-agent/tests/learned.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/learned.agency
@@ -148,3 +148,21 @@ node extrasForCodeEmpty(): boolean {
   } with approve
   return extras.length == 0
 }
+
+// The first-learned-action ordering: the file is on disk before the
+// catalog ever loads, so the lazy scan already contains it and the
+// record must not add a second copy.
+node recordAfterLazyLoadDoesNotDuplicate(): boolean {
+  if (!sandboxed()) {
+    return false
+  }
+  let count = 0
+  handle {
+    recordLearnedSkill("explorer", { name: "repo-orientation", description: "Orient in an unfamiliar repo", location: "one.md" })
+    const tool = learnedSkillsToolFor("explorer")
+    if (tool != null) {
+      count = tool.description.split("<name>repo-orientation</name>").length - 1
+    }
+  } with approve
+  return count == 1
+}

--- a/packages/agency-lang/lib/agents/agency-agent/tests/learned.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/learned.test.json
@@ -7,6 +7,7 @@
     { "nodeName": "learnedToolNamePrefixed", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
     { "nodeName": "inventoryGroupsByAgent", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
     { "nodeName": "extrasForExplorerHasSkillsTool", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "extrasForCodeEmpty", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] }
+    { "nodeName": "extrasForCodeEmpty", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "recordAfterLazyLoadDoesNotDuplicate", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] }
   ]
 }

--- a/packages/agency-lang/lib/agents/agency-agent/tests/learned.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/learned.test.json
@@ -1,0 +1,12 @@
+{
+  "sourceFile": "learned.agency",
+  "tests": [
+    { "nodeName": "lazyLoadRaisesOneScanInterrupt", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "recordSkillVisibleWithoutRescan", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "unknownAgentYieldsNullAndEmpty", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "learnedToolNamePrefixed", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "inventoryGroupsByAgent", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "extrasForExplorerHasSkillsTool", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "extrasForCodeEmpty", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] }
+  ]
+}

--- a/packages/agency-lang/lib/agents/agency-agent/tests/learned.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/learned.test.json
@@ -2,12 +2,11 @@
   "sourceFile": "learned.agency",
   "tests": [
     { "nodeName": "lazyLoadRaisesOneScanInterrupt", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "recordSkillVisibleWithoutRescan", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "invalidateForcesRescan", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
     { "nodeName": "unknownAgentYieldsNullAndEmpty", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "learnedToolNamePrefixed", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "learnedToolNamePrefixedAndOverlongExcluded", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
     { "nodeName": "inventoryGroupsByAgent", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
     { "nodeName": "extrasForExplorerHasSkillsTool", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "extrasForCodeEmpty", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "recordAfterLazyLoadDoesNotDuplicate", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] }
+    { "nodeName": "extrasForCodeEmpty", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] }
   ]
 }

--- a/packages/agency-lang/lib/agents/agency-agent/tests/learnedView.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/learnedView.agency
@@ -4,10 +4,7 @@
  * FIRST and verified (the issue #469 rule).
  */
 import test { _setLearnedRoot } from "../lib/learned.agency"
-import {
-  learnedSkillsRoot,
-  recordLearnedTool,
- } from "../lib/learned.agency"
+import { learnedSkillsRoot } from "../lib/learned.agency"
 import { skillsView, toolboxView } from "../lib/learnedView.agency"
 
 def fixtureRoot(): string {
@@ -30,22 +27,12 @@ node skillsViewListsFixtureSkill(): boolean {
   return view.includes("explorer:") && view.includes("repo-orientation — Orient in an unfamiliar repo")
 }
 
-node toolboxViewListsRecordedTool(): boolean {
+node toolboxViewListsFixtureTool(): boolean {
   if (!sandboxed(fixtureRoot())) {
     return false
   }
-  const entry: any = {
-    name: "hnTop",
-    dir: "${fixtureRoot()}/tools/research/hnTop",
-    module: {},
-    meta: {
-      purpose: "Fetch top stories",
-      request: "{ maxItems: number }"
-    }
-  }
   let view = ""
   handle {
-    recordLearnedTool("research", entry)
     view = toolboxView()
   } with approve
   return view.includes("research:") && view.includes("learned_hnTop — Fetch top stories")

--- a/packages/agency-lang/lib/agents/agency-agent/tests/learnedView.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/learnedView.agency
@@ -1,0 +1,65 @@
+/*
+ * /skills and /toolbox render the inventory grouped by subagent, with a
+ * hint when nothing has been learned. Roots repointed at the fixture
+ * FIRST and verified (the issue #469 rule).
+ */
+import test { _setLearnedRoot } from "../lib/learned.agency"
+import {
+  learnedSkillsRoot,
+  recordLearnedTool,
+ } from "../lib/learned.agency"
+import { skillsView, toolboxView } from "../lib/learnedView.agency"
+
+def fixtureRoot(): string {
+  return "${__dirname}/learned-fixture"
+}
+
+def sandboxed(root: string): boolean {
+  _setLearnedRoot(root)
+  return learnedSkillsRoot() == "${root}/skills"
+}
+
+node skillsViewListsFixtureSkill(): boolean {
+  if (!sandboxed(fixtureRoot())) {
+    return false
+  }
+  let view = ""
+  handle {
+    view = skillsView()
+  } with approve
+  return view.includes("explorer:") && view.includes("repo-orientation — Orient in an unfamiliar repo")
+}
+
+node toolboxViewListsRecordedTool(): boolean {
+  if (!sandboxed(fixtureRoot())) {
+    return false
+  }
+  const entry: any = {
+    name: "hnTop",
+    dir: "${fixtureRoot()}/tools/research/hnTop",
+    module: {},
+    meta: {
+      purpose: "Fetch top stories",
+      request: "{ maxItems: number }"
+    }
+  }
+  let view = ""
+  handle {
+    recordLearnedTool("research", entry)
+    view = toolboxView()
+  } with approve
+  return view.includes("research:") && view.includes("learned_hnTop — Fetch top stories")
+}
+
+node emptyRootsShowHints(): boolean {
+  if (!sandboxed("${__dirname}/learned-fixture-missing")) {
+    return false
+  }
+  let skillsText = ""
+  let toolsText = ""
+  handle {
+    skillsText = skillsView()
+    toolsText = toolboxView()
+  } with approve
+  return skillsText.includes("No learned skills yet") && toolsText.includes("No learned tools yet")
+}

--- a/packages/agency-lang/lib/agents/agency-agent/tests/learnedView.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/learnedView.test.json
@@ -2,7 +2,7 @@
   "sourceFile": "learnedView.agency",
   "tests": [
     { "nodeName": "skillsViewListsFixtureSkill", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "toolboxViewListsRecordedTool", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "toolboxViewListsFixtureTool", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
     { "nodeName": "emptyRootsShowHints", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] }
   ]
 }

--- a/packages/agency-lang/lib/agents/agency-agent/tests/learnedView.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/learnedView.test.json
@@ -1,0 +1,8 @@
+{
+  "sourceFile": "learnedView.agency",
+  "tests": [
+    { "nodeName": "skillsViewListsFixtureSkill", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "toolboxViewListsRecordedTool", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "emptyRootsShowHints", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] }
+  ]
+}

--- a/packages/agency-lang/lib/runtime/builtinPolicies.test.ts
+++ b/packages/agency-lang/lib/runtime/builtinPolicies.test.ts
@@ -17,6 +17,7 @@ describe("builtinPolicy", () => {
       expect(p![effect]).toEqual([
         { match: { dir: "{.,./**}" }, action: "approve" },
         { match: { dir: "{<agency>/stdlib/**,<agency>/dist/**}" }, action: "approve" },
+        { match: { dir: "{<agent-home>/skills/**,<agent-home>/tools/**}" }, action: "approve" },
       ]);
     }
     expect(p!["std::write"]).toBeUndefined();

--- a/packages/agency-lang/lib/runtime/builtinPolicies.test.ts
+++ b/packages/agency-lang/lib/runtime/builtinPolicies.test.ts
@@ -20,7 +20,10 @@ describe("builtinPolicy", () => {
         { match: { dir: "{<agent-home>/skills/**,<agent-home>/tools/**}" }, action: "approve" },
       ]);
     }
-    expect(p!["std::write"]).toBeUndefined();
+    // The one write rule is the narrow toolbox meta.json use-count write.
+    expect(p!["std::write"]).toEqual([
+      { match: { dir: "<agent-home>/tools/**", filename: "meta.json" }, action: "approve" },
+    ]);
   });
 
   it("scopes a toolbox scan like a read under 'recommended' and omits it under 'minimal'", () => {
@@ -39,8 +42,11 @@ describe("builtinPolicy", () => {
   it("scopes 'with-writes' effects on their correct path fields", () => {
     const p = builtinPolicy("with-writes", "/work");
     const scope = "{/work,/work/**}";
-    // dir field
-    expect(p!["std::write"]).toEqual([{ match: { dir: scope }, action: "approve" }]);
+    // dir field, with the toolbox meta.json rule riding along after it
+    expect(p!["std::write"]).toEqual([
+      { match: { dir: scope }, action: "approve" },
+      { match: { dir: "<agent-home>/tools/**", filename: "meta.json" }, action: "approve" },
+    ]);
     // target field (remove) — a fat-fingered "dir" here would silently disable scoping
     expect(p!["std::remove"]).toEqual([{ match: { target: scope }, action: "approve" }]);
     // src + dest fields (copy/move)

--- a/packages/agency-lang/lib/runtime/builtinPolicies.test.ts
+++ b/packages/agency-lang/lib/runtime/builtinPolicies.test.ts
@@ -20,10 +20,9 @@ describe("builtinPolicy", () => {
         { match: { dir: "{<agent-home>/skills/**,<agent-home>/tools/**}" }, action: "approve" },
       ]);
     }
-    // The one write rule is the narrow toolbox meta.json use-count write.
-    expect(p!["std::write"]).toEqual([
-      { match: { dir: "<agent-home>/tools/**", filename: "meta.json" }, action: "approve" },
-    ]);
+    // No std::write rule at all: runTool's bookkeeping goes through the
+    // dedicated recordUse effect, never a write approval.
+    expect(p!["std::write"]).toBeUndefined();
   });
 
   it("scopes a toolbox scan like a read under 'recommended' and omits it under 'minimal'", () => {
@@ -31,6 +30,14 @@ describe("builtinPolicy", () => {
       builtinPolicy("recommended", "/tmp/base")!["std::read"],
     );
     expect(builtinPolicy("minimal", "/tmp/base")!["std::toolbox::scan"]).toBeUndefined();
+  });
+
+  it("approves recordUse only under the agent-home toolboxes", () => {
+    const p = builtinPolicy("recommended", "/tmp/base");
+    expect(p!["std::toolbox::recordUse"]).toEqual([
+      { match: { dir: "<agent-home>/tools/**" }, action: "approve" },
+    ]);
+    expect(builtinPolicy("minimal", "/tmp/base")!["std::toolbox::recordUse"]).toBeUndefined();
   });
 
   it("resolves 'minimal' with memory approved but reads absent", () => {
@@ -42,11 +49,8 @@ describe("builtinPolicy", () => {
   it("scopes 'with-writes' effects on their correct path fields", () => {
     const p = builtinPolicy("with-writes", "/work");
     const scope = "{/work,/work/**}";
-    // dir field, with the toolbox meta.json rule riding along after it
-    expect(p!["std::write"]).toEqual([
-      { match: { dir: scope }, action: "approve" },
-      { match: { dir: "<agent-home>/tools/**", filename: "meta.json" }, action: "approve" },
-    ]);
+    // dir field (write/edit/mkdir)
+    expect(p!["std::write"]).toEqual([{ match: { dir: scope }, action: "approve" }]);
     // target field (remove) — a fat-fingered "dir" here would silently disable scoping
     expect(p!["std::remove"]).toEqual([{ match: { target: scope }, action: "approve" }]);
     // src + dest fields (copy/move)

--- a/packages/agency-lang/lib/runtime/builtinPolicies.ts
+++ b/packages/agency-lang/lib/runtime/builtinPolicies.ts
@@ -52,6 +52,20 @@ export function readScopeRules(): PolicyRule[] {
   ];
 }
 
+// runTool records a use count in the tool's meta.json after every run.
+// Without this rule each learned-tool invocation prompts on that write —
+// and a headless run executes the tool, then reports failure when the
+// metadata write is rejected. Scoped to exactly that file under the
+// agent-home toolboxes; every other write still prompts.
+export function toolboxMetaWriteRules(): PolicyRule[] {
+  return [
+    {
+      match: { dir: `${AGENT_HOME}/tools/**`, filename: "meta.json" },
+      action: "approve",
+    },
+  ];
+}
+
 export const minimalAutoApprovePolicy: Policy = {
   "std::memory::remember": approve,
   "std::memory::forget": approve,
@@ -67,6 +81,7 @@ export const recommendedAutoApprovePolicy: Policy = {
   // through this same policy, so approving the launch grants nothing more.
   "std::run": approve,
   "std::read": readScopeRules(),
+  "std::write": toolboxMetaWriteRules(),
   "std::readBinary": readScopeRules(),
   "std::ls": readScopeRules(),
   "std::glob": readScopeRules(),
@@ -112,7 +127,10 @@ export function withWritesPolicy(baseDir: string): Policy {
   const cwdRule: PolicyRule[] = [{ match: { cwd: scope }, action: "approve" }];
   return {
     ...recommendedAutoApprovePolicy,
-    "std::write": dirRule,
+    // The toolbox meta.json rule rides along: without it, with-writes
+    // would clobber recommended's std::write entry and learned-tool
+    // runs outside the cwd would prompt again.
+    "std::write": [...dirRule, ...toolboxMetaWriteRules()],
     "std::writeBinary": dirRule,
     "std::edit": dirRule,
     "std::mkdir": dirRule,
@@ -142,7 +160,7 @@ export const BUILTIN_POLICIES: { name: string; description: string }[] = [
   {
     name: "recommended",
     description:
-      "Auto-approve reads under the current directory (and the agency install's own docs and skills) and web/search; prompt for reads elsewhere, writes, shell, and git changes.",
+      "Auto-approve reads under the current directory, the agency install's own docs and skills, and the agent home's learned skills/tools (plus their meta.json use-count writes) and web/search; prompt for reads elsewhere, other writes, shell, and git changes.",
   },
   {
     name: "minimal",

--- a/packages/agency-lang/lib/runtime/builtinPolicies.ts
+++ b/packages/agency-lang/lib/runtime/builtinPolicies.ts
@@ -1,5 +1,6 @@
 import {
   AGENCY_INSTALL_DIR_PLACEHOLDER as INSTALL,
+  AGENT_HOME_PLACEHOLDER as AGENT_HOME,
   type Policy,
   type PolicyRule,
   escapeGlob,
@@ -43,6 +44,11 @@ export function readScopeRules(): PolicyRule[] {
   return [
     { match: { dir: "{.,./**}" }, action: "approve" },
     { match: { dir: `{${INSTALL}/stdlib/**,${INSTALL}/dist/**}` }, action: "approve" },
+    // The agent home's learned directories: skills the user taught the
+    // agent and tools it wrote, both saved only through review
+    // interrupts. Reading them back (including runTool's per-run scan)
+    // is inside the default scope; a stricter custom policy overrides.
+    { match: { dir: `{${AGENT_HOME}/skills/**,${AGENT_HOME}/tools/**}` }, action: "approve" },
   ];
 }
 

--- a/packages/agency-lang/lib/runtime/builtinPolicies.ts
+++ b/packages/agency-lang/lib/runtime/builtinPolicies.ts
@@ -52,18 +52,15 @@ export function readScopeRules(): PolicyRule[] {
   ];
 }
 
-// runTool records a use count in the tool's meta.json after every run.
-// Without this rule each learned-tool invocation prompts on that write —
-// and a headless run executes the tool, then reports failure when the
-// metadata write is rejected. Scoped to exactly that file under the
-// agent-home toolboxes; every other write still prompts.
-export function toolboxMetaWriteRules(): PolicyRule[] {
-  return [
-    {
-      match: { dir: `${AGENT_HOME}/tools/**`, filename: "meta.json" },
-      action: "approve",
-    },
-  ];
+// runTool records a use count in the tool's meta.json after every run,
+// behind the dedicated std::toolbox::recordUse effect. Approving the
+// effect (rather than a std::write rule on the file) approves only the
+// stdlib's own bookkeeping write; a raw write rule on meta.json could
+// be satisfied by ANY program landing arbitrary content there, which
+// listTools would then trust as the tool's purpose. Scoped to the
+// agent-home toolboxes; recordUse elsewhere still prompts.
+function toolboxRecordUseRules(): PolicyRule[] {
+  return [{ match: { dir: `${AGENT_HOME}/tools/**` }, action: "approve" }];
 }
 
 export const minimalAutoApprovePolicy: Policy = {
@@ -81,7 +78,6 @@ export const recommendedAutoApprovePolicy: Policy = {
   // through this same policy, so approving the launch grants nothing more.
   "std::run": approve,
   "std::read": readScopeRules(),
-  "std::write": toolboxMetaWriteRules(),
   "std::readBinary": readScopeRules(),
   "std::ls": readScopeRules(),
   "std::glob": readScopeRules(),
@@ -97,6 +93,7 @@ export const recommendedAutoApprovePolicy: Policy = {
   // A scan reads tool sources and meta.json under a directory, so it
   // takes the read scope.
   "std::toolbox::scan": readScopeRules(),
+  "std::toolbox::recordUse": toolboxRecordUseRules(),
   "std::notify": approve,
   "std::clipboardCopy": approve,
   "std::git::status": approve,
@@ -127,10 +124,7 @@ export function withWritesPolicy(baseDir: string): Policy {
   const cwdRule: PolicyRule[] = [{ match: { cwd: scope }, action: "approve" }];
   return {
     ...recommendedAutoApprovePolicy,
-    // The toolbox meta.json rule rides along: without it, with-writes
-    // would clobber recommended's std::write entry and learned-tool
-    // runs outside the cwd would prompt again.
-    "std::write": [...dirRule, ...toolboxMetaWriteRules()],
+    "std::write": dirRule,
     "std::writeBinary": dirRule,
     "std::edit": dirRule,
     "std::mkdir": dirRule,
@@ -160,7 +154,7 @@ export const BUILTIN_POLICIES: { name: string; description: string }[] = [
   {
     name: "recommended",
     description:
-      "Auto-approve reads under the current directory, the agency install's own docs and skills, and the agent home's learned skills/tools (plus their meta.json use-count writes) and web/search; prompt for reads elsewhere, other writes, shell, and git changes.",
+      "Auto-approve reads under the current directory, the agency install's own docs and skills, the agent home's learned skills/tools (plus the toolbox recordUse bookkeeping there) and web/search; prompt for reads elsewhere, writes, shell, and git changes.",
   },
   {
     name: "minimal",

--- a/packages/agency-lang/lib/runtime/policy.test.ts
+++ b/packages/agency-lang/lib/runtime/policy.test.ts
@@ -3,13 +3,14 @@ import {
   checkPolicy,
   resolveDotDirPattern,
   expandAgencyInstallDir,
+  expandAgentHomeDir,
   validatePolicy,
   escapeGlob,
 } from "./policy.js";
 import { getStdlibDir } from "../importPaths.js";
 import path from "path";
 import { mkdtempSync, mkdirSync, symlinkSync, rmSync, realpathSync } from "fs";
-import { tmpdir } from "os";
+import os, { tmpdir } from "os";
 import picomatch from "picomatch";
 
 describe("checkPolicy", () => {
@@ -612,6 +613,71 @@ describe("<agency> dir patterns", () => {
     };
     expect(expandAgencyInstallDir("<agency>/stdlib/**", unresolvable)).toBe("<agency>/stdlib/**");
     expect(expandAgencyInstallDir("/plain/**", unresolvable)).toBe("/plain/**");
+  });
+});
+
+describe("<agent-home> dir patterns", () => {
+  const read = (dir: string) => ({
+    effect: "std::read",
+    message: "m",
+    data: { dir, filename: "x" },
+    origin: "std::fs",
+  });
+  const policy = {
+    "std::read": [
+      {
+        match: { dir: "{<agent-home>/skills/**,<agent-home>/tools/**}" },
+        action: "approve" as const,
+      },
+    ],
+  };
+
+  it("expands to AGENCY_AGENT_HOME when set and non-empty", () => {
+    expect(expandAgentHomeDir("<agent-home>/skills/**", () => "/custom/home")).toBe(
+      "/custom/home/skills/**",
+    );
+  });
+
+  it("escapes glob characters in the resolved home", () => {
+    expect(expandAgentHomeDir("<agent-home>/skills/**", () => "/opt/v*1")).toBe(
+      "/opt/v\\*1/skills/**",
+    );
+  });
+
+  it("leaves a pattern without the token untouched", () => {
+    expect(expandAgentHomeDir("/plain/**", () => "/custom/home")).toBe("/plain/**");
+  });
+
+  it("an empty AGENCY_AGENT_HOME counts as unset (falls back to ~/.agency-agent)", () => {
+    const previous = process.env.AGENCY_AGENT_HOME;
+    process.env.AGENCY_AGENT_HOME = "";
+    try {
+      expect(expandAgentHomeDir("<agent-home>/skills/**")).toBe(
+        `${path.join(os.homedir(), ".agency-agent")}/skills/**`,
+      );
+    } finally {
+      if (previous === undefined) delete process.env.AGENCY_AGENT_HOME;
+      else process.env.AGENCY_AGENT_HOME = previous;
+    }
+  });
+
+  it("`<agent-home>` means the agent home, resolved at match time", () => {
+    const previous = process.env.AGENCY_AGENT_HOME;
+    process.env.AGENCY_AGENT_HOME = "/tmp/agent-home-test";
+    try {
+      expect(checkPolicy(policy, read("/tmp/agent-home-test/skills/explorer")).type).toBe(
+        "approve",
+      );
+      expect(checkPolicy(policy, read("/tmp/agent-home-test/tools/research/hnTop")).type).toBe(
+        "approve",
+      );
+      // The home itself and unrelated dirs: not covered.
+      expect(checkPolicy(policy, read("/tmp/agent-home-test")).type).toBe("propagate");
+      expect(checkPolicy(policy, read("/Users/someone")).type).toBe("propagate");
+    } finally {
+      if (previous === undefined) delete process.env.AGENCY_AGENT_HOME;
+      else process.env.AGENCY_AGENT_HOME = previous;
+    }
   });
 });
 

--- a/packages/agency-lang/lib/runtime/policy.test.ts
+++ b/packages/agency-lang/lib/runtime/policy.test.ts
@@ -648,6 +648,19 @@ describe("<agent-home> dir patterns", () => {
     expect(expandAgentHomeDir("/plain/**", () => "/custom/home")).toBe("/plain/**");
   });
 
+  it("a relative AGENCY_AGENT_HOME resolves to an absolute path (matching canonicalized dirs)", () => {
+    const previous = process.env.AGENCY_AGENT_HOME;
+    process.env.AGENCY_AGENT_HOME = "./my-profile";
+    try {
+      expect(expandAgentHomeDir("<agent-home>/skills/**")).toBe(
+        `${path.resolve("./my-profile")}/skills/**`,
+      );
+    } finally {
+      if (previous === undefined) delete process.env.AGENCY_AGENT_HOME;
+      else process.env.AGENCY_AGENT_HOME = previous;
+    }
+  });
+
   it("an empty AGENCY_AGENT_HOME counts as unset (falls back to ~/.agency-agent)", () => {
     const previous = process.env.AGENCY_AGENT_HOME;
     process.env.AGENCY_AGENT_HOME = "";

--- a/packages/agency-lang/lib/runtime/policy.test.ts
+++ b/packages/agency-lang/lib/runtime/policy.test.ts
@@ -674,6 +674,25 @@ describe("<agent-home> dir patterns", () => {
     }
   });
 
+  it("realpaths a symlinked agent home, matching the canonicalized dirs file effects report", () => {
+    const base = mkdtempSync(path.join(tmpdir(), "policy-home-"));
+    const previous = process.env.AGENCY_AGENT_HOME;
+    try {
+      const real = path.join(base, "real-home");
+      mkdirSync(real);
+      const link = path.join(base, "linked-home");
+      symlinkSync(real, link);
+      process.env.AGENCY_AGENT_HOME = link;
+      // tmpdir() itself may sit behind a symlink (macOS /var), so the
+      // expectation canonicalizes the same way the expander must.
+      expect(expandAgentHomeDir("<agent-home>/skills/**")).toBe(`${realpathSync(real)}/skills/**`);
+    } finally {
+      if (previous === undefined) delete process.env.AGENCY_AGENT_HOME;
+      else process.env.AGENCY_AGENT_HOME = previous;
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+
   it("`<agent-home>` means the agent home, resolved at match time", () => {
     const previous = process.env.AGENCY_AGENT_HOME;
     process.env.AGENCY_AGENT_HOME = "/tmp/agent-home-test";

--- a/packages/agency-lang/lib/runtime/policy.ts
+++ b/packages/agency-lang/lib/runtime/policy.ts
@@ -177,13 +177,23 @@ export function expandAgentHomeDir(pattern: string, home: () => string = default
 
 function defaultAgentHome(): string {
   const override = process.env.AGENCY_AGENT_HOME;
-  if (override !== undefined && override !== "") {
-    // File effects canonicalize their dir to an absolute path before
-    // matching, so a relative override (./my-profile) must be resolved
-    // the same way or the pattern never matches.
-    return path.resolve(override);
+  const home =
+    override !== undefined && override !== ""
+      ? // File effects canonicalize their dir to an absolute path before
+        // matching, so a relative override (./my-profile) must be resolved
+        // the same way or the pattern never matches.
+        path.resolve(override)
+      : path.join(os.homedir(), ".agency-agent");
+  // Realpathed for the same reason the cwd is in resolveDotDirPattern: file
+  // effects realpath their payload dirs, so a symlinked home (macOS /tmp, a
+  // linked profile) must share that path identity or no rule ever matches.
+  try {
+    return realpathSync(home);
+  } catch {
+    // A home that does not exist yet (nothing learned) keeps its lexical
+    // spelling; there is nothing under it to match anyway.
+    return home;
   }
-  return path.join(os.homedir(), ".agency-agent");
 }
 
 function matchesRule(

--- a/packages/agency-lang/lib/runtime/policy.ts
+++ b/packages/agency-lang/lib/runtime/policy.ts
@@ -178,7 +178,10 @@ export function expandAgentHomeDir(pattern: string, home: () => string = default
 function defaultAgentHome(): string {
   const override = process.env.AGENCY_AGENT_HOME;
   if (override !== undefined && override !== "") {
-    return override;
+    // File effects canonicalize their dir to an absolute path before
+    // matching, so a relative override (./my-profile) must be resolved
+    // the same way or the pattern never matches.
+    return path.resolve(override);
   }
   return path.join(os.homedir(), ".agency-agent");
 }
@@ -210,18 +213,14 @@ function matchesRule(
       !raw &&
       key === "dir" &&
       picomatch.isMatch(stripDotSlash(value), stripDotSlash(resolveDotDirPattern(pattern)));
-    const viaInstall =
+    // Each expander is a no-op when its token is absent, so one composed
+    // check covers every placeholder — including a pattern mixing them.
+    const viaPlaceholders =
       !raw &&
       !viaDot &&
       key === "dir" &&
-      picomatch.isMatch(stripDotSlash(value), expandAgencyInstallDir(pattern));
-    const viaAgentHome =
-      !raw &&
-      !viaDot &&
-      !viaInstall &&
-      key === "dir" &&
-      picomatch.isMatch(stripDotSlash(value), expandAgentHomeDir(pattern));
-    if (!raw && !viaDot && !viaInstall && !viaAgentHome) {
+      picomatch.isMatch(stripDotSlash(value), expandAgentHomeDir(expandAgencyInstallDir(pattern)));
+    if (!raw && !viaDot && !viaPlaceholders) {
       return false;
     }
   }

--- a/packages/agency-lang/lib/runtime/policy.ts
+++ b/packages/agency-lang/lib/runtime/policy.ts
@@ -1,5 +1,7 @@
 import picomatch from "picomatch";
 import { realpathSync } from "fs";
+import os from "os";
+import path from "path";
 import { z } from "zod";
 import { getPackageRoot } from "../importPaths.js";
 
@@ -158,6 +160,29 @@ export function expandAgencyInstallDir(
   return pattern.split(AGENCY_INSTALL_DIR_PLACEHOLDER).join(escapeForGlob(resolved));
 }
 
+/** In a `dir` pattern, `<agent-home>` stands for the agent home directory
+ *  (`AGENCY_AGENT_HOME`, or `~/.agency-agent` when unset). The built-in
+ *  read scope uses it for the learned skills and toolbox directories, so a
+ *  saved policy keeps meaning "wherever the agent home is now". */
+export const AGENT_HOME_PLACEHOLDER = "<agent-home>";
+
+// Expanded at match time, like `<agency>`. An empty AGENCY_AGENT_HOME
+// counts as unset — the same guard the agent's config module documents
+// (issue #469) — so a set-but-empty var never turns the home into a
+// cwd-relative path. Exported for tests, which inject the home.
+export function expandAgentHomeDir(pattern: string, home: () => string = defaultAgentHome): string {
+  if (!pattern.includes(AGENT_HOME_PLACEHOLDER)) return pattern;
+  return pattern.split(AGENT_HOME_PLACEHOLDER).join(escapeForGlob(home()));
+}
+
+function defaultAgentHome(): string {
+  const override = process.env.AGENCY_AGENT_HOME;
+  if (override !== undefined && override !== "") {
+    return override;
+  }
+  return path.join(os.homedir(), ".agency-agent");
+}
+
 function matchesRule(
   rule: PolicyRule,
   interrupt: { effect: string; message: string; data: any; origin: string },
@@ -190,7 +215,13 @@ function matchesRule(
       !viaDot &&
       key === "dir" &&
       picomatch.isMatch(stripDotSlash(value), expandAgencyInstallDir(pattern));
-    if (!raw && !viaDot && !viaInstall) {
+    const viaAgentHome =
+      !raw &&
+      !viaDot &&
+      !viaInstall &&
+      key === "dir" &&
+      picomatch.isMatch(stripDotSlash(value), expandAgentHomeDir(pattern));
+    if (!raw && !viaDot && !viaInstall && !viaAgentHome) {
       return false;
     }
   }

--- a/packages/agency-lang/lib/stdlib/skills.ts
+++ b/packages/agency-lang/lib/stdlib/skills.ts
@@ -44,6 +44,15 @@ export function _bundledDocsDir(): string {
  * trusted scan into an unprompted scan of somewhere else entirely. Confining
  * here keeps that trust argument true.
  */
+/**
+ * tarsec's frontmatter serializer, the encode half of the parser
+ * `std::markdown` wraps: `parse(stringify(x))` deep-equals `x` for every
+ * flat string record it accepts. Throws on values the grammar cannot
+ * hold (a key it cannot spell, or a value no quote character can
+ * enclose); Agency callers wrap the call in `try`.
+ */
+export { stringifyFrontmatter as _stringifyFrontmatter } from "tarsec/parsers/markdown";
+
 export function _agentSkillsDir(agent: string): string {
   const root = path.join(getStdlibDir(), "agents", "skills");
   const resolved = path.resolve(root, agent);

--- a/packages/agency-lang/lib/utils/alwaysTag.stdlib.test.ts
+++ b/packages/agency-lang/lib/utils/alwaysTag.stdlib.test.ts
@@ -127,6 +127,7 @@ const EXPECTED: Record<string, string[]> = {
   "mcp::call": ["server", "tool"],
   "std::skills::skillsDir": ["dir/**"],
   "std::skills::commandsDir": ["dir/**"],
+  "std::skills::reviewSkill": ["dir/**"],
   "std::toolbox::scan": ["dir/**"],
   "std::toolbox::review": [],
   "std::memory::enableMemory": [],

--- a/packages/agency-lang/lib/utils/alwaysTag.stdlib.test.ts
+++ b/packages/agency-lang/lib/utils/alwaysTag.stdlib.test.ts
@@ -129,6 +129,7 @@ const EXPECTED: Record<string, string[]> = {
   "std::skills::commandsDir": ["dir/**"],
   "std::skills::reviewSkill": ["dir/**"],
   "std::toolbox::scan": ["dir/**"],
+  "std::toolbox::recordUse": ["dir/**"],
   "std::toolbox::review": [],
   "std::memory::enableMemory": [],
   "std::memory::disableMemory": [],

--- a/packages/agency-lang/package.json
+++ b/packages/agency-lang/package.json
@@ -114,7 +114,7 @@
     "picomatch": "^4.0.4",
     "prompts": "^2.4.2",
     "smoltalk": "^0.12.0",
-    "tarsec": "0.5.3",
+    "tarsec": "0.5.4",
     "typestache": "^0.6.0",
     "vscode-languageserver": "^9.0.1",
     "vscode-languageserver-protocol": "^3.17.5",

--- a/packages/agency-lang/stdlib/agents/writing/rewrite.agency
+++ b/packages/agency-lang/stdlib/agents/writing/rewrite.agency
@@ -36,6 +36,7 @@ def applyFindings(
   findings: Feedback[],
   model: string,
   provider: string,
+  extraTools: any[],
 ): string {
   const findingLines = map(findings, \item -> "- ${item.feedback}").join("\n")
   let guidelinesSection = ""
@@ -64,7 +65,7 @@ ${findingLines}
 ${text}
 </text>
 """
-  return llm(prompt, llmOptions(model: model, provider: provider))
+  return llm(prompt, llmOptions(model: model, provider: provider, tools: extraTools))
 }
 
 /**
@@ -92,6 +93,7 @@ export def writingRewriteAgent(
   maxTime: number = 10m,
   model: string = "",
   provider: string = "",
+  extraTools: any[] = [],
 ): Result<string> {
   """
   Review prose and return it rewritten with the findings applied. If
@@ -109,6 +111,7 @@ export def writingRewriteAgent(
   @param maxTime - Hard wall-clock cap for all rounds together
   @param model - Model override, or "" for the ambient model
   @param provider - Provider for the model override
+  @param extraTools - Extra tools to offer the LLM, appended to the built-in set
   """
   let reviewFailure = ""
   const captured = guard(cost: maxCost, time: maxTime, label: "writingRewriteAgent") {
@@ -142,6 +145,7 @@ export def writingRewriteAgent(
             findings: findings,
             model: model,
             provider: provider,
+            extraTools: extraTools,
           )
         }
       }

--- a/packages/agency-lang/stdlib/skills.agency
+++ b/packages/agency-lang/stdlib/skills.agency
@@ -1,5 +1,7 @@
 import { map } from "std::array"
+import { mkdir } from "std::fs"
 import { frontmatter } from "std::markdown"
+import { exists } from "std::shell"
 
 // `skillsDir` / `commandsDir` raise ONE approval interrupt up front
 // ("scan this directory for skills?"). Reading the matched files is part
@@ -34,7 +36,7 @@ import { _docsDir, _bundledDocsDir, _agentSkillsDir } from "agency-lang/stdlib-l
   ```
 */
 
-type SkillEntry = {
+export type SkillEntry = {
   name: string;
   description: string;
   location: string
@@ -97,6 +99,9 @@ def flatEntry(filename: string, parsedFrontmatter: any): SkillEntry {
 // Providers cap tool-name length: OpenAI at 64 characters, Anthropic at 128.
 // Cap to the stricter 64 so a name is accepted everywhere.
 const MAX_TOOL_NAME_LEN = 64
+
+// Cap on how many files one skills/commands scan will read.
+const MAX_SKILL_FILES = 500
 
 def sanitizeToolSegment(raw: string): string {
   """
@@ -193,32 +198,24 @@ effect std::skills::commandsDir {
   dir: string
 }
 
-def buildSkillsTool(
+export def skillsToolFromEntries(
   dir: string,
-  layout: "flat" | "standard",
+  entries: SkillEntry[],
   name: string = "",
-  recursive: boolean = false,
 ) {
-  let pattern = "*/SKILL.md"
-  if (layout == "flat") {
-    pattern = "*.{md,markdown}"
-    if (recursive) {
-      pattern = "**/*.{md,markdown}"
-    }
-  }
-  let lines: string[] = []
-  const pathsResult = try _glob(pattern, dir, 500, [])
-  if (pathsResult is success(paths)) {
-    lines = map(paths) as path {
-      const data = (try _read(dir, path, 0, 0) |> frontmatter) catch {}
-      let entry = flatEntry(path, data)
-      if (layout == "standard") {
-        entry = standardEntry(path, data)
-      }
-      return renderEntry(entry)
-    }
-  }
+  """
+  Build the skills tool for `dir` from already-scanned entries. Pure: no
+  reads, no interrupts. Callers that already hold a directory's entries
+  (a catalog updated after a save) use this to rebuild the tool without
+  rescanning.
 
+  @param dir - The directory the tool will read skills from
+  @param entries - The skills to list in the tool description
+  @param name - Optional explicit tool name. Sanitized to alphanumerics/underscores and capped at 64 characters; defaults to a name derived from `dir`.
+  """
+  const lines = map(entries) as entry {
+    return renderEntry(entry)
+  }
   const header = "Read a skill file from the skills directory '${dir}' by passing its <location> as `filename` to the tool. Available skills:\n<available_skills>\n"
   const footer = "\n</available_skills>"
   const description = header + lines.join("\n") + footer
@@ -235,6 +232,33 @@ def buildSkillsTool(
     }
   }
   return read.partial(dir: dir).describe(description).rename(toolName)
+}
+
+def buildSkillsTool(
+  dir: string,
+  layout: "flat" | "standard",
+  name: string = "",
+  recursive: boolean = false,
+) {
+  let pattern = "*/SKILL.md"
+  if (layout == "flat") {
+    pattern = "*.{md,markdown}"
+    if (recursive) {
+      pattern = "**/*.{md,markdown}"
+    }
+  }
+  let entries: SkillEntry[] = []
+  const pathsResult = try _glob(pattern, dir, MAX_SKILL_FILES, [])
+  if (pathsResult is success(paths)) {
+    entries = map(paths) as path {
+      const data = (try _read(dir, path, 0, 0) |> frontmatter) catch {}
+      if (layout == "standard") {
+        return standardEntry(path, data)
+      }
+      return flatEntry(path, data)
+    }
+  }
+  return skillsToolFromEntries(dir, entries, name)
 }
 
 export def skillsDir(
@@ -255,6 +279,146 @@ export def skillsDir(
   })
 
   return buildSkillsTool(dir, layout, name)
+}
+
+export def scanSkillsSubdirs(root: string): Record<string, SkillEntry[]> {
+  """
+  Scan a directory whose immediate subdirectories each hold one agent's
+  flat-layout skills. Raises one `std::skills::skillsDir` interrupt for
+  the root; its approval covers the reads. A missing root or a subdir
+  with no markdown files yields no entry for it.
+
+  @param root - The directory holding one subdirectory per agent
+  """
+  return interrupt std::skills::skillsDir("Are you sure you want to scan this directory for skill files?", {
+    dir: root,
+    layout: "flat"
+  })
+
+  let out: Record<string, SkillEntry[]> = {}
+  const pathsResult = try _glob("*/*.{md,markdown}", root, MAX_SKILL_FILES, [])
+  if (pathsResult is failure) {
+    return out
+  }
+  for (path in pathsResult.value) {
+    const scanned = scannedEntry(root, path)
+    if (out[scanned.sub] == undefined) {
+      out[scanned.sub] = []
+    }
+    out[scanned.sub].push(scanned.entry)
+  }
+  return out
+}
+
+// One scanned path, parsed: which agent subdirectory it belongs to and
+// its skill entry. Keeps the grouping loop above to grouping only.
+def scannedEntry(root: string, path: string): { sub: string; entry: SkillEntry } {
+  const slash = path.indexOf("/")
+  const file = path.slice(slash + 1)
+  const data = (try _read(root, path, 0, 0) |> frontmatter) catch {}
+  return {
+    sub: path.slice(0, slash),
+    entry: flatEntry(file, data)
+  }
+}
+
+@alwaysUnder(dir)
+effect std::skills::reviewSkill {
+  dir: string;
+  name: string;
+  content: string
+}
+
+/** The value a handler passes to approve() for std::skills::reviewSkill.
+  A bare approve() counts as accept. */
+export type SkillReview =
+  | { verdict: "accept" }
+  | { verdict: "revise"; feedback: string }
+
+export type WriteSkillOutcome = { saved: SkillEntry } | { revise: string }
+
+// Skill names: lowercase alphanumerics and hyphens, starting with a
+// letter or digit. Mirrors the bundled skills' kebab-case names.
+// Validated, never rewritten, so a user-chosen name is never changed.
+def validSkillName(name: string): boolean {
+  return name =~ re/^[a-z0-9][a-z0-9-]*$/
+}
+
+// What the reviewSkill handler answered. Checked in order: a rejected
+// interrupt arrives as a Failure and is returned as-is so the rejection
+// reason survives; a bare approve() arrives as null and counts as
+// accept. Mirrors the std::toolbox review validation in shape; shared
+// code would couple the two modules over a dozen lines.
+def validateReview(answer: any): Result<SkillReview> {
+  if (answer is failure) {
+    return answer
+  }
+  if (answer == null) {
+    return success({ verdict: "accept" })
+  }
+  if (answer.verdict == "accept") {
+    return success({ verdict: "accept" })
+  }
+  if (answer.verdict == "revise" && answer.feedback is string && answer.feedback != "") {
+    return success({ verdict: "revise", feedback: answer.feedback })
+  }
+  return failure("reviewSkill handler must approve with { verdict: \"accept\" }, { verdict: \"revise\", feedback: \"...\" }, or a bare approve()")
+}
+
+export def writeSkill(
+  dir: string,
+  name: string,
+  description: string,
+  body: string,
+): Result<WriteSkillOutcome> {
+  """
+  Save a skill file into a skills directory, after the user reviews it.
+  Composes the flat-layout markdown (frontmatter with name and
+  description, then the body), raises a `std::skills::reviewSkill`
+  interrupt showing the complete file, and only writes on acceptance. A
+  "revise" review returns the feedback instead of writing, so the caller
+  can redraft. A rejected interrupt fails the call.
+
+  @param dir - The skills directory to write into
+  @param name - The skill's name; also its filename. Lowercase letters, digits, and hyphens.
+  @param description - One line telling the reading agent when to use the skill
+  @param body - The skill's markdown body
+  """
+  if (!validSkillName(name)) {
+    return failure("skill name '${name}' is invalid: use lowercase letters, digits, and hyphens, starting with a letter or digit")
+  }
+  if (description.includes("\n") || description.includes("---")) {
+    return failure("the description must be one line and must not contain ---")
+  }
+  if (body.startsWith("---")) {
+    return failure("the body must not start with --- (it would extend the frontmatter)")
+  }
+  const filename = "${name}.md"
+  if (exists(filename, dir)) {
+    return failure("a skill named ${name} already exists in ${dir}")
+  }
+  const content = "---\nname: ${name}\ndescription: ${description}\n---\n\n${body}\n"
+  const answer = interrupt std::skills::reviewSkill(
+    "Save this skill to ${dir}/${filename}?",
+    { dir: dir, name: name, content: content },
+  )
+  const review = validateReview(answer)
+  if (review is failure) {
+    return review
+  }
+  const verdict = review.value
+  if (verdict.verdict == "revise") {
+    return success({ revise: verdict.feedback })
+  }
+  const made = mkdir(dir)
+  if (made is failure) {
+    return made
+  }
+  const wrote = write(filename, content, dir)
+  if (wrote is failure) {
+    return wrote
+  }
+  return success({ saved: { name: name, description: description, location: filename } })
 }
 
 export def docsSkill(
@@ -385,7 +549,7 @@ export def commandsDir(dir: string): any[] {
     dir: dir
   })
 
-  const pathsResult = try _glob("*.md", dir, 500, [])
+  const pathsResult = try _glob("*.md", dir, MAX_SKILL_FILES, [])
   if (pathsResult is success(paths)) {
     return map(paths) as p {
       const raw = try _read(dir, p, 0, 0) catch ""

--- a/packages/agency-lang/stdlib/skills.agency
+++ b/packages/agency-lang/stdlib/skills.agency
@@ -14,7 +14,7 @@ import { exists } from "std::shell"
 // the interrupt-raising versions have.
 import { _read } from "agency-lang/stdlib-lib/builtins.js"
 import { _glob } from "agency-lang/stdlib-lib/shell.js"
-import { _docsDir, _bundledDocsDir, _agentSkillsDir } from "agency-lang/stdlib-lib/skills.js"
+import { _docsDir, _bundledDocsDir, _agentSkillsDir, _stringifyFrontmatter } from "agency-lang/stdlib-lib/skills.js"
 
 
 /** @module
@@ -97,8 +97,10 @@ def flatEntry(filename: string, parsedFrontmatter: any): SkillEntry {
 }
 
 // Providers cap tool-name length: OpenAI at 64 characters, Anthropic at 128.
-// Cap to the stricter 64 so a name is accepted everywhere.
-const MAX_TOOL_NAME_LEN = 64
+// Cap to the stricter 64 so a name is accepted everywhere. Exported so
+// callers that build prefixed tool names (e.g. the agent's learned_
+// tools) derive their own cap from this one instead of restating 64.
+export static const MAX_TOOL_NAME_LEN = 64
 
 // Cap on how many files one skills/commands scan will read.
 const MAX_SKILL_FILES = 500
@@ -306,6 +308,16 @@ export def scanSkillsSubdirs(
   @param root - The directory holding the subdirectories
   @param subdirs - The subdirectory names to scan
   """
+  // The one interrupt approves scanning under `root`, so every name must
+  // stay a single path segment: `../private` (or an absolute path, or a
+  // `a/b` compound) would carry the approval outside the directory the
+  // user said yes to. Checked before raising, so a bad caller fails
+  // without prompting anyone.
+  for (sub in subdirs) {
+    if (sub == "" || sub == "." || sub == ".." || sub.includes("/") || sub.includes("\\")) {
+      return failure("subdirectory name '${sub}' is not a bare directory name; scanSkillsSubdirs only scans direct subdirectories of its root")
+    }
+  }
   return interrupt std::skills::skillsDir("Are you sure you want to scan this directory for skill files?", {
     dir: root,
     layout: "flat"
@@ -386,24 +398,23 @@ export def writeSkill(
   if (!validSkillName(name)) {
     return failure("skill name '${name}' is invalid: use lowercase letters, digits, and hyphens, starting with a letter or digit")
   }
-  if (description.includes("\n") || description.includes("---")) {
-    return failure("the description must be one line and must not contain ---")
-  }
-  if (description.includes(`"`)) {
-    return failure(`the description must not contain double quotes; use single quotes instead`)
-  }
-  if (body.startsWith("---")) {
-    return failure("the body must not start with --- (it would extend the frontmatter)")
+  if (description.includes("\n")) {
+    return failure("the description must be one line")
   }
   const filename = "${name}.md"
   if (exists(filename, dir)) {
     return failure("a skill named ${name} already exists in ${dir}")
   }
-  // The description is double-quoted so YAML flow syntax in it (a
-  // leading `[` or quote) cannot make the frontmatter unparseable and
-  // silently drop the reviewed description on the next scan. The
-  // no-double-quotes check above is what makes the quoting safe.
-  const content = "---\nname: ${name}\ndescription: \"${description}\"\n---\n\n${body}\n"
+  // tarsec's serializer is the encode half of the parser `frontmatter`
+  // wraps, so whatever it emits reads back verbatim on the next scan —
+  // YAML flow syntax, quotes, or backslashes in the description cannot
+  // silently corrupt or drop the reviewed text. It throws on the rare
+  // value no quoting can hold; `try` turns that into a clean failure.
+  const fm = try _stringifyFrontmatter({ name: name, description: description })
+  if (fm is failure(fmErr)) {
+    return failure("the description cannot be written as frontmatter: ${fmErr}")
+  }
+  const content = "${fm.value}\n${body}\n"
   const answer = interrupt std::skills::reviewSkill(
     "Save this skill to ${dir}/${filename}?",
     { dir: dir, name: name, content: content },

--- a/packages/agency-lang/stdlib/skills.agency
+++ b/packages/agency-lang/stdlib/skills.agency
@@ -234,6 +234,25 @@ export def skillsToolFromEntries(
   return read.partial(dir: dir).describe(description).rename(toolName)
 }
 
+// The one scan pipeline every skills reader shares: glob (capped at
+// MAX_SKILL_FILES per directory), read each file with the interrupt-free
+// primitives (a scan interrupt's approval covers them), parse the
+// frontmatter (tolerating a file it cannot parse), and build the entry.
+def scanEntries(
+  dir: string,
+  pattern: string,
+  build: (string, any) -> SkillEntry,
+): SkillEntry[] {
+  const pathsResult = try _glob(pattern, dir, MAX_SKILL_FILES, [])
+  if (pathsResult is failure) {
+    return []
+  }
+  return map(pathsResult.value) as path {
+    const data = (try _read(dir, path, 0, 0) |> frontmatter) catch {}
+    return build(path, data)
+  }
+}
+
 def buildSkillsTool(
   dir: string,
   layout: "flat" | "standard",
@@ -241,24 +260,15 @@ def buildSkillsTool(
   recursive: boolean = false,
 ) {
   let pattern = "*/SKILL.md"
+  let build = standardEntry
   if (layout == "flat") {
     pattern = "*.{md,markdown}"
+    build = flatEntry
     if (recursive) {
       pattern = "**/*.{md,markdown}"
     }
   }
-  let entries: SkillEntry[] = []
-  const pathsResult = try _glob(pattern, dir, MAX_SKILL_FILES, [])
-  if (pathsResult is success(paths)) {
-    entries = map(paths) as path {
-      const data = (try _read(dir, path, 0, 0) |> frontmatter) catch {}
-      if (layout == "standard") {
-        return standardEntry(path, data)
-      }
-      return flatEntry(path, data)
-    }
-  }
-  return skillsToolFromEntries(dir, entries, name)
+  return skillsToolFromEntries(dir, scanEntries(dir, pattern, build), name)
 }
 
 export def skillsDir(
@@ -281,14 +291,20 @@ export def skillsDir(
   return buildSkillsTool(dir, layout, name)
 }
 
-export def scanSkillsSubdirs(root: string): Record<string, SkillEntry[]> {
+export def scanSkillsSubdirs(
+  root: string,
+  subdirs: string[],
+): Record<string, SkillEntry[]> {
   """
-  Scan a directory whose immediate subdirectories each hold one agent's
+  Scan named subdirectories of a root, each holding one agent's
   flat-layout skills. Raises one `std::skills::skillsDir` interrupt for
-  the root; its approval covers the reads. A missing root or a subdir
-  with no markdown files yields no entry for it.
+  the root; its approval covers the reads. Each subdirectory gets its
+  own MAX_SKILL_FILES scan; one with no markdown files (or that does not
+  exist) yields no entry. Taking the names as a parameter keeps the
+  record's keys caller-chosen data, never something read off the disk.
 
-  @param root - The directory holding one subdirectory per agent
+  @param root - The directory holding the subdirectories
+  @param subdirs - The subdirectory names to scan
   """
   return interrupt std::skills::skillsDir("Are you sure you want to scan this directory for skill files?", {
     dir: root,
@@ -296,30 +312,13 @@ export def scanSkillsSubdirs(root: string): Record<string, SkillEntry[]> {
   })
 
   let out: Record<string, SkillEntry[]> = {}
-  const pathsResult = try _glob("*/*.{md,markdown}", root, MAX_SKILL_FILES, [])
-  if (pathsResult is failure) {
-    return out
-  }
-  for (path in pathsResult.value) {
-    const scanned = scannedEntry(root, path)
-    if (out[scanned.sub] == undefined) {
-      out[scanned.sub] = []
+  for (sub in subdirs) {
+    const entries = scanEntries("${root}/${sub}", "*.{md,markdown}", flatEntry)
+    if (entries.length > 0) {
+      out[sub] = entries
     }
-    out[scanned.sub].push(scanned.entry)
   }
   return out
-}
-
-// One scanned path, parsed: which agent subdirectory it belongs to and
-// its skill entry. Keeps the grouping loop above to grouping only.
-def scannedEntry(root: string, path: string): { sub: string; entry: SkillEntry } {
-  const slash = path.indexOf("/")
-  const file = path.slice(slash + 1)
-  const data = (try _read(root, path, 0, 0) |> frontmatter) catch {}
-  return {
-    sub: path.slice(0, slash),
-    entry: flatEntry(file, data)
-  }
 }
 
 @alwaysUnder(dir)
@@ -390,6 +389,9 @@ export def writeSkill(
   if (description.includes("\n") || description.includes("---")) {
     return failure("the description must be one line and must not contain ---")
   }
+  if (description.includes(`"`)) {
+    return failure(`the description must not contain double quotes; use single quotes instead`)
+  }
   if (body.startsWith("---")) {
     return failure("the body must not start with --- (it would extend the frontmatter)")
   }
@@ -397,7 +399,11 @@ export def writeSkill(
   if (exists(filename, dir)) {
     return failure("a skill named ${name} already exists in ${dir}")
   }
-  const content = "---\nname: ${name}\ndescription: ${description}\n---\n\n${body}\n"
+  // The description is double-quoted so YAML flow syntax in it (a
+  // leading `[` or quote) cannot make the frontmatter unparseable and
+  // silently drop the reviewed description on the next scan. The
+  // no-double-quotes check above is what makes the quoting safe.
+  const content = "---\nname: ${name}\ndescription: \"${description}\"\n---\n\n${body}\n"
   const answer = interrupt std::skills::reviewSkill(
     "Save this skill to ${dir}/${filename}?",
     { dir: dir, name: name, content: content },

--- a/packages/agency-lang/stdlib/toolbox.agency
+++ b/packages/agency-lang/stdlib/toolbox.agency
@@ -18,9 +18,10 @@ import { llmOptions } from "std::agents/lib/shared"
 import { now, format } from "std::date"
 import { mkdir, remove, move } from "std::fs"
 import { ls, exists } from "std::shell"
+import { MAX_TOOL_NAME_LEN } from "std::skills"
 import { Json } from "std::validation"
 
-import { _read } from "agency-lang/stdlib-lib/builtins.js"
+import { _read, _write } from "agency-lang/stdlib-lib/builtins.js"
 import { expandPath } from "agency-lang/stdlib-lib/expandPath.js"
 
 /** @module
@@ -86,9 +87,9 @@ import { expandPath } from "agency-lang/stdlib-lib/expandPath.js"
 // skills directory.
 const MAX_TOOLS = 500
 
-// Providers cap tool names at 64 characters; std::skills truncates to the
-// same cap, this module refuses so a user-chosen name is never changed.
-const MAX_TOOL_NAME_LEN = 64
+// std::skills owns the provider tool-name cap (MAX_TOOL_NAME_LEN, 64).
+// std::skills truncates to it; this module refuses over-long names so a
+// user-chosen name is never changed.
 
 // Added to a tool's own time limit for the subprocess that runs it, so
 // the guard trips before the process is killed. runFile clamps wallClock
@@ -111,6 +112,18 @@ const META_FILE = "meta.json"
 @alwaysUnder(dir)
 effect std::toolbox::scan {
   dir: string
+}
+
+// runTool's use-count bookkeeping, as its own effect rather than a raw
+// std::write: the stdlib composes the written record itself, so
+// approving this effect approves one known, constrained mutation of the
+// tool's meta.json. A policy rule for it cannot be reused to land
+// arbitrary content in the file. The approval covers the write that
+// fulfils it, the way a scan's approval covers its reads.
+@alwaysUnder(dir)
+effect std::toolbox::recordUse {
+  dir: string;
+  name: string
 }
 
 effect std::toolbox::review {
@@ -922,12 +935,18 @@ export def writeTool(
 // ---- running a tool ----
 
 def recordUse(toolDir: string, name: string, meta: ToolMeta): Result {
+  return interrupt std::toolbox::recordUse("Record one use of this tool in its ${META_FILE}?", {
+    dir: toolDir,
+    name: name
+  })
   const used: ToolMeta = {
     ...meta,
     uses: meta.uses + 1,
     lastUsedAt: format(now())
   }
-  return write(META_FILE, JSON.stringify(used, null, 2), toolDir)
+  // The interrupt-free primitive: the recordUse approval covers this
+  // write, the same way a scan approval covers its reads.
+  return try _write(toolDir, META_FILE, JSON.stringify(used, null, 2))
 }
 
 export def runTool(
@@ -937,8 +956,10 @@ export def runTool(
 ): Result<Json> {
   """
   Run a saved tool's `main` node in a subprocess and return what it
-  returned. The tool's meta.json records one more use and the time; it
-  does not record the result.
+  returned. The tool's meta.json records one more use and the time,
+  best-effort behind a `std::toolbox::recordUse` interrupt: a declined
+  or failed record never fails a run that succeeded. It does not record
+  the result.
 
   @param name - The tool's name under dir
   @param request - The tool's input, a value of its Request type
@@ -979,13 +1000,10 @@ export def runTool(
   if (ran is success(finished)) {
     result = finished.data
   }
-  // The tool has run and its effects have happened, so its result is
-  // never dropped: a failed record carries it in the message.
-  const recorded = recordUse(toolDir, name, meta.value)
-  if (recorded is failure(recordErr)) {
-    return failure(
-      "the tool ran and returned ${JSON.stringify(result)}, but ${META_FILE} could not be updated: ${recordErr}",
-    )
-  }
+  // Best-effort bookkeeping: the tool has run and its effects have
+  // happened, so a declined recordUse interrupt or a failed meta.json
+  // write must not turn a successful run into a failure. The use count
+  // is only a count.
+  recordUse(toolDir, name, meta.value)
   return result
 }

--- a/packages/agency-lang/tests/agency/skills-subdirs-fixture/empty/keep.txt
+++ b/packages/agency-lang/tests/agency/skills-subdirs-fixture/empty/keep.txt
@@ -1,0 +1,1 @@
+Non-markdown placeholder so git tracks this empty skills subdirectory; the scan must ignore it.

--- a/packages/agency-lang/tests/agency/skills-subdirs-fixture/explorer/repo-orientation.md
+++ b/packages/agency-lang/tests/agency/skills-subdirs-fixture/explorer/repo-orientation.md
@@ -1,0 +1,6 @@
+---
+name: repo-orientation
+description: Orient in an unfamiliar repo
+---
+
+Read the README and the directory layout first.

--- a/packages/agency-lang/tests/agency/skills-subdirs-fixture/explorer/second.md
+++ b/packages/agency-lang/tests/agency/skills-subdirs-fixture/explorer/second.md
@@ -1,0 +1,6 @@
+---
+name: second
+description: A second explorer skill
+---
+
+Body two.

--- a/packages/agency-lang/tests/agency/skills-subdirs-fixture/research/notes.md
+++ b/packages/agency-lang/tests/agency/skills-subdirs-fixture/research/notes.md
@@ -1,0 +1,6 @@
+---
+name: notes
+description: Research notes skill
+---
+
+Body three.

--- a/packages/agency-lang/tests/agency/skills-subdirs.agency
+++ b/packages/agency-lang/tests/agency/skills-subdirs.agency
@@ -46,3 +46,27 @@ node missingRootYieldsEmpty(): boolean {
   const scanned = scanSkillsSubdirs("${__dirname}/no-such-dir", ["explorer"]) with approve
   return keys(scanned).length == 0
 }
+
+// A subdirectory name that is not a bare path segment would carry the
+// root's one approval outside the root (`../x`), so it fails before any
+// interrupt is raised — the user is never prompted for a scan that
+// would escape what they approved.
+node traversalSubdirFailsBeforeTheInterrupt(): boolean {
+  const bad = ["../escape", "a/b", "..", ".", ""]
+  for (sub in bad) {
+    let scans = 0
+    let result: any = null
+    handle {
+      result = scanSkillsSubdirs(fixture(), [sub])
+    } with (intr) {
+      if (intr.effect == "std::skills::skillsDir") {
+        scans = scans + 1
+      }
+      return approve()
+    }
+    if (!(result is failure) || scans != 0) {
+      return false
+    }
+  }
+  return true
+}

--- a/packages/agency-lang/tests/agency/skills-subdirs.agency
+++ b/packages/agency-lang/tests/agency/skills-subdirs.agency
@@ -13,7 +13,7 @@ def fixture(): string {
 }
 
 node scanGroupsBySubdir(): boolean {
-  const scanned = scanSkillsSubdirs(fixture()) with approve
+  const scanned = scanSkillsSubdirs(fixture(), ["explorer", "research", "empty"]) with approve
   const explorer = scanned["explorer"]
   const research = scanned["research"]
   if (explorer == undefined || research == undefined) {
@@ -25,7 +25,7 @@ node scanGroupsBySubdir(): boolean {
 node scanRaisesOneInterrupt(): boolean {
   let scans = 0
   handle {
-    scanSkillsSubdirs(fixture())
+    scanSkillsSubdirs(fixture(), ["explorer", "research", "empty"])
   } with (intr) {
     if (intr.effect == "std::skills::skillsDir") {
       scans = scans + 1
@@ -36,13 +36,13 @@ node scanRaisesOneInterrupt(): boolean {
 }
 
 node toolFromEntriesListsThem(): boolean {
-  const scanned = scanSkillsSubdirs(fixture()) with approve
+  const scanned = scanSkillsSubdirs(fixture(), ["explorer", "research", "empty"]) with approve
   const tool = skillsToolFromEntries("${fixture()}/explorer", scanned["explorer"], "learned_skills_explorer")
   return tool.description.includes("<name>repo-orientation</name>")
       && tool.description.includes("<description>Orient in an unfamiliar repo</description>")
 }
 
 node missingRootYieldsEmpty(): boolean {
-  const scanned = scanSkillsSubdirs("${__dirname}/no-such-dir") with approve
+  const scanned = scanSkillsSubdirs("${__dirname}/no-such-dir", ["explorer"]) with approve
   return keys(scanned).length == 0
 }

--- a/packages/agency-lang/tests/agency/skills-subdirs.agency
+++ b/packages/agency-lang/tests/agency/skills-subdirs.agency
@@ -1,0 +1,48 @@
+/*
+ * scanSkillsSubdirs groups a root's flat skills by immediate
+ * subdirectory (one scan interrupt for the whole root), and
+ * skillsToolFromEntries rebuilds a skills tool from entries without
+ * rescanning. The fixture holds two explorer skills, one research
+ * skill, and an empty directory.
+ */
+import { keys } from "std::object"
+import { scanSkillsSubdirs, skillsToolFromEntries } from "std::skills"
+
+def fixture(): string {
+  return "${__dirname}/skills-subdirs-fixture"
+}
+
+node scanGroupsBySubdir(): boolean {
+  const scanned = scanSkillsSubdirs(fixture()) with approve
+  const explorer = scanned["explorer"]
+  const research = scanned["research"]
+  if (explorer == undefined || research == undefined) {
+    return false
+  }
+  return explorer.length == 2 && research.length == 1 && scanned["empty"] == undefined
+}
+
+node scanRaisesOneInterrupt(): boolean {
+  let scans = 0
+  handle {
+    scanSkillsSubdirs(fixture())
+  } with (intr) {
+    if (intr.effect == "std::skills::skillsDir") {
+      scans = scans + 1
+    }
+    return approve()
+  }
+  return scans == 1
+}
+
+node toolFromEntriesListsThem(): boolean {
+  const scanned = scanSkillsSubdirs(fixture()) with approve
+  const tool = skillsToolFromEntries("${fixture()}/explorer", scanned["explorer"], "learned_skills_explorer")
+  return tool.description.includes("<name>repo-orientation</name>")
+      && tool.description.includes("<description>Orient in an unfamiliar repo</description>")
+}
+
+node missingRootYieldsEmpty(): boolean {
+  const scanned = scanSkillsSubdirs("${__dirname}/no-such-dir") with approve
+  return keys(scanned).length == 0
+}

--- a/packages/agency-lang/tests/agency/skills-subdirs.test.json
+++ b/packages/agency-lang/tests/agency/skills-subdirs.test.json
@@ -1,0 +1,9 @@
+{
+  "sourceFile": "skills-subdirs.agency",
+  "tests": [
+    { "nodeName": "scanGroupsBySubdir", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "scanRaisesOneInterrupt", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "toolFromEntriesListsThem", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "missingRootYieldsEmpty", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] }
+  ]
+}

--- a/packages/agency-lang/tests/agency/skills-subdirs.test.json
+++ b/packages/agency-lang/tests/agency/skills-subdirs.test.json
@@ -4,6 +4,7 @@
     { "nodeName": "scanGroupsBySubdir", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
     { "nodeName": "scanRaisesOneInterrupt", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
     { "nodeName": "toolFromEntriesListsThem", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "missingRootYieldsEmpty", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] }
+    { "nodeName": "missingRootYieldsEmpty", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "traversalSubdirFailsBeforeTheInterrupt", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] }
   ]
 }

--- a/packages/agency-lang/tests/agency/skills-write.agency
+++ b/packages/agency-lang/tests/agency/skills-write.agency
@@ -59,8 +59,10 @@ node acceptWritesTheFile(): boolean {
   if (raw is failure) {
     return false
   }
+  // A plain description is emitted bare: the serializer only quotes
+  // values the parser would otherwise coerce or misparse.
   return raw.value.includes("name: repo-orientation")
-      && raw.value.includes(`description: "Orient in an unfamiliar repo"`)
+      && raw.value.includes("description: Orient in an unfamiliar repo")
       && raw.value.includes("Read the README first.")
 }
 
@@ -126,10 +128,21 @@ node multilineDescriptionFails(): boolean {
   return ran.outcome is failure && ran.reviews == 0
 }
 
-node bodyStartingWithFenceFails(): boolean {
-  const dir = outDir("fence")
-  const ran = runWrite(dir, "fenced", "Fence body", "---\ninjected: true", { verdict: "accept" })
-  return ran.outcome is failure && ran.reviews == 0
+// A body starting with --- cannot reach the frontmatter: the block is
+// already closed by its own fence, so the body line is just markdown
+// and the next scan still sees the reviewed name and description.
+node bodyStartingWithFenceCannotInject(): boolean {
+  const root = outDir("fence")
+  const ran = runWrite("${root}/explorer", "fenced", "Fence body", "---\ninjected: true", { verdict: "accept" })
+  if (ran.outcome is failure) {
+    return false
+  }
+  const scanned = scanSkillsSubdirs(root, ["explorer"]) with approve
+  const entries = scanned["explorer"]
+  if (entries == undefined || entries.length != 1) {
+    return false
+  }
+  return entries[0].name == "fenced" && entries[0].description == "Fence body"
 }
 
 node badVerdictFails(): boolean {
@@ -155,8 +168,48 @@ node descriptionWithFlowSyntaxRoundTrips(): boolean {
   return entries[0].name == "beta-skill" && entries[0].description == "[Beta] Use when refactoring"
 }
 
-node doubleQuotedDescriptionFails(): boolean {
-  const dir = outDir("quoted")
-  const ran = runWrite(dir, "quoted", `a "best practice" guide`, "Body.", { verdict: "accept" })
+// The serializer battery: each of these descriptions hits a different
+// branch of the frontmatter grammar (quotes, a literal backslash-n, a
+// numeric-looking string, edge whitespace) and every one must read
+// back exactly as reviewed.
+node trickyDescriptionsRoundTrip(): boolean {
+  const root = outDir("tricky")
+  const cases = [
+    { name: "quotes", description: `a "best practice" guide, it's great` },
+    { name: "backslash", description: "literal \\n stays two characters" },
+    { name: "numeric", description: "2024" },
+    { name: "padded", description: " leading and trailing " },
+  ]
+  for (c in cases) {
+    const ran = runWrite("${root}/explorer", c.name, c.description, "Body.", { verdict: "accept" })
+    if (ran.outcome is failure) {
+      return false
+    }
+  }
+  const scanned = scanSkillsSubdirs(root, ["explorer"]) with approve
+  const entries = scanned["explorer"]
+  if (entries == undefined || entries.length != cases.length) {
+    return false
+  }
+  for (c in cases) {
+    let found = false
+    for (entry in entries) {
+      if (entry.name == c.name && entry.description == c.description) {
+        found = true
+      }
+    }
+    if (!found) {
+      return false
+    }
+  }
+  return true
+}
+
+// The one shape no quote character can hold: needs quoting (leading
+// space) but contains all three quote chars. Refused loudly before the
+// user is asked to review anything, never written silently wrong.
+node unrepresentableDescriptionFailsCleanly(): boolean {
+  const dir = outDir("unrepresentable")
+  const ran = runWrite(dir, "unrep", " \"d\" 's' `t`", "Body.", { verdict: "accept" })
   return ran.outcome is failure && ran.reviews == 0
 }

--- a/packages/agency-lang/tests/agency/skills-write.agency
+++ b/packages/agency-lang/tests/agency/skills-write.agency
@@ -5,7 +5,7 @@
  */
 import { remove } from "std::fs"
 import { exists } from "std::shell"
-import { writeSkill, WriteSkillOutcome } from "std::skills"
+import { scanSkillsSubdirs, writeSkill, WriteSkillOutcome } from "std::skills"
 
 // A fresh directory per node: removed up front (the writeTool tests'
 // pattern) so re-runs never trip the duplicate-name refusal.
@@ -60,7 +60,7 @@ node acceptWritesTheFile(): boolean {
     return false
   }
   return raw.value.includes("name: repo-orientation")
-      && raw.value.includes("description: Orient in an unfamiliar repo")
+      && raw.value.includes(`description: "Orient in an unfamiliar repo"`)
       && raw.value.includes("Read the README first.")
 }
 
@@ -136,4 +136,27 @@ node badVerdictFails(): boolean {
   const dir = outDir("bad-verdict")
   const ran = runWrite(dir, "bad-verdict", "Bad verdict", "Body.", { verdict: "banana" })
   return ran.outcome is failure && !exists("bad-verdict.md", dir)
+}
+
+// The description survives a restart: YAML flow syntax in it (leading
+// bracket) must round-trip through the quoted frontmatter and the next
+// session's scan.
+node descriptionWithFlowSyntaxRoundTrips(): boolean {
+  const root = outDir("roundtrip")
+  const ran = runWrite("${root}/explorer", "beta-skill", "[Beta] Use when refactoring", "Body.", { verdict: "accept" })
+  if (ran.outcome is failure) {
+    return false
+  }
+  const scanned = scanSkillsSubdirs(root, ["explorer"]) with approve
+  const entries = scanned["explorer"]
+  if (entries == undefined || entries.length != 1) {
+    return false
+  }
+  return entries[0].name == "beta-skill" && entries[0].description == "[Beta] Use when refactoring"
+}
+
+node doubleQuotedDescriptionFails(): boolean {
+  const dir = outDir("quoted")
+  const ran = runWrite(dir, "quoted", `a "best practice" guide`, "Body.", { verdict: "accept" })
+  return ran.outcome is failure && ran.reviews == 0
 }

--- a/packages/agency-lang/tests/agency/skills-write.agency
+++ b/packages/agency-lang/tests/agency/skills-write.agency
@@ -1,0 +1,139 @@
+/*
+ * writeSkill: the review interrupt gates every save; names are validated,
+ * never rewritten; revise and reject write nothing. Output goes under
+ * test-output/ (gitignored), one directory per node so nodes never collide.
+ */
+import { remove } from "std::fs"
+import { exists } from "std::shell"
+import { writeSkill, WriteSkillOutcome } from "std::skills"
+
+// A fresh directory per node: removed up front (the writeTool tests'
+// pattern) so re-runs never trip the duplicate-name refusal.
+def outDir(node: string): string {
+  const dir = "${__dirname}/test-output/skills-write/${node}"
+  remove(dir) with approve
+  return dir
+}
+
+// Run writeSkill with a scripted review verdict, approving every other
+// interrupt (mkdir/write). Returns the outcome plus how many review
+// interrupts were raised.
+def runWrite(
+  dir: string,
+  name: string,
+  description: string,
+  body: string,
+  verdict: any,
+): { outcome: Result<WriteSkillOutcome>; reviews: number } {
+  let reviews = 0
+  let outcome: Result<WriteSkillOutcome> = failure("not run")
+  handle {
+    outcome = writeSkill(dir, name, description, body)
+  } with (intr) {
+    if (intr.effect == "std::skills::reviewSkill") {
+      reviews = reviews + 1
+      return approve(verdict)
+    }
+    return approve()
+  }
+  return {
+    outcome: outcome,
+    reviews: reviews
+  }
+}
+
+node acceptWritesTheFile(): boolean {
+  const dir = outDir("accept")
+  const ran = runWrite(dir, "repo-orientation", "Orient in an unfamiliar repo", "Read the README first.", { verdict: "accept" })
+  if (ran.outcome is failure) {
+    return false
+  }
+  const saved = ran.outcome.value.saved
+  if (saved == undefined) {
+    return false
+  }
+  if (saved.name != "repo-orientation" || saved.location != "repo-orientation.md") {
+    return false
+  }
+  const raw = read("repo-orientation.md", dir) with approve
+  if (raw is failure) {
+    return false
+  }
+  return raw.value.includes("name: repo-orientation")
+      && raw.value.includes("description: Orient in an unfamiliar repo")
+      && raw.value.includes("Read the README first.")
+}
+
+node bareApproveCountsAsAccept(): boolean {
+  const dir = outDir("bare")
+  const ran = runWrite(dir, "bare-skill", "Bare approve", "Body.", null)
+  if (ran.outcome is failure) {
+    return false
+  }
+  return exists("bare-skill.md", dir)
+}
+
+node reviseReturnsFeedbackAndWritesNothing(): boolean {
+  const dir = outDir("revise")
+  const ran = runWrite(dir, "revised", "Will be revised", "Body.", { verdict: "revise", feedback: "shorter" })
+  if (ran.outcome is failure) {
+    return false
+  }
+  const feedback = ran.outcome.value.revise
+  if (feedback != "shorter") {
+    return false
+  }
+  return !exists("revised.md", dir)
+}
+
+node rejectWritesNothing(): boolean {
+  const dir = outDir("reject")
+  let outcome: Result<WriteSkillOutcome> = success({ revise: "unset" })
+  handle {
+    outcome = writeSkill(dir, "rejected", "Will be rejected", "Body.")
+  } with (intr) {
+    if (intr.effect == "std::skills::reviewSkill") {
+      return reject()
+    }
+    return approve()
+  }
+  if (outcome is success) {
+    return false
+  }
+  return !exists("rejected.md", dir)
+}
+
+node duplicateNameFails(): boolean {
+  const dir = outDir("duplicate")
+  const first = runWrite(dir, "twice", "First save", "Body.", { verdict: "accept" })
+  if (first.outcome is failure) {
+    return false
+  }
+  const second = runWrite(dir, "twice", "Second save", "Body.", { verdict: "accept" })
+  // The duplicate is refused before the user is asked to review anything.
+  return second.outcome is failure && second.reviews == 0
+}
+
+node invalidNameFails(): boolean {
+  const dir = outDir("invalid-name")
+  const ran = runWrite(dir, "Repo Orientation!", "Bad name", "Body.", { verdict: "accept" })
+  return ran.outcome is failure && ran.reviews == 0
+}
+
+node multilineDescriptionFails(): boolean {
+  const dir = outDir("multiline")
+  const ran = runWrite(dir, "multiline", "line one\nline two", "Body.", { verdict: "accept" })
+  return ran.outcome is failure && ran.reviews == 0
+}
+
+node bodyStartingWithFenceFails(): boolean {
+  const dir = outDir("fence")
+  const ran = runWrite(dir, "fenced", "Fence body", "---\ninjected: true", { verdict: "accept" })
+  return ran.outcome is failure && ran.reviews == 0
+}
+
+node badVerdictFails(): boolean {
+  const dir = outDir("bad-verdict")
+  const ran = runWrite(dir, "bad-verdict", "Bad verdict", "Body.", { verdict: "banana" })
+  return ran.outcome is failure && !exists("bad-verdict.md", dir)
+}

--- a/packages/agency-lang/tests/agency/skills-write.test.json
+++ b/packages/agency-lang/tests/agency/skills-write.test.json
@@ -1,0 +1,14 @@
+{
+  "sourceFile": "skills-write.agency",
+  "tests": [
+    { "nodeName": "acceptWritesTheFile", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "bareApproveCountsAsAccept", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "reviseReturnsFeedbackAndWritesNothing", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "rejectWritesNothing", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "duplicateNameFails", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "invalidNameFails", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "multilineDescriptionFails", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "bodyStartingWithFenceFails", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "badVerdictFails", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] }
+  ]
+}

--- a/packages/agency-lang/tests/agency/skills-write.test.json
+++ b/packages/agency-lang/tests/agency/skills-write.test.json
@@ -9,6 +9,8 @@
     { "nodeName": "invalidNameFails", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
     { "nodeName": "multilineDescriptionFails", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
     { "nodeName": "bodyStartingWithFenceFails", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "badVerdictFails", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] }
+    { "nodeName": "badVerdictFails", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "descriptionWithFlowSyntaxRoundTrips", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "doubleQuotedDescriptionFails", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] }
   ]
 }

--- a/packages/agency-lang/tests/agency/skills-write.test.json
+++ b/packages/agency-lang/tests/agency/skills-write.test.json
@@ -8,9 +8,10 @@
     { "nodeName": "duplicateNameFails", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
     { "nodeName": "invalidNameFails", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
     { "nodeName": "multilineDescriptionFails", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "bodyStartingWithFenceFails", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "bodyStartingWithFenceCannotInject", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
     { "nodeName": "badVerdictFails", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
     { "nodeName": "descriptionWithFlowSyntaxRoundTrips", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "doubleQuotedDescriptionFails", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] }
+    { "nodeName": "trickyDescriptionsRoundTrip", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "unrepresentableDescriptionFailsCleanly", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] }
   ]
 }

--- a/packages/agency-lang/tests/agency/toolbox/generate-writeTool-mocks.mjs
+++ b/packages/agency-lang/tests/agency/toolbox/generate-writeTool-mocks.mjs
@@ -96,6 +96,7 @@ const tests = [
   testCase("dateToolSkipsTests", dateRound),
   testCase("staleTestFileDoesNotShip", [...pureRound, ...modelRound]),
   testCase("runToolRunsAndRecords", pureRound),
+  testCase("rejectedRecordUseDoesNotFailTheRun", pureRound),
   testCase("refusedWriteStopsTheRounds", pureRound),
   testCase("aliasedDateCallSkipsTests", aliasRound),
   testCase("refusesATimeLimitOverAnHour", []),

--- a/packages/agency-lang/tests/agency/toolbox/writeTool.agency
+++ b/packages/agency-lang/tests/agency/toolbox/writeTool.agency
@@ -312,6 +312,38 @@ node runToolRunsAndRecords(): boolean {
   return answer is success && answer.value == 42 && recorded
 }
 
+// Bookkeeping is best-effort: rejecting the recordUse interrupt must
+// not fail a run that succeeded. The count simply stays unrecorded.
+node rejectedRecordUseDoesNotFailTheRun(): boolean {
+  cleanup("addNine")
+  const written = runWrite("addNine", OUT, [{
+    verdict: "accept"
+  }])
+  if (written is failure) {
+    cleanup("addNine")
+    return false
+  }
+  let answer: Result = failure("not run")
+  handle {
+    answer = runTool("addNine", {
+      n: 41
+    }, OUT)
+  } with (intr) {
+    if (intr.effect == "std::toolbox::recordUse") {
+      return reject("no bookkeeping")
+    }
+    return approve()
+  }
+  const listed = listTools(OUT) with approve
+  let unrecorded = false
+  if (listed is success(entries)) {
+    const entry = find(entries, \candidate -> candidate.name == "addNine")
+    unrecorded = entry.meta.uses == 0
+  }
+  cleanup("addNine")
+  return answer is success && answer.value == 42 && unrecorded
+}
+
 // A refused write is not something a new draft can fix, so writeTool
 // stops after the first round instead of drafting maxRounds times. If it
 // looped, the error would read "gave up after".

--- a/packages/agency-lang/tests/agency/toolbox/writeTool.test.json
+++ b/packages/agency-lang/tests/agency/toolbox/writeTool.test.json
@@ -651,6 +651,49 @@
       ]
     },
     {
+      "nodeName": "rejectedRecordUseDoesNotFailTheRun",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        {
+          "return": {
+            "code": "import { Json } from \"std::validation\"\n\nexport type Request = {\n  n: number\n}\n\nexport def run(request: Request): Json {\n  \"\"\"\n  Add one to the number in the request.\n\n  @param request - The number to add one to\n  \"\"\"\n  return request.n + 1\n}\n"
+          }
+        },
+        {
+          "return": []
+        },
+        {
+          "return": {
+            "cases": [
+              {
+                "args": {
+                  "request": {
+                    "n": 41
+                  }
+                },
+                "expectedOutput": 42
+              },
+              {
+                "args": {
+                  "request": {
+                    "n": 0
+                  }
+                },
+                "expectedOutput": 1
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
       "nodeName": "refusedWriteStopsTheRounds",
       "input": "",
       "expectedOutput": "true",


### PR DESCRIPTION
The agent can now be taught. "Add this as a skill for the explorer agent" saves a reviewed markdown skill under the agent home; "write the research agent a tool that fetches Hacker News" runs the `std::toolbox` pipeline into that agent's toolbox. Both are usable by the target subagent in the same session, and `/skills` / `/toolbox` list what has accumulated. Spec and plan: `2026-08-31-learned-skills-and-toolbox-{spec,plan}.md` (with the plan review applied).

## The stdlib write half (`std::skills`)

`writeSkill(dir, name, description, body)` composes the flat-layout file itself (raw content could extend the frontmatter), validates the kebab-case name instead of rewriting it, refuses duplicates before raising anything, and shows the complete file in a new `std::skills::reviewSkill` interrupt — accept / revise-with-feedback / reject. A revise verdict returns the feedback so the caller redrafts; only an accepted draft is written. `scanSkillsSubdirs` reads a directory of per-agent skill subdirectories with ONE scan interrupt for the root, and `buildSkillsTool` split into scan + the pure `skillsToolFromEntries`, so a catalog can rebuild a tool without rescanning. The `500` glob cap became the named `MAX_SKILL_FILES` at all three call sites.

## Policy: the agent home joins the default read scope

A new `<agent-home>` dir-pattern placeholder (mirroring `<agency>`, with the empty-env-counts-as-unset guard from #469) and one `readScopeRules` rule covering `<agent-home>/skills/**` and `<agent-home>/tools/**`. Without it, every learned-skill read, catalog scan, and `runTool` call (which rescans its tool directory) would prompt interactively and auto-reject headless. Writes are not widened — saves raise ordinary write interrupts on top of the review gate. Documented as a stated trade in `approval-policies.md`.

## The agent side

- `lib/learned.agency`: session catalogs in module globals (not statics — one long-lived CLI run, updated in place on save; the same-session property). Skills load with one scan interrupt; toolboxes with one `listTools` scan per agent directory that exists. Learned tools are renamed `learned_<name>`, which makes collision with any built-in tool impossible by construction; a test pins that no `codeTools` name uses the prefix.
- Coordinator tools `learnSkill(target, ...)` and `writeToolFor(target, ...)`, with a Learning section in both prompts. Revisions flow back as tool replies the coordinator redrafts from.
- All seven subagents pick up `learnedExtrasFor(<wrapper>)` per invocation via `extraTools` (the rewrite stdlib agent gained the parameter — it was the only one without it); the code subagent appends to its local list in both the interactive and one-shot paths.
- `/skills` and `/toolbox` built-ins render the inventory grouped by subagent.

## Docs and evals

`docs/dev/agents/learned-skills-and-toolbox.md` records the design; `agent-brains.md` drops the stale statics-before-the-policy-handler story (that was the hole #966/#987 fixed, not a pattern). One goal-judged eval (`learned-skill`) teaches the explorer a skill mid-session and checks the explorer uses it.

## Tests

25 new agency test nodes across `skills-write`, `skills-subdirs`, `learned`, `learn`, `learnedWiring`, `learnedView` (all no-LLM; the home-writing ones verify their sandbox before touching anything), plus policy/builtinPolicies vitest cases for the placeholder. Locally green: those suites, the pre-existing skills/toolbox/agentTurn/toolWiring regressions, `make`, `pnpm run typecheck`, `fmt:ts`, `lint:structure`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HnpWia84urcJmjrhQGDDPx
