### PR TITLE
parser: reject def and node names that contain spaces

### DIFF
--- a/packages/agency-lang/lib/parsers/function.test.ts
+++ b/packages/agency-lang/lib/parsers/function.test.ts
@@ -3803,6 +3803,18 @@ describe("declaration names with spaces", () => {
     expect(parsed.message).toMatch(/handoff def getCapital/);
   });
 
+  it("does not suggest a reorder when the name after the modifier still has a space", () => {
+    const parsed = parseAgency(
+      "def handoff get capital(c: string): string { return c }",
+      {},
+      false,
+    );
+    expect(parsed.success).toBe(false);
+    if (parsed.success) return;
+    expect(parsed.message).toMatch(/cannot contain spaces: `handoff get capital`/);
+    expect(parsed.message).not.toMatch(/goes before/);
+  });
+
   it("ignores whitespace between the name and the parameter list", () => {
     const parsed = functionParser("def foo (x: number): number { return x }");
     expect(parsed.success).toBe(true);

--- a/packages/agency-lang/lib/parsers/function.test.ts
+++ b/packages/agency-lang/lib/parsers/function.test.ts
@@ -3778,3 +3778,36 @@ describe("arrow return type", () => {
     );
   });
 });
+
+describe("declaration names with spaces", () => {
+  it("rejects a def whose name has a space in it", () => {
+    const parsed = parseAgency("def foo bar(x: number): number { return x }", {}, false);
+    expect(parsed.success).toBe(false);
+    if (parsed.success) return;
+    expect(parsed.message).toMatch(/`foo bar`/);
+    expect(parsed.message).toMatch(/cannot contain spaces/);
+  });
+
+  it("rejects a node whose name has a space in it", () => {
+    const parsed = parseAgency("node main loop() { print(1) }", {}, false);
+    expect(parsed.success).toBe(false);
+    if (parsed.success) return;
+    expect(parsed.message).toMatch(/`main loop`/);
+  });
+
+  it("tells the author a modifier written after def goes before it", () => {
+    const parsed = parseAgency("def handoff getCapital(c: string): string { return c }", {}, false);
+    expect(parsed.success).toBe(false);
+    if (parsed.success) return;
+    expect(parsed.message).toMatch(/`handoff` goes before `def`/);
+    expect(parsed.message).toMatch(/handoff def getCapital/);
+  });
+
+  it("ignores whitespace between the name and the parameter list", () => {
+    const parsed = functionParser("def foo (x: number): number { return x }");
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.result.functionName).toBe("foo");
+    }
+  });
+});

--- a/packages/agency-lang/lib/parsers/messages.ts
+++ b/packages/agency-lang/lib/parsers/messages.ts
@@ -20,6 +20,22 @@ export const BODY_RESERVED_MODIFIER_MESSAGE =
   "`static` and `export` declarations are only supported at module top level. " +
   "Inside function and node bodies, use `optimize const ...` for optimizable local declarations or ordinary `const`/`let` declarations.";
 
+/** A `def` or `node` name with whitespace inside it. Without this check the
+ *  parser accepts `def foo bar(` with the name "foo bar", and the first thing
+ *  to object is esbuild, deep in the generated TypeScript. */
+export const DECL_NAME_SPACES_MESSAGE = (keyword: string, name: string): string =>
+  `a ${keyword} name cannot contain spaces: \`${name}\``;
+
+/** The same mistake when the first word is a modifier: the author wrote
+ *  `def handoff getCapital(` and meant `handoff def getCapital(`. */
+export const MODIFIER_AFTER_KEYWORD_MESSAGE = (
+  modifier: string,
+  keyword: string,
+  name: string,
+): string => `\`${modifier}\` goes before \`${keyword}\`:
+
+  ${modifier} ${keyword} ${name}(...)`;
+
 export const STATIC_LET_MESSAGE =
   "`static let` is not allowed. Use `static const <name> = ...` for a " +
   "once-per-process binding, or `static <expr>` (e.g. `static foo()`) " +

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -1325,8 +1325,11 @@ const declNameParserFor = (
     if (words.length === 1) {
       return { ...raw, result: name };
     }
-    const message = modifiers.includes(words[0])
-      ? MODIFIER_AFTER_KEYWORD_MESSAGE(words[0], keyword, words.slice(1).join(" "))
+    // Only `def handoff foo(` earns the reorder hint. With three or more
+    // words the suggested line would itself still hold a spaced name.
+    const isMisplacedModifier = words.length === 2 && modifiers.includes(words[0]);
+    const message = isMisplacedModifier
+      ? MODIFIER_AFTER_KEYWORD_MESSAGE(words[0], keyword, words[1])
       : DECL_NAME_SPACES_MESSAGE(keyword, name);
     const declined = committedFailure(message, input);
     getParseState().committedFailure = declined;

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -12,6 +12,7 @@ import {
   BODY_RESERVED_MODIFIER_MESSAGE,
   C_STYLE_FOR_MESSAGE,
   CATCH_ALL_NOT_LAST,
+  DECL_NAME_SPACES_MESSAGE,
   DUPLICATE_ON_CLAUSE,
   EMPTY_HANDLER_BLOCK,
   MALFORMED_ON_CLAUSE,
@@ -19,6 +20,7 @@ import {
   IF_EXPRESSION_MESSAGE,
   INTERFACE_EXTENDS_MESSAGE,
   MATCH_CASES_MESSAGE,
+  MODIFIER_AFTER_KEYWORD_MESSAGE,
   RESERVED_CLASS_MESSAGE,
   STATIC_ASSIGN_MESSAGE,
   STATIC_INNER_MESSAGE,
@@ -1287,16 +1289,53 @@ const declNameHoleParser: Parser<Hole> = map(
   (r: unknown) => (r as { hole: Hole }).hole,
 );
 
+// The modifiers that may precede `def`, in any order, each at most once.
+// A table looped to fixpoint keeps this order-independent and makes a new
+// modifier a one-word addition to FUNCTION_MARKER_KEYWORDS.
+const FUNCTION_MODIFIER_KEYWORDS = ["export", ...FUNCTION_MARKER_KEYWORDS] as const;
+type FunctionModifierKeyword = (typeof FUNCTION_MODIFIER_KEYWORDS)[number];
+
+// The modifiers that may precede `node`.
+const NODE_MODIFIER_KEYWORDS = ["export"] as const;
+
 /** A declaration name: an identifier hole or a raw name. When the input
  *  starts with `#` there is NO raw-name fallback — otherwise a rejected
  *  hole form (`def #...name`) would be swallowed as the literal string
- *  "#...name" instead of failing the parse. */
-const declNameParser: Parser<string | Hole> = (input: string) => {
-  if (input.startsWith("#")) {
-    return declNameHoleParser(input) as ParserResult<string | Hole>;
-  }
-  return many1Till(char("("))(input) as ParserResult<string | Hole>;
+ *  "#...name" instead of failing the parse.
+ *
+ *  A raw name runs up to `(`, so it is checked for whitespace here. Once
+ *  `def NAME` has been read the construct is unambiguous, so the failure
+ *  is committed: an enclosing `or(...)` would otherwise report something
+ *  unrelated. `modifiers` lists the words that may precede `keyword`, so
+ *  `def handoff foo(` gets the message that names the right order. */
+const declNameParserFor = (
+  keyword: "def" | "node",
+  modifiers: readonly string[],
+): Parser<string | Hole> => {
+  return (input: string) => {
+    if (input.startsWith("#")) {
+      return declNameHoleParser(input) as ParserResult<string | Hole>;
+    }
+    const raw = many1Till(char("("))(input);
+    if (!raw.success) {
+      return raw as ParserResult<string | Hole>;
+    }
+    const name = raw.result.trimEnd();
+    const words = name.split(/\s+/);
+    if (words.length === 1) {
+      return { ...raw, result: name };
+    }
+    const message = modifiers.includes(words[0])
+      ? MODIFIER_AFTER_KEYWORD_MESSAGE(words[0], keyword, words.slice(1).join(" "))
+      : DECL_NAME_SPACES_MESSAGE(keyword, name);
+    const declined = committedFailure(message, input);
+    getParseState().committedFailure = declined;
+    return declined as ParserResult<string | Hole>;
+  };
 };
+
+const defNameParser = declNameParserFor("def", FUNCTION_MODIFIER_KEYWORDS);
+const nodeNameParser = declNameParserFor("node", NODE_MODIFIER_KEYWORDS);
 
 export const booleanParser: Parser<BooleanLiteral> = label(
   "a boolean",
@@ -6991,7 +7030,7 @@ const _baseFunctionParser: Parser<any> = memo(
     set("type", "function"),
     capture(oneOfStr(["def", "function"]), "keyword"),
     many1(space),
-    capture(declNameParser, "functionName"),
+    capture(defNameParser, "functionName"),
     char("("),
     optionalSpacesOrNewline,
     captureCaptures(
@@ -7038,12 +7077,6 @@ const exportKeywordParser: Parser<boolean> = or(
   map(seqC(str("export"), spaces), () => true),
   succeed(false),
 );
-
-// The modifiers that may precede `def`, in any order, each at most once.
-// A table looped to fixpoint keeps this order-independent and makes a new
-// modifier a one-word addition to FUNCTION_MARKER_KEYWORDS.
-const FUNCTION_MODIFIER_KEYWORDS = ["export", ...FUNCTION_MARKER_KEYWORDS] as const;
-type FunctionModifierKeyword = (typeof FUNCTION_MODIFIER_KEYWORDS)[number];
 
 const modifierKeywordParser = (keyword: string): Parser<boolean> =>
   or(
@@ -7156,7 +7189,7 @@ export const graphNodeParser: Parser<GraphNodeDefinition> = label(
           optionalSpaces,
           str("node"),
           many1(space),
-          capture(declNameParser, "nodeName"),
+          capture(nodeNameParser, "nodeName"),
           char("("),
           optionalSpacesOrNewline,
           captureCaptures(


### PR DESCRIPTION
## What

The `def` and `node` name parser read every character up to the opening parenthesis, spaces included. So `def handoff getCapital(country: string)` parsed as a function named `handoff getCapital`, and the first thing to object was esbuild:

```
<stdin>:253:25: ERROR: Expected "(" but found "getCapital_impl"
    lineText: 'async function __handoff getCapital_impl(country: string) {'
```

A name with a space inside it is now a committed parse failure. When the first word is a modifier keyword (`export`, `destructive`, `idempotent`, `handoff`), the message says which order to write it in:

```
Line 3, col 5: `handoff` goes before `def`:

  handoff def getCapital(...)
```

Any other two-word name gets "a def name cannot contain spaces: `foo bar`". Nodes get the same check, with `export` as the only modifier it names.

Trailing whitespace before the parenthesis (`def foo (x)`) used to become part of the name and fail the same way at esbuild. It is now trimmed.

## Tests

Four cases at the end of `lib/parsers/function.test.ts`: a def name with a space, a node name with a space, a modifier written after `def`, and a space before the parameter list. All four failed before the change.

## Not in this PR

Parse errors report a line number two higher than the source line. That predates this change (the interface-inheritance error does it too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUozT88afMpi6JnsUahT2s
