### PR TITLE
handoff def: functions that continue the caller conversation

### DIFF
--- a/packages/agency-lang/.claude/skills/agency-language-docs/SKILL.md
+++ b/packages/agency-lang/.claude/skills/agency-language-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agency-language-docs
-description: Developer docs for Agency language semantics and syntax features: blocks and closures, match expressions, null handling, parallel and seq blocks, splices, templates, validation annotations, pkg imports, and the with-approve modifier. Use when changing or reasoning about what an Agency language feature means.
+description: Developer docs for Agency language semantics and syntax features: blocks and closures, match expressions, null handling, parallel and seq blocks, splices, templates, validation annotations, pkg imports, handoff functions, and the with-approve modifier. Use when changing or reasoning about what an Agency language feature means.
 ---
 
 # Language developer docs
@@ -10,6 +10,7 @@ Paths are relative to `packages/agency-lang/`. Read the one that matches the tas
 - `docs/dev/language/agency-function.md` — The wrapper codegen emits around every Agency `def`. Covers tool metadata, argument resolution, and block arguments.
 - `docs/dev/language/closures-and-lambdas.md` — Why Agency has blocks and first-class functions but no lambdas, and what makes adding them hard.
 - `docs/dev/language/effect-patterns.md` — Naming an interrupt effect in a `match` arm and destructuring its payload, how it lowers, and its limits.
+- `docs/dev/language/handoff-functions.md` — `handoff def`: a function that continues its caller's conversation when called as a tool, the marker and resume messages that replace its tool-call bookkeeping, and the one-per-round rule.
 - `docs/dev/language/lambda-sketch.md` — A design sketch for lambdas. Nothing here is implemented.
 - `docs/dev/language/match-expression-positions.md` — Where a `match` may appear as a value, and why each such position has to be wired up by hand.
 - `docs/dev/language/null-and-undefined.md` — Why Agency has exactly one nothing-value, `null`, and treats `undefined` as another spelling of it.

--- a/packages/agency-lang/CLAUDE.md
+++ b/packages/agency-lang/CLAUDE.md
@@ -216,6 +216,7 @@ Other process docs:
 - `docs/dev/language/agency-function.md` — The wrapper codegen emits around every Agency `def`. Covers tool metadata, argument resolution, and block arguments.
 - `docs/dev/language/closures-and-lambdas.md` — Why Agency has blocks and first-class functions but no lambdas, and what makes adding them hard.
 - `docs/dev/language/effect-patterns.md` — Naming an interrupt effect in a `match` arm and destructuring its payload, how it lowers, and its limits.
+- `docs/dev/language/handoff-functions.md` — `handoff def`: a function that continues its caller's conversation when called as a tool, the marker and resume messages that replace its tool-call bookkeeping, and the one-per-round rule.
 - `docs/dev/language/lambda-sketch.md` — A design sketch for lambdas. Nothing here is implemented.
 - `docs/dev/language/match-expression-positions.md` — Where a `match` may appear as a value, and why each such position has to be wired up by hand.
 - `docs/dev/language/null-and-undefined.md` — Why Agency has exactly one nothing-value, `null`, and treats `undefined` as another spelling of it.

--- a/packages/agency-lang/docs/dev/agents/promptRunner.md
+++ b/packages/agency-lang/docs/dev/agents/promptRunner.md
@@ -66,10 +66,9 @@ rounds.
   end and log steps. An interrupted invocation records nothing: its
   invoke step must re-run on resume to consume the user's response.
 - `runnerState.handoffStarts` — for a handoff call, the thread length
-  right after the `.handoffMarker` step rewrote the tool-call message.
-  `finishHandoff` strips the body's system messages from that index on.
-  Recorded inside the marker step: a mid-handoff checkpoint holds the
-  body's messages, so recomputing the length on resume would be wrong.
+  right after the `.handoffMarker` step rewrote the tool-call message,
+  recorded inside that step. `finishHandoff` strips the body's system
+  messages from that index on.
 
 Deterministic reads need no record. Deriving `namedArgs` from
 `toolCall.arguments` inline is fine, because the checkpoint restores the

--- a/packages/agency-lang/docs/dev/agents/promptRunner.md
+++ b/packages/agency-lang/docs/dev/agents/promptRunner.md
@@ -65,6 +65,11 @@ rounds.
   answered the model, so a later pass returns instead of re-entering the
   end and log steps. An interrupted invocation records nothing: its
   invoke step must re-run on resume to consume the user's response.
+- `runnerState.handoffStarts` — for a handoff call, the thread length
+  right after the `.handoffMarker` step rewrote the tool-call message.
+  `finishHandoff` strips the body's system messages from that index on.
+  Recorded inside the marker step: a mid-handoff checkpoint holds the
+  body's messages, so recomputing the length on resume would be wrong.
 
 Deterministic reads need no record. Deriving `namedArgs` from
 `toolCall.arguments` inline is fine, because the checkpoint restores the

--- a/packages/agency-lang/docs/dev/agents/promptRunner.md
+++ b/packages/agency-lang/docs/dev/agents/promptRunner.md
@@ -65,10 +65,6 @@ rounds.
   answered the model, so a later pass returns instead of re-entering the
   end and log steps. An interrupted invocation records nothing: its
   invoke step must re-run on resume to consume the user's response.
-- `runnerState.handoffStarts` — for a handoff call, the thread length
-  right after the `.handoffMarker` step rewrote the tool-call message,
-  recorded inside that step. `finishHandoff` strips the body's system
-  messages from that index on.
 
 Deterministic reads need no record. Deriving `namedArgs` from
 `toolCall.arguments` inline is fine, because the checkpoint restores the

--- a/packages/agency-lang/docs/dev/agents/tool-loop-guards.md
+++ b/packages/agency-lang/docs/dev/agents/tool-loop-guards.md
@@ -119,9 +119,9 @@ call into a marker (docs/dev/language/handoff-functions.md). A sibling
 call in the same round needs that message intact to pair its own tool
 result. So a handoff that shares a round with any other call, an
 intrinsic like `saveDraft` included, gets the `handoffNotAlone` verdict.
-The refusal goes out as a tool message, which is fine: in a mixed round
-the assistant message was never rewritten. The siblings run. The text
-tells the model to call the handoff again by itself.
+The refusal goes out as a tool message; in a mixed round the assistant
+message was never rewritten. The siblings run. The text tells the model
+to call the handoff again by itself.
 
 ## Tests
 

--- a/packages/agency-lang/docs/dev/agents/tool-loop-guards.md
+++ b/packages/agency-lang/docs/dev/agents/tool-loop-guards.md
@@ -1,11 +1,13 @@
-# Tool-loop guards: repeated calls, markup arguments, and rejected calls
+# Tool-loop guards: repeated calls, markup arguments, rejected calls, and handoffs beside other calls
 
-Three refusals in `runPrompt`'s tool loop that stop a model from wasting
-rounds: a repeated call, a markup argument, and a RETRY of an
+Four refusals in `runPrompt`'s tool loop that stop a model from wasting
+rounds: a repeated call, a markup argument, a RETRY of an
 already-rejected call (the first rejected call runs normally up to its
-interrupt; only the identical retry is refused). The repeat and markup
-helpers live in `lib/runtime/toolLoopGuards.ts`; the rejection
-bookkeeping lives in `prompt.ts` itself. All three refusals happen
+interrupt; only the identical retry is refused), and a handoff call that
+shares a round with another call. The repeat and markup helpers live in
+`lib/runtime/toolLoopGuards.ts`; the rejection bookkeeping lives in
+`prompt.ts` itself; the handoff text lives in `lib/runtime/handoff.ts`.
+All four refusals happen
 before the tool's `onToolCallStart` hook, so a refused call never runs,
 never fires hooks, and never counts toward `MAX_TOOL_FAILURES`. The
 model sees the refusal as an ordinary tool message, which is where it
@@ -110,10 +112,23 @@ own step, and persisted in `runnerState`. See "Resume re-runs the code
 between steps" in [`promptRunner.md`](promptRunner.md) for the rule and
 the incident behind it.
 
+## A handoff beside another call
+
+A `handoff def` rewrites the assistant message that carried its tool
+call into a marker (docs/dev/language/handoff-functions.md). A sibling
+call in the same round needs that message intact to pair its own tool
+result. So a handoff that shares a round with any other call, an
+intrinsic like `saveDraft` included, gets the `handoffNotAlone` verdict.
+The refusal goes out as a tool message, which is fine: in a mixed round
+the assistant message was never rewritten. The siblings run. The text
+tells the model to call the handoff again by itself.
+
 ## Tests
 
 - Pure helpers: `lib/runtime/toolLoopGuards.test.ts` (`markupArgument`,
   `repeatKey`, `noteRepeat`).
+- Handoffs: `tests/agency-js/handoff` scripts the mixed round
+  (`notAlone`) and a rejected handoff call (`rejectHandoff`).
 - Rejections: `tests/agency-js/tool-rejection` scripts a handler reject
   (reason + identical-retry gate), an interactive reject with a reason,
   five consecutive rejections removing the tool, an approval resetting

--- a/packages/agency-lang/docs/dev/contributing/message-thread-tests.md
+++ b/packages/agency-lang/docs/dev/contributing/message-thread-tests.md
@@ -34,6 +34,7 @@ There are a lot of cases to test with message threads, so this doc keeps a list 
   - the same agent dispatched twice pushes its persona fresh each time through `ensureSystemMessage` (`twoDispatches`)
   - two handoffs in one round, and a handoff beside an intrinsic `saveDraft` call, are both refused (`twoHandoffs`, `handoffWithDraft`)
   - a structured return value is stringified into the resume message (`objectResult`)
+  - a handoff inside an `async` prompt lands on the prompt's subthread, and one inside a prompt with explicit `messages` lands on that thread; the active thread sees neither (`asyncHandoff`, `explicitMessages`)
   - every request in every scenario is checked for provider-valid shape: tool calls paired with tool results, never ending on an assistant message
 - A handoff function called from code runs on the caller's thread: tests/agency/agents/oracleExplorer.agency (`twoOracleCallsShareTheCallerThread`, `explorerFromCodeLandsOnTheCallerThread`)
 - If I do want to transfer message history to another node, how would I do that?

--- a/packages/agency-lang/docs/dev/contributing/message-thread-tests.md
+++ b/packages/agency-lang/docs/dev/contributing/message-thread-tests.md
@@ -29,7 +29,12 @@ There are a lot of cases to test with message threads, so this doc keeps a list 
   - `subthread {}` inside the body inherits the caller's history and does not flow back (`subthreadInside`)
   - an interrupt inside the body resumes without a second marker (`pauseInside`), and a rejection inside the body reaches the body's own model (`rejectInside`)
   - a failure return hands back with the error (`failureInside`), and a rejected handoff call hands back with the rejection (`rejectHandoff`)
-  - a handoff inside a handoff (`nested`)
+  - a handoff inside a handoff (`nested`), and a pause inside a nested handoff (`nestedPause`)
+  - a pause after the body pushed a persona, which needs the start index to survive the checkpoint (`pauseWithPersona`)
+  - the same agent dispatched twice pushes its persona fresh each time through `ensureSystemMessage` (`twoDispatches`)
+  - two handoffs in one round, and a handoff beside an intrinsic `saveDraft` call, are both refused (`twoHandoffs`, `handoffWithDraft`)
+  - a structured return value is stringified into the resume message (`objectResult`)
+  - every request in every scenario is checked for provider-valid shape: tool calls paired with tool results, never ending on an assistant message
 - A handoff function called from code runs on the caller's thread: tests/agency/agents/oracleExplorer.agency (`twoOracleCallsShareTheCallerThread`, `explorerFromCodeLandsOnTheCallerThread`)
 - If I do want to transfer message history to another node, how would I do that?
 

--- a/packages/agency-lang/docs/dev/contributing/message-thread-tests.md
+++ b/packages/agency-lang/docs/dev/contributing/message-thread-tests.md
@@ -35,6 +35,9 @@ There are a lot of cases to test with message threads, so this doc keeps a list 
   - two handoffs in one round, and a handoff beside an intrinsic `saveDraft` call, are both refused (`twoHandoffs`, `handoffWithDraft`)
   - a structured return value is stringified into the resume message (`objectResult`)
   - a handoff inside an `async` prompt lands on the prompt's subthread, and one inside a prompt with explicit `messages` lands on that thread; the active thread sees neither (`asyncHandoff`, `explicitMessages`)
+  - the caller's own system prompt is visible to the body and survives the hand-back (`callerSystemVisible`)
+  - two async prompts each dispatch a handoff at the same time and neither disturbs the other's thread (`twoAsyncHandoffs`)
+  - a race-loser cancellation inside a handoff removes the body's persona and leaves the marker (`cancelledHandoff`)
   - every request in every scenario is checked for provider-valid shape: tool calls paired with tool results, never ending on an assistant message
 - A handoff function called from code runs on the caller's thread: tests/agency/agents/oracleExplorer.agency (`twoOracleCallsShareTheCallerThread`, `explorerFromCodeLandsOnTheCallerThread`)
 - If I do want to transfer message history to another node, how would I do that?

--- a/packages/agency-lang/docs/dev/contributing/message-thread-tests.md
+++ b/packages/agency-lang/docs/dev/contributing/message-thread-tests.md
@@ -21,7 +21,16 @@ There are a lot of cases to test with message threads, so this doc keeps a list 
 - Not in a thread, but one LLM call depends on the result of another LLM call.: tests/agency/threads/no-thread-dependent-call.agency
 - In a parallel thread, but one LLM call depends on the result of another LLM call. (test not yet written)
 
-- Another thought: what about tools? What if a func that assumed it will be threaded is called as a tool?
+- A function called as a tool gets a fresh thread store; a `handoff def` called as a tool continues the caller's thread. Cases, all in tests/agency-js/handoff:
+  - the body's messages land on the caller's thread, with the marker in place of the tool call and a resume message at the end (`basic`)
+  - system messages the body pushes are removed when it returns (`persona`)
+  - a handoff beside another call is refused (`notAlone`)
+  - `thread {}` inside the body still isolates (`threadInside`)
+  - `subthread {}` inside the body inherits the caller's history and does not flow back (`subthreadInside`)
+  - an interrupt inside the body resumes without a second marker (`pauseInside`), and a rejection inside the body reaches the body's own model (`rejectInside`)
+  - a failure return hands back with the error (`failureInside`), and a rejected handoff call hands back with the rejection (`rejectHandoff`)
+  - a handoff inside a handoff (`nested`)
+- A handoff function called from code runs on the caller's thread: tests/agency/agents/oracleExplorer.agency (`twoOracleCallsShareTheCallerThread`, `explorerFromCodeLandsOnTheCallerThread`)
 - If I do want to transfer message history to another node, how would I do that?
 
 - We also need to test messages being returned from an agent to JavaScript

--- a/packages/agency-lang/docs/dev/language/handoff-functions.md
+++ b/packages/agency-lang/docs/dev/language/handoff-functions.md
@@ -1,0 +1,106 @@
+# Handoff functions
+
+A `handoff def` is a function that, when a model calls it as a tool,
+continues the caller's conversation instead of starting its own. Its
+`llm()` calls append to the caller's message thread, and the tool-call
+bookkeeping is replaced by two plain messages. The spec is
+`2026-09-02-thread-sharing-invocation-spec.md` at the repo root.
+
+## Why
+
+An ordinary tool runs on a fresh, empty `ThreadStore`. That is correct
+for a leaf tool, and it exists because the caller's thread ends, at the
+moment of the call, with an assistant message carrying the tool call.
+Providers require a tool result right after that message, so nothing
+else may be appended there.
+
+A subagent called as an ordinary tool therefore starts blind and reports
+back a summary. The coordinator never sees what the explorer read. A
+handoff removes the dangling tool call instead of working around it, so
+the body's messages can land on the caller's thread as valid history.
+
+## What happens
+
+1. The model calls a handoff tool. The `.gate` step refuses it with
+   `handoffNotAlone` if any other call shares the round.
+2. The `.handoffMarker` step rewrites the last message on the thread,
+   the assistant message carrying the tool call: its text is kept, the
+   tool call is dropped, and `[dispatching name: args]` is appended. The
+   thread length after the rewrite is recorded in
+   `runnerState.handoffStarts[invocationKey]`.
+3. `runInvokeStep` calls the body without installing a fresh
+   `ThreadStore`. The body's `llm()` calls reach the caller's active
+   thread through the branch frame, which `pr.parallel` pointer-shares
+   (`shareThreads: true`).
+4. When the body returns, `finishHandoff` removes every system-role
+   message from the recorded start index onward and pushes a user-role
+   `[name finished. <result>]\nContinue with the user's request.`
+   The return value is always included, even when it repeats the body's
+   last assistant message. A failure or rejection takes the same route
+   with the text an ordinary tool message would have carried.
+
+The return value still reaches the code that awaited the call, through
+`setResultOnBranch`, unchanged.
+
+## Threads inside the body
+
+`thread {}` still isolates. `subthread {}` inherits the caller's history
+plus the marker and does not flow back. System messages the body pushes
+are scoped to the dispatch.
+
+## Called from code
+
+A handoff function called from code, not by a model, is an ordinary
+function call. Functions are transparent to threads, so the body's
+`llm()` calls append to the caller's active thread, and nothing is
+stripped or handed back afterwards. The stdlib oracle and explorer used
+to isolate themselves with a `thread(...)` wrapper; that wrapper would
+opt them out of the handoff, so it is gone, and a from-code call now
+leaves the persona, the reads, and the answer on the caller's thread.
+This was decided on 2026-09-02 as a clean break. A caller who wants
+isolation writes `thread { oracleAgent(...) }`. The agents push their
+persona through `ensureSystemMessage` from `std::thread`, which skips
+the push when the active thread already holds it.
+
+## Resume
+
+A checkpoint taken inside a handoff holds the caller's thread with the
+marker and the body's messages so far. On resume the `.handoffMarker`
+step is skipped (it is in `completedSteps`), the start index comes back
+from `runnerState`, and the `.invoke` step re-runs to consume the user's
+response, as for any tool. There is no orphaned tool call for
+`threadRepair` to repair.
+
+## Known limits
+
+- One handoff per round. A mixed round refuses the handoff and runs the
+  siblings.
+- The marker carries the arguments as JSON with no cap. If a brief
+  turns out to be large enough to matter, cap it there.
+- An `llm()` call that passes explicit `messages`, or an `async` prompt
+  (which runs on a subthread that is not the active thread), holds a
+  thread that is not the store's active thread. A handoff inside such a
+  call lands the body's messages on the active thread and the marker
+  and resume on the call's own thread. Neither is invalid, but they are
+  not the same transcript.
+- A served function (`agency serve`, HTTP or MCP) is invoked outside
+  the tool loop, so a served handoff function is an ordinary call. Its
+  docstring's promise to continue the conversation does not apply
+  there.
+
+## Files
+
+- `lib/types/function.ts` — `FUNCTION_MARKER_KEYWORDS`, the `handoff`
+  marker, and the two conversions the parser, formatter, and codegen
+  read.
+- `lib/parsers/parsers.ts` — the modifier table spreads the keyword
+  list.
+- `lib/runtime/agencyFunction.ts` — the runtime `ToolMarkers.handoff`.
+- `lib/runtime/handoff.ts` — marker, resume, and refusal text;
+  `applyHandoffMarker`, `finishHandoff`.
+- `lib/runtime/prompt.ts` — the gate verdict, the `.handoffMarker`
+  step, the store skip in `runInvokeStep`, and `pushToolReply`.
+- `tests/agency-js/handoff/` — the end-to-end suite.
+- `stdlib/agents/oracle.agency`, `explorer.agency`, and the coordinator
+  wrappers under `lib/agents/agency-agent/brains/coordinator/subagents/`
+  — the handoff functions that ship.

--- a/packages/agency-lang/docs/dev/language/handoff-functions.md
+++ b/packages/agency-lang/docs/dev/language/handoff-functions.md
@@ -24,22 +24,28 @@ the body's messages can land on the caller's thread as valid history.
    `handoffNotAlone` if any other call shares the round.
 2. The `.handoffMarker` step rewrites the last message on the thread,
    the assistant message carrying the tool call: its text is kept, the
-   tool call is dropped, and `[dispatching name: args]` is appended. The
-   thread length after the rewrite is recorded in
-   `runnerState.handoffStarts[invocationKey]`.
-3. `runInvokeStep` calls the body without installing a fresh
-   `ThreadStore`. It runs the body under `ThreadStore.withActive` with
-   the prompt's own thread, the one carrying the marker. That is the
-   active thread for an ordinary prompt, a subthread for an `async`
+   tool call is dropped, and `[dispatching name: args]` is appended.
+3. `runInvokeStep` runs the body in a frame whose thread store is a
+   view of the caller's store with the prompt's own thread active, the
+   thread carrying the marker (`ThreadStore.viewWithActive`). That is
+   the active thread for an ordinary prompt, a subthread for an `async`
    prompt, and an unregistered thread for a prompt given explicit
    `messages`; in every case the body's `llm()` calls land on the same
-   thread as the marker and the resume message.
+   thread as the marker. The view has its own active stack, so two
+   prompts running at once cannot disturb each other.
 4. When the body returns, `finishHandoff` removes every system-role
-   message from the recorded start index onward and pushes a user-role
+   message after this dispatch's marker and pushes a user-role
    `[name finished. <result>]\nContinue with the user's request.`
    The return value is always included, even when it repeats the body's
    last assistant message. A failure or rejection takes the same route
-   with the text an ordinary tool message would have carried.
+   with the text an ordinary tool message would have carried. A
+   cancelled body (Esc, a race loser, a timeout) gets no resume message;
+   its system messages are removed on the way out and the marker stays.
+
+The strip is anchored on the marker, not on a recorded position: memory
+compaction rewrites the thread and shifts every index, while the marker
+message survives as an object. A marker that compaction summarized away
+took the body's earlier system messages with it.
 
 The return value still reaches the code that awaited the call, through
 `setResultOnBranch`, unchanged.
@@ -49,6 +55,12 @@ The return value still reaches the code that awaited the call, through
 `thread {}` still isolates. `subthread {}` inherits the caller's history
 plus the marker and does not flow back. System messages the body pushes
 are scoped to the dispatch.
+
+The caller's own system messages are live during the body. The body's
+request sends the whole thread, so a subagent sees the caller's system
+prompt alongside its own persona. That is the point of continuing the
+conversation, and a subagent prompt that must not be read that way
+belongs in an ordinary tool.
 
 ## Called from code
 
@@ -68,10 +80,9 @@ it.
 
 A checkpoint taken inside a handoff holds the caller's thread with the
 marker and the body's messages so far. On resume the `.handoffMarker`
-step is skipped (it is in `completedSteps`), the start index comes back
-from `runnerState`, and the `.invoke` step re-runs to consume the user's
-response, as for any tool. There is no orphaned tool call for
-`threadRepair` to repair.
+step is skipped (it is in `completedSteps`) and the `.invoke` step
+re-runs to consume the user's response, as for any tool. There is no
+orphaned tool call for `threadRepair` to repair.
 
 ## Known limits
 
@@ -94,9 +105,8 @@ response, as for any tool. There is no orphaned tool call for
 - `lib/runtime/handoff.ts` — marker, resume, and refusal text;
   `applyHandoffMarker`, `finishHandoff`.
 - `lib/runtime/prompt.ts` — the gate verdict, the `.handoffMarker`
-  step, the `withActive` binding in `runInvokeStep`, and
-  `pushToolReply`.
-- `lib/runtime/state/threadStore.ts` — `withActive`.
+  step, `invokeOnThread`, and `pushToolReply`.
+- `lib/runtime/state/threadStore.ts` — `viewWithActive`.
 - `tests/agency-js/handoff/` — the end-to-end suite.
 - `stdlib/agents/oracle.agency`, `explorer.agency`, and the coordinator
   wrappers under `lib/agents/agency-agent/brains/coordinator/subagents/`

--- a/packages/agency-lang/docs/dev/language/handoff-functions.md
+++ b/packages/agency-lang/docs/dev/language/handoff-functions.md
@@ -3,8 +3,7 @@
 A `handoff def` is a function that, when a model calls it as a tool,
 continues the caller's conversation instead of starting its own. Its
 `llm()` calls append to the caller's message thread, and the tool-call
-bookkeeping is replaced by two plain messages. The spec is
-`2026-09-02-thread-sharing-invocation-spec.md` at the repo root.
+bookkeeping is replaced by two plain messages.
 
 ## Why
 
@@ -29,9 +28,12 @@ the body's messages can land on the caller's thread as valid history.
    thread length after the rewrite is recorded in
    `runnerState.handoffStarts[invocationKey]`.
 3. `runInvokeStep` calls the body without installing a fresh
-   `ThreadStore`. The body's `llm()` calls reach the caller's active
-   thread through the branch frame, which `pr.parallel` pointer-shares
-   (`shareThreads: true`).
+   `ThreadStore`. It runs the body under `ThreadStore.withActive` with
+   the prompt's own thread, the one carrying the marker. That is the
+   active thread for an ordinary prompt, a subthread for an `async`
+   prompt, and an unregistered thread for a prompt given explicit
+   `messages`; in every case the body's `llm()` calls land on the same
+   thread as the marker and the resume message.
 4. When the body returns, `finishHandoff` removes every system-role
    message from the recorded start index onward and pushes a user-role
    `[name finished. <result>]\nContinue with the user's request.`
@@ -55,12 +57,12 @@ function call. Functions are transparent to threads, so the body's
 `llm()` calls append to the caller's active thread, and nothing is
 stripped or handed back afterwards. The stdlib oracle and explorer used
 to isolate themselves with a `thread(...)` wrapper; that wrapper would
-opt them out of the handoff, so it is gone, and a from-code call now
+opt them out of the handoff, so it is gone, and a from-code call
 leaves the persona, the reads, and the answer on the caller's thread.
-This was decided on 2026-09-02 as a clean break. A caller who wants
-isolation writes `thread { oracleAgent(...) }`. The agents push their
-persona through `ensureSystemMessage` from `std::thread`, which skips
-the push when the active thread already holds it.
+A caller who wants isolation writes `thread { oracleAgent(...) }`. The
+agents push their persona through `ensureSystemMessage` from
+`std::thread`, which skips the push when the active thread already holds
+it.
 
 ## Resume
 
@@ -75,14 +77,7 @@ response, as for any tool. There is no orphaned tool call for
 
 - One handoff per round. A mixed round refuses the handoff and runs the
   siblings.
-- The marker carries the arguments as JSON with no cap. If a brief
-  turns out to be large enough to matter, cap it there.
-- An `llm()` call that passes explicit `messages`, or an `async` prompt
-  (which runs on a subthread that is not the active thread), holds a
-  thread that is not the store's active thread. A handoff inside such a
-  call lands the body's messages on the active thread and the marker
-  and resume on the call's own thread. Neither is invalid, but they are
-  not the same transcript.
+- The marker carries the arguments as JSON with no cap.
 - A served function (`agency serve`, HTTP or MCP) is invoked outside
   the tool loop, so a served handoff function is an ordinary call. Its
   docstring's promise to continue the conversation does not apply
@@ -99,7 +94,9 @@ response, as for any tool. There is no orphaned tool call for
 - `lib/runtime/handoff.ts` — marker, resume, and refusal text;
   `applyHandoffMarker`, `finishHandoff`.
 - `lib/runtime/prompt.ts` — the gate verdict, the `.handoffMarker`
-  step, the store skip in `runInvokeStep`, and `pushToolReply`.
+  step, the `withActive` binding in `runInvokeStep`, and
+  `pushToolReply`.
+- `lib/runtime/state/threadStore.ts` — `withActive`.
 - `tests/agency-js/handoff/` — the end-to-end suite.
 - `stdlib/agents/oracle.agency`, `explorer.agency`, and the coordinator
   wrappers under `lib/agents/agency-agent/brains/coordinator/subagents/`

--- a/packages/agency-lang/docs/dev/runtime/threads.md
+++ b/packages/agency-lang/docs/dev/runtime/threads.md
@@ -176,6 +176,8 @@ The isolation is not cosmetic. Without it, an `llm()` call inside a tool body wo
 
 The fresh store is lazy rather than `withDefaultActive`, so a leaf tool that never calls `llm()` does not emit a phantom `threadCreated` event.
 
+**Second exception — handoff functions** (`handoff def`): the tool loop does not install a fresh store for these. The assistant message carrying the tool call is rewritten into a marker first, so nothing dangles, and the body's `llm()` calls append to the caller's active thread. See `docs/dev/language/handoff-functions.md`.
+
 ---
 
 ## What happens if a variable is assigned to a thread?

--- a/packages/agency-lang/docs/site/stdlib/agency.md
+++ b/packages/agency-lang/docs/site/stdlib/agency.md
@@ -174,6 +174,7 @@ export type ExportInfo = {
   effects: string[];
   destructive: boolean;
   idempotent: boolean;
+  handoff: boolean;
   reexportedFrom?: string
 }
 ```
@@ -189,7 +190,7 @@ export type ModuleInfo = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L707))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L708))
 
 ### AST
 
@@ -212,7 +213,7 @@ export type AST = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L756))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L757))
 
 ### Code
 
@@ -234,7 +235,7 @@ export type Code = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L813))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L814))
 
 ### HoleInfo
 
@@ -248,7 +249,7 @@ export type HoleInfo = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L820))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L821))
 
 ## Effects
 
@@ -300,7 +301,7 @@ effect std::run {
 export static const CLI_NOT_AVAILABLE = "The agency command line is not available here. Use the tools instead: typecheck(source) or typecheckFile(dir, filename) for type errors; testFile(dir, filename) to run a .test.json harness (write the files it tests first); runFile(dir, filename, node) to run a program; parseAST, format, describe for source analysis."
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L1049))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L1050))
 
 ## Functions
 
@@ -679,7 +680,7 @@ Map each exported node and function in the source to the list of
 describe(source: string): Result<ModuleInfo>
 ```
 
-Describe what an Agency module exports: each exported function, node, type, const, and re-export, in source order, with its signature, docstring, transitive effect list, and destructive/idempotent markers. Anything marked @hidden is left out, as is anything whose name starts with an underscore - both are the same visibility rule `agency doc` applies, so this is the module surface a reader sees. Re-exports from std:: modules resolve to full entries; re-exports from relative paths cannot be read from a source string and come back with effects ["unknown"]. Use this instead of reading source when generating code shaped by a module - for example, one handler per effect its tools can raise.
+Describe what an Agency module exports: each exported function, node, type, const, and re-export, in source order, with its signature, docstring, transitive effect list, and destructive/idempotent/handoff markers. Anything marked @hidden is left out, as is anything whose name starts with an underscore - both are the same visibility rule `agency doc` applies, so this is the module surface a reader sees. Re-exports from std:: modules resolve to full entries; re-exports from relative paths cannot be read from a source string and come back with effects ["unknown"]. Use this instead of reading source when generating code shaped by a module - for example, one handler per effect its tools can raise.
 
   @param source - Agency source code as a string
 
@@ -697,7 +698,7 @@ module doc comment's one-line summary.
 
 **Returns:** `Result<ModuleInfo>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L717))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L718))
 
 ### typecheckFile
 
@@ -723,7 +724,7 @@ Type-check an Agency file on disk. The file is read from dir/filename,
 
 **Throws:** `std::read`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L731))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L732))
 
 ### parseAST
 
@@ -743,7 +744,7 @@ Parse Agency source code into an abstract syntax tree.
 
 **Returns:** `Result<AST>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L762))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L763))
 
 ### writeAST
 
@@ -780,7 +781,7 @@ Output is canonical formatter output (the same style as `pnpm run fmt`):
 
 **Throws:** `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L774))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L775))
 
 ### format
 
@@ -800,7 +801,7 @@ Format Agency source code with the standard Agency formatter.
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L800))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L801))
 
 ### loadTemplate
 
@@ -825,7 +826,7 @@ Load an Agency file containing holes as a template.
 
 **Throws:** `std::read`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L828))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L829))
 
 ### holesOf
 
@@ -845,7 +846,7 @@ The unfilled holes in a template, in the order they appear. Each entry has the h
 
 **Returns:** `HoleInfo[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L847))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L848))
 
 ### fill
 
@@ -867,7 +868,7 @@ Fill holes in a template. Plain values become literals and are never parsed; Cod
 
 **Returns:** `Result<Code>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L856))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L857))
 
 ### combine
 
@@ -891,7 +892,7 @@ Merge several Code fragments into one, in order. Use this to build one
 
 **Returns:** `Result<Code>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L869))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L870))
 
 ### toSource
 
@@ -911,7 +912,7 @@ Print a Code value back to Agency source, including any unfilled holes.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L882))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L883))
 
 ### parseExpr
 
@@ -931,7 +932,7 @@ Parse a single Agency expression into a Code fragment that can fill an expr hole
 
 **Returns:** `Result<Code>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L891))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L892))
 
 ### parseStatements
 
@@ -951,7 +952,7 @@ Parse a list of Agency statements into a Code fragment that can fill a statement
 
 **Returns:** `Result<Code>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L900))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L901))
 
 ### formatFile
 
@@ -979,7 +980,7 @@ Read and write happen inside the same interrupt, so approving it approves both.
 
 **Throws:** `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L911))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L912))
 
 ### walkAST
 
@@ -1008,7 +1009,7 @@ Walk every node in a deep-cloned copy of the AST, invoking the visitor
 
 **Returns:** [AST](#ast)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L935))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L936))
 
 ### getNodesOfType
 
@@ -1030,7 +1031,7 @@ Parse Agency source code and return every AST node whose `type` field matches an
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L955))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L956))
 
 ### getImports
 
@@ -1050,7 +1051,7 @@ Return every import statement in the source (i.e. `import { x } from "..."`).
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L968))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L969))
 
 ### getFunctions
 
@@ -1070,7 +1071,7 @@ Return every function definition (`def foo(...) { ... }`) in the source.
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L977))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L978))
 
 ### getGraphNodes
 
@@ -1090,7 +1091,7 @@ Return every graph node definition (`node main() { ... }`) in the source.
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L986))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L987))
 
 ### filterImports
 
@@ -1142,7 +1143,7 @@ Parse Agency source, drop imports that fail the policy, and return the resulting
 
 **Returns:** `Result<{ source: string; filtered: boolean }>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L1013))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L1014))
 
 ### getVersion
 
@@ -1154,7 +1155,7 @@ Get the current version of the Agency standard library.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L1039))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L1040))
 
 ### cliHandles
 
@@ -1174,7 +1175,7 @@ Whether `cli` runs this agency subcommand in-process.
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L1053))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L1054))
 
 ### cli
 
@@ -1198,4 +1199,4 @@ Run an `agency <subcommand> <file>` command line through the matching function: 
 
 **Throws:** `std::read`, `std::guard`, `std::run`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L1062))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L1063))

--- a/packages/agency-lang/docs/site/stdlib/agents/explorer.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/explorer.md
@@ -48,14 +48,9 @@ Survey a codebase or a body of documentation and return an organized
   many files. Reads widely before synthesizing, and cites what it read. It
   never changes anything.
 
-  Called as a tool, the explorer continues your conversation: it sees
-  everything said so far, and every file it reads stays in your history
-  when it hands back. Say how much ground to cover; the reads are yours to
-  keep afterwards, so scope the question.
-
-  Called from code, it runs on your current thread like any function, and
-  its system prompt, reads, and answer stay there. Wrap the call in
-  `thread { ... }` for an isolated survey.
+  The explorer continues your conversation: it sees everything said so
+  far, and every file it reads stays in your history when it hands back.
+  Say how much ground to cover, and scope the question tightly.
 
   @param question - The question, and the scope you want covered
   @param context - Extra material folded into the prompt, or ""
@@ -64,6 +59,10 @@ Survey a codebase or a body of documentation and return an organized
   @param model - Model override, or "" for the ambient model
   @param provider - Provider for the model override
   @param extraTools - Extra tools to offer the LLM, appended to the built-in set
+
+Called from code, this runs on the caller's thread like any function:
+ *  the system prompt, the reads, and the answer stay there. Wrap the call
+ *  in `thread { ... }` for an isolated survey.
 
 **Parameters:**
 
@@ -81,4 +80,4 @@ Survey a codebase or a body of documentation and return an organized
 
 **Throws:** `std::guard`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/explorer.agency#L149))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/explorer.agency#L152))

--- a/packages/agency-lang/docs/site/stdlib/agents/explorer.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/explorer.md
@@ -39,7 +39,6 @@ explorerAgent(
   maxTime: number = 15m,
   model: string = "",
   provider: string = "",
-  session: string = "",
   extraTools: any[] = [],
 ): Result<string>
 ```
@@ -49,8 +48,14 @@ Survey a codebase or a body of documentation and return an organized
   many files. Reads widely before synthesizing, and cites what it read. It
   never changes anything.
 
-  Pass a self-contained question and say how much ground to cover: this agent
-  starts fresh and cannot see your conversation.
+  Called as a tool, the explorer continues your conversation: it sees
+  everything said so far, and every file it reads stays in your history
+  when it hands back. Say how much ground to cover; the reads are yours to
+  keep afterwards, so scope the question.
+
+  Called from code, it runs on your current thread like any function, and
+  its system prompt, reads, and answer stay there. Wrap the call in
+  `thread { ... }` for an isolated survey.
 
   @param question - The question, and the scope you want covered
   @param context - Extra material folded into the prompt, or ""
@@ -58,7 +63,6 @@ Survey a codebase or a body of documentation and return an organized
   @param maxTime - Hard wall-clock cap
   @param model - Model override, or "" for the ambient model
   @param provider - Provider for the model override
-  @param session - Session name to share a thread across calls, or "" for isolated
   @param extraTools - Extra tools to offer the LLM, appended to the built-in set
 
 **Parameters:**
@@ -71,11 +75,10 @@ Survey a codebase or a body of documentation and return an organized
 | maxTime | `number` | 15m |
 | model | `string` | "" |
 | provider | `string` | "" |
-| session | `string` | "" |
 | extraTools | `any[]` | [] |
 
 **Returns:** `Result<string>`
 
 **Throws:** `std::guard`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/explorer.agency#L151))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/explorer.agency#L149))

--- a/packages/agency-lang/docs/site/stdlib/agents/oracle.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/oracle.md
@@ -49,14 +49,9 @@ Ask for a second opinion on a hard problem: whether a plan is sound,
   design. Reads the code and returns a written analysis ending in a concrete
   recommendation. It never changes anything.
 
-  Called as a tool, the oracle continues your conversation: it sees
-  everything said so far, and its reading and reasoning stay in your
-  history when it hands back. Ask the question itself; there is no need to
-  restate the context.
-
-  Called from code, it runs on your current thread like any function, and
-  its system prompt, reads, and answer stay there. Wrap the call in
-  `thread { ... }` for an isolated consult.
+  The oracle continues your conversation: it sees everything said so far,
+  and its reading and reasoning stay in your history when it hands back.
+  Ask the question itself; there is no need to restate the context.
 
   @param question - The question
   @param context - Extra material folded into the prompt, or ""
@@ -65,6 +60,10 @@ Ask for a second opinion on a hard problem: whether a plan is sound,
   @param model - Model override, or "" for the ambient model
   @param provider - Provider for the model override
   @param extraTools - Extra tools to offer the LLM, appended to the built-in set
+
+Called from code, this runs on the caller's thread like any function:
+ *  the system prompt, the reads, and the answer stay there. Wrap the call
+ *  in `thread { ... }` for an isolated consult.
 
 **Parameters:**
 
@@ -82,4 +81,4 @@ Ask for a second opinion on a hard problem: whether a plan is sound,
 
 **Throws:** `std::guard`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/oracle.agency#L121))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/oracle.agency#L124))

--- a/packages/agency-lang/docs/site/stdlib/agents/oracle.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/oracle.md
@@ -40,7 +40,6 @@ oracleAgent(
   maxTime: number = 15m,
   model: string = "",
   provider: string = "",
-  session: string = "",
   extraTools: any[] = [],
 ): Result<string>
 ```
@@ -50,17 +49,21 @@ Ask for a second opinion on a hard problem: whether a plan is sound,
   design. Reads the code and returns a written analysis ending in a concrete
   recommendation. It never changes anything.
 
-  Pass a self-contained question: this agent starts fresh and cannot see your
-  conversation. Include the plan, the relevant file paths, and what you have
-  already tried.
+  Called as a tool, the oracle continues your conversation: it sees
+  everything said so far, and its reading and reasoning stay in your
+  history when it hands back. Ask the question itself; there is no need to
+  restate the context.
 
-  @param question - The question, with all the context needed to answer it
+  Called from code, it runs on your current thread like any function, and
+  its system prompt, reads, and answer stay there. Wrap the call in
+  `thread { ... }` for an isolated consult.
+
+  @param question - The question
   @param context - Extra material folded into the prompt, or ""
   @param maxCost - Hard spend cap
   @param maxTime - Hard wall-clock cap
   @param model - Model override, or "" for the ambient model
   @param provider - Provider for the model override
-  @param session - Session name to share a thread across calls, or "" for isolated
   @param extraTools - Extra tools to offer the LLM, appended to the built-in set
 
 **Parameters:**
@@ -73,11 +76,10 @@ Ask for a second opinion on a hard problem: whether a plan is sound,
 | maxTime | `number` | 15m |
 | model | `string` | "" |
 | provider | `string` | "" |
-| session | `string` | "" |
 | extraTools | `any[]` | [] |
 
 **Returns:** `Result<string>`
 
 **Throws:** `std::guard`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/oracle.agency#L123))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/oracle.agency#L121))

--- a/packages/agency-lang/docs/site/stdlib/thread.md
+++ b/packages/agency-lang/docs/site/stdlib/thread.md
@@ -372,11 +372,12 @@ ensureSystemMessage(msg: string)
 ```
 
 Push `msg` as a system message unless the active thread already holds it.
-  Use it for an agent's persona: called twice from code on one thread, the
-  agent keeps one persona; called as a handoff, whose system messages are
-  removed when it hands back, it pushes the persona fresh on every dispatch.
 
   @param msg - The system message
+
+For an agent's persona. An agent called twice from code on one thread
+ *  keeps one persona; a handoff, whose system messages are removed when it
+ *  hands back, pushes the persona fresh on every dispatch.
 
 **Parameters:**
 
@@ -384,7 +385,7 @@ Push `msg` as a system message unless the active thread already holds it.
 |---|---|---|
 | msg | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L226))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L229))
 
 ### getTokens
 

--- a/packages/agency-lang/docs/site/stdlib/thread.md
+++ b/packages/agency-lang/docs/site/stdlib/thread.md
@@ -35,7 +35,7 @@ export type AttachmentSource =
   | { kind: "base64"; base64: string; mimeType: string }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L57))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L58))
 
 ### Attachment
 
@@ -46,7 +46,7 @@ export type Attachment =
   | null }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L66))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L67))
 
 ### MessageAttachment
 
@@ -59,7 +59,7 @@ export type MessageAttachment =
   | null }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L75))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L76))
 
 ### ModelCost
 
@@ -78,7 +78,7 @@ export type ModelCost = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L249))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L245))
 
 ### GuardFailureData
 
@@ -93,7 +93,7 @@ export type GuardFailureData = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L274))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L270))
 
 ### ThreadMessage
 
@@ -104,7 +104,7 @@ export type ThreadMessage = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L297))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L293))
 
 ### ThreadInfo
 
@@ -120,7 +120,7 @@ export type ThreadInfo = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L302))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L298))
 
 ## Functions
 
@@ -144,7 +144,7 @@ Add a system message to the current thread's message history.
 | msg | `string` |  |
 | label | `string` | "" |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L80))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L81))
 
 ### userMessage
 
@@ -166,7 +166,7 @@ Add a user message to the current thread's message history. Use this
 | msg | `string \| (string \| MessageAttachment)[]` |  |
 | label | `string` | "" |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L92))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L93))
 
 ### toolMessage
 
@@ -194,7 +194,7 @@ Add a synthetic tool call and its result to the current thread, as if the
 | result | `string` |  |
 | label | `string` | "" |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L104))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L105))
 
 ### image
 
@@ -223,7 +223,7 @@ Build an image attachment for a multimodal llm() call. The source is
 
 **Returns:** [Attachment](#attachment)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L125))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L126))
 
 ### file
 
@@ -254,7 +254,7 @@ Build a file (e.g. PDF) attachment for a multimodal llm() call.
 
 **Returns:** [Attachment](#attachment)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L141))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L142))
 
 ### audio
 
@@ -287,7 +287,7 @@ Build an audio attachment for a multimodal llm() call. Only usable in
 
 **Returns:** [MessageAttachment](#messageattachment)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L158))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L159))
 
 ### attachToReply
 
@@ -309,7 +309,7 @@ Queue an attachment to be shown to the model after the current tool
 |---|---|---|
 | attachment | [Attachment](#attachment) |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L177))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L178))
 
 ### assistantMessage
 
@@ -331,7 +331,7 @@ Add an assistant message to the current thread's message history.
 | msg | `string` |  |
 | label | `string` | "" |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L190))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L191))
 
 ### getCost
 
@@ -350,7 +350,7 @@ Inside a fork/race branch this includes the parent's accumulated cost
 
 **Returns:** `number`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L207))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L208))
 
 ### threadIsNew
 
@@ -363,7 +363,7 @@ True when the current message thread has no messages yet. Use it inside a
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L215))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L216))
 
 ### ensureSystemMessage
 
@@ -385,7 +385,7 @@ For an agent's persona. An agent called twice from code on one thread
 |---|---|---|
 | msg | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L229))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L227))
 
 ### getTokens
 
@@ -397,7 +397,7 @@ Return the cumulative token count for the current execution branch.
 
 **Returns:** `number`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L242))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L238))
 
 ### getModelCosts
 
@@ -415,7 +415,7 @@ Unlike the per-branch cost/token accessors, this reads process-wide
 
 **Returns:** `ModelCost[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L265))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L261))
 
 ### listThreads
 
@@ -448,7 +448,7 @@ Summary sourcing: threads opened with `thread(summarize: true)` are
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L374))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L370))
 
 ### sessionThreadId
 
@@ -467,7 +467,7 @@ Slug-form id of the thread that `thread(session: name)` resumes (e.g.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L427))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L423))
 
 ### currentThreadId
 
@@ -482,7 +482,7 @@ Slug-form id of the active thread (e.g. "t3"), or `""` outside any
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L435))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L431))
 
 ### getThread
 
@@ -514,4 +514,4 @@ Read a slice of a thread's messages. Returns success holding `[]`
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L445))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L441))

--- a/packages/agency-lang/docs/site/stdlib/thread.md
+++ b/packages/agency-lang/docs/site/stdlib/thread.md
@@ -78,7 +78,7 @@ export type ModelCost = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L230))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L249))
 
 ### GuardFailureData
 
@@ -93,7 +93,7 @@ export type GuardFailureData = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L255))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L274))
 
 ### ThreadMessage
 
@@ -104,7 +104,7 @@ export type ThreadMessage = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L278))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L297))
 
 ### ThreadInfo
 
@@ -120,7 +120,7 @@ export type ThreadInfo = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L283))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L302))
 
 ## Functions
 
@@ -365,6 +365,27 @@ True when the current message thread has no messages yet. Use it inside a
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L215))
 
+### ensureSystemMessage
+
+```ts
+ensureSystemMessage(msg: string)
+```
+
+Push `msg` as a system message unless the active thread already holds it.
+  Use it for an agent's persona: called twice from code on one thread, the
+  agent keeps one persona; called as a handoff, whose system messages are
+  removed when it hands back, it pushes the persona fresh on every dispatch.
+
+  @param msg - The system message
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| msg | `string` |  |
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L226))
+
 ### getTokens
 
 ```ts
@@ -375,7 +396,7 @@ Return the cumulative token count for the current execution branch.
 
 **Returns:** `number`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L223))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L242))
 
 ### getModelCosts
 
@@ -393,7 +414,7 @@ Unlike the per-branch cost/token accessors, this reads process-wide
 
 **Returns:** `ModelCost[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L246))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L265))
 
 ### listThreads
 
@@ -426,7 +447,7 @@ Summary sourcing: threads opened with `thread(summarize: true)` are
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L355))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L374))
 
 ### sessionThreadId
 
@@ -445,7 +466,7 @@ Slug-form id of the thread that `thread(session: name)` resumes (e.g.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L408))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L427))
 
 ### currentThreadId
 
@@ -460,7 +481,7 @@ Slug-form id of the active thread (e.g. "t3"), or `""` outside any
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L416))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L435))
 
 ### getThread
 
@@ -492,4 +513,4 @@ Read a slice of a thread's messages. Returns success holding `[]`
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L426))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L445))

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/coordinator.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/coordinator.agency
@@ -114,6 +114,26 @@ def promptText(prompt: string | (string | Attachment)[]): string {
   }
 }
 
+// The oracle and explorer are handoffs: as tools they continue the
+// caller's thread. Called directly by --target there is no caller thread
+// to continue, so give each its own, as the other subagents do for
+// themselves.
+def oracleTurn(userMsg: string): string {
+  let reply = ""
+  thread(label: "oracle", summarize: true) {
+    reply = oracleAgent(userMsg)
+  }
+  return reply
+}
+
+def explorerTurn(userMsg: string): string {
+  let reply = ""
+  thread(label: "explorer", summarize: true) {
+    reply = explorerAgent(userMsg)
+  }
+  return reply
+}
+
 def coordinatorRunTurn(
   target: string,
   prompt: string | (string | Attachment)[],
@@ -121,8 +141,8 @@ def coordinatorRunTurn(
   return match(target) {
     "code" => codeAgent(promptText(prompt))
     "research" => researchAgent(promptText(prompt))
-    "oracle" => oracleAgent(promptText(prompt))
-    "explorer" => explorerAgent(promptText(prompt))
+    "oracle" => oracleTurn(promptText(prompt))
+    "explorer" => explorerTurn(promptText(prompt))
     "review" => reviewAgent(promptText(prompt))
     "writing" => writingAgent(promptText(prompt))
     "rewrite" => rewriteAgent(promptText(prompt))

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/prompts/main-large.md
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/prompts/main-large.md
@@ -2,8 +2,9 @@ You are the top-level coordinator of an Agency-language assistant. You
 receive every user message and decide how to respond.
 
 You have direct tools and subagent tools. The direct tools run in your
-own context; each subagent runs in its own isolated context and starts
-fresh, so pass it a self-contained message.
+own context. Most subagents run in their own isolated context and start
+fresh, so pass them a self-contained message; the oracle and the
+explorer continue this conversation instead, as their sections say.
 
 Direct tools:
 

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/prompts/main-large.md
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/prompts/main-large.md
@@ -82,9 +82,9 @@ know and what you can read directly. If you already have an answer and
 the oracle's verdict wouldn't change what you do next, skip the
 consult.
 
-Pass the oracle a self-contained question — it does not see your
-conversation. Include the specific question, the plan or diff under
-review, the relevant file paths, and what has already been tried.
+The oracle continues your conversation and sees everything above it.
+Ask the question itself; do not restate the context. Call it alone, with
+no other tool calls in the same response.
 
 ## Explorer
 
@@ -94,8 +94,11 @@ findings — "summarize the docs", "tour this module", "how does X work
 across the codebase". For anything narrower, do the reads yourself.
 
 Give it explicit scope ("all of `docs/site/guide/`", "the
-`lib/parsers/` module") and the specific questions to answer, in a
-self-contained brief — it does not see your conversation.
+`lib/parsers/` module") and the specific questions to answer. The
+explorer continues your conversation and sees everything above it.
+Every file it reads stays in your history, so name the questions and
+scope tightly. Call it alone, with no other tool calls in the same
+response.
 
 ## What you are
 

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/prompts/main-small.md
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/prompts/main-small.md
@@ -17,10 +17,12 @@ fresh — pass a self-contained message):
 - `reviewAgent(userMsg)` — check non-trivial new Agency code for
   syntax and type errors; pass the code to review.
 - `oracleAgent(userMsg)` — second opinion before acting on something
-  expensive to get wrong. Not for conversational questions or opinions
-  the user asked you for — answer those yourself.
+  expensive to get wrong. It sees this conversation; ask the question
+  itself, and call it alone. Not for conversational questions or
+  opinions the user asked you for — answer those yourself.
 - `explorerAgent(userMsg)` — only for questions needing many files read
-  and synthesized; name the questions and the scope.
+  and synthesized; it sees this conversation and its reads stay in your
+  history, so name the questions and the scope, and call it alone.
 - `writingAgent(userMsg)` — review prose for readability; pass the text
   or file path and who it is for. Reports only, unless the user asked
   for the fixes to be applied.

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/prompts/main-small.md
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/prompts/main-small.md
@@ -8,8 +8,9 @@ Direct tools (run in your own context):
 - `generateImageFile(prompt, path, size, images)` — create or edit an
   image; do not route image work to codeAgent.
 
-Subagent tools (each runs in its own isolated context and starts
-fresh — pass a self-contained message):
+Subagent tools (each starts fresh in its own context and needs a
+self-contained message, except where its entry says it sees this
+conversation):
 
 - `codeAgent(userMsg)` — changes things: write, edit, run, typecheck.
   Also Agency syntax and CLI questions.

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/subagents/code.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/subagents/code.agency
@@ -110,8 +110,8 @@ export static const codeTools: any[] = [
   agencyCli,
   superpowersSkill,
   // A handoff: the oracle continues the coder's thread, so it sees the
-  // actual diff and build output rather than a restatement, and its
-  // reads stay in the coder's history. Intended.
+  // actual diff and build output, and its reads stay in the coder's
+  // history.
   oracleAgent,
 ]
 

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/subagents/code.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/subagents/code.agency
@@ -109,6 +109,9 @@ export static const codeTools: any[] = [
   ...codingAgentTools(),
   agencyCli,
   superpowersSkill,
+  // A handoff: the oracle continues the coder's thread, so it sees the
+  // actual diff and build output rather than a restatement, and its
+  // reads stay in the coder's history. Intended.
   oracleAgent,
 ]
 

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/subagents/explorer.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/subagents/explorer.agency
@@ -2,10 +2,11 @@
  * The explorer, as the agency agent's coordinator sees it.
  *
  * The agent itself lives in std::agents/explorer, so users get the same
- * surveyor in their own agents. This wrapper supplies the two things that
- * are the agency agent's business and not the stdlib's: the slow-model slot
- * the user selected, and a shared session so repeated surveys in one run
- * continue a conversation rather than starting cold.
+ * surveyor in their own agents. This wrapper supplies the slow-model slot
+ * the user selected, which is the agency agent's business and not the
+ * stdlib's. It is a handoff: the explorer continues the coordinator's
+ * conversation, so it sees everything above and every file it reads stays
+ * in the coordinator's history.
  *
  * The docstring below is what the coordinator reads when deciding whether to
  * call this, so it is written for routing, not for the agent's own behavior.
@@ -15,7 +16,7 @@ import { explorerAgent as stdExplorerAgent } from "std::agents/explorer"
 import { getSlowModel, getSlowProvider } from "../../../shared.agency"
 import { announce } from "../lib/announce.agency"
 
-export def explorerAgent(userMsg: string): string {
+export handoff def explorerAgent(userMsg: string): string {
   """
   Ask the explorer — a read-only researcher — to survey many files and
   return a synthesized answer. Use it only when the answer genuinely
@@ -30,18 +31,17 @@ export def explorerAgent(userMsg: string): string {
   answered and the scope to cover ("all of docs/site/guide/", "the
   lib/parsers/ module").
 
-  Pass a self-contained brief — the explorer does not see your
-  conversation.
+  The explorer continues this conversation: it sees everything above, and
+  every file it reads stays in your history, so scope the questions
+  tightly. Call it alone, with no other tool calls in the same response.
 
-  @param userMsg - the specific questions to answer and the scope to
-    cover, with any context from the conversation the explorer needs
+  @param userMsg - the specific questions to answer and the scope to cover
   """
   announce("explorer", userMsg)
   const result = stdExplorerAgent(
     question: userMsg,
     model: getSlowModel(),
     provider: getSlowProvider(),
-    session: "explorer",
   )
   if (isFailure(result)) {
     return "The explorer could not finish: ${result.error}"

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/subagents/oracle.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/subagents/oracle.agency
@@ -2,10 +2,11 @@
  * The oracle, as the agency agent's coordinator sees it.
  *
  * The agent itself lives in std::agents/oracle, so users get the same
- * reviewer in their own agents. This wrapper supplies the two things that
- * are the agency agent's business and not the stdlib's: the slow-model slot
- * the user selected, and a shared session so repeated consults in one run
- * continue a conversation rather than starting cold.
+ * reviewer in their own agents. This wrapper supplies the slow-model slot
+ * the user selected, which is the agency agent's business and not the
+ * stdlib's. It is a handoff: the oracle continues the coordinator's
+ * conversation, so it sees everything above and its reasoning stays in
+ * the coordinator's history.
  *
  * The docstring below is what the coordinator reads when deciding whether to
  * call this, so it is written for routing, not for the agent's own behavior.
@@ -15,7 +16,7 @@ import { oracleAgent as stdOracleAgent } from "std::agents/oracle"
 import { getSlowModel, getSlowProvider } from "../../../shared.agency"
 import { announce } from "../lib/announce.agency"
 
-export def oracleAgent(userMsg: string): string {
+export handoff def oracleAgent(userMsg: string): string {
   """
   Ask the oracle — a read-only senior reviewer — for a second opinion
   before acting on something that would be expensive to get wrong. Call
@@ -32,19 +33,17 @@ export def oracleAgent(userMsg: string): string {
   know and what you can read directly. A second opinion is worth its cost
   when you're about to act, not when you're about to reply.
 
-  Pass a self-contained question — the oracle does not see your
-  conversation. Include the specific question, the relevant file paths,
-  and what you've already tried.
+  The oracle continues this conversation: it sees everything above, and
+  its reading and reasoning stay in your history. Ask the question itself.
+  Call it alone, with no other tool calls in the same response.
 
-  @param userMsg - the question, with all the context the oracle
-    needs to answer it
+  @param userMsg - the question
   """
   announce("oracle", userMsg)
   const result = stdOracleAgent(
     question: userMsg,
     model: getSlowModel(),
     provider: getSlowProvider(),
-    session: "oracle",
   )
   if (isFailure(result)) {
     return "The oracle could not finish: ${result.error}"

--- a/packages/agency-lang/lib/backends/agencyGenerator.test.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.test.ts
@@ -1378,6 +1378,23 @@ describe("AgencyGenerator - destructive/idempotent markers", () => {
     return new AgencyGenerator().generate(parseResult.result).output.trim();
   };
 
+  it("round-trips handoff defs, export first", () => {
+    expect(roundTrip("handoff def explorer(q: string): string {\n  return q\n}")).toContain(
+      "handoff def explorer",
+    );
+    expect(roundTrip("handoff export def explorer(q: string): string {\n  return q\n}")).toContain(
+      "export handoff def explorer",
+    );
+  });
+
+  it("a call to a function named handoff is still a call", () => {
+    // The modifier loop must fail and fall through when `handoff` is not
+    // followed by a def, so a plain call keeps parsing as a call.
+    expect(roundTrip("def handoff(n: number): number {\n  return n\n}\nhandoff(1)")).toContain(
+      "handoff(1)",
+    );
+  });
+
   it("round-trips destructive and idempotent defs", () => {
     expect(roundTrip("destructive def rm(p: string) {\n  return 1\n}")).toContain(
       "destructive def rm",

--- a/packages/agency-lang/lib/backends/agencyGenerator.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.ts
@@ -51,7 +51,12 @@ import { LEGAL_IDENTIFIER } from "../parsers/parsers.js";
 import { comprehensionPrefixString } from "../types/comprehension.js";
 import { BlockArgument } from "../types/blockArgument.js";
 import { AgencyArray, AgencyObject, AgencyObjectKV } from "../types/dataStructures.js";
-import { FunctionCall, FunctionDefinition, FunctionParameter } from "../types/function.js";
+import {
+  FunctionCall,
+  FunctionDefinition,
+  FunctionParameter,
+  markerKeywordsOf,
+} from "../types/function.js";
 import { GraphNodeDefinition } from "../types/graphNode.js";
 import { IfElse } from "../types/ifElse.js";
 import {
@@ -1258,10 +1263,10 @@ export class AgencyGenerator {
     const { body } = node;
 
     const prefixes: string[] = [];
-    if (node.exported) prefixes.push("export");
-    if (node.markers?.destructive) prefixes.push("destructive");
-    if (node.markers?.idempotent) prefixes.push("idempotent");
-    prefixes.push("def");
+    if (node.exported) {
+      prefixes.push("export");
+    }
+    prefixes.push(...markerKeywordsOf(node.markers), "def");
     const prefix = `${prefixes.join(" ")} ${declaredName(node.functionName)}`;
     const signature = this.buildSignature(prefix, node, " {", "source");
 

--- a/packages/agency-lang/lib/backends/typescriptBuilder.integration.test.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.integration.test.ts
@@ -282,6 +282,8 @@ destructive def rm(id: string): string {
     expect(dOut).toMatch(/markers:\s*\{\s*destructive:\s*true/);
     const iOut = generateWithBuilder(`idempotent def compileIt(s: string): string { return s }`);
     expect(iOut).toMatch(/markers:\s*\{\s*idempotent:\s*true/);
+    const hOut = generateWithBuilder(`handoff def explorer(q: string): string { return q }`);
+    expect(hOut).toMatch(/markers:\s*\{\s*handoff:\s*true/);
     const plainOut = generateWithBuilder(`def plain(id: string): string { return id }`);
     expect(plainOut).not.toContain("markers:");
   });

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -59,7 +59,13 @@ import { AccessChainElement, ValueAccess } from "../types/access.js";
 import { AgencyArray, AgencyObject, AgencyObjectKV } from "../types/dataStructures.js";
 import { ForLoop } from "../types/forLoop.js";
 import { TryExpression } from "../types/tryExpression.js";
-import { FunctionCall, FunctionDefinition, FunctionParameter } from "../types/function.js";
+import {
+  FunctionCall,
+  FunctionDefinition,
+  FunctionMarkers,
+  FunctionParameter,
+  markerKeywordsOf,
+} from "../types/function.js";
 import { GraphNodeDefinition } from "../types/graphNode.js";
 import { HandleBlock } from "../types/handleBlock.js";
 import { WithModifier } from "../types/withModifier.js";
@@ -129,6 +135,15 @@ import { ScopeManager } from "./typescriptBuilder/scopeManager.js";
 import { StepPathTracker } from "./typescriptBuilder/stepPathTracker.js";
 import { NameClassifier } from "./typescriptBuilder/nameClassifier.js";
 import { functionContainsDestructiveBlock } from "./functionContainsDestructiveBlock.js";
+
+/** The markers a def's AgencyFunction carries. Destructive is derived: the
+ *  raw `destructive def` marker OR a `destructive { }` region in the body.
+ *  (The entry flip / `inDestructiveFunction` still key on the raw marker
+ *  alone, so a contains-region-only function does not commit at entry.) */
+function toolMarkersOf(node: FunctionDefinition): FunctionMarkers {
+  const destructive = !!node.markers?.destructive || functionContainsDestructiveBlock(node.body);
+  return { ...node.markers, destructive };
+}
 import { DestructiveTracking } from "./typescriptBuilder/destructiveTracking.js";
 import {
   FinalizeCodegen,
@@ -2450,19 +2465,13 @@ export class TypeScriptBuilder {
       toolDefinition: toolDef,
       exported: ts.bool(!!node.exported),
     };
-    // Carry the retry-safety markers so the tool loop and MCP adapter can
-    // read them off the registered AgencyFunction. Emitted only when set.
-    // "Destructive" for metadata purposes is DERIVED: the raw `destructive def`
-    // marker OR the presence of a `destructive { }` region in the body. (The
-    // entry flip / `inDestructiveFunction` still key on the raw marker alone —
-    // see `:2266` — so a contains-region-only function does not commit at
-    // entry.)
-    const isDestructive =
-      !!node.markers?.destructive || functionContainsDestructiveBlock(node.body);
-    if (isDestructive || node.markers?.idempotent) {
-      const markerProps: Record<string, TsNode> = {};
-      if (isDestructive) markerProps.destructive = ts.bool(true);
-      if (node.markers?.idempotent) markerProps.idempotent = ts.bool(true);
+    // Carry the markers so the tool loop and MCP adapter can read them off
+    // the registered AgencyFunction. Emitted only when at least one is set.
+    const markerKeywords = markerKeywordsOf(toolMarkersOf(node));
+    if (markerKeywords.length > 0) {
+      const markerProps = Object.fromEntries(
+        markerKeywords.map((keyword) => [keyword, ts.bool(true)]),
+      );
       createProps.markers = ts.obj(markerProps);
     }
     const createCall = $.id("__AgencyFunction")

--- a/packages/agency-lang/lib/parsers/function.test.ts
+++ b/packages/agency-lang/lib/parsers/function.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  RESERVED_WORDS,
   functionParser,
   functionParameterParser,
   docStringParser,
@@ -2228,8 +2229,9 @@ describe("functionParser with destructive/idempotent markers", () => {
     }
   });
 
-  it("a def named handoff still parses", () => {
+  it("a def named handoff still parses, and handoff is reserved for identifier holes", () => {
     expect(functionParser("def handoff(): number { return 1 }").success).toBe(true);
+    expect(RESERVED_WORDS).toContain("handoff");
   });
 
   it("parses destructive def", () => {

--- a/packages/agency-lang/lib/parsers/function.test.ts
+++ b/packages/agency-lang/lib/parsers/function.test.ts
@@ -2193,6 +2193,32 @@ describe("functionParser with export keyword", () => {
 });
 
 describe("functionParser with destructive/idempotent markers", () => {
+  it("parses handoff def", () => {
+    const parsed = functionParser("handoff def explorer(q: string): string { return q }");
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.result.markers).toEqual({ handoff: true });
+    }
+  });
+
+  it("parses export + handoff in either order", () => {
+    for (const source of [
+      "export handoff def explorer(q: string): string { return q }",
+      "handoff export def explorer(q: string): string { return q }",
+    ]) {
+      const parsed = functionParser(source);
+      expect(parsed.success).toBe(true);
+      if (parsed.success) {
+        expect(parsed.result.exported).toBe(true);
+        expect(parsed.result.markers).toEqual({ handoff: true });
+      }
+    }
+  });
+
+  it("a def named handoff still parses", () => {
+    expect(functionParser("def handoff(): number { return 1 }").success).toBe(true);
+  });
+
   it("parses destructive def", () => {
     const r = functionParser("destructive def rm(p: string) { return 1 }");
     expect(r.success).toBe(true);

--- a/packages/agency-lang/lib/parsers/function.test.ts
+++ b/packages/agency-lang/lib/parsers/function.test.ts
@@ -2215,6 +2215,19 @@ describe("functionParser with destructive/idempotent markers", () => {
     }
   });
 
+  it("parses handoff beside another marker in either order", () => {
+    for (const source of [
+      "handoff destructive def rm(p: string): string { return p }",
+      "destructive handoff def rm(p: string): string { return p }",
+    ]) {
+      const parsed = functionParser(source);
+      expect(parsed.success).toBe(true);
+      if (parsed.success) {
+        expect(parsed.result.markers).toEqual({ destructive: true, handoff: true });
+      }
+    }
+  });
+
   it("a def named handoff still parses", () => {
     expect(functionParser("def handoff(): number { return 1 }").success).toBe(true);
   });

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -280,6 +280,7 @@ export const RESERVED_WORDS: readonly string[] = [
   "with",
   "destructive",
   "idempotent",
+  "handoff",
   "optimize",
   "class",
   "true",

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -107,6 +107,8 @@ import {
   FunctionCall,
   FunctionDefinition,
   FunctionMarkers,
+  FUNCTION_MARKER_KEYWORDS,
+  markersFromKeywords,
   FunctionParameter,
   InterpolationSegment,
   Literal,
@@ -7038,40 +7040,39 @@ const exportKeywordParser: Parser<boolean> = or(
 
 // The modifiers that may precede `def`, in any order, each at most once.
 // A table looped to fixpoint keeps this order-independent and makes a new
-// modifier a one-line addition.
-const FUNCTION_MODIFIER_KEYWORDS = ["export", "destructive", "idempotent"] as const;
+// modifier a one-word addition to FUNCTION_MARKER_KEYWORDS.
+const FUNCTION_MODIFIER_KEYWORDS = ["export", ...FUNCTION_MARKER_KEYWORDS] as const;
 type FunctionModifierKeyword = (typeof FUNCTION_MODIFIER_KEYWORDS)[number];
 
-const modifierKeywordParser = (kw: string): Parser<boolean> =>
+const modifierKeywordParser = (keyword: string): Parser<boolean> =>
   or(
-    map(seqC(str(kw), spaces), () => true),
+    map(seqC(str(keyword), spaces), () => true),
     succeed(false),
   );
 
 type FunctionModifiers = {
   isExported: boolean;
-  isDestructive: boolean;
-  isIdempotent: boolean;
+  markers: FunctionMarkers;
 };
 
 function parseFunctionModifiers(
   input: string,
 ): { success: true; rest: string; modifiers: FunctionModifiers } | { success: false } {
   let rest = input;
-  const seen: Record<FunctionModifierKeyword, boolean> = {
-    export: false,
-    destructive: false,
-    idempotent: false,
-  };
+  const seen = Object.fromEntries(
+    FUNCTION_MODIFIER_KEYWORDS.map((keyword) => [keyword, false]),
+  ) as Record<FunctionModifierKeyword, boolean>;
   let progressed = true;
   while (progressed) {
     progressed = false;
-    for (const kw of FUNCTION_MODIFIER_KEYWORDS) {
-      if (seen[kw]) continue;
-      const r = modifierKeywordParser(kw)(rest);
-      if (r.success && r.result) {
-        seen[kw] = true;
-        rest = r.rest;
+    for (const keyword of FUNCTION_MODIFIER_KEYWORDS) {
+      if (seen[keyword]) {
+        continue;
+      }
+      const parsed = modifierKeywordParser(keyword)(rest);
+      if (parsed.success && parsed.result) {
+        seen[keyword] = true;
+        rest = parsed.rest;
         progressed = true;
       }
     }
@@ -7081,21 +7082,18 @@ function parseFunctionModifiers(
   // reject the conflict here: both are set on the AST and the type checker
   // reports a clear diagnostic (AG7006). A parse failure would only surface
   // a generic "unexpected modifier".
+  const markerKeywords = FUNCTION_MARKER_KEYWORDS.filter((keyword) => seen[keyword]);
   return {
     success: true,
     rest,
-    modifiers: {
-      isExported: seen.export,
-      isDestructive: seen.destructive,
-      isIdempotent: seen.idempotent,
-    },
+    modifiers: { isExported: seen.export, markers: markersFromKeywords(markerKeywords) },
   };
 }
 
 const _functionParserInner: Parser<FunctionDefinition> = (input: string) => {
   const mods = parseFunctionModifiers(input);
   if (!mods.success) return failure("unexpected modifier", input);
-  const { isExported, isDestructive, isIdempotent } = mods.modifiers;
+  const { isExported, markers } = mods.modifiers;
 
   const baseResult = _baseFunctionParser(mods.rest);
   if (!baseResult.success) return baseResult;
@@ -7111,15 +7109,12 @@ const _functionParserInner: Parser<FunctionDefinition> = (input: string) => {
   // Only attach `raises` when a clause was present (optional() yields null);
   // keeps the AST shape unchanged for functions without a raises clause.
   if (_raises) result.raises = _raises;
-  if (isExported) result.exported = true;
-  // Markers travel as one object, present only when at least one is set,
-  // each field only when true — keeps AST JSON and exact-match tests clean.
-  // Both may be set when the source conflicts (`destructive idempotent`);
-  // the type checker reports that as AG7006.
-  if (isDestructive || isIdempotent) {
-    const markers: FunctionMarkers = {};
-    if (isDestructive) markers.destructive = true;
-    if (isIdempotent) markers.idempotent = true;
+  if (isExported) {
+    result.exported = true;
+  }
+  // Present only when at least one marker is set — keeps AST JSON and
+  // exact-match tests clean.
+  if (Object.keys(markers).length > 0) {
     result.markers = markers;
   }
 

--- a/packages/agency-lang/lib/runtime/agencyFunction.ts
+++ b/packages/agency-lang/lib/runtime/agencyFunction.ts
@@ -65,11 +65,14 @@ export type ToolDefinition = {
   schema: unknown;
 };
 
-/** Retry-safety markers carried on a registered tool. Inline shape so the
- *  runtime stays decoupled from the compiler's AST types. */
+/** Markers carried on a registered tool. Inline shape so the runtime
+ *  stays decoupled from the compiler's AST types. */
 export type ToolMarkers = {
   destructive?: boolean;
   idempotent?: boolean;
+  /** Called as a tool, this function continues the caller's conversation.
+   *  Read by the tool loop in prompt.ts. */
+  handoff?: boolean;
 };
 
 export type AgencyFunctionOpts = {

--- a/packages/agency-lang/lib/runtime/handoff.test.ts
+++ b/packages/agency-lang/lib/runtime/handoff.test.ts
@@ -7,9 +7,14 @@ import {
   handoffMarkerText,
   handoffNotAloneMessage,
   handoffResumeText,
+  stripHandoffSystemMessages,
 } from "./handoff.js";
 
 const toolCall = () => new smoltalk.ToolCall("call-1", "explorer", { question: "why" });
+const args = { question: "why" };
+
+const contents = (thread: MessageThread) => thread.getMessages().map((message) => message.content);
+const roles = (thread: MessageThread) => thread.getMessages().map((message) => message.role);
 
 describe("applyHandoffMarker", () => {
   it("keeps the assistant's text, drops the tool call, appends the marker, keeps the label", () => {
@@ -19,13 +24,10 @@ describe("applyHandoffMarker", () => {
       smoltalk.assistantMessage("I'll ask the explorer.", { toolCalls: [toolCall()] }),
       "main",
     );
-    const start = applyHandoffMarker(thread, "explorer", { question: "why" });
+    applyHandoffMarker(thread, "explorer", args);
     const last = thread.getMessages()[1];
-    expect(start).toBe(2);
     expect(last.role).toBe("assistant");
-    expect(last.content).toBe(
-      `I'll ask the explorer.\n\n${handoffMarkerText("explorer", { question: "why" })}`,
-    );
+    expect(last.content).toBe(`I'll ask the explorer.\n\n${handoffMarkerText("explorer", args)}`);
     const json = last.toJSON() as { toolCalls?: unknown[] };
     expect(json.toolCalls ?? []).toEqual([]);
     expect(thread.labelAt(1)).toBe("main");
@@ -35,10 +37,8 @@ describe("applyHandoffMarker", () => {
     const thread = new MessageThread();
     thread.push(smoltalk.userMessage("hello"));
     thread.push(smoltalk.assistantMessage(null, { toolCalls: [toolCall()] }));
-    applyHandoffMarker(thread, "explorer", { question: "why" });
-    expect(thread.getMessages()[1].content).toBe(
-      handoffMarkerText("explorer", { question: "why" }),
-    );
+    applyHandoffMarker(thread, "explorer", args);
+    expect(thread.getMessages()[1].content).toBe(handoffMarkerText("explorer", args));
   });
 
   it("refuses a thread that does not end on an assistant message", () => {
@@ -48,21 +48,72 @@ describe("applyHandoffMarker", () => {
   });
 });
 
+/** A thread as it stands when a handoff body returns: the caller's own
+ *  system prompt, the marker, then the body's persona and work. */
+const threadAfterBody = () => {
+  const thread = new MessageThread();
+  thread.push(smoltalk.systemMessage("caller persona"));
+  thread.push(smoltalk.userMessage("hello"));
+  thread.push(smoltalk.assistantMessage(handoffMarkerText("explorer", args)));
+  thread.push(smoltalk.systemMessage("subagent persona"));
+  thread.push(smoltalk.userMessage("brief"));
+  thread.push(smoltalk.assistantMessage("the answer"));
+  return thread;
+};
+
 describe("finishHandoff", () => {
-  it("removes system messages pushed since the start index and hands control back", () => {
+  it("removes the system messages after the marker and hands control back", () => {
+    const thread = threadAfterBody();
+    finishHandoff(thread, "explorer", args, "the answer");
+    expect(roles(thread)).toEqual(["system", "user", "assistant", "user", "assistant", "user"]);
+    expect(contents(thread)[0]).toBe("caller persona");
+    expect(contents(thread)[5]).toBe(handoffResumeText("explorer", "the answer"));
+  });
+
+  it("strips only after the newest marker for this dispatch", () => {
+    const thread = threadAfterBody();
+    thread.push(smoltalk.userMessage(handoffResumeText("explorer", "the answer")));
+    thread.push(smoltalk.assistantMessage(handoffMarkerText("explorer", args)));
+    thread.push(smoltalk.systemMessage("second persona"));
+    thread.push(smoltalk.assistantMessage("second answer"));
+    // The first dispatch's persona is still there because nothing stripped
+    // it in this synthetic thread; the second dispatch must not reach back
+    // past its own marker and remove it.
+    finishHandoff(thread, "explorer", args, "second answer");
+    expect(contents(thread)).toContain("subagent persona");
+    expect(contents(thread)).not.toContain("second persona");
+  });
+
+  it("survives memory compaction shifting every index", () => {
+    const thread = threadAfterBody();
+    // Compaction keeps the leading system prefix, replaces a middle run
+    // with one summary, and keeps the tail. Here the marker and the
+    // persona sit in the tail, one position lower than before.
+    const original = thread.getMessages();
+    const summary = smoltalk.systemMessage("summary of earlier turns");
+    thread.setMessages([original[0], summary, original[2], original[3], original[4], original[5]]);
+    finishHandoff(thread, "explorer", args, "the answer");
+    expect(contents(thread)).toContain("summary of earlier turns");
+    expect(contents(thread)).not.toContain("subagent persona");
+    expect(roles(thread)).toEqual(["system", "system", "assistant", "user", "assistant", "user"]);
+  });
+
+  it("leaves a compacted-away dispatch alone and still hands back", () => {
     const thread = new MessageThread();
     thread.push(smoltalk.systemMessage("caller persona"));
-    thread.push(smoltalk.userMessage("hello"));
-    thread.push(smoltalk.assistantMessage(handoffMarkerText("explorer", {})));
-    const start = thread.getMessages().length;
-    thread.push(smoltalk.systemMessage("subagent persona"));
-    thread.push(smoltalk.userMessage("brief"));
+    thread.push(smoltalk.systemMessage("summary that swallowed the marker and the persona"));
     thread.push(smoltalk.assistantMessage("the answer"));
-    finishHandoff(thread, start, "explorer", "the answer");
-    const roles = thread.getMessages().map((message) => message.role);
-    expect(roles).toEqual(["system", "user", "assistant", "user", "assistant", "user"]);
-    expect(thread.getMessages()[0].content).toBe("caller persona");
-    expect(thread.getMessages()[5].content).toBe(handoffResumeText("explorer", "the answer"));
+    finishHandoff(thread, "explorer", args, "the answer");
+    expect(roles(thread)).toEqual(["system", "system", "assistant", "user"]);
+  });
+});
+
+describe("stripHandoffSystemMessages", () => {
+  it("removes the body's system messages without a resume message, for a cancelled dispatch", () => {
+    const thread = threadAfterBody();
+    stripHandoffSystemMessages(thread, "explorer", args);
+    expect(contents(thread)).not.toContain("subagent persona");
+    expect(roles(thread)).toEqual(["system", "user", "assistant", "user", "assistant"]);
   });
 });
 

--- a/packages/agency-lang/lib/runtime/handoff.test.ts
+++ b/packages/agency-lang/lib/runtime/handoff.test.ts
@@ -26,7 +26,8 @@ describe("applyHandoffMarker", () => {
     expect(last.content).toBe(
       `I'll ask the explorer.\n\n${handoffMarkerText("explorer", { question: "why" })}`,
     );
-    expect(last.toJSON().toolCalls ?? []).toEqual([]);
+    const json = last.toJSON() as { toolCalls?: unknown[] };
+    expect(json.toolCalls ?? []).toEqual([]);
     expect(thread.labelAt(1)).toBe("main");
   });
 

--- a/packages/agency-lang/lib/runtime/handoff.test.ts
+++ b/packages/agency-lang/lib/runtime/handoff.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import * as smoltalk from "smoltalk";
+import { MessageThread } from "./state/messageThread.js";
+import {
+  applyHandoffMarker,
+  finishHandoff,
+  handoffMarkerText,
+  handoffNotAloneMessage,
+  handoffResumeText,
+} from "./handoff.js";
+
+const toolCall = () => new smoltalk.ToolCall("call-1", "explorer", { question: "why" });
+
+describe("applyHandoffMarker", () => {
+  it("keeps the assistant's text, drops the tool call, appends the marker, keeps the label", () => {
+    const thread = new MessageThread();
+    thread.push(smoltalk.userMessage("hello"));
+    thread.push(
+      smoltalk.assistantMessage("I'll ask the explorer.", { toolCalls: [toolCall()] }),
+      "main",
+    );
+    const start = applyHandoffMarker(thread, "explorer", { question: "why" });
+    const last = thread.getMessages()[1];
+    expect(start).toBe(2);
+    expect(last.role).toBe("assistant");
+    expect(last.content).toBe(
+      `I'll ask the explorer.\n\n${handoffMarkerText("explorer", { question: "why" })}`,
+    );
+    expect(last.toJSON().toolCalls ?? []).toEqual([]);
+    expect(thread.labelAt(1)).toBe("main");
+  });
+
+  it("uses the marker alone when the assistant wrote no text", () => {
+    const thread = new MessageThread();
+    thread.push(smoltalk.userMessage("hello"));
+    thread.push(smoltalk.assistantMessage(null, { toolCalls: [toolCall()] }));
+    applyHandoffMarker(thread, "explorer", { question: "why" });
+    expect(thread.getMessages()[1].content).toBe(
+      handoffMarkerText("explorer", { question: "why" }),
+    );
+  });
+
+  it("refuses a thread that does not end on an assistant message", () => {
+    const thread = new MessageThread();
+    thread.push(smoltalk.userMessage("hello"));
+    expect(() => applyHandoffMarker(thread, "explorer", {})).toThrow(/assistant/);
+  });
+});
+
+describe("finishHandoff", () => {
+  it("removes system messages pushed since the start index and hands control back", () => {
+    const thread = new MessageThread();
+    thread.push(smoltalk.systemMessage("caller persona"));
+    thread.push(smoltalk.userMessage("hello"));
+    thread.push(smoltalk.assistantMessage(handoffMarkerText("explorer", {})));
+    const start = thread.getMessages().length;
+    thread.push(smoltalk.systemMessage("subagent persona"));
+    thread.push(smoltalk.userMessage("brief"));
+    thread.push(smoltalk.assistantMessage("the answer"));
+    finishHandoff(thread, start, "explorer", "the answer");
+    const roles = thread.getMessages().map((message) => message.role);
+    expect(roles).toEqual(["system", "user", "assistant", "user", "assistant", "user"]);
+    expect(thread.getMessages()[0].content).toBe("caller persona");
+    expect(thread.getMessages()[5].content).toBe(handoffResumeText("explorer", "the answer"));
+  });
+});
+
+describe("message text", () => {
+  it("names the tool in every message", () => {
+    expect(handoffNotAloneMessage("explorer")).toContain("explorer");
+    expect(handoffNotAloneMessage("explorer")).toContain("only tool call");
+    expect(handoffMarkerText("explorer", { q: 1 })).toBe('[dispatching explorer: {"q":1}]');
+    expect(handoffResumeText("explorer", "x")).toBe(
+      "[explorer finished. x]\nContinue with the user's request.",
+    );
+  });
+});

--- a/packages/agency-lang/lib/runtime/handoff.ts
+++ b/packages/agency-lang/lib/runtime/handoff.ts
@@ -1,0 +1,73 @@
+/**
+ * Message plumbing for handoff functions (`handoff def`). When a model
+ * calls one as a tool, the tool loop keeps the body on the caller's
+ * thread and replaces the tool-call bookkeeping with two plain messages:
+ * an assistant-role marker where the tool call was, and a user-role
+ * resume message when the body returns. See
+ * docs/dev/language/handoff-functions.md.
+ *
+ * These helpers only touch a MessageThread. Where they are called from,
+ * and why each call sits inside an idempotent step, is prompt.ts's
+ * business.
+ */
+import * as smoltalk from "smoltalk";
+import type { MessageThread } from "./state/messageThread.js";
+
+/** The refusal for a handoff call that shares a round with another call. */
+export function handoffNotAloneMessage(toolName: string): string {
+  return (
+    `Error: ${toolName} continues this conversation, so it must be the only tool call in its round. ` +
+    `It was not run. Call it again by itself, with no other tool calls in the same response.`
+  );
+}
+
+export function handoffMarkerText(toolName: string, args: Record<string, unknown>): string {
+  return `[dispatching ${toolName}: ${JSON.stringify(args)}]`;
+}
+
+export function handoffResumeText(toolName: string, body: string): string {
+  return `[${toolName} finished. ${body}]\nContinue with the user's request.`;
+}
+
+/**
+ * Rewrite the assistant message that carried the handoff tool call: keep
+ * its text, drop the tool call, append the marker. Returns the thread
+ * length afterwards, which is the index of the first message the body
+ * will push.
+ */
+export function applyHandoffMarker(
+  thread: MessageThread,
+  toolName: string,
+  args: Record<string, unknown>,
+): number {
+  const messages = thread.getMessages();
+  const index = messages.length - 1;
+  const last = messages[index];
+  if (last === undefined || last.role !== "assistant") {
+    throw new Error(
+      `handoff: expected the thread to end with the assistant message carrying the tool call, found ${last?.role ?? "an empty thread"}`,
+    );
+  }
+  const text = typeof last.content === "string" ? last.content.trim() : "";
+  const marker = handoffMarkerText(toolName, args);
+  const content = text === "" ? marker : `${text}\n\n${marker}`;
+  thread.replaceAt(index, smoltalk.assistantMessage(content));
+  return messages.length;
+}
+
+/**
+ * Close a handoff: remove the system messages the body pushed (its
+ * persona is not useful to the caller afterwards and would grow the
+ * context on every dispatch), then hand control back with a user-role
+ * message that carries the body's result. A system message has no
+ * partner to unpair, which is what makes removing it safe.
+ */
+export function finishHandoff(
+  thread: MessageThread,
+  startIndex: number,
+  toolName: string,
+  body: string,
+): void {
+  thread.removeMatching(startIndex, (message) => message.role === "system");
+  thread.push(smoltalk.userMessage(handoffResumeText(toolName, body)));
+}

--- a/packages/agency-lang/lib/runtime/handoff.ts
+++ b/packages/agency-lang/lib/runtime/handoff.ts
@@ -3,12 +3,9 @@
  * calls one as a tool, the tool loop keeps the body on the caller's
  * thread and replaces the tool-call bookkeeping with two plain messages:
  * an assistant-role marker where the tool call was, and a user-role
- * resume message when the body returns. See
+ * resume message when the body returns. These helpers only touch a
+ * MessageThread; prompt.ts decides when to call them. See
  * docs/dev/language/handoff-functions.md.
- *
- * These helpers only touch a MessageThread. Where they are called from,
- * and why each call sits inside an idempotent step, is prompt.ts's
- * business.
  */
 import * as smoltalk from "smoltalk";
 import type { MessageThread } from "./state/messageThread.js";

--- a/packages/agency-lang/lib/runtime/handoff.ts
+++ b/packages/agency-lang/lib/runtime/handoff.ts
@@ -28,15 +28,13 @@ export function handoffResumeText(toolName: string, body: string): string {
 
 /**
  * Rewrite the assistant message that carried the handoff tool call: keep
- * its text, drop the tool call, append the marker. Returns the thread
- * length afterwards, which is the index of the first message the body
- * will push.
+ * its text, drop the tool call, append the marker.
  */
 export function applyHandoffMarker(
   thread: MessageThread,
   toolName: string,
   args: Record<string, unknown>,
-): number {
+): void {
   const messages = thread.getMessages();
   const index = messages.length - 1;
   const last = messages[index];
@@ -49,22 +47,62 @@ export function applyHandoffMarker(
   const marker = handoffMarkerText(toolName, args);
   const content = text === "" ? marker : `${text}\n\n${marker}`;
   thread.replaceAt(index, smoltalk.assistantMessage(content));
-  return messages.length;
+}
+
+/** The index of this dispatch's marker, searching from the end so the
+ *  newest dispatch of a tool wins. -1 when memory compaction has
+ *  summarized the marker away. */
+function markerIndex(
+  thread: MessageThread,
+  toolName: string,
+  args: Record<string, unknown>,
+): number {
+  const marker = handoffMarkerText(toolName, args);
+  const messages = thread.getMessages();
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index];
+    if (
+      message.role === "assistant" &&
+      typeof message.content === "string" &&
+      message.content.endsWith(marker)
+    ) {
+      return index;
+    }
+  }
+  return -1;
 }
 
 /**
- * Close a handoff: remove the system messages the body pushed (its
- * persona is not useful to the caller afterwards and would grow the
- * context on every dispatch), then hand control back with a user-role
- * message that carries the body's result. A system message has no
- * partner to unpair, which is what makes removing it safe.
+ * Remove the system messages the body pushed: every system message after
+ * this dispatch's marker. Anchored on the marker rather than on a recorded
+ * position because memory compaction rewrites the thread and shifts every
+ * index. A marker that compaction summarized away took the body's earlier
+ * system messages with it, so there is nothing left to remove.
+ */
+export function stripHandoffSystemMessages(
+  thread: MessageThread,
+  toolName: string,
+  args: Record<string, unknown>,
+): void {
+  const index = markerIndex(thread, toolName, args);
+  if (index === -1) {
+    return;
+  }
+  thread.removeMatching(index + 1, (message) => message.role === "system");
+}
+
+/**
+ * Close a handoff: remove the body's system messages (its persona is not
+ * useful to the caller afterwards and would grow the context on every
+ * dispatch), then hand control back with a user-role message that carries
+ * the body's result.
  */
 export function finishHandoff(
   thread: MessageThread,
-  startIndex: number,
   toolName: string,
+  args: Record<string, unknown>,
   body: string,
 ): void {
-  thread.removeMatching(startIndex, (message) => message.role === "system");
+  stripHandoffSystemMessages(thread, toolName, args);
   thread.push(smoltalk.userMessage(handoffResumeText(toolName, body)));
 }

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -51,6 +51,7 @@ import { failure, isFailure, isSuccess, markDestructiveWork } from "./result.js"
 import type { SourceLocationOpts } from "./state/checkpointStore.js";
 import type { RuntimeContext } from "./state/context.js";
 import type { LlmDefaults } from "../stdlib/llm.js";
+import { applyHandoffMarker, finishHandoff, handoffNotAloneMessage } from "./handoff.js";
 import { MessageThread, type MessageThreadJSON } from "./state/messageThread.js";
 import { StateStack, claimFrameForScope } from "./state/stateStack.js";
 import { ThreadStore } from "./state/threadStore.js";
@@ -207,9 +208,49 @@ const REJECTION_REMOVAL_SUFFIX =
  *  verdict recomputed on resume could differ from the one the call
  *  originally acted on. */
 type GateVerdict =
-  "removed" | "unhandled" | "tooManyRounds" | "markup" | "priorRejected" | "repeated" | "proceed";
+  | "removed"
+  | "unhandled"
+  | "tooManyRounds"
+  | "handoffNotAlone"
+  | "markup"
+  | "priorRejected"
+  | "repeated"
+  | "proceed";
 
 type FailureTier = "destructive" | "neverStarted" | "idempotent" | "neutral";
+
+/**
+ * Run `invoke` in a copy of the current ALS frame whose `threads` slot is
+ * a fresh, empty ThreadStore. The tool body inherits the frame's `ctx`
+ * and `stack` (the branch's per-tool-call stack, set up by
+ * `runBatch.runInBranchAlsFrame`), which branch-aware cancellation and
+ * per-branch state depend on. The `threads` slot must NOT be inherited:
+ * if the body issues its own `llm()` call, that nested prompt would push
+ * messages into the OUTER prompt's MessageThread, whose last message is
+ * `assistant(tool_calls=[this tool])`, a shape OpenAI rejects with "An
+ * assistant message with 'tool_calls' must be followed by tool
+ * messages". So an ordinary tool invocation is a fresh conversation.
+ * (A handoff function is the exception; see runInvokeStep.)
+ *
+ * The store is bare, NOT `withDefaultActive`: the latter eagerly creates
+ * and logs a default thread on every tool call, so a leaf tool that never
+ * calls llm() (the common case) would emit a phantom `threadCreated
+ * thread #0` in the trace. `getOrCreateActive` creates and logs the
+ * default thread only if the body actually issues an llm()/userMessage()
+ * call.
+ */
+async function invokeOnFreshThreadStore<T>(
+  ctx: RuntimeContext<GraphState>,
+  invoke: () => Promise<T>,
+): Promise<T> {
+  const parentFrame = agencyStore.getStore();
+  if (!parentFrame) {
+    return invoke();
+  }
+  const freshThreads = new ThreadStore();
+  freshThreads.setStatelogClient(ctx.statelogClient);
+  return agencyStore.run({ ...parentFrame, threads: freshThreads }, invoke);
+}
 
 /** Classify a tool failure. Most-specific fact wins: a started destructive
  *  operation, then a proved-nothing-ran, then the tool's own idempotent
@@ -1068,49 +1109,37 @@ export async function runPrompt(args: {
       callKey: string;
       branchKey: string;
       branchStack: StateStack;
+      /** `round.<round>.tool.<slug>`, the key of this call's durable
+       *  records in runnerState (see promptRunner.md). */
+      invocationKey: string;
     }): Promise<{
       toolResult: any;
       invokeOutcome: "success" | "failed" | "rejected" | "interrupted" | "crashed";
       interrupts?: any[];
     }> => {
-      const { handler, toolCall, namedArgs, callKey, branchKey, branchStack } = args;
+      const { handler, toolCall, namedArgs, callKey, branchKey, branchStack, invocationKey } = args;
       let toolResult: any;
       ctx.enterToolCall();
       try {
-        // The tool body inherits the calling ALS frame's `ctx` and
-        // `stack` (the branch's per-tool-call stack, set up by
-        // `runBatch.runInBranchAlsFrame`) — those are correct for
-        // branch-aware cancellation and per-branch state. The
-        // `threads` slot, however, must NOT be inherited. If the tool
-        // body issues its own `llm()` call, that nested prompt would
-        // push messages into the OUTER prompt's MessageThread (whose
-        // last message is `assistant(tool_calls=[this tool])`),
-        // producing a thread shape OpenAI rejects with "An assistant
-        // message with 'tool_calls' must be followed by tool
-        // messages". A nested tool invocation is logically a fresh
-        // conversation, so install a fresh ThreadStore for the
-        // duration of this invoke. Pre-ALS, `setupFunction` produced
-        // the same outcome via its `state.threads || new ThreadStore()`
-        // fallback whenever a function was reached via tool dispatch.
-        const parentFrame = agencyStore.getStore();
-        // Lazy, NOT `withDefaultActive`: the latter eagerly creates and
-        // logs a default thread on every tool call, so a leaf tool that
-        // never calls llm() (the common case) emits a confusing phantom
-        // `threadCreated thread #0` in the trace. With a bare store the
-        // default thread is created + logged lazily by `getOrCreateActive`
-        // only if the tool body actually issues an llm()/userMessage()
-        // call — at which point the thread is real and worth logging.
-        const freshThreads = new ThreadStore();
-        freshThreads.setStatelogClient(ctx.statelogClient);
         const invokeAsTool = () =>
           handler.invoke({
             type: "named",
             positionalArgs: [],
             namedArgs,
           });
-        toolResult = parentFrame
-          ? await agencyStore.run({ ...parentFrame, threads: freshThreads }, invokeAsTool)
-          : await invokeAsTool();
+        // A handoff continues the caller's conversation. The branch frame
+        // already pointer-shares the caller's ThreadStore (pr.parallel
+        // passes shareThreads: true), and the .handoffMarker step rewrote
+        // the assistant message that carried this tool call, so nothing
+        // dangles: the body's llm() calls append to the caller's active
+        // thread. Every other tool gets a fresh store; see
+        // invokeOnFreshThreadStore for why.
+        const continuesCallerThread = !!handler.markers?.handoff;
+        if (continuesCallerThread) {
+          toolResult = await invokeAsTool();
+        } else {
+          toolResult = await invokeOnFreshThreadStore(ctx, invokeAsTool);
+        }
       } catch (error: unknown) {
         // A cancellation (user pressed Esc, race-loser, timeout) is not a
         // tool crash. Let it propagate so the turn unwinds cleanly —
@@ -1178,12 +1207,12 @@ export async function runPrompt(args: {
         if (removed) {
           removedTools.push(handler.name);
         }
-        messages.push(
-          smoltalk.toolMessage(
-            `Tool call rejected: ${capped}. ${removed ? REJECTION_REMOVAL_SUFFIX : REJECTION_SUFFIX}`,
-            { tool_call_id: toolCall.id, name: toolCall.name },
-          ),
-        );
+        pushToolReply({
+          content: `Tool call rejected: ${capped}. ${removed ? REJECTION_REMOVAL_SUFFIX : REJECTION_SUFFIX}`,
+          toolCall,
+          handler,
+          invocationKey,
+        });
         stack.deleteBranch(branchKey);
         return { toolResult, invokeOutcome: "rejected" };
       };
@@ -1212,12 +1241,12 @@ export async function runPrompt(args: {
         });
         const tier = failureTier(toolResult, handler.markers);
         const pushMessage = (suffix: string) => {
-          messages.push(
-            smoltalk.toolMessage(`Error: ${cappedError}. ${suffix}`, {
-              tool_call_id: toolCall.id,
-              name: toolCall.name,
-            }),
-          );
+          pushToolReply({
+            content: `Error: ${cappedError}. ${suffix}`,
+            toolCall,
+            handler,
+            invocationKey,
+          });
         };
         if (tier === "destructive") {
           pushMessage(TIER_SUFFIX.destructive);
@@ -1269,15 +1298,47 @@ export async function runPrompt(args: {
       // only CONSECUTIVE rejections remove it.
       rejectionCounts[handler.name] = 0;
       stack.setResultOnBranch(branchKey, toolResult);
-      pushSuccessToolMessage({ toolResult, toolCall, handler, branchStack });
+      pushSuccessToolMessage({ toolResult, toolCall, handler, branchStack, invocationKey });
       return { toolResult, invokeOutcome: "success" };
     };
 
     // Push a plain notice ToolMessage for one call — the refusal gates
-    // (unhandled, round cap, removed, markup, repeat, prior rejection) all
-    // answer the model this way.
+    // (unhandled, round cap, removed, markup, repeat, prior rejection,
+    // handoff not alone) all answer the model this way. A refusal happens
+    // before the .handoffMarker step, so the assistant message is intact
+    // and the notice pairs with its tool_use even for a handoff.
     const pushToolNotice = (text: string, toolCall: smoltalk.ToolCallJSON): void => {
       messages.push(smoltalk.toolMessage(text, { tool_call_id: toolCall.id, name: toolCall.name }));
+    };
+
+    // Answer the model for one invoked call. An ordinary tool gets a
+    // tool message paired with its tool_use. A handoff has no tool_use
+    // to pair with (the .handoffMarker step rewrote it), so it gets the
+    // user-role resume message instead, after the body's system
+    // messages are stripped. This is the ONE place that asks which of
+    // the two a call gets. `content` may be a structured value (an
+    // under-cap result passes through unstringified, and ToolMessage
+    // accepts it at runtime); the resume message needs text, so the
+    // handoff branch stringifies. The fallback start index strips
+    // nothing: a missing record must never reach back into the
+    // caller's own system prompt.
+    const pushToolReply = (args: {
+      content: any;
+      toolCall: smoltalk.ToolCallJSON;
+      handler: AgencyFunction;
+      invocationKey: string;
+    }): void => {
+      const { content, toolCall, handler, invocationKey } = args;
+      if (handler.markers?.handoff) {
+        const start: number =
+          self.runnerState.handoffStarts?.[invocationKey] ?? messages.getMessages().length;
+        const text = typeof content === "string" ? content : stringifyToolResult(content);
+        finishHandoff(messages, start, handler.name, text);
+        return;
+      }
+      messages.push(
+        smoltalk.toolMessage(content, { tool_call_id: toolCall.id, name: toolCall.name }),
+      );
     };
 
     // The refusal-gate decision for one call, in refusal-priority order.
@@ -1289,8 +1350,11 @@ export async function runPrompt(args: {
       handler: AgencyFunction | null;
       markupArg: string | null;
       callKey: string;
+      /** How many tool calls the model made this round, intrinsics
+       *  included. A handoff must be the round's only call. */
+      roundSize: number;
     }): GateVerdict => {
-      const { toolCall, handler, markupArg, callKey } = args;
+      const { toolCall, handler, markupArg, callKey, roundSize } = args;
       if (removedTools.includes(toolCall.name)) {
         return "removed";
       }
@@ -1299,6 +1363,13 @@ export async function runPrompt(args: {
       }
       if (self.toolCallRound >= effectiveMaxToolCallRounds) {
         return "tooManyRounds";
+      }
+      // A handoff rewrites the assistant message that carried its tool
+      // call. A sibling call in the same round still needs that message
+      // intact to pair its own tool result, so a mixed round refuses the
+      // handoff and lets the siblings run.
+      if (handler.markers?.handoff && roundSize > 1) {
+        return "handoffNotAlone";
       }
       if (markupArg !== null) {
         return "markup";
@@ -1332,6 +1403,8 @@ export async function runPrompt(args: {
           return `Error: Tool ${name} has been removed from this conversation after repeated failures or rejections, and will not be executed.`;
         case "unhandled":
           return `Error: No handler found for tool call ${name}`;
+        case "handoffNotAlone":
+          return handoffNotAloneMessage(name);
         case "tooManyRounds":
           return `Error: Maximum number of tool call rounds (${effectiveMaxToolCallRounds}) exceeded. This tool call will not be executed.`;
         case "markup":
@@ -1363,30 +1436,21 @@ export async function runPrompt(args: {
       toolCall: smoltalk.ToolCallJSON;
       handler: AgencyFunction;
       branchStack: StateStack;
+      invocationKey: string;
     }): void => {
-      const { toolResult, toolCall, handler, branchStack } = args;
+      const { toolResult, toolCall, handler, branchStack, invocationKey } = args;
       const replyMarker = harvestReplyAttachments({
         queued: branchStack.drainPendingReplyAttachments(),
         runnerState: self.runnerState,
         model: clientConfig.model,
         toolName: handler.name,
       });
-      messages.push(
-        smoltalk.toolMessage(
-          // `as any` mirrors the pre-existing call: capToolResultForLlm
-          // returns `any` (an under-cap structured result passes through
-          // unstringified) and ToolMessage accepts it at runtime.
-          appendReplyMarker(
-            capToolResultForLlm(unwrapToolResultForLlm(toolResult, handler.name), toolResultCap),
-            replyMarker,
-            stringifyToolResult,
-          ) as any,
-          {
-            tool_call_id: toolCall.id,
-            name: toolCall.name,
-          },
-        ),
+      const content = appendReplyMarker(
+        capToolResultForLlm(unwrapToolResultForLlm(toolResult, handler.name), toolResultCap),
+        replyMarker,
+        stringifyToolResult,
       );
+      pushToolReply({ content, toolCall, handler, invocationKey });
     };
 
     // Validation-retry outer loop: each iteration drains tool calls, then
@@ -1524,6 +1588,7 @@ export async function runPrompt(args: {
                   handler,
                   markupArg,
                   callKey,
+                  roundSize: toolCalls.length,
                 });
               });
               const verdict: GateVerdict = self.runnerState.gateVerdicts[invocationKey];
@@ -1561,6 +1626,33 @@ export async function runPrompt(args: {
               if (handler === null) {
                 // Unreachable: a missing handler yields the "unhandled" verdict.
                 return;
+              }
+
+              // A handoff replaces the assistant message that carried
+              // its tool call with a marker, and remembers where the
+              // body's messages will start so finishHandoff can strip
+              // the body's system messages later. Both are durable: the
+              // thread in a mid-handoff checkpoint already holds the
+              // rewritten message and the body's messages, so a resumed
+              // pass must neither rewrite again nor recompute the start.
+              //
+              // applyHandoffMarker requires the thread to end on that
+              // assistant message. It does here: the handoff is the
+              // round's only call (the handoffNotAlone gate), so no
+              // intrinsic ack or sibling result sits after it, and the
+              // round boundary that delivers attachments, queued
+              // messages, and guard feedback runs after the tools, not
+              // before. Anything new that pushes between the request
+              // step and this step would surface as a throw here.
+              if (handler.markers?.handoff) {
+                self.runnerState.handoffStarts ??= {};
+                await b.step(`${invocationKey}.handoffMarker`, async () => {
+                  self.runnerState.handoffStarts[invocationKey] = applyHandoffMarker(
+                    messages,
+                    handler.name,
+                    namedArgs,
+                  );
+                });
               }
 
               const branchKey = `tool_${callSlug}`;
@@ -1631,6 +1723,7 @@ export async function runPrompt(args: {
                     callKey,
                     branchKey,
                     branchStack,
+                    invocationKey,
                   });
                   toolResult = outcome.toolResult;
                   invokeOutcome = outcome.invokeOutcome;

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -221,23 +221,16 @@ type FailureTier = "destructive" | "neverStarted" | "idempotent" | "neutral";
 
 /**
  * Run `invoke` in a copy of the current ALS frame whose `threads` slot is
- * a fresh, empty ThreadStore. The tool body inherits the frame's `ctx`
- * and `stack` (the branch's per-tool-call stack, set up by
- * `runBatch.runInBranchAlsFrame`), which branch-aware cancellation and
- * per-branch state depend on. The `threads` slot must NOT be inherited:
- * if the body issues its own `llm()` call, that nested prompt would push
- * messages into the OUTER prompt's MessageThread, whose last message is
- * `assistant(tool_calls=[this tool])`, a shape OpenAI rejects with "An
- * assistant message with 'tool_calls' must be followed by tool
- * messages". So an ordinary tool invocation is a fresh conversation.
- * (A handoff function is the exception; see runInvokeStep.)
+ * a fresh, empty ThreadStore. The body keeps the frame's `ctx` and
+ * `stack`, which branch-aware cancellation and per-branch state depend
+ * on. It must not keep `threads`: an `llm()` call in the body would push
+ * onto the outer prompt's thread, whose last message is the assistant's
+ * tool call, a shape OpenAI rejects ("An assistant message with
+ * 'tool_calls' must be followed by tool messages"). A handoff function is
+ * the exception; see runInvokeStep.
  *
- * The store is bare, NOT `withDefaultActive`: the latter eagerly creates
- * and logs a default thread on every tool call, so a leaf tool that never
- * calls llm() (the common case) would emit a phantom `threadCreated
- * thread #0` in the trace. `getOrCreateActive` creates and logs the
- * default thread only if the body actually issues an llm()/userMessage()
- * call.
+ * The store is bare, not `withDefaultActive`, so a leaf tool that never
+ * calls llm() does not log a phantom default thread.
  */
 async function invokeOnFreshThreadStore<T>(
   ctx: RuntimeContext<GraphState>,
@@ -1127,16 +1120,15 @@ export async function runPrompt(args: {
             positionalArgs: [],
             namedArgs,
           });
-        // A handoff continues the caller's conversation. The branch frame
-        // already pointer-shares the caller's ThreadStore (pr.parallel
-        // passes shareThreads: true), and the .handoffMarker step rewrote
-        // the assistant message that carried this tool call, so nothing
-        // dangles: the body's llm() calls append to the caller's active
-        // thread. Every other tool gets a fresh store; see
-        // invokeOnFreshThreadStore for why.
+        // A handoff continues this prompt's conversation: the body's llm()
+        // calls append to `messages`, the thread that carries the marker.
+        // That is usually the active thread, but an async prompt runs on a
+        // subthread and explicit `messages` are not in the store at all,
+        // so bind the body to `messages` rather than to whatever is active.
+        // Every other tool gets a fresh store.
         const continuesCallerThread = !!handler.markers?.handoff;
         if (continuesCallerThread) {
-          toolResult = await invokeAsTool();
+          toolResult = await getRuntimeContext().threads.withActive(messages, invokeAsTool);
         } else {
           toolResult = await invokeOnFreshThreadStore(ctx, invokeAsTool);
         }
@@ -1313,15 +1305,11 @@ export async function runPrompt(args: {
 
     // Answer the model for one invoked call. An ordinary tool gets a
     // tool message paired with its tool_use. A handoff has no tool_use
-    // to pair with (the .handoffMarker step rewrote it), so it gets the
-    // user-role resume message instead, after the body's system
-    // messages are stripped. This is the ONE place that asks which of
-    // the two a call gets. `content` may be a structured value (an
-    // under-cap result passes through unstringified, and ToolMessage
-    // accepts it at runtime); the resume message needs text, so the
-    // handoff branch stringifies. The fallback start index strips
-    // nothing: a missing record must never reach back into the
-    // caller's own system prompt.
+    // (the .handoffMarker step rewrote it), so it gets the user-role
+    // resume message instead, after the body's system messages are
+    // stripped. `content` may be structured; the resume message needs
+    // text. A missing start index strips nothing rather than reaching
+    // back into the caller's own system prompt.
     const pushToolReply = (args: {
       content: any;
       toolCall: smoltalk.ToolCallJSON;
@@ -1629,21 +1617,13 @@ export async function runPrompt(args: {
               }
 
               // A handoff replaces the assistant message that carried
-              // its tool call with a marker, and remembers where the
-              // body's messages will start so finishHandoff can strip
-              // the body's system messages later. Both are durable: the
-              // thread in a mid-handoff checkpoint already holds the
-              // rewritten message and the body's messages, so a resumed
-              // pass must neither rewrite again nor recompute the start.
-              //
-              // applyHandoffMarker requires the thread to end on that
-              // assistant message. It does here: the handoff is the
-              // round's only call (the handoffNotAlone gate), so no
-              // intrinsic ack or sibling result sits after it, and the
-              // round boundary that delivers attachments, queued
-              // messages, and guard feedback runs after the tools, not
-              // before. Anything new that pushes between the request
-              // step and this step would surface as a throw here.
+              // its tool call with a marker and records where the body's
+              // messages start, so finishHandoff can strip the body's
+              // system messages. Both live in the checkpoint, so a
+              // resumed pass neither rewrites again nor recomputes the
+              // start. The thread ends on that assistant message here
+              // because the handoff is the round's only call and the
+              // round boundary runs after the tools.
               if (handler.markers?.handoff) {
                 self.runnerState.handoffStarts ??= {};
                 await b.step(`${invocationKey}.handoffMarker`, async () => {

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -51,7 +51,12 @@ import { failure, isFailure, isSuccess, markDestructiveWork } from "./result.js"
 import type { SourceLocationOpts } from "./state/checkpointStore.js";
 import type { RuntimeContext } from "./state/context.js";
 import type { LlmDefaults } from "../stdlib/llm.js";
-import { applyHandoffMarker, finishHandoff, handoffNotAloneMessage } from "./handoff.js";
+import {
+  applyHandoffMarker,
+  finishHandoff,
+  handoffNotAloneMessage,
+  stripHandoffSystemMessages,
+} from "./handoff.js";
 import { MessageThread, type MessageThreadJSON } from "./state/messageThread.js";
 import { StateStack, claimFrameForScope } from "./state/stateStack.js";
 import { ThreadStore } from "./state/threadStore.js";
@@ -243,6 +248,21 @@ async function invokeOnFreshThreadStore<T>(
   const freshThreads = new ThreadStore();
   freshThreads.setStatelogClient(ctx.statelogClient);
   return agencyStore.run({ ...parentFrame, threads: freshThreads }, invoke);
+}
+
+/**
+ * Run `invoke` in a copy of the current ALS frame whose `threads` slot is
+ * a view of the caller's store with `thread` active. The view has its own
+ * active stack, so two prompts running at once (two `async llm()` calls,
+ * say) cannot interleave pushes and pops on a shared one.
+ */
+async function invokeOnThread<T>(thread: MessageThread, invoke: () => Promise<T>): Promise<T> {
+  const parentFrame = agencyStore.getStore();
+  if (!parentFrame) {
+    return invoke();
+  }
+  const view = parentFrame.threads.viewWithActive(thread);
+  return agencyStore.run({ ...parentFrame, threads: view }, invoke);
 }
 
 /** Classify a tool failure. Most-specific fact wins: a started destructive
@@ -1102,15 +1122,12 @@ export async function runPrompt(args: {
       callKey: string;
       branchKey: string;
       branchStack: StateStack;
-      /** `round.<round>.tool.<slug>`, the key of this call's durable
-       *  records in runnerState (see promptRunner.md). */
-      invocationKey: string;
     }): Promise<{
       toolResult: any;
       invokeOutcome: "success" | "failed" | "rejected" | "interrupted" | "crashed";
       interrupts?: any[];
     }> => {
-      const { handler, toolCall, namedArgs, callKey, branchKey, branchStack, invocationKey } = args;
+      const { handler, toolCall, namedArgs, callKey, branchKey, branchStack } = args;
       let toolResult: any;
       ctx.enterToolCall();
       try {
@@ -1128,7 +1145,7 @@ export async function runPrompt(args: {
         // Every other tool gets a fresh store.
         const continuesCallerThread = !!handler.markers?.handoff;
         if (continuesCallerThread) {
-          toolResult = await getRuntimeContext().threads.withActive(messages, invokeAsTool);
+          toolResult = await invokeOnThread(messages, invokeAsTool);
         } else {
           toolResult = await invokeOnFreshThreadStore(ctx, invokeAsTool);
         }
@@ -1138,8 +1155,14 @@ export async function runPrompt(args: {
         // logging it as an error and feeding a bogus failure message back
         // to the model (as the crash path below does) would both spam
         // "Tool call X crashed" for every tool on the stack and corrupt
-        // the thread. Mirrors the function/node catch re-throws.
+        // the thread. Mirrors the function/node catch re-throws. A
+        // cancelled handoff never reaches finishHandoff, so its body's
+        // system messages are removed here; the marker stays as the
+        // record of what was attempted.
         if (isAbortError(error)) {
+          if (handler.markers?.handoff) {
+            stripHandoffSystemMessages(messages, handler.name, namedArgs);
+          }
           stack.deleteBranch(branchKey);
           throw error;
         }
@@ -1203,7 +1226,7 @@ export async function runPrompt(args: {
           content: `Tool call rejected: ${capped}. ${removed ? REJECTION_REMOVAL_SUFFIX : REJECTION_SUFFIX}`,
           toolCall,
           handler,
-          invocationKey,
+          namedArgs,
         });
         stack.deleteBranch(branchKey);
         return { toolResult, invokeOutcome: "rejected" };
@@ -1237,7 +1260,7 @@ export async function runPrompt(args: {
             content: `Error: ${cappedError}. ${suffix}`,
             toolCall,
             handler,
-            invocationKey,
+            namedArgs,
           });
         };
         if (tier === "destructive") {
@@ -1290,7 +1313,7 @@ export async function runPrompt(args: {
       // only CONSECUTIVE rejections remove it.
       rejectionCounts[handler.name] = 0;
       stack.setResultOnBranch(branchKey, toolResult);
-      pushSuccessToolMessage({ toolResult, toolCall, handler, branchStack, invocationKey });
+      pushSuccessToolMessage({ toolResult, toolCall, handler, branchStack, namedArgs });
       return { toolResult, invokeOutcome: "success" };
     };
 
@@ -1299,8 +1322,13 @@ export async function runPrompt(args: {
     // handoff not alone) all answer the model this way. A refusal happens
     // before the .handoffMarker step, so the assistant message is intact
     // and the notice pairs with its tool_use even for a handoff.
+    const pushToolMessage = (content: any, toolCall: smoltalk.ToolCallJSON): void => {
+      messages.push(
+        smoltalk.toolMessage(content, { tool_call_id: toolCall.id, name: toolCall.name }),
+      );
+    };
     const pushToolNotice = (text: string, toolCall: smoltalk.ToolCallJSON): void => {
-      messages.push(smoltalk.toolMessage(text, { tool_call_id: toolCall.id, name: toolCall.name }));
+      pushToolMessage(text, toolCall);
     };
 
     // Answer the model for one invoked call. An ordinary tool gets a
@@ -1308,25 +1336,19 @@ export async function runPrompt(args: {
     // (the .handoffMarker step rewrote it), so it gets the user-role
     // resume message instead, after the body's system messages are
     // stripped. `content` may be structured; the resume message needs
-    // text. A missing start index strips nothing rather than reaching
-    // back into the caller's own system prompt.
+    // text.
     const pushToolReply = (args: {
       content: any;
       toolCall: smoltalk.ToolCallJSON;
       handler: AgencyFunction;
-      invocationKey: string;
+      namedArgs: Record<string, any>;
     }): void => {
-      const { content, toolCall, handler, invocationKey } = args;
+      const { content, toolCall, handler, namedArgs } = args;
       if (handler.markers?.handoff) {
-        const start: number =
-          self.runnerState.handoffStarts?.[invocationKey] ?? messages.getMessages().length;
-        const text = typeof content === "string" ? content : stringifyToolResult(content);
-        finishHandoff(messages, start, handler.name, text);
+        finishHandoff(messages, handler.name, namedArgs, stringifyToolResult(content));
         return;
       }
-      messages.push(
-        smoltalk.toolMessage(content, { tool_call_id: toolCall.id, name: toolCall.name }),
-      );
+      pushToolMessage(content, toolCall);
     };
 
     // The refusal-gate decision for one call, in refusal-priority order.
@@ -1424,9 +1446,9 @@ export async function runPrompt(args: {
       toolCall: smoltalk.ToolCallJSON;
       handler: AgencyFunction;
       branchStack: StateStack;
-      invocationKey: string;
+      namedArgs: Record<string, any>;
     }): void => {
-      const { toolResult, toolCall, handler, branchStack, invocationKey } = args;
+      const { toolResult, toolCall, handler, branchStack, namedArgs } = args;
       const replyMarker = harvestReplyAttachments({
         queued: branchStack.drainPendingReplyAttachments(),
         runnerState: self.runnerState,
@@ -1438,7 +1460,7 @@ export async function runPrompt(args: {
         replyMarker,
         stringifyToolResult,
       );
-      pushToolReply({ content, toolCall, handler, invocationKey });
+      pushToolReply({ content, toolCall, handler, namedArgs });
     };
 
     // Validation-retry outer loop: each iteration drains tool calls, then
@@ -1617,21 +1639,14 @@ export async function runPrompt(args: {
               }
 
               // A handoff replaces the assistant message that carried
-              // its tool call with a marker and records where the body's
-              // messages start, so finishHandoff can strip the body's
-              // system messages. Both live in the checkpoint, so a
-              // resumed pass neither rewrites again nor recomputes the
-              // start. The thread ends on that assistant message here
-              // because the handoff is the round's only call and the
-              // round boundary runs after the tools.
+              // its tool call with a marker. The rewritten thread is in
+              // the checkpoint, so a resumed pass does not rewrite again.
+              // The thread ends on that assistant message here because
+              // the handoff is the round's only call and the round
+              // boundary runs after the tools.
               if (handler.markers?.handoff) {
-                self.runnerState.handoffStarts ??= {};
                 await b.step(`${invocationKey}.handoffMarker`, async () => {
-                  self.runnerState.handoffStarts[invocationKey] = applyHandoffMarker(
-                    messages,
-                    handler.name,
-                    namedArgs,
-                  );
+                  applyHandoffMarker(messages, handler.name, namedArgs);
                 });
               }
 
@@ -1703,7 +1718,6 @@ export async function runPrompt(args: {
                     callKey,
                     branchKey,
                     branchStack,
-                    invocationKey,
                   });
                   toolResult = outcome.toolResult;
                   invokeOutcome = outcome.invokeOutcome;

--- a/packages/agency-lang/lib/runtime/state/messageThread.test.ts
+++ b/packages/agency-lang/lib/runtime/state/messageThread.test.ts
@@ -315,3 +315,38 @@ describe("repair generation — markRepaired / isNewerThan", () => {
     expect(live.isNewerThan(snapshot)).toBe(false); // snapshot post-repair → fine
   });
 });
+
+describe("MessageThread.replaceAt", () => {
+  it("swaps the message and keeps its label", () => {
+    const thread = new MessageThread();
+    thread.push(smoltalk.userMessage("q"), "ask");
+    thread.push(smoltalk.assistantMessage("a"), "answer");
+    thread.replaceAt(1, smoltalk.assistantMessage("b"));
+    expect(thread.getMessages().map((message) => message.content)).toEqual(["q", "b"]);
+    expect(thread.labelAt(1)).toBe("answer");
+  });
+
+  it("refuses an index outside the thread", () => {
+    const thread = new MessageThread();
+    thread.push(smoltalk.userMessage("q"));
+    expect(() => thread.replaceAt(1, smoltalk.userMessage("x"))).toThrow();
+  });
+});
+
+describe("MessageThread.removeMatching", () => {
+  it("removes matching messages from the index on and keeps the other labels", () => {
+    const thread = new MessageThread();
+    thread.push(smoltalk.systemMessage("keep: before the index"), "s0");
+    thread.push(smoltalk.userMessage("u1"), "u1");
+    thread.push(smoltalk.systemMessage("drop"), "s1");
+    thread.push(smoltalk.assistantMessage("a1"), "a1");
+    thread.push(smoltalk.systemMessage("drop too"), "s2");
+    thread.removeMatching(1, (message) => message.role === "system");
+    expect(thread.getMessages().map((message) => message.content)).toEqual([
+      "keep: before the index",
+      "u1",
+      "a1",
+    ]);
+    expect([0, 1, 2].map((index) => thread.labelAt(index))).toEqual(["s0", "u1", "a1"]);
+  });
+});

--- a/packages/agency-lang/lib/runtime/state/messageThread.test.ts
+++ b/packages/agency-lang/lib/runtime/state/messageThread.test.ts
@@ -330,6 +330,8 @@ describe("MessageThread.replaceAt", () => {
     const thread = new MessageThread();
     thread.push(smoltalk.userMessage("q"));
     expect(() => thread.replaceAt(1, smoltalk.userMessage("x"))).toThrow();
+    expect(() => thread.replaceAt(-1, smoltalk.userMessage("x"))).toThrow();
+    expect(thread.getMessages().map((message) => message.content)).toEqual(["q"]);
   });
 });
 

--- a/packages/agency-lang/lib/runtime/state/messageThread.ts
+++ b/packages/agency-lang/lib/runtime/state/messageThread.ts
@@ -82,7 +82,8 @@ export class MessageThread {
    *  instead of a reason to reach past them:
    *
    *  - `push` — the only append.
-   *  - `removeAt` — the only removal.
+   *  - `removeAt` and `removeMatching` — the only removals.
+   *  - `replaceAt` — the only in-place swap.
    *  - `adoptFrom` — take on another thread's messages and labels.
    *  - the constructor and `setMessages` — the only replacements.
    *
@@ -144,6 +145,26 @@ export class MessageThread {
   removeAt(index: number): void {
     this.messages.splice(index, 1);
     this.messageLabels.splice(index, 1);
+  }
+
+  /** Swap the message at `index` for `message`, keeping its label. For an
+   *  edit of ONE message that must not reset the labels of the others. */
+  replaceAt(index: number, message: smoltalk.Message): void {
+    if (index < 0 || index >= this.messages.length) {
+      throw new Error(`replaceAt: index ${index} is outside a thread of ${this.messages.length}`);
+    }
+    this.messages[index] = message;
+  }
+
+  /** Remove every message at or after `fromIndex` that `matches`, taking
+   *  labels with them. Walks backwards so each removal leaves the indexes
+   *  still to visit untouched. */
+  removeMatching(fromIndex: number, matches: (message: smoltalk.Message) => boolean): void {
+    for (let index = this.messages.length - 1; index >= fromIndex; index--) {
+      if (matches(this.messages[index])) {
+        this.removeAt(index);
+      }
+    }
   }
 
   /** Take on `other`'s messages AND labels while keeping this thread's

--- a/packages/agency-lang/lib/runtime/state/threadStore.test.ts
+++ b/packages/agency-lang/lib/runtime/state/threadStore.test.ts
@@ -111,50 +111,34 @@ describe("ThreadStore.openSession", () => {
   });
 });
 
-describe("ThreadStore.withActive", () => {
-  it("runs the body with a registered thread active and restores the previous one", async () => {
+describe("ThreadStore.viewWithActive", () => {
+  it("makes the thread active in the view and leaves the store's own stack alone", () => {
     const store = new ThreadStore();
     const main = store.getOrCreateActive();
     const side = store.createAndReturnSubthread();
-    expect(store.active()).toBe(main);
-    let seen: MessageThread | undefined;
-    await store.withActive(side, async () => {
-      seen = store.active();
-    });
-    expect(seen).toBe(side);
+    const view = store.viewWithActive(side);
+    expect(view.active()).toBe(side);
     expect(store.active()).toBe(main);
   });
 
-  it("registers a thread the store has never seen, and pops it afterwards", async () => {
+  it("registers a thread the store has never seen, in the shared registry", () => {
     const store = new ThreadStore();
-    const main = store.getOrCreateActive();
+    store.getOrCreateActive();
     const foreign = new MessageThread();
-    await store.withActive(foreign, async () => {
-      expect(store.active()).toBe(foreign);
-    });
-    expect(store.active()).toBe(main);
+    const view = store.viewWithActive(foreign);
+    expect(view.active()).toBe(foreign);
     expect(Object.values(store.threads)).toContain(foreign);
   });
 
-  it("pushes nothing when the thread is already active", async () => {
+  it("gives two callers independent active stacks over one registry", () => {
     const store = new ThreadStore();
-    const main = store.getOrCreateActive();
-    const depth = store.activeStack.length;
-    await store.withActive(main, async () => {
-      expect(store.activeStack.length).toBe(depth);
-    });
-    expect(store.active()).toBe(main);
-  });
-
-  it("restores the previous thread when the body throws", async () => {
-    const store = new ThreadStore();
-    const main = store.getOrCreateActive();
-    const side = store.createAndReturnSubthread();
-    await expect(
-      store.withActive(side, async () => {
-        throw new Error("boom");
-      }),
-    ).rejects.toThrow("boom");
-    expect(store.active()).toBe(main);
+    store.getOrCreateActive();
+    const first = store.createAndReturnSubthread();
+    const second = store.createAndReturnSubthread();
+    const viewA = store.viewWithActive(first);
+    const viewB = store.viewWithActive(second);
+    viewA.pushActive(viewA.createSubthread());
+    expect(viewB.active()).toBe(second);
+    expect(Object.keys(viewA.threads)).toEqual(Object.keys(viewB.threads));
   });
 });

--- a/packages/agency-lang/lib/runtime/state/threadStore.test.ts
+++ b/packages/agency-lang/lib/runtime/state/threadStore.test.ts
@@ -110,3 +110,51 @@ describe("ThreadStore.openSession", () => {
     expect(restored.sessions.coding).toBe(store.sessions.coding);
   });
 });
+
+describe("ThreadStore.withActive", () => {
+  it("runs the body with a registered thread active and restores the previous one", async () => {
+    const store = new ThreadStore();
+    const main = store.getOrCreateActive();
+    const side = store.createAndReturnSubthread();
+    expect(store.active()).toBe(main);
+    let seen: MessageThread | undefined;
+    await store.withActive(side, async () => {
+      seen = store.active();
+    });
+    expect(seen).toBe(side);
+    expect(store.active()).toBe(main);
+  });
+
+  it("registers a thread the store has never seen, and pops it afterwards", async () => {
+    const store = new ThreadStore();
+    const main = store.getOrCreateActive();
+    const foreign = new MessageThread();
+    await store.withActive(foreign, async () => {
+      expect(store.active()).toBe(foreign);
+    });
+    expect(store.active()).toBe(main);
+    expect(Object.values(store.threads)).toContain(foreign);
+  });
+
+  it("pushes nothing when the thread is already active", async () => {
+    const store = new ThreadStore();
+    const main = store.getOrCreateActive();
+    const depth = store.activeStack.length;
+    await store.withActive(main, async () => {
+      expect(store.activeStack.length).toBe(depth);
+    });
+    expect(store.active()).toBe(main);
+  });
+
+  it("restores the previous thread when the body throws", async () => {
+    const store = new ThreadStore();
+    const main = store.getOrCreateActive();
+    const side = store.createAndReturnSubthread();
+    await expect(
+      store.withActive(side, async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+    expect(store.active()).toBe(main);
+  });
+});

--- a/packages/agency-lang/lib/runtime/state/threadStore.ts
+++ b/packages/agency-lang/lib/runtime/state/threadStore.ts
@@ -273,6 +273,34 @@ export class ThreadStore {
     return id !== undefined ? this.threads[id] : undefined;
   }
 
+  /** Run `body` with `thread` active, then restore the previous active
+   *  thread. A thread this store does not know (one built from explicit
+   *  `messages`) is registered first. Nothing is pushed when `thread` is
+   *  already active, so a resumed call that re-enters here stays
+   *  balanced. */
+  async withActive<T>(thread: MessageThread, body: () => Promise<T>): Promise<T> {
+    if (this.active() === thread) {
+      return body();
+    }
+    const id = this.idOf(thread) ?? this.register(thread);
+    this.pushActive(id);
+    try {
+      return await body();
+    } finally {
+      this.popActive();
+    }
+  }
+
+  private idOf(thread: MessageThread): MessageThreadID | undefined {
+    return Object.keys(this.threads).find((id) => this.threads[id] === thread);
+  }
+
+  private register(thread: MessageThread): MessageThreadID {
+    const id = (this.counter++).toString();
+    this.threads[id] = thread;
+    return id;
+  }
+
   // Get the active thread, or create a new one, push it active, and return it.
   getOrCreateActive(): MessageThread {
     const existing = this.active();

--- a/packages/agency-lang/lib/runtime/state/threadStore.ts
+++ b/packages/agency-lang/lib/runtime/state/threadStore.ts
@@ -273,22 +273,13 @@ export class ThreadStore {
     return id !== undefined ? this.threads[id] : undefined;
   }
 
-  /** Run `body` with `thread` active, then restore the previous active
-   *  thread. A thread this store does not know (one built from explicit
-   *  `messages`) is registered first. Nothing is pushed when `thread` is
-   *  already active, so a resumed call that re-enters here stays
-   *  balanced. */
-  async withActive<T>(thread: MessageThread, body: () => Promise<T>): Promise<T> {
-    if (this.active() === thread) {
-      return body();
-    }
+  /** A view of this store, sharing the registry, whose active thread is
+   *  `thread`. A thread this store does not know (one built from explicit
+   *  `messages`) is registered first. The view has its own active stack,
+   *  so concurrent callers never push and pop on each other. */
+  viewWithActive(thread: MessageThread): ThreadStore {
     const id = this.idOf(thread) ?? this.register(thread);
-    this.pushActive(id);
-    try {
-      return await body();
-    } finally {
-      this.popActive();
-    }
+    return this.restoreBranchView([id]);
   }
 
   private idOf(thread: MessageThread): MessageThreadID | undefined {

--- a/packages/agency-lang/lib/stdlib/agency.ts
+++ b/packages/agency-lang/lib/stdlib/agency.ts
@@ -217,6 +217,7 @@ export type ExportInfo = {
   effects: string[];
   destructive: boolean;
   idempotent: boolean;
+  handoff: boolean;
   /** The module path this export was re-exported from, else null. */
   reexportedFrom: string | null;
 };
@@ -338,6 +339,7 @@ function localExportInfos(
         effects: effects[name] ?? [],
         destructive: node.markers?.destructive === true,
         idempotent: node.markers?.idempotent === true,
+        handoff: node.markers?.handoff === true,
         reexportedFrom: null,
       },
     ];
@@ -356,6 +358,7 @@ function localExportInfos(
         // destructive or idempotent.
         destructive: false,
         idempotent: false,
+        handoff: false,
         reexportedFrom: null,
       },
     ];
@@ -371,6 +374,7 @@ function localExportInfos(
         effects: [],
         destructive: false,
         idempotent: false,
+        handoff: false,
         reexportedFrom: null,
       },
     ];
@@ -392,6 +396,7 @@ function localExportInfos(
         effects: [],
         destructive: false,
         idempotent: false,
+        handoff: false,
         reexportedFrom: null,
       }));
   }
@@ -477,6 +482,8 @@ function resolveNamedReExports(
         // Re-export sites may add tool markers the source did not have.
         destructive: base.destructive || (body.destructiveNames ?? []).includes(sourceName),
         idempotent: base.idempotent || (body.idempotentNames ?? []).includes(sourceName),
+        // A re-export cannot add handoff; it comes only from the def.
+        handoff: base.handoff,
       },
     ];
   });
@@ -500,6 +507,7 @@ function thinReExport(sourceName: string, localName: string, from: string): Expo
     effects: ["unknown"],
     destructive: false,
     idempotent: false,
+    handoff: false,
     reexportedFrom: from,
   };
 }

--- a/packages/agency-lang/lib/stdlib/thread.ts
+++ b/packages/agency-lang/lib/stdlib/thread.ts
@@ -300,6 +300,19 @@ export async function _threadIsNew(): Promise<boolean> {
   return threads.get(activeId).messages.length === 0;
 }
 
+/** True when the active thread already holds a system message with
+ *  exactly this content. Reads the messages in place; nothing is copied. */
+export async function _threadHasSystemMessage(content: string): Promise<boolean> {
+  const { threads } = getRuntimeContext();
+  const active = threads.active();
+  if (active === undefined) {
+    return false;
+  }
+  return active.messages.some(
+    (message) => message.role === "system" && message.content === content,
+  );
+}
+
 export type ModelCost = ModelUsage;
 
 /**

--- a/packages/agency-lang/lib/types/function.ts
+++ b/packages/agency-lang/lib/types/function.ts
@@ -46,17 +46,37 @@ export const VALID_CALLBACK_NAMES = [
 
 export type CallbackName = (typeof VALID_CALLBACK_NAMES)[number];
 
-/** Per-function retry-safety markers. Carried as one object from the AST
- *  through the symbol table and registries so adding a marker is a
- *  one-field change, not a parallel-boolean mirror pass across many files.
- *  Each field is present only when true. */
+/** The keywords that set a marker on a `def`, in the order the formatter
+ *  prints them. The parser accepts them in any order. */
+export const FUNCTION_MARKER_KEYWORDS = ["destructive", "idempotent", "handoff"] as const;
+export type FunctionMarkerKeyword = (typeof FUNCTION_MARKER_KEYWORDS)[number];
+
+/** Per-function markers. Carried as one object from the AST through the
+ *  symbol table and registries so adding a marker is a one-word change to
+ *  FUNCTION_MARKER_KEYWORDS plus a field here. Each field is present only
+ *  when true. */
 export type FunctionMarkers = {
   /** Re-running (or re-calling after a failure that started executing) may
    *  cause harm — the tool loop removes the tool if this ran. */
   destructive?: boolean;
   /** Re-calling with the same arguments has no additional effect. */
   idempotent?: boolean;
+  /** Called as a tool, the function continues the caller's conversation:
+   *  it runs on the caller's message thread and its tool-call bookkeeping
+   *  is replaced by a marker and a resume message. See
+   *  docs/dev/language/handoff-functions.md. */
+  handoff?: boolean;
 };
+
+/** The keywords set on `markers`, in print order. */
+export function markerKeywordsOf(markers: FunctionMarkers | undefined): FunctionMarkerKeyword[] {
+  return FUNCTION_MARKER_KEYWORDS.filter((keyword) => markers?.[keyword] === true);
+}
+
+/** A markers object with exactly `keywords` set. */
+export function markersFromKeywords(keywords: readonly FunctionMarkerKeyword[]): FunctionMarkers {
+  return Object.fromEntries(keywords.map((keyword) => [keyword, true]));
+}
 
 export type FunctionDefinition = BaseNode & {
   type: "function";

--- a/packages/agency-lang/stdlib/agency.agency
+++ b/packages/agency-lang/stdlib/agency.agency
@@ -701,6 +701,7 @@ export type ExportInfo = {
   effects: string[];
   destructive: boolean;
   idempotent: boolean;
+  handoff: boolean;
   reexportedFrom: string | null
 }
 
@@ -716,7 +717,7 @@ exports (lowering targets, not caller surface). `description` is the
 module doc comment's one-line summary. */
 export idempotent def describe(source: string): Result<ModuleInfo> {
   """
-  Describe what an Agency module exports: each exported function, node, type, const, and re-export, in source order, with its signature, docstring, transitive effect list, and destructive/idempotent markers. Anything marked @hidden is left out, as is anything whose name starts with an underscore - both are the same visibility rule `agency doc` applies, so this is the module surface a reader sees. Re-exports from std:: modules resolve to full entries; re-exports from relative paths cannot be read from a source string and come back with effects ["unknown"]. Use this instead of reading source when generating code shaped by a module - for example, one handler per effect its tools can raise.
+  Describe what an Agency module exports: each exported function, node, type, const, and re-export, in source order, with its signature, docstring, transitive effect list, and destructive/idempotent/handoff markers. Anything marked @hidden is left out, as is anything whose name starts with an underscore - both are the same visibility rule `agency doc` applies, so this is the module surface a reader sees. Re-exports from std:: modules resolve to full entries; re-exports from relative paths cannot be read from a source string and come back with effects ["unknown"]. Use this instead of reading source when generating code shaped by a module - for example, one handler per effect its tools can raise.
 
   @param source - Agency source code as a string
   """

--- a/packages/agency-lang/stdlib/agents/explorer.agency
+++ b/packages/agency-lang/stdlib/agents/explorer.agency
@@ -146,6 +146,9 @@ def survey(
   )
 }
 
+/** Called from code, this runs on the caller's thread like any function:
+ *  the system prompt, the reads, and the answer stay there. Wrap the call
+ *  in `thread { ... }` for an isolated survey. */
 export handoff def explorerAgent(
   question: string,
   context: string = "",
@@ -161,14 +164,9 @@ export handoff def explorerAgent(
   many files. Reads widely before synthesizing, and cites what it read. It
   never changes anything.
 
-  Called as a tool, the explorer continues your conversation: it sees
-  everything said so far, and every file it reads stays in your history
-  when it hands back. Say how much ground to cover; the reads are yours to
-  keep afterwards, so scope the question.
-
-  Called from code, it runs on your current thread like any function, and
-  its system prompt, reads, and answer stay there. Wrap the call in
-  `thread { ... }` for an isolated survey.
+  The explorer continues your conversation: it sees everything said so
+  far, and every file it reads stays in your history when it hands back.
+  Say how much ground to cover, and scope the question tightly.
 
   @param question - The question, and the scope you want covered
   @param context - Extra material folded into the prompt, or ""

--- a/packages/agency-lang/stdlib/agents/explorer.agency
+++ b/packages/agency-lang/stdlib/agents/explorer.agency
@@ -18,7 +18,7 @@ import {
   SAVE_DRAFT_HINT,
  } from "std::agents/lib/toolkits"
 import { agentSkill } from "std::skills"
-import { systemMessage, threadIsNew } from "std::thread"
+import { ensureSystemMessage } from "std::thread"
 
 import { communicationTools } from "./lib/toolkits.agency"
 
@@ -132,9 +132,7 @@ def survey(
   provider: string,
   extraTools: any[],
 ): string {
-  if (threadIsNew()) {
-    systemMessage(systemPrompt)
-  }
+  ensureSystemMessage(systemPrompt)
   return llm(
     withContext(task: question, context: context),
     llmOptions(
@@ -148,14 +146,13 @@ def survey(
   )
 }
 
-export def explorerAgent(
+export handoff def explorerAgent(
   question: string,
   context: string = "",
   maxCost: number = $20.00,
   maxTime: number = 15m,
   model: string = "",
   provider: string = "",
-  session: string = "",
   extraTools: any[] = [],
 ): Result<string> {
   """
@@ -164,8 +161,14 @@ export def explorerAgent(
   many files. Reads widely before synthesizing, and cites what it read. It
   never changes anything.
 
-  Pass a self-contained question and say how much ground to cover: this agent
-  starts fresh and cannot see your conversation.
+  Called as a tool, the explorer continues your conversation: it sees
+  everything said so far, and every file it reads stays in your history
+  when it hands back. Say how much ground to cover; the reads are yours to
+  keep afterwards, so scope the question.
+
+  Called from code, it runs on your current thread like any function, and
+  its system prompt, reads, and answer stay there. Wrap the call in
+  `thread { ... }` for an isolated survey.
 
   @param question - The question, and the scope you want covered
   @param context - Extra material folded into the prompt, or ""
@@ -173,21 +176,18 @@ export def explorerAgent(
   @param maxTime - Hard wall-clock cap
   @param model - Model override, or "" for the ambient model
   @param provider - Provider for the model override
-  @param session - Session name to share a thread across calls, or "" for isolated
   @param extraTools - Extra tools to offer the LLM, appended to the built-in set
   """
 
   return guard(cost: maxCost, time: maxTime, label: "explorerAgent") {
     let reply = ""
-    thread(label: "explorerAgent", summarize: true, session: session) {
-      reply = survey(
-        question: question,
-        context: context,
-        model: model,
-        provider: provider,
-        extraTools: extraTools,
-      )
-    }
+    reply = survey(
+      question: question,
+      context: context,
+      model: model,
+      provider: provider,
+      extraTools: extraTools,
+    )
     return reply
 
     // Salvage the model's best-so-far saveDraft if an outer budget guard

--- a/packages/agency-lang/stdlib/agents/oracle.agency
+++ b/packages/agency-lang/stdlib/agents/oracle.agency
@@ -118,6 +118,9 @@ def consider(
   )
 }
 
+/** Called from code, this runs on the caller's thread like any function:
+ *  the system prompt, the reads, and the answer stay there. Wrap the call
+ *  in `thread { ... }` for an isolated consult. */
 export handoff def oracleAgent(
   question: string,
   context: string = "",
@@ -133,14 +136,9 @@ export handoff def oracleAgent(
   design. Reads the code and returns a written analysis ending in a concrete
   recommendation. It never changes anything.
 
-  Called as a tool, the oracle continues your conversation: it sees
-  everything said so far, and its reading and reasoning stay in your
-  history when it hands back. Ask the question itself; there is no need to
-  restate the context.
-
-  Called from code, it runs on your current thread like any function, and
-  its system prompt, reads, and answer stay there. Wrap the call in
-  `thread { ... }` for an isolated consult.
+  The oracle continues your conversation: it sees everything said so far,
+  and its reading and reasoning stay in your history when it hands back.
+  Ask the question itself; there is no need to restate the context.
 
   @param question - The question
   @param context - Extra material folded into the prompt, or ""

--- a/packages/agency-lang/stdlib/agents/oracle.agency
+++ b/packages/agency-lang/stdlib/agents/oracle.agency
@@ -20,7 +20,7 @@ import {
   SAVE_DRAFT_HINT,
  } from "std::agents/lib/toolkits"
 import { agentSkill } from "std::skills"
-import { systemMessage, threadIsNew } from "std::thread"
+import { ensureSystemMessage } from "std::thread"
 
 static const skills = agentSkill("oracle")
 
@@ -104,9 +104,7 @@ def consider(
   provider: string,
   extraTools: any[],
 ): string {
-  if (threadIsNew()) {
-    systemMessage(systemPrompt)
-  }
+  ensureSystemMessage(systemPrompt)
   return llm(
     withContext(task: question, context: context),
     llmOptions(
@@ -120,14 +118,13 @@ def consider(
   )
 }
 
-export def oracleAgent(
+export handoff def oracleAgent(
   question: string,
   context: string = "",
   maxCost: number = $20.00,
   maxTime: number = 15m,
   model: string = "",
   provider: string = "",
-  session: string = "",
   extraTools: any[] = [],
 ): Result<string> {
   """
@@ -136,31 +133,33 @@ export def oracleAgent(
   design. Reads the code and returns a written analysis ending in a concrete
   recommendation. It never changes anything.
 
-  Pass a self-contained question: this agent starts fresh and cannot see your
-  conversation. Include the plan, the relevant file paths, and what you have
-  already tried.
+  Called as a tool, the oracle continues your conversation: it sees
+  everything said so far, and its reading and reasoning stay in your
+  history when it hands back. Ask the question itself; there is no need to
+  restate the context.
 
-  @param question - The question, with all the context needed to answer it
+  Called from code, it runs on your current thread like any function, and
+  its system prompt, reads, and answer stay there. Wrap the call in
+  `thread { ... }` for an isolated consult.
+
+  @param question - The question
   @param context - Extra material folded into the prompt, or ""
   @param maxCost - Hard spend cap
   @param maxTime - Hard wall-clock cap
   @param model - Model override, or "" for the ambient model
   @param provider - Provider for the model override
-  @param session - Session name to share a thread across calls, or "" for isolated
   @param extraTools - Extra tools to offer the LLM, appended to the built-in set
   """
 
   return guard(cost: maxCost, time: maxTime, label: "oracleAgent") {
     let reply = ""
-    thread(label: "oracleAgent", summarize: true, session: session) {
-      reply = consider(
-        question: question,
-        context: context,
-        model: model,
-        provider: provider,
-        extraTools: extraTools,
-      )
-    }
+    reply = consider(
+      question: question,
+      context: context,
+      model: model,
+      provider: provider,
+      extraTools: extraTools,
+    )
     return reply
 
     // Salvage the model's best-so-far saveDraft if an outer budget guard

--- a/packages/agency-lang/stdlib/thread.agency
+++ b/packages/agency-lang/stdlib/thread.agency
@@ -37,6 +37,7 @@ import {
   _getTokens,
   _getModelCosts,
   _threadIsNew,
+  _threadHasSystemMessage,
  } from "agency-lang/stdlib-lib/thread.js"
 
 import { _installSlowInputImpl } from "agency-lang/stdlib-lib/builtins.js"
@@ -220,9 +221,6 @@ export idempotent def threadIsNew(): boolean {
   return _threadIsNew()
 }
 
-// Enough to read any thread an agent runs on in one call.
-static const THREAD_READ_LIMIT = 100000
-
 /** For an agent's persona. An agent called twice from code on one thread
  *  keeps one persona; a handoff, whose system messages are removed when it
  *  hands back, pushes the persona fresh on every dispatch. */
@@ -232,9 +230,7 @@ export def ensureSystemMessage(msg: string) {
 
   @param msg - The system message
   """
-  const messages = getThread(currentThreadId(), 0, THREAD_READ_LIMIT) catch []
-  const present = some(messages, \message -> message.role == "system" && message.content == msg)
-  if (!present) {
+  if (!_threadHasSystemMessage(msg)) {
     systemMessage(msg)
   }
 }

--- a/packages/agency-lang/stdlib/thread.agency
+++ b/packages/agency-lang/stdlib/thread.agency
@@ -220,6 +220,25 @@ export idempotent def threadIsNew(): boolean {
   return _threadIsNew()
 }
 
+// Enough to read any thread an agent runs on in one call.
+static const THREAD_READ_LIMIT = 100000
+
+export def ensureSystemMessage(msg: string) {
+  """
+  Push `msg` as a system message unless the active thread already holds it.
+  Use it for an agent's persona: called twice from code on one thread, the
+  agent keeps one persona; called as a handoff, whose system messages are
+  removed when it hands back, it pushes the persona fresh on every dispatch.
+
+  @param msg - The system message
+  """
+  const messages = getThread(currentThreadId(), 0, THREAD_READ_LIMIT) catch []
+  const present = some(messages, \message -> message.role == "system" && message.content == msg)
+  if (!present) {
+    systemMessage(msg)
+  }
+}
+
 export def getTokens(): number {
   """
   Return the cumulative token count for the current execution branch.

--- a/packages/agency-lang/stdlib/thread.agency
+++ b/packages/agency-lang/stdlib/thread.agency
@@ -223,12 +223,12 @@ export idempotent def threadIsNew(): boolean {
 // Enough to read any thread an agent runs on in one call.
 static const THREAD_READ_LIMIT = 100000
 
+/** For an agent's persona. An agent called twice from code on one thread
+ *  keeps one persona; a handoff, whose system messages are removed when it
+ *  hands back, pushes the persona fresh on every dispatch. */
 export def ensureSystemMessage(msg: string) {
   """
   Push `msg` as a system message unless the active thread already holds it.
-  Use it for an agent's persona: called twice from code on one thread, the
-  agent keeps one persona; called as a handoff, whose system messages are
-  removed when it hands back, it pushes the persona fresh on every dispatch.
 
   @param msg - The system message
   """

--- a/packages/agency-lang/tests/agency-js/handoff/agent.agency
+++ b/packages/agency-lang/tests/agency-js/handoff/agent.agency
@@ -1,7 +1,7 @@
 // Handoff functions through the real tool loop, against a scripted
 // model. Each node dispatches one handoff and the test reads the
 // caller's thread back from the final request the model sees.
-import { systemMessage } from "std::thread"
+import { systemMessage, ensureSystemMessage } from "std::thread"
 
 // A leaf tool for the subagents to call.
 def lookup(key: string): string {
@@ -14,6 +14,13 @@ handoff def subagent(question: string): string {
 
 handoff def personaAgent(question: string): string {
   systemMessage("persona: be terse")
+  return llm("brief: ${question}")
+}
+
+// The stdlib agents' persona pattern: pushed only when the thread does
+// not already hold it.
+handoff def terseAgent(question: string): string {
+  ensureSystemMessage("persona: be terse")
   return llm("brief: ${question}")
 }
 
@@ -43,8 +50,21 @@ handoff def pausingAgent(question: string): string {
   return llm("brief: ${question}", { tools: [pauseMe] })
 }
 
+// Pushes a persona, then pauses. The persona must still be stripped
+// after the resume, which needs the recorded start index to survive
+// the checkpoint.
+handoff def pausingPersonaAgent(question: string): string {
+  systemMessage("persona: be patient")
+  return llm("brief: ${question}", { tools: [pauseMe] })
+}
+
 handoff def failingAgent(question: string): Result<string> {
   return failure("boom")
+}
+
+// Returns a structured value, so the resume message has to stringify it.
+handoff def objectAgent(question: string): any {
+  return { answer: "obj", n: 1 }
 }
 
 // Raises before doing anything, so rejecting it rejects the handoff
@@ -57,6 +77,11 @@ handoff def gatedAgent(question: string): string {
 // A handoff that offers a handoff.
 handoff def outerAgent(question: string): string {
   return llm("outer brief: ${question}", { tools: [subagent] })
+}
+
+// A handoff that offers a handoff that pauses.
+handoff def outerPausingAgent(question: string): string {
+  return llm("outer brief: ${question}", { tools: [pausingAgent] })
 }
 
 node basic() {
@@ -98,4 +123,34 @@ node rejectHandoff() {
 
 node nested() {
   return llm("Answer with the outer agent.", { tools: [outerAgent] })
+}
+
+node pauseWithPersona() {
+  return llm("Answer with the pausing persona agent.", { tools: [pausingPersonaAgent] })
+}
+
+node twoDispatches() {
+  return llm("Ask the terse agent twice.", { tools: [terseAgent] })
+}
+
+node twoHandoffs() {
+  return llm("Use both agents at once.", { tools: [subagent, personaAgent] })
+}
+
+// saveDraft is an intrinsic call; it counts toward the round like any
+// other call. It needs a def with a declared return type.
+def withDraft(): string {
+  return llm("Use the subagent and save a draft.", { tools: [subagent, saveDraft] })
+}
+
+node handoffWithDraft() {
+  return withDraft()
+}
+
+node objectResult() {
+  return llm("Answer with the object agent.", { tools: [objectAgent] })
+}
+
+node nestedPause() {
+  return llm("Answer with the outer pausing agent.", { tools: [outerPausingAgent] })
 }

--- a/packages/agency-lang/tests/agency-js/handoff/agent.agency
+++ b/packages/agency-lang/tests/agency-js/handoff/agent.agency
@@ -1,7 +1,7 @@
 // Handoff functions through the real tool loop, against a scripted
 // model. Each node dispatches one handoff and the test reads the
 // caller's thread back from the final request the model sees.
-import { systemMessage, ensureSystemMessage } from "std::thread"
+import { systemMessage, ensureSystemMessage, listThreads, getThread } from "std::thread"
 
 // A leaf tool for the subagents to call.
 def lookup(key: string): string {
@@ -84,6 +84,13 @@ handoff def outerPausingAgent(question: string): string {
   return llm("outer brief: ${question}", { tools: [pausingAgent] })
 }
 
+// Pushes a persona, then asks the model. The test parks that request
+// until a race abort fires.
+handoff def parkingAgent(question: string): string {
+  systemMessage("persona: be parked")
+  return llm("parked: ${question}")
+}
+
 node basic() {
   return llm("Answer with the subagent.", { tools: [subagent, lookup] })
 }
@@ -163,6 +170,38 @@ node asyncHandoff() {
   const sideAnswer = await side
   const mainAnswer = llm("What happened?")
   return "${sideAnswer} / ${mainAnswer}"
+}
+
+// The caller's own system prompt is live during the body and survives
+// the hand-back; only the body's system messages are removed.
+node callerSystemVisible() {
+  systemMessage("caller rules")
+  return llm("Answer with the persona agent.", { tools: [personaAgent] })
+}
+
+// Two async prompts each dispatch a handoff at the same time. Each
+// body must land on its own prompt's subthread.
+node twoAsyncHandoffs() {
+  const first = async llm("A", { tools: [subagent] })
+  const second = async llm("B", { tools: [subagent] })
+  const firstAnswer = await first
+  const secondAnswer = await second
+  const mainAnswer = llm("What happened?")
+  return "${firstAnswer} / ${secondAnswer} / ${mainAnswer}"
+}
+
+// A race whose loser is inside a handoff body. The abort unwinds the
+// body without a hand-back; the persona it pushed must not stay on the
+// loser's thread. Returns every thread's messages for the test to read.
+node cancelledHandoff(): any {
+  const winner = race([1, 2]) as item {
+    if (item == 1) {
+      return llm("fast")
+    }
+    return llm("slow", { tools: [parkingAgent] })
+  }
+  const infos = listThreads(lazySummarize: false) catch []
+  return map(infos, \info -> getThread(info.id, 0, 1000) catch [])
 }
 
 // Explicit messages give the prompt a thread the store has never seen. A

--- a/packages/agency-lang/tests/agency-js/handoff/agent.agency
+++ b/packages/agency-lang/tests/agency-js/handoff/agent.agency
@@ -154,3 +154,25 @@ node objectResult() {
 node nestedPause() {
   return llm("Answer with the outer pausing agent.", { tools: [outerPausingAgent] })
 }
+
+// An async prompt runs on a subthread that is not the active thread. A
+// handoff inside it must land on that subthread, not on the main thread
+// the next llm() call reads.
+node asyncHandoff() {
+  const side = async llm("Answer with the subagent.", { tools: [subagent] })
+  const sideAnswer = await side
+  const mainAnswer = llm("What happened?")
+  return "${sideAnswer} / ${mainAnswer}"
+}
+
+// Explicit messages give the prompt a thread the store has never seen. A
+// handoff inside it must land on that thread.
+node explicitMessages() {
+  const options: any = {
+    tools: [subagent],
+    messages: [{ role: "user", content: "earlier context" }],
+  }
+  const first = llm("Answer with the subagent.", options)
+  const second = llm("What happened?")
+  return "${first} / ${second}"
+}

--- a/packages/agency-lang/tests/agency-js/handoff/agent.agency
+++ b/packages/agency-lang/tests/agency-js/handoff/agent.agency
@@ -1,0 +1,101 @@
+// Handoff functions through the real tool loop, against a scripted
+// model. Each node dispatches one handoff and the test reads the
+// caller's thread back from the final request the model sees.
+import { systemMessage } from "std::thread"
+
+// A leaf tool for the subagents to call.
+def lookup(key: string): string {
+  return "value-of-${key}"
+}
+
+handoff def subagent(question: string): string {
+  return llm("brief: ${question}", { tools: [lookup] })
+}
+
+handoff def personaAgent(question: string): string {
+  systemMessage("persona: be terse")
+  return llm("brief: ${question}")
+}
+
+handoff def threadedAgent(question: string): string {
+  let answer = ""
+  thread {
+    answer = llm("brief: ${question}")
+  }
+  return answer
+}
+
+handoff def subthreadedAgent(question: string): string {
+  let answer = ""
+  subthread {
+    answer = llm("brief: ${question}")
+  }
+  return answer
+}
+
+// Raises with no handler in scope, so the run pauses inside the handoff.
+def pauseMe(id: string): string {
+  const _ok = interrupt("pause ${id}")
+  return "ran ${id}"
+}
+
+handoff def pausingAgent(question: string): string {
+  return llm("brief: ${question}", { tools: [pauseMe] })
+}
+
+handoff def failingAgent(question: string): Result<string> {
+  return failure("boom")
+}
+
+// Raises before doing anything, so rejecting it rejects the handoff
+// call itself at the outer loop.
+handoff def gatedAgent(question: string): string {
+  const _ok = interrupt("gate ${question}")
+  return llm("brief: ${question}")
+}
+
+// A handoff that offers a handoff.
+handoff def outerAgent(question: string): string {
+  return llm("outer brief: ${question}", { tools: [subagent] })
+}
+
+node basic() {
+  return llm("Answer with the subagent.", { tools: [subagent, lookup] })
+}
+
+node persona() {
+  return llm("Answer with the persona agent.", { tools: [personaAgent] })
+}
+
+node notAlone() {
+  return llm("Use both tools at once.", { tools: [subagent, lookup] })
+}
+
+node threadInside() {
+  return llm("Answer with the threaded agent.", { tools: [threadedAgent] })
+}
+
+node subthreadInside() {
+  return llm("Answer with the subthreaded agent.", { tools: [subthreadedAgent] })
+}
+
+node pauseInside() {
+  return llm("Answer with the pausing agent.", { tools: [pausingAgent] })
+}
+
+// Same shape as pauseInside; the test rejects instead of approving.
+node rejectInside() {
+  return llm("Answer with the pausing agent.", { tools: [pausingAgent] })
+}
+
+node failureInside() {
+  return llm("Answer with the failing agent.", { tools: [failingAgent] })
+}
+
+node rejectHandoff() {
+  return llm("Answer with the gated agent.", { tools: [gatedAgent] })
+}
+
+node nested() {
+  return llm("Answer with the outer agent.", { tools: [outerAgent] })
+}

--- a/packages/agency-lang/tests/agency-js/handoff/fixture.json
+++ b/packages/agency-lang/tests/agency-js/handoff/fixture.json
@@ -2,6 +2,7 @@
   "basic": {
     "result": "outer done",
     "requestCount": 4,
+    "allWellFormed": true,
     "roles": ["user", "assistant", "user", "assistant", "tool", "assistant", "user"],
     "markerOnAssistant": true,
     "toolTexts": ["value-of-k"],
@@ -12,6 +13,7 @@
   "persona": {
     "result": "persona done",
     "requestCount": 3,
+    "allWellFormed": true,
     "bodySawPersona": 1,
     "callerKeptPersona": 0,
     "roles": ["user", "assistant", "user", "assistant", "user"]
@@ -19,6 +21,7 @@
   "notAlone": {
     "result": "notAlone done",
     "requestCount": 2,
+    "allWellFormed": true,
     "refused": 1,
     "siblingRan": true,
     "assistantKeptToolCalls": true,
@@ -28,6 +31,7 @@
   "threadInside": {
     "result": "thread done",
     "requestCount": 3,
+    "allWellFormed": true,
     "bodyRequestLength": 1,
     "roles": ["user", "assistant", "user"],
     "resume": 1
@@ -35,6 +39,7 @@
   "subthreadInside": {
     "result": "subthread done",
     "requestCount": 3,
+    "allWellFormed": true,
     "bodySawCaller": 1,
     "roles": ["user", "assistant", "user"],
     "resume": 1
@@ -43,6 +48,7 @@
     "pausedWithInterrupt": true,
     "result": "pause done",
     "requestCount": 4,
+    "allWellFormed": true,
     "markers": 1,
     "resumes": 1,
     "roles": ["user", "assistant", "user", "assistant", "tool", "assistant", "user"],
@@ -51,6 +57,7 @@
   "rejectInside": {
     "result": "reject done",
     "requestCount": 4,
+    "allWellFormed": true,
     "rejectionSeenByBody": 1,
     "markers": 1,
     "resumes": 1,
@@ -59,12 +66,14 @@
   "failureInside": {
     "result": "failure done",
     "requestCount": 2,
+    "allWellFormed": true,
     "roles": ["user", "assistant", "user"],
     "resumeCarriesError": 1
   },
   "rejectHandoff": {
     "result": "rejectHandoff done",
     "requestCount": 2,
+    "allWellFormed": true,
     "roles": ["user", "assistant", "user"],
     "markers": 1,
     "resumeCarriesRejection": 1
@@ -72,9 +81,61 @@
   "nested": {
     "result": "nested done",
     "requestCount": 5,
+    "allWellFormed": true,
     "roles": ["user", "assistant", "user", "assistant", "user", "assistant", "user", "assistant", "user"],
     "markers": 2,
     "resumes": 2,
     "toolMessages": 0
+  },
+  "pauseWithPersona": {
+    "result": "pausePersona done",
+    "requestCount": 4,
+    "allWellFormed": true,
+    "bodySawPersona": 1,
+    "callerKeptPersona": 0,
+    "markers": 1,
+    "roles": ["user", "assistant", "user", "assistant", "tool", "assistant", "user"]
+  },
+  "twoDispatches": {
+    "result": "twice done",
+    "requestCount": 5,
+    "allWellFormed": true,
+    "firstBodySawPersona": 1,
+    "secondBodySawPersona": 1,
+    "callerKeptPersona": 0,
+    "markers": 2,
+    "resumes": 2
+  },
+  "twoHandoffs": {
+    "result": "twoHandoffs done",
+    "requestCount": 2,
+    "allWellFormed": true,
+    "refused": 2,
+    "toolStarts": [],
+    "markers": 0
+  },
+  "handoffWithDraft": {
+    "result": "draft done",
+    "requestCount": 2,
+    "allWellFormed": true,
+    "refused": 1,
+    "toolStarts": ["saveDraft"],
+    "markers": 0
+  },
+  "objectResult": {
+    "result": "object done",
+    "requestCount": 2,
+    "allWellFormed": true,
+    "roles": ["user", "assistant", "user"],
+    "resumeCarriesJson": 1
+  },
+  "nestedPause": {
+    "result": "nestedPause done",
+    "requestCount": 6,
+    "allWellFormed": true,
+    "roles": ["user", "assistant", "user", "assistant", "user", "assistant", "tool", "assistant", "user", "assistant", "user"],
+    "markers": 2,
+    "resumes": 2,
+    "toolTexts": ["ran p4"]
   }
 }

--- a/packages/agency-lang/tests/agency-js/handoff/fixture.json
+++ b/packages/agency-lang/tests/agency-js/handoff/fixture.json
@@ -1,0 +1,80 @@
+{
+  "basic": {
+    "result": "outer done",
+    "requestCount": 4,
+    "roles": ["user", "assistant", "user", "assistant", "tool", "assistant", "user"],
+    "markerOnAssistant": true,
+    "toolTexts": ["value-of-k"],
+    "resumeCarriesResult": true,
+    "subagentSawCaller": true,
+    "toolStarts": ["subagent", "lookup"]
+  },
+  "persona": {
+    "result": "persona done",
+    "requestCount": 3,
+    "bodySawPersona": 1,
+    "callerKeptPersona": 0,
+    "roles": ["user", "assistant", "user", "assistant", "user"]
+  },
+  "notAlone": {
+    "result": "notAlone done",
+    "requestCount": 2,
+    "refused": 1,
+    "siblingRan": true,
+    "assistantKeptToolCalls": true,
+    "toolStarts": ["lookup"],
+    "markers": 0
+  },
+  "threadInside": {
+    "result": "thread done",
+    "requestCount": 3,
+    "bodyRequestLength": 1,
+    "roles": ["user", "assistant", "user"],
+    "resume": 1
+  },
+  "subthreadInside": {
+    "result": "subthread done",
+    "requestCount": 3,
+    "bodySawCaller": 1,
+    "roles": ["user", "assistant", "user"],
+    "resume": 1
+  },
+  "pauseInside": {
+    "pausedWithInterrupt": true,
+    "result": "pause done",
+    "requestCount": 4,
+    "markers": 1,
+    "resumes": 1,
+    "roles": ["user", "assistant", "user", "assistant", "tool", "assistant", "user"],
+    "toolTexts": ["ran p1"]
+  },
+  "rejectInside": {
+    "result": "reject done",
+    "requestCount": 4,
+    "rejectionSeenByBody": 1,
+    "markers": 1,
+    "resumes": 1,
+    "roles": ["user", "assistant", "user", "assistant", "tool", "assistant", "user"]
+  },
+  "failureInside": {
+    "result": "failure done",
+    "requestCount": 2,
+    "roles": ["user", "assistant", "user"],
+    "resumeCarriesError": 1
+  },
+  "rejectHandoff": {
+    "result": "rejectHandoff done",
+    "requestCount": 2,
+    "roles": ["user", "assistant", "user"],
+    "markers": 1,
+    "resumeCarriesRejection": 1
+  },
+  "nested": {
+    "result": "nested done",
+    "requestCount": 5,
+    "roles": ["user", "assistant", "user", "assistant", "user", "assistant", "user", "assistant", "user"],
+    "markers": 2,
+    "resumes": 2,
+    "toolMessages": 0
+  }
+}

--- a/packages/agency-lang/tests/agency-js/handoff/fixture.json
+++ b/packages/agency-lang/tests/agency-js/handoff/fixture.json
@@ -3,12 +3,25 @@
     "result": "outer done",
     "requestCount": 4,
     "allWellFormed": true,
-    "roles": ["user", "assistant", "user", "assistant", "tool", "assistant", "user"],
+    "roles": [
+      "user",
+      "assistant",
+      "user",
+      "assistant",
+      "tool",
+      "assistant",
+      "user"
+    ],
     "markerOnAssistant": true,
-    "toolTexts": ["value-of-k"],
+    "toolTexts": [
+      "value-of-k"
+    ],
     "resumeCarriesResult": true,
     "subagentSawCaller": true,
-    "toolStarts": ["subagent", "lookup"]
+    "toolStarts": [
+      "subagent",
+      "lookup"
+    ]
   },
   "persona": {
     "result": "persona done",
@@ -16,7 +29,13 @@
     "allWellFormed": true,
     "bodySawPersona": 1,
     "callerKeptPersona": 0,
-    "roles": ["user", "assistant", "user", "assistant", "user"]
+    "roles": [
+      "user",
+      "assistant",
+      "user",
+      "assistant",
+      "user"
+    ]
   },
   "notAlone": {
     "result": "notAlone done",
@@ -25,7 +44,9 @@
     "refused": 1,
     "siblingRan": true,
     "assistantKeptToolCalls": true,
-    "toolStarts": ["lookup"],
+    "toolStarts": [
+      "lookup"
+    ],
     "markers": 0
   },
   "threadInside": {
@@ -33,7 +54,11 @@
     "requestCount": 3,
     "allWellFormed": true,
     "bodyRequestLength": 1,
-    "roles": ["user", "assistant", "user"],
+    "roles": [
+      "user",
+      "assistant",
+      "user"
+    ],
     "resume": 1
   },
   "subthreadInside": {
@@ -41,7 +66,11 @@
     "requestCount": 3,
     "allWellFormed": true,
     "bodySawCaller": 1,
-    "roles": ["user", "assistant", "user"],
+    "roles": [
+      "user",
+      "assistant",
+      "user"
+    ],
     "resume": 1
   },
   "pauseInside": {
@@ -51,8 +80,18 @@
     "allWellFormed": true,
     "markers": 1,
     "resumes": 1,
-    "roles": ["user", "assistant", "user", "assistant", "tool", "assistant", "user"],
-    "toolTexts": ["ran p1"]
+    "roles": [
+      "user",
+      "assistant",
+      "user",
+      "assistant",
+      "tool",
+      "assistant",
+      "user"
+    ],
+    "toolTexts": [
+      "ran p1"
+    ]
   },
   "rejectInside": {
     "result": "reject done",
@@ -61,20 +100,36 @@
     "rejectionSeenByBody": 1,
     "markers": 1,
     "resumes": 1,
-    "roles": ["user", "assistant", "user", "assistant", "tool", "assistant", "user"]
+    "roles": [
+      "user",
+      "assistant",
+      "user",
+      "assistant",
+      "tool",
+      "assistant",
+      "user"
+    ]
   },
   "failureInside": {
     "result": "failure done",
     "requestCount": 2,
     "allWellFormed": true,
-    "roles": ["user", "assistant", "user"],
+    "roles": [
+      "user",
+      "assistant",
+      "user"
+    ],
     "resumeCarriesError": 1
   },
   "rejectHandoff": {
     "result": "rejectHandoff done",
     "requestCount": 2,
     "allWellFormed": true,
-    "roles": ["user", "assistant", "user"],
+    "roles": [
+      "user",
+      "assistant",
+      "user"
+    ],
     "markers": 1,
     "resumeCarriesRejection": 1
   },
@@ -82,7 +137,17 @@
     "result": "nested done",
     "requestCount": 5,
     "allWellFormed": true,
-    "roles": ["user", "assistant", "user", "assistant", "user", "assistant", "user", "assistant", "user"],
+    "roles": [
+      "user",
+      "assistant",
+      "user",
+      "assistant",
+      "user",
+      "assistant",
+      "user",
+      "assistant",
+      "user"
+    ],
     "markers": 2,
     "resumes": 2,
     "toolMessages": 0
@@ -94,7 +159,15 @@
     "bodySawPersona": 1,
     "callerKeptPersona": 0,
     "markers": 1,
-    "roles": ["user", "assistant", "user", "assistant", "tool", "assistant", "user"]
+    "roles": [
+      "user",
+      "assistant",
+      "user",
+      "assistant",
+      "tool",
+      "assistant",
+      "user"
+    ]
   },
   "twoDispatches": {
     "result": "twice done",
@@ -119,23 +192,78 @@
     "requestCount": 2,
     "allWellFormed": true,
     "refused": 1,
-    "toolStarts": ["saveDraft"],
+    "toolStarts": [
+      "saveDraft"
+    ],
     "markers": 0
   },
   "objectResult": {
     "result": "object done",
     "requestCount": 2,
     "allWellFormed": true,
-    "roles": ["user", "assistant", "user"],
+    "roles": [
+      "user",
+      "assistant",
+      "user"
+    ],
     "resumeCarriesJson": 1
   },
   "nestedPause": {
     "result": "nestedPause done",
     "requestCount": 6,
     "allWellFormed": true,
-    "roles": ["user", "assistant", "user", "assistant", "user", "assistant", "tool", "assistant", "user", "assistant", "user"],
+    "roles": [
+      "user",
+      "assistant",
+      "user",
+      "assistant",
+      "user",
+      "assistant",
+      "tool",
+      "assistant",
+      "user",
+      "assistant",
+      "user"
+    ],
     "markers": 2,
     "resumes": 2,
-    "toolTexts": ["ran p4"]
+    "toolTexts": [
+      "ran p4"
+    ]
+  },
+  "asyncHandoff": {
+    "result": "async done / main sees",
+    "requestCount": 4,
+    "allWellFormed": true,
+    "bodySawCaller": 1,
+    "asyncFinalRoles": [
+      "user",
+      "assistant",
+      "user",
+      "assistant",
+      "user"
+    ],
+    "mainThreadRoles": [
+      "user"
+    ],
+    "mainThreadSawHandoff": 0
+  },
+  "explicitMessages": {
+    "result": "explicit done / second sees",
+    "requestCount": 4,
+    "allWellFormed": true,
+    "bodySawExplicit": true,
+    "explicitFinalRoles": [
+      "user",
+      "user",
+      "assistant",
+      "user",
+      "assistant",
+      "user"
+    ],
+    "activeThreadRoles": [
+      "user"
+    ],
+    "activeThreadSawHandoff": 0
   }
 }

--- a/packages/agency-lang/tests/agency-js/handoff/fixture.json
+++ b/packages/agency-lang/tests/agency-js/handoff/fixture.json
@@ -265,5 +265,40 @@
       "user"
     ],
     "activeThreadSawHandoff": 0
+  },
+  "callerSystemVisible": {
+    "result": "caller done",
+    "requestCount": 3,
+    "allWellFormed": true,
+    "bodySawCallerRules": 1,
+    "bodySawOwnPersona": 1,
+    "callerKeptRules": 1,
+    "callerKeptPersona": 0,
+    "roles": [
+      "system",
+      "user",
+      "assistant",
+      "user",
+      "assistant",
+      "user"
+    ]
+  },
+  "twoAsyncHandoffs": {
+    "result": "async done / async done / main sees",
+    "requestCount": 7,
+    "allWellFormed": true,
+    "asyncFinals": 2,
+    "eachFinalHoldsOneBody": true,
+    "mainThreadRoles": [
+      "user"
+    ],
+    "mainThreadSawHandoff": 0
+  },
+  "cancelledHandoff": {
+    "loserThreadFound": true,
+    "parkedRequestSawPersona": true,
+    "loserKeptPersona": 0,
+    "loserKeptMarker": 1,
+    "loserMarkedCancelled": 1
   }
 }

--- a/packages/agency-lang/tests/agency-js/handoff/llmMocks.json
+++ b/packages/agency-lang/tests/agency-js/handoff/llmMocks.json
@@ -1,0 +1,46 @@
+[
+  { "toolCall": { "name": "subagent", "args": { "question": "q1" } } },
+  { "toolCall": { "name": "lookup", "args": { "key": "k" } } },
+  { "return": "inner answer" },
+  { "return": "outer done" },
+
+  { "toolCall": { "name": "personaAgent", "args": { "question": "q2" } } },
+  { "return": "terse" },
+  { "return": "persona done" },
+
+  { "toolCalls": [
+      { "name": "subagent", "args": { "question": "q3" } },
+      { "name": "lookup", "args": { "key": "k3" } }
+  ] },
+  { "return": "notAlone done" },
+
+  { "toolCall": { "name": "threadedAgent", "args": { "question": "q4" } } },
+  { "return": "threaded answer" },
+  { "return": "thread done" },
+
+  { "toolCall": { "name": "subthreadedAgent", "args": { "question": "q5" } } },
+  { "return": "subthreaded answer" },
+  { "return": "subthread done" },
+
+  { "toolCall": { "name": "pausingAgent", "args": { "question": "q6" } } },
+  { "toolCall": { "name": "pauseMe", "args": { "id": "p1" } } },
+  { "return": "paused answer" },
+  { "return": "pause done" },
+
+  { "toolCall": { "name": "pausingAgent", "args": { "question": "q7" } } },
+  { "toolCall": { "name": "pauseMe", "args": { "id": "p2" } } },
+  { "return": "rejected answer" },
+  { "return": "reject done" },
+
+  { "toolCall": { "name": "failingAgent", "args": { "question": "q8" } } },
+  { "return": "failure done" },
+
+  { "toolCall": { "name": "gatedAgent", "args": { "question": "q11" } } },
+  { "return": "rejectHandoff done" },
+
+  { "toolCall": { "name": "outerAgent", "args": { "question": "q9" } } },
+  { "toolCall": { "name": "subagent", "args": { "question": "q10" } } },
+  { "return": "deep answer" },
+  { "return": "middle answer" },
+  { "return": "nested done" }
+]

--- a/packages/agency-lang/tests/agency-js/handoff/llmMocks.json
+++ b/packages/agency-lang/tests/agency-js/handoff/llmMocks.json
@@ -85,5 +85,9 @@
   { "toolCall": { "name": "subagent", "args": { "question": "e1" } } },
   { "return": "explicit inner" },
   { "return": "explicit done" },
-  { "return": "second sees" }
+  { "return": "second sees" },
+
+  { "toolCall": { "name": "personaAgent", "args": { "question": "c1" } } },
+  { "return": "ruled" },
+  { "return": "caller done" }
 ]

--- a/packages/agency-lang/tests/agency-js/handoff/llmMocks.json
+++ b/packages/agency-lang/tests/agency-js/handoff/llmMocks.json
@@ -75,5 +75,15 @@
   { "toolCall": { "name": "pauseMe", "args": { "id": "p4" } } },
   { "return": "deep paused" },
   { "return": "middle paused" },
-  { "return": "nestedPause done" }
+  { "return": "nestedPause done" },
+
+  { "toolCall": { "name": "subagent", "args": { "question": "a1" } } },
+  { "return": "async inner" },
+  { "return": "async done" },
+  { "return": "main sees" },
+
+  { "toolCall": { "name": "subagent", "args": { "question": "e1" } } },
+  { "return": "explicit inner" },
+  { "return": "explicit done" },
+  { "return": "second sees" }
 ]

--- a/packages/agency-lang/tests/agency-js/handoff/llmMocks.json
+++ b/packages/agency-lang/tests/agency-js/handoff/llmMocks.json
@@ -42,5 +42,38 @@
   { "toolCall": { "name": "subagent", "args": { "question": "q10" } } },
   { "return": "deep answer" },
   { "return": "middle answer" },
-  { "return": "nested done" }
+  { "return": "nested done" },
+
+  { "toolCall": { "name": "pausingPersonaAgent", "args": { "question": "q12" } } },
+  { "toolCall": { "name": "pauseMe", "args": { "id": "p3" } } },
+  { "return": "persona paused answer" },
+  { "return": "pausePersona done" },
+
+  { "toolCall": { "name": "terseAgent", "args": { "question": "d1" } } },
+  { "return": "one" },
+  { "toolCall": { "name": "terseAgent", "args": { "question": "d2" } } },
+  { "return": "two" },
+  { "return": "twice done" },
+
+  { "toolCalls": [
+      { "name": "subagent", "args": { "question": "t1" } },
+      { "name": "personaAgent", "args": { "question": "t2" } }
+  ] },
+  { "return": "twoHandoffs done" },
+
+  { "toolCalls": [
+      { "name": "subagent", "args": { "question": "s1" } },
+      { "name": "saveDraft", "args": { "value": "draft" } }
+  ] },
+  { "return": "draft done" },
+
+  { "toolCall": { "name": "objectAgent", "args": { "question": "o1" } } },
+  { "return": "object done" },
+
+  { "toolCall": { "name": "outerPausingAgent", "args": { "question": "n1" } } },
+  { "toolCall": { "name": "pausingAgent", "args": { "question": "n2" } } },
+  { "toolCall": { "name": "pauseMe", "args": { "id": "p4" } } },
+  { "return": "deep paused" },
+  { "return": "middle paused" },
+  { "return": "nestedPause done" }
 ]

--- a/packages/agency-lang/tests/agency-js/handoff/test.js
+++ b/packages/agency-lang/tests/agency-js/handoff/test.js
@@ -9,6 +9,12 @@ import {
   failureInside,
   rejectHandoff,
   nested,
+  pauseWithPersona,
+  twoDispatches,
+  twoHandoffs,
+  handoffWithDraft,
+  objectResult,
+  nestedPause,
   respondToInterrupts,
   approve,
   reject,
@@ -42,6 +48,32 @@ const hasToolCalls = (message) =>
 const toolTexts = (messages) =>
   messages.filter((message) => message.role === "tool").map(text).sort();
 
+// Would a real provider accept this request? The mock client accepts
+// anything, so this is the check that a handoff never leaves a dangling
+// tool call behind: every assistant message that carries N tool calls
+// is followed by exactly N tool messages, tool messages appear nowhere
+// else, and a request never ends on an assistant message.
+const wellFormed = (messages) => {
+  let owed = 0;
+  for (const message of messages) {
+    if (message.role === "tool") {
+      if (owed === 0) {
+        return false;
+      }
+      owed -= 1;
+      continue;
+    }
+    if (owed > 0) {
+      return false;
+    }
+    if (message.role === "assistant" && hasToolCalls(message)) {
+      owed = message.toolCalls.length;
+    }
+  }
+  return owed === 0 && messages[messages.length - 1]?.role !== "assistant";
+};
+const allWellFormed = (state) => state.requests.every(wellFormed);
+
 const results = {};
 
 // The subagent's messages land on the caller's thread: the marker
@@ -56,6 +88,7 @@ const results = {};
   results.basic = {
     result: result.data,
     requestCount: state.requests.length,
+    allWellFormed: allWellFormed(state),
     roles: roles(final),
     markerOnAssistant:
       final[1].role === "assistant" &&
@@ -80,6 +113,7 @@ const results = {};
   results.persona = {
     result: result.data,
     requestCount: state.requests.length,
+    allWellFormed: allWellFormed(state),
     bodySawPersona: count(state.requests[1], "persona: be terse"),
     callerKeptPersona: count(last(state), "persona: be terse"),
     roles: roles(last(state)),
@@ -95,6 +129,7 @@ const results = {};
   results.notAlone = {
     result: result.data,
     requestCount: state.requests.length,
+    allWellFormed: allWellFormed(state),
     refused: count(final, "must be the only tool call in its round"),
     siblingRan: toolTexts(final).includes("value-of-k3"),
     assistantKeptToolCalls: hasToolCalls(final[1]),
@@ -111,6 +146,7 @@ const results = {};
   results.threadInside = {
     result: result.data,
     requestCount: state.requests.length,
+    allWellFormed: allWellFormed(state),
     bodyRequestLength: state.requests[1].length,
     roles: roles(last(state)),
     resume: count(last(state), "[threadedAgent finished. threaded answer]"),
@@ -125,6 +161,7 @@ const results = {};
   results.subthreadInside = {
     result: result.data,
     requestCount: state.requests.length,
+    allWellFormed: allWellFormed(state),
     bodySawCaller: count(state.requests[1], "[dispatching subthreadedAgent"),
     roles: roles(last(state)),
     resume: count(last(state), "[subthreadedAgent finished. subthreaded answer]"),
@@ -146,6 +183,7 @@ const results = {};
     pausedWithInterrupt,
     result: resumed.data,
     requestCount: state.requests.length,
+    allWellFormed: allWellFormed(state),
     markers: count(final, "[dispatching pausingAgent"),
     resumes: count(final, "pausingAgent finished"),
     roles: roles(final),
@@ -167,6 +205,7 @@ const results = {};
   results.rejectInside = {
     result: resumed.data,
     requestCount: state.requests.length,
+    allWellFormed: allWellFormed(state),
     rejectionSeenByBody: count(final, "Tool call rejected: not today"),
     markers: count(final, "[dispatching pausingAgent"),
     resumes: count(final, "[pausingAgent finished. rejected answer]"),
@@ -183,6 +222,7 @@ const results = {};
   results.failureInside = {
     result: result.data,
     requestCount: state.requests.length,
+    allWellFormed: allWellFormed(state),
     roles: roles(final),
     resumeCarriesError: count(final, "[failingAgent finished. Error: boom"),
   };
@@ -202,6 +242,7 @@ const results = {};
   results.rejectHandoff = {
     result: resumed.data,
     requestCount: state.requests.length,
+    allWellFormed: allWellFormed(state),
     roles: roles(final),
     markers: count(final, "[dispatching gatedAgent"),
     resumeCarriesRejection: count(final, "[gatedAgent finished. Tool call rejected: nope"),
@@ -217,10 +258,117 @@ const results = {};
   results.nested = {
     result: result.data,
     requestCount: state.requests.length,
+    allWellFormed: allWellFormed(state),
     roles: roles(final),
     markers: count(final, "[dispatching"),
     resumes: count(final, "finished."),
     toolMessages: final.filter((message) => message.role === "tool").length,
+  };
+}
+
+// The body pushes a persona and then pauses. Stripping it after the
+// resume needs the start index recorded before the checkpoint, so this
+// is the test that the record survives the round trip.
+{
+  const { state, callbacks } = makeCapture();
+  const paused = await pauseWithPersona({ callbacks });
+  const resumed = await respondToInterrupts(paused.data, [approve()], {
+    metadata: { callbacks },
+  });
+  const final = last(state);
+  results.pauseWithPersona = {
+    result: resumed.data,
+    requestCount: state.requests.length,
+    allWellFormed: allWellFormed(state),
+    bodySawPersona: count(state.requests[1], "persona: be patient"),
+    callerKeptPersona: count(final, "persona: be patient"),
+    markers: count(final, "[dispatching pausingPersonaAgent"),
+    roles: roles(final),
+  };
+}
+
+// The same agent dispatched twice. ensureSystemMessage pushes the persona
+// on each dispatch, because the hand-back strips it, and never twice
+// within one dispatch.
+{
+  const { state, callbacks } = makeCapture();
+  const result = await twoDispatches({ callbacks });
+  const final = last(state);
+  results.twoDispatches = {
+    result: result.data,
+    requestCount: state.requests.length,
+    allWellFormed: allWellFormed(state),
+    firstBodySawPersona: count(state.requests[1], "persona: be terse"),
+    secondBodySawPersona: count(state.requests[3], "persona: be terse"),
+    callerKeptPersona: count(final, "persona: be terse"),
+    markers: count(final, "[dispatching terseAgent"),
+    resumes: count(final, "terseAgent finished"),
+  };
+}
+
+// Two handoffs in one round: both are refused, neither runs.
+{
+  const { state, callbacks } = makeCapture();
+  const result = await twoHandoffs({ callbacks });
+  const final = last(state);
+  results.twoHandoffs = {
+    result: result.data,
+    requestCount: state.requests.length,
+    allWellFormed: allWellFormed(state),
+    refused: count(final, "must be the only tool call in its round"),
+    toolStarts: state.toolStarts,
+    markers: count(final, "[dispatching"),
+  };
+}
+
+// A handoff beside an intrinsic saveDraft call is a mixed round too: the
+// draft is filed and the handoff is refused.
+{
+  const { state, callbacks } = makeCapture();
+  const result = await handoffWithDraft({ callbacks });
+  const final = last(state);
+  results.handoffWithDraft = {
+    result: result.data,
+    requestCount: state.requests.length,
+    allWellFormed: allWellFormed(state),
+    refused: count(final, "must be the only tool call in its round"),
+    toolStarts: state.toolStarts,
+    markers: count(final, "[dispatching"),
+  };
+}
+
+// A structured return value is stringified into the resume message.
+{
+  const { state, callbacks } = makeCapture();
+  const result = await objectResult({ callbacks });
+  const final = last(state);
+  results.objectResult = {
+    result: result.data,
+    requestCount: state.requests.length,
+    allWellFormed: allWellFormed(state),
+    roles: roles(final),
+    resumeCarriesJson: count(final, '[objectAgent finished. {"answer":"obj","n":1}]'),
+  };
+}
+
+// A pause inside a handoff inside a handoff: two runPrompt frames each
+// hold their own start index, and both resume without duplicating a
+// marker or a resume message.
+{
+  const { state, callbacks } = makeCapture();
+  const paused = await nestedPause({ callbacks });
+  const resumed = await respondToInterrupts(paused.data, [approve()], {
+    metadata: { callbacks },
+  });
+  const final = last(state);
+  results.nestedPause = {
+    result: resumed.data,
+    requestCount: state.requests.length,
+    allWellFormed: allWellFormed(state),
+    roles: roles(final),
+    markers: count(final, "[dispatching"),
+    resumes: count(final, "finished."),
+    toolTexts: toolTexts(final),
   };
 }
 

--- a/packages/agency-lang/tests/agency-js/handoff/test.js
+++ b/packages/agency-lang/tests/agency-js/handoff/test.js
@@ -15,6 +15,8 @@ import {
   handoffWithDraft,
   objectResult,
   nestedPause,
+  asyncHandoff,
+  explicitMessages,
   respondToInterrupts,
   approve,
   reject,
@@ -193,8 +195,7 @@ const results = {};
 
 // The same pause, rejected. The rejection is the leaf tool's, inside the
 // body, so it reaches the body's own model as a tool message and the
-// body still hands back normally. This pins the rejection route through
-// the loop that runs inside a handoff.
+// body still hands back normally.
 {
   const { state, callbacks } = makeCapture();
   const paused = await rejectInside({ callbacks });
@@ -267,8 +268,7 @@ const results = {};
 }
 
 // The body pushes a persona and then pauses. Stripping it after the
-// resume needs the start index recorded before the checkpoint, so this
-// is the test that the record survives the round trip.
+// resume needs the start index recorded before the checkpoint.
 {
   const { state, callbacks } = makeCapture();
   const paused = await pauseWithPersona({ callbacks });
@@ -369,6 +369,43 @@ const results = {};
     markers: count(final, "[dispatching"),
     resumes: count(final, "finished."),
     toolTexts: toolTexts(final),
+  };
+}
+
+// A handoff inside an async prompt lands on the prompt's subthread. The
+// main thread's next request must not see any of it.
+{
+  const { state, callbacks } = makeCapture();
+  const result = await asyncHandoff({ callbacks });
+  const final = last(state);
+  results.asyncHandoff = {
+    result: result.data,
+    requestCount: state.requests.length,
+    allWellFormed: allWellFormed(state),
+    bodySawCaller: count(state.requests[1], "[dispatching subagent"),
+    asyncFinalRoles: roles(state.requests[2]),
+    mainThreadRoles: roles(final),
+    mainThreadSawHandoff: count(final, "[dispatching") + count(final, "async inner"),
+  };
+}
+
+// A handoff inside a prompt with explicit messages lands on that thread,
+// which the store had never seen. The active thread's next request must
+// not see any of it.
+{
+  const { state, callbacks } = makeCapture();
+  const result = await explicitMessages({ callbacks });
+  const final = last(state);
+  results.explicitMessages = {
+    result: result.data,
+    requestCount: state.requests.length,
+    allWellFormed: allWellFormed(state),
+    bodySawExplicit:
+      count(state.requests[1], "earlier context") === 1 &&
+      count(state.requests[1], "[dispatching subagent") === 1,
+    explicitFinalRoles: roles(state.requests[2]),
+    activeThreadRoles: roles(final),
+    activeThreadSawHandoff: count(final, "[dispatching") + count(final, "explicit inner"),
   };
 }
 

--- a/packages/agency-lang/tests/agency-js/handoff/test.js
+++ b/packages/agency-lang/tests/agency-js/handoff/test.js
@@ -17,11 +17,16 @@ import {
   nestedPause,
   asyncHandoff,
   explicitMessages,
+  callerSystemVisible,
+  twoAsyncHandoffs,
+  cancelledHandoff,
   respondToInterrupts,
   approve,
   reject,
+  __setLLMClient,
 } from "./agent.js";
 import { writeFileSync } from "fs";
+import { ToolCall } from "smoltalk";
 
 // Record every request the model sees, in order. The last request of a
 // node is the caller's final round, which shows the caller's thread
@@ -406,6 +411,153 @@ const results = {};
     explicitFinalRoles: roles(state.requests[2]),
     activeThreadRoles: roles(final),
     activeThreadSawHandoff: count(final, "[dispatching") + count(final, "explicit inner"),
+  };
+}
+
+// The caller's own system prompt is visible to the body and is still
+// there after the hand-back; the strip reaches only past the marker.
+{
+  const { state, callbacks } = makeCapture();
+  const result = await callerSystemVisible({ callbacks });
+  const final = last(state);
+  results.callerSystemVisible = {
+    result: result.data,
+    requestCount: state.requests.length,
+    allWellFormed: allWellFormed(state),
+    bodySawCallerRules: count(state.requests[1], "caller rules"),
+    bodySawOwnPersona: count(state.requests[1], "persona: be terse"),
+    callerKeptRules: count(final, "caller rules"),
+    callerKeptPersona: count(final, "persona: be terse"),
+    roles: roles(final),
+  };
+}
+
+// The scenarios below need a model that answers by what it was asked,
+// because their requests interleave and a queue in call order would
+// hand the wrong script to the wrong prompt. `lastUserText` is the most
+// recent user message of the request.
+const USAGE = { inputTokens: 1, outputTokens: 1, cachedInputTokens: 0, totalTokens: 2 };
+const COST = { inputCost: 0, outputCost: 0, totalCost: 0, currency: "USD" };
+const lastUserText = (config) => {
+  const json = config.messages.map((message) =>
+    typeof message.toJSON === "function" ? message.toJSON() : message,
+  );
+  const user = [...json].reverse().find((message) => message.role === "user");
+  return typeof user?.content === "string" ? user.content : "";
+};
+const answer = (output) => ({
+  success: true,
+  value: { output, toolCalls: [], model: "test", usage: USAGE, cost: COST },
+});
+const dispatch = (name, args) => ({
+  success: true,
+  value: {
+    output: null,
+    toolCalls: [new ToolCall(`call-${name}`, name, args)],
+    model: "test",
+    usage: USAGE,
+    cost: COST,
+  },
+});
+const parkUntilAbort = (config) =>
+  new Promise((resolve, reject) => {
+    const abortError = () => Object.assign(new Error("Request was aborted."), { name: "AbortError" });
+    const signal = config?.abortSignal;
+    if (!signal) {
+      reject(new Error("expected an abortSignal on the parked request"));
+      return;
+    }
+    if (signal.aborted) {
+      reject(abortError());
+      return;
+    }
+    signal.addEventListener("abort", () => reject(abortError()));
+  });
+const answeringClient = (rules) => ({
+  async text(config) {
+    return rules(lastUserText(config), config);
+  },
+  async *textStream(config) {
+    const reply = await this.text(config);
+    yield { type: "done", result: reply.value };
+  },
+  async embed() {
+    return { success: false, error: "not implemented" };
+  },
+});
+
+// Two async prompts, each dispatching a handoff at the same time. Each
+// prompt's final request holds exactly its own body; the main thread
+// holds neither.
+{
+  __setLLMClient(
+    answeringClient((asked) => {
+      if (asked === "A" || asked === "B") {
+        return dispatch("subagent", { question: asked });
+      }
+      if (asked.startsWith("brief:")) {
+        return answer("inner");
+      }
+      if (asked.startsWith("[subagent finished")) {
+        return answer("async done");
+      }
+      return answer("main sees");
+    }),
+  );
+  const { state, callbacks } = makeCapture();
+  const result = await twoAsyncHandoffs({ callbacks });
+  const finals = state.requests.filter((messages) => count(messages, "[subagent finished") === 1);
+  const main = last(state);
+  results.twoAsyncHandoffs = {
+    result: result.data,
+    requestCount: state.requests.length,
+    allWellFormed: allWellFormed(state),
+    asyncFinals: finals.length,
+    eachFinalHoldsOneBody: finals.every(
+      (messages) =>
+        roles(messages).join(",") === "user,assistant,user,assistant,user" &&
+        count(messages, "[dispatching subagent") === 1 &&
+        count(messages, "brief: " + text(messages[0])) === 1,
+    ),
+    mainThreadRoles: roles(main),
+    mainThreadSawHandoff: count(main, "[dispatching"),
+  };
+}
+
+// A race loser inside a handoff body. The winner is held until the
+// loser's body has pushed its persona and sent its request, so the abort
+// lands mid-body. The persona is gone from the loser's thread afterwards
+// and the marker stays as the record of the attempt.
+{
+  let releaseWinner = () => {};
+  const parkedRequestStarted = new Promise((resolve) => {
+    releaseWinner = resolve;
+  });
+  __setLLMClient(
+    answeringClient(async (asked, config) => {
+      if (asked === "fast") {
+        await parkedRequestStarted;
+        return answer("fast");
+      }
+      if (asked === "slow") {
+        return dispatch("parkingAgent", { question: "p" });
+      }
+      releaseWinner();
+      return parkUntilAbort(config);
+    }),
+  );
+  const { state, callbacks } = makeCapture();
+  const result = await cancelledHandoff({ callbacks });
+  const threads = Array.isArray(result.data) ? result.data : [];
+  const loser = threads.find((messages) => count(messages, "[dispatching parkingAgent") === 1);
+  results.cancelledHandoff = {
+    loserThreadFound: loser !== undefined,
+    parkedRequestSawPersona: state.requests.some(
+      (messages) => count(messages, "parked: p") === 1 && count(messages, "persona: be parked") === 1,
+    ),
+    loserKeptPersona: loser === undefined ? null : count(loser, "persona: be parked"),
+    loserKeptMarker: loser === undefined ? null : count(loser, "[dispatching parkingAgent"),
+    loserMarkedCancelled: loser === undefined ? null : count(loser, "[Response cancelled.]"),
   };
 }
 

--- a/packages/agency-lang/tests/agency-js/handoff/test.js
+++ b/packages/agency-lang/tests/agency-js/handoff/test.js
@@ -1,0 +1,227 @@
+import {
+  basic,
+  persona,
+  notAlone,
+  threadInside,
+  subthreadInside,
+  pauseInside,
+  rejectInside,
+  failureInside,
+  rejectHandoff,
+  nested,
+  respondToInterrupts,
+  approve,
+  reject,
+} from "./agent.js";
+import { writeFileSync } from "fs";
+
+// Record every request the model sees, in order. The last request of a
+// node is the caller's final round, which shows the caller's thread
+// after the handoff came back.
+const makeCapture = () => {
+  const state = { requests: [], toolStarts: [] };
+  const callbacks = {
+    onLLMCallStart: ({ messages }) => {
+      state.requests.push(messages);
+    },
+    onToolCallStart: ({ toolName }) => {
+      state.toolStarts.push(toolName);
+    },
+  };
+  return { state, callbacks };
+};
+
+const text = (message) =>
+  typeof message.content === "string" ? message.content : JSON.stringify(message.content);
+const roles = (messages) => messages.map((message) => message.role);
+const last = (state) => state.requests[state.requests.length - 1];
+const count = (messages, needle) =>
+  messages.filter((message) => text(message).includes(needle)).length;
+const hasToolCalls = (message) =>
+  Array.isArray(message.toolCalls) && message.toolCalls.length > 0;
+const toolTexts = (messages) =>
+  messages.filter((message) => message.role === "tool").map(text).sort();
+
+const results = {};
+
+// The subagent's messages land on the caller's thread: the marker
+// replaces the tool call, the leaf tool's exchange stays paired, and the
+// resume message carries the result. The subagent's first request shows
+// it saw the caller's history.
+{
+  const { state, callbacks } = makeCapture();
+  const result = await basic({ callbacks });
+  const final = last(state);
+  const subagentFirst = state.requests[1];
+  results.basic = {
+    result: result.data,
+    requestCount: state.requests.length,
+    roles: roles(final),
+    markerOnAssistant:
+      final[1].role === "assistant" &&
+      text(final[1]).includes("[dispatching subagent") &&
+      !hasToolCalls(final[1]),
+    toolTexts: toolTexts(final),
+    resumeCarriesResult: text(final[final.length - 1]).includes(
+      "[subagent finished. inner answer]",
+    ),
+    subagentSawCaller:
+      text(subagentFirst[0]) === "Answer with the subagent." &&
+      count(subagentFirst, "[dispatching subagent") === 1,
+    toolStarts: state.toolStarts,
+  };
+}
+
+// A system message the body pushes is visible to the body's own request
+// and gone from the caller's thread afterwards.
+{
+  const { state, callbacks } = makeCapture();
+  const result = await persona({ callbacks });
+  results.persona = {
+    result: result.data,
+    requestCount: state.requests.length,
+    bodySawPersona: count(state.requests[1], "persona: be terse"),
+    callerKeptPersona: count(last(state), "persona: be terse"),
+    roles: roles(last(state)),
+  };
+}
+
+// A handoff beside another call is refused as an ordinary tool message;
+// the sibling runs; the assistant message keeps its tool calls.
+{
+  const { state, callbacks } = makeCapture();
+  const result = await notAlone({ callbacks });
+  const final = last(state);
+  results.notAlone = {
+    result: result.data,
+    requestCount: state.requests.length,
+    refused: count(final, "must be the only tool call in its round"),
+    siblingRan: toolTexts(final).includes("value-of-k3"),
+    assistantKeptToolCalls: hasToolCalls(final[1]),
+    toolStarts: state.toolStarts,
+    markers: count(final, "[dispatching"),
+  };
+}
+
+// thread {} inside a handoff body still isolates: the body's request
+// starts empty and none of its messages reach the caller.
+{
+  const { state, callbacks } = makeCapture();
+  const result = await threadInside({ callbacks });
+  results.threadInside = {
+    result: result.data,
+    requestCount: state.requests.length,
+    bodyRequestLength: state.requests[1].length,
+    roles: roles(last(state)),
+    resume: count(last(state), "[threadedAgent finished. threaded answer]"),
+  };
+}
+
+// subthread {} inside a handoff body inherits the caller's history and
+// does not flow back.
+{
+  const { state, callbacks } = makeCapture();
+  const result = await subthreadInside({ callbacks });
+  results.subthreadInside = {
+    result: result.data,
+    requestCount: state.requests.length,
+    bodySawCaller: count(state.requests[1], "[dispatching subthreadedAgent"),
+    roles: roles(last(state)),
+    resume: count(last(state), "[subthreadedAgent finished. subthreaded answer]"),
+  };
+}
+
+// An interrupt inside the body pauses the run. After approval the run
+// resumes without a second marker or a second resume message.
+{
+  const { state, callbacks } = makeCapture();
+  const paused = await pauseInside({ callbacks });
+  const pausedWithInterrupt =
+    Array.isArray(paused.data) && paused.data[0]?.type === "interrupt";
+  const resumed = await respondToInterrupts(paused.data, [approve()], {
+    metadata: { callbacks },
+  });
+  const final = last(state);
+  results.pauseInside = {
+    pausedWithInterrupt,
+    result: resumed.data,
+    requestCount: state.requests.length,
+    markers: count(final, "[dispatching pausingAgent"),
+    resumes: count(final, "pausingAgent finished"),
+    roles: roles(final),
+    toolTexts: toolTexts(final),
+  };
+}
+
+// The same pause, rejected. The rejection is the leaf tool's, inside the
+// body, so it reaches the body's own model as a tool message and the
+// body still hands back normally. This pins the rejection route through
+// the loop that runs inside a handoff.
+{
+  const { state, callbacks } = makeCapture();
+  const paused = await rejectInside({ callbacks });
+  const resumed = await respondToInterrupts(paused.data, [reject("not today")], {
+    metadata: { callbacks },
+  });
+  const final = last(state);
+  results.rejectInside = {
+    result: resumed.data,
+    requestCount: state.requests.length,
+    rejectionSeenByBody: count(final, "Tool call rejected: not today"),
+    markers: count(final, "[dispatching pausingAgent"),
+    resumes: count(final, "[pausingAgent finished. rejected answer]"),
+    roles: roles(final),
+  };
+}
+
+// A body that returns a failure hands back with the error in the resume
+// message and no tool message anywhere.
+{
+  const { state, callbacks } = makeCapture();
+  const result = await failureInside({ callbacks });
+  const final = last(state);
+  results.failureInside = {
+    result: result.data,
+    requestCount: state.requests.length,
+    roles: roles(final),
+    resumeCarriesError: count(final, "[failingAgent finished. Error: boom"),
+  };
+}
+
+// The handoff call itself is rejected: the body raises before its
+// llm(), the rejection makes the body return a rejected failure, and the
+// outer loop's recordRejection hands back through the resume message.
+// No tool message anywhere, and the marker stays.
+{
+  const { state, callbacks } = makeCapture();
+  const paused = await rejectHandoff({ callbacks });
+  const resumed = await respondToInterrupts(paused.data, [reject("nope")], {
+    metadata: { callbacks },
+  });
+  const final = last(state);
+  results.rejectHandoff = {
+    result: resumed.data,
+    requestCount: state.requests.length,
+    roles: roles(final),
+    markers: count(final, "[dispatching gatedAgent"),
+    resumeCarriesRejection: count(final, "[gatedAgent finished. Tool call rejected: nope"),
+  };
+}
+
+// A handoff inside a handoff: two markers, two resumes, no tool
+// messages, all on the one thread.
+{
+  const { state, callbacks } = makeCapture();
+  const result = await nested({ callbacks });
+  const final = last(state);
+  results.nested = {
+    result: result.data,
+    requestCount: state.requests.length,
+    roles: roles(final),
+    markers: count(final, "[dispatching"),
+    resumes: count(final, "finished."),
+    toolMessages: final.filter((message) => message.role === "tool").length,
+  };
+}
+
+writeFileSync("__result.json", JSON.stringify(results, null, 2));

--- a/packages/agency-lang/tests/agency/agents/oracleExplorer.agency
+++ b/packages/agency-lang/tests/agency/agents/oracleExplorer.agency
@@ -1,5 +1,6 @@
 import { oracleAgent, buildTools as oracleTools } from "std::agents/oracle"
 import { explorerAgent, buildTools as explorerTools } from "std::agents/explorer"
+import { getThread, currentThreadId } from "std::thread"
 
 def hasTool(tools: any[], name: string): boolean {
   return some(tools, \tool -> tool.name == name)
@@ -43,4 +44,25 @@ node neitherHasDuplicateToolNames(): boolean {
     }
   }
   return true
+}
+
+// From code the agents run on the caller's thread like any function.
+// Two calls push one persona and leave both replies where the caller
+// can read them.
+const WHOLE_THREAD = 1000
+
+node twoOracleCallsShareTheCallerThread(): boolean {
+  const first = oracleAgent(question: "is this plan sound")
+  const second = oracleAgent(question: "and the tests?")
+  const messages = getThread(currentThreadId(), 0, WHOLE_THREAD) catch []
+  const personas = filter(messages, \message -> message.role == "system")
+  const replies = filter(messages, \message -> message.role == "assistant")
+  return personas.length == 1 && replies.length == 2
+}
+
+node explorerFromCodeLandsOnTheCallerThread(): boolean {
+  const survey = explorerAgent(question: "summarize the parsers")
+  const messages = getThread(currentThreadId(), 0, WHOLE_THREAD) catch []
+  const replies = filter(messages, \message -> message.role == "assistant")
+  return replies.length == 1
 }

--- a/packages/agency-lang/tests/agency/agents/oracleExplorer.test.json
+++ b/packages/agency-lang/tests/agency/agents/oracleExplorer.test.json
@@ -1,9 +1,11 @@
 {
   "tests": [
-    { "nodeName": "oracleAnswers", "description": "the oracle returns its analysis as a success Result", "input": "", "expectedOutput": "\"the plan is sound, proceed\"", "evaluationCriteria": [{ "type": "exact" }], "useTestLLMProvider": true, "llmMocks": [{ "return": "the plan is sound, proceed" }] },
-    { "nodeName": "explorerAnswers", "description": "the explorer returns its survey as a success Result", "input": "", "expectedOutput": "\"the parsers are combinator-based\"", "evaluationCriteria": [{ "type": "exact" }], "useTestLLMProvider": true, "llmMocks": [{ "return": "the parsers are combinator-based" }] },
-    { "nodeName": "bothAreReadOnly", "description": "neither agent carries a tool that changes anything", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "toolsMatchTheirJobs", "description": "each carries the tools its job needs", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "neitherHasDuplicateToolNames", "description": "no duplicate tool names in either agent", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] }
+    {"nodeName": "oracleAnswers", "description": "the oracle returns its analysis as a success Result", "input": "", "expectedOutput": "\"the plan is sound, proceed\"", "evaluationCriteria": [{"type": "exact"}], "useTestLLMProvider": true, "llmMocks": [{"return": "the plan is sound, proceed"}]},
+    {"nodeName": "explorerAnswers", "description": "the explorer returns its survey as a success Result", "input": "", "expectedOutput": "\"the parsers are combinator-based\"", "evaluationCriteria": [{"type": "exact"}], "useTestLLMProvider": true, "llmMocks": [{"return": "the parsers are combinator-based"}]},
+    {"nodeName": "bothAreReadOnly", "description": "neither agent carries a tool that changes anything", "input": "", "expectedOutput": "true", "evaluationCriteria": [{"type": "exact"}]},
+    {"nodeName": "toolsMatchTheirJobs", "description": "each carries the tools its job needs", "input": "", "expectedOutput": "true", "evaluationCriteria": [{"type": "exact"}]},
+    {"nodeName": "neitherHasDuplicateToolNames", "description": "no duplicate tool names in either agent", "input": "", "expectedOutput": "true", "evaluationCriteria": [{"type": "exact"}]},
+    {"nodeName": "twoOracleCallsShareTheCallerThread", "description": "from code, two oracle calls share the caller thread and push one persona", "input": "", "expectedOutput": "true", "evaluationCriteria": [{"type": "exact"}], "useTestLLMProvider": true, "llmMocks": [{"return": "sound"}, {"return": "the tests are fine"}]},
+    {"nodeName": "explorerFromCodeLandsOnTheCallerThread", "description": "from code, the explorer reply lands on the caller thread", "input": "", "expectedOutput": "true", "evaluationCriteria": [{"type": "exact"}], "useTestLLMProvider": true, "llmMocks": [{"return": "the parsers are combinator-based"}]}
   ]
 }


### PR DESCRIPTION
## What

A new function modifier, `handoff def`. When a model calls a handoff function as a tool, the function runs on the caller's message thread instead of a fresh one, and the tool-call bookkeeping is replaced by two plain messages: an assistant-role marker where the tool call was, and a user-role resume message when the body returns. The subagent's work becomes part of the caller's conversation.

Spec: `2026-09-02-thread-sharing-invocation-spec.md` at the repo root. Dev doc: `docs/dev/language/handoff-functions.md`.

After a turn, the coordinator's thread reads:

```
user:      How does the typechecker interact with the preprocessor?
assistant: [dispatching explorerAgent: {"userMsg": "How does the typechecker..."}]
user:      <the brief the explorer sends itself>
assistant: I'll start with the preprocessor's entry points. [tool_use: read x3]
tool:      ...file contents...
assistant: The typechecker runs after the preprocessor because ...
user:      [explorerAgent finished. The typechecker runs after ...]
           Continue with the user's request.
assistant: Here's how they interact: ...
```

## How

- The marker rides the existing `markers` mechanism (`destructive`, `idempotent`) from the parser to the `AgencyFunction`. The keyword list now lives in one table, `FUNCTION_MARKER_KEYWORDS`, that the parser, formatter, and codegen all read.
- In the tool loop: a `.handoffMarker` step rewrites the assistant tool-call message and records the start index in `runnerState.handoffStarts`; `runInvokeStep` skips the fresh `ThreadStore`; one `pushToolReply` decides tool message versus resume message for every reply route (success, failure, rejection). A handoff that shares a round with any other call is refused with the `handoffNotAlone` gate verdict.
- System messages the body pushes are removed on hand-back. `thread {}` inside the body still isolates; `subthread {}` inherits the caller's history.
- Three durable records for resume: the gate verdict (existing), the marker step's start index (new), and the invoke outcome (existing). A mid-handoff interrupt resumes without a second marker; there is no orphaned tool call to repair.

## Breaking change: the stdlib oracle and explorer from code

`std::agents` `oracleAgent` and `explorerAgent` are now `handoff def`. They drop their `thread(label:..., session:)` wrapper and the `session` parameter. Called as tools they continue the caller's conversation. Called from code they run on the caller's thread like any function, so the persona, reads, and answer stay there. A caller who wants the old isolation writes `thread { oracleAgent(...) }`. The persona goes through a new `std::thread` helper, `ensureSystemMessage`, so two calls on one thread push it once. Decided 2026-09-02.

The coordinator offers both as handoffs, and the coding agent's oracle is a handoff too (on purpose: it sees the coder's real diff).

## Tests

- `tests/agency-js/handoff`: ten scripted scenarios against the deterministic client (basic, persona stripped, mixed round refused, thread inside, subthread inside, pause and resume, rejection inside, rejected handoff, failure return, nested).
- `tests/agency/agents/oracleExplorer.agency`: two new nodes pin the from-code behavior.
- Unit tests for the parser, formatter, codegen, `MessageThread.replaceAt` and `removeMatching`, and the handoff helpers.
- `tool-rejection` and `repeated-tool-calls` still pass.

## Not in this PR

Mixed rounds, merging an isolated tool's messages back, thread compaction, any default change, a check that a handoff body calls `llm()`, the user-facing guide page.

## Acceptance check CI cannot run

The `packaging-decision` eval: an oracle dispatched after an explorer should stop re-deriving the explorer's work. The explorer's reads now sit uncompacted on the coordinator's main thread, so record the run's cost and the final request's token count before and after alongside that observation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTaMYjLxBUfm67QboMHizA
