### PR TITLE
Add agency effects, a discovery command for the approval-flag vocabulary

### DIFF
--- a/packages/agency-lang/.claude/skills/agency-cli-docs/SKILL.md
+++ b/packages/agency-lang/.claude/skills/agency-cli-docs/SKILL.md
@@ -10,6 +10,7 @@ Paths are relative to `packages/agency-lang/`. Read the one that matches the tas
 - `docs/dev/cli/cli-arguments.md` — How one command line carries both agency's own flags and the program's.
 - `docs/dev/cli/vendored-commander.md` — The vendored commander fork, what was changed in it, and the rules for keeping it in sync.
 - `docs/dev/cli/doc-cache.md` — The incremental cache behind `agency doc`, and how it decides a page is stale.
+- `docs/dev/cli/effects-command.md` — `agency effects`, which lists the capability sets and built-in policies the approval flags accept, and where its data comes from.
 - `docs/dev/cli/test-cli-sandbox.md` — The flag combination that makes it safe to run Agency code you do not trust.
 - `docs/dev/cli/debugger.md` — The interactive debugger: stepping, inspecting variables, and rewinding.
 - `docs/dev/cli/debugger-tests.md` — Driving the debugger headlessly in tests.

--- a/packages/agency-lang/CLAUDE.md
+++ b/packages/agency-lang/CLAUDE.md
@@ -313,6 +313,7 @@ Other process docs:
 - `docs/dev/cli/debugger-tests.md` — Driving the debugger headlessly in tests.
 - `docs/dev/cli/debugger.md` — The interactive debugger: stepping, inspecting variables, and rewinding.
 - `docs/dev/cli/doc-cache.md` — The incremental cache behind `agency doc`, and how it decides a page is stale.
+- `docs/dev/cli/effects-command.md` — `agency effects`, which lists the capability sets and built-in policies the approval flags accept, and where its data comes from.
 - `docs/dev/cli/logs-viewer.md` — The interactive viewer for a single statelog trace, including the timeline.
 - `docs/dev/cli/runs-explorer.md` — The cross-run table `agency logs` opens when pointed at several paths.
 - `docs/dev/cli/test-cli-sandbox.md` — The flag combination that makes it safe to run Agency code you do not trust.

--- a/packages/agency-lang/docs/dev/cli/effects-command.md
+++ b/packages/agency-lang/docs/dev/cli/effects-command.md
@@ -1,41 +1,25 @@
-# `agency effects`: discovering the approval-flag vocabulary
+# `agency effects`: where the data comes from
 
-`agency effects` answers "what names can I put in `--approve`,
-`--reject`, and `--policy`?". It is a read-only command over data that
-already exists; it compiles nothing and needs no project context.
+User-facing behavior is documented in `docs/site/cli/effects.md`. This
+page covers the implementation choices a future change needs to know.
 
-## What it shows
-
-- `agency effects` — the built-in capability sets (name and the first
-  sentence of each doc comment), then the built-in policies (the same
-  name-and-description pairs `agency agent --policy` prints), then flag
-  usage.
-- `agency effects FileRead` — one set in full: the whole doc comment,
-  the composition when the set is declared from other sets
-  (`FileSystem = FileRead + FileWrite`), and the flat member list —
-  which is exactly what a flag grants.
-- `agency effects std::write` — the reverse question: which sets
-  include this effect. An effect no set includes can still be named
-  directly in the flags.
-- `agency effects with-writes` — a built-in policy's description and
-  its resolved JSON (`builtinPolicy(name, cwd)`), so dir-scoped rules
-  show the paths they would really match at this launch directory.
-- An unknown name errors with a near-miss hint. This differs from the
-  flags on purpose: an unmatched bare name in `--approve` must fall
-  back to a plain effect name for compatibility, but a discovery
-  command has no compatibility to preserve.
-
-## Where the data comes from
-
-- Sets: `builtinEffectSets()` (`lib/runtime/effectSets.ts`), the parsed
-  table over `stdlib/capabilities.agency` that flag expansion also uses.
-  One loader, one definition; see the notes in that file for the doc
-  comment pairing and the once-per-process cache.
-- Policies: `BUILTIN_POLICIES` / `builtinPolicy` from
-  `lib/runtime/builtinPolicies.ts`, the same definitions every
-  `--policy` flag resolves.
-
-The rendering lives in `lib/cli/effects.ts` as pure string-returning
-functions (`renderEffectsList`, `renderSetDetail`, ...) unit-tested in
-`effects.test.ts`; `effects.spawn.test.ts` runs the built CLI end to
-end.
+- Sets come from `builtinEffectSets()` (`lib/runtime/effectSets.ts`) —
+  the parsed table over `stdlib/capabilities.agency` that flag expansion
+  also uses, so the command and the flags cannot disagree. That file
+  documents the doc-comment pairing and the once-per-process cache.
+- Policies come from `BUILTIN_POLICIES` / `builtinPolicy`
+  (`lib/runtime/builtinPolicies.ts`), the definitions every `--policy`
+  flag resolves. The policy detail view resolves against the process
+  cwd so dir-scoped rules print the paths they would really match.
+- An unknown name errors here even though the flags fall back. The
+  flags must keep an unmatched bare name working as a plain effect name
+  (bare effect declarations are legal); a discovery command has no
+  compatibility to preserve, so it can afford the typo error.
+- Rendering is pure string-returning functions in `lib/cli/effects.ts`,
+  unit-tested directly; `effects.spawn.test.ts` runs the built CLI.
+  Colors use `ttyColor`, which noops when stdout is not a TTY, so both
+  test layers assert plain strings.
+- `effects` is in `AGENCY_SAFE_SUBCOMMANDS`
+  (`lib/runtime/builtinPolicies.ts`), so the agent's exec-based
+  `agencyCli` tool can run it under the default policies without
+  prompting.

--- a/packages/agency-lang/docs/dev/cli/effects-command.md
+++ b/packages/agency-lang/docs/dev/cli/effects-command.md
@@ -1,0 +1,41 @@
+# `agency effects`: discovering the approval-flag vocabulary
+
+`agency effects` answers "what names can I put in `--approve`,
+`--reject`, and `--policy`?". It is a read-only command over data that
+already exists; it compiles nothing and needs no project context.
+
+## What it shows
+
+- `agency effects` — the built-in capability sets (name and the first
+  sentence of each doc comment), then the built-in policies (the same
+  name-and-description pairs `agency agent --policy` prints), then flag
+  usage.
+- `agency effects FileRead` — one set in full: the whole doc comment,
+  the composition when the set is declared from other sets
+  (`FileSystem = FileRead + FileWrite`), and the flat member list —
+  which is exactly what a flag grants.
+- `agency effects std::write` — the reverse question: which sets
+  include this effect. An effect no set includes can still be named
+  directly in the flags.
+- `agency effects with-writes` — a built-in policy's description and
+  its resolved JSON (`builtinPolicy(name, cwd)`), so dir-scoped rules
+  show the paths they would really match at this launch directory.
+- An unknown name errors with a near-miss hint. This differs from the
+  flags on purpose: an unmatched bare name in `--approve` must fall
+  back to a plain effect name for compatibility, but a discovery
+  command has no compatibility to preserve.
+
+## Where the data comes from
+
+- Sets: `builtinEffectSets()` (`lib/runtime/effectSets.ts`), the parsed
+  table over `stdlib/capabilities.agency` that flag expansion also uses.
+  One loader, one definition; see the notes in that file for the doc
+  comment pairing and the once-per-process cache.
+- Policies: `BUILTIN_POLICIES` / `builtinPolicy` from
+  `lib/runtime/builtinPolicies.ts`, the same definitions every
+  `--policy` flag resolves.
+
+The rendering lives in `lib/cli/effects.ts` as pure string-returning
+functions (`renderEffectsList`, `renderSetDetail`, ...) unit-tested in
+`effects.test.ts`; `effects.spawn.test.ts` runs the built CLI end to
+end.

--- a/packages/agency-lang/docs/site/.vitepress/config.mts
+++ b/packages/agency-lang/docs/site/.vitepress/config.mts
@@ -258,6 +258,7 @@ export default defineConfig({
             { text: "coverage", link: "/cli/coverage" },
             { text: "debug", link: "/cli/debug" },
             { text: "doc", link: "/cli/doc" },
+            { text: "effects", link: "/cli/effects" },
             { text: "eval", link: "/cli/eval" },
             { text: "eval-judge", link: "/cli/eval-judge" },
             { text: "format", link: "/cli/format" },

--- a/packages/agency-lang/docs/site/cli/agent.md
+++ b/packages/agency-lang/docs/site/cli/agent.md
@@ -15,6 +15,23 @@ Launches the Agency language assistant agent — an LLM agent that knows about A
 
 This is a convenient way to get help with Agency without leaving your terminal.
 
+## Approval flags
+
+The agent asks before doing anything its policy does not already
+decide. Three flags shape that for a single session:
+
+```
+agency agent --policy with-writes
+agency agent --approve FileRead --reject Shell
+```
+
+`--policy` picks the base policy (a built-in name or a policy-file
+path); `--approve` and `--reject` overlay effects or capability-set
+names on top of it. None of these change your saved `policy.json`. See
+[the policy flags](/cli/policy#approving-and-rejecting-with-flags) for
+the details and [`agency effects`](/cli/effects) for the names they
+accept.
+
 ## Budget flags
 
 - `agency agent --max-cost <dollars>` — abort if the agent's LLM spend exceeds this many dollars. `0` means no paid spend (local models only); negative means no limit.

--- a/packages/agency-lang/docs/site/cli/effects.md
+++ b/packages/agency-lang/docs/site/cli/effects.md
@@ -1,0 +1,80 @@
+---
+title: Effects
+description: Documents the `agency effects` command, which lists the built-in capability sets and policies that the --approve, --reject, and --policy flags accept.
+---
+
+# Effects
+
+```
+agency effects
+```
+
+Lists the names you can pass to the approval flags: the built-in
+capability sets for [`--approve` and `--reject`](/cli/policy#approving-and-rejecting-with-flags),
+and the built-in policies for `--policy`.
+
+```
+Effect sets:
+  FileRead     Read-only filesystem access: reading files and listing/searching paths.
+  FileWrite    Filesystem mutation: creating, editing, moving, copying, and deleting.
+  FileSystem   All filesystem access — reads and writes.
+  Shell        Arbitrary command / process execution.
+  ...
+
+Built-in policies:
+  minimal      ...
+  recommended  ...
+  with-writes  recommended + auto-approve file writes and git changes, scoped to the current directory and its children.
+  approve-all  ...
+
+Use a set or an effect name with --approve / --reject, a policy with --policy:
+  agency agent --policy with-writes --reject Shell
+```
+
+A capability set is a named group of related interrupt effects, declared
+in [`std::capabilities`](/stdlib/capabilities). Passing a set name to
+`--approve` or `--reject` is shorthand for naming every effect in the
+set.
+
+## Describing one name
+
+Pass a name to see it in full.
+
+A **set name** shows the set's documentation, what it is composed of,
+and the effects a flag would actually grant:
+
+```
+$ agency effects FileSystem
+FileSystem
+
+All filesystem access — reads and writes.
+
+FileSystem = FileRead + FileWrite
+
+Member effects:
+  std::read
+  std::readBinary
+  ...
+```
+
+An **effect name** (it contains `::`) answers the reverse question —
+which sets would grant it:
+
+```
+$ agency effects std::write
+Sets that include std::write:
+  FileWrite
+  FileSystem
+```
+
+A **built-in policy name** shows the policy's description and its full
+rule set as JSON, resolved against your current directory — so
+dir-scoped rules show the real paths they would match if you launched
+with that policy here:
+
+```
+agency effects with-writes
+```
+
+An unknown name is an error, with a suggestion when it looks like a
+typo of a real one.

--- a/packages/agency-lang/docs/site/cli/policy.md
+++ b/packages/agency-lang/docs/site/cli/policy.md
@@ -9,6 +9,37 @@ description: Documents the `agency policy` CLI commands for generating and exten
 
 See the [policies guide](/guide/policies) for what policies are and how they're used at runtime. This page covers the CLI tools for managing them.
 
+## Approving and rejecting with flags
+
+`agency run`, `agency test`, and `agency agent` all take the same three
+flags:
+
+- `--policy <name|path>` — the base policy for the run: a built-in name
+  (`minimal`, `recommended`, `with-writes`, `approve-all`) or a path to
+  a policy JSON file.
+- `--approve <effects>` — effects to auto-approve, ahead of the base
+  policy's own rules.
+- `--reject <effects>` — effects to auto-reject. A reject outranks an
+  approve for the same effect.
+
+`--approve` and `--reject` take a comma- or whitespace-separated list.
+Each entry is an effect name (`std::write`), or the name of a built-in
+capability set from [`std::capabilities`](/stdlib/capabilities), which
+stands for every effect in the set:
+
+```bash
+agency agent --approve FileRead --reject Shell
+agency run --policy recommended --approve std::write foo.agency
+```
+
+Run [`agency effects`](/cli/effects) to see the sets, the built-in
+policies, and what each one means.
+
+On the agent, the flags apply for that session only: they combine with
+whatever policy the run resolved (your saved `policy.json`, a built-in,
+or a `--policy` path) and are never written back to the saved policy
+file.
+
 ## Generating a policy
 
 ```

--- a/packages/agency-lang/lib/agents/agency-agent/lib/args.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/args.agency
@@ -68,11 +68,11 @@ export def parseAgentArgs() {
         },
         approve: {
           type: "string",
-          description: "Comma-separated interrupt effects or capability set names to auto-approve for this run (e.g. std::write,std::git::commit or FileRead), ahead of the active policy's own rules. Session-only; never saved."
+          description: "Comma-separated interrupt effects or capability set names to auto-approve for this run (e.g. std::write,std::git::commit or FileRead; see: agency effects), ahead of the active policy's own rules. Session-only; never saved."
         },
         reject: {
           type: "string",
-          description: "Comma-separated interrupt effects or capability set names to auto-reject for this run. A reject outranks an approve for the same effect. Session-only; never saved."
+          description: "Comma-separated interrupt effects or capability set names to auto-reject for this run (see: agency effects). A reject outranks an approve for the same effect. Session-only; never saved."
         },
         continue: {
           type: "boolean",

--- a/packages/agency-lang/lib/agents/agency-agent/tests/execPolicy.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/execPolicy.agency
@@ -40,6 +40,11 @@ node minimalApprovesDoc(): boolean {
   return checkPolicy(minimalAutoApprovePolicy, execIntr("doc")).type == "approve"
 }
 
+node minimalApprovesEffects(): boolean {
+  // The discovery command reads only shipped metadata.
+  return checkPolicy(minimalAutoApprovePolicy, execIntr("effects")).type == "approve"
+}
+
 node doesNotApproveOtherSubcommands(): boolean {
   // `run` is not in the allow-list, so it must NOT be auto-approved.
   return checkPolicy(minimalAutoApprovePolicy, execIntr("run")).type != "approve"

--- a/packages/agency-lang/lib/agents/agency-agent/tests/execPolicy.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/execPolicy.test.json
@@ -25,6 +25,12 @@
       "evaluationCriteria": [{ "type": "exact" }]
     },
     {
+      "nodeName": "minimalApprovesEffects",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
       "nodeName": "doesNotApproveOtherSubcommands",
       "input": "",
       "expectedOutput": "true",

--- a/packages/agency-lang/lib/cli/effects.spawn.test.ts
+++ b/packages/agency-lang/lib/cli/effects.spawn.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { execFile } from "child_process";
+import { promisify } from "util";
+import path from "path";
+
+const execFileAsync = promisify(execFile);
+const CLI = path.resolve("dist/scripts/agency.js");
+
+async function effects(
+  ...args: string[]
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  try {
+    const { stdout, stderr } = await execFileAsync("node", [CLI, "effects", ...args]);
+    return { code: 0, stdout, stderr };
+  } catch (err: any) {
+    return { code: err.code ?? 1, stdout: err.stdout ?? "", stderr: err.stderr ?? "" };
+  }
+}
+
+describe("agency effects", () => {
+  it("lists sets and built-in policies", async () => {
+    const { code, stdout } = await effects();
+    expect(code).toBe(0);
+    expect(stdout).toContain("FileRead");
+    expect(stdout).toContain("Read-only filesystem access");
+    expect(stdout).toContain("Built-in policies:");
+    expect(stdout).toContain("with-writes");
+  });
+
+  it("describes one set with its members", async () => {
+    const { code, stdout } = await effects("FileRead");
+    expect(code).toBe(0);
+    expect(stdout).toContain("std::read");
+    expect(stdout).toContain("std::grep");
+  });
+
+  it("shows a nested set's composition", async () => {
+    const { stdout } = await effects("FileSystem");
+    expect(stdout).toContain("FileSystem = FileRead + FileWrite");
+  });
+
+  it("reverse-looks-up an effect name", async () => {
+    const { code, stdout } = await effects("std::write");
+    expect(code).toBe(0);
+    expect(stdout).toContain("FileWrite");
+    expect(stdout).toContain("FileSystem");
+  });
+
+  it("prints a built-in policy resolved against the cwd", async () => {
+    const { code, stdout } = await effects("with-writes");
+    expect(code).toBe(0);
+    expect(stdout).toContain('"std::write"');
+    expect(stdout).toContain('"action": "approve"');
+  });
+
+  it("errors on an unknown name with a near-miss hint", async () => {
+    const { code, stderr } = await effects("FileReed");
+    expect(code).toBe(1);
+    expect(stderr).toContain("FileRead");
+  });
+});

--- a/packages/agency-lang/lib/cli/effects.spawn.test.ts
+++ b/packages/agency-lang/lib/cli/effects.spawn.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { execFile } from "child_process";
+import { existsSync } from "fs";
 import { promisify } from "util";
 import path from "path";
 
@@ -17,7 +18,7 @@ async function effects(
   }
 }
 
-describe("agency effects", () => {
+describe.skipIf(!existsSync(CLI))("agency effects", () => {
   it("lists sets and built-in policies", async () => {
     const { code, stdout } = await effects();
     expect(code).toBe(0);

--- a/packages/agency-lang/lib/cli/effects.test.ts
+++ b/packages/agency-lang/lib/cli/effects.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import {
+  renderEffectsList,
+  renderSetDetail,
+  renderEffectLookup,
+  renderPolicyDetail,
+  renderUnknownName,
+  firstSentence,
+} from "./effects.js";
+import { builtinEffectSets } from "@/runtime/effectSets.js";
+import { BUILTIN_POLICIES } from "@/runtime/builtinPolicies.js";
+
+const sets = builtinEffectSets();
+
+describe("firstSentence", () => {
+  it("cuts at the first sentence boundary", () => {
+    expect(firstSentence("Read-only access: files. Also more words.")).toBe(
+      "Read-only access: files.",
+    );
+  });
+
+  it("collapses newlines inside the sentence", () => {
+    expect(firstSentence("Read-only\nfilesystem access. Rest.")).toBe(
+      "Read-only filesystem access.",
+    );
+  });
+
+  it("returns a dot-less doc whole", () => {
+    expect(firstSentence("No trailing dot")).toBe("No trailing dot");
+  });
+});
+
+describe("renderEffectsList", () => {
+  const out = renderEffectsList(sets, BUILTIN_POLICIES);
+
+  it("lists every set with its doc line", () => {
+    expect(out).toContain("FileRead");
+    expect(out).toContain("Read-only filesystem access");
+    expect(out).toContain("Shell");
+  });
+
+  it("lists the built-in policies", () => {
+    expect(out).toContain("Built-in policies:");
+    expect(out).toContain("with-writes");
+    expect(out).toContain("approve-all");
+  });
+
+  it("shows flag usage", () => {
+    expect(out).toContain("--approve");
+    expect(out).toContain("--policy");
+  });
+});
+
+describe("renderSetDetail", () => {
+  it("shows the full doc and one member per line", () => {
+    const out = renderSetDetail(sets["FileRead"]);
+    expect(out).toContain("Read-only filesystem access");
+    expect(out).toContain("std::read");
+    expect(out).toContain("std::grep");
+  });
+
+  it("shows the composition of a nested set before the flat list", () => {
+    const out = renderSetDetail(sets["FileSystem"]);
+    expect(out.indexOf("FileRead + FileWrite")).toBeGreaterThanOrEqual(0);
+    expect(out.indexOf("FileRead + FileWrite")).toBeLessThan(out.indexOf("std::read"));
+  });
+});
+
+describe("renderEffectLookup", () => {
+  it("names every set containing the effect", () => {
+    const out = renderEffectLookup("std::write", sets);
+    expect(out).toContain("FileWrite");
+    expect(out).toContain("FileSystem");
+    expect(out).not.toContain("FileRead\n");
+  });
+
+  it("says when no set contains it", () => {
+    const out = renderEffectLookup("myapp::exec", sets);
+    expect(out).toContain("No built-in set");
+  });
+});
+
+describe("renderPolicyDetail", () => {
+  it("shows the description and the resolved policy JSON", () => {
+    const out = renderPolicyDetail("with-writes", "recommended + writes.", {
+      "std::write": [{ match: { dir: "/tmp/**" }, action: "approve" }],
+    });
+    expect(out).toContain("recommended + writes.");
+    expect(out).toContain('"std::write"');
+    expect(out).toContain("/tmp/**");
+  });
+});
+
+describe("renderUnknownName", () => {
+  it("names a near-miss", () => {
+    const out = renderUnknownName("FileReed", sets, ["minimal", "recommended"]);
+    expect(out).toContain("FileRead");
+  });
+
+  it("points at the listing when nothing is close", () => {
+    const out = renderUnknownName("Zzz", sets, ["minimal"]);
+    expect(out).toContain("agency effects");
+  });
+});

--- a/packages/agency-lang/lib/cli/effects.test.ts
+++ b/packages/agency-lang/lib/cli/effects.test.ts
@@ -28,6 +28,17 @@ describe("firstSentence", () => {
   it("returns a dot-less doc whole", () => {
     expect(firstSentence("No trailing dot")).toBe("No trailing dot");
   });
+
+  it("does not cut at an abbreviation mid-sentence", () => {
+    expect(firstSentence("Events (incl. calendar authorization).")).toBe(
+      "Events (incl. calendar authorization).",
+    );
+  });
+
+  it("renders the real Calendar doc whole", () => {
+    // The doc that motivated the boundary rule: "incl." must not truncate.
+    expect(firstSentence(sets["Calendar"].doc)).toContain("authorization)");
+  });
 });
 
 describe("renderEffectsList", () => {

--- a/packages/agency-lang/lib/cli/effects.ts
+++ b/packages/agency-lang/lib/cli/effects.ts
@@ -48,11 +48,14 @@ export function effectsCmd(name?: string): void {
   process.exit(1);
 }
 
-/** The first sentence of a doc comment, newlines collapsed. */
+/** The first sentence of a doc comment, newlines collapsed. A period
+ *  counts as a boundary only when the next sentence begins (whitespace
+ *  then an uppercase letter), so an abbreviation mid-sentence — the
+ *  Calendar set's "(incl. calendar authorization)" — does not truncate. */
 export function firstSentence(doc: string): string {
   const flat = doc.replace(/\s+/g, " ").trim();
-  const dot = flat.indexOf(". ");
-  return dot === -1 ? flat : flat.slice(0, dot + 1);
+  const boundary = flat.match(/\.(?=\s+[A-Z])/);
+  return boundary?.index === undefined ? flat : flat.slice(0, boundary.index + 1);
 }
 
 function twoColumn(rows: [string, string][]): string {

--- a/packages/agency-lang/lib/cli/effects.ts
+++ b/packages/agency-lang/lib/cli/effects.ts
@@ -1,4 +1,5 @@
 import { builtinEffectSets, type EffectSetInfo } from "@/runtime/effectSets.js";
+import { ttyColor } from "@/utils/termcolors.js";
 import { nearMissSetName } from "@/runtime/policyFlags.js";
 import { BUILTIN_POLICIES, builtinPolicy, builtinPolicyNames } from "@/runtime/builtinPolicies.js";
 import type { Policy } from "@/runtime/policy.js";
@@ -10,7 +11,8 @@ type PolicyEntry = { name: string; description: string };
  * argument, list the built-in capability sets and policies. With a set
  * name, describe the set; with an effect name (contains `::`), name the
  * sets that include it; with a built-in policy name, print its resolved
- * policy. Plain text output.
+ * policy. Plain text, with `ttyColor` accents that noop when stdout is
+ * not a TTY.
  */
 export function effectsCmd(name?: string): void {
   let sets: Record<string, EffectSetInfo>;
@@ -60,7 +62,8 @@ export function firstSentence(doc: string): string {
 
 function twoColumn(rows: [string, string][]): string {
   const width = Math.max(...rows.map(([name]) => name.length)) + 2;
-  return rows.map(([name, text]) => `  ${name.padEnd(width)}${text}`).join("\n");
+  // Pad before coloring: ANSI codes would count toward padEnd's width.
+  return rows.map(([name, text]) => `  ${ttyColor.cyan(name.padEnd(width))}${text}`).join("\n");
 }
 
 export function renderEffectsList(
@@ -72,10 +75,10 @@ export function renderEffectsList(
   );
   const policyRows = policies.map((p) => [p.name, p.description] as [string, string]);
   return [
-    "Effect sets:",
+    ttyColor.bold("Effect sets:"),
     twoColumn(setRows),
     "",
-    "Built-in policies:",
+    ttyColor.bold("Built-in policies:"),
     twoColumn(policyRows),
     "",
     "Use a set or an effect name with --approve / --reject, a policy with --policy:",
@@ -86,13 +89,13 @@ export function renderEffectsList(
 }
 
 export function renderSetDetail(set: EffectSetInfo): string {
-  const lines = [set.name, "", set.doc, ""];
+  const lines = [ttyColor.bold(set.name), "", set.doc, ""];
   if (set.composedOf.length > 0) {
     lines.push(`${set.name} = ${set.composedOf.join(" + ")}`, "");
   }
-  lines.push("Member effects:");
+  lines.push(ttyColor.bold("Member effects:"));
   for (const member of set.members) {
-    lines.push(`  ${member}`);
+    lines.push(`  ${ttyColor.cyan(member)}`);
   }
   lines.push("");
   return lines.join("\n");
@@ -103,16 +106,16 @@ export function renderEffectLookup(effect: string, sets: Record<string, EffectSe
   if (containing.length === 0) {
     return `No built-in set includes ${effect}. It can still be named directly in --approve / --reject.\n`;
   }
-  const lines = [`Sets that include ${effect}:`];
+  const lines = [ttyColor.bold(`Sets that include ${effect}:`)];
   for (const set of containing) {
-    lines.push(`  ${set.name}`);
+    lines.push(`  ${ttyColor.cyan(set.name)}`);
   }
   lines.push("");
   return lines.join("\n");
 }
 
 export function renderPolicyDetail(name: string, description: string, policy: Policy): string {
-  return [name, "", description, "", JSON.stringify(policy, null, 2), ""].join("\n");
+  return [ttyColor.bold(name), "", description, "", JSON.stringify(policy, null, 2), ""].join("\n");
 }
 
 export function renderUnknownName(
@@ -124,6 +127,6 @@ export function renderUnknownName(
   const hint = near === null ? "" : ` Did you mean ${near}?`;
   return (
     `"${name}" is not a built-in effect set or policy.${hint} ` +
-    `Run \`agency effects\` for the full list; effect names contain "::" (e.g. std::read).`
+    `Run \`agency effects\` for the full list. Effect names (usually namespaced, like std::read, though bare names are legal too) can be passed to --approve / --reject directly.`
   );
 }

--- a/packages/agency-lang/lib/cli/effects.ts
+++ b/packages/agency-lang/lib/cli/effects.ts
@@ -1,0 +1,126 @@
+import { builtinEffectSets, type EffectSetInfo } from "@/runtime/effectSets.js";
+import { nearMissSetName } from "@/runtime/policyFlags.js";
+import { BUILTIN_POLICIES, builtinPolicy, builtinPolicyNames } from "@/runtime/builtinPolicies.js";
+import type { Policy } from "@/runtime/policy.js";
+
+type PolicyEntry = { name: string; description: string };
+
+/**
+ * `agency effects [name]`: what the approval flags accept. With no
+ * argument, list the built-in capability sets and policies. With a set
+ * name, describe the set; with an effect name (contains `::`), name the
+ * sets that include it; with a built-in policy name, print its resolved
+ * policy. Plain text output.
+ */
+export function effectsCmd(name?: string): void {
+  let sets: Record<string, EffectSetInfo>;
+  try {
+    sets = builtinEffectSets();
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+    return;
+  }
+
+  if (name === undefined) {
+    process.stdout.write(renderEffectsList(sets, BUILTIN_POLICIES));
+    return;
+  }
+  if (name.includes("::")) {
+    process.stdout.write(renderEffectLookup(name, sets));
+    return;
+  }
+  const policy = BUILTIN_POLICIES.find((p) => p.name === name);
+  if (policy !== undefined) {
+    // Resolved against the process cwd, like `--policy <name>` at launch,
+    // so dir-scoped rules show the paths they would really match.
+    process.stdout.write(
+      renderPolicyDetail(policy.name, policy.description, builtinPolicy(name, process.cwd())!),
+    );
+    return;
+  }
+  const set = sets[name];
+  if (set !== undefined) {
+    process.stdout.write(renderSetDetail(set));
+    return;
+  }
+  console.error(renderUnknownName(name, sets, builtinPolicyNames()));
+  process.exit(1);
+}
+
+/** The first sentence of a doc comment, newlines collapsed. */
+export function firstSentence(doc: string): string {
+  const flat = doc.replace(/\s+/g, " ").trim();
+  const dot = flat.indexOf(". ");
+  return dot === -1 ? flat : flat.slice(0, dot + 1);
+}
+
+function twoColumn(rows: [string, string][]): string {
+  const width = Math.max(...rows.map(([name]) => name.length)) + 2;
+  return rows.map(([name, text]) => `  ${name.padEnd(width)}${text}`).join("\n");
+}
+
+export function renderEffectsList(
+  sets: Record<string, EffectSetInfo>,
+  policies: PolicyEntry[],
+): string {
+  const setRows = Object.values(sets).map(
+    (set) => [set.name, firstSentence(set.doc)] as [string, string],
+  );
+  const policyRows = policies.map((p) => [p.name, p.description] as [string, string]);
+  return [
+    "Effect sets:",
+    twoColumn(setRows),
+    "",
+    "Built-in policies:",
+    twoColumn(policyRows),
+    "",
+    "Use a set or an effect name with --approve / --reject, a policy with --policy:",
+    "  agency agent --policy with-writes --reject Shell",
+    "Run `agency effects <name>` for one set, effect, or policy in full.",
+    "",
+  ].join("\n");
+}
+
+export function renderSetDetail(set: EffectSetInfo): string {
+  const lines = [set.name, "", set.doc, ""];
+  if (set.composedOf.length > 0) {
+    lines.push(`${set.name} = ${set.composedOf.join(" + ")}`, "");
+  }
+  lines.push("Member effects:");
+  for (const member of set.members) {
+    lines.push(`  ${member}`);
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+export function renderEffectLookup(effect: string, sets: Record<string, EffectSetInfo>): string {
+  const containing = Object.values(sets).filter((set) => set.members.includes(effect));
+  if (containing.length === 0) {
+    return `No built-in set includes ${effect}. It can still be named directly in --approve / --reject.\n`;
+  }
+  const lines = [`Sets that include ${effect}:`];
+  for (const set of containing) {
+    lines.push(`  ${set.name}`);
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+export function renderPolicyDetail(name: string, description: string, policy: Policy): string {
+  return [name, "", description, "", JSON.stringify(policy, null, 2), ""].join("\n");
+}
+
+export function renderUnknownName(
+  name: string,
+  sets: Record<string, EffectSetInfo>,
+  policyNames: string[],
+): string {
+  const near = nearMissSetName(name, [...Object.keys(sets), ...policyNames]);
+  const hint = near === null ? "" : ` Did you mean ${near}?`;
+  return (
+    `"${name}" is not a built-in effect set or policy.${hint} ` +
+    `Run \`agency effects\` for the full list; effect names contain "::" (e.g. std::read).`
+  );
+}

--- a/packages/agency-lang/lib/runtime/builtinPolicies.ts
+++ b/packages/agency-lang/lib/runtime/builtinPolicies.ts
@@ -18,6 +18,7 @@ const AGENCY_SAFE_SUBCOMMANDS = [
   "definition",
   "diagnostics",
   "doc",
+  "effects",
   "literate",
 ];
 

--- a/packages/agency-lang/lib/runtime/policyFlags.ts
+++ b/packages/agency-lang/lib/runtime/policyFlags.ts
@@ -45,8 +45,9 @@ function expandSetNames(names: string[], flag: string): string[] {
 }
 
 /** A set name this one probably meant: a case-only mismatch, or one edit
- *  (insert, delete, or replace) away. */
-function nearMissSetName(name: string, setNames: string[]): string | null {
+ *  (insert, delete, or replace) away. Also used by `agency effects` for
+ *  its unknown-name error. */
+export function nearMissSetName(name: string, setNames: string[]): string | null {
   const exact = setNames.find((s) => s.toLowerCase() === name.toLowerCase());
   if (exact !== undefined) {
     return exact;

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -102,6 +102,7 @@ import { review } from "@/cli/review.js";
 import { policyGen } from "@/cli/policy.js";
 import { resolveRunPolicy } from "@/cli/runPolicy.js";
 import { interruptsCmd } from "@/cli/interrupts.js";
+import { effectsCmd } from "@/cli/effects.js";
 import {
   scheduleAdd,
   scheduleList,
@@ -440,7 +441,7 @@ export function createProgram(deps: CliDependencies = {}): Command {
         )
         .option(
           "--approve <effects>",
-          "Comma-separated interrupt effects or capability set names (e.g. FileRead) to auto-approve",
+          "Comma-separated interrupt effects or capability set names (e.g. FileRead; see: agency effects) to auto-approve",
         )
         .option(
           "--reject <effects>",
@@ -569,7 +570,7 @@ export function createProgram(deps: CliDependencies = {}): Command {
     .option("--policy <name|path>", "interrupt policy: a built-in or a policy JSON file")
     .option(
       "--approve <effects>",
-      "comma-separated interrupt effects or capability set names (e.g. FileRead) to auto-approve",
+      "comma-separated interrupt effects or capability set names (e.g. FileRead; see: agency effects) to auto-approve",
     )
     .option(
       "--reject <effects>",
@@ -1240,7 +1241,7 @@ export function createProgram(deps: CliDependencies = {}): Command {
     )
     .option(
       "--approve <effects>",
-      "Comma-separated interrupt effects or capability set names (e.g. FileRead) to auto-approve in every test case",
+      "Comma-separated interrupt effects or capability set names (e.g. FileRead; see: agency effects) to auto-approve in every test case",
     )
     .option(
       "--reject <effects>",
@@ -2354,6 +2355,17 @@ export function createProgram(deps: CliDependencies = {}): Command {
     .action((file: string, options: { output?: string; existing?: string }) => {
       const config = getConfig();
       policyGen(config, file, options);
+    });
+
+  program
+    .command("effects")
+    .description("List the built-in effect sets and policies the approval flags accept")
+    .argument(
+      "[name]",
+      "A set name (FileRead), an effect name (std::read), or a built-in policy name to describe",
+    )
+    .action((name?: string) => {
+      effectsCmd(name);
     });
 
   program


### PR DESCRIPTION
PR 2 of 2 from the effect-sets spec: `agency effects`, the discovery command for what the approval flags accept.

```
$ agency effects
Effect sets:
  FileRead     Read-only filesystem access: reading files and listing/searching paths.
  FileWrite    Filesystem mutation: creating, editing, moving, copying, and deleting.
  ...
Built-in policies:
  minimal      ...
  with-writes  recommended + auto-approve file writes and git changes, scoped to the current directory and its children.
  ...
```

With an argument: a set name shows the full doc, the composition (`FileSystem = FileRead + FileWrite`), and the flat member list; an effect name (`std::write`) lists the sets that include it; a built-in policy name shows its description and the policy **resolved against the cwd**, so dir-scoped rules show the paths they would really match here. An unknown name errors with a near-miss hint — unlike the flags, which fall back for compatibility, a discovery command can afford the error.

## How it works

Everything reads data that already exists: `builtinEffectSets()` (the table flag expansion uses, from #1000) and `BUILTIN_POLICIES`/`builtinPolicy`. Rendering is pure string-returning functions in `lib/cli/effects.ts`; `nearMissSetName` is now exported from `policyFlags` for the error hint. The flag-help pointers deferred from #1000 land here: `run`/`test`/`remote call` and the agent's `--approve`/`--reject` descriptions now say `see: agency effects`.

## Testing

Unit tests on every renderer (13) and spawn tests over the built CLI (6): the list with both sections, set detail, nested-set composition, reverse lookup, resolved policy JSON, and the unknown-name error with exit 1. Also `pnpm run typecheck`, `pnpm run lint:structure`, `pnpm run fmt:ts` after a full `make` (the agent's flag descriptions changed).

## Docs

`docs/dev/cli/effects-command.md`, with index lines in `CLAUDE.md` and the `agency-cli-docs` skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qh4zR96LWmg3kyGbCti4XR
