### PR TITLE
policy: <agent-home> placeholder, learned skills and tools in the read scope, recordUse effect

### DIFF
--- a/packages/agency-lang/docs/dev/agents/approval-policies.md
+++ b/packages/agency-lang/docs/dev/agents/approval-policies.md
@@ -58,8 +58,10 @@ question, a review) get no "always" answers at all.
 ## What `recommended` lets the agent read
 
 The read-only file effects (`std::read`, `std::readBinary`, `std::ls`,
-`std::glob`, `std::grep`) are approved in two places only
-(`readScopeRules` in `lib/runtime/builtinPolicies.ts`):
+`std::glob`, `std::grep`) and the scan effects that read a whole
+directory under one approval (`std::skills::skillsDir`,
+`std::skills::commandsDir`, `std::toolbox::scan`) are approved in three
+places only (`readScopeRules` in `lib/runtime/builtinPolicies.ts`):
 
 - the launch directory and everything under it, written as `{.,./**}` so
   the rule keeps meaning "wherever the agent runs" after the policy is
@@ -68,17 +70,55 @@ The read-only file effects (`std::read`, `std::readBinary`, `std::ls`,
   `{<agency>/stdlib/**,<agency>/dist/**}`. The docs tools (`agencyGuide`,
   `agencyStdlib`, ...) are `read` partially applied to
   `stdlib/docs/<section>`, and the bundled skills are read the same way, so
-  without this rule those tools return rejections in a headless run.
+  without this rule those tools return rejections in a headless run;
+- the agent home's learned skills and tools, written as
+  `{<agent-home>/skills,<agent-home>/skills/**,<agent-home>/tools,<agent-home>/tools/**}`.
+  The roots are listed as well as their contents because a catalog scan
+  of the whole directory names the root itself in its payload. Those directories
+  hold skills the user taught the agent and tools it wrote, and both
+  enter them only through a review interrupt. Without this rule every
+  read of a learned skill, every catalog scan, and every `runTool` would
+  prompt, and would auto-reject headless. The rule reaches every
+  `recommended` run, not only the agent, and the policy's description
+  says so. The home itself is not covered, so `~/.agency-agent/policy.json`
+  and `settings.json` still prompt.
 
-Both rules are placeholders, not paths. `.` expands to the process cwd and
-`<agency>` to the directory the agency package is installed in
-(`AGENCY_INSTALL_DIR_PLACEHOLDER`, `expandAgencyInstallDir`,
-`getPackageRoot`), each at match time. The copy the agent saves to
-`~/.agency-agent/policy.json` therefore pins neither the directory it was
-first run in nor the install path of one version. After an upgrade moves the
-package, the same rule still matches. A root that cannot be found (a bundled build
-with no `package.json` above it) leaves `<agency>` as written and the rule
-simply never matches.
+`recommended` also approves `std::toolbox::recordUse` under
+`<agent-home>/tools/**`, the effect `runTool` raises before counting a
+use in the tool's `meta.json`. It is an effect of its own rather than a
+`std::write` rule on that filename because a path glob cannot tell the
+stdlib's bookkeeping from any program writing arbitrary content into
+`meta.json`, whose `purpose` text `listTools` then trusts and whose
+`maxTime` sets the run's time limit. Approving the effect approves only
+the record the stdlib composes. No `std::write` is approved anywhere.
+
+The save and review gates (`std::skills::save`, `std::skills::review`,
+`std::toolbox::save`, `std::toolbox::review`) have no rule in any
+built-in but `approve-all`. They prompt.
+
+All three read rules are placeholders, not paths. `.` expands to the
+process cwd, `<agency>` to the directory the agency package is installed
+in (`AGENCY_INSTALL_DIR_PLACEHOLDER`, `expandAgencyInstallDir`,
+`getPackageRoot`), and `<agent-home>` to `AGENCY_AGENT_HOME` or
+`~/.agency-agent` (`AGENT_HOME_PLACEHOLDER`, `expandAgentHomeDir`,
+`agentHomeDir` in `lib/runtime/agentHome.ts`), each at match time. An
+empty `AGENCY_AGENT_HOME` counts as unset, and a relative one resolves
+against the cwd, the way the `--agent-home` flag does. The copy the
+agent saves to `~/.agency-agent/policy.json` therefore pins neither the
+directory it was first run in, nor the install path of one version, nor
+one machine's home. A root that cannot be found (a bundled build with no
+`package.json` above it) leaves `<agency>` as written and the rule simply
+never matches.
+
+The expanded home is resolved through `root()` in `lib/stdlib/contained.ts`,
+the same walker every file effect uses for the directory in its payload,
+so a home reached through a symlinked ancestor (`/tmp` on macOS, a linked
+`$HOME`) matches the payload's spelling. The scan and save effects in
+`std::skills` and `std::toolbox` put that spelling in their payloads too,
+so one rule covers a read and the scan that precedes it. This is not
+support for symlinks inside the home: below an approved directory, a
+symlinked skill or tool directory is hidden from scans and refused by
+reads and writes (see `docs/dev/stdlib/contained-files.md`).
 
 A policy file saved before this change keeps its old catch-all read rules;
 there is no migration. Delete the file (the agent writes a fresh

--- a/packages/agency-lang/docs/dev/agents/approval-policies.md
+++ b/packages/agency-lang/docs/dev/agents/approval-policies.md
@@ -78,10 +78,8 @@ places only (`readScopeRules` in `lib/runtime/builtinPolicies.ts`):
   hold skills the user taught the agent and tools it wrote, and both
   enter them only through a review interrupt. Without this rule every
   read of a learned skill, every catalog scan, and every `runTool` would
-  prompt, and would auto-reject headless. The rule reaches every
-  `recommended` run, not only the agent, and the policy's description
-  says so. The home itself is not covered, so `~/.agency-agent/policy.json`
-  and `settings.json` still prompt.
+  prompt, and would auto-reject headless. The home itself is not covered,
+  so `~/.agency-agent/policy.json` and `settings.json` still prompt.
 
 `recommended` also approves `std::toolbox::recordUse` under
 `<agent-home>/tools/**`, the effect `runTool` raises before counting a
@@ -115,10 +113,10 @@ the same walker every file effect uses for the directory in its payload,
 so a home reached through a symlinked ancestor (`/tmp` on macOS, a linked
 `$HOME`) matches the payload's spelling. The scan and save effects in
 `std::skills` and `std::toolbox` put that spelling in their payloads too,
-so one rule covers a read and the scan that precedes it. This is not
-support for symlinks inside the home: below an approved directory, a
-symlinked skill or tool directory is hidden from scans and refused by
-reads and writes (see `docs/dev/stdlib/contained-files.md`).
+so one rule covers a read and the scan that precedes it. Below an
+approved directory, a symlinked skill or tool directory is hidden from
+scans and refused by reads and writes, as everywhere else (see
+`docs/dev/stdlib/contained-files.md`).
 
 A policy file saved before this change keeps its old catch-all read rules;
 there is no migration. Delete the file (the agent writes a fresh

--- a/packages/agency-lang/docs/dev/stdlib/skills-write.md
+++ b/packages/agency-lang/docs/dev/stdlib/skills-write.md
@@ -128,9 +128,7 @@ threat model.
 `std::skills::skillsDir` and `std::skills::commandsDir` take the same
 read scope as `std::read` in the recommended policy (`readScopeRules`):
 the launch directory, the agency install, and the agent home's learned
-skills and tools. Before this they were approved anywhere, which let a
-scan read a directory a plain `read` would have prompted for. The save
-and review gates have no rule and prompt.
+skills and tools. The save and review gates have no rule and prompt.
 
 ## The frontmatter round-trip
 

--- a/packages/agency-lang/docs/dev/stdlib/skills-write.md
+++ b/packages/agency-lang/docs/dev/stdlib/skills-write.md
@@ -43,17 +43,13 @@ dangling symlink fails the open atomically — because the pre-interrupt
 check is stale by save time: approval can take arbitrarily long, and a
 file created in the meantime must never be overwritten.
 
-The `dir` in the interrupt payload is absolutized (`~` expanded,
-resolved against the process cwd), so relative and `~`-led spellings
-produce the same payload and an always-scope rule saved from a save
-approval names one directory regardless of how the caller spelled it.
-One gap remains: the write that follows realpaths its directory
-(`prepareContainedPath`), and the save payload cannot — the directory
-may not exist until `mkdir` runs after approval. So a directory reached
-through a symlinked ancestor still yields two spellings (on macOS,
-`/tmp/skills` for the save and `/private/tmp/skills` for the write),
-and one always-scope rule will not cover both interrupts there. An
-empty `dir` is refused before any prompt.
+The `dir` in the interrupt payload is the real spelling (`~` expanded,
+resolved against the process cwd, links in the spelling followed once:
+`_realDir` from `lib/stdlib/contained.ts`), so relative, `~`-led, and
+symlink-spelled directories produce the same payload the write that
+follows will report, and an always-scope rule saved from a save approval
+covers both interrupts. Every scan payload in this module is spelled the
+same way. An empty `dir` is refused before any prompt.
 
 ## The design loop
 
@@ -126,6 +122,15 @@ containment checks realpath through those ancestors consistently. An
 attacker who can replace an ancestor of the approved root controls the
 data's parent directory and is outside this (and every file effect's)
 threat model.
+
+## What the recommended policy approves
+
+`std::skills::skillsDir` and `std::skills::commandsDir` take the same
+read scope as `std::read` in the recommended policy (`readScopeRules`):
+the launch directory, the agency install, and the agent home's learned
+skills and tools. Before this they were approved anywhere, which let a
+scan read a directory a plain `read` would have prompted for. The save
+and review gates have no rule and prompt.
 
 ## The frontmatter round-trip
 

--- a/packages/agency-lang/docs/dev/stdlib/toolbox.md
+++ b/packages/agency-lang/docs/dev/stdlib/toolbox.md
@@ -164,14 +164,20 @@ It then lists the directory with `ls` from `std::shell` (which raises
 `std::ls`), and keeps the directories whose names are not `staging` and
 do not start with a dot. The recommended policy gives `std::toolbox::scan` the same `dir` scope
 as `std::read`, so a toolbox outside the working directory prompts. `listTools` refuses an empty `dir`, since the
-primitives would resolve it to the process cwd. `ls` counts every entry
+primitives would resolve it to the process cwd, and puts its real
+spelling (`_realDir`) in the scan payload, so the payload names one
+directory however the caller spelled it and a policy rule written for
+reads matches it. `ls` counts every entry
 against its cap and does not say when it stopped, so a listing that
 reaches the cap is reported as a failure. It is not returned as a
 shortened catalog. The per-tool reads
 of `impl.agency` and `meta.json` use `_read`, covered by that one scan
 approval. `runTool` and the post-publish read in `saveTool` raise the
 same scan for the one tool directory they read, so no `_read` runs
-without an approval that names its directory. A toolbox directory that does not exist
+without an approval that names its directory. Every one of those reads
+takes the toolbox root as its approved directory, so a symlinked tool
+directory cannot carry a scan approval elsewhere: `ls` leaves the link
+out of the catalog, and `runTool` does not find it. A toolbox directory that does not exist
 yet is an empty catalog.
 
 Each entry carries `module` (what `describe` says about `run`: signature,
@@ -189,10 +195,14 @@ stops the tool before it has side effects. It then runs `main` through
 `runFile`, with `wallClock` set to the tool's own `maxTime` plus
 headroom, so the guard trips before the subprocess is killed. `runFile`
 clamps `wallClock` to an hour, so `stage` refuses a `maxTime` above
-an hour minus that headroom. It then rewrites `meta.json` with
-one more use and the time. If that write fails, the returned failure
-carries the tool's result in its message, since the tool has already
-run. Otherwise it returns the node's own `Result`.
+an hour minus that headroom. It then counts the use in
+`meta.json`, behind a `std::toolbox::recordUse` interrupt naming the
+tool's directory. The write that fulfils the approval takes the toolbox
+root as its approved directory, like every other write. The count is best-effort: the tool has already run, so
+a declined interrupt or a failed write leaves the count where it was and
+`runTool` returns the node's own `Result`. Why the count is an effect of
+its own, and what the recommended policy does with it, is in
+`docs/dev/agents/approval-policies.md`.
 
 ## Model calls and mocks
 

--- a/packages/agency-lang/docs/site/stdlib/skills.md
+++ b/packages/agency-lang/docs/site/stdlib/skills.md
@@ -127,7 +127,7 @@ effect std::skills::review {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L493))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L491))
 
 ## Functions
 
@@ -261,7 +261,7 @@ draft-revise-accept loop is `designSkill`, which ends by calling this.
 
 **Throws:** `std::skills::save`, `std::mkdir`, `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L433))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L431))
 
 ### designSkill
 
@@ -312,7 +312,7 @@ the write. This is the function to hand to a model as a tool.
 
 **Throws:** `std::skills::review`, `std::skills::save`, `std::mkdir`, `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L601))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L599))
 
 ### docsSkill
 
@@ -337,7 +337,7 @@ Build a docs tool for an LLM over the packaged Agency documentation.
 |---|---|---|
 | section | `\| "guide" \| "cli" \| "diagnostics" \| "stdlib" \| "agent"` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L646))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L644))
 
 ### bundledDocsDir
 
@@ -350,7 +350,7 @@ The directory holding the Agency docs that ship inside the package. A
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L667))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L665))
 
 ### agentSkill
 
@@ -370,7 +370,7 @@ Build a skills tool over the skills shipped for one agent. The returned
 |---|---|---|
 | agent | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L675))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L673))
 
 ### commandsDir
 
@@ -423,7 +423,7 @@ root), pass an absolute path: `"${cwd()}/.claude/commands"`.
 
 **Throws:** `std::skills::commandsDir`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L763))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L761))
 
 ### expandSlash
 
@@ -462,4 +462,4 @@ agency agent`, yielding `"/foo\n"`) dispatch correctly.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L822))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L820))

--- a/packages/agency-lang/docs/site/stdlib/skills.md
+++ b/packages/agency-lang/docs/site/stdlib/skills.md
@@ -127,7 +127,7 @@ effect std::skills::review {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L488))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L493))
 
 ## Functions
 
@@ -261,7 +261,7 @@ draft-revise-accept loop is `designSkill`, which ends by calling this.
 
 **Throws:** `std::skills::save`, `std::mkdir`, `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L428))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L433))
 
 ### designSkill
 
@@ -312,7 +312,7 @@ the write. This is the function to hand to a model as a tool.
 
 **Throws:** `std::skills::review`, `std::skills::save`, `std::mkdir`, `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L596))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L601))
 
 ### docsSkill
 
@@ -337,7 +337,7 @@ Build a docs tool for an LLM over the packaged Agency documentation.
 |---|---|---|
 | section | `\| "guide" \| "cli" \| "diagnostics" \| "stdlib" \| "agent"` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L641))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L646))
 
 ### bundledDocsDir
 
@@ -350,7 +350,7 @@ The directory holding the Agency docs that ship inside the package. A
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L662))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L667))
 
 ### agentSkill
 
@@ -370,7 +370,7 @@ Build a skills tool over the skills shipped for one agent. The returned
 |---|---|---|
 | agent | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L670))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L675))
 
 ### commandsDir
 
@@ -423,7 +423,7 @@ root), pass an absolute path: `"${cwd()}/.claude/commands"`.
 
 **Throws:** `std::skills::commandsDir`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L758))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L763))
 
 ### expandSlash
 
@@ -462,4 +462,4 @@ agency agent`, yielding `"/foo\n"`) dispatch correctly.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L817))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L822))

--- a/packages/agency-lang/docs/site/stdlib/toolbox.md
+++ b/packages/agency-lang/docs/site/stdlib/toolbox.md
@@ -338,4 +338,4 @@ Run a saved tool's `main` node in a subprocess and return what it
 
 **Throws:** `std::toolbox::scan`, `std::run`, `std::guard`, `std::toolbox::recordUse`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L1111))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L1109))

--- a/packages/agency-lang/docs/site/stdlib/toolbox.md
+++ b/packages/agency-lang/docs/site/stdlib/toolbox.md
@@ -76,7 +76,7 @@ export type ModuleFacts = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L135))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L144))
 
 ### ToolMeta
 
@@ -95,7 +95,7 @@ export type ToolMeta = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L142))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L151))
 
 ### ToolEntry
 
@@ -114,7 +114,7 @@ export type ToolEntry = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L154))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L163))
 
 ## Effects
 
@@ -129,6 +129,18 @@ effect std::toolbox::scan {
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L112))
 
+### std::toolbox::recordUse
+
+```ts
+@alwaysUnder(dir)
+effect std::toolbox::recordUse {
+  dir: string;
+  name: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L120))
+
 ### std::toolbox::review
 
 ```ts
@@ -141,7 +153,7 @@ effect std::toolbox::review {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L116))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L125))
 
 ### std::toolbox::save
 
@@ -155,7 +167,7 @@ effect std::toolbox::save {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L127))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L136))
 
 ## Functions
 
@@ -183,7 +195,7 @@ List the tools in a toolbox directory. Raises a `std::toolbox::scan`
 
 **Throws:** `std::toolbox::scan`, `std::ls`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L327))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L336))
 
 ### designTool
 
@@ -241,7 +253,7 @@ published through the same `std::toolbox::save` gate `writeTool` uses.
 
 **Throws:** `std::remove`, `std::mkdir`, `std::toolbox::review`, `std::toolbox::save`, `std::toolbox::scan`, `std::write`, `std::move`, `std::read`, `std::guard`, `std::run`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L989))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L998))
 
 ### writeTool
 
@@ -293,7 +305,7 @@ in `designTool` ends by publishing through this same gate.
 
 **Throws:** `std::remove`, `std::mkdir`, `std::toolbox::save`, `std::toolbox::scan`, `std::write`, `std::move`, `std::read`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L1053))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L1062))
 
 ### runTool
 
@@ -306,8 +318,9 @@ runTool(
 ```
 
 Run a saved tool's `main` node in a subprocess and return what it
-  returned. The tool's meta.json records one more use and the time; it
-  does not record the result.
+  returned. The tool's meta.json counts one more use and the time. A
+  declined or failed count does not fail the run. The result is not
+  recorded.
 
   @param name - The tool's name under dir
   @param request - The tool's input, a value of its Request type
@@ -323,6 +336,6 @@ Run a saved tool's `main` node in a subprocess and return what it
 
 **Returns:** `Result<Json>`
 
-**Throws:** `std::toolbox::scan`, `std::run`, `std::guard`, `std::write`
+**Throws:** `std::toolbox::scan`, `std::run`, `std::guard`, `std::toolbox::recordUse`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L1096))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/toolbox.agency#L1111))

--- a/packages/agency-lang/lib/cli/mcp.ts
+++ b/packages/agency-lang/lib/cli/mcp.ts
@@ -1,6 +1,6 @@
-import * as os from "os";
 import * as path from "path";
 import { isFailure } from "@/runtime/index.js";
+import { agentHomeDir } from "@/runtime/agentHome.js";
 import { _addMcpServer, _removeMcpServer, _readMcpServersFromFile } from "@/stdlib/mcp.js";
 
 // The "what" for `agency mcp …`. Commander does the parsing; these thin actions
@@ -9,13 +9,8 @@ import { _addMcpServer, _removeMcpServer, _readMcpServersFromFile } from "@/stdl
 
 type ScopeOpts = { global?: boolean };
 
-function agentHome(): string {
-  const override = process.env.AGENCY_AGENT_HOME;
-  return override ? path.resolve(override) : path.join(os.homedir(), ".agency-agent");
-}
-
 const projectFile = (): string => path.resolve(process.cwd(), "agency.json");
-const globalFile = (): string => path.join(agentHome(), "settings.json");
+const globalFile = (): string => path.join(agentHomeDir(), "settings.json");
 
 const scopeFile = (o: ScopeOpts): string => (o.global ? globalFile() : projectFile());
 const scopeName = (o: ScopeOpts): string => (o.global ? "global" : "project");

--- a/packages/agency-lang/lib/runtime/agentHome.ts
+++ b/packages/agency-lang/lib/runtime/agentHome.ts
@@ -1,0 +1,15 @@
+import os from "os";
+import path from "path";
+
+/** The agent home directory: `AGENCY_AGENT_HOME`, or `~/.agency-agent`.
+ *  An empty variable counts as unset, so a set-but-blank value never
+ *  turns the home into the current directory. A relative override is
+ *  resolved against the process cwd, the way the `--agent-home` launcher
+ *  resolves it. */
+export function agentHomeDir(): string {
+  const override = process.env.AGENCY_AGENT_HOME;
+  if (override !== undefined && override !== "") {
+    return path.resolve(override);
+  }
+  return path.join(os.homedir(), ".agency-agent");
+}

--- a/packages/agency-lang/lib/runtime/builtinPolicies.test.ts
+++ b/packages/agency-lang/lib/runtime/builtinPolicies.test.ts
@@ -17,16 +17,48 @@ describe("builtinPolicy", () => {
       expect(p![effect]).toEqual([
         { match: { dir: "{.,./**}" }, action: "approve" },
         { match: { dir: "{<agency>/stdlib/**,<agency>/dist/**}" }, action: "approve" },
+        {
+          match: {
+            dir: "{<agent-home>/skills,<agent-home>/skills/**,<agent-home>/tools,<agent-home>/tools/**}",
+          },
+          action: "approve",
+        },
       ]);
     }
+    // No std::write rule at all: the toolbox use count goes through its
+    // own effect, never a write approval.
     expect(p!["std::write"]).toBeUndefined();
   });
 
-  it("scopes a toolbox scan like a read under 'recommended' and omits it under 'minimal'", () => {
-    expect(builtinPolicy("recommended", "/tmp/base")!["std::toolbox::scan"]).toEqual(
-      builtinPolicy("recommended", "/tmp/base")!["std::read"],
-    );
-    expect(builtinPolicy("minimal", "/tmp/base")!["std::toolbox::scan"]).toBeUndefined();
+  it("scopes every scan like a read under 'recommended' and omits them under 'minimal'", () => {
+    const scans = ["std::toolbox::scan", "std::skills::skillsDir", "std::skills::commandsDir"];
+    for (const effect of scans) {
+      expect(builtinPolicy("recommended", "/tmp/base")![effect]).toEqual(
+        builtinPolicy("recommended", "/tmp/base")!["std::read"],
+      );
+      expect(builtinPolicy("minimal", "/tmp/base")![effect]).toBeUndefined();
+    }
+  });
+
+  it("approves the toolbox use count only under the agent home's toolbox", () => {
+    expect(builtinPolicy("recommended", "/tmp/base")!["std::toolbox::recordUse"]).toEqual([
+      { match: { dir: "<agent-home>/tools/**" }, action: "approve" },
+    ]);
+    expect(builtinPolicy("minimal", "/tmp/base")!["std::toolbox::recordUse"]).toBeUndefined();
+  });
+
+  it("leaves the save and review gates undecided under every built-in but approve-all", () => {
+    for (const name of ["recommended", "minimal", "with-writes"]) {
+      const p = builtinPolicy(name, "/tmp/base")!;
+      for (const effect of [
+        "std::skills::save",
+        "std::skills::review",
+        "std::toolbox::save",
+        "std::toolbox::review",
+      ]) {
+        expect(p[effect]).toBeUndefined();
+      }
+    }
   });
 
   it("resolves 'minimal' with memory approved but reads absent", () => {

--- a/packages/agency-lang/lib/runtime/builtinPolicies.ts
+++ b/packages/agency-lang/lib/runtime/builtinPolicies.ts
@@ -1,5 +1,6 @@
 import {
   AGENCY_INSTALL_DIR_PLACEHOLDER as INSTALL,
+  AGENT_HOME_PLACEHOLDER as AGENT_HOME,
   type Policy,
   type PolicyRule,
   escapeGlob,
@@ -31,20 +32,35 @@ function agencyExecApproveRules(): PolicyRule[] {
 
 const approve: PolicyRule[] = [{ action: "approve" }];
 
-// Where the read-only file tools may look without asking: the launch
-// directory and, because the agent's docs tools (`agencyGuide` and friends)
-// and bundled skills are plain reads of shipped files, the agency install
-// itself. Both are placeholders the matcher expands at match time (`.` to
-// the process cwd, `<agency>` to the package root; see
-// docs/dev/agents/approval-policies.md), so a saved copy of this policy keeps
-// meaning "wherever the agent runs, wherever agency is installed now".
-// Reads anywhere else fall through: a prompt in an interactive session, an
-// automatic rejection in a headless one.
+// Where the read-only file tools may look without asking. The launch
+// directory. The agency install itself, because the agent's docs tools
+// (`agencyGuide` and friends) and bundled skills are plain reads of
+// shipped files. The agent home's learned skills and tools, which only
+// enter those directories through a review interrupt. All three are
+// placeholders the matcher expands at match time (`.` to the process cwd,
+// `<agency>` to the package root, `<agent-home>` to the agent home, see
+// docs/dev/agents/approval-policies.md), so a saved copy of this policy
+// keeps meaning "wherever the agent runs, wherever agency is installed
+// now". Reads anywhere else fall through: a prompt in an interactive
+// session, an automatic rejection in a headless one.
 export function readScopeRules(): PolicyRule[] {
   return [
     { match: { dir: "{.,./**}" }, action: "approve" },
     { match: { dir: `{${INSTALL}/stdlib/**,${INSTALL}/dist/**}` }, action: "approve" },
+    {
+      match: {
+        dir: `{${AGENT_HOME}/skills,${AGENT_HOME}/skills/**,${AGENT_HOME}/tools,${AGENT_HOME}/tools/**}`,
+      },
+      action: "approve",
+    },
   ];
+}
+
+// runTool's use count in a tool's meta.json. An effect of its own, never
+// a std::write rule on the file; docs/dev/agents/approval-policies.md
+// says why.
+function toolboxRecordUseRules(): PolicyRule[] {
+  return [{ match: { dir: `${AGENT_HOME}/tools/**` }, action: "approve" }];
 }
 
 export const minimalAutoApprovePolicy: Policy = {
@@ -77,11 +93,12 @@ export const recommendedAutoApprovePolicy: Policy = {
   "std::weather": approve,
   "std::search": approve,
   "std::tavilySearch": approve,
-  "std::skills::skillsDir": approve,
-  "std::skills::commandsDir": approve,
-  // A scan reads tool sources and meta.json under a directory, so it
-  // takes the read scope.
+  // A scan reads every skill, command, or tool file under a directory,
+  // so it takes the read scope.
+  "std::skills::skillsDir": readScopeRules(),
+  "std::skills::commandsDir": readScopeRules(),
   "std::toolbox::scan": readScopeRules(),
+  "std::toolbox::recordUse": toolboxRecordUseRules(),
   "std::notify": approve,
   "std::clipboardCopy": approve,
   "std::git::status": approve,
@@ -142,7 +159,7 @@ export const BUILTIN_POLICIES: { name: string; description: string }[] = [
   {
     name: "recommended",
     description:
-      "Auto-approve reads under the current directory (and the agency install's own docs and skills) and web/search; prompt for reads elsewhere, writes, shell, and git changes.",
+      "Auto-approve reads under the current directory, the agency install's own docs and skills, and the agent home's learned skills and tools (plus the toolbox use count there), and web/search; prompt for reads elsewhere, writes, shell, and git changes.",
   },
   {
     name: "minimal",

--- a/packages/agency-lang/lib/runtime/policy.test.ts
+++ b/packages/agency-lang/lib/runtime/policy.test.ts
@@ -714,6 +714,15 @@ describe("<agent-home> dir patterns", () => {
     }
   });
 
+  it("keeps a comma in the home literal inside a brace group", () => {
+    withAgentHome("/nowhere/a,b", () => {
+      expect(checkPolicy(policy, read("/nowhere/a,b/skills/x")).type).toBe("approve");
+      // An unescaped comma would split the brace group and approve these.
+      expect(checkPolicy(policy, read("/nowhere/a")).type).toBe("propagate");
+      expect(checkPolicy(policy, read("b/skills")).type).toBe("propagate");
+    });
+  });
+
   it("matches a pattern that mixes <agency> and <agent-home> in one brace group", () => {
     const mixed = {
       "std::read": [

--- a/packages/agency-lang/lib/runtime/policy.test.ts
+++ b/packages/agency-lang/lib/runtime/policy.test.ts
@@ -3,13 +3,14 @@ import {
   checkPolicy,
   resolveDotDirPattern,
   expandAgencyInstallDir,
+  expandAgentHomeDir,
   validatePolicy,
   escapeGlob,
 } from "./policy.js";
 import { getStdlibDir } from "../importPaths.js";
 import path from "path";
 import { mkdtempSync, mkdirSync, symlinkSync, rmSync, realpathSync } from "fs";
-import { tmpdir } from "os";
+import os, { tmpdir } from "os";
 import picomatch from "picomatch";
 
 describe("checkPolicy", () => {
@@ -612,6 +613,120 @@ describe("<agency> dir patterns", () => {
     };
     expect(expandAgencyInstallDir("<agency>/stdlib/**", unresolvable)).toBe("<agency>/stdlib/**");
     expect(expandAgencyInstallDir("/plain/**", unresolvable)).toBe("/plain/**");
+  });
+});
+
+describe("<agent-home> dir patterns", () => {
+  const read = (dir: string) => ({
+    effect: "std::read",
+    message: "m",
+    data: { dir, filename: "x" },
+    origin: "std::fs",
+  });
+  const policy = {
+    "std::read": [
+      {
+        match: {
+          dir: "{<agent-home>/skills,<agent-home>/skills/**,<agent-home>/tools,<agent-home>/tools/**}",
+        },
+        action: "approve" as const,
+      },
+    ],
+  };
+
+  function withAgentHome<T>(value: string | undefined, body: () => T): T {
+    const previous = process.env.AGENCY_AGENT_HOME;
+    if (value === undefined) delete process.env.AGENCY_AGENT_HOME;
+    else process.env.AGENCY_AGENT_HOME = value;
+    try {
+      return body();
+    } finally {
+      if (previous === undefined) delete process.env.AGENCY_AGENT_HOME;
+      else process.env.AGENCY_AGENT_HOME = previous;
+    }
+  }
+
+  it("expands to the injected home", () => {
+    expect(expandAgentHomeDir("<agent-home>/skills/**", () => "/custom/home")).toBe(
+      "/custom/home/skills/**",
+    );
+  });
+
+  it("escapes glob characters in the resolved home", () => {
+    expect(expandAgentHomeDir("<agent-home>/skills/**", () => "/opt/v*1")).toBe(
+      "/opt/v\\*1/skills/**",
+    );
+  });
+
+  it("leaves a pattern without the token untouched", () => {
+    expect(expandAgentHomeDir("/plain/**", () => "/custom/home")).toBe("/plain/**");
+  });
+
+  it("resolves a relative AGENCY_AGENT_HOME to an absolute path", () => {
+    withAgentHome("./my-profile", () => {
+      expect(expandAgentHomeDir("<agent-home>/skills/**")).toBe(
+        `${path.resolve("./my-profile")}/skills/**`,
+      );
+    });
+  });
+
+  it("treats an empty AGENCY_AGENT_HOME as unset", () => {
+    withAgentHome("", () => {
+      expect(expandAgentHomeDir("<agent-home>/skills/**")).toBe(
+        `${path.join(os.homedir(), ".agency-agent")}/skills/**`,
+      );
+    });
+  });
+
+  it("expands to the realpath of the home, the spelling file effects report", () => {
+    const base = mkdtempSync(path.join(tmpdir(), "policy-home-"));
+    try {
+      const real = path.join(base, "real-home");
+      mkdirSync(real);
+      const link = path.join(base, "linked-home");
+      symlinkSync(real, link);
+      withAgentHome(link, () => {
+        expect(expandAgentHomeDir("<agent-home>/skills/**")).toBe(
+          `${realpathSync(real)}/skills/**`,
+        );
+      });
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  it("matches reads under the home's skills and tools and nothing else", () => {
+    const base = mkdtempSync(path.join(tmpdir(), "policy-home-"));
+    try {
+      const home = realpathSync(base);
+      withAgentHome(home, () => {
+        // The roots themselves: what a catalog scan of the whole
+        // directory puts in its payload.
+        expect(checkPolicy(policy, read(`${home}/skills`)).type).toBe("approve");
+        expect(checkPolicy(policy, read(`${home}/tools`)).type).toBe("approve");
+        expect(checkPolicy(policy, read(`${home}/skills/explorer`)).type).toBe("approve");
+        expect(checkPolicy(policy, read(`${home}/tools/hnTop`)).type).toBe("approve");
+        expect(checkPolicy(policy, read(home)).type).toBe("propagate");
+        expect(checkPolicy(policy, read("/Users/someone")).type).toBe("propagate");
+      });
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  it("matches a pattern that mixes <agency> and <agent-home> in one brace group", () => {
+    const mixed = {
+      "std::read": [
+        {
+          match: { dir: "{<agency>/stdlib/**,<agent-home>/skills/**}" },
+          action: "approve" as const,
+        },
+      ],
+    };
+    withAgentHome("/nowhere/agent-home", () => {
+      expect(checkPolicy(mixed, read("/nowhere/agent-home/skills/x")).type).toBe("approve");
+      expect(checkPolicy(mixed, read(path.join(getStdlibDir(), "docs"))).type).toBe("approve");
+    });
   });
 });
 

--- a/packages/agency-lang/lib/runtime/policy.ts
+++ b/packages/agency-lang/lib/runtime/policy.ts
@@ -102,10 +102,6 @@ function stripDotSlash(s: string): string {
 // whose name contains glob characters (say `v*1`) would widen the rule to
 // its siblings — a safety boundary, so the substituted prefix must match
 // itself only. Glob syntax stays live only in the user-written suffix.
-function escapeForGlob(s: string): string {
-  return s.replace(/[\\*?[\]{}()!+@|]/g, "\\$&");
-}
-
 // In a `dir` pattern, `.` also means "wherever the agent was launched".
 // Tools absolutize the dir they put in interrupt data, so a literal `.` in
 // a policy file could never match those; resolving it lets a static policy
@@ -132,7 +128,7 @@ export function resolveDotDirPattern(pattern: string, cwd: string = process.cwd(
   // would otherwise be interpreted as replacement-string syntax.
   return pattern.replace(
     /(^|\{|,)\.(?=$|\/|,|\})/g,
-    (_match, prefix) => prefix + escapeForGlob(realCwd),
+    (_match, prefix) => prefix + escapeGlob(realCwd),
   );
 }
 
@@ -157,7 +153,7 @@ export function expandAgencyInstallDir(
   } catch {
     return pattern;
   }
-  return pattern.split(AGENCY_INSTALL_DIR_PLACEHOLDER).join(escapeForGlob(resolved));
+  return pattern.split(AGENCY_INSTALL_DIR_PLACEHOLDER).join(escapeGlob(resolved));
 }
 
 /** In a `dir` pattern, `<agent-home>` stands for the agent home directory
@@ -166,20 +162,18 @@ export function expandAgencyInstallDir(
  *  keeps meaning "wherever the agent home is now". */
 export const AGENT_HOME_PLACEHOLDER = "<agent-home>";
 
-// Expanded at match time, like `<agency>`. Exported for tests, which
-// inject the home.
+/** Expand `<agent-home>` at match time, like `<agency>`. The home is
+ *  escaped so a path containing glob or brace characters stays literal. */
 export function expandAgentHomeDir(
   pattern: string,
   home: () => string = canonicalAgentHome,
 ): string {
   if (!pattern.includes(AGENT_HOME_PLACEHOLDER)) return pattern;
-  return pattern.split(AGENT_HOME_PLACEHOLDER).join(escapeForGlob(home()));
+  return pattern.split(AGENT_HOME_PLACEHOLDER).join(escapeGlob(home()));
 }
 
-// The real spelling, through the one walker every file effect uses for
-// its payload, so a home behind a symlinked ancestor matches the payload.
-// A home that does not exist yet keeps a lexical tail; a home whose
-// spelling cannot be resolved falls back to the lexical path.
+/** The real spelling of the agent home, the spelling file effects put in
+ *  their payloads. A home that does not exist yet keeps a lexical tail. */
 function canonicalAgentHome(): string {
   const home = agentHomeDir();
   try {
@@ -216,8 +210,6 @@ function matchesRule(
       !raw &&
       key === "dir" &&
       picomatch.isMatch(stripDotSlash(value), stripDotSlash(resolveDotDirPattern(pattern)));
-    // Each expander leaves a pattern without its token alone, so one check
-    // covers every placeholder, including a pattern that mixes them.
     const viaPlaceholders =
       !raw &&
       !viaDot &&

--- a/packages/agency-lang/lib/runtime/policy.ts
+++ b/packages/agency-lang/lib/runtime/policy.ts
@@ -2,6 +2,8 @@ import picomatch from "picomatch";
 import { realpathSync } from "fs";
 import { z } from "zod";
 import { getPackageRoot } from "../importPaths.js";
+import { agentHomeDir } from "./agentHome.js";
+import { root } from "../stdlib/contained.js";
 
 export const PolicyRuleSchema = z
   .object({
@@ -158,6 +160,35 @@ export function expandAgencyInstallDir(
   return pattern.split(AGENCY_INSTALL_DIR_PLACEHOLDER).join(escapeForGlob(resolved));
 }
 
+/** In a `dir` pattern, `<agent-home>` stands for the agent home directory
+ *  (`AGENCY_AGENT_HOME`, or `~/.agency-agent`). The built-in read scope
+ *  uses it for the learned skills and tools directories, so a saved policy
+ *  keeps meaning "wherever the agent home is now". */
+export const AGENT_HOME_PLACEHOLDER = "<agent-home>";
+
+// Expanded at match time, like `<agency>`. Exported for tests, which
+// inject the home.
+export function expandAgentHomeDir(
+  pattern: string,
+  home: () => string = canonicalAgentHome,
+): string {
+  if (!pattern.includes(AGENT_HOME_PLACEHOLDER)) return pattern;
+  return pattern.split(AGENT_HOME_PLACEHOLDER).join(escapeForGlob(home()));
+}
+
+// The real spelling, through the one walker every file effect uses for
+// its payload, so a home behind a symlinked ancestor matches the payload.
+// A home that does not exist yet keeps a lexical tail; a home whose
+// spelling cannot be resolved falls back to the lexical path.
+function canonicalAgentHome(): string {
+  const home = agentHomeDir();
+  try {
+    return root(home).real;
+  } catch {
+    return home;
+  }
+}
+
 function matchesRule(
   rule: PolicyRule,
   interrupt: { effect: string; message: string; data: any; origin: string },
@@ -185,12 +216,14 @@ function matchesRule(
       !raw &&
       key === "dir" &&
       picomatch.isMatch(stripDotSlash(value), stripDotSlash(resolveDotDirPattern(pattern)));
-    const viaInstall =
+    // Each expander leaves a pattern without its token alone, so one check
+    // covers every placeholder, including a pattern that mixes them.
+    const viaPlaceholders =
       !raw &&
       !viaDot &&
       key === "dir" &&
-      picomatch.isMatch(stripDotSlash(value), expandAgencyInstallDir(pattern));
-    if (!raw && !viaDot && !viaInstall) {
+      picomatch.isMatch(stripDotSlash(value), expandAgentHomeDir(expandAgencyInstallDir(pattern)));
+    if (!raw && !viaDot && !viaPlaceholders) {
       return false;
     }
   }

--- a/packages/agency-lang/lib/stdlib/skills.ts
+++ b/packages/agency-lang/lib/stdlib/skills.ts
@@ -26,14 +26,6 @@ export function _bundledDocsDir(): string {
 export { stringifyFrontmatter as _stringifyFrontmatter } from "tarsec/parsers/markdown";
 
 /**
- * The standard dir resolution (`~` expansion, then absolutize against the
- * process cwd) — the same base `prepareContainedPath` uses, so an effect
- * payload built from the result matches the `std::write` payload raised
- * for the same directory.
- */
-export { resolveCwdPath as _resolveCwdPath } from "./resolveDir.js";
-
-/**
  * Absolute path to the skills we ship for one agent, under
  * `stdlib/agents/skills/<agent>`. Resolved through getStdlibDir for the
  * same reason as _docsDir: a path relative to the calling file works in the

--- a/packages/agency-lang/lib/utils/alwaysTag.stdlib.test.ts
+++ b/packages/agency-lang/lib/utils/alwaysTag.stdlib.test.ts
@@ -153,6 +153,7 @@ const EXPECTED: Record<string, string[]> = {
   // make the look meaningless, so nothing is pinned.
   "std::skills::review": [],
   "std::toolbox::scan": ["dir/**"],
+  "std::toolbox::recordUse": ["dir/**"],
   "std::toolbox::review": [],
   "std::toolbox::save": ["dir/**"],
   "std::memory::enableMemory": [],

--- a/packages/agency-lang/stdlib/skills.agency
+++ b/packages/agency-lang/stdlib/skills.agency
@@ -15,7 +15,7 @@ import { exists } from "std::shell"
 import { _read } from "agency-lang/stdlib-lib/builtins.js"
 import { _glob } from "agency-lang/stdlib-lib/shell.js"
 import { _realDir } from "agency-lang/stdlib-lib/contained.js"
-import { _docsDir, _bundledDocsDir, _agentSkillsDir, _stringifyFrontmatter, _resolveCwdPath } from "agency-lang/stdlib-lib/skills.js"
+import { _docsDir, _bundledDocsDir, _agentSkillsDir, _stringifyFrontmatter } from "agency-lang/stdlib-lib/skills.js"
 
 
 /** @module
@@ -411,11 +411,16 @@ def checkSkillInputs(dir: string, name: string, description: string): Result<str
   if (dir.trim() == "") {
     return failure("dir must not be empty")
   }
-  const absDir = _resolveCwdPath(dir)
-  if (exists("${name}.md", absDir)) {
-    return failure("a skill named ${name} already exists in ${absDir}")
+  // The real spelling, so the save payload names the directory the way
+  // the write that follows will report it, and one policy rule covers both.
+  const absDir = try _realDir(dir)
+  if (isFailure(absDir)) {
+    return absDir
   }
-  return success(absDir)
+  if (exists("${name}.md", absDir.value)) {
+    return failure("a skill named ${name} already exists in ${absDir.value}")
+  }
+  return success(absDir.value)
 }
 
 /**

--- a/packages/agency-lang/stdlib/skills.agency
+++ b/packages/agency-lang/stdlib/skills.agency
@@ -411,8 +411,6 @@ def checkSkillInputs(dir: string, name: string, description: string): Result<str
   if (dir.trim() == "") {
     return failure("dir must not be empty")
   }
-  // The real spelling, so the save payload names the directory the way
-  // the write that follows will report it, and one policy rule covers both.
   const absDir = try _realDir(dir)
   if (isFailure(absDir)) {
     return absDir

--- a/packages/agency-lang/stdlib/toolbox.agency
+++ b/packages/agency-lang/stdlib/toolbox.agency
@@ -20,7 +20,7 @@ import { mkdir, remove, move } from "std::fs"
 import { ls, exists } from "std::shell"
 import { Json } from "std::validation"
 
-import { _read } from "agency-lang/stdlib-lib/builtins.js"
+import { _read, _write } from "agency-lang/stdlib-lib/builtins.js"
 import { _realDir } from "agency-lang/stdlib-lib/contained.js"
 
 /** @module
@@ -111,6 +111,15 @@ const META_FILE = "meta.json"
 @alwaysUnder(dir)
 effect std::toolbox::scan {
   dir: string
+}
+
+// runTool's use count. Its own effect, so a policy can approve the
+// stdlib's record without approving any std::write to meta.json. The
+// approval covers the write that fulfils it.
+@alwaysUnder(dir)
+effect std::toolbox::recordUse {
+  dir: string;
+  name: string
 }
 
 effect std::toolbox::review {
@@ -1084,13 +1093,19 @@ export def writeTool(
 
 // ---- running a tool ----
 
-def recordUse(toolDir: string, name: string, meta: ToolMeta): Result {
+def recordUse(root: string, name: string, meta: ToolMeta): Result {
+  return interrupt std::toolbox::recordUse("Record one use of this tool in its ${META_FILE}?", {
+    dir: "${root}/${name}",
+    name: name
+  })
   const used: ToolMeta = {
     ...meta,
     uses: meta.uses + 1,
     lastUsedAt: format(now())
   }
-  return write(META_FILE, JSON.stringify(used, null, 2), toolDir)
+  // Written under the toolbox root the approval named, so a link planted
+  // at the tool directory afterwards is refused.
+  return try _write(root, "${name}/${META_FILE}", JSON.stringify(used, null, 2), "overwrite")
 }
 
 export def runTool(
@@ -1100,8 +1115,9 @@ export def runTool(
 ): Result<Json> {
   """
   Run a saved tool's `main` node in a subprocess and return what it
-  returned. The tool's meta.json records one more use and the time; it
-  does not record the result.
+  returned. The tool's meta.json counts one more use and the time. A
+  declined or failed count does not fail the run. The result is not
+  recorded.
 
   @param name - The tool's name under dir
   @param request - The tool's input, a value of its Request type
@@ -1142,13 +1158,7 @@ export def runTool(
   if (ran is success(finished)) {
     result = finished.data
   }
-  // The tool has run and its effects have happened, so its result is
-  // never dropped: a failed record carries it in the message.
-  const recorded = recordUse(toolDir, name, meta.value)
-  if (recorded is failure(recordErr)) {
-    return failure(
-      "the tool ran and returned ${JSON.stringify(result)}, but ${META_FILE} could not be updated: ${recordErr}",
-    )
-  }
+  // Best-effort: the tool has already run.
+  recordUse(root.value, name, meta.value)
   return result
 }

--- a/packages/agency-lang/stdlib/toolbox.agency
+++ b/packages/agency-lang/stdlib/toolbox.agency
@@ -1103,8 +1103,6 @@ def recordUse(root: string, name: string, meta: ToolMeta): Result {
     uses: meta.uses + 1,
     lastUsedAt: format(now())
   }
-  // Written under the toolbox root the approval named, so a link planted
-  // at the tool directory afterwards is refused.
   return try _write(root, "${name}/${META_FILE}", JSON.stringify(used, null, 2), "overwrite")
 }
 

--- a/packages/agency-lang/tests/agency/skills-dir.agency
+++ b/packages/agency-lang/tests/agency/skills-dir.agency
@@ -1,4 +1,6 @@
-import { skillsDir } from "std::skills"
+import { mkdir, remove } from "std::fs"
+import { exists, exec } from "std::shell"
+import { skillsDir, commandsDir } from "std::skills"
 
 def stdDesc(): string {
   const tool = skillsDir(__dirname + "/skills-dir-fixture/std", "standard") with approve
@@ -105,4 +107,31 @@ node explicitNameOverrides(): boolean {
 node explicitNameSanitized(): boolean {
   const tool = skillsDir(__dirname + "/skills-dir-fixture/flat", "flat", "My Cool Skill!") with approve
   return tool.name == "My_Cool_Skill"
+}
+
+// Both scan payloads name the real directory, the spelling a read would
+// report, so one policy rule covers a scan and the reads under it. The
+// link is proven reachable first.
+node scanPayloadsAreTheRealDirectory(): boolean {
+  const fixture = __dirname + "/skills-dir-fixture/flat"
+  const link = __dirname + "/test-output/linked-skills"
+  mkdir(__dirname + "/test-output") with approve
+  remove(link) with approve
+  const linked = exec("ln", ["-s", fixture, link]) with approve
+  if (linked is failure || linked.exitCode != 0) {
+    return false
+  }
+  const reachable = exists("greet.md", link)
+  const seen: string[] = []
+  handle {
+    skillsDir(link, "flat")
+    commandsDir(link)
+  } with (intr) {
+    if (intr.effect == "std::skills::skillsDir" || intr.effect == "std::skills::commandsDir") {
+      seen.push(intr.data.dir)
+    }
+    return approve()
+  }
+  remove(link) with approve
+  return reachable && seen.join(",") == "${fixture},${fixture}"
 }

--- a/packages/agency-lang/tests/agency/skills-dir.test.json
+++ b/packages/agency-lang/tests/agency/skills-dir.test.json
@@ -1,17 +1,18 @@
 {
   "tests": [
-    { "nodeName": "standardHasNamedSkill", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "standardFallsBackToDirNameWhenNoFrontmatter", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "standardFallsBackToDirNameWhenNameAbsent", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "flatHasNamedSkill", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "flatFallsBackToTitle", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "flatFallsBackToFilenameWhenNoFrontmatter", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "flatXmlEscapesDescription", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "emptyDirectoryProducesEmptySkillList", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "derivedNameCappedTo64", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "derivedNameKeepsTail", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "siblingDeepPathsStayDistinct", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "explicitNameOverrides", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "explicitNameSanitized", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] }
+    {"nodeName": "standardHasNamedSkill", "input": "", "expectedOutput": "true", "evaluationCriteria": [{"type": "exact"}]},
+    {"nodeName": "standardFallsBackToDirNameWhenNoFrontmatter", "input": "", "expectedOutput": "true", "evaluationCriteria": [{"type": "exact"}]},
+    {"nodeName": "standardFallsBackToDirNameWhenNameAbsent", "input": "", "expectedOutput": "true", "evaluationCriteria": [{"type": "exact"}]},
+    {"nodeName": "flatHasNamedSkill", "input": "", "expectedOutput": "true", "evaluationCriteria": [{"type": "exact"}]},
+    {"nodeName": "flatFallsBackToTitle", "input": "", "expectedOutput": "true", "evaluationCriteria": [{"type": "exact"}]},
+    {"nodeName": "flatFallsBackToFilenameWhenNoFrontmatter", "input": "", "expectedOutput": "true", "evaluationCriteria": [{"type": "exact"}]},
+    {"nodeName": "flatXmlEscapesDescription", "input": "", "expectedOutput": "true", "evaluationCriteria": [{"type": "exact"}]},
+    {"nodeName": "emptyDirectoryProducesEmptySkillList", "input": "", "expectedOutput": "true", "evaluationCriteria": [{"type": "exact"}]},
+    {"nodeName": "derivedNameCappedTo64", "input": "", "expectedOutput": "true", "evaluationCriteria": [{"type": "exact"}]},
+    {"nodeName": "derivedNameKeepsTail", "input": "", "expectedOutput": "true", "evaluationCriteria": [{"type": "exact"}]},
+    {"nodeName": "siblingDeepPathsStayDistinct", "input": "", "expectedOutput": "true", "evaluationCriteria": [{"type": "exact"}]},
+    {"nodeName": "explicitNameOverrides", "input": "", "expectedOutput": "true", "evaluationCriteria": [{"type": "exact"}]},
+    {"nodeName": "explicitNameSanitized", "input": "", "expectedOutput": "true", "evaluationCriteria": [{"type": "exact"}]},
+    {"nodeName": "scanPayloadsAreTheRealDirectory", "input": "", "expectedOutput": "true", "evaluationCriteria": [{"type": "exact"}]}
   ]
 }

--- a/packages/agency-lang/tests/agency/toolbox/designTool.agency
+++ b/packages/agency-lang/tests/agency/toolbox/designTool.agency
@@ -1,5 +1,5 @@
 import { remove, mkdir } from "std::fs"
-import { exists, ls } from "std::shell"
+import { exists, ls, exec } from "std::shell"
 import { designTool, listTools, runTool } from "std::toolbox"
 
 const OUT = __dirname + "/test-output"
@@ -322,7 +322,8 @@ node staleTestFileDoesNotShip(): boolean {
 }
 
 // Write a tool, run it, and check the record: one use, a last-used time,
-// and the createdAt from the write kept as it was.
+// and the createdAt from the write kept as it was. The record goes
+// through a recordUse interrupt naming the tool's directory.
 node runToolRunsAndRecords(): boolean {
   cleanup("addEight")
   const written = runDesign("addEight", OUT, ["accept"])
@@ -331,9 +332,19 @@ node runToolRunsAndRecords(): boolean {
     return false
   }
   const createdAt = written.value.meta.createdAt
-  const answer = runTool("addEight", {
-    n: 41
-  }, OUT) with approve
+  let recordDir = ""
+  let answer: Result = failure("not run")
+  handle {
+    answer = runTool("addEight", {
+      n: 41
+    }, OUT)
+  } with (intr) {
+    if (intr.effect == "std::toolbox::recordUse") {
+      recordDir = intr.data.dir
+    }
+    return approve()
+  }
+  const namedTheTool = recordDir == "${OUT}/addEight"
   const listed = listTools(OUT) with approve
   let recorded = false
   if (listed is success(entries)) {
@@ -341,7 +352,64 @@ node runToolRunsAndRecords(): boolean {
     recorded = entry.meta.uses == 1 && entry.meta.lastUsedAt != null && entry.meta.createdAt == createdAt && createdAt != ""
   }
   cleanup("addEight")
-  return answer is success && answer.value == 42 && recorded
+  return answer is success && answer.value == 42 && recorded && namedTheTool
+}
+
+// The count is only a count: a declined recordUse leaves meta.json as it
+// was and the run still returns the tool's result.
+node declinedRecordUseKeepsTheResult(): boolean {
+  cleanup("addSixteen")
+  const written = runDesign("addSixteen", OUT, ["accept"])
+  if (written is failure) {
+    cleanup("addSixteen")
+    return false
+  }
+  let answer: Result = failure("not run")
+  handle {
+    answer = runTool("addSixteen", {
+      n: 1
+    }, OUT)
+  } with (intr) {
+    if (intr.effect == "std::toolbox::recordUse") {
+      return reject("no bookkeeping")
+    }
+    return approve()
+  }
+  const listed = listTools(OUT) with approve
+  let unrecorded = false
+  if (listed is success(entries)) {
+    const entry = find(entries, \candidate -> candidate.name == "addSixteen")
+    unrecorded = entry.meta.uses == 0 && entry.meta.lastUsedAt == null
+  }
+  cleanup("addSixteen")
+  return answer is success && answer.value == 2 && unrecorded
+}
+
+// A tool directory that is a symlink does not carry the scan approval to
+// its target: listTools leaves it out and runTool does not find it, since
+// linked entries are hidden below an approved directory. The link is
+// proven reachable first.
+node symlinkedToolIsRefused(): boolean {
+  const box = "${OUT}/linkbox"
+  remove(box) with approve
+  mkdir(box) with approve
+  const linked = exec("ln", ["-s", "${TOOLS}/good", "${box}/linked"]) with approve
+  if (linked is failure || linked.exitCode != 0) {
+    return false
+  }
+  // Standalone exists follows the caller's own spelling; under `box` the
+  // link would be hidden, which is the behavior under test.
+  const reachable = exists("${box}/linked/tool.agency")
+  const listed = listTools(box) with approve
+  let unlisted = false
+  if (listed is success(entries)) {
+    unlisted = !some(entries, \candidate -> candidate.name == "linked")
+  }
+  const ran = runTool("linked", {
+    n: 1
+  }, box) with approve
+  remove(box) with approve
+  return reachable && unlisted && ran is failure && "${ran.error}" =~ re/no tool named|symlink/
 }
 
 // A refused write is not something a new draft can fix, so designTool

--- a/packages/agency-lang/tests/agency/toolbox/designTool.test.json
+++ b/packages/agency-lang/tests/agency/toolbox/designTool.test.json
@@ -788,6 +788,61 @@
       ]
     },
     {
+      "nodeName": "declinedRecordUseKeepsTheResult",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        {
+          "return": {
+            "code": "import { Json } from \"std::validation\"\n\nexport type Request = {\n  n: number\n}\n\nexport def run(request: Request): Json {\n  \"\"\"\n  Add one to the number in the request.\n\n  @param request - The number to add one to\n  \"\"\"\n  return request.n + 1\n}\n"
+          }
+        },
+        {
+          "return": []
+        },
+        {
+          "return": {
+            "cases": [
+              {
+                "args": {
+                  "request": {
+                    "n": 41
+                  }
+                },
+                "expectedOutput": 42
+              },
+              {
+                "args": {
+                  "request": {
+                    "n": 0
+                  }
+                },
+                "expectedOutput": 1
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "nodeName": "symlinkedToolIsRefused",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "useTestLLMProvider": true,
+      "llmMocks": []
+    },
+    {
       "nodeName": "refusedWriteStopsTheRounds",
       "input": "",
       "expectedOutput": "true",

--- a/packages/agency-lang/tests/agency/toolbox/generate-designTool-mocks.mjs
+++ b/packages/agency-lang/tests/agency/toolbox/generate-designTool-mocks.mjs
@@ -105,6 +105,8 @@ const tests = [
   testCase("dateToolSkipsTests", dateRound),
   testCase("staleTestFileDoesNotShip", [...pureRound, ...modelRound]),
   testCase("runToolRunsAndRecords", pureRound),
+  testCase("declinedRecordUseKeepsTheResult", pureRound),
+  testCase("symlinkedToolIsRefused", []),
   testCase("refusedWriteStopsTheRounds", pureRound),
   testCase("aliasedDateCallSkipsTests", aliasRound),
   testCase("refusesATimeLimitOverAnHour", []),

--- a/packages/agency-lang/tests/agency/toolbox/listTools.agency
+++ b/packages/agency-lang/tests/agency/toolbox/listTools.agency
@@ -1,6 +1,9 @@
+import { mkdir, remove } from "std::fs"
+import { exists, exec } from "std::shell"
 import { listTools, ToolEntry } from "std::toolbox"
 
 const FIXTURES = __dirname + "/fixtures/tools"
+const OUT = __dirname + "/test-output"
 
 def catalog() {
   return listTools(FIXTURES) with approve
@@ -104,4 +107,29 @@ node missingToolboxIsEmpty(): boolean {
     return false
   }
   return entries.value.length == 0
+}
+
+// The scan payload names the real directory, the spelling a read would
+// report, so one policy rule covers both. The link is proven reachable
+// first.
+node scanPayloadIsTheRealDirectory(): boolean {
+  const link = "${OUT}/linked-tools"
+  mkdir(OUT) with approve
+  remove(link) with approve
+  const linked = exec("ln", ["-s", FIXTURES, link]) with approve
+  if (linked is failure || linked.exitCode != 0) {
+    return false
+  }
+  const reachable = exists("good/tool.agency", link)
+  let payloadDir = ""
+  handle {
+    listTools(link)
+  } with (intr) {
+    if (intr.effect == "std::toolbox::scan") {
+      payloadDir = intr.data.dir
+    }
+    return approve()
+  }
+  remove(link) with approve
+  return reachable && payloadDir == FIXTURES
 }

--- a/packages/agency-lang/tests/agency/toolbox/listTools.test.json
+++ b/packages/agency-lang/tests/agency/toolbox/listTools.test.json
@@ -89,6 +89,16 @@
           "type": "exact"
         }
       ]
+    },
+    {
+      "nodeName": "scanPayloadIsTheRealDirectory",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Replaces #1014 (PR 3 of the skills-and-toolbox split: the policy half). #1014 was written before the contained file API (#1024, #1025, #1026) and carried its own symlink defenses. Rebasing would have meant untangling 22 conflict hunks whose old side is code we now want gone, so this PR starts from main, carries the policy work over unchanged, and rewrites the three stdlib files by hand. Nothing here changes what the agent does. It changes what the built-in policies decide without asking.

## The `<agent-home>` placeholder

`<agent-home>` in a `dir` pattern expands at match time to `AGENCY_AGENT_HOME` or `~/.agency-agent`, the way `<agency>` expands to the install root. An empty variable counts as unset and a relative one resolves against the cwd, matching the `--agent-home` launcher. The expansion goes through `root()` from `contained.ts`, the same walker every file effect uses for the directory in its payload, so a home behind a symlinked ancestor (`/tmp` on macOS) matches, and a home that does not exist yet keeps a lexical tail under its nearest real ancestor.

`agentHomeDir` in `lib/runtime/agentHome.ts` is the one resolver. `agency mcp` used to have its own copy.

The matcher expands every placeholder in one pass, so a pattern that mixes `<agency>` and `<agent-home>` in one brace group works.

## What `recommended` now decides

- Reads under `<agent-home>/skills` and `<agent-home>/tools`, and below them, are approved. Both directories hold only what a review interrupt let in. Without this, every learned-skill read, catalog scan, and `runTool` prompts and auto-rejects headless. The home itself is not covered.
- `std::skills::skillsDir` and `std::skills::commandsDir` take the read scope instead of an unscoped approve. A scan could otherwise read a directory a plain `read` would have prompted for.
- `std::toolbox::recordUse`, new, is approved under `<agent-home>/tools/**`.
- The save and review gates have no rule in any built-in policy but `approve-all`. A test pins that.

## `std::toolbox::recordUse`

`runTool` counts a use in the tool's `meta.json` behind this effect, not a `std::write`. A path glob cannot tell the stdlib's bookkeeping from any program writing arbitrary content into `meta.json`, whose `purpose` text `listTools` trusts and whose `maxTime` sets the run's time limit. The count is best-effort: a declined interrupt or a failed write leaves it where it was and the run returns its result. The write goes through `_write` with the toolbox root as its approved directory.

## What #1014 had that this PR does not

- `writeContainedFile.ts` and its test (226 lines). `writeText` in `contained.ts` does this.
- An `allowedPaths` guard on `_write`. The underscore primitives take a required root now.
- `canonicalDir` in `resolveDir.ts`, its own realpath walk. `root()` is the one walker.
- The scan payloads already carry the real directory on main (#1024), so the `skills.agency` and most `toolbox.agency` changes were already there. The skills save payload is the one place that still used the lexical spelling; it now uses `_realDir`.

## The open threads on #1014

All nine were about the symlink handling. They close as follows: the FIFO, short-write, truncation, and root-parent findings on `writeContainedFile` are moot, since the file is gone and `writeText` writes a validated sibling and renames it; the glob that excluded the `skills` and `tools` roots was already fixed on that branch and is carried here; the payload-spelling findings are covered by `_realDir` on every scan and save; the `_glob` with no allowed paths and the `metaFacts` default-before-read findings are covered by the required root on every primitive; the lexical-home finding is covered by `root()`.

## Testing

- `lib/runtime/policy.test.ts`: the placeholder's expansion, escaping, relative and empty env values, the real path, matching under the home and nowhere else, a mixed-placeholder pattern.
- `lib/runtime/builtinPolicies.test.ts`: the third read rule, every scan scoped like a read, the use-count rule, the gates undecided.
- `tests/agency/toolbox/designTool.agency`: the record names the tool directory, a declined record keeps the result and the count, a symlinked tool is unlisted and not run, with a positive control that the link is reachable.
- `tests/agency/toolbox/listTools.agency` and `tests/agency/skills-dir.agency`: scan payloads are the real directory.
- The always-scope table, `lib/cli/mcp.test.ts`, `runPolicy`, `effects`, typecheck, prettier, structural lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01932VFdBf79Jhq6wMEp7wg9
