### PR TITLE
Policy: the agent-home placeholder, scoped scans, and the toolbox use count

### DIFF
--- a/packages/agency-lang/docs/dev/agents/approval-policies.md
+++ b/packages/agency-lang/docs/dev/agents/approval-policies.md
@@ -112,12 +112,6 @@ inside the home: the reads and the use-count write under these
 approvals refuse a symlinked skill or tool directory (see `docs/dev/stdlib/skills-write.md`
 and `docs/dev/stdlib/toolbox.md`).
 
-The matcher tries each `dir` pattern three ways: as written, with `.`
-expanded, and with every placeholder expanded in one pass. One pass,
-because each expander leaves a pattern without its token alone, so a
-pattern that mixes `<agency>` and `<agent-home>` in one brace group
-works too.
-
 A policy file saved before this change keeps its old catch-all read rules;
 there is no migration. Delete the file (the agent writes a fresh
 recommended policy on the next launch) or edit the five read effects.

--- a/packages/agency-lang/docs/dev/agents/approval-policies.md
+++ b/packages/agency-lang/docs/dev/agents/approval-policies.md
@@ -53,8 +53,10 @@ question, a review) get no "always" answers at all.
 ## What `recommended` lets the agent read
 
 The read-only file effects (`std::read`, `std::readBinary`, `std::ls`,
-`std::glob`, `std::grep`) are approved in two places only
-(`readScopeRules` in `lib/runtime/builtinPolicies.ts`):
+`std::glob`, `std::grep`) and the scan effects that read a whole
+directory under one approval (`std::skills::skillsDir`,
+`std::skills::commandsDir`, `std::toolbox::scan`) are approved in three
+places only (`readScopeRules` in `lib/runtime/builtinPolicies.ts`):
 
 - the launch directory and everything under it, written as `{.,./**}` so
   the rule keeps meaning "wherever the agent runs" after the policy is
@@ -63,17 +65,58 @@ The read-only file effects (`std::read`, `std::readBinary`, `std::ls`,
   `{<agency>/stdlib/**,<agency>/dist/**}`. The docs tools (`agencyGuide`,
   `agencyStdlib`, ...) are `read` partially applied to
   `stdlib/docs/<section>`, and the bundled skills are read the same way, so
-  without this rule those tools return rejections in a headless run.
+  without this rule those tools return rejections in a headless run;
+- the agent home's learned skills and tools, written as
+  `{<agent-home>/skills/**,<agent-home>/tools/**}`. Those directories
+  hold skills the user taught the agent and tools it wrote, and both
+  enter them only through a review interrupt. Without this rule every
+  read of a learned skill, every catalog scan, and every `runTool` would
+  prompt, and would auto-reject headless. The rule reaches every
+  `recommended` run, not only the agent, and the policy's description
+  says so. The home itself is not covered, so `~/.agency-agent/policy.json`
+  and `settings.json` still prompt.
 
-Both rules are placeholders, not paths. `.` expands to the process cwd and
-`<agency>` to the directory the agency package is installed in
-(`AGENCY_INSTALL_DIR_PLACEHOLDER`, `expandAgencyInstallDir`,
-`getPackageRoot`), each at match time. The copy the agent saves to
-`~/.agency-agent/policy.json` therefore pins neither the directory it was
-first run in nor the install path of one version. After an upgrade moves the
-package, the same rule still matches. A root that cannot be found (a bundled build
-with no `package.json` above it) leaves `<agency>` as written and the rule
-simply never matches.
+`recommended` also approves `std::toolbox::recordUse` under
+`<agent-home>/tools/**`, the effect `runTool` raises before counting a
+use in the tool's `meta.json`. It is an effect of its own rather than a
+`std::write` rule on that filename because a path glob cannot tell the
+stdlib's bookkeeping from any program writing arbitrary content into
+`meta.json`, whose `purpose` text `listTools` then trusts and whose
+`maxTime` sets the run's time limit. Approving the effect approves only
+the record the stdlib composes. No `std::write` is approved anywhere.
+
+The save and review gates (`std::skills::save`, `std::skills::review`,
+`std::toolbox::save`, `std::toolbox::review`) have no rule in any
+built-in but `approve-all`. They prompt.
+
+All three read rules are placeholders, not paths. `.` expands to the
+process cwd, `<agency>` to the directory the agency package is installed
+in (`AGENCY_INSTALL_DIR_PLACEHOLDER`, `expandAgencyInstallDir`,
+`getPackageRoot`), and `<agent-home>` to `AGENCY_AGENT_HOME` or
+`~/.agency-agent` (`AGENT_HOME_PLACEHOLDER`, `expandAgentHomeDir`,
+`agentHomeDir` in `lib/runtime/agentHome.ts`), each at match time. An
+empty `AGENCY_AGENT_HOME` counts as unset, and a relative one resolves
+against the cwd, the way the `--agent-home` flag does. The copy the
+agent saves to `~/.agency-agent/policy.json` therefore pins neither the
+directory it was first run in, nor the install path of one version, nor
+one machine's home. A root that cannot be found (a bundled build with no
+`package.json` above it) leaves `<agency>` as written and the rule simply
+never matches.
+
+The expanded home is realpathed, for the reason the cwd is in
+`resolveDotDirPattern`: file effects put the realpath of their directory
+in the interrupt payload, so a home reached through a symlinked ancestor
+(`/tmp` on macOS, a linked `$HOME`) would otherwise never match. This is
+the spelling the payload already uses. It is not support for symlinks
+inside the home: the reads and the use-count write under these
+approvals refuse a symlinked skill or tool directory (see `docs/dev/stdlib/skills-write.md`
+and `docs/dev/stdlib/toolbox.md`).
+
+The matcher tries each `dir` pattern three ways: as written, with `.`
+expanded, and with every placeholder expanded in one pass. One pass,
+because each expander leaves a pattern without its token alone, so a
+pattern that mixes `<agency>` and `<agent-home>` in one brace group
+works too.
 
 A policy file saved before this change keeps its old catch-all read rules;
 there is no migration. Delete the file (the agent writes a fresh

--- a/packages/agency-lang/docs/dev/agents/approval-policies.md
+++ b/packages/agency-lang/docs/dev/agents/approval-policies.md
@@ -67,7 +67,9 @@ places only (`readScopeRules` in `lib/runtime/builtinPolicies.ts`):
   `stdlib/docs/<section>`, and the bundled skills are read the same way, so
   without this rule those tools return rejections in a headless run;
 - the agent home's learned skills and tools, written as
-  `{<agent-home>/skills/**,<agent-home>/tools/**}`. Those directories
+  `{<agent-home>/skills,<agent-home>/skills/**,<agent-home>/tools,<agent-home>/tools/**}`.
+  The roots are listed as well as their contents because a catalog scan
+  of the whole directory names the root itself in its payload. Those directories
   hold skills the user taught the agent and tools it wrote, and both
   enter them only through a review interrupt. Without this rule every
   read of a learned skill, every catalog scan, and every `runTool` would
@@ -106,7 +108,10 @@ never matches.
 The expanded home is realpathed, for the reason the cwd is in
 `resolveDotDirPattern`: file effects put the realpath of their directory
 in the interrupt payload, so a home reached through a symlinked ancestor
-(`/tmp` on macOS, a linked `$HOME`) would otherwise never match. This is
+(`/tmp` on macOS, a linked `$HOME`) would otherwise never match. The
+scan and save effects in `std::skills` and `std::toolbox` put the same
+spelling in their payloads (`canonicalDir` in `lib/stdlib/resolveDir.ts`),
+so one rule covers a read and the scan that precedes it. This is
 the spelling the payload already uses. It is not support for symlinks
 inside the home: the reads and the use-count write under these
 approvals refuse a symlinked skill or tool directory (see `docs/dev/stdlib/skills-write.md`

--- a/packages/agency-lang/docs/dev/stdlib/skills-write.md
+++ b/packages/agency-lang/docs/dev/stdlib/skills-write.md
@@ -127,6 +127,15 @@ attacker who can replace an ancestor of the approved root controls the
 data's parent directory and is outside this (and every file effect's)
 threat model.
 
+## What the recommended policy approves
+
+`std::skills::skillsDir` and `std::skills::commandsDir` take the same
+read scope as `std::read` in the recommended policy (`readScopeRules`):
+the launch directory, the agency install, and the agent home's learned
+skills and tools. Before this they were approved anywhere, which let a
+scan read a directory a plain `read` would have prompted for. The save
+and review gates have no rule and prompt.
+
 ## The frontmatter round-trip
 
 The description is serialized with tarsec's `stringifyFrontmatter`

--- a/packages/agency-lang/docs/dev/stdlib/skills-write.md
+++ b/packages/agency-lang/docs/dev/stdlib/skills-write.md
@@ -43,17 +43,14 @@ dangling symlink fails the open atomically — because the pre-interrupt
 check is stale by save time: approval can take arbitrarily long, and a
 file created in the meantime must never be overwritten.
 
-The `dir` in the interrupt payload is absolutized (`~` expanded,
-resolved against the process cwd), so relative and `~`-led spellings
-produce the same payload and an always-scope rule saved from a save
-approval names one directory regardless of how the caller spelled it.
-One gap remains: the write that follows realpaths its directory
-(`prepareContainedPath`), and the save payload cannot — the directory
-may not exist until `mkdir` runs after approval. So a directory reached
-through a symlinked ancestor still yields two spellings (on macOS,
-`/tmp/skills` for the save and `/private/tmp/skills` for the write),
-and one always-scope rule will not cover both interrupts there. An
-empty `dir` is refused before any prompt.
+The `dir` in the interrupt payload is canonical (`~` expanded, resolved
+against the process cwd, realpathed through its nearest existing
+ancestor: `canonicalDir`), so relative, `~`-led, and symlink-spelled
+directories produce the same payload the write that follows will report
+(`prepareContainedPath` realpaths the same way), and an always-scope
+rule saved from a save approval covers both interrupts. Every scan
+payload in this module is spelled the same way. An empty `dir` is
+refused before any prompt.
 
 ## The design loop
 

--- a/packages/agency-lang/docs/dev/stdlib/toolbox.md
+++ b/packages/agency-lang/docs/dev/stdlib/toolbox.md
@@ -164,14 +164,23 @@ It then lists the directory with `ls` from `std::shell` (which raises
 `std::ls`), and keeps the directories whose names are not `staging` and
 do not start with a dot. The recommended policy gives `std::toolbox::scan` the same `dir` scope
 as `std::read`, so a toolbox outside the working directory prompts. `listTools` refuses an empty `dir`, since the
-primitives would resolve it to the process cwd. `ls` counts every entry
+primitives would resolve it to the process cwd, and absolutizes it, so
+the scan payload names one directory however the caller spelled it and a
+policy pattern that expands to an absolute path can match it. `ls` counts every entry
 against its cap and does not say when it stopped, so a listing that
 reaches the cap is reported as a failure. It is not returned as a
 shortened catalog. The per-tool reads
 of `impl.agency` and `meta.json` use `_read`, covered by that one scan
 approval. `runTool` and the post-publish read in `saveTool` raise the
 same scan for the one tool directory they read, so no `_read` runs
-without an approval that names its directory. A toolbox directory that does not exist
+without an approval that names its directory. Every one of those reads
+is contained in the toolbox root (`readContainedFile`, the
+descriptor-validated read `std::skills` also uses): the open refuses a
+symlink, and the opened file is checked to sit inside the root. A tool
+directory that is a symlink is already left out of the catalog, because
+`ls` reports a link rather than a directory, and the contained read
+stops `runTool` from running it. That matters now that the recommended
+policy approves scans of the agent home's toolbox without asking. A toolbox directory that does not exist
 yet is an empty catalog.
 
 Each entry carries `module` (what `describe` says about `run`: signature,
@@ -189,10 +198,20 @@ stops the tool before it has side effects. It then runs `main` through
 `runFile`, with `wallClock` set to the tool's own `maxTime` plus
 headroom, so the guard trips before the subprocess is killed. `runFile`
 clamps `wallClock` to an hour, so `stage` refuses a `maxTime` above
-an hour minus that headroom. It then rewrites `meta.json` with
-one more use and the time. If that write fails, the returned failure
-carries the tool's result in its message, since the tool has already
-run. Otherwise it returns the node's own `Result`.
+an hour minus that headroom. It then counts the use in
+`meta.json`, behind a `std::toolbox::recordUse` interrupt naming the
+tool's directory. The write that fulfils the approval uses the
+interrupt-free `_write`, contained in the toolbox root the same way the
+reads are (`writeContainedFile`, which also refuses to create a file
+under a symlinked directory). The count is best-effort: the tool has
+already run, so a declined interrupt or a failed write leaves the count
+where it was and `runTool` returns the node's own `Result`.
+
+`recordUse` is an effect of its own so a policy can approve it without
+approving any `std::write`. A write rule on `meta.json` would approve a
+program writing anything there, and `listTools` trusts the file's
+`purpose` and `runTool` its `maxTime`. The recommended policy approves
+the effect under the agent home's toolbox.
 
 ## Model calls and mocks
 

--- a/packages/agency-lang/docs/dev/stdlib/toolbox.md
+++ b/packages/agency-lang/docs/dev/stdlib/toolbox.md
@@ -164,9 +164,9 @@ It then lists the directory with `ls` from `std::shell` (which raises
 `std::ls`), and keeps the directories whose names are not `staging` and
 do not start with a dot. The recommended policy gives `std::toolbox::scan` the same `dir` scope
 as `std::read`, so a toolbox outside the working directory prompts. `listTools` refuses an empty `dir`, since the
-primitives would resolve it to the process cwd, and absolutizes it, so
-the scan payload names one directory however the caller spelled it and a
-policy pattern that expands to an absolute path can match it. `ls` counts every entry
+primitives would resolve it to the process cwd, and canonicalizes it
+(`canonicalDir`), so the scan payload names one directory however the
+caller spelled it and a policy rule written for reads matches it. `ls` counts every entry
 against its cap and does not say when it stopped, so a listing that
 reaches the cap is reported as a failure. It is not returned as a
 shortened catalog. The per-tool reads

--- a/packages/agency-lang/docs/dev/stdlib/toolbox.md
+++ b/packages/agency-lang/docs/dev/stdlib/toolbox.md
@@ -174,13 +174,11 @@ of `impl.agency` and `meta.json` use `_read`, covered by that one scan
 approval. `runTool` and the post-publish read in `saveTool` raise the
 same scan for the one tool directory they read, so no `_read` runs
 without an approval that names its directory. Every one of those reads
-is contained in the toolbox root (`readContainedFile`, the
-descriptor-validated read `std::skills` also uses): the open refuses a
-symlink, and the opened file is checked to sit inside the root. A tool
-directory that is a symlink is already left out of the catalog, because
-`ls` reports a link rather than a directory, and the contained read
-stops `runTool` from running it. That matters now that the recommended
-policy approves scans of the agent home's toolbox without asking. A toolbox directory that does not exist
+is contained in the toolbox root through `readContainedFile`, so a
+symlinked tool directory cannot carry a scan approval elsewhere. `ls`
+reports a link rather than a directory, so such a tool is already left
+out of the catalog, and the contained read stops `runTool` from running
+it. A toolbox directory that does not exist
 yet is an empty catalog.
 
 Each entry carries `module` (what `describe` says about `run`: signature,
@@ -200,18 +198,13 @@ headroom, so the guard trips before the subprocess is killed. `runFile`
 clamps `wallClock` to an hour, so `stage` refuses a `maxTime` above
 an hour minus that headroom. It then counts the use in
 `meta.json`, behind a `std::toolbox::recordUse` interrupt naming the
-tool's directory. The write that fulfils the approval uses the
-interrupt-free `_write`, contained in the toolbox root the same way the
-reads are (`writeContainedFile`, which also refuses to create a file
-under a symlinked directory). The count is best-effort: the tool has
-already run, so a declined interrupt or a failed write leaves the count
-where it was and `runTool` returns the node's own `Result`.
-
-`recordUse` is an effect of its own so a policy can approve it without
-approving any `std::write`. A write rule on `meta.json` would approve a
-program writing anything there, and `listTools` trusts the file's
-`purpose` and `runTool` its `maxTime`. The recommended policy approves
-the effect under the agent home's toolbox.
+tool's directory. The write that fulfils the approval is contained in
+the toolbox root through `writeContainedFile`, the write-side twin of
+the read helper. The count is best-effort: the tool has already run, so
+a declined interrupt or a failed write leaves the count where it was and
+`runTool` returns the node's own `Result`. Why the count is an effect of
+its own, and what the recommended policy does with it, is in
+`docs/dev/agents/approval-policies.md`.
 
 ## Model calls and mocks
 

--- a/packages/agency-lang/docs/site/stdlib/skills.md
+++ b/packages/agency-lang/docs/site/stdlib/skills.md
@@ -51,7 +51,7 @@ export type SkillGroup = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L305))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L308))
 
 ## Effects
 
@@ -114,7 +114,7 @@ effect std::skills::save {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L371))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L374))
 
 ### std::skills::review
 
@@ -127,7 +127,7 @@ effect std::skills::review {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L485))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L488))
 
 ## Functions
 
@@ -219,7 +219,7 @@ needs as its `dir`.
 
 **Throws:** `std::skills::skillsDir`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L317))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L320))
 
 ### writeSkill
 
@@ -261,7 +261,7 @@ draft-revise-accept loop is `designSkill`, which ends by calling this.
 
 **Throws:** `std::skills::save`, `std::mkdir`, `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L425))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L428))
 
 ### designSkill
 
@@ -312,7 +312,7 @@ the write. This is the function to hand to a model as a tool.
 
 **Throws:** `std::skills::review`, `std::skills::save`, `std::mkdir`, `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L593))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L596))
 
 ### docsSkill
 
@@ -337,7 +337,7 @@ Build a docs tool for an LLM over the packaged Agency documentation.
 |---|---|---|
 | section | `\| "guide" \| "cli" \| "diagnostics" \| "stdlib" \| "agent"` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L638))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L641))
 
 ### bundledDocsDir
 
@@ -350,7 +350,7 @@ The directory holding the Agency docs that ship inside the package. A
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L659))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L662))
 
 ### agentSkill
 
@@ -370,7 +370,7 @@ Build a skills tool over the skills shipped for one agent. The returned
 |---|---|---|
 | agent | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L667))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L670))
 
 ### commandsDir
 
@@ -423,7 +423,7 @@ root), pass an absolute path: `"${cwd()}/.claude/commands"`.
 
 **Throws:** `std::skills::commandsDir`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L755))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L758))
 
 ### expandSlash
 
@@ -462,4 +462,4 @@ agency agent`, yielding `"/foo\n"`) dispatch correctly.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L810))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L813))

--- a/packages/agency-lang/docs/site/stdlib/toolbox.md
+++ b/packages/agency-lang/docs/site/stdlib/toolbox.md
@@ -76,7 +76,7 @@ export type ModuleFacts = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L135))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L145))
 
 ### ToolMeta
 
@@ -95,7 +95,7 @@ export type ToolMeta = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L142))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L152))
 
 ### ToolEntry
 
@@ -114,7 +114,7 @@ export type ToolEntry = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L154))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L164))
 
 ## Effects
 
@@ -129,6 +129,18 @@ effect std::toolbox::scan {
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L112))
 
+### std::toolbox::recordUse
+
+```ts
+@alwaysUnder(dir)
+effect std::toolbox::recordUse {
+  dir: string;
+  name: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L121))
+
 ### std::toolbox::review
 
 ```ts
@@ -141,7 +153,7 @@ effect std::toolbox::review {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L116))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L126))
 
 ### std::toolbox::save
 
@@ -155,7 +167,7 @@ effect std::toolbox::save {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L127))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L137))
 
 ## Functions
 
@@ -183,7 +195,7 @@ List the tools in a toolbox directory. Raises a `std::toolbox::scan`
 
 **Throws:** `std::toolbox::scan`, `std::ls`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L323))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L339))
 
 ### designTool
 
@@ -241,7 +253,7 @@ published through the same `std::toolbox::save` gate `writeTool` uses.
 
 **Throws:** `std::remove`, `std::mkdir`, `std::toolbox::review`, `std::toolbox::save`, `std::toolbox::scan`, `std::write`, `std::move`, `std::read`, `std::guard`, `std::run`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L985))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L1001))
 
 ### writeTool
 
@@ -293,7 +305,7 @@ in `designTool` ends by publishing through this same gate.
 
 **Throws:** `std::remove`, `std::mkdir`, `std::toolbox::save`, `std::toolbox::scan`, `std::write`, `std::move`, `std::read`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L1049))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L1065))
 
 ### runTool
 
@@ -306,8 +318,9 @@ runTool(
 ```
 
 Run a saved tool's `main` node in a subprocess and return what it
-  returned. The tool's meta.json records one more use and the time; it
-  does not record the result.
+  returned. The tool's meta.json records one more use and the time,
+  behind a `std::toolbox::recordUse` interrupt. A declined or failed
+  record does not fail the run. The result is not recorded.
 
   @param name - The tool's name under dir
   @param request - The tool's input, a value of its Request type
@@ -323,6 +336,6 @@ Run a saved tool's `main` node in a subprocess and return what it
 
 **Returns:** `Result<Json>`
 
-**Throws:** `std::toolbox::scan`, `std::run`, `std::guard`, `std::write`
+**Throws:** `std::toolbox::scan`, `std::run`, `std::guard`, `std::toolbox::recordUse`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L1092))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L1114))

--- a/packages/agency-lang/docs/site/stdlib/toolbox.md
+++ b/packages/agency-lang/docs/site/stdlib/toolbox.md
@@ -76,7 +76,7 @@ export type ModuleFacts = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L145))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L144))
 
 ### ToolMeta
 
@@ -95,7 +95,7 @@ export type ToolMeta = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L152))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L151))
 
 ### ToolEntry
 
@@ -114,7 +114,7 @@ export type ToolEntry = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L164))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L163))
 
 ## Effects
 
@@ -139,7 +139,7 @@ effect std::toolbox::recordUse {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L121))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L120))
 
 ### std::toolbox::review
 
@@ -153,7 +153,7 @@ effect std::toolbox::review {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L126))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L125))
 
 ### std::toolbox::save
 
@@ -167,7 +167,7 @@ effect std::toolbox::save {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L137))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L136))
 
 ## Functions
 
@@ -195,7 +195,7 @@ List the tools in a toolbox directory. Raises a `std::toolbox::scan`
 
 **Throws:** `std::toolbox::scan`, `std::ls`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L339))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L335))
 
 ### designTool
 
@@ -253,7 +253,7 @@ published through the same `std::toolbox::save` gate `writeTool` uses.
 
 **Throws:** `std::remove`, `std::mkdir`, `std::toolbox::review`, `std::toolbox::save`, `std::toolbox::scan`, `std::write`, `std::move`, `std::read`, `std::guard`, `std::run`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L1001))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L997))
 
 ### writeTool
 
@@ -305,7 +305,7 @@ in `designTool` ends by publishing through this same gate.
 
 **Throws:** `std::remove`, `std::mkdir`, `std::toolbox::save`, `std::toolbox::scan`, `std::write`, `std::move`, `std::read`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L1065))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L1061))
 
 ### runTool
 
@@ -318,9 +318,9 @@ runTool(
 ```
 
 Run a saved tool's `main` node in a subprocess and return what it
-  returned. The tool's meta.json records one more use and the time,
-  behind a `std::toolbox::recordUse` interrupt. A declined or failed
-  record does not fail the run. The result is not recorded.
+  returned. The tool's meta.json counts one more use and the time. A
+  declined or failed count does not fail the run. The result is not
+  recorded.
 
   @param name - The tool's name under dir
   @param request - The tool's input, a value of its Request type
@@ -338,4 +338,4 @@ Run a saved tool's `main` node in a subprocess and return what it
 
 **Throws:** `std::toolbox::scan`, `std::run`, `std::guard`, `std::toolbox::recordUse`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L1114))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L1110))

--- a/packages/agency-lang/lib/cli/mcp.ts
+++ b/packages/agency-lang/lib/cli/mcp.ts
@@ -1,6 +1,6 @@
-import * as os from "os";
 import * as path from "path";
 import { isFailure } from "@/runtime/index.js";
+import { agentHomeDir } from "@/runtime/agentHome.js";
 import { _addMcpServer, _removeMcpServer, _readMcpServersFromFile } from "@/stdlib/mcp.js";
 
 // The "what" for `agency mcp …`. Commander does the parsing; these thin actions
@@ -9,13 +9,8 @@ import { _addMcpServer, _removeMcpServer, _readMcpServersFromFile } from "@/stdl
 
 type ScopeOpts = { global?: boolean };
 
-function agentHome(): string {
-  const override = process.env.AGENCY_AGENT_HOME;
-  return override ? path.resolve(override) : path.join(os.homedir(), ".agency-agent");
-}
-
 const projectFile = (): string => path.resolve(process.cwd(), "agency.json");
-const globalFile = (): string => path.join(agentHome(), "settings.json");
+const globalFile = (): string => path.join(agentHomeDir(), "settings.json");
 
 const scopeFile = (o: ScopeOpts): string => (o.global ? globalFile() : projectFile());
 const scopeName = (o: ScopeOpts): string => (o.global ? "global" : "project");

--- a/packages/agency-lang/lib/runtime/agentHome.ts
+++ b/packages/agency-lang/lib/runtime/agentHome.ts
@@ -1,0 +1,15 @@
+import os from "os";
+import path from "path";
+
+/** The agent home directory: `AGENCY_AGENT_HOME`, or `~/.agency-agent`.
+ *  An empty variable counts as unset, so a set-but-blank value never
+ *  turns the home into the current directory. A relative override is
+ *  resolved against the process cwd, the way the `--agent-home` launcher
+ *  resolves it. */
+export function agentHomeDir(): string {
+  const override = process.env.AGENCY_AGENT_HOME;
+  if (override !== undefined && override !== "") {
+    return path.resolve(override);
+  }
+  return path.join(os.homedir(), ".agency-agent");
+}

--- a/packages/agency-lang/lib/runtime/builtinPolicies.test.ts
+++ b/packages/agency-lang/lib/runtime/builtinPolicies.test.ts
@@ -17,7 +17,12 @@ describe("builtinPolicy", () => {
       expect(p![effect]).toEqual([
         { match: { dir: "{.,./**}" }, action: "approve" },
         { match: { dir: "{<agency>/stdlib/**,<agency>/dist/**}" }, action: "approve" },
-        { match: { dir: "{<agent-home>/skills/**,<agent-home>/tools/**}" }, action: "approve" },
+        {
+          match: {
+            dir: "{<agent-home>/skills,<agent-home>/skills/**,<agent-home>/tools,<agent-home>/tools/**}",
+          },
+          action: "approve",
+        },
       ]);
     }
     // No std::write rule at all: the toolbox use count goes through its

--- a/packages/agency-lang/lib/runtime/builtinPolicies.test.ts
+++ b/packages/agency-lang/lib/runtime/builtinPolicies.test.ts
@@ -17,16 +17,43 @@ describe("builtinPolicy", () => {
       expect(p![effect]).toEqual([
         { match: { dir: "{.,./**}" }, action: "approve" },
         { match: { dir: "{<agency>/stdlib/**,<agency>/dist/**}" }, action: "approve" },
+        { match: { dir: "{<agent-home>/skills/**,<agent-home>/tools/**}" }, action: "approve" },
       ]);
     }
+    // No std::write rule at all: the toolbox use count goes through its
+    // own effect, never a write approval.
     expect(p!["std::write"]).toBeUndefined();
   });
 
-  it("scopes a toolbox scan like a read under 'recommended' and omits it under 'minimal'", () => {
-    expect(builtinPolicy("recommended", "/tmp/base")!["std::toolbox::scan"]).toEqual(
-      builtinPolicy("recommended", "/tmp/base")!["std::read"],
-    );
-    expect(builtinPolicy("minimal", "/tmp/base")!["std::toolbox::scan"]).toBeUndefined();
+  it("scopes every scan like a read under 'recommended' and omits them under 'minimal'", () => {
+    const scans = ["std::toolbox::scan", "std::skills::skillsDir", "std::skills::commandsDir"];
+    for (const effect of scans) {
+      expect(builtinPolicy("recommended", "/tmp/base")![effect]).toEqual(
+        builtinPolicy("recommended", "/tmp/base")!["std::read"],
+      );
+      expect(builtinPolicy("minimal", "/tmp/base")![effect]).toBeUndefined();
+    }
+  });
+
+  it("approves the toolbox use count only under the agent home's toolbox", () => {
+    expect(builtinPolicy("recommended", "/tmp/base")!["std::toolbox::recordUse"]).toEqual([
+      { match: { dir: "<agent-home>/tools/**" }, action: "approve" },
+    ]);
+    expect(builtinPolicy("minimal", "/tmp/base")!["std::toolbox::recordUse"]).toBeUndefined();
+  });
+
+  it("leaves the save and review gates undecided under every built-in but approve-all", () => {
+    for (const name of ["recommended", "minimal", "with-writes"]) {
+      const p = builtinPolicy(name, "/tmp/base")!;
+      for (const effect of [
+        "std::skills::save",
+        "std::skills::review",
+        "std::toolbox::save",
+        "std::toolbox::review",
+      ]) {
+        expect(p[effect]).toBeUndefined();
+      }
+    }
   });
 
   it("resolves 'minimal' with memory approved but reads absent", () => {

--- a/packages/agency-lang/lib/runtime/builtinPolicies.ts
+++ b/packages/agency-lang/lib/runtime/builtinPolicies.ts
@@ -1,5 +1,6 @@
 import {
   AGENCY_INSTALL_DIR_PLACEHOLDER as INSTALL,
+  AGENT_HOME_PLACEHOLDER as AGENT_HOME,
   type Policy,
   type PolicyRule,
   escapeGlob,
@@ -31,20 +32,33 @@ function agencyExecApproveRules(): PolicyRule[] {
 
 const approve: PolicyRule[] = [{ action: "approve" }];
 
-// Where the read-only file tools may look without asking: the launch
-// directory and, because the agent's docs tools (`agencyGuide` and friends)
-// and bundled skills are plain reads of shipped files, the agency install
-// itself. Both are placeholders the matcher expands at match time (`.` to
-// the process cwd, `<agency>` to the package root; see
-// docs/dev/agents/approval-policies.md), so a saved copy of this policy keeps
-// meaning "wherever the agent runs, wherever agency is installed now".
-// Reads anywhere else fall through: a prompt in an interactive session, an
-// automatic rejection in a headless one.
+// Where the read-only file tools may look without asking. The launch
+// directory. The agency install itself, because the agent's docs tools
+// (`agencyGuide` and friends) and bundled skills are plain reads of
+// shipped files. The agent home's learned skills and tools, which only
+// enter those directories through a review interrupt. All three are
+// placeholders the matcher expands at match time (`.` to the process cwd,
+// `<agency>` to the package root, `<agent-home>` to the agent home, see
+// docs/dev/agents/approval-policies.md), so a saved copy of this policy
+// keeps meaning "wherever the agent runs, wherever agency is installed
+// now". Reads anywhere else fall through: a prompt in an interactive
+// session, an automatic rejection in a headless one.
 export function readScopeRules(): PolicyRule[] {
   return [
     { match: { dir: "{.,./**}" }, action: "approve" },
     { match: { dir: `{${INSTALL}/stdlib/**,${INSTALL}/dist/**}` }, action: "approve" },
+    { match: { dir: `{${AGENT_HOME}/skills/**,${AGENT_HOME}/tools/**}` }, action: "approve" },
   ];
+}
+
+// runTool counts a use in the tool's meta.json behind this effect. It is
+// an effect of its own, not a std::write rule on the file, because a
+// path glob cannot tell the stdlib's bookkeeping from a program writing
+// arbitrary content into meta.json, whose purpose text listTools then
+// trusts. Approving the effect approves only the record the stdlib
+// composes. Scoped to the agent home's toolbox.
+function toolboxRecordUseRules(): PolicyRule[] {
+  return [{ match: { dir: `${AGENT_HOME}/tools/**` }, action: "approve" }];
 }
 
 export const minimalAutoApprovePolicy: Policy = {
@@ -72,11 +86,12 @@ export const recommendedAutoApprovePolicy: Policy = {
   "std::weather": approve,
   "std::search": approve,
   "std::tavilySearch": approve,
-  "std::skills::skillsDir": approve,
-  "std::skills::commandsDir": approve,
-  // A scan reads tool sources and meta.json under a directory, so it
-  // takes the read scope.
+  // A scan reads every skill, command, or tool file under a directory,
+  // so it takes the read scope.
+  "std::skills::skillsDir": readScopeRules(),
+  "std::skills::commandsDir": readScopeRules(),
   "std::toolbox::scan": readScopeRules(),
+  "std::toolbox::recordUse": toolboxRecordUseRules(),
   "std::notify": approve,
   "std::clipboardCopy": approve,
   "std::git::status": approve,
@@ -137,7 +152,7 @@ export const BUILTIN_POLICIES: { name: string; description: string }[] = [
   {
     name: "recommended",
     description:
-      "Auto-approve reads under the current directory (and the agency install's own docs and skills) and web/search; prompt for reads elsewhere, writes, shell, and git changes.",
+      "Auto-approve reads under the current directory, the agency install's own docs and skills, and the agent home's learned skills and tools (plus the toolbox use count there), and web/search; prompt for reads elsewhere, writes, shell, and git changes.",
   },
   {
     name: "minimal",

--- a/packages/agency-lang/lib/runtime/builtinPolicies.ts
+++ b/packages/agency-lang/lib/runtime/builtinPolicies.ts
@@ -51,12 +51,9 @@ export function readScopeRules(): PolicyRule[] {
   ];
 }
 
-// runTool counts a use in the tool's meta.json behind this effect. It is
-// an effect of its own, not a std::write rule on the file, because a
-// path glob cannot tell the stdlib's bookkeeping from a program writing
-// arbitrary content into meta.json, whose purpose text listTools then
-// trusts. Approving the effect approves only the record the stdlib
-// composes. Scoped to the agent home's toolbox.
+// runTool's use count in a tool's meta.json. An effect of its own, never
+// a std::write rule on the file; docs/dev/agents/approval-policies.md
+// says why.
 function toolboxRecordUseRules(): PolicyRule[] {
   return [{ match: { dir: `${AGENT_HOME}/tools/**` }, action: "approve" }];
 }

--- a/packages/agency-lang/lib/runtime/builtinPolicies.ts
+++ b/packages/agency-lang/lib/runtime/builtinPolicies.ts
@@ -47,7 +47,12 @@ export function readScopeRules(): PolicyRule[] {
   return [
     { match: { dir: "{.,./**}" }, action: "approve" },
     { match: { dir: `{${INSTALL}/stdlib/**,${INSTALL}/dist/**}` }, action: "approve" },
-    { match: { dir: `{${AGENT_HOME}/skills/**,${AGENT_HOME}/tools/**}` }, action: "approve" },
+    {
+      match: {
+        dir: `{${AGENT_HOME}/skills,${AGENT_HOME}/skills/**,${AGENT_HOME}/tools,${AGENT_HOME}/tools/**}`,
+      },
+      action: "approve",
+    },
   ];
 }
 

--- a/packages/agency-lang/lib/runtime/policy.test.ts
+++ b/packages/agency-lang/lib/runtime/policy.test.ts
@@ -3,13 +3,14 @@ import {
   checkPolicy,
   resolveDotDirPattern,
   expandAgencyInstallDir,
+  expandAgentHomeDir,
   validatePolicy,
   escapeGlob,
 } from "./policy.js";
 import { getStdlibDir } from "../importPaths.js";
 import path from "path";
 import { mkdtempSync, mkdirSync, symlinkSync, rmSync, realpathSync } from "fs";
-import { tmpdir } from "os";
+import os, { tmpdir } from "os";
 import picomatch from "picomatch";
 
 describe("checkPolicy", () => {
@@ -612,6 +613,114 @@ describe("<agency> dir patterns", () => {
     };
     expect(expandAgencyInstallDir("<agency>/stdlib/**", unresolvable)).toBe("<agency>/stdlib/**");
     expect(expandAgencyInstallDir("/plain/**", unresolvable)).toBe("/plain/**");
+  });
+});
+
+describe("<agent-home> dir patterns", () => {
+  const read = (dir: string) => ({
+    effect: "std::read",
+    message: "m",
+    data: { dir, filename: "x" },
+    origin: "std::fs",
+  });
+  const policy = {
+    "std::read": [
+      {
+        match: { dir: "{<agent-home>/skills/**,<agent-home>/tools/**}" },
+        action: "approve" as const,
+      },
+    ],
+  };
+
+  function withAgentHome<T>(value: string | undefined, body: () => T): T {
+    const previous = process.env.AGENCY_AGENT_HOME;
+    if (value === undefined) delete process.env.AGENCY_AGENT_HOME;
+    else process.env.AGENCY_AGENT_HOME = value;
+    try {
+      return body();
+    } finally {
+      if (previous === undefined) delete process.env.AGENCY_AGENT_HOME;
+      else process.env.AGENCY_AGENT_HOME = previous;
+    }
+  }
+
+  it("expands to the injected home", () => {
+    expect(expandAgentHomeDir("<agent-home>/skills/**", () => "/custom/home")).toBe(
+      "/custom/home/skills/**",
+    );
+  });
+
+  it("escapes glob characters in the resolved home", () => {
+    expect(expandAgentHomeDir("<agent-home>/skills/**", () => "/opt/v*1")).toBe(
+      "/opt/v\\*1/skills/**",
+    );
+  });
+
+  it("leaves a pattern without the token untouched", () => {
+    expect(expandAgentHomeDir("/plain/**", () => "/custom/home")).toBe("/plain/**");
+  });
+
+  it("resolves a relative AGENCY_AGENT_HOME to an absolute path", () => {
+    withAgentHome("./my-profile", () => {
+      expect(expandAgentHomeDir("<agent-home>/skills/**")).toBe(
+        `${path.resolve("./my-profile")}/skills/**`,
+      );
+    });
+  });
+
+  it("treats an empty AGENCY_AGENT_HOME as unset", () => {
+    withAgentHome("", () => {
+      expect(expandAgentHomeDir("<agent-home>/skills/**")).toBe(
+        `${path.join(os.homedir(), ".agency-agent")}/skills/**`,
+      );
+    });
+  });
+
+  it("expands to the realpath of the home, the spelling file effects report", () => {
+    const base = mkdtempSync(path.join(tmpdir(), "policy-home-"));
+    try {
+      const real = path.join(base, "real-home");
+      mkdirSync(real);
+      const link = path.join(base, "linked-home");
+      symlinkSync(real, link);
+      withAgentHome(link, () => {
+        expect(expandAgentHomeDir("<agent-home>/skills/**")).toBe(
+          `${realpathSync(real)}/skills/**`,
+        );
+      });
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  it("matches reads under the home's skills and tools and nothing else", () => {
+    const base = mkdtempSync(path.join(tmpdir(), "policy-home-"));
+    try {
+      const home = realpathSync(base);
+      withAgentHome(home, () => {
+        expect(checkPolicy(policy, read(`${home}/skills/explorer`)).type).toBe("approve");
+        expect(checkPolicy(policy, read(`${home}/tools/hnTop`)).type).toBe("approve");
+        expect(checkPolicy(policy, read(home)).type).toBe("propagate");
+        expect(checkPolicy(policy, read("/Users/someone")).type).toBe("propagate");
+      });
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  it("matches a pattern that mixes <agency> and <agent-home> in one brace group", () => {
+    const mixed = {
+      "std::read": [
+        {
+          match: { dir: "{<agency>/stdlib/**,<agent-home>/skills/**}" },
+          action: "approve" as const,
+        },
+      ],
+    };
+    withAgentHome("/nowhere/agent-home", () => {
+      expect(checkPolicy(mixed, read("/nowhere/agent-home/skills/x")).type).toBe("approve");
+      expect(checkPolicy(mixed, read(path.join(getStdlibDir(), "docs"))).type).toBe("approve");
+    });
   });
 });
 

--- a/packages/agency-lang/lib/runtime/policy.test.ts
+++ b/packages/agency-lang/lib/runtime/policy.test.ts
@@ -626,7 +626,9 @@ describe("<agent-home> dir patterns", () => {
   const policy = {
     "std::read": [
       {
-        match: { dir: "{<agent-home>/skills/**,<agent-home>/tools/**}" },
+        match: {
+          dir: "{<agent-home>/skills,<agent-home>/skills/**,<agent-home>/tools,<agent-home>/tools/**}",
+        },
         action: "approve" as const,
       },
     ],
@@ -698,6 +700,10 @@ describe("<agent-home> dir patterns", () => {
     try {
       const home = realpathSync(base);
       withAgentHome(home, () => {
+        // The roots themselves: what a catalog scan of the whole
+        // directory puts in its payload.
+        expect(checkPolicy(policy, read(`${home}/skills`)).type).toBe("approve");
+        expect(checkPolicy(policy, read(`${home}/tools`)).type).toBe("approve");
         expect(checkPolicy(policy, read(`${home}/skills/explorer`)).type).toBe("approve");
         expect(checkPolicy(policy, read(`${home}/tools/hnTop`)).type).toBe("approve");
         expect(checkPolicy(policy, read(home)).type).toBe("propagate");

--- a/packages/agency-lang/lib/runtime/policy.ts
+++ b/packages/agency-lang/lib/runtime/policy.ts
@@ -176,10 +176,8 @@ export function expandAgentHomeDir(
 }
 
 // Realpathed for the reason the cwd is in resolveDotDirPattern: file
-// effects realpath the dir in their payload, so a home reached through a
-// symlinked ancestor (macOS /tmp, a linked $HOME) must share that
-// spelling or no rule ever matches. A home that does not exist yet keeps
-// its lexical spelling.
+// effects put the realpath in their payload. A home that does not exist
+// yet keeps its lexical spelling.
 function canonicalAgentHome(): string {
   const home = agentHomeDir();
   try {

--- a/packages/agency-lang/lib/runtime/policy.ts
+++ b/packages/agency-lang/lib/runtime/policy.ts
@@ -2,6 +2,7 @@ import picomatch from "picomatch";
 import { realpathSync } from "fs";
 import { z } from "zod";
 import { getPackageRoot } from "../importPaths.js";
+import { agentHomeDir } from "./agentHome.js";
 
 export const PolicyRuleSchema = z
   .object({
@@ -158,6 +159,36 @@ export function expandAgencyInstallDir(
   return pattern.split(AGENCY_INSTALL_DIR_PLACEHOLDER).join(escapeForGlob(resolved));
 }
 
+/** In a `dir` pattern, `<agent-home>` stands for the agent home directory
+ *  (`AGENCY_AGENT_HOME`, or `~/.agency-agent`). The built-in read scope
+ *  uses it for the learned skills and tools directories, so a saved policy
+ *  keeps meaning "wherever the agent home is now". */
+export const AGENT_HOME_PLACEHOLDER = "<agent-home>";
+
+// Expanded at match time, like `<agency>`. Exported for tests, which
+// inject the home.
+export function expandAgentHomeDir(
+  pattern: string,
+  home: () => string = canonicalAgentHome,
+): string {
+  if (!pattern.includes(AGENT_HOME_PLACEHOLDER)) return pattern;
+  return pattern.split(AGENT_HOME_PLACEHOLDER).join(escapeForGlob(home()));
+}
+
+// Realpathed for the reason the cwd is in resolveDotDirPattern: file
+// effects realpath the dir in their payload, so a home reached through a
+// symlinked ancestor (macOS /tmp, a linked $HOME) must share that
+// spelling or no rule ever matches. A home that does not exist yet keeps
+// its lexical spelling.
+function canonicalAgentHome(): string {
+  const home = agentHomeDir();
+  try {
+    return realpathSync(home);
+  } catch {
+    return home;
+  }
+}
+
 function matchesRule(
   rule: PolicyRule,
   interrupt: { effect: string; message: string; data: any; origin: string },
@@ -185,12 +216,14 @@ function matchesRule(
       !raw &&
       key === "dir" &&
       picomatch.isMatch(stripDotSlash(value), stripDotSlash(resolveDotDirPattern(pattern)));
-    const viaInstall =
+    // Each expander leaves a pattern without its token alone, so one check
+    // covers every placeholder, including a pattern that mixes them.
+    const viaPlaceholders =
       !raw &&
       !viaDot &&
       key === "dir" &&
-      picomatch.isMatch(stripDotSlash(value), expandAgencyInstallDir(pattern));
-    if (!raw && !viaDot && !viaInstall) {
+      picomatch.isMatch(stripDotSlash(value), expandAgentHomeDir(expandAgencyInstallDir(pattern)));
+    if (!raw && !viaDot && !viaPlaceholders) {
       return false;
     }
   }

--- a/packages/agency-lang/lib/stdlib/builtins.ts
+++ b/packages/agency-lang/lib/stdlib/builtins.ts
@@ -9,6 +9,7 @@ import { detectPlatform } from "./utils.js";
 import { resolvePath } from "./resolvePath.js";
 import { expandPath } from "./expandPath.js";
 import { readContainedFile } from "../utils/readContainedFile.js";
+import { writeContainedFile } from "../utils/writeContainedFile.js";
 import { AgencyCancelledError } from "../runtime/errors.js";
 import { getRuntimeContext } from "../runtime/asyncContext.js";
 import { FakeClock } from "../runtime/clock.js";
@@ -263,6 +264,21 @@ function readContainedAny(filePath: string, allowedRoots: string[]): string {
   throw lastErr;
 }
 
+// The first root that accepts the file wins; the last refusal is rethrown.
+// Validation precedes every write, so a refused root writes nothing.
+function writeContainedAny(filePath: string, content: string, allowedRoots: string[]): void {
+  let lastErr: unknown = new Error("no allowed roots");
+  for (const root of allowedRoots) {
+    try {
+      writeContainedFile(expandPath(root), filePath, content);
+      return;
+    } catch (err) {
+      lastErr = err;
+    }
+  }
+  throw lastErr;
+}
+
 const VALID_WRITE_MODES = ["overwrite", "append", "create-only"] as const;
 export type WriteMode = (typeof VALID_WRITE_MODES)[number];
 
@@ -274,11 +290,26 @@ async function _writeBytes(
   filename: string,
   data: string | Buffer,
   mode: WriteMode = "overwrite",
+  allowedPaths?: string[],
 ): Promise<boolean> {
   if (!VALID_WRITE_MODES.includes(mode)) {
     throw new Error(`Invalid mode '${mode}'. Must be one of: ${VALID_WRITE_MODES.join(", ")}.`);
   }
   const filePath = await resolvePath(dir, filename);
+  if (allowedPaths && allowedPaths.length > 0) {
+    // Descriptor-validated overwrite: the bytes provably land inside an
+    // allowed root, with no window in which a swap to a symlink can
+    // redirect the write (see writeContainedFile). Only whole-file
+    // writes take this path.
+    if (mode !== "overwrite") {
+      throw new Error(`allowedPaths is only supported with mode 'overwrite', got '${mode}'.`);
+    }
+    if (typeof data !== "string") {
+      throw new Error("allowedPaths is only supported for text writes.");
+    }
+    writeContainedAny(filePath, data, allowedPaths);
+    return true;
+  }
   if (mode === "create-only") {
     // The "wx" flag makes create-only atomic: an existing file (or a
     // dangling symlink at the target) fails the open itself, with no
@@ -303,8 +334,9 @@ export async function _write(
   filename: string,
   content: string,
   mode: WriteMode = "overwrite",
+  allowedPaths?: string[],
 ): Promise<boolean> {
-  return _writeBytes(dir, filename, content, mode);
+  return _writeBytes(dir, filename, content, mode, allowedPaths);
 }
 
 export async function _writeBinary(

--- a/packages/agency-lang/lib/stdlib/builtins.ts
+++ b/packages/agency-lang/lib/stdlib/builtins.ts
@@ -297,10 +297,8 @@ async function _writeBytes(
   }
   const filePath = await resolvePath(dir, filename);
   if (allowedPaths && allowedPaths.length > 0) {
-    // Descriptor-validated overwrite: the bytes provably land inside an
-    // allowed root, with no window in which a swap to a symlink can
-    // redirect the write (see writeContainedFile). Only whole-file
-    // writes take this path.
+    // Descriptor-validated overwrite, the write-side twin of the _read
+    // branch above (see writeContainedFile).
     if (mode !== "overwrite") {
       throw new Error(`allowedPaths is only supported with mode 'overwrite', got '${mode}'.`);
     }

--- a/packages/agency-lang/lib/stdlib/resolveDir.ts
+++ b/packages/agency-lang/lib/stdlib/resolveDir.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
 import { assertContained } from "./assertContained.js";
@@ -8,6 +9,26 @@ import { expandPath } from "./expandPath.js";
  *  await `resolveDir` (e.g. `_readSkill`) use this instead of copying it. */
 export function resolveCwdPath(target: string): string {
   return path.resolve(process.cwd(), expandPath(target));
+}
+
+/** The spelling a file effect puts in its interrupt payload: absolutized
+ *  and realpathed, so a policy rule matches one directory however the
+ *  caller wrote it. A directory that does not exist yet is resolved
+ *  through its nearest existing ancestor, so a save into a new directory
+ *  still names the place the write will land. */
+export function canonicalDir(target: string): string {
+  const lexical = resolveCwdPath(target);
+  let current = lexical;
+  const tail: string[] = [];
+  while (current !== path.dirname(current)) {
+    try {
+      return path.resolve(fs.realpathSync(current), ...tail.reverse());
+    } catch {
+      tail.push(path.basename(current));
+      current = path.dirname(current);
+    }
+  }
+  return lexical;
 }
 
 /**

--- a/packages/agency-lang/lib/stdlib/skills.ts
+++ b/packages/agency-lang/lib/stdlib/skills.ts
@@ -47,7 +47,7 @@ export { stringifyFrontmatter as _stringifyFrontmatter } from "tarsec/parsers/ma
  * payload built from the result matches the `std::write` payload raised
  * for the same directory.
  */
-export { resolveCwdPath as _resolveCwdPath } from "./resolveDir.js";
+export { canonicalDir as _canonicalDir } from "./resolveDir.js";
 
 /**
  * Absolute path to the skills we ship for one agent, under

--- a/packages/agency-lang/lib/utils/alwaysTag.stdlib.test.ts
+++ b/packages/agency-lang/lib/utils/alwaysTag.stdlib.test.ts
@@ -151,6 +151,7 @@ const EXPECTED: Record<string, string[]> = {
   // make the look meaningless, so nothing is pinned.
   "std::skills::review": [],
   "std::toolbox::scan": ["dir/**"],
+  "std::toolbox::recordUse": ["dir/**"],
   "std::toolbox::review": [],
   "std::toolbox::save": ["dir/**"],
   "std::memory::enableMemory": [],

--- a/packages/agency-lang/lib/utils/writeContainedFile.test.ts
+++ b/packages/agency-lang/lib/utils/writeContainedFile.test.ts
@@ -1,0 +1,118 @@
+import { describe, test, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import { writeContainedFile } from "./writeContainedFile.js";
+import { safeDeleteDirectoryWithin } from "../utils.js";
+
+function makeDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(process.cwd(), prefix));
+}
+
+function cleanup(dir: string): void {
+  expect(safeDeleteDirectoryWithin(process.cwd(), dir).success).toBe(true);
+}
+
+describe("writeContainedFile", () => {
+  test("overwrites a regular file inside the root", () => {
+    const dir = makeDir(".wcf-ok-");
+    try {
+      fs.mkdirSync(path.join(dir, "sub"));
+      const target = path.join(dir, "sub", "a.txt");
+      fs.writeFileSync(target, "a much longer original");
+      writeContainedFile(dir, target, "new");
+      expect(fs.readFileSync(target, "utf-8")).toBe("new");
+    } finally {
+      cleanup(dir);
+    }
+  });
+
+  test("creates a missing file whose parent is a real directory inside the root", () => {
+    const dir = makeDir(".wcf-create-");
+    try {
+      fs.mkdirSync(path.join(dir, "sub"));
+      const target = path.join(dir, "sub", "a.txt");
+      writeContainedFile(dir, target, "made");
+      expect(fs.readFileSync(target, "utf-8")).toBe("made");
+    } finally {
+      cleanup(dir);
+    }
+  });
+
+  test("a final-component symlink is not followed", () => {
+    const parent = makeDir(".wcf-link-");
+    try {
+      const root = path.join(parent, "root");
+      fs.mkdirSync(root);
+      const secret = path.join(parent, "secret.txt");
+      fs.writeFileSync(secret, "secret");
+      fs.symlinkSync(secret, path.join(root, "link.txt"));
+      expect(() => writeContainedFile(root, path.join(root, "link.txt"), "x")).toThrow();
+      expect(fs.readFileSync(secret, "utf-8")).toBe("secret");
+    } finally {
+      cleanup(parent);
+    }
+  });
+
+  test("a new file under a symlinked directory is refused", () => {
+    const parent = makeDir(".wcf-linkdir-");
+    try {
+      const root = path.join(parent, "root");
+      fs.mkdirSync(root);
+      const outside = path.join(parent, "outside");
+      fs.mkdirSync(outside);
+      fs.symlinkSync(outside, path.join(root, "tool"));
+      // Positive control: the link is reachable through the filesystem.
+      expect(fs.existsSync(path.join(root, "tool"))).toBe(true);
+      expect(() => writeContainedFile(root, path.join(root, "tool", "meta.json"), "x")).toThrow(
+        /symlink/,
+      );
+      expect(fs.existsSync(path.join(outside, "meta.json"))).toBe(false);
+    } finally {
+      cleanup(parent);
+    }
+  });
+
+  test("swap seam: an ancestor replaced by a link outside between open and validation is refused", () => {
+    const parent = makeDir(".wcf-swap-");
+    try {
+      const root = path.join(parent, "root");
+      fs.mkdirSync(path.join(root, "sub"), { recursive: true });
+      const target = path.join(root, "sub", "a.txt");
+      fs.writeFileSync(target, "inside");
+      fs.mkdirSync(path.join(parent, "outside"));
+      fs.writeFileSync(path.join(parent, "outside", "a.txt"), "secret");
+      expect(() =>
+        writeContainedFile(root, target, "x", {
+          afterOpen: () => {
+            fs.renameSync(path.join(root, "sub"), path.join(root, "sub.moved"));
+            fs.symlinkSync(path.join(parent, "outside"), path.join(root, "sub"));
+          },
+        }),
+      ).toThrow(/outside/);
+      // Neither file received the bytes.
+      expect(fs.readFileSync(path.join(root, "sub.moved", "a.txt"), "utf-8")).toBe("inside");
+      expect(fs.readFileSync(path.join(parent, "outside", "a.txt"), "utf-8")).toBe("secret");
+    } finally {
+      cleanup(parent);
+    }
+  });
+
+  test("swap seam: a swap undone again after the open is caught by file identity", () => {
+    const dir = makeDir(".wcf-ident-");
+    try {
+      const target = path.join(dir, "a.txt");
+      fs.writeFileSync(target, "original");
+      expect(() =>
+        writeContainedFile(dir, target, "x", {
+          afterOpen: () => {
+            fs.unlinkSync(target);
+            fs.writeFileSync(target, "replacement");
+          },
+        }),
+      ).toThrow(/changed between validation and write/);
+      expect(fs.readFileSync(target, "utf-8")).toBe("replacement");
+    } finally {
+      cleanup(dir);
+    }
+  });
+});

--- a/packages/agency-lang/lib/utils/writeContainedFile.test.ts
+++ b/packages/agency-lang/lib/utils/writeContainedFile.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from "vitest";
 import * as fs from "fs";
 import * as path from "path";
+import { execFileSync } from "child_process";
 import { writeContainedFile } from "./writeContainedFile.js";
 import { safeDeleteDirectoryWithin } from "../utils.js";
 
@@ -69,6 +70,16 @@ describe("writeContainedFile", () => {
       expect(fs.existsSync(path.join(outside, "meta.json"))).toBe(false);
     } finally {
       cleanup(parent);
+    }
+  });
+
+  test("a FIFO is refused without blocking", () => {
+    const dir = makeDir(".wcf-fifo-");
+    try {
+      execFileSync("mkfifo", [path.join(dir, "pipe")]);
+      expect(() => writeContainedFile(dir, path.join(dir, "pipe"), "x")).toThrow();
+    } finally {
+      cleanup(dir);
     }
   });
 

--- a/packages/agency-lang/lib/utils/writeContainedFile.test.ts
+++ b/packages/agency-lang/lib/utils/writeContainedFile.test.ts
@@ -39,6 +39,17 @@ describe("writeContainedFile", () => {
     }
   });
 
+  test("creates a missing file directly under the root", () => {
+    const dir = makeDir(".wcf-create-root-");
+    try {
+      const target = path.join(dir, "meta.json");
+      writeContainedFile(dir, target, "made");
+      expect(fs.readFileSync(target, "utf-8")).toBe("made");
+    } finally {
+      cleanup(dir);
+    }
+  });
+
   test("a final-component symlink is not followed", () => {
     const parent = makeDir(".wcf-link-");
     try {

--- a/packages/agency-lang/lib/utils/writeContainedFile.ts
+++ b/packages/agency-lang/lib/utils/writeContainedFile.ts
@@ -1,0 +1,82 @@
+/**
+ * Writes a regular file that must live inside `root`, with no window in
+ * which a swap can redirect the write. The write-side twin of
+ * readContainedFile: the descriptor is what gets validated, and no byte
+ * is written before it passes.
+ *
+ *   1. open O_WRONLY|O_NOFOLLOW — a final-component symlink fails to open.
+ *      A file that does not exist yet is created with O_CREAT|O_EXCL after
+ *      its parent directory is validated the same way (below).
+ *   2. fstat the descriptor: must be a regular file.
+ *   3. realpath the path AFTER the open and require it to sit strictly
+ *      inside root — this catches an ancestor swapped to a link that is
+ *      still in place.
+ *   4. stat that real path and require the same (dev, ino) as the
+ *      descriptor — this catches a swap that was undone again after the
+ *      open.
+ *   5. truncate and write through the descriptor.
+ *
+ * Creating a file has one residue: if an ancestor is swapped to a link
+ * between the parent check and the create, an empty file can be left at
+ * the link's target. Nothing is written into it, and the call fails.
+ */
+import * as fs from "fs";
+import * as path from "path";
+import { isStrictDescendant } from "../utils.js";
+
+export type WriteContainedFileSeams = {
+  /** Test-only: runs between the open and the validation, where a
+   *  concurrent swap would land. */
+  afterOpen?: () => void;
+};
+
+export function writeContainedFile(
+  root: string,
+  target: string,
+  content: string,
+  seams: WriteContainedFileSeams = {},
+): void {
+  const realRoot = fs.realpathSync(path.resolve(root));
+  const fd = openForWrite(realRoot, target);
+  try {
+    const opened = fs.fstatSync(fd);
+    if (!opened.isFile()) {
+      throw new Error(`'${target}' is not a regular file`);
+    }
+    seams.afterOpen?.();
+    const real = fs.realpathSync(target);
+    if (!isStrictDescendant(realRoot, real)) {
+      throw new Error(`'${target}' resolves to '${real}', which is outside '${realRoot}'`);
+    }
+    const onDisk = fs.statSync(real);
+    if (onDisk.dev !== opened.dev || onDisk.ino !== opened.ino) {
+      throw new Error(`'${target}' changed between validation and write`);
+    }
+    fs.ftruncateSync(fd);
+    fs.writeSync(fd, content);
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+function openForWrite(realRoot: string, target: string): number {
+  const noFollow = fs.constants.O_WRONLY | fs.constants.O_NOFOLLOW;
+  try {
+    return fs.openSync(target, noFollow);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw err;
+    }
+  }
+  // The file is new. Its parent must already be a real directory strictly
+  // inside root, so a symlinked tool directory cannot receive a new file.
+  const parent = path.dirname(target);
+  if (fs.lstatSync(parent).isSymbolicLink()) {
+    throw new Error(`'${parent}' is a symlink`);
+  }
+  const realParent = fs.realpathSync(parent);
+  if (!isStrictDescendant(realRoot, realParent)) {
+    throw new Error(`'${parent}' resolves to '${realParent}', which is outside '${realRoot}'`);
+  }
+  return fs.openSync(target, noFollow | fs.constants.O_CREAT | fs.constants.O_EXCL, 0o644);
+}

--- a/packages/agency-lang/lib/utils/writeContainedFile.ts
+++ b/packages/agency-lang/lib/utils/writeContainedFile.ts
@@ -71,14 +71,15 @@ function openForWrite(realRoot: string, target: string): number {
       throw err;
     }
   }
-  // The file is new. Its parent must already be a real directory strictly
-  // inside root, so a symlinked tool directory cannot receive a new file.
+  // The file is new. Its parent must already be a real directory that is
+  // the root or inside it, so a symlinked tool directory cannot receive a
+  // new file.
   const parent = path.dirname(target);
   if (fs.lstatSync(parent).isSymbolicLink()) {
     throw new Error(`'${parent}' is a symlink`);
   }
   const realParent = fs.realpathSync(parent);
-  if (!isStrictDescendant(realRoot, realParent)) {
+  if (realParent !== realRoot && !isStrictDescendant(realRoot, realParent)) {
     throw new Error(`'${parent}' resolves to '${realParent}', which is outside '${realRoot}'`);
   }
   return fs.openSync(target, noFollow | fs.constants.O_CREAT | fs.constants.O_EXCL, 0o644);

--- a/packages/agency-lang/lib/utils/writeContainedFile.ts
+++ b/packages/agency-lang/lib/utils/writeContainedFile.ts
@@ -4,9 +4,10 @@
  * readContainedFile: the descriptor is what gets validated, and no byte
  * is written before it passes.
  *
- *   1. open O_WRONLY|O_NOFOLLOW — a final-component symlink fails to open.
- *      A file that does not exist yet is created with O_CREAT|O_EXCL after
- *      its parent directory is validated the same way (below).
+ *   1. open O_WRONLY|O_NONBLOCK|O_NOFOLLOW — a final-component symlink
+ *      fails to open; a FIFO fails or returns instead of blocking. A file
+ *      that does not exist yet is created with O_CREAT|O_EXCL after its
+ *      parent directory is validated the same way (below).
  *   2. fstat the descriptor: must be a regular file.
  *   3. realpath the path AFTER the open and require it to sit strictly
  *      inside root — this catches an ancestor swapped to a link that is
@@ -53,14 +54,16 @@ export function writeContainedFile(
       throw new Error(`'${target}' changed between validation and write`);
     }
     fs.ftruncateSync(fd);
-    fs.writeSync(fd, content);
+    // writeFileSync on a descriptor loops until every byte is written; a
+    // bare writeSync may stop short and report the count.
+    fs.writeFileSync(fd, content, "utf-8");
   } finally {
     fs.closeSync(fd);
   }
 }
 
 function openForWrite(realRoot: string, target: string): number {
-  const noFollow = fs.constants.O_WRONLY | fs.constants.O_NOFOLLOW;
+  const noFollow = fs.constants.O_WRONLY | fs.constants.O_NONBLOCK | fs.constants.O_NOFOLLOW;
   try {
     return fs.openSync(target, noFollow);
   } catch (err) {

--- a/packages/agency-lang/stdlib/skills.agency
+++ b/packages/agency-lang/stdlib/skills.agency
@@ -14,7 +14,7 @@ import { exists } from "std::shell"
 // the interrupt-raising versions have.
 import { _read } from "agency-lang/stdlib-lib/builtins.js"
 import { _glob } from "agency-lang/stdlib-lib/shell.js"
-import { _docsDir, _bundledDocsDir, _agentSkillsDir, _stringifyFrontmatter, _resolveCwdPath } from "agency-lang/stdlib-lib/skills.js"
+import { _docsDir, _bundledDocsDir, _agentSkillsDir, _stringifyFrontmatter, _canonicalDir } from "agency-lang/stdlib-lib/skills.js"
 
 
 /** @module
@@ -292,8 +292,11 @@ export def skillsDir(
   @param layout - "standard" (default) for subdirectory-per-skill with SKILL.md, "flat" for a directory of loose Markdown files.
   @param name - Optional explicit tool name. Sanitized to alphanumerics/underscores and capped at 64 characters. Defaults to a name derived from `dir`; set this to override it — e.g. for a stable, readable name, or to disambiguate two tools whose derived names would collide.
   """
+  // The payload names the directory the way a read would, so the same
+  // policy rule covers both. The tool keeps the caller's spelling, which
+  // its derived name is built from.
   return interrupt std::skills::skillsDir("Are you sure you want to scan this directory for skill files?", {
-    dir: dir,
+    dir: _canonicalDir(dir),
     layout: layout
   })
 
@@ -342,10 +345,10 @@ export def scanSkillsSubdirs(
   if (subdirs.length == 0) {
     return success(Object.create(null))
   }
-  // Absolutized so the interrupt payload — and any always-scope rule
+  // Canonical, so the interrupt payload — and any always-scope rule
   // saved from it — names one directory regardless of the caller's
   // spelling.
-  const absRoot = _resolveCwdPath(root)
+  const absRoot = _canonicalDir(root)
   return interrupt std::skills::skillsDir("Are you sure you want to scan this directory for skill files?", {
     dir: absRoot,
     layout: "flat"
@@ -392,8 +395,8 @@ def renderFrontmatter(name: string, description: string): Result<string> {
   return fm
 }
 
-// Runs before anyone is asked. Returns the absolutized directory, so
-// the interrupt payloads name one directory however the caller spelled it.
+// Runs before anyone is asked. Returns the canonical directory, so the
+// interrupt payloads name one directory however the caller spelled it.
 def checkSkillInputs(dir: string, name: string, description: string): Result<string> {
   if (!validSkillName(name)) {
     return failure("skill name '${name}' is invalid: use kebab-case, lowercase letters and digits separated by single hyphens")
@@ -408,7 +411,7 @@ def checkSkillInputs(dir: string, name: string, description: string): Result<str
   if (dir.trim() == "") {
     return failure("dir must not be empty")
   }
-  const absDir = _resolveCwdPath(dir)
+  const absDir = _canonicalDir(dir)
   if (exists("${name}.md", absDir)) {
     return failure("a skill named ${name} already exists in ${absDir}")
   }
@@ -760,7 +763,7 @@ export def commandsDir(dir: string): any[] {
   @param dir - Directory containing command markdown files.
   """
   return interrupt std::skills::commandsDir("Are you sure you want to scan this directory for slash command files?", {
-    dir: dir
+    dir: _canonicalDir(dir)
   })
 
   const pathsResult = try _glob("*.md", dir, MAX_SKILL_FILES, [])

--- a/packages/agency-lang/stdlib/toolbox.agency
+++ b/packages/agency-lang/stdlib/toolbox.agency
@@ -21,7 +21,7 @@ import { ls, exists } from "std::shell"
 import { Json } from "std::validation"
 
 import { _read, _write } from "agency-lang/stdlib-lib/builtins.js"
-import { resolveCwdPath } from "agency-lang/stdlib-lib/resolveDir.js"
+import { canonicalDir } from "agency-lang/stdlib-lib/resolveDir.js"
 
 /** @module
   @summary Keep a directory of tools an agent wrote.
@@ -190,13 +190,13 @@ const EMPTY_MODULE: ModuleFacts = {
 
 // Every entry point takes the toolbox directory the same way. An empty
 // string is refused because the file primitives would resolve it to the
-// process cwd. Absolutized so the interrupt payloads name one directory
-// however the caller spelled it.
+// process cwd. Canonical (absolute, realpathed), so the interrupt
+// payloads name one directory however the caller spelled it.
 def expandRoot(dir: string): Result<string> {
   if (dir == "") {
     return failure("dir must name the toolbox directory. Got an empty string")
   }
-  return success(resolveCwdPath(dir))
+  return success(canonicalDir(dir))
 }
 
 def runExport(info: ModuleInfo): ExportInfo | null {

--- a/packages/agency-lang/stdlib/toolbox.agency
+++ b/packages/agency-lang/stdlib/toolbox.agency
@@ -20,8 +20,8 @@ import { mkdir, remove, move } from "std::fs"
 import { ls, exists } from "std::shell"
 import { Json } from "std::validation"
 
-import { _read } from "agency-lang/stdlib-lib/builtins.js"
-import { expandPath } from "agency-lang/stdlib-lib/expandPath.js"
+import { _read, _write } from "agency-lang/stdlib-lib/builtins.js"
+import { resolveCwdPath } from "agency-lang/stdlib-lib/resolveDir.js"
 
 /** @module
   @summary Keep a directory of tools an agent wrote.
@@ -113,6 +113,16 @@ effect std::toolbox::scan {
   dir: string
 }
 
+// runTool's use count, as its own effect rather than a std::write: the
+// stdlib composes the record, so approving this approves one known
+// change to the tool's meta.json and cannot be reused to land arbitrary
+// content there. The approval covers the write that fulfils it.
+@alwaysUnder(dir)
+effect std::toolbox::recordUse {
+  dir: string;
+  name: string
+}
+
 effect std::toolbox::review {
   name: string;
   stagingDir: string;
@@ -181,12 +191,14 @@ const EMPTY_MODULE: ModuleFacts = {
 
 // Every entry point takes the toolbox directory the same way. An empty
 // string is refused because the file primitives would resolve it to the
-// process cwd.
+// process cwd. Absolutized so the interrupt payloads name one directory
+// however the caller spelled it, and so a policy pattern that expands to
+// an absolute path can match them.
 def expandRoot(dir: string): Result<string> {
   if (dir == "") {
-    return failure("dir must name the toolbox directory; got an empty string")
+    return failure("dir must name the toolbox directory. Got an empty string")
   }
-  return success(expandPath(dir))
+  return success(resolveCwdPath(dir))
 }
 
 def runExport(info: ModuleInfo): ExportInfo | null {
@@ -201,8 +213,12 @@ def factsOf(exported: ExportInfo): ModuleFacts {
   }
 }
 
-def moduleFacts(toolDir: string): Result<ModuleFacts> {
-  const source = try _read(toolDir, IMPL_FILE, 0, 0)
+// The reads under a scan approval are contained in the toolbox root:
+// the open refuses a symlink, and the descriptor is checked to sit
+// inside the root, so a symlinked tool directory cannot carry the
+// approval elsewhere.
+def moduleFacts(root: string, toolDir: string): Result<ModuleFacts> {
+  const source = try _read(toolDir, IMPL_FILE, 0, 0, [root])
   if (source is failure) {
     return source
   }
@@ -231,11 +247,11 @@ type MetaFile = {
 // A missing meta.json is the default record. A present one that cannot be
 // read, is not JSON, or has a field of the wrong type is a failure, so a
 // corrupt file never passes as a healthy tool.
-def metaFacts(toolDir: string): Result<ToolMeta> {
+def metaFacts(root: string, toolDir: string): Result<ToolMeta> {
   if (!exists(META_FILE, toolDir)) {
     return success(DEFAULT_META)
   }
-  const raw = try _read(toolDir, META_FILE, 0, 0)
+  const raw = try _read(toolDir, META_FILE, 0, 0, [root])
   if (raw is failure(readErr)) {
     return failure("${META_FILE} could not be read: ${readErr}")
   }
@@ -268,8 +284,8 @@ def presentFields(file: MetaFile): Record<string, Json> {
 
 def entryFor(root: string, name: string): ToolEntry {
   const toolDir = "${root}/${name}"
-  const module = moduleFacts(toolDir)
-  const meta = metaFacts(toolDir)
+  const module = moduleFacts(root, toolDir)
+  const meta = metaFacts(root, toolDir)
   const moduleFields: ModuleFacts = module catch EMPTY_MODULE
   const metaFields: ToolMeta = meta catch DEFAULT_META
   const problems: string[] = []
@@ -592,7 +608,7 @@ def assembleTool(source: string, settings: DraftSettings): Result<ModuleFacts> {
   if (requestOk is failure) {
     return requestOk
   }
-  return moduleFacts(settings.stagingDir)
+  return moduleFacts(settings.stagingDir, settings.stagingDir)
 }
 
 def requestSignature(source: string): Result<string> {
@@ -1080,13 +1096,19 @@ export def writeTool(
 
 // ---- running a tool ----
 
-def recordUse(toolDir: string, name: string, meta: ToolMeta): Result {
+def recordUse(root: string, name: string, meta: ToolMeta): Result {
+  const toolDir = "${root}/${name}"
+  return interrupt std::toolbox::recordUse("Record one use of this tool in its ${META_FILE}?", {
+    dir: toolDir,
+    name: name
+  })
   const used: ToolMeta = {
     ...meta,
     uses: meta.uses + 1,
     lastUsedAt: format(now())
   }
-  return write(META_FILE, JSON.stringify(used, null, 2), toolDir)
+  // Contained in the toolbox root, like the reads under a scan.
+  return try _write(toolDir, META_FILE, JSON.stringify(used, null, 2), "overwrite", [root])
 }
 
 export def runTool(
@@ -1096,8 +1118,9 @@ export def runTool(
 ): Result<Json> {
   """
   Run a saved tool's `main` node in a subprocess and return what it
-  returned. The tool's meta.json records one more use and the time; it
-  does not record the result.
+  returned. The tool's meta.json records one more use and the time,
+  behind a `std::toolbox::recordUse` interrupt. A declined or failed
+  record does not fail the run. The result is not recorded.
 
   @param name - The tool's name under dir
   @param request - The tool's input, a value of its Request type
@@ -1121,7 +1144,7 @@ export def runTool(
   return interrupt std::toolbox::scan("Are you sure you want to read this tool?", {
     dir: toolDir
   })
-  const meta = metaFacts(toolDir)
+  const meta = metaFacts(root.value, toolDir)
   if (meta is failure) {
     return meta
   }
@@ -1138,13 +1161,8 @@ export def runTool(
   if (ran is success(finished)) {
     result = finished.data
   }
-  // The tool has run and its effects have happened, so its result is
-  // never dropped: a failed record carries it in the message.
-  const recorded = recordUse(toolDir, name, meta.value)
-  if (recorded is failure(recordErr)) {
-    return failure(
-      "the tool ran and returned ${JSON.stringify(result)}, but ${META_FILE} could not be updated: ${recordErr}",
-    )
-  }
+  // The tool has run and its effects have happened. A declined interrupt
+  // or a failed write leaves the count unrecorded and returns the result.
+  recordUse(root.value, name, meta.value)
   return result
 }

--- a/packages/agency-lang/stdlib/toolbox.agency
+++ b/packages/agency-lang/stdlib/toolbox.agency
@@ -113,10 +113,9 @@ effect std::toolbox::scan {
   dir: string
 }
 
-// runTool's use count, as its own effect rather than a std::write: the
-// stdlib composes the record, so approving this approves one known
-// change to the tool's meta.json and cannot be reused to land arbitrary
-// content there. The approval covers the write that fulfils it.
+// runTool's use count. Its own effect, so a policy can approve the
+// stdlib's record without approving any std::write to meta.json. The
+// approval covers the write that fulfils it.
 @alwaysUnder(dir)
 effect std::toolbox::recordUse {
   dir: string;
@@ -192,8 +191,7 @@ const EMPTY_MODULE: ModuleFacts = {
 // Every entry point takes the toolbox directory the same way. An empty
 // string is refused because the file primitives would resolve it to the
 // process cwd. Absolutized so the interrupt payloads name one directory
-// however the caller spelled it, and so a policy pattern that expands to
-// an absolute path can match them.
+// however the caller spelled it.
 def expandRoot(dir: string): Result<string> {
   if (dir == "") {
     return failure("dir must name the toolbox directory. Got an empty string")
@@ -213,10 +211,8 @@ def factsOf(exported: ExportInfo): ModuleFacts {
   }
 }
 
-// The reads under a scan approval are contained in the toolbox root:
-// the open refuses a symlink, and the descriptor is checked to sit
-// inside the root, so a symlinked tool directory cannot carry the
-// approval elsewhere.
+// The reads under a scan approval are contained in the toolbox root, so
+// a symlinked tool directory cannot carry the approval elsewhere.
 def moduleFacts(root: string, toolDir: string): Result<ModuleFacts> {
   const source = try _read(toolDir, IMPL_FILE, 0, 0, [root])
   if (source is failure) {
@@ -1118,9 +1114,9 @@ export def runTool(
 ): Result<Json> {
   """
   Run a saved tool's `main` node in a subprocess and return what it
-  returned. The tool's meta.json records one more use and the time,
-  behind a `std::toolbox::recordUse` interrupt. A declined or failed
-  record does not fail the run. The result is not recorded.
+  returned. The tool's meta.json counts one more use and the time. A
+  declined or failed count does not fail the run. The result is not
+  recorded.
 
   @param name - The tool's name under dir
   @param request - The tool's input, a value of its Request type
@@ -1161,8 +1157,7 @@ export def runTool(
   if (ran is success(finished)) {
     result = finished.data
   }
-  // The tool has run and its effects have happened. A declined interrupt
-  // or a failed write leaves the count unrecorded and returns the result.
+  // Best-effort: the tool has already run.
   recordUse(root.value, name, meta.value)
   return result
 }

--- a/packages/agency-lang/tests/agency/skills-dir.agency
+++ b/packages/agency-lang/tests/agency/skills-dir.agency
@@ -1,4 +1,6 @@
-import { skillsDir } from "std::skills"
+import { mkdir, remove } from "std::fs"
+import { exists, exec } from "std::shell"
+import { skillsDir, commandsDir } from "std::skills"
 
 def stdDesc(): string {
   const tool = skillsDir(__dirname + "/skills-dir-fixture/std", "standard") with approve
@@ -105,4 +107,31 @@ node explicitNameOverrides(): boolean {
 node explicitNameSanitized(): boolean {
   const tool = skillsDir(__dirname + "/skills-dir-fixture/flat", "flat", "My Cool Skill!") with approve
   return tool.name == "My_Cool_Skill"
+}
+
+// Both scan payloads name the real directory, the spelling a read would
+// report, so one policy rule covers a scan and the reads under it. The
+// link is proven reachable first.
+node scanPayloadsAreTheRealDirectory(): boolean {
+  const fixture = __dirname + "/skills-dir-fixture/flat"
+  const link = __dirname + "/test-output/linked-skills"
+  mkdir(__dirname + "/test-output") with approve
+  remove(link) with approve
+  const linked = exec("ln", ["-s", fixture, link]) with approve
+  if (linked is failure || linked.exitCode != 0) {
+    return false
+  }
+  const reachable = exists("greet.md", link)
+  const seen: string[] = []
+  handle {
+    skillsDir(link, "flat")
+    commandsDir(link)
+  } with (intr) {
+    if (intr.effect == "std::skills::skillsDir" || intr.effect == "std::skills::commandsDir") {
+      seen.push(intr.data.dir)
+    }
+    return approve()
+  }
+  remove(link) with approve
+  return reachable && seen.join(",") == "${fixture},${fixture}"
 }

--- a/packages/agency-lang/tests/agency/skills-dir.test.json
+++ b/packages/agency-lang/tests/agency/skills-dir.test.json
@@ -1,17 +1,18 @@
 {
   "tests": [
-    { "nodeName": "standardHasNamedSkill", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "standardFallsBackToDirNameWhenNoFrontmatter", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "standardFallsBackToDirNameWhenNameAbsent", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "flatHasNamedSkill", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "flatFallsBackToTitle", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "flatFallsBackToFilenameWhenNoFrontmatter", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "flatXmlEscapesDescription", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "emptyDirectoryProducesEmptySkillList", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "derivedNameCappedTo64", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "derivedNameKeepsTail", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "siblingDeepPathsStayDistinct", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "explicitNameOverrides", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "explicitNameSanitized", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] }
+    {"nodeName": "standardHasNamedSkill", "input": "", "expectedOutput": "true", "evaluationCriteria": [{"type": "exact"}]},
+    {"nodeName": "standardFallsBackToDirNameWhenNoFrontmatter", "input": "", "expectedOutput": "true", "evaluationCriteria": [{"type": "exact"}]},
+    {"nodeName": "standardFallsBackToDirNameWhenNameAbsent", "input": "", "expectedOutput": "true", "evaluationCriteria": [{"type": "exact"}]},
+    {"nodeName": "flatHasNamedSkill", "input": "", "expectedOutput": "true", "evaluationCriteria": [{"type": "exact"}]},
+    {"nodeName": "flatFallsBackToTitle", "input": "", "expectedOutput": "true", "evaluationCriteria": [{"type": "exact"}]},
+    {"nodeName": "flatFallsBackToFilenameWhenNoFrontmatter", "input": "", "expectedOutput": "true", "evaluationCriteria": [{"type": "exact"}]},
+    {"nodeName": "flatXmlEscapesDescription", "input": "", "expectedOutput": "true", "evaluationCriteria": [{"type": "exact"}]},
+    {"nodeName": "emptyDirectoryProducesEmptySkillList", "input": "", "expectedOutput": "true", "evaluationCriteria": [{"type": "exact"}]},
+    {"nodeName": "derivedNameCappedTo64", "input": "", "expectedOutput": "true", "evaluationCriteria": [{"type": "exact"}]},
+    {"nodeName": "derivedNameKeepsTail", "input": "", "expectedOutput": "true", "evaluationCriteria": [{"type": "exact"}]},
+    {"nodeName": "siblingDeepPathsStayDistinct", "input": "", "expectedOutput": "true", "evaluationCriteria": [{"type": "exact"}]},
+    {"nodeName": "explicitNameOverrides", "input": "", "expectedOutput": "true", "evaluationCriteria": [{"type": "exact"}]},
+    {"nodeName": "explicitNameSanitized", "input": "", "expectedOutput": "true", "evaluationCriteria": [{"type": "exact"}]},
+    {"nodeName": "scanPayloadsAreTheRealDirectory", "input": "", "expectedOutput": "true", "evaluationCriteria": [{"type": "exact"}]}
   ]
 }

--- a/packages/agency-lang/tests/agency/toolbox/designTool.agency
+++ b/packages/agency-lang/tests/agency/toolbox/designTool.agency
@@ -394,7 +394,7 @@ node symlinkedToolIsRefused(): boolean {
   remove(box) with approve
   mkdir(box) with approve
   const linked = exec("ln", ["-s", "${TOOLS}/good", "${box}/linked"]) with approve
-  if (linked is failure) {
+  if (linked is failure || linked.exitCode != 0) {
     return false
   }
   const reachable = exists("linked/tool.agency", box)

--- a/packages/agency-lang/tests/agency/toolbox/designTool.agency
+++ b/packages/agency-lang/tests/agency/toolbox/designTool.agency
@@ -1,5 +1,5 @@
 import { remove, mkdir } from "std::fs"
-import { exists, ls } from "std::shell"
+import { exists, ls, exec } from "std::shell"
 import { designTool, listTools, runTool } from "std::toolbox"
 
 const OUT = __dirname + "/test-output"
@@ -322,7 +322,8 @@ node staleTestFileDoesNotShip(): boolean {
 }
 
 // Write a tool, run it, and check the record: one use, a last-used time,
-// and the createdAt from the write kept as it was.
+// and the createdAt from the write kept as it was. The record goes
+// through a recordUse interrupt naming the tool's directory.
 node runToolRunsAndRecords(): boolean {
   cleanup("addEight")
   const written = runDesign("addEight", OUT, ["accept"])
@@ -331,9 +332,19 @@ node runToolRunsAndRecords(): boolean {
     return false
   }
   const createdAt = written.value.meta.createdAt
-  const answer = runTool("addEight", {
-    n: 41
-  }, OUT) with approve
+  let recordDir = ""
+  let answer: Result = failure("not run")
+  handle {
+    answer = runTool("addEight", {
+      n: 41
+    }, OUT)
+  } with (intr) {
+    if (intr.effect == "std::toolbox::recordUse") {
+      recordDir = intr.data.dir
+    }
+    return approve()
+  }
+  const namedTheTool = recordDir == "${OUT}/addEight"
   const listed = listTools(OUT) with approve
   let recorded = false
   if (listed is success(entries)) {
@@ -341,7 +352,62 @@ node runToolRunsAndRecords(): boolean {
     recorded = entry.meta.uses == 1 && entry.meta.lastUsedAt != null && entry.meta.createdAt == createdAt && createdAt != ""
   }
   cleanup("addEight")
-  return answer is success && answer.value == 42 && recorded
+  return answer is success && answer.value == 42 && recorded && namedTheTool
+}
+
+// The count is only a count: a declined recordUse leaves meta.json as it
+// was and the run still returns the tool's result.
+node declinedRecordUseKeepsTheResult(): boolean {
+  cleanup("addSixteen")
+  const written = runDesign("addSixteen", OUT, ["accept"])
+  if (written is failure) {
+    cleanup("addSixteen")
+    return false
+  }
+  let answer: Result = failure("not run")
+  handle {
+    answer = runTool("addSixteen", {
+      n: 1
+    }, OUT)
+  } with (intr) {
+    if (intr.effect == "std::toolbox::recordUse") {
+      return reject("no bookkeeping")
+    }
+    return approve()
+  }
+  const listed = listTools(OUT) with approve
+  let unrecorded = false
+  if (listed is success(entries)) {
+    const entry = find(entries, \candidate -> candidate.name == "addSixteen")
+    unrecorded = entry.meta.uses == 0 && entry.meta.lastUsedAt == null
+  }
+  cleanup("addSixteen")
+  return answer is success && answer.value == 2 && unrecorded
+}
+
+// A tool directory that is a symlink does not carry the scan approval to
+// its target: listTools leaves it out (ls reports a link, not a
+// directory) and runTool's contained read refuses it. The link is proven
+// reachable first.
+node symlinkedToolIsRefused(): boolean {
+  const box = "${OUT}/linkbox"
+  remove(box) with approve
+  mkdir(box) with approve
+  const linked = exec("ln", ["-s", "${TOOLS}/good", "${box}/linked"]) with approve
+  if (linked is failure) {
+    return false
+  }
+  const reachable = exists("linked/tool.agency", box)
+  const listed = listTools(box) with approve
+  let unlisted = false
+  if (listed is success(entries)) {
+    unlisted = !some(entries, \candidate -> candidate.name == "linked")
+  }
+  const ran = runTool("linked", {
+    n: 1
+  }, box) with approve
+  remove(box) with approve
+  return reachable && unlisted && ran is failure && "${ran.error}" =~ re/outside/
 }
 
 // A refused write is not something a new draft can fix, so designTool

--- a/packages/agency-lang/tests/agency/toolbox/designTool.test.json
+++ b/packages/agency-lang/tests/agency/toolbox/designTool.test.json
@@ -788,6 +788,61 @@
       ]
     },
     {
+      "nodeName": "declinedRecordUseKeepsTheResult",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        {
+          "return": {
+            "code": "import { Json } from \"std::validation\"\n\nexport type Request = {\n  n: number\n}\n\nexport def run(request: Request): Json {\n  \"\"\"\n  Add one to the number in the request.\n\n  @param request - The number to add one to\n  \"\"\"\n  return request.n + 1\n}\n"
+          }
+        },
+        {
+          "return": []
+        },
+        {
+          "return": {
+            "cases": [
+              {
+                "args": {
+                  "request": {
+                    "n": 41
+                  }
+                },
+                "expectedOutput": 42
+              },
+              {
+                "args": {
+                  "request": {
+                    "n": 0
+                  }
+                },
+                "expectedOutput": 1
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "nodeName": "symlinkedToolIsRefused",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "useTestLLMProvider": true,
+      "llmMocks": []
+    },
+    {
       "nodeName": "refusedWriteStopsTheRounds",
       "input": "",
       "expectedOutput": "true",

--- a/packages/agency-lang/tests/agency/toolbox/generate-designTool-mocks.mjs
+++ b/packages/agency-lang/tests/agency/toolbox/generate-designTool-mocks.mjs
@@ -105,6 +105,8 @@ const tests = [
   testCase("dateToolSkipsTests", dateRound),
   testCase("staleTestFileDoesNotShip", [...pureRound, ...modelRound]),
   testCase("runToolRunsAndRecords", pureRound),
+  testCase("declinedRecordUseKeepsTheResult", pureRound),
+  testCase("symlinkedToolIsRefused", []),
   testCase("refusedWriteStopsTheRounds", pureRound),
   testCase("aliasedDateCallSkipsTests", aliasRound),
   testCase("refusesATimeLimitOverAnHour", []),

--- a/packages/agency-lang/tests/agency/toolbox/listTools.agency
+++ b/packages/agency-lang/tests/agency/toolbox/listTools.agency
@@ -1,6 +1,9 @@
+import { mkdir, remove } from "std::fs"
+import { exists, exec } from "std::shell"
 import { listTools, ToolEntry } from "std::toolbox"
 
 const FIXTURES = __dirname + "/fixtures/tools"
+const OUT = __dirname + "/test-output"
 
 def catalog() {
   return listTools(FIXTURES) with approve
@@ -104,4 +107,29 @@ node missingToolboxIsEmpty(): boolean {
     return false
   }
   return entries.value.length == 0
+}
+
+// The scan payload names the real directory, the spelling a read would
+// report, so one policy rule covers both. The link is proven reachable
+// first.
+node scanPayloadIsTheRealDirectory(): boolean {
+  const link = "${OUT}/linked-tools"
+  mkdir(OUT) with approve
+  remove(link) with approve
+  const linked = exec("ln", ["-s", FIXTURES, link]) with approve
+  if (linked is failure || linked.exitCode != 0) {
+    return false
+  }
+  const reachable = exists("good/tool.agency", link)
+  let payloadDir = ""
+  handle {
+    listTools(link)
+  } with (intr) {
+    if (intr.effect == "std::toolbox::scan") {
+      payloadDir = intr.data.dir
+    }
+    return approve()
+  }
+  remove(link) with approve
+  return reachable && payloadDir == FIXTURES
 }

--- a/packages/agency-lang/tests/agency/toolbox/listTools.test.json
+++ b/packages/agency-lang/tests/agency/toolbox/listTools.test.json
@@ -89,6 +89,16 @@
           "type": "exact"
         }
       ]
+    },
+    {
+      "nodeName": "scanPayloadIsTheRealDirectory",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
PR 3 of 5 splitting #1001 (learned skills and toolbox): the policy half. PR 1 (#1004) shipped the skills write surface and PR 2 (#1013) the design loops. Nothing here changes what the agent does. It changes what the built-in policies decide without asking.

## The agent-home placeholder

`<agent-home>` in a `dir` pattern expands at match time to `AGENCY_AGENT_HOME` or `~/.agency-agent`, the way `<agency>` expands to the install root. An empty variable counts as unset and a relative one resolves against the cwd, matching the `--agent-home` launcher. The expansion is realpathed, for the reason the cwd already is in `resolveDotDirPattern`: file effects put the realpath of their directory in the payload, so a home behind a symlinked ancestor (`/tmp` on macOS) would otherwise never match. That is the payload's spelling, not symlink support inside the home. See the last section.

`agentHomeDir` in `lib/runtime/agentHome.ts` is now the one resolver. `agency mcp` used to have its own copy.

The matcher expands every placeholder in one pass instead of one guard per placeholder, so a pattern that mixes `<agency>` and `<agent-home>` in one brace group works. That was a #1001 review finding.

## What `recommended` now decides

- Reads under `<agent-home>/skills/**` and `<agent-home>/tools/**` are approved, in the shared `readScopeRules`. Both directories hold only what a review interrupt let in. Without this, every learned-skill read, catalog scan, and `runTool` prompts and auto-rejects headless. The rule reaches every `recommended` run, and the policy description says so. The home itself is not covered.
- `std::skills::skillsDir` and `std::skills::commandsDir` take the read scope instead of an unscoped approve. Flagged on #1004: a scan could read a directory a plain `read` would have prompted for.
- `std::toolbox::recordUse`, new, is approved under `<agent-home>/tools/**`.
- The save and review gates have no rule in any built-in but `approve-all`. A test pins that.

## `std::toolbox::recordUse`

`runTool` counts a use in the tool's `meta.json` behind this effect, not a `std::write`. A path glob cannot tell the stdlib's bookkeeping from any program writing arbitrary content into `meta.json`, whose `purpose` text `listTools` trusts and whose `maxTime` sets the run's time limit. That `std::write` glob was the #1001 hole. The count is best-effort: a declined interrupt or a failed write leaves it where it was and the run returns its result.

## Symlinks

An auto-approved scan or write under a lexical glob must not follow a symlink out of the toolbox. The toolbox reads now pass the root as an allowed path, so they go through the descriptor-validated `readContainedFile` that `std::skills` uses, and the use-count write goes through a new `writeContainedFile`, its write-side twin (open with `O_NOFOLLOW`, validate the descriptor, then write). `_write` takes an `allowedPaths` like `_read`. A symlinked tool directory was already left out of `listTools`, since `ls` reports a link, and now `runTool` refuses it too. Toolbox roots are absolutized so their payloads can match an absolute pattern.

## Testing

- `lib/runtime/policy.test.ts`: the placeholder's expansion, escaping, relative and empty env values, the realpath, matching under the home and nowhere else, and a mixed-placeholder pattern.
- `lib/runtime/builtinPolicies.test.ts`: the third read rule, every scan scoped like a read, the use-count rule, and the gates undecided.
- `lib/utils/writeContainedFile.test.ts`: overwrite, create, a final-component symlink, a symlinked parent, and both swap seams, each checking no bytes landed.
- `tests/agency/toolbox/designTool.agency`: the record names the tool directory, a declined record keeps the result and the count, and a symlinked tool is unlisted and refused, with a positive control that the link is reachable.
- `lib/cli/runPolicy.test.ts`, `lib/cli/effects.test.ts`, the always-scope table, `writeTool.agency`, `listTools.agency`, typecheck, prettier, lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0124WbyxEy5GBdLnYfZnLVyg
