### PR TITLE
Fix the cert-and-checker calendar flake: openssl space-pads single-digit expiry days

### DIFF
--- a/packages/agency-lang/evals/agency-agent/cert-and-checker/graderFiles/test_outputs.py
+++ b/packages/agency-lang/evals/agency-agent/cert-and-checker/graderFiles/test_outputs.py
@@ -59,7 +59,12 @@ def test_verification_file():
     digest = fingerprint.split("=", 1)[1].strip().replace(":", "").lower()
     assert digest in text.replace(":", "").lower(), "verification.txt does not hold the SHA-256 fingerprint"
     _before, after = cert_dates()
-    assert after.strftime("%Y-%m-%d") in text or after.strftime("%b %d") in text, "verification.txt does not show the expiry date"
+    # openssl prints single-digit days space-padded ("Dec  1"), which
+    # neither strftime form matches; collapse runs of spaces and accept
+    # the unpadded day too.
+    collapsed = re.sub(r"[ \t]+", " ", text)
+    expiry_forms = [after.strftime("%Y-%m-%d"), after.strftime("%b %d"), f"{after.strftime('%b')} {after.day}"]
+    assert any(form in collapsed for form in expiry_forms), "verification.txt does not show the expiry date"
 
 
 def test_checker_runs_clean():


### PR DESCRIPTION
CI went red today on every branch (first seen on #1004, but unrelated to it): `checks.test.ts > the checks discriminate > cert-and-checker: solution passes every check` fails with "verification.txt does not show the expiry date".

## The bug

It is a calendar time bomb. The check accepts the expiry date in exactly two spellings:

```python
assert after.strftime("%Y-%m-%d") in text or after.strftime("%b %d") in text
```

But `verification.txt` gets its dates verbatim from `openssl x509 -noout -dates`, and openssl prints single-digit days space-padded:

```
notAfter=Dec  1 03:44:55 2026 GMT
```

`%Y-%m-%d` gives `2026-12-01` and `%b %d` gives `Dec 01` — neither appears in `Dec  1`. The task creates a certificate valid for 90 days, so the reference solution fails its own check whenever today + 90 days lands on the 1st through the 9th of a month. That became true on 2026-09-02 UTC (expiry Dec 1) and stays true through Sep 9.

## The fix

Collapse runs of spaces in the file and accept the unpadded day as a third spelling. Verified against a real run of the solution: the old assertion fails on today's output (`expiry=2026-12-01`), the new one passes, and double-digit days still match. The other `%b %d` uses in the file are `strptime` parsing, which tolerates the padding.

This blocks #1004 (and any other PR) until merged; the failed `unit-tests (3)` job needs a rerun after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015htcNM5hn6ceStKg9Bbw3V
