### PR TITLE
std::llm: gate registerProviderModule behind a std::llm::registerProvider effect

### DIFF
--- a/packages/agency-lang/docs/dev/security/roadmap.md
+++ b/packages/agency-lang/docs/dev/security/roadmap.md
@@ -186,7 +186,9 @@ walking up from cwd; `client.providerModules` is a list of JS files loaded
 with a dynamic import at bootstrap. Fix: under `--agency-only`, never load
 provider modules named by a config discovered under the tree being run;
 longer term, find a pattern for provider modules that is not "a JS path in
-project config".
+project config". The runtime twin, `std::llm::registerProviderModule(path)`,
+is gated (#1021): it raises `std::llm::registerProvider` with the real path
+before the load, and no built-in policy approves it.
 
 ### C3. `agency.json` in the untrusted tree redirects `llm()`; `--agency-only` ignores the runner's config (#969)
 
@@ -383,6 +385,7 @@ it is what lets them become total denial rather than workdir-scoping.
 | B3 sandbox flags imply no policy | #970 | open |
 | C1 `node_modules` shadowing | #967 | open |
 | C2 provider modules from tree config | #968 | open |
+| `registerProviderModule` at runtime, gated by `std::llm::registerProvider` | #1021 | done |
 | C3 `llm()` redirect; `--agency-only` ignores config | #969 | open |
 | C4 child env allowlist | #990 | open |
 | C5 deny child OS capabilities (`--permission`) | #989 | open |

--- a/packages/agency-lang/docs/site/guide/custom-providers.md
+++ b/packages/agency-lang/docs/site/guide/custom-providers.md
@@ -100,7 +100,10 @@ deep subagents stay local too; it ignores `--model`/`--provider`/`--fastmodel`/
 Programmatically, `std::agency/local` exposes the same operations
 (`downloadModel`, `listDownloadedModels`, `aliasModel`, `registerLocalModel`,
 …), and `std::llm`'s `registerProviderModule(path)` registers any custom
-provider module at runtime.
+provider module at runtime. That call raises `std::llm::registerProvider`
+with the module's real path, because the module runs as code in the
+process. Approve it interactively, or with a policy rule that names the
+path; no built-in policy approves it.
 
 The rest of this page covers the fully manual route for any custom provider.
 

--- a/packages/agency-lang/docs/site/stdlib/llm.md
+++ b/packages/agency-lang/docs/site/stdlib/llm.md
@@ -68,9 +68,20 @@ export type HostedModelInfo = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L141))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L153))
 
 ## Effects
+
+### std::llm::registerProvider
+
+```ts
+@always(path)
+effect std::llm::registerProvider {
+  path: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L132))
 
 ### std::read
 
@@ -82,7 +93,7 @@ effect std::read {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L186))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L198))
 
 ## Functions
 
@@ -178,7 +189,7 @@ Return the first provider in `order` whose API-key environment variable
 ### registerProviderModule
 
 ```ts
-registerProviderModule(path: string)
+registerProviderModule(path: string): Result
 ```
 
 Load a provider module by path at runtime and register its custom provider
@@ -192,7 +203,11 @@ Load a provider module by path at runtime and register its custom provider
 |---|---|---|
 | path | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L129))
+**Returns:** `Result`
+
+**Throws:** `std::llm::registerProvider`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L134))
 
 ### listHostedModels
 
@@ -205,7 +220,7 @@ Return all known hosted text models (the built-in catalog plus any
 
 **Returns:** `HostedModelInfo[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L151))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L163))
 
 ### hostedModelInfo
 
@@ -226,7 +241,7 @@ Metadata for one hosted model by name, or null if the name is unknown or
 
 **Returns:** `HostedModelInfo | null`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L159))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L171))
 
 ### modelSupportsInput
 
@@ -251,7 +266,7 @@ Whether a model accepts a given input modality ("image" or "pdf").
 
 **Returns:** `boolean | null`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L169))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L181))
 
 ### loadModelData
 
@@ -276,4 +291,4 @@ Load model data from a JSON file (the shape `agency models refresh`
 
 **Throws:** `std::read`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L200))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L212))

--- a/packages/agency-lang/lib/runtime/builtinPolicies.test.ts
+++ b/packages/agency-lang/lib/runtime/builtinPolicies.test.ts
@@ -47,7 +47,7 @@ describe("builtinPolicy", () => {
     expect(builtinPolicy("minimal", "/tmp/base")!["std::toolbox::recordUse"]).toBeUndefined();
   });
 
-  it("leaves the save and review gates undecided under every built-in but approve-all", () => {
+  it("leaves the save, review, and provider-load gates undecided under every built-in but approve-all", () => {
     for (const name of ["recommended", "minimal", "with-writes"]) {
       const p = builtinPolicy(name, "/tmp/base")!;
       for (const effect of [
@@ -55,6 +55,7 @@ describe("builtinPolicy", () => {
         "std::skills::review",
         "std::toolbox::save",
         "std::toolbox::review",
+        "std::llm::registerProvider",
       ]) {
         expect(p[effect]).toBeUndefined();
       }

--- a/packages/agency-lang/lib/stdlib/llm.registerProviderModule.test.ts
+++ b/packages/agency-lang/lib/stdlib/llm.registerProviderModule.test.ts
@@ -32,4 +32,17 @@ describe("_registerProviderModule", () => {
     await _registerProviderModule(p);
     expect(smoltalk.getClient({ model: "m", provider: "rpm-test" }).constructor.name).toBe("RPM");
   });
+
+  it("refuses a symlink at the module path and loads nothing", async () => {
+    const target = path.join(here, "__tmp_rpm_target.mjs");
+    fs.writeFileSync(
+      target,
+      `export function register({ registerProvider }) { registerProvider("rpm-test", class {}); }`,
+    );
+    const link = path.join(here, "__tmp_rpm_link.mjs");
+    fs.symlinkSync(target, link);
+    tmp.push(target, link);
+    await expect(_registerProviderModule(link)).rejects.toThrow(/symlink/);
+    expect(() => smoltalk.getClient({ model: "m", provider: "rpm-test" })).toThrow();
+  });
 });

--- a/packages/agency-lang/lib/stdlib/llm.ts
+++ b/packages/agency-lang/lib/stdlib/llm.ts
@@ -1,4 +1,4 @@
-import { fixedPath, readText, type Located } from "./contained.js";
+import { fixedPath, resolveUnder, readText, type Located } from "./contained.js";
 import { agencyStore, getRuntimeContext } from "../runtime/asyncContext.js";
 import type { RetryConfig } from "../runtime/llmRetry.js";
 import { loadProviderModuleByPath } from "../runtime/providerModules.js";
@@ -67,10 +67,15 @@ export function _setLlmOptions(opts: LlmDefaults): void {
 
 /** Load a provider module by path at runtime and register its provider into
  *  agency's own smoltalk — the runtime counterpart of `loadProviderModules`
- *  (which runs at bootstrap). Lets any program register a custom provider on
- *  demand. */
-export async function _registerProviderModule(modulePath: string): Promise<void> {
-  await loadProviderModuleByPath(modulePath);
+ *  (which runs at bootstrap). The Agency wrapper raised
+ *  `std::llm::registerProvider` on the real path, so the default `locate`
+ *  refuses a link in it, and a link at the file itself is refused too. */
+export async function _registerProviderModule(
+  modulePath: string,
+  locate: (p: string) => Located = fixedPath,
+): Promise<void> {
+  const located = locate(modulePath);
+  await loadProviderModuleByPath(resolveUnder(located.root, located.target));
 }
 
 /**

--- a/packages/agency-lang/lib/utils/alwaysTag.stdlib.test.ts
+++ b/packages/agency-lang/lib/utils/alwaysTag.stdlib.test.ts
@@ -73,6 +73,7 @@ const EXPECTED: Record<string, string[]> = {
   "std::copy": ["src/**", "dest/**"],
   "std::move": ["src/**", "dest/**"],
   "std::applyPatch": [],
+  "std::llm::registerProvider": ["path"],
   "std::exec": ["command", "subcommand"],
   "std::bash": ["command", "cwd"],
   "std::run": [],

--- a/packages/agency-lang/stdlib/llm.agency
+++ b/packages/agency-lang/stdlib/llm.agency
@@ -126,14 +126,26 @@ export def pickProvider(order: string[] = ["anthropic", "google", "openai"]): Re
   return failure("No LLM API key found. Set one of: ${checked}")
 }
 
-export def registerProviderModule(path: string) {
+// Loading a provider module runs its JavaScript in this process, so the
+// load is gated like any other effect. The payload names the real path.
+@always(path)
+effect std::llm::registerProvider { path: string }
+
+export def registerProviderModule(path: string): Result {
   """
   Load a provider module by path at runtime and register its custom provider
   for llm() calls. The module must export register({ registerProvider }).
 
   @param path - Path to the provider module (.mjs/.js)
   """
-  _registerProviderModule(path)
+  const real = try _realTarget(path)
+  if (isFailure(real)) {
+    return real
+  }
+  return interrupt std::llm::registerProvider("Load this provider module? It runs as code in this process.", {
+    path: real.value
+  })
+  return try _registerProviderModule(real.value)
 }
 
 // The TS HostedModelInfo in lib/stdlib/llm.ts mirrors this field order, and


### PR DESCRIPTION
Closes #1021.

`std::llm::registerProviderModule(path)` loads a JavaScript file and runs it to register a custom LLM provider. Any program could call it with no approval. It now raises an interrupt first.

## What changed

- New effect `std::llm::registerProvider { path }`, raised with the module's real path (`_realTarget`) before the load. The message says the module runs as code in the process.
- After approval the load goes through `fixedPath` and `resolveUnder`, so a link planted in the spelling, or at the file itself, is refused. A direct TypeScript caller can pass `wholePath` as the locator, the same seam `_loadModelData` has.
- `registerProviderModule` returns a `Result`, so a rejection or a failed load is reported instead of thrown.
- No built-in policy approves the effect except `approve-all`. The gate test that pins the save and review gates now pins this one too.
- `@always(path)` on the effect, so an interactive user can save "always load this module" for one path. The always-scope table has the row.

## Who is affected

- `--local` is not. It loads the llama.cpp provider by package name in the CLI process and never calls this function.
- `client.providerModules` in `agency.json` is not. Those load at startup before any handler exists. That is roadmap item C2 (#968), still open; the roadmap now notes this runtime twin is done.
- A program calling `registerProviderModule` gets a prompt under `--interactive`, needs a policy rule headless, and prompts under `agency agent`. Nothing in the repo calls it; the custom-providers guide documents it and now says the call prompts.

## Testing

- `llm.registerProviderModule.test.ts`: the existing load test, plus a symlinked module path that is refused and registers nothing.
- `builtinPolicies.test.ts`: no built-in but approve-all decides the effect.
- The always-scope table, `effects` CLI test, typecheck, prettier, structural lint, `make`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01932VFdBf79Jhq6wMEp7wg9
