### PR TITLE
agency agent: title from the whole first exchange; raise tool-call round limits

### DIFF
--- a/packages/agency-lang/docs/dev/agents/agent-sessions.md
+++ b/packages/agency-lang/docs/dev/agents/agent-sessions.md
@@ -25,8 +25,9 @@ tool, so it raises no interrupt and the user's policy is not asked about it.
 - `lib/agents/agency-agent/lib/sessions.agency` — the index, save, read,
   and the picker label.
 - `lib/agents/agency-agent/lib/sessionTitle.agency` — the one-line title:
-  from the first prompt on turn 1, then from the tail of the `main` thread
-  every `TITLE_EVERY` turns. One LLM call in its own thread; fails open to "".
+  from the tail of the `main` thread (the reply included) on turn 1 and
+  every `TITLE_EVERY` turns after. One LLM call in its own thread; fails
+  open to "".
 - `lib/agents/agency-agent/lib/resume.agency` — which session this run is
   (`chooseSession`, `startSession`), the restore, the per-turn record
   (`recordTurn`), and the footer text (`sessionTitle`).

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -150,11 +150,9 @@ node main() {
     args.flags["max-tool-call-rounds"] ?? null,
     isOneShot,
   )
-  if (maxRounds != null) {
-    setLlmOptions({
-      maxToolCallRounds: maxRounds
-    })
-  }
+  setLlmOptions({
+    maxToolCallRounds: maxRounds
+  })
   const maxResultChars = args.flags["max-tool-result-chars"]
   if (maxResultChars != null) {
     setLlmOptions({

--- a/packages/agency-lang/lib/agents/agency-agent/lib/args.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/args.agency
@@ -125,7 +125,7 @@ export def parseAgentArgs() {
         },
         "max-tool-call-rounds": {
           type: "number",
-          description: "Max LLM tool-call rounds before a tool loop halts (default 10 interactive, 50 in one-shot/-p mode)"
+          description: "Max LLM tool-call rounds before a tool loop halts (default 50 interactive, 100 in one-shot/-p mode)"
         },
         "max-tool-result-chars": {
           type: "number",

--- a/packages/agency-lang/lib/agents/agency-agent/lib/resume.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/resume.agency
@@ -187,11 +187,12 @@ export def recordTurn(userMsg: string): SaveTarget | null {
   record.turns = record.turns + 1
   record.lastActive = now()
   if (!_titlePinned && shouldRefreshTitle(record.turns)) {
-    // Turn 1 titles the first prompt; later refreshes summarize the
-    // conversation so far.
-    let source = userMsg
-    if (record.turns > 1) {
-      source = conversationText(_conversation)
+    // Title the conversation so far, the reply included, so turn 1 sees
+    // the first exchange and not just the prompt. The prompt alone is the
+    // fallback when the brain's thread cannot be read.
+    let source = conversationText(_conversation)
+    if (source == "") {
+      source = userMsg
     }
     const title = titleFor(source)
     if (title != "") {

--- a/packages/agency-lang/lib/agents/agency-agent/lib/sessionTitle.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/sessionTitle.agency
@@ -1,8 +1,8 @@
 /** @module
   @summary The one-line title a saved session shows in the resume picker
-  and the REPL footer. Written from the first prompt, then rewritten
-  every few turns as a summary of the conversation so far, unless the
-  user set one with `/rename`.
+  and the REPL footer. Written after the first turn and rewritten every
+  few turns as a summary of the conversation so far, unless the user set
+  one with `/rename`.
 */
 import { getThread, listThreads, sessionThreadId } from "std::thread"
 
@@ -63,8 +63,7 @@ export def cleanTitle(raw: string): string {
   return oneLine.slice(0, MAX_TITLE_CHARS)
 }
 
-/** One short title for `text`, which is either the first prompt or the
-  conversation so far. Runs in its own thread so the call never touches
+/** One short title for `text`, the conversation so far. Runs in its own thread so the call never touches
   the coordinator's conversation. Fails open to "": a title is never
   worth failing a turn over. */
 export def titleFor(text: string): string {

--- a/packages/agency-lang/lib/agents/agency-agent/shared.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/shared.agency
@@ -27,22 +27,26 @@ import { slotKind } from "./lib/slots.agency"
 // One-shot runs (--print / piped / a positional query) have no REPL for the
 // user to say "keep going", so an autonomous task gets more tool rounds by
 // default than the interactive baked default (10).
-export static const ONE_SHOT_MAX_TOOL_CALL_ROUNDS = 50
+export static const ONE_SHOT_MAX_TOOL_CALL_ROUNDS = 100
+
+// Interactive turns get fewer rounds than one-shot: a user is there to
+// ask for more.
+export static const INTERACTIVE_MAX_TOOL_CALL_ROUNDS = 50
 
 /** Effective maxToolCallRounds for a run. An explicit --max-tool-call-rounds
   always wins; otherwise a one-shot run gets ONE_SHOT_MAX_TOOL_CALL_ROUNDS and
-  an interactive run returns null (keep the compiled default). */
+  an interactive run gets INTERACTIVE_MAX_TOOL_CALL_ROUNDS. */
 export def resolveMaxToolCallRounds(
   explicit: number | null,
   oneShot: boolean,
-): number | null {
+): number {
   if (explicit != null) {
     return explicit
   }
   if (oneShot) {
     return ONE_SHOT_MAX_TOOL_CALL_ROUNDS
   }
-  return null
+  return INTERACTIVE_MAX_TOOL_CALL_ROUNDS
 }
 
 

--- a/packages/agency-lang/lib/agents/agency-agent/tests/oneShotRounds.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/oneShotRounds.agency
@@ -1,20 +1,28 @@
 // resolveMaxToolCallRounds: an explicit --max-tool-call-rounds always wins;
-// otherwise one-shot runs get the higher default and interactive runs keep the
-// compiled default (null).
-import { resolveMaxToolCallRounds } from "../shared.agency"
+// otherwise one-shot runs get the higher default and interactive runs the
+// lower one.
+import {
+  resolveMaxToolCallRounds,
+  ONE_SHOT_MAX_TOOL_CALL_ROUNDS,
+  INTERACTIVE_MAX_TOOL_CALL_ROUNDS,
+ } from "../shared.agency"
 
 node explicitWinsOverOneShot(): boolean {
   return resolveMaxToolCallRounds(7, true) == 7
 }
 
-node oneShotDefaults50(): boolean {
-  return resolveMaxToolCallRounds(null, true) == 50
+node oneShotDefault(): boolean {
+  return resolveMaxToolCallRounds(null, true) == ONE_SHOT_MAX_TOOL_CALL_ROUNDS
 }
 
 node explicitWinsOverInteractive(): boolean {
   return resolveMaxToolCallRounds(3, false) == 3
 }
 
-node interactiveKeepsBaked(): boolean {
-  return resolveMaxToolCallRounds(null, false) == null
+node interactiveDefault(): boolean {
+  return resolveMaxToolCallRounds(null, false) == INTERACTIVE_MAX_TOOL_CALL_ROUNDS
+}
+
+node oneShotGetsMore(): boolean {
+  return ONE_SHOT_MAX_TOOL_CALL_ROUNDS > INTERACTIVE_MAX_TOOL_CALL_ROUNDS
 }

--- a/packages/agency-lang/lib/agents/agency-agent/tests/oneShotRounds.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/oneShotRounds.test.json
@@ -1,9 +1,55 @@
 {
   "sourceFile": "oneShotRounds.agency",
   "tests": [
-    { "nodeName": "explicitWinsOverOneShot", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "oneShotDefaults50", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "explicitWinsOverInteractive", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "interactiveKeepsBaked", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] }
+    {
+      "nodeName": "explicitWinsOverOneShot",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "oneShotDefault",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "explicitWinsOverInteractive",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "interactiveDefault",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "oneShotGetsMore",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
## What

Two fixes to `agency agent`:

1. **Session titles read the whole first exchange.** `recordTurn` titled turn 1 from the user's prompt alone and only read the conversation on later refreshes. Now every refresh, turn 1 included, reads the tail of the conversation thread, so the assistant's reply counts too. The prompt alone is the fallback when the thread cannot be read.

2. **Higher tool-call round limits.** Interactive turns go from 10 (the compiled default) to 50, and one-shot runs from 50 to 100. Both defaults now live in `shared.agency` and `resolveMaxToolCallRounds` always returns a number.

## Tests

- `lib/agents/agency-agent/tests/oneShotRounds.agency` updated for the new defaults (5 pass).
- `tests/agency/agency-agent-sessions.agency` still passes.

## Not done

- `docs/site/agent/index.md` still says "Defaults to 10 interactive, 50 in one-shot mode". Left alone since user-facing docs are edited by the owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ByjGRLbXwjSJdpK4R7JSP1
