### PR TITLE
agency agent: budgets belong to the subagent call, and a stopped handoff points at its work

### DIFF
--- a/packages/agency-lang/.claude/skills/agency-agent-docs/SKILL.md
+++ b/packages/agency-lang/.claude/skills/agency-agent-docs/SKILL.md
@@ -13,6 +13,7 @@ Paths are relative to `packages/agency-lang/`. Read the one that matches the tas
 - `docs/dev/agents/harness-and-model.md` — How to divide credit between harness and model, the six tiers a fix can land in, and what a harness genuinely cannot do.
 - `docs/dev/agents/harness-guidelines.md` — The prescriptive companion: must-dos and must-nots for building and changing the agent harness.
 - `docs/dev/agents/approval-policies.md` — How approval policy rules match, and the matching rules that have caused surprises.
+- `docs/dev/agents/subagent-budgets.md` — How a stated deadline reaches a subagent as a tool parameter, what happens when its guard trips, and why the harness no longer guards the whole turn.
 - `docs/dev/agents/tool-loop-guards.md` — The three refusals that stop a model wasting rounds: a repeated call, an argument that is really tool-call markup, and a call identical to one already rejected.
 - `docs/dev/agents/reply-attachments.md` — How a tool hands images back to the model, given that most providers reject image parts in tool results.
 - `docs/dev/agents/promptRunner.md` — The control-flow helper behind `runPrompt`, and the rule that tool-loop decisions must be durable: made inside a step, persisted in `runnerState`.

--- a/packages/agency-lang/CLAUDE.md
+++ b/packages/agency-lang/CLAUDE.md
@@ -283,6 +283,7 @@ Other process docs:
 - `docs/dev/agents/promptRunner.md` — The control-flow helper behind `runPrompt`, and the rule that tool-loop decisions must be durable: made inside a step, persisted in `runnerState`.
 - `docs/dev/agents/reply-attachments.md` — How a tool hands images back to the model, given that most providers reject image parts in tool results.
 - `docs/dev/agents/self-writing-agent.md` — Investigation notes from the experiment behind that argument.
+- `docs/dev/agents/subagent-budgets.md` — How a stated deadline reaches a subagent as a tool parameter, what happens when its guard trips, and why the harness no longer guards the whole turn.
 - `docs/dev/agents/tool-loop-guards.md` — The three refusals that stop a model wasting rounds: a repeated call, an argument that is really tool-call markup, and a call identical to one already rejected.
 - `docs/dev/agents/why-agents-write-code.md` — The argument for letting an agent write and run programs instead of giving it more tools.
 - `docs/dev/agents/writing-rewrite-agent.md` — The rewrite agent over the writing reviewer: the passes loop, why a reviewer failure is not a clean pass, and how its eval suite shares the reviewer suite's files.

--- a/packages/agency-lang/docs/dev/agents/agent-brains.md
+++ b/packages/agency-lang/docs/dev/agents/agent-brains.md
@@ -3,7 +3,7 @@
 The Agency agent (`agency agent`, source in `lib/agents/agency-agent/`) is
 split into two parts. The **harness** is everything a user of the command
 line sees and everything that keeps the agent safe: flags, the REPL, the
-approval policy handler, the per-turn budget guard, slash commands,
+approval policy handler, the hard stop for a subagent budget trip, slash commands,
 attachments. The **brain** is the part that answers a turn. There can be
 several brains; `--brain <name>` picks one. This note explains the split,
 the record a brain must provide, where the safety boundary sits, and how to
@@ -15,7 +15,7 @@ We want to try different designs for "how does the agent answer a turn"
 (one coordinator LLM with subagents, a single tool-less call, something
 else) without rewriting the parts every design shares. Before the split,
 the coordinator module owned both the routing *and* pieces of the harness
-(the budget guard, slash expansion, attachment detection), so a second
+(the budget-trip handler, slash expansion, attachment detection), so a second
 design would have had to copy them. Now the harness owns those, and a brain
 is a small record it calls.
 

--- a/packages/agency-lang/docs/dev/agents/subagent-budgets.md
+++ b/packages/agency-lang/docs/dev/agents/subagent-budgets.md
@@ -1,91 +1,49 @@
 # Subagent budgets
 
-How a deadline or spend limit the user states reaches the subagent that
-does the work, what happens when it runs out, and why the harness no
-longer wraps the whole turn in a guard.
+A budget is a parameter on the subagent tool call, enforced by the
+stdlib agent's own guard. The harness does not guard the turn.
 
-## The shape
+## Where a budget comes from
 
-There are exactly two places a budget can come from:
+- The `--max-time` and `--max-cost` flags cap the whole agent process. The
+  runtime installs them as a root budget before any Agency code runs
+  (`installRootBudget`, `lib/runtime/node.ts`), and a root budget cannot
+  be granted more.
+- `researchAgent`, `explorerAgent`, and `oracleAgent` take `maxSeconds`
+  and `maxDollars`. The coordinator fills them in from the user's words,
+  the wrapper converts them, and the stdlib agent's guard enforces them.
+  Unset means the stdlib agent's default.
 
-- **The `--max-time` and `--max-cost` flags.** These cap the whole agent
-  process. The runtime installs them as a root budget before any Agency
-  code runs (`installRootBudget`, `lib/runtime/node.ts`), and a root budget
-  cannot be granted more. Nothing in the agent's own code is involved.
-- **A parameter on the subagent tool.** `researchAgent`, `explorerAgent`,
-  and `oracleAgent` take `maxSeconds` and `maxDollars`. The coordinator
-  fills them in from the user's words ("do this in five minutes" becomes
-  `maxSeconds: 300`), the wrapper converts them to the milliseconds and
-  dollars the stdlib agent takes, and the stdlib agent's own `guard`
-  enforces them. When the model sets neither, the wrapper passes the
-  stdlib agent's usual default, so the cap is the same as calling that
-  agent directly.
+`codeAgent` runs on fixed internal budgets and does not take the
+parameters yet.
 
-The conversion and the stop text live in
-`brains/coordinator/lib/budgets.agency`. `codeAgent` still runs on fixed
-internal budgets; giving it the same parameters means threading them
-through its triage, escalation, and supervision paths, and is not done
-yet.
-
-## What happens when a budget runs out
+## When a budget runs out
 
 1. The stdlib agent's guard trips and raises `std::guard`.
-2. No handler inside the agent owns the trip, so it reaches
-   `guardStopHandler` in `lib/budget.agency`, the handler `runTurn` wraps
-   every turn in. It prints one line in an interactive session and
-   rejects. Rejecting is what makes the budget a hard stop: passing would
-   park the turn on an interrupt nobody answers.
-3. The guard converts the rejection at its own site into a failure, or
-   into a success carrying the saved draft when the agent saved one.
-4. The subagent wrapper turns that into the tool's result through
-   `agentOutcome`: a failure whose text names the budget that ran out
-   ("its time budget of 5m ran out"), and an empty answer is reported as
-   a stop rather than a blank success.
-5. The coordinator's tool loop pushes the resume message for a stopped
-   handoff (`finishStoppedHandoff`, `lib/runtime/handoff.ts`): the
-   subagent stopped, why, and that its work is in the messages above from
-   the line where it was dispatched onward. The loop then makes the coordinator's next
-   request as it would after any tool.
-6. The coordinator continues with the user's request from that work. The
-   prompt tells it to answer if the work is enough, say what is unfinished
-   if not, and not to re-dispatch the same task on its own.
+2. `budgeted` (`brains/coordinator/lib/budgets.agency`) wraps each call
+   with a handler that rejects a trip carrying the agent's guard label and
+   remembers it. `guardStopHandler` (`lib/budget.agency`), which `runTurn`
+   installs, rejects every trip that reaches the top of the turn, so no
+   trip parks the turn on an unanswered interrupt.
+3. The guard converts the rejection into a failure, or into a success
+   carrying the saved draft. `budgeted` returns a failure naming the
+   budget either way ("its time budget of 5m ran out"), because a draft
+   returned as a success would be announced as a finished answer.
+4. The tool loop pushes the stopped-handoff resume message
+   (`finishStoppedHandoff`, `lib/runtime/handoff.ts`): the subagent
+   stopped, why, and that its work is in the messages above. The
+   coordinator's next request follows as after any tool.
 
-Step 5 is the payoff of the handoff design: a research agent that ran for
-four of its five minutes has left every search result on the coordinator's
-thread, so the coordinator can answer from them without another call.
+The whole-turn guard that used to wrap the coordinator's own loop is gone:
+rejecting it unwound the coordinator along with the subagent, so nothing
+could pick the research up from the thread. It also took the mid-run
+"give me more time?" prompt with it.
 
-## Why the turn guard is gone
+## Tests
 
-The harness used to parse a deadline out of the user's message with an
-extra LLM call and wrap the entire turn, the coordinator's own `llm()`
-loop included, in a guard labeled `agency-turn`. When that guard tripped
-and the user declined more time, the reject unwound the coordinator along
-with the subagent, so nothing could pick the research up. In one session
-the researcher had finished a complete answer, a review sent it back for
-revision, the turn guard tripped during the revision, and the user got a
-bare "stopped" line with the research sitting unread in the thread.
-
-The guard was in the wrong place. "Five minutes" limits the research. It
-does not limit the coordinator reading what the research found. Putting
-the budget on the tool call keeps the coordinator outside it, and the
-coordinator decides what the user meant without a separate parsing call.
-
-What was dropped with it: the mid-run "I've used 5m, give me more time?"
-prompt. The coordinator can ask the same question with the partial results
-in hand, which is a better moment for it.
-
-## Files
-
-- `lib/agents/agency-agent/lib/budget.agency`: `guardStopHandler`.
-- `lib/agents/agency-agent/lib/turn.agency`: `runTurn` installs it.
-- `lib/agents/agency-agent/brains/coordinator/lib/budgets.agency`:
-  `timeBudget`, `costBudget`, `describeStop`, `agentOutcome`.
-- `lib/agents/agency-agent/brains/coordinator/subagents/{research,explorer,oracle}.agency`:
-  the tool parameters and their docstrings, which are what the model reads.
-- `lib/runtime/handoff.ts` and `lib/runtime/prompt.ts`: the stopped resume
-  message, pushed for a handoff that fails or comes back aborted.
-- `lib/agents/agency-agent/brains/coordinator/prompts/main-*.md`: the
-  "Budgets and subagents that stop early" section.
-- Tests: `lib/agents/agency-agent/tests/turn.agency`
-  (`budgetTripIsHardStopAndBrainContinues`) and
-  `tests/agency-js/handoff/` (`failureInside`).
+- `lib/agents/agency-agent/brains/coordinator/tests/budgets.agency`:
+  `budgeted` with a drafting, a finishing, and an empty fake agent.
+- `lib/agents/agency-agent/tests/turn.agency`:
+  `budgetTripIsHardStopAndBrainContinues`.
+- `tests/agency/guards/unowned-guard-rejected.agency`: `guardStopHandler`.
+- `tests/agency-js/handoff/`: `failureInside`.

--- a/packages/agency-lang/docs/dev/agents/subagent-budgets.md
+++ b/packages/agency-lang/docs/dev/agents/subagent-budgets.md
@@ -1,0 +1,91 @@
+# Subagent budgets
+
+How a deadline or spend limit the user states reaches the subagent that
+does the work, what happens when it runs out, and why the harness no
+longer wraps the whole turn in a guard.
+
+## The shape
+
+There are exactly two places a budget can come from:
+
+- **The `--max-time` and `--max-cost` flags.** These cap the whole agent
+  process. The runtime installs them as a root budget before any Agency
+  code runs (`installRootBudget`, `lib/runtime/node.ts`), and a root budget
+  cannot be granted more. Nothing in the agent's own code is involved.
+- **A parameter on the subagent tool.** `researchAgent`, `explorerAgent`,
+  and `oracleAgent` take `maxSeconds` and `maxDollars`. The coordinator
+  fills them in from the user's words ("do this in five minutes" becomes
+  `maxSeconds: 300`), the wrapper converts them to the milliseconds and
+  dollars the stdlib agent takes, and the stdlib agent's own `guard`
+  enforces them. When the model sets neither, the wrapper passes the
+  stdlib agent's usual default, so the cap is the same as calling that
+  agent directly.
+
+The conversion and the stop text live in
+`brains/coordinator/lib/budgets.agency`. `codeAgent` still runs on fixed
+internal budgets; giving it the same parameters means threading them
+through its triage, escalation, and supervision paths, and is not done
+yet.
+
+## What happens when a budget runs out
+
+1. The stdlib agent's guard trips and raises `std::guard`.
+2. No handler inside the agent owns the trip, so it reaches
+   `guardStopHandler` in `lib/budget.agency`, the handler `runTurn` wraps
+   every turn in. It prints one line in an interactive session and
+   rejects. Rejecting is what makes the budget a hard stop: passing would
+   park the turn on an interrupt nobody answers.
+3. The guard converts the rejection at its own site into a failure, or
+   into a success carrying the saved draft when the agent saved one.
+4. The subagent wrapper turns that into the tool's result through
+   `agentOutcome`: a failure whose text names the budget that ran out
+   ("its time budget of 5m ran out"), and an empty answer is reported as
+   a stop rather than a blank success.
+5. The coordinator's tool loop pushes the resume message for a stopped
+   handoff (`finishStoppedHandoff`, `lib/runtime/handoff.ts`): the
+   subagent stopped, why, and that its work is in the messages above from
+   the line where it was dispatched onward. The loop then makes the coordinator's next
+   request as it would after any tool.
+6. The coordinator continues with the user's request from that work. The
+   prompt tells it to answer if the work is enough, say what is unfinished
+   if not, and not to re-dispatch the same task on its own.
+
+Step 5 is the payoff of the handoff design: a research agent that ran for
+four of its five minutes has left every search result on the coordinator's
+thread, so the coordinator can answer from them without another call.
+
+## Why the turn guard is gone
+
+The harness used to parse a deadline out of the user's message with an
+extra LLM call and wrap the entire turn, the coordinator's own `llm()`
+loop included, in a guard labeled `agency-turn`. When that guard tripped
+and the user declined more time, the reject unwound the coordinator along
+with the subagent, so nothing could pick the research up. In one session
+the researcher had finished a complete answer, a review sent it back for
+revision, the turn guard tripped during the revision, and the user got a
+bare "stopped" line with the research sitting unread in the thread.
+
+The guard was in the wrong place. "Five minutes" limits the research. It
+does not limit the coordinator reading what the research found. Putting
+the budget on the tool call keeps the coordinator outside it, and the
+coordinator decides what the user meant without a separate parsing call.
+
+What was dropped with it: the mid-run "I've used 5m, give me more time?"
+prompt. The coordinator can ask the same question with the partial results
+in hand, which is a better moment for it.
+
+## Files
+
+- `lib/agents/agency-agent/lib/budget.agency`: `guardStopHandler`.
+- `lib/agents/agency-agent/lib/turn.agency`: `runTurn` installs it.
+- `lib/agents/agency-agent/brains/coordinator/lib/budgets.agency`:
+  `timeBudget`, `costBudget`, `describeStop`, `agentOutcome`.
+- `lib/agents/agency-agent/brains/coordinator/subagents/{research,explorer,oracle}.agency`:
+  the tool parameters and their docstrings, which are what the model reads.
+- `lib/runtime/handoff.ts` and `lib/runtime/prompt.ts`: the stopped resume
+  message, pushed for a handoff that fails or comes back aborted.
+- `lib/agents/agency-agent/brains/coordinator/prompts/main-*.md`: the
+  "Budgets and subagents that stop early" section.
+- Tests: `lib/agents/agency-agent/tests/turn.agency`
+  (`budgetTripIsHardStopAndBrainContinues`) and
+  `tests/agency-js/handoff/` (`failureInside`).

--- a/packages/agency-lang/docs/dev/language/handoff-functions.md
+++ b/packages/agency-lang/docs/dev/language/handoff-functions.md
@@ -40,17 +40,14 @@ the body's messages can land on the caller's thread as valid history.
    last assistant message. A rejection takes the same route with the
    text an ordinary tool message would have carried.
 
-   A failure, or an aborted result from an outer guard trip, takes a
-   different route: `finishStoppedHandoff` pushes
-   `[name stopped before finishing: <reason>]` followed by a line saying
-   the work so far is in the messages above, from the dispatch marker
-   onward, and to continue with the user's request from it. An ordinary
-   tool that fails has nothing to show. A handoff that fails has left
-   every search, read, and draft on the caller's thread, and the caller
-   should use them. The reason is
-   the failure's error text, or `describeAbortCause` for an abort. A
-   cancelled body (Esc, a race loser) gets no resume message; its system
-   messages are removed on the way out and the marker stays.
+   A failure, or an aborted result from an outer guard trip, goes
+   through `finishStoppedHandoff` instead, which pushes
+   `[name stopped before finishing: <reason>]` and a line saying the
+   work so far is in the messages above and to continue with the user's
+   request from it. The reason is the failure's error text, or
+   `describeAbortCause` for an abort. A cancelled body (Esc, a race
+   loser) gets no resume message; its system messages are removed on
+   the way out and the marker stays.
 
 The strip is anchored on the marker, not on a recorded position: memory
 compaction rewrites the thread and shifts every index, while the marker

--- a/packages/agency-lang/docs/dev/language/handoff-functions.md
+++ b/packages/agency-lang/docs/dev/language/handoff-functions.md
@@ -37,10 +37,20 @@ the body's messages can land on the caller's thread as valid history.
    message after this dispatch's marker and pushes a user-role
    `[name finished. <result>]\nContinue with the user's request.`
    The return value is always included, even when it repeats the body's
-   last assistant message. A failure or rejection takes the same route
-   with the text an ordinary tool message would have carried. A
-   cancelled body (Esc, a race loser, a timeout) gets no resume message;
-   its system messages are removed on the way out and the marker stays.
+   last assistant message. A rejection takes the same route with the
+   text an ordinary tool message would have carried.
+
+   A failure, or an aborted result from an outer guard trip, takes a
+   different route: `finishStoppedHandoff` pushes
+   `[name stopped before finishing: <reason>]` followed by a line saying
+   the work so far is in the messages above, from the dispatch marker
+   onward, and to continue with the user's request from it. An ordinary
+   tool that fails has nothing to show. A handoff that fails has left
+   every search, read, and draft on the caller's thread, and the caller
+   should use them. The reason is
+   the failure's error text, or `describeAbortCause` for an abort. A
+   cancelled body (Esc, a race loser) gets no resume message; its system
+   messages are removed on the way out and the marker stays.
 
 The strip is anchored on the marker, not on a recorded position: memory
 compaction rewrites the thread and shifts every index, while the marker

--- a/packages/agency-lang/docs/site/stdlib/agents/agency/researcher.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/agency/researcher.md
@@ -72,4 +72,4 @@ Answer a question about the Agency language from the bundled documentation,
 
 **Throws:** `std::guard`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/researcher.agency#L67))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/agency/researcher.agency#L60))

--- a/packages/agency-lang/docs/site/stdlib/agents/researcher.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/researcher.md
@@ -29,7 +29,7 @@ export type ResearchEvalInput = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/researcher.agency#L220))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/researcher.agency#L221))
 
 ## Functions
 
@@ -98,4 +98,4 @@ Answer a research question from web and Wikipedia sources and return a
 
 **Throws:** `std::guard`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/researcher.agency#L147))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/researcher.agency#L150))

--- a/packages/agency-lang/docs/site/stdlib/spill.md
+++ b/packages/agency-lang/docs/site/stdlib/spill.md
@@ -17,8 +17,8 @@ A command can print far more than a model should be handed in one tool
   `AGENCY_TOOL_OUTPUT_DIR` to move it.
 
   Two tools read the files back: `readSpill` for the whole file or a slice
-  of lines, and `grepSpill` to search one. Both take a file name, never a
-  path, so they cannot reach anything else. Each raises its own effect, so
+  of lines, and `grepSpill` to search one. Both take a file name, so
+  they cannot reach anything outside the directory. Each raises its own effect, so
   a policy can approve reading saved output without opening the
   general-purpose read tools any wider.
 
@@ -44,7 +44,7 @@ effect std::spill::write {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/spill.agency#L51))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/spill.agency#L53))
 
 ### std::spill::read
 
@@ -57,7 +57,7 @@ effect std::spill::read {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/spill.agency#L54))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/spill.agency#L56))
 
 ## Constants
 
@@ -81,7 +81,7 @@ The directory saved tool output lives in.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/spill.agency#L56))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/spill.agency#L58))
 
 ### keepOutput
 
@@ -109,7 +109,7 @@ What the model gets back for a command's output.
 
 **Throws:** `std::spill::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/spill.agency#L63))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/spill.agency#L65))
 
 ### readSpill
 
@@ -139,14 +139,14 @@ Read a saved tool-output file, named in a "full output saved as" notice. Returns
 
 **Throws:** `std::spill::read`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/spill.agency#L100))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/spill.agency#L102))
 
 ### grepSpill
 
 ```ts
 grepSpill(
   pattern: string,
-  filename: string = "",
+  filename: string,
   maxResults: number = 100,
 ): Result raises <std::spill::read>
 ```
@@ -154,7 +154,7 @@ grepSpill(
 Search a saved tool-output file for a regular expression. Each match comes back with its line number and line text. Patterns use JavaScript regex syntax.
 
   @param pattern - The regular expression to search for
-  @param filename - The file's name from a "full output saved as" notice. Empty searches every saved file.
+  @param filename - The file's name from a "full output saved as" notice. A name only, never a path.
   @param maxResults - Most matches to return
 
 **Parameters:**
@@ -162,11 +162,11 @@ Search a saved tool-output file for a regular expression. Each match comes back 
 | Name | Type | Default |
 |---|---|---|
 | pattern | `string` |  |
-| filename | `string` | "" |
+| filename | `string` |  |
 | maxResults | `number` | 100 |
 
 **Returns:** `Result`
 
 **Throws:** `std::spill::read`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/spill.agency#L118))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/spill.agency#L120))

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/README.md
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/README.md
@@ -2,7 +2,7 @@
 
 This directory is one *brain* of the Agency agent: the part that answers a
 turn. The harness around it (`agent.agency` and `lib/`) owns the command
-line, the REPL, the approval policy handler, the per-turn budget guard,
+line, the REPL, the approval policy handler, the hard stop for a subagent budget trip,
 slash-command expansion, and attachment detection. None of that lives here.
 `docs/dev/agents/agent-brains.md` explains the split; this file explains how this
 particular brain is put together.

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/coordinator.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/coordinator.agency
@@ -121,8 +121,7 @@ def promptText(prompt: string | (string | Attachment)[]): string {
   }
 }
 
-// A subagent called directly by --target has no coordinator to read its
-// Result, so a stop becomes the reply text.
+// A --target call has no coordinator to read the Result.
 def replyText(name: string, result: Result<string>): string {
   if (isFailure(result)) {
     return "${name} stopped before finishing: ${result.error}"

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/coordinator.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/coordinator.agency
@@ -121,6 +121,19 @@ def promptText(prompt: string | (string | Attachment)[]): string {
   }
 }
 
+// A subagent called directly by --target has no coordinator to read its
+// Result, so a stop becomes the reply text.
+def replyText(name: string, result: Result<string>): string {
+  if (isFailure(result)) {
+    return "${name} stopped before finishing: ${result.error}"
+  }
+  return result.value
+}
+
+def researchTurn(userMsg: string): string {
+  return replyText("The researcher", researchAgent(userMsg))
+}
+
 // The oracle and explorer are handoffs: as tools they continue the
 // caller's thread. Called directly by --target there is no caller thread
 // to continue, so give each its own, as the other subagents do for
@@ -128,7 +141,7 @@ def promptText(prompt: string | (string | Attachment)[]): string {
 def oracleTurn(userMsg: string): string {
   let reply = ""
   thread(label: "oracle", summarize: true) {
-    reply = oracleAgent(userMsg)
+    reply = replyText("The oracle", oracleAgent(userMsg))
   }
   return reply
 }
@@ -136,7 +149,7 @@ def oracleTurn(userMsg: string): string {
 def explorerTurn(userMsg: string): string {
   let reply = ""
   thread(label: "explorer", summarize: true) {
-    reply = explorerAgent(userMsg)
+    reply = replyText("The explorer", explorerAgent(userMsg))
   }
   return reply
 }
@@ -147,7 +160,7 @@ def coordinatorRunTurn(
 ): string {
   return match(target) {
     "code" => codeAgent(promptText(prompt))
-    "research" => researchAgent(promptText(prompt))
+    "research" => researchTurn(promptText(prompt))
     "oracle" => oracleTurn(promptText(prompt))
     "explorer" => explorerTurn(promptText(prompt))
     "review" => reviewAgent(promptText(prompt))

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/lib/budgets.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/lib/budgets.agency
@@ -1,17 +1,11 @@
 /** @module
-  @summary Budget plumbing shared by the coordinator's subagent tools: turning
-  the seconds and dollars the model passes into the milliseconds the stdlib
-  agents take, and turning a stopped agent's failure into one readable line.
-
-  The coordinator is the one that hears "do this in five minutes", so the
-  budget is a tool parameter the coordinator fills in. Each subagent tool
-  passes the budget straight to the
-  stdlib agent it wraps, and that agent's own guard enforces it. When the
-  guard trips, the failure comes back here to be described.
+  @summary Budget plumbing for the coordinator's subagent tools: convert the
+  seconds and dollars the model passes, run the stdlib agent under its label,
+  and report a budget stop as a failure that names the budget.
 */
 import { formatDuration } from "std::date"
 
-/** The stdlib agent's own time cap when the model set none, in milliseconds. */
+/** Milliseconds for the stdlib agent's `maxTime`. */
 export def timeBudget(maxSeconds: number | null, fallback: number): number {
   if (maxSeconds == null) {
     return fallback
@@ -19,37 +13,48 @@ export def timeBudget(maxSeconds: number | null, fallback: number): number {
   return maxSeconds * 1000
 }
 
-/** The stdlib agent's own cost cap when the model set none. */
+/** Dollars for the stdlib agent's `maxCost`. */
 export def costBudget(maxDollars: number | null, fallback: number): number {
   return maxDollars ?? fallback
 }
 
-/** One line saying why an agent stopped, for the resume message the
-  coordinator reads. A guard failure names the budget that ran out; anything
-  else is passed through as text. */
-export def describeStop(error: any): string {
-  if (error is string) {
-    return error
+def describeTrip(trip: any): string {
+  if (trip.dimension == "time") {
+    return "its time budget of ${formatDuration(trip.limit)} ran out"
   }
-  if (error.type == "timeoutFailure") {
-    return "its time budget of ${formatDuration(error.maxTime)} ran out"
-  }
-  if (error.type == "guardFailure") {
-    return "its cost budget of $${error.maxCost} ran out"
-  }
-  return "${error}"
+  return "its cost budget of $${trip.limit} ran out"
 }
 
-/** Turn a stdlib agent's Result into the tool's Result: a failure carries
-  the readable stop reason, and an answer that came back empty (the guard
-  salvaged nothing) is reported as a stop too rather than as a blank
-  success. */
-export def agentOutcome(result: Result<string>): Result<string> {
+export def budgeted(label: string, block: () -> Result<string>): Result<string> {
+  """
+  Run a stdlib agent and return its Result, except that a trip of the guard
+  carrying `label` becomes a failure naming the budget that ran out. The
+  guard itself turns a rejected trip into success carrying the saved draft,
+  which would read as a finished answer; the handoff's work is on the
+  thread already, so the stop is what the coordinator needs to hear.
+
+  @param label - the label of the agent's own guard
+  @param block - the call to the agent
+  """
+  let trip: any = null
+  let result: Result<string> = success("")
+  handle {
+    result = block()
+  } with (intr) {
+    if (intr.effect != "std::guard" || intr.data.label != label) {
+      return pass()
+    }
+    trip = intr.data
+    return reject()
+  }
+  if (trip != null) {
+    return failure(describeTrip(trip))
+  }
   if (isFailure(result)) {
-    return failure(describeStop(result.error))
+    return failure("${result.error}")
   }
   if (result.value == "") {
-    return failure("it stopped before producing an answer")
+    return failure("it returned no answer")
   }
   return result
 }

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/lib/budgets.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/lib/budgets.agency
@@ -1,0 +1,55 @@
+/** @module
+  @summary Budget plumbing shared by the coordinator's subagent tools: turning
+  the seconds and dollars the model passes into the milliseconds the stdlib
+  agents take, and turning a stopped agent's failure into one readable line.
+
+  The coordinator is the one that hears "do this in five minutes", so the
+  budget is a tool parameter the coordinator fills in. Each subagent tool
+  passes the budget straight to the
+  stdlib agent it wraps, and that agent's own guard enforces it. When the
+  guard trips, the failure comes back here to be described.
+*/
+import { formatDuration } from "std::date"
+
+/** The stdlib agent's own time cap when the model set none, in milliseconds. */
+export def timeBudget(maxSeconds: number | null, fallback: number): number {
+  if (maxSeconds == null) {
+    return fallback
+  }
+  return maxSeconds * 1000
+}
+
+/** The stdlib agent's own cost cap when the model set none. */
+export def costBudget(maxDollars: number | null, fallback: number): number {
+  return maxDollars ?? fallback
+}
+
+/** One line saying why an agent stopped, for the resume message the
+  coordinator reads. A guard failure names the budget that ran out; anything
+  else is passed through as text. */
+export def describeStop(error: any): string {
+  if (error is string) {
+    return error
+  }
+  if (error.type == "timeoutFailure") {
+    return "its time budget of ${formatDuration(error.maxTime)} ran out"
+  }
+  if (error.type == "guardFailure") {
+    return "its cost budget of $${error.maxCost} ran out"
+  }
+  return "${error}"
+}
+
+/** Turn a stdlib agent's Result into the tool's Result: a failure carries
+  the readable stop reason, and an answer that came back empty (the guard
+  salvaged nothing) is reported as a stop too rather than as a blank
+  success. */
+export def agentOutcome(result: Result<string>): Result<string> {
+  if (isFailure(result)) {
+    return failure(describeStop(result.error))
+  }
+  if (result.value == "") {
+    return failure("it stopped before producing an answer")
+  }
+  return result
+}

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/prompts/main-large.md
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/prompts/main-large.md
@@ -154,3 +154,8 @@ with them — don't sprint to implementation.
 
 - Make sure the user is following what you're doing. Use the `whatIAmDoing` tool frequently to tell the user what you're doing. (Subagent dispatches are announced automatically — narrate everything else.)
 - Also use the `elapsedTime` tool frequently to check how much time has elapsed since you started the task. If the user gave you a time constraint to work within, make sure you finish the task within that time constraint. For simple tasks, make sure you don't spend too long researching things before giving an answer.
+
+## Budgets and subagents that stop early
+
+- When the user gives a deadline or a spend limit for work you hand to a subagent, put it on the call: `maxSeconds` for time ("in five minutes" is 300) and `maxDollars` for money. The subagent's own guard enforces it and stops the subagent when it runs out. Do not rely on the subagent to watch the clock from the task text.
+- When a subagent stops before finishing, its reply says so, and everything it did is in this conversation above that line. Read that work and continue with the user's request from it: answer if it is enough, and say plainly what is unfinished if it is not. Do not dispatch the same subagent again for the same task unless the user asks for more.

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/prompts/main-small.md
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/prompts/main-small.md
@@ -59,3 +59,8 @@ Only reference files that live in the user's own working directory. Never cite a
 
 - Make sure the user is following what you're doing. Use the `whatIAmDoing` tool frequently to tell the user what you're doing. (Subagent dispatches are announced automatically — narrate everything else.)
 - Also use the `elapsedTime` tool frequently to check how much time has elapsed since you started the task. If the user gave you a time constraint to work within, make sure you finish the task within that time constraint. For simple tasks, make sure you don't spend too long researching things before giving an answer.
+
+## Budgets and subagents that stop early
+
+- When the user gives a deadline or a spend limit for work you hand to a subagent, put it on the call: `maxSeconds` for time ("in five minutes" is 300) and `maxDollars` for money. The subagent's own guard enforces it and stops the subagent when it runs out. Do not rely on the subagent to watch the clock from the task text.
+- When a subagent stops before finishing, its reply says so, and everything it did is in this conversation above that line. Read that work and continue with the user's request from it: answer if it is enough, and say plainly what is unfinished if it is not. Do not dispatch the same subagent again for the same task unless the user asks for more.

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/subagents/explorer.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/subagents/explorer.agency
@@ -15,7 +15,7 @@ import { explorerAgent as stdExplorerAgent } from "std::agents/explorer"
 
 import { getSlowModel, getSlowProvider } from "../../../shared.agency"
 import { announce } from "../lib/announce.agency"
-import { agentOutcome, costBudget, timeBudget } from "../lib/budgets.agency"
+import { budgeted, costBudget, timeBudget } from "../lib/budgets.agency"
 
 export handoff def explorerAgent(
   userMsg: string,
@@ -38,19 +38,19 @@ export handoff def explorerAgent(
 
   @param userMsg - the specific questions to answer and the scope to
     cover, with any context from the conversation the explorer needs
-  @param maxSeconds - stop the survey after this many seconds of working
-    time. Set it when the user gave a deadline. Leave it null for the
-    default of 15 minutes.
-  @param maxDollars - stop the survey after spending this many dollars.
-    Leave it null for the default of $20.
+  @param maxSeconds - working-time cap in seconds, when the user gave a
+    deadline; null for the default (15 minutes).
+  @param maxDollars - spend cap in dollars, when the user gave one; null
+    for the default ($20).
   """
   announce("explorer", userMsg)
-  const result = stdExplorerAgent(
-    question: userMsg,
-    maxCost: costBudget(maxDollars, $20.00),
-    maxTime: timeBudget(maxSeconds, 15m),
-    model: getSlowModel(),
-    provider: getSlowProvider(),
-  )
-  return agentOutcome(result)
+  return budgeted("explorerAgent") {
+    return stdExplorerAgent(
+      question: userMsg,
+      maxCost: costBudget(maxDollars, $20.00),
+      maxTime: timeBudget(maxSeconds, 15m),
+      model: getSlowModel(),
+      provider: getSlowProvider(),
+    )
+  }
 }

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/subagents/explorer.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/subagents/explorer.agency
@@ -15,8 +15,13 @@ import { explorerAgent as stdExplorerAgent } from "std::agents/explorer"
 
 import { getSlowModel, getSlowProvider } from "../../../shared.agency"
 import { announce } from "../lib/announce.agency"
+import { agentOutcome, costBudget, timeBudget } from "../lib/budgets.agency"
 
-export handoff def explorerAgent(userMsg: string): string {
+export handoff def explorerAgent(
+  userMsg: string,
+  maxSeconds: number | null = null,
+  maxDollars: number | null = null,
+): Result<string> {
   """
   Ask the explorer — a read-only researcher — to survey many files and
   return a synthesized answer. Use it only when the answer genuinely
@@ -33,15 +38,19 @@ export handoff def explorerAgent(userMsg: string): string {
 
   @param userMsg - the specific questions to answer and the scope to
     cover, with any context from the conversation the explorer needs
+  @param maxSeconds - stop the survey after this many seconds of working
+    time. Set it when the user gave a deadline. Leave it null for the
+    default of 15 minutes.
+  @param maxDollars - stop the survey after spending this many dollars.
+    Leave it null for the default of $20.
   """
   announce("explorer", userMsg)
   const result = stdExplorerAgent(
     question: userMsg,
+    maxCost: costBudget(maxDollars, $20.00),
+    maxTime: timeBudget(maxSeconds, 15m),
     model: getSlowModel(),
     provider: getSlowProvider(),
   )
-  if (isFailure(result)) {
-    return "The explorer could not finish: ${result.error}"
-  }
-  return result.value
+  return agentOutcome(result)
 }

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/subagents/oracle.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/subagents/oracle.agency
@@ -15,7 +15,7 @@ import { oracleAgent as stdOracleAgent } from "std::agents/oracle"
 
 import { getSlowModel, getSlowProvider } from "../../../shared.agency"
 import { announce } from "../lib/announce.agency"
-import { agentOutcome, costBudget, timeBudget } from "../lib/budgets.agency"
+import { budgeted, costBudget, timeBudget } from "../lib/budgets.agency"
 
 export handoff def oracleAgent(
   userMsg: string,
@@ -43,19 +43,19 @@ export handoff def oracleAgent(
   Call it alone, with no other tool calls in the same response.
 
   @param userMsg - the question
-  @param maxSeconds - stop the consult after this many seconds of working
-    time. Set it when the user gave a deadline. Leave it null for the
-    default of 15 minutes.
-  @param maxDollars - stop the consult after spending this many dollars.
-    Leave it null for the default of $20.
+  @param maxSeconds - working-time cap in seconds, when the user gave a
+    deadline; null for the default (15 minutes).
+  @param maxDollars - spend cap in dollars, when the user gave one; null
+    for the default ($20).
   """
   announce("oracle", userMsg)
-  const result = stdOracleAgent(
-    question: userMsg,
-    maxCost: costBudget(maxDollars, $20.00),
-    maxTime: timeBudget(maxSeconds, 15m),
-    model: getSlowModel(),
-    provider: getSlowProvider(),
-  )
-  return agentOutcome(result)
+  return budgeted("oracleAgent") {
+    return stdOracleAgent(
+      question: userMsg,
+      maxCost: costBudget(maxDollars, $20.00),
+      maxTime: timeBudget(maxSeconds, 15m),
+      model: getSlowModel(),
+      provider: getSlowProvider(),
+    )
+  }
 }

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/subagents/oracle.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/subagents/oracle.agency
@@ -15,8 +15,13 @@ import { oracleAgent as stdOracleAgent } from "std::agents/oracle"
 
 import { getSlowModel, getSlowProvider } from "../../../shared.agency"
 import { announce } from "../lib/announce.agency"
+import { agentOutcome, costBudget, timeBudget } from "../lib/budgets.agency"
 
-export handoff def oracleAgent(userMsg: string): string {
+export handoff def oracleAgent(
+  userMsg: string,
+  maxSeconds: number | null = null,
+  maxDollars: number | null = null,
+): Result<string> {
   """
   Ask the oracle — a read-only senior reviewer — for a second opinion
   before acting on something that would be expensive to get wrong. Call
@@ -38,15 +43,19 @@ export handoff def oracleAgent(userMsg: string): string {
   Call it alone, with no other tool calls in the same response.
 
   @param userMsg - the question
+  @param maxSeconds - stop the consult after this many seconds of working
+    time. Set it when the user gave a deadline. Leave it null for the
+    default of 15 minutes.
+  @param maxDollars - stop the consult after spending this many dollars.
+    Leave it null for the default of $20.
   """
   announce("oracle", userMsg)
   const result = stdOracleAgent(
     question: userMsg,
+    maxCost: costBudget(maxDollars, $20.00),
+    maxTime: timeBudget(maxSeconds, 15m),
     model: getSlowModel(),
     provider: getSlowProvider(),
   )
-  if (isFailure(result)) {
-    return "The oracle could not finish: ${result.error}"
-  }
-  return result.value
+  return agentOutcome(result)
 }

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/subagents/research.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/subagents/research.agency
@@ -22,7 +22,7 @@ import { setMemoryId } from "std::memory"
 import { highlight } from "std::syntax"
 
 import { announce } from "../lib/announce.agency"
-import { agentOutcome, costBudget, timeBudget } from "../lib/budgets.agency"
+import { budgeted, costBudget, timeBudget } from "../lib/budgets.agency"
 
 export static const researchTools: any[] = [...memoryTools(), ...planningTools(), highlight.partial(language: "ts"), print]
 
@@ -50,27 +50,27 @@ export handoff def researchAgent(
     itself (its syntax, types, stdlib, or CLI), which routes to the agent
     that reads the bundled Agency documentation. Leave it false for every
     other subject, including questions about other languages.
-  @param maxSeconds - stop the research after this many seconds of working
-    time. Set it when the user gave a deadline ("in five minutes" is 300).
-    Leave it null for the default of 30 minutes (10 for an Agency topic).
-  @param maxDollars - stop the research after spending this many dollars.
-    Set it when the user gave a spend limit. Leave it null for the default
-    of $50 ($10 for an Agency topic).
+  @param maxSeconds - working-time cap in seconds, when the user gave a
+    deadline; null for the default (30 minutes, 10 for an Agency topic).
+  @param maxDollars - spend cap in dollars, when the user gave one; null
+    for the default ($50, $10 for an Agency topic).
   """
   announce("research", userMsg)
   setMemoryId("research")
-  let result: Result<string> = success("")
   if (agencyTopic) {
-    result = agencyResearcherAgent(
-      question: userMsg,
-      context: replStyle,
-      maxCost: costBudget(maxDollars, $10.00),
-      maxTime: timeBudget(maxSeconds, 10m),
-      session: "research",
-      extraTools: researchTools,
-    )
-  } else {
-    result = researcherAgent(
+    return budgeted("agencyResearcherAgent") {
+      return agencyResearcherAgent(
+        question: userMsg,
+        context: replStyle,
+        maxCost: costBudget(maxDollars, $10.00),
+        maxTime: timeBudget(maxSeconds, 10m),
+        session: "research",
+        extraTools: researchTools,
+      )
+    }
+  }
+  return budgeted("researcherAgent") {
+    return researcherAgent(
       task: userMsg,
       context: replStyle,
       maxCost: costBudget(maxDollars, $50.00),
@@ -79,5 +79,4 @@ export handoff def researchAgent(
       extraTools: researchTools,
     )
   }
-  return agentOutcome(result)
 }

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/subagents/research.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/subagents/research.agency
@@ -22,6 +22,7 @@ import { setMemoryId } from "std::memory"
 import { highlight } from "std::syntax"
 
 import { announce } from "../lib/announce.agency"
+import { agentOutcome, costBudget, timeBudget } from "../lib/budgets.agency"
 
 export static const researchTools: any[] = [...memoryTools(), ...planningTools(), highlight.partial(language: "ts"), print]
 
@@ -36,7 +37,9 @@ Keep replies brief. Cite sources. Show, do not lecture."""
 export handoff def researchAgent(
   userMsg: string,
   agencyTopic: boolean = false,
-): string {
+  maxSeconds: number | null = null,
+  maxDollars: number | null = null,
+): Result<string> {
   """
   Answer a question that needs reading rather than writing: looking something
   up, summarizing a document, gathering background, or recalling a stored
@@ -47,6 +50,12 @@ export handoff def researchAgent(
     itself (its syntax, types, stdlib, or CLI), which routes to the agent
     that reads the bundled Agency documentation. Leave it false for every
     other subject, including questions about other languages.
+  @param maxSeconds - stop the research after this many seconds of working
+    time. Set it when the user gave a deadline ("in five minutes" is 300).
+    Leave it null for the default of 30 minutes (10 for an Agency topic).
+  @param maxDollars - stop the research after spending this many dollars.
+    Set it when the user gave a spend limit. Leave it null for the default
+    of $50 ($10 for an Agency topic).
   """
   announce("research", userMsg)
   setMemoryId("research")
@@ -55,6 +64,8 @@ export handoff def researchAgent(
     result = agencyResearcherAgent(
       question: userMsg,
       context: replStyle,
+      maxCost: costBudget(maxDollars, $10.00),
+      maxTime: timeBudget(maxSeconds, 10m),
       session: "research",
       extraTools: researchTools,
     )
@@ -62,12 +73,11 @@ export handoff def researchAgent(
     result = researcherAgent(
       task: userMsg,
       context: replStyle,
+      maxCost: costBudget(maxDollars, $50.00),
+      maxTime: timeBudget(maxSeconds, 30m),
       session: "research",
       extraTools: researchTools,
     )
   }
-  if (isFailure(result)) {
-    return "Research did not finish: ${result.error}"
-  }
-  return result.value
+  return agentOutcome(result)
 }

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/tests/budgets.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/tests/budgets.agency
@@ -1,0 +1,80 @@
+/*
+ * budgeted(): a subagent that overruns its own guard comes back as a
+ * failure naming the budget, even when the guard salvaged a draft. Fake
+ * agents stand in for the stdlib ones; the guard label is what budgeted
+ * matches on.
+ */
+import test { _advanceTime } from "std::date"
+
+import { guardStopHandler } from "../../../lib/budget.agency"
+import { budgeted } from "../lib/budgets.agency"
+
+def overrunWithDraft(): string {
+  saveDraft("PARTIAL")
+  _advanceTime(20000)
+  return "FULL"
+
+  finalize as draft {
+    return draft ?? ""
+  }
+}
+
+def draftingAgent(): Result<string> {
+  return guard(cost: $5, time: 10s, label: "fakeAgent") {
+    return overrunWithDraft()
+  }
+}
+
+def promptAgent(): Result<string> {
+  return guard(cost: $5, time: 10s, label: "fakeAgent") {
+    return "FULL"
+  }
+}
+
+def emptyAgent(): Result<string> {
+  return guard(cost: $5, time: 10s, label: "fakeAgent") {
+    return ""
+  }
+}
+
+def describe(r: Result<string>): string {
+  if (isFailure(r)) {
+    return "failure:${r.error}"
+  }
+  return "success:${r.value}"
+}
+
+// The guard alone would return success("PARTIAL") here, which the tool
+// loop would announce as a finished answer.
+node tripWithDraftIsAStop(): string {
+  let out = ""
+  handle {
+    out = describe(budgeted("fakeAgent") { return draftingAgent() })
+  } with guardStopHandler
+  return out
+}
+
+node finishedAgentPassesThrough(): string {
+  let out = ""
+  handle {
+    out = describe(budgeted("fakeAgent") { return promptAgent() })
+  } with guardStopHandler
+  return out
+}
+
+node emptyAnswerIsAStop(): string {
+  let out = ""
+  handle {
+    out = describe(budgeted("fakeAgent") { return emptyAgent() })
+  } with guardStopHandler
+  return out
+}
+
+// A trip of some other guard is not this agent's stop.
+node otherLabelIsNotOurs(): string {
+  let out = ""
+  handle {
+    out = describe(budgeted("someOtherAgent") { return draftingAgent() })
+  } with guardStopHandler
+  return out
+}

--- a/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/tests/budgets.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/brains/coordinator/tests/budgets.test.json
@@ -1,0 +1,48 @@
+{
+  "tests": [
+    {
+      "nodeName": "tripWithDraftIsAStop",
+      "fakeClock": true,
+      "input": "",
+      "expectedOutput": "\"failure:its time budget of 10s ran out\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "finishedAgentPassesThrough",
+      "fakeClock": true,
+      "input": "",
+      "expectedOutput": "\"success:FULL\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "emptyAnswerIsAStop",
+      "fakeClock": true,
+      "input": "",
+      "expectedOutput": "\"failure:it returned no answer\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "otherLabelIsNotOurs",
+      "fakeClock": true,
+      "input": "",
+      "expectedOutput": "\"success:PARTIAL\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/lib/agents/agency-agent/lib/budget.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/budget.agency
@@ -1,213 +1,41 @@
 /** @module
-  @summary Per-turn time and cost budgets parsed from the user's own words.
+  @summary What happens when a subagent's budget runs out: the trip is a
+  hard stop, and the coordinator carries on from the work left behind.
 
-  The user often states a soft deadline in plain language ("be quick, no
-  more than 30 seconds"). This module turns that into a real `guard` around
-  the turn. Three pieces:
+  Budgets belong to the tool call. The coordinator hears the user say "in
+  five minutes" and passes `maxSeconds` (or `maxDollars`) to the subagent
+  tool it dispatches; that tool hands the number to the stdlib agent it
+  wraps, whose own `guard` enforces it. The harness does not parse a
+  deadline out of the message, and does not wrap the turn in a guard. The
+  only whole-agent budget is the root budget the `--max-time` and
+  `--max-cost` flags install, which the runtime enforces before any Agency
+  code runs and which no handler can extend.
 
-  - `parseTurnBudget` reads a budget out of the message and stores it. It
-    runs once per turn and resets every turn, so a deadline stated on one
-    message never leaks into the next.
-  - `budgetTime` / `budgetCost` hand the stored budget (or a generous
-    fallback) to the guard `coordinator.runTurn` wraps around the turn.
-  - `turnBudgetHandler` is the top-level handler for that guard. When the
-    budget trips it asks the user whether to grant more, and either extends
-    the guard in place or stops. It also rejects any OTHER guard trip that
-    reaches it — an unowned budget cap is honored as a hard stop rather
-    than parking the turn on a question nobody answers.
-
-  Why a guard and not a "check the clock" tool: a tool the model must choose
-  to call has no forcing function, and the model is suspended inside slow
-  tool calls exactly when the time is burning. The guard is enforced by the
-  runtime, cancels the in-flight call when it fires, and resumes in place
-  when granted more budget.
+  `guardStopHandler` is the top-level handler for the `std::guard` trips
+  those subagent guards raise. It rejects every one: the guard converts the
+  rejection to a failure (or the saved draft) at its own site, the subagent
+  tool returns that to the coordinator's tool loop, and the loop pushes a
+  resume message saying the subagent stopped and its work is in the thread
+  above. The coordinator continues from there. Passing instead would park
+  the turn at an interrupt nobody answers.
 */
-import { formatDuration } from "std::date"
-
 import { isInteractive } from "./trace.agency"
 
-// The guard's label. The handler answers ONLY the trip carrying this label.
-// A subagent's own cost/time caps raise the same `std::guard` effect, so
-// without the label filter this handler would answer the wrong guard and
-// corrupt its accounting (the same rule `std::supervise` follows).
-export static const TURN_BUDGET_LABEL = "agency-turn"
-
-// Per-run (global, not static): each session starts clean, and the value is
-// overwritten at the top of every turn. This carries the parsed budget from
-// the parse site to the guard site without threading it through dispatch.
-let _maxTimeMs: number | null = null
-let _maxCost: number | null = null
-
-// Generous fallbacks so the guard always has a concrete number. A turn with
-// no stated budget runs under these, which are high enough never to bite a
-// normal turn but still cap a true runaway.
-export def budgetTime(): number { return _maxTimeMs ?? 1h }
-export def budgetCost(): number { return _maxCost ?? $50.00 }
-
-// The best-so-far value from the guard trip, captured when the user (or a
-// one-shot run) declines more budget. The trip carries `draftValue` — the
-// innermost saveDraft on the whole branch — so it crosses the subagents'
-// own guards, which salvage-on-abort alone cannot. runTurn reads this to
-// show the partial instead of a bare "stopped" line.
-let _lastPartial: any = null
-
-export def lastTurnPartial(): any { return _lastPartial }
-export def clearTurnPartial() { _lastPartial = null }
-
-type ParsedBudget = {
-  // null means the user stated no limit for that dimension. Never invent a
-  // deadline: a hallucinated 30s would cut off a turn that never asked for
-  // one.
-  maxSeconds: number | null
-  maxDollars: number | null
-}
-
-// A cheap gate so the extraction LLM call only fires when the message
-// plausibly names a limit. Most turns have no deadline, and an extra
-// round-trip on every one of them is the very slowness this feature fights.
-def hasBudgetClue(msg: string): boolean {
-  const lower = msg.toLowerCase()
-  const clues = ["second", "minute", "hour", "quick", "fast", "$", "budget"]
-  for (clue in clues) {
-    if (lower.includes(clue)) {
-      return true
-    }
-  }
-  return false
-}
-
-export def parseTurnBudget(msg: string) {
+export def guardStopHandler(intr: any): any {
   """
-  Read any time/cost budget from the user's message and store it for this
-  turn. Resets the budget every turn: a deadline on one message does not
-  carry to the next.
-  """
-  if (!hasBudgetClue(msg)) {
-    _maxTimeMs = null
-    _maxCost = null
-    return
-  }
-  // Isolated thread so the extraction Q&A never pollutes the coordinator's
-  // conversation.
-  let parsed: ParsedBudget = { maxSeconds: null, maxDollars: null }
-  thread(label: "budgetParse", session: "budgetParse") {
-    const extracted: ParsedBudget = llm(
-      """
-      Extract any explicit time or cost budget the user stated for this
-      task. Fill a field ONLY if the user named a concrete limit (a number
-      of seconds/minutes/hours, or a dollar amount). Vague urgency like
-      "quickly" with no number is NOT a budget: return null for it.
-
-      Message: ${msg}
-      """,
-    )
-    parsed = extracted
-  }
-  if (parsed.maxSeconds == null) {
-    _maxTimeMs = null
-  } else {
-    _maxTimeMs = parsed.maxSeconds * 1000
-  }
-  _maxCost = parsed.maxDollars
-}
-
-type MoreBudget = {
-  grant: boolean
-  extraSeconds: number | null
-  extraDollars: number | null
-}
-
-def parseMoreBudget(reply: string): MoreBudget {
-  let parsed: MoreBudget = { grant: false, extraSeconds: null, extraDollars: null }
-  thread(label: "budgetParse", session: "budgetParse") {
-    const extracted: MoreBudget = llm(
-      """
-      The user was asked whether to grant an agent more time or money to
-      finish a task. Read their reply. Set grant to true only if they agreed
-      to give more. Fill extraSeconds / extraDollars with any amount they
-      named, else null.
-
-      Reply: ${reply}
-      """,
-    )
-    parsed = extracted
-  }
-  return parsed
-}
-
-export def turnBudgetHandler(intr: any): any {
-  """
-  Top-level handler for the per-turn budget guard. Answers every guard trip
-  that reaches it: this turn's trip (matched by label) can be granted more
-  budget; any other guard trip has no owner by the time it gets here and is
-  rejected, so the budget is a hard stop instead of a question nobody
-  answers. Non-guard interrupts pass through to the policy handler.
+  Top-level handler for budget trips. A `std::guard` trip that reaches this
+  handler has no owner below it, so the budget is honored as a hard stop:
+  reject, and let the guard site salvage the draft. Every other interrupt
+  passes through to the policy handler.
   """
   if (intr.effect != "std::guard") {
     return pass()
   }
-  if (intr.data.label != TURN_BUDGET_LABEL) {
-    // A guard trip that reaches this handler has no owner: handlers below
-    // us had their chance, and nothing above us answers guards. Passing
-    // would park the whole turn at a checkpoint nobody will ever resume
-    // (the orphaned tool_use incident, 2026-07-22 design doc). Honor the
-    // budget as a hard stop: reject converts the trip to a Failure at the
-    // guard site, where the caller salvages via finalize or draftValue.
-    // _lastPartial is deliberately NOT set here — that slot is the
-    // TURN's best-so-far for runTurn to show when the turn stops, and
-    // this turn is continuing; the inner guard's own salvage carries its
-    // partial back through the Result.
-    if (isInteractive()) {
-      const who = intr.data.label ?? "a subagent"
-      print(color.yellow(
-        "⏳ The ${intr.data.dimension} budget for ${who} ran out; stopping that step with its best result so far.",
-      ))
-    }
-    return reject()
+  if (isInteractive()) {
+    const who = intr.data.label ?? "a subagent"
+    print(color.yellow(
+      "⏳ The ${intr.data.dimension} budget for ${who} ran out; stopping that step with its best result so far.",
+    ))
   }
-
-  // One-shot / piped runs: nobody is here to answer, so honor the budget as
-  // a hard stop rather than blocking on a prompt that never returns. Keep
-  // the best-so-far draft so runTurn can still show it.
-  if (!isInteractive()) {
-    _lastPartial = intr.data.draftValue
-    return reject()
-  }
-
-  const dimension = intr.data.dimension
-  const spent = intr.data.spent
-  const limit = intr.data.limit
-  let spentLabel = "$${spent.toFixed(2)}"
-  if (dimension == "time") {
-    spentLabel = formatDuration(spent)
-  }
-
-  const prompt = "\n⏳ I've used ${spentLabel} on this and I'm not done. Give me more ${dimension}? (e.g. '30 more seconds', or 'no')\n> "
-  const reply = input(color.yellow(prompt))
-  const decision = parseMoreBudget(reply)
-  if (!decision.grant) {
-    // Keep the best-so-far draft so runTurn shows it instead of just a
-    // "stopped" line. draftValue is the innermost saveDraft on the branch,
-    // so it survives the subagents' own guards.
-    _lastPartial = intr.data.draftValue
-    return reject()
-  }
-
-  // The runtime refuses a grant that leaves the budget still over its limit.
-  // By the time a trip is answered the work has already run past the limit
-  // (further on a loaded machine), so the grant must first cover that
-  // overshoot, then add what the user offered. A bare "yes" with no amount
-  // gets a default grant — overshoot alone would leave zero headroom and
-  // trip again immediately. Extend only the dimension that tripped.
-  const overshoot = spent - limit
-  if (dimension == "time") {
-    return approve({
-      maxTime: overshoot + (decision.extraSeconds ?? 60) * 1000,
-      message: "The user granted more time. Wrap up as soon as you reasonably can.",
-    })
-  }
-  return approve({
-    maxCost: overshoot + (decision.extraDollars ?? $1),
-    message: "The user granted more budget. Wrap up as soon as you reasonably can.",
-  })
+  return reject()
 }

--- a/packages/agency-lang/lib/agents/agency-agent/lib/budget.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/budget.agency
@@ -1,32 +1,20 @@
 /** @module
-  @summary What happens when a subagent's budget runs out: the trip is a
-  hard stop, and the coordinator carries on from the work left behind.
+  @summary The top-level handler for a subagent's budget trip: a hard stop.
 
-  Budgets belong to the tool call. The coordinator hears the user say "in
-  five minutes" and passes `maxSeconds` (or `maxDollars`) to the subagent
-  tool it dispatches; that tool hands the number to the stdlib agent it
-  wraps, whose own `guard` enforces it. The harness does not parse a
-  deadline out of the message, and does not wrap the turn in a guard. The
-  only whole-agent budget is the root budget the `--max-time` and
-  `--max-cost` flags install, which the runtime enforces before any Agency
-  code runs and which no handler can extend.
-
-  `guardStopHandler` is the top-level handler for the `std::guard` trips
-  those subagent guards raise. It rejects every one: the guard converts the
-  rejection to a failure (or the saved draft) at its own site, the subagent
-  tool returns that to the coordinator's tool loop, and the loop pushes a
-  resume message saying the subagent stopped and its work is in the thread
-  above. The coordinator continues from there. Passing instead would park
-  the turn at an interrupt nobody answers.
+  A budget is a parameter on the subagent tool call (`maxSeconds`,
+  `maxDollars`), enforced by the stdlib agent's own `guard`. The harness
+  does not guard the turn; a whole-agent limit comes only from the
+  `--max-time` and `--max-cost` flags, which the runtime installs as a root
+  budget. See docs/dev/agents/subagent-budgets.md.
 */
 import { isInteractive } from "./trace.agency"
 
 export def guardStopHandler(intr: any): any {
   """
-  Top-level handler for budget trips. A `std::guard` trip that reaches this
-  handler has no owner below it, so the budget is honored as a hard stop:
-  reject, and let the guard site salvage the draft. Every other interrupt
-  passes through to the policy handler.
+  Reject every `std::guard` trip that reaches the top of the turn, so the
+  guard site converts it to a failure or the saved draft and the brain
+  continues. Passing would park the turn on an interrupt nobody answers.
+  Every other interrupt passes through to the policy handler.
   """
   if (intr.effect != "std::guard") {
     return pass()

--- a/packages/agency-lang/lib/agents/agency-agent/lib/turn.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/turn.agency
@@ -1,8 +1,9 @@
 /** @module
   @summary The harness side of a turn: which brain is selected, the one
   session wrapper that installs the policy handler, and the per-turn work
-  (budget guard, slash expansion, attachments) that happens before the brain
-  sees the message. See docs/dev/agents/agent-brains.md.
+  (slash expansion, attachments, the hard stop for a subagent budget trip)
+  that happens before the brain sees the message. See
+  docs/dev/agents/agent-brains.md.
 */
 import { map } from "std::array"
 import { cliPolicyHandler } from "std::policy"
@@ -12,15 +13,7 @@ import { pushMessage } from "std::ui/cli"
 
 import { AgentBrain, BrainContext } from "../brains/brain.agency"
 import { detectAttachments, modalityFilter } from "./attachments.agency"
-import {
-  TURN_BUDGET_LABEL,
-  budgetTime,
-  budgetCost,
-  parseTurnBudget,
-  turnBudgetHandler,
-  lastTurnPartial,
-  clearTurnPartial,
- } from "./budget.agency"
+import { guardStopHandler } from "./budget.agency"
 import { projectCommands } from "./commandPalette.agency"
 import { groundingText } from "./grounding.agency"
 import { getPolicyForAgent } from "./policy.agency"
@@ -169,36 +162,12 @@ def dispatchToBrain(target: string, userMsg: string): string {
 
 export def runTurn(target: string, userMsg: string): string {
   """
-  Run one user turn under a time/cost guard parsed from the user's message.
-  A single guard wraps the whole turn — the brain and every subagent it
-  calls — so the budget is a true total. When the guard trips,
-  `turnBudgetHandler` asks the user whether to grant more and resumes in
-  place, or stops.
+  Run one user turn. A subagent's budget trip that no inner handler owns is
+  answered here as a hard stop, so the subagent returns its best result and
+  the brain continues. A whole-agent limit comes only from the `--max-time`
+  and `--max-cost` flags, which the runtime enforces as a root budget.
   """
-  parseTurnBudget(userMsg)
-  clearTurnPartial()
   handle {
-    const result = guard(time: budgetTime(), cost: budgetCost(), label: TURN_BUDGET_LABEL) {
-      return dispatchToBrain(target, userMsg)
-    }
-    return match(result) {
-      success(reply) => reply
-      failure(f) => {
-        let dimension = "cost"
-        if (f.type == "timeoutFailure") {
-          dimension = "time"
-        }
-        // Show the best-so-far draft the handler kept, if any. The draft is
-        // the innermost saveDraft from anywhere in the turn.
-        const partial = lastTurnPartial()
-        if (partial != null && partial != "") {
-          const header = color.yellow(
-            "⏳ Stopped (over the ${dimension} budget). Best answer so far:",
-          )
-          return "${header}\n\n${partial}"
-        }
-        return color.yellow("⏳ Stopped: over the ${dimension} budget for this turn.")
-      }
-    }
-  } with turnBudgetHandler
+    return dispatchToBrain(target, userMsg)
+  } with guardStopHandler
 }

--- a/packages/agency-lang/lib/agents/agency-agent/tests/stubBrains.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/stubBrains.agency
@@ -126,21 +126,30 @@ export def selfApprovingBrain(): AgentBrain {
   }
 }
 
-// One deterministic LLM call gives the real turn guard non-zero cost.
-def costlyRunTurn(
+// A subagent-style budget: one deterministic LLM call under a cost guard
+// too small to cover it, the way a coordinator's subagent tool caps the
+// stdlib agent it wraps. The reply records whether the brain got to
+// continue after the trip.
+def guardedRunTurn(
   target: string,
   prompt: string | (string | Attachment)[],
 ): string {
-  return llm("Return the test reply.")
+  const result = guard(cost: $0.000001, label: "sub") {
+    return llm("Return the test reply.")
+  }
+  if (isFailure(result)) {
+    return "stopped|${result.error.label}"
+  }
+  return "finished|${result.value}"
 }
 
-export def costlyBrain(): AgentBrain {
+export def guardedBrain(): AgentBrain {
   return {
-    name: "costly",
-    session: "costly",
-    description: "test stub that incurs deterministic LLM cost",
+    name: "guarded",
+    session: "guarded",
+    description: "test stub whose one LLM call runs under a tiny cost guard",
     startTargets: [],
     init: recordingInit,
-    runTurn: costlyRunTurn
+    runTurn: guardedRunTurn
   }
 }

--- a/packages/agency-lang/lib/agents/agency-agent/tests/stubBrains.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/stubBrains.agency
@@ -126,10 +126,8 @@ export def selfApprovingBrain(): AgentBrain {
   }
 }
 
-// A subagent-style budget: one deterministic LLM call under a cost guard
-// too small to cover it, the way a coordinator's subagent tool caps the
-// stdlib agent it wraps. The reply records whether the brain got to
-// continue after the trip.
+// One deterministic LLM call under a cost guard too small to cover it.
+// The reply records whether the brain continued after the trip.
 def guardedRunTurn(
   target: string,
   prompt: string | (string | Attachment)[],

--- a/packages/agency-lang/lib/agents/agency-agent/tests/turn.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/turn.agency
@@ -110,11 +110,9 @@ def approveExceptGuard(intr: any): any {
   return approve()
 }
 
-// A budget trip inside the brain is a hard stop for that step, not for the
-// turn: the harness rejects the trip, the guard returns a failure naming
-// itself, and the brain's reply is built from that failure. If the harness
-// passed on the trip instead, the turn would park on an unanswered
-// interrupt and this node would never return a string.
+// A budget trip inside the brain stops that step, not the turn: the harness
+// rejects the trip and the brain's reply is built from the failure. If the
+// harness passed instead, the turn would park on an unanswered interrupt.
 node budgetTripIsHardStopAndBrainContinues(): string {
   setInteractive(false)
   setBrain(guardedBrain())

--- a/packages/agency-lang/lib/agents/agency-agent/tests/turn.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/turn.agency
@@ -1,14 +1,13 @@
 /*
  * Harness tests: the work that happens around a brain (slash expansion,
- * attachments, the budget guard) and the session wrapper that installs the
- * policy handler around init and every turn. Uses stub brains; no real
- * coordinator involved.
+ * attachments, the hard stop for a budget trip) and the session wrapper
+ * that installs the policy handler around init and every turn. Uses stub
+ * brains; no real coordinator involved.
  *
  * `slashCommandExpands` depends on the working directory being
  * packages/agency-lang, whose .claude/commands/check-tests.md is the
  * fixture (projectCommands is a static read of ${cwd()}/.claude/commands).
  */
-import { budgetCost, budgetTime } from "../lib/budget.agency"
 import { setInteractive } from "../lib/trace.agency"
 import {
   setBrain,
@@ -22,7 +21,7 @@ import { applyResolved } from "../shared.agency"
 import {
   recordingBrain,
   selfApprovingBrain,
-  costlyBrain,
+  guardedBrain,
   initCount,
   lastTarget,
   lastPromptKind,
@@ -101,26 +100,29 @@ node namedTargetGetsBareTextWithoutReading(): string {
   return "${reply}|${lastTarget()}|${lastPromptKind()}|${lastAttachmentCount()}|${_readBinaryInterrupts}"
 }
 
-// The harness calls parseTurnBudget, uses both parsed dimensions, and resets
-// them on the next clue-free turn.
-node budgetIsParsedAndReset(): string {
-  setBrain(recordingBrain())
-  const firstReply = runTurn("", "answer within 2 minutes and $1.25: what is 1+1") with approve
-  const firstReachedBrain = lastText().includes("1+1")
-  const parsedTime = budgetTime()
-  const parsedCost = budgetCost()
-  const secondReply = runTurn("", "ordinary follow-up") with approve
-  return "${firstReply}|${firstReachedBrain}|${parsedTime == 120000}|${parsedCost == 1.25}|${secondReply}|${budgetTime() == 1h}|${budgetCost() == 50}"
+// Approve everything the harness raises around the turn, but leave a
+// std::guard trip to the harness's own handler: a blanket approve would
+// answer the trip itself.
+def approveExceptGuard(intr: any): any {
+  if (intr.effect == "std::guard") {
+    return pass()
+  }
+  return approve()
 }
 
-// Parsing alone is insufficient: a deterministic LLM call must actually trip
-// the cost guard. If runTurn stops wrapping the brain in guard(...), this
-// returns the stub reply and the assertion fails.
-node parsedBudgetGuardsBrain(): boolean {
+// A budget trip inside the brain is a hard stop for that step, not for the
+// turn: the harness rejects the trip, the guard returns a failure naming
+// itself, and the brain's reply is built from that failure. If the harness
+// passed on the trip instead, the turn would park on an unanswered
+// interrupt and this node would never return a string.
+node budgetTripIsHardStopAndBrainContinues(): string {
   setInteractive(false)
-  setBrain(costlyBrain())
-  const reply = runTurn("", "spend no more than $0.000001") with approve
-  return reply.includes("over the cost budget")
+  setBrain(guardedBrain())
+  let reply = ""
+  handle {
+    reply = runTurn("", "hello")
+  } with approveExceptGuard
+  return reply
 }
 
 // The unit tests for modalityFilter prove its internals. This integration

--- a/packages/agency-lang/lib/agents/agency-agent/tests/turn.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/turn.test.json
@@ -1,29 +1,111 @@
 {
   "sourceFile": "turn.agency",
   "tests": [
-    { "nodeName": "plainMessageReachesBrain", "input": "", "expectedOutput": "\"stub reply|true|array|0\"", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "slashCommandExpands", "input": "", "expectedOutput": "\"false|true\"", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "mainTargetGetsAttachment", "input": "", "expectedOutput": "\"array|1|true\"", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "namedTargetGetsBareTextWithoutReading", "input": "", "expectedOutput": "\"stub reply|worker|text|0|0\"", "evaluationCriteria": [{ "type": "exact" }] },
     {
-      "nodeName": "budgetIsParsedAndReset", "input": "", "expectedOutput": "\"stub reply|true|true|true|stub reply|true|true\"",
-      "evaluationCriteria": [{ "type": "exact" }],
-      "useTestLLMProvider": true,
-      "llmMocks": [{ "return": { "maxSeconds": 120, "maxDollars": 1.25 } }]
-    },
-    {
-      "nodeName": "parsedBudgetGuardsBrain", "input": "", "expectedOutput": "true",
-      "evaluationCriteria": [{ "type": "exact" }],
-      "useTestLLMProvider": true,
-      "llmMocks": [
-        { "return": { "maxSeconds": null, "maxDollars": 0.000001 } },
-        { "return": "costly reply" }
+      "nodeName": "plainMessageReachesBrain",
+      "input": "",
+      "expectedOutput": "\"stub reply|true|array|0\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
       ]
     },
-    { "nodeName": "textOnlyModelDropsAttachment", "input": "", "expectedOutput": "\"array|0\"", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "sessionRunsInitAndPolicyWins", "input": "", "expectedOutput": "\"true|rejected|rejected|rejected|1|true\"", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "sessionPassesInteractiveContext", "input": "", "expectedOutput": "\"true|true|true|true|1\"", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "resolvesBrainNamePrecedence", "input": "", "expectedOutput": "\"flag-brain|settings-brain|settings-brain|coordinator\"", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "resolvesStartTargets", "input": "", "expectedOutput": "\"true|true|true|true\"", "evaluationCriteria": [{ "type": "exact" }] }
+    {
+      "nodeName": "slashCommandExpands",
+      "input": "",
+      "expectedOutput": "\"false|true\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "mainTargetGetsAttachment",
+      "input": "",
+      "expectedOutput": "\"array|1|true\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "namedTargetGetsBareTextWithoutReading",
+      "input": "",
+      "expectedOutput": "\"stub reply|worker|text|0|0\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "budgetTripIsHardStopAndBrainContinues",
+      "input": "",
+      "expectedOutput": "\"stopped|sub\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        {
+          "return": "costly reply"
+        }
+      ]
+    },
+    {
+      "nodeName": "textOnlyModelDropsAttachment",
+      "input": "",
+      "expectedOutput": "\"array|0\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "sessionRunsInitAndPolicyWins",
+      "input": "",
+      "expectedOutput": "\"true|rejected|rejected|rejected|1|true\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "sessionPassesInteractiveContext",
+      "input": "",
+      "expectedOutput": "\"true|true|true|true|1\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "resolvesBrainNamePrecedence",
+      "input": "",
+      "expectedOutput": "\"flag-brain|settings-brain|settings-brain|coordinator\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "resolvesStartTargets",
+      "input": "",
+      "expectedOutput": "\"true|true|true|true\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
   ]
 }

--- a/packages/agency-lang/lib/runtime/handoff.ts
+++ b/packages/agency-lang/lib/runtime/handoff.ts
@@ -27,6 +27,19 @@ export function handoffResumeText(toolName: string, body: string): string {
 }
 
 /**
+ * The resume message for a handoff that failed or was aborted partway.
+ * A handoff leaves everything it did on the caller's thread, so the
+ * caller is told where that work is and to carry on from it.
+ */
+export function handoffStoppedText(toolName: string, reason: string): string {
+  return (
+    `[${toolName} stopped before finishing: ${reason}]\n` +
+    `Its work so far is in the messages above, from the line where it was dispatched onward. ` +
+    `Continue with the user's request using that work, and say what is unfinished.`
+  );
+}
+
+/**
  * Rewrite the assistant message that carried the handoff tool call: keep
  * its text, drop the tool call, append the marker.
  */
@@ -105,4 +118,16 @@ export function finishHandoff(
 ): void {
   stripHandoffSystemMessages(thread, toolName, args);
   thread.push(smoltalk.userMessage(handoffResumeText(toolName, body)));
+}
+
+/** Close a handoff that failed or was aborted: same cleanup as
+ *  finishHandoff, but the resume message says the work is above. */
+export function finishStoppedHandoff(
+  thread: MessageThread,
+  toolName: string,
+  args: Record<string, unknown>,
+  reason: string,
+): void {
+  stripHandoffSystemMessages(thread, toolName, args);
+  thread.push(smoltalk.userMessage(handoffStoppedText(toolName, reason)));
 }

--- a/packages/agency-lang/lib/runtime/handoff.ts
+++ b/packages/agency-lang/lib/runtime/handoff.ts
@@ -26,16 +26,11 @@ export function handoffResumeText(toolName: string, body: string): string {
   return `[${toolName} finished. ${body}]\nContinue with the user's request.`;
 }
 
-/**
- * The resume message for a handoff that failed or was aborted partway.
- * A handoff leaves everything it did on the caller's thread, so the
- * caller is told where that work is and to carry on from it.
- */
+/** The resume message for a handoff that failed or was aborted partway. */
 export function handoffStoppedText(toolName: string, reason: string): string {
   return (
     `[${toolName} stopped before finishing: ${reason}]\n` +
-    `Its work so far is in the messages above, from the line where it was dispatched onward. ` +
-    `Continue with the user's request using that work, and say what is unfinished.`
+    `Its work so far is in the messages above. Continue with the user's request using that work.`
   );
 }
 
@@ -120,8 +115,7 @@ export function finishHandoff(
   thread.push(smoltalk.userMessage(handoffResumeText(toolName, body)));
 }
 
-/** Close a handoff that failed or was aborted: same cleanup as
- *  finishHandoff, but the resume message says the work is above. */
+/** Close a handoff that failed or was aborted. */
 export function finishStoppedHandoff(
   thread: MessageThread,
   toolName: string,

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -15,7 +15,7 @@ import {
   runGateAndFeedback,
   type BoundaryContext,
 } from "./turnBoundary.js";
-import { AgencyCancelledError, isAbortError, readCause } from "./errors.js";
+import { AgencyCancelledError, describeAbortCause, isAbortError, readCause } from "./errors.js";
 import { recordCompletionUsage } from "./recordPaidUsage.js";
 import { projectProviderTokenUsage } from "./invocationUsage.js";
 import { resolveCompletionModel } from "./modelIdentity.js";
@@ -54,9 +54,11 @@ import type { LlmDefaults } from "../stdlib/llm.js";
 import {
   applyHandoffMarker,
   finishHandoff,
+  finishStoppedHandoff,
   handoffNotAloneMessage,
   stripHandoffSystemMessages,
 } from "./handoff.js";
+import { isAborted } from "./abortedResult.js";
 import { MessageThread, type MessageThreadJSON } from "./state/messageThread.js";
 import { StateStack, claimFrameForScope } from "./state/stateStack.js";
 import { ThreadStore } from "./state/threadStore.js";
@@ -1261,6 +1263,7 @@ export async function runPrompt(args: {
             toolCall,
             handler,
             namedArgs,
+            stoppedReason: cappedError,
           });
         };
         if (tier === "destructive") {
@@ -1313,6 +1316,22 @@ export async function runPrompt(args: {
       // only CONSECUTIVE rejections remove it.
       rejectionCounts[handler.name] = 0;
       stack.setResultOnBranch(branchKey, toolResult);
+      if (isAborted(toolResult) && toolResult.cause.kind === "guardTrip") {
+        // An outer guard stopped the tool mid-flight. The aborted value
+        // still travels up the stack to unwind this loop, but the thread
+        // must not record it as a success carrying raw JSON: the model
+        // reads why the call stopped instead. A cancel (Esc, a race
+        // loser) keeps its own path, where the turn is ending anyway.
+        const reason = describeAbortCause(toolResult.cause);
+        pushToolReply({
+          content: `Error: ${reason}.`,
+          toolCall,
+          handler,
+          namedArgs,
+          stoppedReason: reason,
+        });
+        return { toolResult, invokeOutcome: "failed" };
+      }
       pushSuccessToolMessage({ toolResult, toolCall, handler, branchStack, namedArgs });
       return { toolResult, invokeOutcome: "success" };
     };
@@ -1336,15 +1355,23 @@ export async function runPrompt(args: {
     // (the .handoffMarker step rewrote it), so it gets the user-role
     // resume message instead, after the body's system messages are
     // stripped. `content` may be structured; the resume message needs
-    // text.
+    // text. `stoppedReason` is set when the call failed or was aborted:
+    // a handoff's work is already on this thread, so its resume message
+    // points the model at that work instead of the plain error text an
+    // ordinary tool gets.
     const pushToolReply = (args: {
       content: any;
       toolCall: smoltalk.ToolCallJSON;
       handler: AgencyFunction;
       namedArgs: Record<string, any>;
+      stoppedReason?: string;
     }): void => {
-      const { content, toolCall, handler, namedArgs } = args;
+      const { content, toolCall, handler, namedArgs, stoppedReason } = args;
       if (handler.markers?.handoff) {
+        if (stoppedReason !== undefined) {
+          finishStoppedHandoff(messages, handler.name, namedArgs, stoppedReason);
+          return;
+        }
         finishHandoff(messages, handler.name, namedArgs, stringifyToolResult(content));
         return;
       }

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -1318,10 +1318,9 @@ export async function runPrompt(args: {
       stack.setResultOnBranch(branchKey, toolResult);
       if (isAborted(toolResult) && toolResult.cause.kind === "guardTrip") {
         // An outer guard stopped the tool mid-flight. The aborted value
-        // still travels up the stack to unwind this loop, but the thread
-        // must not record it as a success carrying raw JSON: the model
-        // reads why the call stopped instead. A cancel (Esc, a race
-        // loser) keeps its own path, where the turn is ending anyway.
+        // still unwinds this loop; the thread records why the call
+        // stopped rather than a success carrying raw JSON. A cancel
+        // (Esc, a race loser) keeps its own path.
         const reason = describeAbortCause(toolResult.cause);
         pushToolReply({
           content: `Error: ${reason}.`,
@@ -1355,10 +1354,9 @@ export async function runPrompt(args: {
     // (the .handoffMarker step rewrote it), so it gets the user-role
     // resume message instead, after the body's system messages are
     // stripped. `content` may be structured; the resume message needs
-    // text. `stoppedReason` is set when the call failed or was aborted:
-    // a handoff's work is already on this thread, so its resume message
-    // points the model at that work instead of the plain error text an
-    // ordinary tool gets.
+    // text. `stoppedReason` is set when the call failed or was aborted;
+    // a handoff's resume message then points at the work already on this
+    // thread instead of carrying the error text an ordinary tool gets.
     const pushToolReply = (args: {
       content: any;
       toolCall: smoltalk.ToolCallJSON;

--- a/packages/agency-lang/tests/agency-js/handoff/fixture.json
+++ b/packages/agency-lang/tests/agency-js/handoff/fixture.json
@@ -119,7 +119,9 @@
       "assistant",
       "user"
     ],
-    "resumeCarriesError": 1
+    "resumeSaysStopped": 1,
+    "resumePointsAtWork": 1,
+    "finishedLineAbsent": true
   },
   "rejectHandoff": {
     "result": "rejectHandoff done",

--- a/packages/agency-lang/tests/agency-js/handoff/test.js
+++ b/packages/agency-lang/tests/agency-js/handoff/test.js
@@ -219,8 +219,10 @@ const results = {};
   };
 }
 
-// A body that returns a failure hands back with the error in the resume
-// message and no tool message anywhere.
+// A body that returns a failure hands back with no tool message anywhere.
+// Its messages are still on the caller's thread, so the resume message
+// says it stopped and points the caller at that work instead of carrying
+// a bare error.
 {
   const { state, callbacks } = makeCapture();
   const result = await failureInside({ callbacks });
@@ -230,7 +232,9 @@ const results = {};
     requestCount: state.requests.length,
     allWellFormed: allWellFormed(state),
     roles: roles(final),
-    resumeCarriesError: count(final, "[failingAgent finished. Error: boom"),
+    resumeSaysStopped: count(final, "[failingAgent stopped before finishing: boom]"),
+    resumePointsAtWork: count(final, "Its work so far is in the messages above"),
+    finishedLineAbsent: count(final, "[failingAgent finished.") === 0,
   };
 }
 

--- a/packages/agency-lang/tests/agency/guards/unowned-guard-rejected.agency
+++ b/packages/agency-lang/tests/agency/guards/unowned-guard-rejected.agency
@@ -1,12 +1,9 @@
-// turnBudgetHandler used to pass foreign std::guard trips through, and
-// since nothing above it answers guards, an unlabeled inner guard parked
-// the turn forever (the orphaned tool_use incident). Now a foreign trip is
-// rejected: the budget is a hard stop, the trip converts to a Failure at
-// the guard site, and the caller salvages like any other guard failure.
-// These tests drive the REAL handler — turn-budget-partial.agency only
-// imitates it.
+// The agent harness rejects every std::guard trip that reaches the top of
+// a turn. The trip converts to a Failure at the guard site, and the caller
+// salvages like any other guard failure. These tests drive the REAL
+// handler.
 import test { _advanceTime } from "std::date"
-import { turnBudgetHandler, TURN_BUDGET_LABEL } from "../../../lib/agents/agency-agent/lib/budget.agency"
+import { guardStopHandler } from "../../../lib/agents/agency-agent/lib/budget.agency"
 import { setInteractive } from "../../../lib/agents/agency-agent/lib/trace.agency"
 
 // Stands in for a subagent body that saves a partial, then overruns its
@@ -44,15 +41,12 @@ def innerBare(): Result<string> {
 }
 
 // Each node states its own interactivity instead of inheriting the
-// module default (true) — otherwise the file is order-sensitive: one
-// node flipping the module-global flag would silently change which
-// branch its siblings exercise.
+// module default (true), so the file is not order-sensitive.
 
-// Foreign label + salvage: reject converts the trip to a Failure at the
-// guard site, where finalize-as-draft turns it into a success carrying
-// the partial. This is the claim "salvage still runs", demonstrated.
+// Salvage: reject converts the trip to a Failure at the guard site, where
+// finalize-as-draft turns it into a success carrying the partial.
 // Interactive: covers the notice-then-reject branch.
-node foreignGuardSalvage() {
+node guardSalvage() {
   setInteractive(true)
   handle {
     const r = innerWithSalvage()
@@ -60,41 +54,25 @@ node foreignGuardSalvage() {
       return "salvaged:${v}"
     }
     return "no-salvage"
-  } with turnBudgetHandler
+  } with guardStopHandler
 }
 
-// Foreign label, no salvage: a plain Failure the caller can match on.
-// Non-interactive: covers the reject-without-notice branch.
-node foreignGuardBare() {
+// No salvage: a plain Failure the caller can match on. Non-interactive:
+// covers the reject-without-notice branch.
+node guardBare() {
   setInteractive(false)
   handle {
     const r = innerBare()
     return "failure:${isFailure(r)}"
-  } with turnBudgetHandler
+  } with guardStopHandler
 }
 
-// The handler's OWN label still takes the non-interactive reject path,
-// proving the label match is intact. Must be non-interactive: the
-// interactive own-label path prompts via input() and would hang the
-// harness.
-node ownLabelReject() {
-  setInteractive(false)
-  handle {
-    const r = guard(time: 50ms, label: TURN_BUDGET_LABEL) {
-      return workBare()
-    }
-    return "failure:${isFailure(r)}"
-  } with turnBudgetHandler
-}
-
-// Non-guard interrupts must still pass through to whoever is outside —
-// here, the test harness resolves it. Getting the early-return split
-// wrong would make the agent reject tool approvals, which would be far
-// worse than the bug being fixed.
+// Non-guard interrupts pass through to whoever is outside; here, the test
+// harness resolves it.
 node nonGuardPassthrough() {
   setInteractive(false)
   handle {
     interrupt("confirm")
     return "resolved"
-  } with turnBudgetHandler
+  } with guardStopHandler
 }

--- a/packages/agency-lang/tests/agency/guards/unowned-guard-rejected.test.json
+++ b/packages/agency-lang/tests/agency/guards/unowned-guard-rejected.test.json
@@ -1,43 +1,50 @@
 {
   "tests": [
     {
-      "nodeName": "foreignGuardSalvage",
+      "nodeName": "guardSalvage",
       "fakeClock": true,
-      "description": "A foreign std::guard trip is rejected by turnBudgetHandler; the inner guard's finalize-as-draft salvage turns the Failure into a success carrying the saved partial.",
+      "description": "A std::guard trip is rejected by guardStopHandler; the inner guard's finalize-as-draft salvage turns the Failure into a success carrying the saved partial.",
       "input": "",
       "expectedOutput": "\"salvaged:PARTIAL\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "interruptHandlers": [],
       "llmMocks": []
     },
     {
-      "nodeName": "foreignGuardBare",
+      "nodeName": "guardBare",
       "fakeClock": true,
-      "description": "A foreign std::guard trip with no salvage is rejected into a plain Failure instead of parking the turn.",
+      "description": "A std::guard trip with no salvage is rejected into a plain Failure instead of parking the turn.",
       "input": "",
       "expectedOutput": "\"failure:true\"",
-      "evaluationCriteria": [{ "type": "exact" }],
-      "interruptHandlers": [],
-      "llmMocks": []
-    },
-    {
-      "nodeName": "ownLabelReject",
-      "fakeClock": true,
-      "description": "The turn-budget label still routes through the handler's own path: non-interactive runs honor the budget as a hard stop.",
-      "input": "",
-      "expectedOutput": "\"failure:true\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "interruptHandlers": [],
       "llmMocks": []
     },
     {
       "nodeName": "nonGuardPassthrough",
       "fakeClock": true,
-      "description": "Non-guard interrupts pass through turnBudgetHandler to the outer resolver.",
+      "description": "Non-guard interrupts pass through guardStopHandler to the outer resolver.",
       "input": "",
       "expectedOutput": "\"resolved\"",
-      "evaluationCriteria": [{ "type": "exact" }],
-      "interruptHandlers": [{ "action": "approve", "expectedMessage": "confirm" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "interruptHandlers": [
+        {
+          "action": "approve",
+          "expectedMessage": "confirm"
+        }
+      ],
       "llmMocks": []
     }
   ]


### PR DESCRIPTION
## What changed

**Budgets are a parameter on the subagent call.** `researchAgent`, `explorerAgent`, and `oracleAgent` take `maxSeconds` and `maxDollars`. The coordinator fills them in from the user's words ("in five minutes" is 300), the wrapper converts them and passes them to the stdlib agent, and that agent's own guard enforces them. With neither set, the stdlib agent's usual default applies. The coordinator prompt says when to set them.

**The turn guard is gone.** The harness used to parse a deadline out of the message with an extra LLM call and wrap the whole turn, the coordinator's own `llm()` loop included, in a guard labeled `agency-turn`. That guard and the parser are removed. The only whole-agent limit is the root budget the `--max-time` and `--max-cost` flags install, which the runtime enforces before any Agency code runs.

**A stopped handoff points at its work.** When a subagent's guard trips, the harness handler rejects it as a hard stop, the wrapper returns a failure naming the budget that ran out, and the tool loop pushes a resume message: `[researchAgent stopped before finishing: its time budget of 5m ran out]`, followed by a line saying the work so far is in the messages above and to continue with the user's request from it. An aborted result from an outer guard trip gets the same message instead of being recorded as a success carrying raw JSON. The coordinator prompt says to continue from that work and say what is unfinished.

## Why

In a session on 2026-09-05 the user asked for research "in no more than 5 minutes". The researcher had a complete answer at 2.5 minutes, a review sent it back for revision, and the turn guard tripped during the revision. Because the guard wrapped the coordinator too, rejecting it unwound everything, and the user got a bare "stopped" line while all the research sat in the shared thread. Asking "summarize findings so far" by hand produced the summary from that thread in one call. This PR makes that happen without the extra ask.

Dev note: `docs/dev/agents/subagent-budgets.md`.

## Not in this PR

`codeAgent` still runs on fixed internal budgets. Giving it the same parameters means threading them through its triage, escalation, and supervision paths.

The mid-run "give me more time?" prompt is dropped with the turn guard. The coordinator can ask the same question with the partial results in hand.

## Tests

- `lib/agents/agency-agent/tests/turn.agency`: `budgetTripIsHardStopAndBrainContinues` replaces the two turn-budget cases. A brain runs one LLM call under a tiny cost guard; the harness rejects the trip and the brain's reply is built from the failure.
- `tests/agency-js/handoff`: `failureInside` now checks the stopped message and that the old "finished" line is absent. The race-cancellation case is unchanged.
- Ran: `make`, `pnpm run typecheck`, `pnpm run lint:structure`, `pnpm run fmt:ts`, the turn tests, the handoff suite, the coordinator tool-wiring tests, and the runtime handoff and prompt unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jea8gkmJKtGzcj4X4ngyqt
