### PR TITLE
agency local: a backend per model, the mlx: prefix, and running against an MLX server

### DIFF
--- a/packages/agency-lang/.claude/skills/agency-llm-docs/SKILL.md
+++ b/packages/agency-lang/.claude/skills/agency-llm-docs/SKILL.md
@@ -10,5 +10,6 @@ Paths are relative to `packages/agency-lang/`. Read the one that matches the tas
 - `docs/dev/llm/smoltalk.md` — The external library Agency routes every LLM call through.
 - `docs/dev/llm/llm-clients.md` — The `LLMClient` interface, for swapping smoltalk out for something else.
 - `docs/dev/llm/local-models.md` — How local-model support is wired, from the provider to model download and verification.
+- `docs/dev/llm/mlx-local-models.md` — The `mlx` backend: the `backend` field and `mlx:` prefix, how a run finds the served model name, the per-model record file, and `remove -f`.
 - `docs/dev/llm/local-model-integration.md` — The integration suite that downloads and runs a real local model.
 - `docs/dev/llm/speech-via-smoltalk.md` — Speech-to-text and text-to-speech, routed through the LLM client so they inherit cost accounting and tracing.

--- a/packages/agency-lang/2026-09-07-mlx-local-models-spec.md
+++ b/packages/agency-lang/2026-09-07-mlx-local-models-spec.md
@@ -1,0 +1,557 @@
+# MLX local models in Agency
+
+Written 2026-09-07 on branch `adit/mlx-spike`. The smoltalk half is
+`/Users/adityabhargava/smoltalk/packages/smoltalk/2026-09-07-mlx-provider-spec.md`.
+
+## What you will be able to do
+
+```bash
+# Download a model. Resumes if interrupted.
+agency local download mlx:mlx-community/Qwen3-Coder-Next-4bit
+
+# Serve it. Stays in this terminal. Ctrl-C stops it.
+agency local serve mlx:mlx-community/Qwen3-Coder-Next-4bit
+
+# Or serve two models at once, if they both fit in memory.
+agency local serve mlx:mlx-community/Qwen3-Coder-Next-4bit mlx:mlx-community/Qwen3.8-27B-4bit
+
+# In another terminal, use it.
+agency run --local mlx:mlx-community/Qwen3-Coder-Next-4bit my.agency
+agency agent --local mlx:mlx-community/Qwen3-Coder-Next-4bit
+```
+
+Today `agency local` works with one kind of model: GGUF files, run by
+llama.cpp inside the Agency process. This spec adds a second kind: MLX
+models, run by a Python server on a Mac. The rest of this document explains
+how the current system works, then what changes.
+
+## Part 1: How local models work today
+
+### The catalog
+
+`CURATED_LOCAL_MODELS` in `lib/stdlib/localModels.ts` is a table of about 25
+models. Each entry looks like this:
+
+```ts
+"qwen3.5-2b": {
+  uri: "hf:unsloth/Qwen3.5-2B-GGUF:Q4_K_M",
+  params: "2B",
+  sizeBytes: 1280000000,
+  category: "general",
+  contextWindow: 131072,
+  license: "apache-2.0",
+  description: "Most popular modern small general model.",
+  sha256: "aaf42c8b…",
+},
+```
+
+The `uri` names one GGUF file in a Hugging Face repo. The `sha256` is the
+hash of that file. The same table is published as `data/model-catalog.json`,
+and `agency local refresh` pulls new entries from there.
+
+### Aliases
+
+You can add your own names in `agency.json`:
+
+```jsonc
+{
+  "client": {
+    "modelAliases": {
+      "my7b": "hf:Qwen/Qwen2.5-7B-Instruct-GGUF:Q4_K_M",
+      "coder": { "uri": "hf:…", "params": "30B", "sha256": "…" }
+    }
+  }
+}
+```
+
+A value is either a URI string or an object with the same fields as a catalog
+entry. `ModelAliasSchema` in `lib/config.ts` validates the object form.
+
+### Where files go
+
+`defaultCacheDir()` picks the models directory. It checks, in order:
+
+1. The `AGENCY_MODELS_DIR` environment variable.
+2. `client.modelsDir` in the nearest `agency.json`.
+3. `~/.agency-agent/models`.
+
+GGUF files sit flat in that directory.
+
+### Downloading
+
+`_downloadModel(name)` resolves the name to a URI, then asks the
+`smoltalk-llama-cpp` package to download it. After a fresh download it hashes
+the file. A mismatch moves the file to `<file>.invalidSha` and fails. Finally
+it records the download in `downloads.json`, which `agency local list` reads
+to show a tick next to downloaded models.
+
+### Running
+
+`agency run --local qwen3.5-2b` downloads the model if needed and sets the
+provider to `llama-cpp`. `agency agent --local qwen3.5-2b` does the same and
+also switches the agent to a smaller prompt with output capped at 2000
+tokens, because small GGUF models misbehave with long prompts. That table is
+`PROVIDER_CAPABILITIES` in `lib/agents/agency-agent/lib/capabilities.agency`.
+
+### The install check
+
+Downloading and running need the `smoltalk-llama-cpp` package. `agency local
+download` refuses to run without it. `agency local list` works without it.
+
+## Part 2: What MLX needs that GGUF does not
+
+### The server
+
+An MLX model is a Hugging Face repo of safetensors files. It cannot run in
+Node. It runs in a Python server that you start yourself:
+
+```bash
+mlx_lm.server --model mlx-community/Qwen3-Coder-Next-4bit --port 8080
+```
+
+The server loads the model once, keeps it in memory, and answers requests in
+the OpenAI format. Agency reaches it through a new smoltalk provider named
+`mlx`. That provider is specified in the smoltalk document linked above.
+
+Agency will not start this server in the background for you, and it never
+loads a model you did not name. You run `agency local serve` with the models
+you want, in a terminal where you can see the logs. A request for any other
+model is an error.
+
+Four facts about the server shape the design:
+
+1. It prints nothing while loading. The only way to know the model is ready
+   is to send a request and wait.
+2. Its `--max-tokens` flag defaults to 512. Agency does not set `max_tokens`
+   on requests, so without a larger value every long reply is cut off.
+3. It loads any model a request names, even if a different one is loaded,
+   and there is no flag to stop it. Each process holds one model at a time.
+   This is why `serve` puts its own small server in front of it. See 3.5.
+4. `ps` shows about 3GB for a server holding a 42GB model. Activity Monitor
+   shows the real number.
+
+### The download
+
+Hugging Face gives a plain HTTP client everything needed. The tree API lists
+every file with its size and hash:
+
+```
+GET https://huggingface.co/api/models/mlx-community/Qwen3-Coder-Next-4bit/tree/main?recursive=true
+
+{ "path": "model-00001-of-00009.safetensors", "size": 5132893190,
+  "lfs": { "oid": "fb30a272…" } }
+```
+
+`lfs.oid` is the file's SHA-256. The download URL for a file redirects to a
+CDN that accepts byte ranges:
+
+```
+GET https://huggingface.co/mlx-community/Qwen3-Coder-Next-4bit/resolve/main/model-00001-of-00009.safetensors
+Range: bytes=1000-1999
+
+206 Partial Content
+content-range: bytes 1000-1999/5132893190
+```
+
+So Agency can download each file as many parallel chunks, resume at any byte,
+and verify the result. No Python and no new npm package are needed.
+
+`HF_TOKEN` only raises rate limits. It does not make downloads faster. Gated
+repos need it to download at all. Nothing else does.
+
+## Part 3: Design
+
+### 3.1 Naming a model
+
+You name an MLX model with a new `mlx:` prefix:
+
+```bash
+agency local download mlx:mlx-community/Qwen3-Coder-Next-4bit          # latest commit
+agency local download mlx:mlx-community/Qwen3-Coder-Next-4bit@7b9321e  # pinned commit
+```
+
+`hf:` URIs and `.gguf` paths still mean GGUF. A directory path means an MLX
+model if it contains a `config.json` and at least one `.safetensors` file:
+
+```bash
+agency local alias add coder /Volumes/adit-agency-models-sept-2026/hf/hub/models--mlx-community--Qwen3-Coder-Next-4bit/snapshots/7b9321eabb85ce79625cac3f61ea691e4ea984b5
+```
+
+This is how models you already downloaded another way become usable without
+moving them.
+
+Every model in Hugging Face's standard layout has a `config.json` describing
+its architecture, and its weights in `.safetensors` files. That layout is
+what `mlx_lm.server` loads. A GGUF model is one file with that information
+inside it, so it never has a `config.json`. Agency does not create either
+file.
+
+### 3.2 The `backend` field
+
+Every catalog entry and every object-form alias has a `backend` field. The
+value is `"llama-cpp"` or `"mlx"`:
+
+```ts
+"qwen3-coder-next": {
+  backend: "mlx",
+  uri: "mlx:mlx-community/Qwen3-Coder-Next-4bit",
+  params: "80B (3B active)",
+  sizeBytes: 44855709150,
+  …
+},
+```
+
+The field is required. An entry without it is an error:
+
+```
+agency.json: alias "coder" has no "backend". Add "backend": "llama-cpp" or
+"backend": "mlx" to the entry in /Users/me/project/agency.json.
+```
+
+If the field disagrees with the URI, that is also an error. A unit test
+checks every built-in entry has the field, so this error can only come from
+a user's `agency.json` or a remote catalog. A remote catalog entry without
+the field is skipped with a warning.
+
+A string-form alias like `"my7b": "hf:…"` has no field. Its prefix says what
+it is.
+
+### 3.3 Where MLX models are stored
+
+MLX models go in the same models directory as GGUF files, under an `mlx`
+subdirectory:
+
+```
+<modelsDir>/
+  qwen3.5-2b-Q4_K_M.gguf
+  downloads.json
+  mlx/
+    mlx-community--Qwen3-Coder-Next-4bit/
+      .agency-model.json
+      config.json
+      model-00001-of-00009.safetensors
+      …
+```
+
+To keep models on an external drive, set `client.modelsDir` in `agency.json`.
+This setting already exists.
+
+`.agency-model.json` records what has been downloaded:
+
+```json
+{
+  "repo": "mlx-community/Qwen3-Coder-Next-4bit",
+  "revision": "7b9321eabb85ce79625cac3f61ea691e4ea984b5",
+  "files": {
+    "config.json": { "size": 22196, "complete": true },
+    "model-00001-of-00009.safetensors": {
+      "size": 5132893190,
+      "sha256": "fb30a272…",
+      "complete": false,
+      "chunks": [0, 1, 2, 5]
+    }
+  }
+}
+```
+
+A model is complete when every file is complete. `serve` refuses an
+incomplete model and tells you to run `download` again.
+
+### 3.4 `agency local download`
+
+For an `mlx:` model, `download` uses new code in `lib/stdlib/hubDownload.ts`.
+The GGUF path is unchanged. The install check for `smoltalk-llama-cpp`
+applies only to GGUF.
+
+The downloader works like this:
+
+1. Read the model API for the commit hash, and the tree API for the file
+   list.
+2. Split every file into 64MB chunks. Skip chunks that `.agency-model.json`
+   says are done.
+3. Run 8 workers. Each takes the next chunk, sends a `Range` request, and
+   writes the bytes at the right offset in the file. When a chunk lands, it
+   is recorded in `.agency-model.json`.
+4. When a file's last chunk lands, hash the file. On mismatch, move it to
+   `<file>.invalidSha` and fail. Small files with no hash are checked by
+   size.
+
+If you interrupt the download and run it again, only the missing chunks are
+fetched. If the repo has moved to a new commit since, the download refuses:
+
+```
+<dir> holds revision 7b9321e, but mlx-community/Qwen3-Coder-Next-4bit is now
+at 9c1f0a2. Remove it or pin the old revision with mlx:<repo>@7b9321e.
+```
+
+The number of workers is `client.mlx.downloadConcurrency` in `agency.json`,
+default 8. The right number has not been measured.
+
+If `HF_TOKEN` is set, it is sent as a header. It is never written anywhere.
+A gated repo without it fails with:
+
+```
+This repo is gated. Set HF_TOKEN to a Hugging Face token that has accepted its terms.
+```
+
+Progress is one line when a file starts, a byte counter, and one line when a
+file verifies.
+
+**One rule bent.** Every file operation under `lib/stdlib` goes through
+`contained.ts`, and a lint rule enforces it. `contained.ts` has no way to
+write bytes at an offset inside an existing file. So `hubDownload.ts` uses
+`fs` directly for that one operation and is added to the lint allow-list,
+`FS_IMPORTERS` in `eslint.config.js`, with that reason.
+
+### 3.5 `agency local serve`
+
+```
+agency local serve <model> [<model> ...] [--port 8080] [--max-tokens 16384] [--python <path>]
+```
+
+This serves the models you name, in your terminal, and nothing else. It
+exists so you do not have to know five things: which Python to use, where
+the weights are, the 512-token default, the port, and how to tell a model
+has loaded.
+
+Here is what you see:
+
+```
+$ agency local serve mlx:mlx-community/Qwen3-Coder-Next-4bit mlx:mlx-community/Qwen3.8-27B-4bit
+Loading mlx-community/Qwen3-Coder-Next-4bit (44.9 GB)… ready in 2m 14s
+Loading mlx-community/Qwen3.8-27B-4bit (15.0 GB)… ready in 48s
+Serving 2 models on http://127.0.0.1:8080/v1:
+  mlx-community/Qwen3-Coder-Next-4bit
+  mlx-community/Qwen3.8-27B-4bit
+
+  agency run --local mlx:mlx-community/Qwen3-Coder-Next-4bit your.agency
+  agency agent --local mlx:mlx-community/Qwen3-Coder-Next-4bit
+```
+
+**How it works.** `mlx_lm.server` holds one model per process and loads any
+model a request names. So `serve` does not expose it directly. It starts one
+`mlx_lm.server` process per model on internal ports, and listens on port
+8080 itself. Each request's `model` field picks the process to forward to.
+Responses stream back unchanged. A request for a model you did not name
+never reaches any process. It gets this reply:
+
+```
+HTTP 404
+{ "error": { "message": "This server is serving mlx-community/Qwen3-Coder-Next-4bit and mlx-community/Qwen3.8-27B-4bit. It is not serving mlx-community/DeepSeek-V4-Flash-4bit. Start it with: agency local serve mlx:mlx-community/DeepSeek-V4-Flash-4bit" } }
+```
+
+The smoltalk provider shows that message as the error. Nothing in Agency or
+smoltalk ever loads a model on its own.
+
+To serve models on two ports, run `serve` twice in two terminals with
+different `--port` values, and set `MLX_BASE_URL` for the run that should
+use the second one.
+
+**Steps, in order:**
+
+1. Each name is resolved. A GGUF model is an error:
+
+   ```
+   "qwen3.5-2b" is a GGUF model. agency local serve is for MLX models;
+   run it with agency run --local qwen3.5-2b instead.
+   ```
+
+2. The sizes are added up and compared to the machine's memory. If they do
+   not fit, `serve` warns and continues:
+
+   ```
+   Warning: these models total 196.4 GB and this machine has 64 GB of memory.
+   ```
+
+3. A missing or incomplete model is an error. `serve` never downloads:
+
+   ```
+   mlx-community/Qwen3-Coder-Next-4bit is not downloaded. Run:
+     agency local download mlx:mlx-community/Qwen3-Coder-Next-4bit
+   ```
+
+4. A Python is chosen: `--python`, then `client.mlx.python` in
+   `agency.json`, then `AGENCY_MLX_PYTHON`, then
+   `~/.agency-agent/mlx-env/bin/python`. `serve` runs
+   `<python> -c "import mlx_lm"` to check it. If that fails, the command
+   prints this and exits:
+
+   ```
+   /Users/me/.agency-agent/mlx-env/bin/python cannot import mlx_lm.
+   Agency does not install Python. Create an environment once:
+
+     python3.12 -m venv /Users/me/.agency-agent/mlx-env
+     /Users/me/.agency-agent/mlx-env/bin/pip install mlx-lm
+
+   Python 3.11 or newer is required. Or point --python at a Python that has
+   mlx-lm installed.
+   ```
+
+5. One `mlx_lm.server` starts per model, one at a time, with its output in
+   your terminal:
+
+   ```
+   <python> -m mlx_lm.server --model <dir> --host 127.0.0.1 --port <internal> --max-tokens 16384
+   ```
+
+   The server prints nothing when a model finishes loading. So after each
+   start, `serve` sends one request with `max_tokens: 1` and waits. The
+   reply means the model is loaded. Then it prints `ready in 2m 14s`.
+
+6. The front door starts on `--port` and prints the model list.
+
+7. Ctrl-C stops everything. The command exits non-zero if any process died.
+
+The front door and the argument builder are in `lib/cli/localServe.ts`.
+`serveArgs(dir, port, opts)` is a pure function. The forwarder is a plain
+`http.createServer` that reads the `model` field from the request body,
+picks the matching internal port, and pipes the request and response
+through.
+
+### 3.6 Running against the server
+
+`agency run --local <mlx model>` sets the provider to `mlx` and the model to
+the string the server will report. It downloads nothing and registers
+nothing. `agency agent --local <mlx model>` does the same for every model
+slot. The agent's `PROVIDER_CAPABILITIES` table gets an `mlx` entry with
+`memory: false` and nothing else. MLX models are large enough for the full
+prompt.
+
+The model string must match what `serve` used, or the front door refuses
+the request. A test checks that `serve` and `run --local` produce the same
+string for the same name.
+
+If no server is running, the error is:
+
+```
+Could not reach the MLX server at http://127.0.0.1:8080/v1. Start one with:
+  agency local serve <model>
+```
+
+If the server is running but not serving that model, the error is the front
+door's message from 3.5.
+
+### 3.7 `list`, `resolve`, `remove`
+
+`agency local list` gains a BACKEND column. An MLX model gets its tick from a
+complete `.agency-model.json`. Unclaimed directories under `mlx/` appear
+under OTHER FILES.
+
+`agency local resolve coder` prints the backend and the target:
+
+```
+mlx  mlx:mlx-community/Qwen3-Coder-Next-4bit
+```
+
+`agency local remove <name>` no longer deletes files by default. It removes
+the alias, if there is one, and says where the files are:
+
+```
+$ agency local remove coder
+Removed alias "coder" from /Users/me/agency.json.
+The model files are still at /Volumes/…/mlx/mlx-community--Qwen3-Coder-Next-4bit (44.9 GB).
+Run again with -f to delete them.
+```
+
+For a built-in catalog name the first line says there is no alias to remove.
+`-f` deletes the files: the `.gguf` file, or the whole MLX directory. A
+directory outside the models directory is never deleted. This changes the
+GGUF behaviour, which deletes the file at once today.
+
+### 3.8 The stdlib wrapper
+
+`stdlib/agency/local.agency` keeps every function. `downloadModel` returns a
+`.gguf` path or a model directory. `listDownloadedModels` entries gain
+`backend`. `registerLocalModel` returns the directory for an MLX model and
+registers nothing. One new function:
+
+```ts
+// The models the server on baseUrl is serving, or null if it is not running.
+export def mlxServerModels(baseUrl: string = ""): string[] | null
+```
+
+The front door answers `GET /v1/models` with the list it serves, which is
+what this function reads.
+
+### 3.9 Not in this spec
+
+- Starting the server in the background.
+- Vision models. `mlx_lm.server` cannot load them.
+- MLX entries in the built-in catalog. A follow-up once download is proven.
+- Changes under `docs/site`. The `local.md` page needs the new command; that
+  is the owner's call.
+
+### 3.10 Tests
+
+No test downloads a real model or starts a real server.
+
+Pure unit tests:
+
+1. Each row of the naming table in 3.1 resolves to the right backend.
+2. Missing, wrong, and correct `backend` values give the messages in 3.2.
+3. Every built-in catalog entry has `backend`.
+4. Chunk planning skips done chunks and complete files.
+5. `serveArgs` builds the right argv for each flag.
+6. `serve` and `run --local` produce the same model string.
+7. The memory warning appears when the sizes exceed a given total, and
+   not otherwise.
+8. `formatLocalList` renders the BACKEND column and the MLX tick.
+
+Against a fake Hugging Face, a local `http.createServer` that implements the
+model API, the tree API, and `resolve/` with redirects and `Range`:
+
+9. A clean download produces byte-identical files.
+10. An interrupted download resumes without re-requesting done chunks. The
+    fake counts requests per range.
+11. A corrupted file is quarantined, and the next run re-downloads only it.
+12. A `403` on a cached CDN URL causes one re-resolve.
+13. A changed revision refuses with the message in 3.4.
+14. A gated `401` gives the token message. With a token, the header is sent.
+
+Against fake chat servers standing in for `mlx_lm.server`, with `spawn`
+stubbed:
+
+15. `serve` prints `ready` for each model after its fake answers the
+    one-token request.
+16. The front door forwards a request to the fake whose model matches, and
+    streams the reply through unchanged.
+17. A request for a model not on the list gets the 404 message and reaches
+    no fake.
+18. `mlxServerModels` returns the list the front door serves.
+
+### 3.11 Documentation
+
+- New dev doc `docs/dev/llm/mlx-local-models.md`, indexed in `CLAUDE.md` and
+  the `agency-llm-docs` skill.
+- One paragraph at the top of `docs/dev/llm/local-models.md` saying it
+  covers GGUF only.
+- Docstrings in `local.agency`. `make` regenerates the reference page.
+
+### 3.12 Delivery order
+
+Four PRs. `serve` comes before `download` because the owner's models are
+already on disk.
+
+1. The smoltalk `mlx` provider. Release 0.13.0.
+2. The `backend` field, the `mlx:` prefix, directory aliases, `list` and
+   `resolve` and `remove`, `run --local` and `agent --local`. After this you
+   can alias a snapshot directory, start the server by hand, and run against
+   it.
+3. `agency local serve`.
+4. The downloader.
+
+## Decisions
+
+Decided on 2026-09-07:
+
+- The `mlx` provider is a built-in smoltalk client, not a package.
+- `hubDownload.ts` goes on the `fs` allow-list.
+- `serve` does not download. It tells you to run `download`.
+- `remove` keeps files unless you pass `-f`, for GGUF and MLX alike.
+- `mlx:` is a prefix, not a flag.
+
+Still open:
+
+1. **String-form aliases.** `"my7b": "hf:…"` has no `backend` field. The
+   plans keep the shorthand and read the backend from the prefix. Say so if
+   you want it retired instead.

--- a/packages/agency-lang/2026-09-07-mlx-plan-1-backend-and-naming.md
+++ b/packages/agency-lang/2026-09-07-mlx-plan-1-backend-and-naming.md
@@ -1,0 +1,1013 @@
+# MLX Plan 1: Backend and Naming
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Teach `agency local` that a model has a backend, add the `mlx:` prefix and directory aliases, and let `run --local` and `agent --local` use an MLX server that is already running.
+
+**Architecture:** A `Backend` type and a `backend` field run through the catalog, aliases, and config schema. One function, `_resolveModel`, returns both the backend and the target for any name. Every command that used `_resolveModelName` branches on the backend. Nothing in this PR starts or downloads an MLX model.
+
+**Tech Stack:** TypeScript, zod, vitest. smoltalk 0.13.0 with the `mlx` provider.
+
+**Spec:** `2026-09-07-mlx-local-models-spec.md`, sections 3.1, 3.2, 3.6, 3.7, 3.8. Read Part 1 of the spec first.
+
+## Global Constraints
+
+- `backend` is `"llama-cpp"` or `"mlx"`. It is required on every catalog entry and every object-form alias. A string-form alias reads its backend from its prefix.
+- A directory is an MLX model when it contains `config.json` and at least one `.safetensors` file.
+- `remove` keeps files unless `-f` is passed. This applies to GGUF too.
+- No new npm dependency.
+- Run commands from `packages/agency-lang` in the worktree.
+- Save test output to a file. Run only the test files this plan touches, never the whole suite.
+- Run `pnpm run fmt:ts` and `pnpm run lint:structure` before each commit.
+- Commit messages go in a file and are passed with `git commit -F`.
+- Never commit to `main`. Check `git branch --show-current` before every commit.
+
+---
+
+### Task 0: Branch and smoltalk pin
+
+**Files:**
+- Modify: `package.json` (`"smoltalk": "^0.12.1"`)
+
+- [ ] **Step 1: Branch from main**
+
+```bash
+cd /Users/adityabhargava/agency-lang
+git worktree add worktree-mlx-backend -b adit/mlx-backend main
+cd worktree-mlx-backend/packages/agency-lang
+```
+
+Copy the spec and this plan from the `adit/mlx-spike` branch into this worktree so they travel with the PR:
+
+```bash
+git checkout adit/mlx-spike -- packages/agency-lang/2026-09-07-mlx-local-models-spec.md packages/agency-lang/2026-09-07-mlx-plan-1-backend-and-naming.md
+```
+
+- [ ] **Step 2: Pin smoltalk**
+
+Change `"smoltalk": "^0.12.1"` to `"smoltalk": "^0.13.0"` in `package.json`, then:
+
+```bash
+pnpm install
+pnpm exec node -e 'import("smoltalk").then(m => console.log(typeof m.getClient))'
+```
+
+Expected: `function`. If 0.13.0 is not published yet, use the smoltalk workspace path the way `pnpm-lock.yaml` did during the llama-cpp work, and note it in the PR.
+
+- [ ] **Step 3: Build and commit**
+
+```bash
+make > /tmp/make.log 2>&1; tail -5 /tmp/make.log
+git add package.json pnpm-lock.yaml packages/agency-lang/2026-09-07-mlx-*.md
+printf 'mlx: pin smoltalk 0.13.0 and bring the spec and plan\n' > /tmp/msg.txt
+git commit -F /tmp/msg.txt
+```
+
+---
+
+### Task 1: The `Backend` type and URI classification
+
+**Files:**
+- Modify: `lib/stdlib/localModels.ts` (near `isGgufPath`, `isModelUri`, `isCatalogUri`, around line 336)
+- Test: `lib/stdlib/localModels.test.ts`
+
+**Interfaces:**
+- Produces:
+  ```ts
+  export type Backend = "llama-cpp" | "mlx";
+  export function isMlxUri(v: string): boolean;          // "mlx:org/repo" or "mlx:org/repo@rev"
+  export function parseMlxUri(v: string): { repo: string; revision: string | undefined };
+  export function isModelDir(p: string): boolean;        // config.json + a .safetensors file
+  export function backendOfTarget(target: string): Backend;
+  ```
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `lib/stdlib/localModels.test.ts`, importing the four new functions:
+
+```ts
+describe("backend of a target", () => {
+  it("hf: URIs and .gguf paths are llama-cpp", () => {
+    expect(backendOfTarget("hf:org/repo:Q4_K_M")).toBe("llama-cpp");
+    expect(backendOfTarget("/models/x.gguf")).toBe("llama-cpp");
+  });
+
+  it("mlx: URIs are mlx, with and without a revision", () => {
+    expect(isMlxUri("mlx:mlx-community/Qwen3-Coder-Next-4bit")).toBe(true);
+    expect(parseMlxUri("mlx:mlx-community/Qwen3-Coder-Next-4bit")).toEqual({
+      repo: "mlx-community/Qwen3-Coder-Next-4bit",
+      revision: undefined,
+    });
+    expect(parseMlxUri("mlx:mlx-community/Qwen3-Coder-Next-4bit@7b9321e")).toEqual({
+      repo: "mlx-community/Qwen3-Coder-Next-4bit",
+      revision: "7b9321e",
+    });
+    expect(backendOfTarget("mlx:mlx-community/Qwen3-Coder-Next-4bit")).toBe("mlx");
+  });
+
+  it("a directory with config.json and a safetensors file is an mlx model", () => {
+    const model = path.join(dir, "m");
+    fs.mkdirSync(model);
+    fs.writeFileSync(path.join(model, "config.json"), "{}");
+    expect(isModelDir(model)).toBe(false);
+    fs.writeFileSync(path.join(model, "model.safetensors"), "");
+    expect(isModelDir(model)).toBe(true);
+    expect(backendOfTarget(model)).toBe("mlx");
+  });
+
+  it("a path that is neither is an error", () => {
+    expect(() => backendOfTarget(path.join(dir, "nothing-here"))).toThrow(
+      /not a model: expected a \.gguf file or a directory containing config\.json/,
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run and watch them fail**
+
+```bash
+pnpm exec vitest run lib/stdlib/localModels.test.ts > /tmp/t1.log 2>&1; grep -E "✓|✗|×|FAIL|Error" /tmp/t1.log | head -20
+```
+
+Expected: the new tests fail on missing exports.
+
+- [ ] **Step 3: Implement**
+
+In `lib/stdlib/localModels.ts`, next to `isGgufPath`:
+
+```ts
+export type Backend = "llama-cpp" | "mlx";
+
+const MLX_URI = /^mlx:([^@\s/]+\/[^@\s/]+)(?:@([0-9a-fA-F]{7,40}|[\w.-]+))?$/;
+
+export function isMlxUri(v: string): boolean {
+  return MLX_URI.test(v);
+}
+
+/** Split "mlx:org/repo@rev" into its parts. Throws on any other shape. */
+export function parseMlxUri(v: string): { repo: string; revision: string | undefined } {
+  const m = MLX_URI.exec(v);
+  if (m === null) {
+    throw new Error(`"${v}" is not an mlx: URI. Expected mlx:<org>/<repo> or mlx:<org>/<repo>@<revision>.`);
+  }
+  return { repo: m[1], revision: m[2] };
+}
+
+/** A Hugging Face model directory: config.json plus at least one weights file. */
+export function isModelDir(p: string): boolean {
+  const located = wholePath(p);
+  const info = stat(located.root, located.target);
+  if (info === null || !info.isDirectory()) {
+    return false;
+  }
+  const entries = list(root(p), ".");
+  const hasConfig = entries.some((e) => e.type === "file" && e.name === "config.json");
+  const hasWeights = entries.some((e) => e.type === "file" && e.name.endsWith(".safetensors"));
+  return hasConfig && hasWeights;
+}
+
+/** Which engine runs a resolved target. */
+export function backendOfTarget(target: string): Backend {
+  if (isGgufPath(target) || /^(hf:|https?:)/.test(target)) {
+    return "llama-cpp";
+  }
+  if (isMlxUri(target)) {
+    return "mlx";
+  }
+  if (isModelDir(target)) {
+    return "mlx";
+  }
+  throw new Error(
+    `"${target}" is not a model: expected a .gguf file or a directory containing config.json.`,
+  );
+}
+```
+
+Update `isModelUri` to also accept `mlx:`, and `isCatalogUri` to accept `mlx:` while still refusing `http://`.
+
+- [ ] **Step 4: Run, then commit**
+
+```bash
+pnpm exec vitest run lib/stdlib/localModels.test.ts > /tmp/t1.log 2>&1; tail -8 /tmp/t1.log
+pnpm run fmt:ts && pnpm run lint:structure
+git add lib/stdlib/localModels.ts lib/stdlib/localModels.test.ts
+printf 'local models: a Backend type, mlx: URIs, and model directories\n' > /tmp/msg.txt
+git commit -F /tmp/msg.txt
+```
+
+---
+
+### Task 2: The `backend` field on entries, aliases, and the schema
+
+**Files:**
+- Modify: `lib/stdlib/localModels.ts` (`ModelInfo`, `AliasObject`, `CatalogModel`, `ModelNameEntry`, `CatalogModelSchema`, every entry of `CURATED_LOCAL_MODELS`, `readModelAliases`, `metaFrom`)
+- Modify: `lib/config.ts` (`ModelAliasSchema`)
+- Modify: `data/model-catalog.json` (every entry)
+- Test: `lib/stdlib/localModels.test.ts`, `lib/config.modelAliases.test.ts`
+
+**Interfaces:**
+- Produces: `backend: Backend` on `ModelInfo`, `AliasObject`, `CatalogModel`, `ModelNameEntry`.
+- Produces: `readModelAliases(file)` throws the messages below for a bad object alias.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `lib/stdlib/localModels.test.ts`:
+
+```ts
+describe("backend field", () => {
+  it("every curated entry has a backend that matches its uri", () => {
+    for (const [name, info] of Object.entries(CURATED_LOCAL_MODELS)) {
+      expect(info.backend, name).toBe(backendOfTarget(info.uri));
+    }
+  });
+
+  it("an object alias without backend is an error naming the file", () => {
+    fs.writeFileSync(
+      aliasFile,
+      JSON.stringify({ client: { modelAliases: { coder: { uri: "hf:org/repo:Q4_K_M" } } } }),
+    );
+    expect(() => _resolveModelName("coder", aliasFile)).toThrow(
+      `alias "coder" has no "backend". Add "backend": "llama-cpp" or "backend": "mlx" to the entry in ${aliasFile}.`,
+    );
+  });
+
+  it("an object alias whose backend disagrees with its uri is an error", () => {
+    fs.writeFileSync(
+      aliasFile,
+      JSON.stringify({
+        client: { modelAliases: { coder: { backend: "mlx", uri: "hf:org/repo:Q4_K_M" } } },
+      }),
+    );
+    expect(() => _resolveModelName("coder", aliasFile)).toThrow(
+      /says backend "mlx" but its uri "hf:org\/repo:Q4_K_M" is a GGUF file/,
+    );
+  });
+
+  it("a string alias reads its backend from the prefix", () => {
+    fs.writeFileSync(
+      aliasFile,
+      JSON.stringify({ client: { modelAliases: { coder: "mlx:mlx-community/Qwen3-Coder-Next-4bit" } } }),
+    );
+    const entry = _listModelNames(aliasFile).find((e) => e.name === "coder");
+    expect(entry?.backend).toBe("mlx");
+  });
+
+  it("a remote catalog entry without backend is skipped with a warning", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const parsed = parseCatalog(
+      JSON.stringify({
+        version: 1,
+        models: {
+          ok: { backend: "llama-cpp", uri: "hf:org/ok:Q4_K_M" },
+          bad: { uri: "hf:org/bad:Q4_K_M" },
+        },
+      }),
+    );
+    expect(Object.keys(parsed)).toEqual(["ok"]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('skipping "bad"'));
+    warn.mockRestore();
+  });
+});
+```
+
+In `lib/config.modelAliases.test.ts`, add `backend: "llama-cpp"` to the fully-populated entry in the round-trip test, and add:
+
+```ts
+  it("an object alias needs a backend", () => {
+    const result = AgencyConfigSchema.safeParse({
+      client: { modelAliases: { x: { uri: "hf:org/repo:Q4_K_M" } } },
+    });
+    expect(result.success).toBe(false);
+  });
+```
+
+- [ ] **Step 2: Run and watch them fail**
+
+```bash
+pnpm exec vitest run lib/stdlib/localModels.test.ts lib/config.modelAliases.test.ts > /tmp/t2.log 2>&1; grep -E "×|FAIL" /tmp/t2.log | head
+```
+
+- [ ] **Step 3: Implement**
+
+1. Add `backend: Backend;` as the first field of `ModelInfo`, `AliasObject`, `CatalogModel`, and `ModelNameEntry` in `lib/stdlib/localModels.ts`.
+2. Add `backend: "llama-cpp",` as the first line of every entry in `CURATED_LOCAL_MODELS` and every entry in `data/model-catalog.json`.
+3. In `CatalogModelSchema`, add `backend: z.enum(["llama-cpp", "mlx"]),` with no `.optional()`. A missing field now fails the entry, and the existing skip-and-warn path handles it.
+4. In `ModelAliasSchema` in `lib/config.ts`, add `backend: z.enum(["llama-cpp", "mlx"]),` to the object branch.
+5. Replace `readModelAliases` with a version that validates object aliases:
+
+```ts
+export function readModelAliases(file: string = ""): Record<string, AliasValue> {
+  const resolved = resolveAliasFile(file);
+  const cfg = readJson(resolved);
+  const aliases = (cfg.client?.modelAliases ?? {}) as Record<string, AliasValue>;
+  for (const [name, value] of Object.entries(aliases)) {
+    if (typeof value === "string") continue;
+    if (value.backend === undefined) {
+      throw new Error(
+        `${path.basename(resolved)}: alias "${name}" has no "backend". Add "backend": "llama-cpp" or "backend": "mlx" to the entry in ${resolved}.`,
+      );
+    }
+    const fromUri = backendOfTarget(value.uri);
+    if (value.backend !== fromUri) {
+      const what = fromUri === "llama-cpp" ? "a GGUF file" : "an MLX model";
+      throw new Error(
+        `${path.basename(resolved)}: alias "${name}" says backend "${value.backend}" but its uri "${value.uri}" is ${what}. Change one of them in ${resolved}.`,
+      );
+    }
+  }
+  return aliases;
+}
+```
+
+6. In `metaFrom`, copy `backend` when the source is an object. In `_listModelNames`, set `backend: backendOfTarget(aliasUri(value))` for string aliases and `backend: info.backend` for curated entries.
+
+- [ ] **Step 4: Run, then commit**
+
+```bash
+pnpm exec vitest run lib/stdlib/localModels.test.ts lib/config.modelAliases.test.ts lib/cli/local.test.ts > /tmp/t2.log 2>&1; tail -8 /tmp/t2.log
+pnpm run fmt:ts && pnpm run lint:structure
+git add lib/stdlib/localModels.ts lib/config.ts data/model-catalog.json lib/stdlib/localModels.test.ts lib/config.modelAliases.test.ts
+printf 'local models: require a backend on every catalog entry and object alias\n' > /tmp/msg.txt
+git commit -F /tmp/msg.txt
+```
+
+---
+
+### Task 3: `_resolveModel` and the `resolve` command
+
+**Files:**
+- Modify: `lib/stdlib/localModels.ts` (next to `_resolveModelName`)
+- Modify: `lib/cli/local.ts` (`runResolve`)
+- Test: `lib/stdlib/localModels.test.ts`, `lib/cli/local.test.ts`
+
+**Interfaces:**
+- Produces:
+  ```ts
+  export type ResolvedModel = { backend: Backend; target: string };
+  export function _resolveModel(value: string, file?: string): ResolvedModel;
+  ```
+  `_resolveModelName` stays and returns `_resolveModel(value, file).target`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+describe("_resolveModel", () => {
+  it("returns backend and target for a curated name", () => {
+    expect(_resolveModel("smollm2-135m")).toEqual({
+      backend: "llama-cpp",
+      target: CURATED_LOCAL_MODELS["smollm2-135m"].uri,
+    });
+  });
+
+  it("returns mlx for an mlx: URI and for a directory alias", () => {
+    const model = path.join(dir, "m");
+    fs.mkdirSync(model);
+    fs.writeFileSync(path.join(model, "config.json"), "{}");
+    fs.writeFileSync(path.join(model, "model.safetensors"), "");
+    fs.writeFileSync(aliasFile, JSON.stringify({ client: { modelAliases: { local: model } } }));
+    expect(_resolveModel("mlx:org/repo")).toEqual({ backend: "mlx", target: "mlx:org/repo" });
+    expect(_resolveModel("local", aliasFile)).toEqual({ backend: "mlx", target: model });
+  });
+
+  it("the unknown-name error mentions mlx: URIs", () => {
+    expect(() => _resolveModel("nope")).toThrow(/or pass a \.gguf path, an "hf:" URI, an "mlx:" URI, or a model directory/);
+  });
+});
+```
+
+In `lib/cli/local.test.ts`, add a test that `runResolve("smollm2-135m")` prints `llama-cpp  hf:unsloth/SmolLM2-135M-Instruct-GGUF:Q4_K_M`, using the same console-capture pattern the file uses for `runList`.
+
+- [ ] **Step 2: Run and watch them fail**
+
+```bash
+pnpm exec vitest run lib/stdlib/localModels.test.ts lib/cli/local.test.ts > /tmp/t3.log 2>&1; grep -E "×|FAIL" /tmp/t3.log | head
+```
+
+- [ ] **Step 3: Implement**
+
+```ts
+export type ResolvedModel = { backend: Backend; target: string };
+
+export function _resolveModel(value: string, file: string = ""): ResolvedModel {
+  if (isGgufPath(value) || isModelUri(value) || isModelDir(value)) {
+    return { backend: backendOfTarget(value), target: value };
+  }
+  const aliases = readModelAliases(file);
+  const aliasVal = aliases[value];
+  const curated = CURATED_LOCAL_MODELS[value];
+  if (aliasVal !== undefined) {
+    const target = aliasUri(aliasVal);
+    return { backend: backendOfTarget(target), target };
+  }
+  if (curated !== undefined) {
+    return { backend: curated.backend, target: curated.uri };
+  }
+  const names = [...Object.keys(CURATED_LOCAL_MODELS), ...Object.keys(aliases)].join(", ");
+  throw new Error(
+    `Unknown local model "${value}". Known names: ${names || "(none)"}; ` +
+      `or pass a .gguf path, an "hf:" URI, an "mlx:" URI, or a model directory.`,
+  );
+}
+
+export function _resolveModelName(value: string, file: string = ""): string {
+  return _resolveModel(value, file).target;
+}
+```
+
+In `lib/cli/local.ts`:
+
+```ts
+export function runResolve(value: string): void {
+  const { backend, target } = _resolveModel(value);
+  console.log(`${backend}  ${target}`);
+}
+```
+
+- [ ] **Step 4: Run, then commit**
+
+```bash
+pnpm exec vitest run lib/stdlib/localModels.test.ts lib/cli/local.test.ts > /tmp/t3.log 2>&1; tail -8 /tmp/t3.log
+pnpm run fmt:ts && pnpm run lint:structure
+git add lib/stdlib/localModels.ts lib/cli/local.ts lib/stdlib/localModels.test.ts lib/cli/local.test.ts
+printf 'local models: _resolveModel returns the backend; resolve prints it\n' > /tmp/msg.txt
+git commit -F /tmp/msg.txt
+```
+
+---
+
+### Task 4: `run --local` and `agent --local` for MLX
+
+**Files:**
+- Modify: `lib/cli/localFlag.ts`
+- Modify: `lib/agents/agency-agent/shared.agency` (`configureLocalModel`, around line 451)
+- Modify: `lib/agents/agency-agent/lib/capabilities.agency` (`PROVIDER_CAPABILITIES`)
+- Modify: `stdlib/agency/local.agency` (new `localModelBackend`, docstrings)
+- Modify: `lib/agents/agency-agent/lib/args.agency` (the `--local` description, line 101)
+- Test: `lib/cli/localFlag.test.ts`
+
+**Interfaces:**
+- Consumes: `_resolveModel` from Task 3.
+- Produces in `lib/stdlib/localModels.ts`:
+  ```ts
+  /** The string the MLX server reports for this model: the directory path
+   *  for a directory target, else the repo id from the mlx: URI. */
+  export function _mlxServedName(resolved: ResolvedModel): string;
+  ```
+  Plan 2's `serve` uses the same function, which is what keeps the two sides equal.
+- Produces in `local.agency`: `localModelBackend(value: string): string` and `mlxServedName(value: string): string`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `lib/cli/localFlag.test.ts`:
+
+```ts
+describe("resolveLocalRunFlag for mlx", () => {
+  it("pins the mlx provider and passes the repo id, with no download", async () => {
+    const flag = await resolveLocalRunFlag("mlx:mlx-community/Qwen3-Coder-Next-4bit");
+    expect(flag).toEqual({
+      model: "mlx-community/Qwen3-Coder-Next-4bit",
+      explicitProvider: "mlx",
+    });
+    expect(smoltalkPkg.hasProvider("llama-cpp")).toBe(false);
+  });
+
+  it("passes a directory alias as its absolute path", async () => {
+    const model = path.join(here, `__tmp_model_${process.pid}`);
+    fs.mkdirSync(model, { recursive: true });
+    fs.writeFileSync(path.join(model, "config.json"), "{}");
+    fs.writeFileSync(path.join(model, "model.safetensors"), "");
+    try {
+      const flag = await resolveLocalRunFlag(model);
+      expect(flag).toEqual({ model: model, explicitProvider: "mlx" });
+    } finally {
+      fs.rmSync(model, { recursive: true, force: true });
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run and watch them fail**
+
+```bash
+pnpm exec vitest run lib/cli/localFlag.test.ts > /tmp/t4.log 2>&1; grep -E "×|FAIL" /tmp/t4.log | head
+```
+
+- [ ] **Step 3: Implement**
+
+In `lib/stdlib/localModels.ts`:
+
+```ts
+export function _mlxServedName(resolved: ResolvedModel): string {
+  if (isMlxUri(resolved.target)) {
+    return parseMlxUri(resolved.target).repo;
+  }
+  return path.resolve(resolved.target);
+}
+```
+
+In `lib/cli/localFlag.ts`:
+
+```ts
+export async function resolveLocalRunFlag(value: string): Promise<ResolvedModelFlag> {
+  const resolved = _resolveModel(value);
+  if (resolved.backend === "mlx") {
+    // The server is already running, started with `agency local serve`.
+    return { model: _mlxServedName(resolved), explicitProvider: "mlx" };
+  }
+  const modelPath = await _registerLocalModel(value);
+  return { model: path.resolve(modelPath), explicitProvider: "llama-cpp" };
+}
+```
+
+In `stdlib/agency/local.agency`, add:
+
+```
+export def localModelBackend(value: string): string {
+  """
+  Which engine runs a model: "llama-cpp" for GGUF files, "mlx" for MLX
+  models served by `agency local serve`.
+
+  @param value - name, alias, hf: URI, mlx: URI, .gguf path, or model directory
+  """
+  return _resolveModel(value).backend
+}
+
+export def mlxServedName(value: string): string {
+  """
+  The model name to send to the MLX server for this model. It is the same
+  string `agency local serve` gives the server.
+
+  @param value - name, alias, mlx: URI, or model directory
+  """
+  return _mlxServedName(_resolveModel(value))
+}
+```
+
+Import `_resolveModel` and `_mlxServedName` at the top of the file. Update the `registerLocalModel` docstring: "For an MLX model this registers nothing and returns the name to send to the server. Start the server first with `agency local serve`."
+
+In `shared.agency`, at the top of `configureLocalModel`:
+
+```
+  const backend = localModelBackend(value)
+  if (backend == "mlx") {
+    const served = mlxServedName(value)
+    const m: Resolved = {
+      model: served,
+      provider: "mlx",
+      via: "local"
+    }
+    applyResolved({ main: m, reasoning: m, embedding: { model: "", provider: "mlx", via: "local" } })
+    refreshCapabilities(value, "mlx")
+    return
+  }
+```
+
+Import `localModelBackend` and `mlxServedName` from `std::agency/local` next to `registerLocalModel`. Match the file's existing formatting for the `applyResolved` call.
+
+In `capabilities.agency`, add after the `llama-cpp` entry:
+
+```
+  // No embeddings endpoint. The models are large enough for the full prompt.
+  mlx: {
+    memory: false
+  }
+```
+
+In `args.agency`, change the `--local` description to: "Run a local model: a curated short name, an alias, an hf: URI, a .gguf path, an mlx: URI, or a model directory. GGUF models download if needed and need: npm i -g smoltalk-llama-cpp. MLX models need a running server: agency local serve <model>. Pins all slots to the local model; mutually exclusive with --model/--fastmodel/--slowmodel."
+
+- [ ] **Step 4: Build, run, and commit**
+
+```bash
+make > /tmp/make.log 2>&1; tail -5 /tmp/make.log
+pnpm exec vitest run lib/cli/localFlag.test.ts lib/stdlib/localModels.test.ts > /tmp/t4.log 2>&1; tail -8 /tmp/t4.log
+pnpm run agency test tests/agency/agency-agent-smoke > /tmp/t4b.log 2>&1; tail -5 /tmp/t4b.log
+pnpm run fmt:ts && pnpm run lint:structure
+git add lib/cli/localFlag.ts lib/stdlib/localModels.ts stdlib/agency/local.agency lib/agents/agency-agent/shared.agency lib/agents/agency-agent/lib/capabilities.agency lib/agents/agency-agent/lib/args.agency lib/cli/localFlag.test.ts
+printf 'run --local and agent --local: use a running MLX server for mlx models\n' > /tmp/msg.txt
+git commit -F /tmp/msg.txt
+```
+
+`make` is needed because `.agency` files under `lib/agents` and `stdlib` compile at build time.
+
+---
+
+### Task 5: `list` with a BACKEND column and MLX directories
+
+**Files:**
+- Modify: `lib/stdlib/localModels.ts` (`formatLocalList`, `_listDownloadedModels`)
+- Create: `lib/stdlib/mlxModelRecord.ts`
+- Test: `lib/stdlib/localModels.test.ts`, `lib/stdlib/mlxModelRecord.test.ts`
+
+**Interfaces:**
+- Produces in `mlxModelRecord.ts`:
+  ```ts
+  export const MLX_SUBDIR = "mlx";
+  export const RECORD_FILE = ".agency-model.json";
+  export type MlxFileRecord = { size: number; sha256?: string; complete: boolean; chunks?: number[] };
+  export type MlxModelRecord = { repo: string; revision: string; files: Record<string, MlxFileRecord> };
+  export function mlxModelDirName(repo: string): string;            // "org--repo"
+  export function mlxModelDir(cacheDir: string, repo: string): string;
+  export function readMlxModelRecord(dir: string): MlxModelRecord | null;
+  export function writeMlxModelRecord(dir: string, record: MlxModelRecord): void;
+  export function isMlxModelComplete(record: MlxModelRecord): boolean;
+  ```
+- Produces: `_listDownloadedModels` entries gain `backend: Backend`. MLX entries have `name` = the repo id and `path` = the directory.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `lib/stdlib/mlxModelRecord.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+  mlxModelDirName,
+  mlxModelDir,
+  readMlxModelRecord,
+  writeMlxModelRecord,
+  isMlxModelComplete,
+  RECORD_FILE,
+} from "./mlxModelRecord.js";
+
+let dir: string;
+beforeEach(() => {
+  dir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "mlxrec-")));
+});
+afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+describe("mlx model record", () => {
+  it("names the directory org--repo under mlx/", () => {
+    expect(mlxModelDirName("mlx-community/Qwen3-Coder-Next-4bit")).toBe(
+      "mlx-community--Qwen3-Coder-Next-4bit",
+    );
+    expect(mlxModelDir(dir, "org/repo")).toBe(path.join(dir, "mlx", "org--repo"));
+  });
+
+  it("round-trips a record and reports completeness", () => {
+    const model = path.join(dir, "mlx", "org--repo");
+    fs.mkdirSync(model, { recursive: true });
+    const record = {
+      repo: "org/repo",
+      revision: "abc",
+      files: {
+        "config.json": { size: 10, complete: true },
+        "model.safetensors": { size: 100, sha256: "00", complete: false, chunks: [0] },
+      },
+    };
+    writeMlxModelRecord(model, record);
+    expect(readMlxModelRecord(model)).toEqual(record);
+    expect(isMlxModelComplete(record)).toBe(false);
+    record.files["model.safetensors"].complete = true;
+    expect(isMlxModelComplete(record)).toBe(true);
+  });
+
+  it("a missing or corrupt record reads as null", () => {
+    const model = path.join(dir, "mlx", "org--repo");
+    fs.mkdirSync(model, { recursive: true });
+    expect(readMlxModelRecord(model)).toBeNull();
+    fs.writeFileSync(path.join(model, RECORD_FILE), "{not json");
+    expect(readMlxModelRecord(model)).toBeNull();
+  });
+});
+```
+
+In `lib/stdlib/localModels.test.ts`, extend the `formatLocalList` tests: build an `entries` list with one `backend: "mlx"` entry whose target is `mlx:org/repo`, a `files` list with an MLX entry `{ name: "org/repo", path, sizeBytes, backend: "mlx", complete: true }`, and assert the rendered table has a `BACKEND` header, the row shows `mlx`, and the row has the tick. Add one MLX file entry that no catalog row claims and assert it appears under `OTHER FILES` as `org/other  (mlx)  1.00 GB`.
+
+- [ ] **Step 2: Run and watch them fail**
+
+```bash
+pnpm exec vitest run lib/stdlib/mlxModelRecord.test.ts lib/stdlib/localModels.test.ts > /tmp/t5.log 2>&1; grep -E "×|FAIL" /tmp/t5.log | head
+```
+
+- [ ] **Step 3: Implement `mlxModelRecord.ts`**
+
+```ts
+import * as path from "node:path";
+import { root, stat, readText, writeText, mkdir } from "./contained.js";
+
+export const MLX_SUBDIR = "mlx";
+export const RECORD_FILE = ".agency-model.json";
+
+export type MlxFileRecord = { size: number; sha256?: string; complete: boolean; chunks?: number[] };
+export type MlxModelRecord = { repo: string; revision: string; files: Record<string, MlxFileRecord> };
+
+export function mlxModelDirName(repo: string): string {
+  return repo.replace("/", "--");
+}
+
+export function mlxModelDir(cacheDir: string, repo: string): string {
+  return path.join(cacheDir, MLX_SUBDIR, mlxModelDirName(repo));
+}
+
+/** The record in `dir`, or null when it is missing or not valid JSON. */
+export function readMlxModelRecord(dir: string): MlxModelRecord | null {
+  const r = root(dir);
+  if (stat(r, RECORD_FILE) === null) {
+    return null;
+  }
+  try {
+    const parsed: unknown = JSON.parse(readText(r, RECORD_FILE));
+    if (parsed === null || typeof parsed !== "object") {
+      return null;
+    }
+    const rec = parsed as MlxModelRecord;
+    if (typeof rec.repo !== "string" || typeof rec.revision !== "string" || typeof rec.files !== "object") {
+      return null;
+    }
+    return rec;
+  } catch {
+    return null;
+  }
+}
+
+/** Replaces the file through a temp file and rename, so a crash mid-write
+ *  leaves the previous record. */
+export function writeMlxModelRecord(dir: string, record: MlxModelRecord): void {
+  const r = root(dir);
+  mkdir(r, ".");
+  writeText(r, RECORD_FILE, JSON.stringify(record, null, 2) + "\n");
+}
+
+export function isMlxModelComplete(record: MlxModelRecord): boolean {
+  return Object.values(record.files).every((f) => f.complete);
+}
+```
+
+- [ ] **Step 4: Implement the listing changes**
+
+In `lib/stdlib/localModels.ts`:
+
+1. Change the `_listDownloadedModels` return type to `{ name: string; path: string; sizeBytes: number; backend: Backend; complete: boolean }[]`. GGUF entries get `backend: "llama-cpp", complete: true`. Then append MLX entries: for each directory under `<dir>/mlx` that has a record, push `{ name: record.repo, path: <dir>, sizeBytes: <sum of file sizes on disk>, backend: "mlx", complete: isMlxModelComplete(record) }`. Sum sizes with `list(root(modelDir), ".")`.
+2. In `formatLocalList`, add `"BACKEND"` between `"NAME"` and `"PARAMS"` in `headers`, a matching column, and `backend: e.backend` on each row. For an MLX entry, the tick comes from a file whose `name` equals `parseMlxUri(e.target).repo` (or whose `path` equals the target for a directory alias) and whose `complete` is true. For an MLX file under OTHER FILES, render `  ${f.name}  (mlx)  ${formatGB(f.sizeBytes)}`.
+
+- [ ] **Step 5: Run, then commit**
+
+```bash
+pnpm exec vitest run lib/stdlib/mlxModelRecord.test.ts lib/stdlib/localModels.test.ts lib/cli/local.test.ts > /tmp/t5.log 2>&1; tail -8 /tmp/t5.log
+pnpm run fmt:ts && pnpm run lint:structure
+git add lib/stdlib/mlxModelRecord.ts lib/stdlib/mlxModelRecord.test.ts lib/stdlib/localModels.ts lib/stdlib/localModels.test.ts
+printf 'agency local list: a BACKEND column and downloaded MLX models\n' > /tmp/msg.txt
+git commit -F /tmp/msg.txt
+```
+
+---
+
+### Task 6: `remove` keeps files unless `-f`
+
+**Files:**
+- Modify: `lib/cli/local.ts` (`runRemove`)
+- Modify: `scripts/agency.ts` (the `remove` subcommand, around line 1747)
+- Modify: `lib/stdlib/localModels.ts` (`_removeModel`, new `_removeMlxModel`)
+- Modify: `stdlib/agency/local.agency` (`removeModel` docstring)
+- Test: `lib/cli/local.test.ts`, `lib/stdlib/localModels.test.ts`
+
+**Interfaces:**
+- Produces: `runRemove(name: string, opts: { force: boolean })`.
+- Produces: `_removeMlxModel(repo: string, cacheDir?: string): boolean`, which deletes `<cacheDir>/mlx/<org>--<repo>` and returns false if absent.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `lib/cli/local.test.ts`, with console captured the way the file already does:
+
+```ts
+describe("runRemove", () => {
+  it("without -f removes the alias, keeps the files, and says how to delete them", () => {
+    // alias "coder" -> a .gguf in a temp models dir, via AGENCY_MODELS_DIR
+    // ...set up as in the alias round-trip test...
+    runRemove("coder", { force: false });
+    expect(output).toContain(`Removed alias "coder" from ${aliasFile}.`);
+    expect(output).toContain("The model files are still at");
+    expect(output).toContain("Run again with -f to delete them.");
+    expect(fs.existsSync(ggufPath)).toBe(true);
+  });
+
+  it("with -f deletes the files", () => {
+    runRemove("coder", { force: true });
+    expect(fs.existsSync(ggufPath)).toBe(false);
+  });
+
+  it("a curated name without -f says there is no alias and where the file is", () => {
+    runRemove("smollm2-135m", { force: false });
+    expect(output).toContain('"smollm2-135m" is a built-in catalog entry, so there is no alias to remove.');
+  });
+});
+```
+
+In `lib/stdlib/localModels.test.ts`:
+
+```ts
+it("_removeMlxModel deletes the model directory under mlx/ and refuses anything else", () => {
+  const model = path.join(dir, "mlx", "org--repo");
+  fs.mkdirSync(model, { recursive: true });
+  fs.writeFileSync(path.join(model, "config.json"), "{}");
+  expect(_removeMlxModel("org/repo", dir)).toBe(true);
+  expect(fs.existsSync(model)).toBe(false);
+  expect(_removeMlxModel("org/repo", dir)).toBe(false);
+});
+```
+
+- [ ] **Step 2: Run and watch them fail**
+
+```bash
+pnpm exec vitest run lib/cli/local.test.ts lib/stdlib/localModels.test.ts > /tmp/t6.log 2>&1; grep -E "×|FAIL" /tmp/t6.log | head
+```
+
+- [ ] **Step 3: Implement**
+
+In `lib/stdlib/localModels.ts`:
+
+```ts
+/** Delete an MLX model directory from the cache. Only directories under
+ *  `<cacheDir>/mlx` are ever removed. */
+export function _removeMlxModel(repo: string, cacheDir: string = ""): boolean {
+  const cache = root(path.join(resolveCacheDir(cacheDir), MLX_SUBDIR));
+  const name = mlxModelDirName(repo);
+  const info = stat(cache, name);
+  if (info === null || !info.isDirectory()) {
+    return false;
+  }
+  remove(cache, name);
+  return true;
+}
+```
+
+In `lib/cli/local.ts`:
+
+```ts
+export function runRemove(name: string, opts: { force: boolean }): void {
+  const resolved = _resolveModel(name);
+  const aliases = readModelAliases();
+  const where = describeModelFiles(resolved);   // path + size line, or null if nothing on disk
+
+  if (!opts.force) {
+    if (Object.hasOwn(aliases, name)) {
+      const { file } = _unaliasModel(name);
+      console.log(`Removed alias "${name}" from ${file}.`);
+    } else if (name in CURATED_LOCAL_MODELS) {
+      console.log(`"${name}" is a built-in catalog entry, so there is no alias to remove.`);
+    }
+    if (where !== null) {
+      console.log(`The model files are still at ${where}.`);
+      console.log("Run again with -f to delete them.");
+    }
+    return;
+  }
+
+  if (resolved.backend === "mlx") {
+    gateMlxInsideCache(resolved);   // throws "That model is not in the models directory; remove it yourself."
+    const removed = _removeMlxModel(parseMlxUri(resolved.target).repo);
+    console.log(removed ? `Deleted ${where}` : `Not found: ${name}`);
+    return;
+  }
+  gate();
+  const removed = _removeModel(path.basename(resolved.target));
+  console.log(removed ? `Deleted ${where}` : `Not found: ${name}`);
+}
+```
+
+Write `describeModelFiles` and `gateMlxInsideCache` as small helpers in the same file. `describeModelFiles` returns `"<path> (44.9 GB)"` using the manifest for GGUF and the record for MLX, or `null`.
+
+In `scripts/agency.ts`:
+
+```ts
+  localCmd
+    .command("remove")
+    .description("Remove a model's alias. With -f, delete its files from the models directory")
+    .argument("<name>")
+    .option("-f, --force", "Delete the model files")
+    .action((name: string, opts: { force?: boolean }) => localRemove(name, { force: opts.force === true }));
+```
+
+Update the `removeModel` docstring in `local.agency` to say it deletes files and is what `agency local remove -f` calls.
+
+- [ ] **Step 4: Run, then commit**
+
+```bash
+make > /tmp/make.log 2>&1; tail -3 /tmp/make.log
+pnpm exec vitest run lib/cli/local.test.ts lib/stdlib/localModels.test.ts > /tmp/t6.log 2>&1; tail -8 /tmp/t6.log
+pnpm run fmt:ts && pnpm run lint:structure
+git add lib/cli/local.ts scripts/agency.ts lib/stdlib/localModels.ts stdlib/agency/local.agency lib/cli/local.test.ts lib/stdlib/localModels.test.ts
+printf 'agency local remove: keep files unless -f is passed\n' > /tmp/msg.txt
+git commit -F /tmp/msg.txt
+```
+
+---
+
+### Task 7: Download picker and gate
+
+**Files:**
+- Modify: `lib/cli/local.ts` (`runDownload`, `downloadChoices`, `gate`)
+- Modify: `lib/stdlib/localModels.ts` (`_downloadModel`)
+- Test: `lib/cli/local.test.ts`
+
+This PR does not download MLX models. It makes `download` say so clearly.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+it("download of an mlx model says it is not supported yet", async () => {
+  await expect(_downloadModel("mlx:org/repo")).rejects.toThrow(
+    "Downloading MLX models is not supported yet. Download it another way and alias its directory: agency local alias add <name> <dir>",
+  );
+});
+```
+
+- [ ] **Step 2: Implement**
+
+At the top of `_downloadModel`, before `requireSupport()`:
+
+```ts
+  const resolved = _resolveModel(value);
+  if (resolved.backend === "mlx") {
+    throw new Error(
+      "Downloading MLX models is not supported yet. Download it another way and alias its directory: agency local alias add <name> <dir>",
+    );
+  }
+```
+
+In `runDownload`, move `gate()` below the resolution so an `mlx:` value reaches the message above instead of the install hint. Change the custom picker choice text to `custom (hf: URI, .gguf path, mlx: URI, or model directory)…`.
+
+- [ ] **Step 3: Run, then commit**
+
+```bash
+pnpm exec vitest run lib/cli/local.test.ts lib/stdlib/localModels.test.ts > /tmp/t7.log 2>&1; tail -8 /tmp/t7.log
+pnpm run fmt:ts && pnpm run lint:structure
+git add lib/cli/local.ts lib/stdlib/localModels.ts lib/cli/local.test.ts lib/stdlib/localModels.test.ts
+printf 'agency local download: say that MLX downloads come later\n' > /tmp/msg.txt
+git commit -F /tmp/msg.txt
+```
+
+Plan 3 replaces this message with the real downloader.
+
+---
+
+### Task 8: Dev doc
+
+**Files:**
+- Create: `docs/dev/llm/mlx-local-models.md`
+- Modify: `docs/dev/llm/local-models.md` (one paragraph at the top)
+- Modify: `CLAUDE.md` (the LLM plumbing index, near line 315)
+- Modify: `.claude/skills/agency-llm-docs/SKILL.md`
+
+- [ ] **Step 1: Write the doc**
+
+`docs/dev/llm/mlx-local-models.md` with these sections, each a few paragraphs in the style of `local-models.md`:
+
+1. Two backends. What `Backend` is, where `backendOfTarget` decides, the `mlx:` prefix, and the directory rule.
+2. The `backend` field. Where it is required, the two error messages, and why string aliases are exempt.
+3. Running against a server. `_mlxServedName` and why `serve` and `run --local` must produce the same string. The `mlx` capabilities entry.
+4. The record file. `mlxModelRecord.ts`, the directory layout, and that `list` reads it.
+5. `remove` and `-f`.
+6. What is not here yet: `serve` (plan 2) and download (plan 3).
+
+Add to the top of `local-models.md`: "This page covers the `llama-cpp` backend, which runs GGUF files in-process. MLX models, which run in a server, are in `mlx-local-models.md`."
+
+Add the index line in `CLAUDE.md` and the skill file:
+
+```
+- `docs/dev/llm/mlx-local-models.md` — The `mlx` backend: the `backend` field and `mlx:` prefix, how a run finds the served model name, the per-model record file, and the serve and download commands.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/dev/llm/mlx-local-models.md docs/dev/llm/local-models.md CLAUDE.md .claude/skills/agency-llm-docs/SKILL.md
+printf 'docs: mlx-local-models dev doc\n' > /tmp/msg.txt
+git commit -F /tmp/msg.txt
+```
+
+---
+
+### Task 9: Check on the Studio, then open the PR
+
+- [ ] **Step 1: Run against a hand-started server**
+
+On the Studio, with `~/mlx-env` from the spike:
+
+```bash
+~/mlx-env/bin/python -m mlx_lm.server --model /Volumes/adit-agency-models-sept-2026/hf/hub/models--mlx-community--Qwen3-Coder-Next-4bit/snapshots/7b9321eabb85ce79625cac3f61ea691e4ea984b5 --port 8080 --max-tokens 16384
+```
+
+In another terminal:
+
+```bash
+agency local alias add coder /Volumes/adit-agency-models-sept-2026/hf/hub/models--mlx-community--Qwen3-Coder-Next-4bit/snapshots/7b9321eabb85ce79625cac3f61ea691e4ea984b5
+agency local resolve coder
+agency local list
+pnpm run agency run --local coder spikes/mlx-tool-calling/add.agency
+pnpm run agency agent --local coder --approve FileRead --print "Read secret.txt in spikes/mlx-tool-calling and tell me the passphrase."
+```
+
+Expected: `resolve` prints `mlx  /Volumes/…`, `list` shows `coder` with backend `mlx`, the program prints `add called with 17 and 25`, and the agent returns the passphrase.
+
+- [ ] **Step 2: Typecheck, then open the PR**
+
+```bash
+pnpm run typecheck > /tmp/tc.log 2>&1; tail -3 /tmp/tc.log
+pnpm run fmt:ts && pnpm run lint:structure
+git push -u origin adit/mlx-backend
+```
+
+Write the PR body to a file. Say what a user can now do, list the `remove` behaviour change, and link the spec. Open with `gh pr create --body-file`. Do not merge.

--- a/packages/agency-lang/CLAUDE.md
+++ b/packages/agency-lang/CLAUDE.md
@@ -313,6 +313,7 @@ Other process docs:
 - `docs/dev/llm/llm-clients.md` — The `LLMClient` interface, for swapping smoltalk out for something else.
 - `docs/dev/llm/local-model-integration.md` — The integration suite that downloads and runs a real local model.
 - `docs/dev/llm/local-models.md` — How local-model support is wired, from the provider to model download and verification.
+- `docs/dev/llm/mlx-local-models.md` — The `mlx` backend: the `backend` field and `mlx:` prefix, how a run finds the served model name, the per-model record file, and `remove -f`.
 - `docs/dev/llm/smoltalk.md` — The external library Agency routes every LLM call through.
 - `docs/dev/llm/speech-via-smoltalk.md` — Speech-to-text and text-to-speech, routed through the LLM client so they inherit cost accounting and tracing.
 

--- a/packages/agency-lang/data/model-catalog.json
+++ b/packages/agency-lang/data/model-catalog.json
@@ -2,6 +2,7 @@
   "version": 1,
   "models": {
     "smollm2-135m": {
+      "backend": "llama-cpp",
       "uri": "hf:unsloth/SmolLM2-135M-Instruct-GGUF:Q4_K_M",
       "params": "135M",
       "sizeBytes": 105000000,
@@ -12,6 +13,7 @@
       "sha256": "ed5fa30c487b282ec156c29062f1222e5c20875a944ac98289dbd242e947f747"
     },
     "qwen3.5-0.8b": {
+      "backend": "llama-cpp",
       "uri": "hf:unsloth/Qwen3.5-0.8B-GGUF:Q4_K_M",
       "params": "0.8B",
       "sizeBytes": 500000000,
@@ -22,6 +24,7 @@
       "sha256": "bd258782e35f7f458f8aced1adc053e6e92e89bc735ba3be89d38a06121dc517"
     },
     "qwen3.5-2b": {
+      "backend": "llama-cpp",
       "uri": "hf:unsloth/Qwen3.5-2B-GGUF:Q4_K_M",
       "params": "2B",
       "sizeBytes": 1280000000,
@@ -32,6 +35,7 @@
       "sha256": "aaf42c8b7c3cab2bf3d69c355048d4a0ee9973d48f16c731c0520ee914699223"
     },
     "qwen3.5-4b": {
+      "backend": "llama-cpp",
       "uri": "hf:unsloth/Qwen3.5-4B-GGUF:Q4_K_M",
       "params": "4B",
       "sizeBytes": 2400000000,
@@ -42,6 +46,7 @@
       "sha256": "00fe7986ff5f6b463e62455821146049db6f9313603938a70800d1fb69ef11a4"
     },
     "gemma-4-e2b": {
+      "backend": "llama-cpp",
       "uri": "hf:unsloth/gemma-4-E2B-it-GGUF:Q4_K_M",
       "params": "2B (E2B)",
       "sizeBytes": 3110000000,
@@ -52,6 +57,7 @@
       "sha256": "740185b21d22ceb83a11c3aa62ad5842ef32c70f6096d756bbee85a1e4ec34b8"
     },
     "gemma-4-e4b": {
+      "backend": "llama-cpp",
       "uri": "hf:unsloth/gemma-4-E4B-it-GGUF:Q4_K_M",
       "params": "4B (E4B)",
       "sizeBytes": 4980000000,
@@ -62,6 +68,7 @@
       "sha256": "85a896a047553e842f25297ee5b031d64ff30147d9c4af17b1e4b394cd1fab87"
     },
     "granite-4.1-8b": {
+      "backend": "llama-cpp",
       "uri": "hf:unsloth/granite-4.1-8b-GGUF:Q4_K_M",
       "params": "8B",
       "sizeBytes": 5350000000,
@@ -72,6 +79,7 @@
       "sha256": "0f45c1af986e9900bb3b6ba46a25937e1bb80426935bc242d88c9ca90e9f5c88"
     },
     "qwen3.5-9b": {
+      "backend": "llama-cpp",
       "uri": "hf:unsloth/Qwen3.5-9B-GGUF:Q4_K_M",
       "params": "9B",
       "sizeBytes": 5500000000,
@@ -82,6 +90,7 @@
       "sha256": "03b74727a860a56338e042c4420bb3f04b2fec5734175f4cb9fa853daf52b7e8"
     },
     "gemma-4-12b": {
+      "backend": "llama-cpp",
       "uri": "hf:unsloth/gemma-4-12b-it-GGUF:Q4_K_M",
       "params": "12B",
       "sizeBytes": 7120000000,
@@ -92,6 +101,7 @@
       "sha256": "0a270ec9fe6b34f4a0d33992b6135117b484ebc4766ab76b51d4ae8c457e4c42"
     },
     "gpt-oss-20b": {
+      "backend": "llama-cpp",
       "uri": "hf:unsloth/gpt-oss-20b-GGUF:Q4_K_M",
       "params": "20B",
       "sizeBytes": 12000000000,
@@ -102,6 +112,7 @@
       "sha256": "c27536640e410032865dc68781d80a08b98f8db5e93575919af8ccc0568aeb4f"
     },
     "mistral-small-3.1": {
+      "backend": "llama-cpp",
       "uri": "hf:unsloth/Mistral-Small-3.1-24B-Instruct-2503-GGUF:Q4_K_M",
       "params": "24B",
       "sizeBytes": 14000000000,
@@ -112,6 +123,7 @@
       "sha256": "6d670773c3908584349d41a5048d1472226b593c881fd394e8ac196c802e81e2"
     },
     "mistral-small-3.2": {
+      "backend": "llama-cpp",
       "uri": "hf:unsloth/Mistral-Small-3.2-24B-Instruct-2506-GGUF:Q4_K_M",
       "params": "24B",
       "sizeBytes": 14333000000,
@@ -122,6 +134,7 @@
       "sha256": "a3cc56310807ed0d145eaf9f018ccda9ae7ad8edb41ec870aa2454b0d4700b3c"
     },
     "qwen3.5-27b": {
+      "backend": "llama-cpp",
       "uri": "hf:unsloth/Qwen3.5-27B-GGUF:Q4_K_M",
       "params": "27B",
       "sizeBytes": 16000000000,
@@ -132,6 +145,7 @@
       "sha256": "84b5f7f112156d63836a01a69dc3f11a6ba63b10a23b8ca7a7efaf52d5a2d806"
     },
     "gemma-4-26b-a4b": {
+      "backend": "llama-cpp",
       "uri": "hf:unsloth/gemma-4-26B-A4B-it-GGUF:Q4_K_M",
       "params": "26B (A4B)",
       "sizeBytes": 16900000000,
@@ -142,6 +156,7 @@
       "sha256": "f2c28b3dc4776931ac6f879e11f203dec637ea0f14267a86ec8f6165f63f293f"
     },
     "gemma-4-31b": {
+      "backend": "llama-cpp",
       "uri": "hf:unsloth/gemma-4-31B-it-GGUF:Q4_K_M",
       "params": "31B",
       "sizeBytes": 18300000000,
@@ -152,6 +167,7 @@
       "sha256": "38bd64c852c4b460434cc7162fa9bdcf242faf86502581a754cb72956bb17f84"
     },
     "qwen3.5-35b-a3b": {
+      "backend": "llama-cpp",
       "uri": "hf:unsloth/Qwen3.5-35B-A3B-GGUF:Q4_K_M",
       "params": "35B (A3B)",
       "sizeBytes": 22016000000,
@@ -162,6 +178,7 @@
       "sha256": "3b46d1066bc91cc2d613e3bc22ce691dd77e6f0d33c9060690d24ce6de494375"
     },
     "deepseek-r1-distill-llama-8b": {
+      "backend": "llama-cpp",
       "uri": "hf:unsloth/DeepSeek-R1-Distill-Llama-8B-GGUF:Q4_K_M",
       "params": "8B",
       "sizeBytes": 4920000000,
@@ -172,6 +189,7 @@
       "sha256": "0addb1339a82385bcd973186cd80d18dcc71885d45eabd899781a118d03827d9"
     },
     "deepseek-r1-0528-qwen3-8b": {
+      "backend": "llama-cpp",
       "uri": "hf:unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF:Q4_K_M",
       "params": "8B",
       "sizeBytes": 5030000000,
@@ -182,6 +200,7 @@
       "sha256": "a86349a4180c4e6bb43f874c29c404fa2be3f90b15509bd6d86f697dba724ec1"
     },
     "phi-4-reasoning": {
+      "backend": "llama-cpp",
       "uri": "hf:unsloth/Phi-4-reasoning-GGUF:Q4_K_M",
       "params": "14B",
       "sizeBytes": 9050000000,
@@ -192,6 +211,7 @@
       "sha256": "960d3870b218f91116c55bf81dc313e6cdbce31b1047bb2bc8bc7ea47899b032"
     },
     "magistral-small-2509": {
+      "backend": "llama-cpp",
       "uri": "hf:unsloth/Magistral-Small-2509-GGUF:Q4_K_M",
       "params": "24B",
       "sizeBytes": 14333000000,
@@ -202,6 +222,7 @@
       "sha256": "6d3e5f2a83ed9d64bd3382fb03be2f6e0bc7596a9de16e107bf22f959891945b"
     },
     "devstral-small-2507": {
+      "backend": "llama-cpp",
       "uri": "hf:mistralai/Devstral-Small-2507_gguf:Q4_K_M",
       "params": "24B",
       "sizeBytes": 14300000000,
@@ -212,6 +233,7 @@
       "sha256": "1bcc2b1b7b7ea3168ba2dbe782432c464f2240598bd193930122c41b117c1796"
     },
     "devstral-small-2-24b": {
+      "backend": "llama-cpp",
       "uri": "hf:unsloth/Devstral-Small-2-24B-Instruct-2512-GGUF:Q4_K_M",
       "params": "24B",
       "sizeBytes": 14334000000,
@@ -222,6 +244,7 @@
       "sha256": "d14ba9edee1bb4c4996a726deb81e49ae81800a3216f0774634238c380aee496"
     },
     "qwen3-coder-30b-a3b": {
+      "backend": "llama-cpp",
       "uri": "hf:unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF:Q4_K_M",
       "params": "30B (A3B)",
       "sizeBytes": 19000000000,
@@ -232,6 +255,7 @@
       "sha256": "fadc3e5f8d42bf7e894a785b05082e47daee4df26680389817e2093056f088ad"
     },
     "nomic-embed-text": {
+      "backend": "llama-cpp",
       "uri": "hf:nomic-ai/nomic-embed-text-v1.5-GGUF:Q4_K_M",
       "params": "137M",
       "sizeBytes": 89000000,

--- a/packages/agency-lang/docs/dev/llm/local-models.md
+++ b/packages/agency-lang/docs/dev/llm/local-models.md
@@ -1,6 +1,8 @@
 # Local models
 
-How `agency`'s local-model support is wired, end to end.
+How `agency`'s local-model support is wired, end to end. This page covers
+the `llama-cpp` backend, which runs GGUF files inside the Agency process.
+MLX models, which run in a server, are in `mlx-local-models.md`.
 
 ## Provider
 

--- a/packages/agency-lang/docs/dev/llm/local-models.md
+++ b/packages/agency-lang/docs/dev/llm/local-models.md
@@ -145,8 +145,8 @@ file, or sharded, as described below. We then verify integrity:
 
 Because we verify only freshly-downloaded files, a pin change (e.g. via
 `agency local refresh`) does **not** retroactively re-check a file you already
-have cached. Run `agency local remove <name>` to force a fresh, verified
-re-download.
+have cached. Run `agency local remove <name> -f` to delete the file and force
+a fresh, verified re-download.
 
 ### Updating the pins
 

--- a/packages/agency-lang/docs/dev/llm/mlx-local-models.md
+++ b/packages/agency-lang/docs/dev/llm/mlx-local-models.md
@@ -14,9 +14,15 @@ agency agent --local coder
 ```
 
 The server is `mlx_lm.server`, a Python program from the `mlx-lm` package.
-The user starts it. Agency reaches it through smoltalk's built-in `mlx`
-provider, which speaks the OpenAI chat format to `http://127.0.0.1:8080/v1`
-by default. The spec for the whole feature is
+The user starts it on a model:
+
+```bash
+~/mlx-env/bin/python -m mlx_lm.server --model /Volumes/models/hf/hub/models--mlx-community--Qwen3-Coder-Next-4bit/snapshots/7b93 --port 8080 --max-tokens 16384
+```
+
+Agency reaches it through smoltalk's built-in `mlx` provider, which speaks
+the OpenAI chat format to `http://127.0.0.1:8080/v1` by default, or to
+`MLX_BASE_URL`. The spec for the whole feature is
 `2026-09-07-mlx-local-models-spec.md` in the package root.
 
 ## Two backends
@@ -71,17 +77,18 @@ provider to `mlx` and the model to `_mlxServedName(resolved)`:
 - a repo id for an `mlx:` URI, so `mlx:org/repo@rev` sends `org/repo`;
 - the absolute directory path for a model directory.
 
-`agency local serve` gives `mlx_lm.server` the same string. The server serves
-whatever model a request names, and loads it if it is not loaded, so the two
-sides must agree or a run can trigger a load. Both sides call the one
-function. The agent's `PROVIDER_CAPABILITIES` table has an `mlx` entry with
-`memory: false` only; the server has no embeddings endpoint, and the models
-are large enough for the full prompt.
+The server serves whatever model a request names, and loads it if it is not
+loaded. So the string Agency sends must be the string the server was started
+with, or a run can trigger a load of another model. Start the server with
+the repo id or the absolute directory path, whichever `resolve` prints.
+
+The agent's `PROVIDER_CAPABILITIES` table has an `mlx` entry with
+`memory: false` only. The server has no embeddings endpoint, so the agent's
+memory stays off. The models are large enough for the full prompt.
 
 ## The record file and the directory layout
 
-Models Agency downloads itself go under the models directory, one folder per
-repo:
+MLX models under the models directory sit one folder per repo:
 
 ```
 <modelsDir>/
@@ -95,22 +102,22 @@ repo:
 ```
 
 `lib/stdlib/mlxModelRecord.ts` owns `.agency-model.json`: the repo, the commit
-it came from, and per-file size, hash, and progress. `list` reads it to mark
-a model downloaded, and to show an interrupted download as incomplete under
-OTHER FILES. `_listDownloadedModels` returns GGUF files and recorded MLX
+it came from, and per-file size, hash, and progress. A directory under `mlx/`
+without a valid record is not a model. `list` reads the record to mark a
+model downloaded, and to show an incomplete one under OTHER FILES. A pinned
+revision in an `mlx:` URI must match the record's commit, by prefix, to get
+the tick. `_listDownloadedModels` returns GGUF files and recorded MLX
 directories together, each tagged with its backend.
 
 ## `remove` and `-f`
 
 `agency local remove <name>` removes the alias and keeps the files. It prints
-where they are and says to run again with `-f` to delete them. `-f` deletes
-the `.gguf` file or the whole MLX directory. A directory outside the models
-directory is never deleted. This holds for GGUF models too, which used to be
-deleted on the first call.
+where they are and says to run again with `-f` to delete them. `-f` removes
+the alias and deletes the `.gguf` file or the whole MLX directory. A directory
+outside the models directory is never deleted. An alias whose directory has
+gone can still be removed. This holds for GGUF models too.
 
-## Not here yet
+## Downloading
 
-`agency local serve`, which starts the server and refuses models it was not
-given, and `agency local download mlx:…`, which fetches a repo from Hugging
-Face, are the next two PRs. Until then `download` of an `mlx:` URI says so
-and points at `alias add`.
+`agency local download` of an `mlx:` URI is refused with a message that
+points at `alias add`. A model directory passed to it is returned as is.

--- a/packages/agency-lang/docs/dev/llm/mlx-local-models.md
+++ b/packages/agency-lang/docs/dev/llm/mlx-local-models.md
@@ -1,0 +1,116 @@
+# MLX local models
+
+How Agency runs MLX models. The GGUF path, which runs a model inside the
+Agency process through llama.cpp, is in `local-models.md`. This page covers
+the second backend, which runs a model in a server on a Mac.
+
+The user-facing shape:
+
+```bash
+agency local alias add coder /Volumes/models/hf/hub/models--mlx-community--Qwen3-Coder-Next-4bit/snapshots/7b93
+agency local resolve coder            # mlx  /Volumes/models/...
+agency run --local coder my.agency    # provider mlx, model = that directory
+agency agent --local coder
+```
+
+The server is `mlx_lm.server`, a Python program from the `mlx-lm` package.
+The user starts it. Agency reaches it through smoltalk's built-in `mlx`
+provider, which speaks the OpenAI chat format to `http://127.0.0.1:8080/v1`
+by default. The spec for the whole feature is
+`2026-09-07-mlx-local-models-spec.md` in the package root.
+
+## Two backends
+
+`Backend` in `lib/stdlib/localModels.ts` is `"llama-cpp" | "mlx"`. Every
+model Agency knows about has exactly one. `backendOfTarget(target)` decides:
+
+| Target | Backend |
+|---|---|
+| `hf:org/repo:Q4_K_M`, `https://…/x.gguf`, `x.gguf` | `llama-cpp` |
+| `mlx:org/repo`, `mlx:org/repo@rev` | `mlx` |
+| A directory with `config.json` and a `.safetensors` file | `mlx` |
+| Anything else | throws "is not a model" |
+
+The directory rule is what makes models downloaded by other tools usable.
+Every model in Hugging Face's standard layout has a `config.json` and its
+weights in `.safetensors` files. That is what `mlx_lm.server` loads. A GGUF
+model is one file with that information inside it, so it never matches.
+
+`_resolveModel(value)` turns a name, alias, URI, or path into
+`{ backend, target }`. `_resolveModelName` returns only the target and stays
+for the callers that need a string.
+
+## The `backend` field
+
+Every entry in `CURATED_LOCAL_MODELS`, in `data/model-catalog.json`, and every
+object-form alias in `agency.json` carries `backend`. It is required, and it
+must agree with the URI. `readModelAliases` throws for a bad alias:
+
+```
+agency.json: alias "coder" has no "backend". Add "backend": "llama-cpp" or
+"backend": "mlx" to the entry in /Users/me/project/agency.json.
+
+agency.json: alias "coder" says backend "mlx" but its uri "hf:org/repo:Q4_K_M"
+is a GGUF file. Change one of them in /Users/me/project/agency.json.
+```
+
+`CatalogModelSchema` refuses a remote catalog entry without the field or with
+a disagreeing one, and the refresh skips it with a warning, the same way it
+skips a bad URI. A test walks the built-in table, so those errors can only
+come from a user's file or a remote catalog.
+
+A string-form alias, `"my7b": "hf:…"`, has nowhere to put the field. Its
+prefix is its backend.
+
+## Running against the server
+
+`agency run --local <name>` and `agency agent --local <name>` branch on the
+backend. For `mlx` they download nothing and register nothing. They set the
+provider to `mlx` and the model to `_mlxServedName(resolved)`:
+
+- a repo id for an `mlx:` URI, so `mlx:org/repo@rev` sends `org/repo`;
+- the absolute directory path for a model directory.
+
+`agency local serve` gives `mlx_lm.server` the same string. The server serves
+whatever model a request names, and loads it if it is not loaded, so the two
+sides must agree or a run can trigger a load. Both sides call the one
+function. The agent's `PROVIDER_CAPABILITIES` table has an `mlx` entry with
+`memory: false` only; the server has no embeddings endpoint, and the models
+are large enough for the full prompt.
+
+## The record file and the directory layout
+
+Models Agency downloads itself go under the models directory, one folder per
+repo:
+
+```
+<modelsDir>/
+  qwen3.5-2b-Q4_K_M.gguf
+  downloads.json
+  mlx/
+    mlx-community--Qwen3-Coder-Next-4bit/
+      .agency-model.json
+      config.json
+      model-00001-of-00009.safetensors
+```
+
+`lib/stdlib/mlxModelRecord.ts` owns `.agency-model.json`: the repo, the commit
+it came from, and per-file size, hash, and progress. `list` reads it to mark
+a model downloaded, and to show an interrupted download as incomplete under
+OTHER FILES. `_listDownloadedModels` returns GGUF files and recorded MLX
+directories together, each tagged with its backend.
+
+## `remove` and `-f`
+
+`agency local remove <name>` removes the alias and keeps the files. It prints
+where they are and says to run again with `-f` to delete them. `-f` deletes
+the `.gguf` file or the whole MLX directory. A directory outside the models
+directory is never deleted. This holds for GGUF models too, which used to be
+deleted on the first call.
+
+## Not here yet
+
+`agency local serve`, which starts the server and refuses models it was not
+given, and `agency local download mlx:…`, which fetches a repo from Hugging
+Face, are the next two PRs. Until then `download` of an `mlx:` URI says so
+and points at `alias add`.

--- a/packages/agency-lang/docs/site/cli/local.md
+++ b/packages/agency-lang/docs/site/cli/local.md
@@ -1,21 +1,35 @@
 ---
 title: local
-description: Documents the `agency local` command, which downloads, lists, aliases, and removes local GGUF models used by the `llama-cpp` provider.
+description: Documents the `agency local` command, which downloads, lists, aliases, and removes local models. GGUF models run through the `llama-cpp` provider; MLX models run in a server through the `mlx` provider.
 ---
 
 # local
 
-Use this to manage and run local models. Backed by `smoltalk-llama-cpp` + `node-llama-cpp`; install once with `npm i -g smoltalk-llama-cpp` before any subcommand that downloads/inspects models.
+Use this to manage and run local models. There are two kinds:
+
+- **GGUF models** run inside the Agency process through llama.cpp. Install `smoltalk-llama-cpp` once with `npm i -g smoltalk-llama-cpp` before downloading or running one.
+- **MLX models** run in a server on a Mac with Apple Silicon. You start the server yourself with `mlx_lm.server` from the Python `mlx-lm` package. Agency sends it requests. Nothing extra to install on the Agency side.
+
+Every model has a **backend**, `llama-cpp` or `mlx`. The name you type says which it is:
+
+| You type | Backend |
+|---|---|
+| a curated name such as `qwen3.5-2b` | from the catalog entry |
+| `hf:org/repo:Q4_K_M` or a `.gguf` path | `llama-cpp` |
+| `mlx:org/repo` or `mlx:org/repo@revision` | `mlx` |
+| a directory holding `config.json` and `.safetensors` files | `mlx` |
 
 ```bash
 agency local download                     # pick a model from the catalog interactively
 agency local download qwen3.5-2b          # curated name, alias, hf: URI, or .gguf path
-agency local list                         # the catalog, with downloaded models marked
+agency local list                         # the catalog, with backends and downloaded models marked
 agency local list -l                      # ...and each model's description
-agency local remove my-model.gguf         # delete a downloaded file by its name in the cache
-agency local resolve my7b                 # show what a name/alias maps to
+agency local remove my7b                  # remove the alias, keep the files
+agency local remove my7b -f               # remove the alias and delete the files
+agency local resolve my7b                 # show the backend and what a name/alias maps to
 
 agency local alias add my7b hf:Qwen/Qwen2.5-7B-Instruct-GGUF:Q4_K_M
+agency local alias add coder /models/mlx-community--Qwen3-Coder-Next-4bit   # an MLX model directory
 agency local alias list                   # curated + your aliases, with descriptions
 agency local alias remove my7b
 ```
@@ -25,21 +39,43 @@ The agent and `agency run` have shortcuts for the common case:
 ```bash
 agency agent --local qwen3.5-2b           # download (if needed) + run the agent locally
 agency run --local qwen3.5-2b my.agency   # download (if needed) + run a program locally
+agency run --local coder my.agency        # an MLX model: needs a running mlx_lm.server
 ```
 
 The agent's `--local` runs the local model as both the fast and slow model, so the deep subagents stay local too; it ignores `--model`/`--fastmodel`/`--slowmodel`. On `agency run`, `--local` and `--model` are mutually exclusive. See the [local models guide](/guide/using-local-models) for a walkthrough.
+
+### Running an MLX model
+
+An MLX model is a Hugging Face repo of `.safetensors` files, such as `mlx-community/Qwen3-Coder-Next-4bit`. Agency does not run it itself. Start the server on the model directory, then run against it:
+
+```bash
+# Terminal 1. Python 3.11 or newer with mlx-lm installed.
+python3 -m mlx_lm.server --model /models/mlx-community--Qwen3-Coder-Next-4bit --port 8080 --max-tokens 16384
+
+# Terminal 2.
+agency local alias add coder /models/mlx-community--Qwen3-Coder-Next-4bit
+agency run --local coder my.agency
+```
+
+Agency sends the server the same string you gave `--model`: the directory path for a directory alias, or the repo id for an `mlx:` URI. The server serves whatever model a request names and loads it if it is not loaded, so start the server with the string `agency local resolve` prints.
+
+The server listens on `http://127.0.0.1:8080/v1` by default. For another port, set `MLX_BASE_URL` or `client.baseUrl.mlx` in `agency.json`.
+
+The directory must hold real files. A Hugging Face cache snapshot directory holds symlinks, which Agency does not follow. Download with `hf download <repo> --local-dir <dir>` to get real files.
+
+Downloading an MLX model with `agency local download` is not supported yet.
 
 ### Subcommands
 
 | command | purpose |
 |---|---|
-| `agency local list` | Show the full catalog with a checkmark and on-disk size for downloaded models. The first line names the models directory. Files that match no catalog entry appear under `OTHER FILES`. Add `-l` / `--long` to print each model's description on its own line below its row. Works without `smoltalk-llama-cpp` installed. |
-| `agency local download [value]` | Download a model if not already cached; prints the source it resolved to and the local path. `<value>` may be a curated short name, an alias, an `hf:` URI, or an existing `.gguf` path. With no value, opens an interactive picker (in scripts it prints the catalog and exits 1 instead). |
-| `agency local remove <file>` | Delete a downloaded `.gguf` from the cache, by its file name as shown in `OTHER FILES` or the models directory. |
-| `agency local resolve <value>` | Show what a name/alias maps to, without downloading. |
+| `agency local list` | Show the full catalog with each model's backend, and a checkmark and on-disk size for downloaded models. The first line names the models directory. Files that match no catalog entry appear under `OTHER FILES`. Add `-l` / `--long` to print each model's description on its own line below its row. Works without `smoltalk-llama-cpp` installed. |
+| `agency local download [value]` | Download a GGUF model if not already cached; prints the source it resolved to and the local path. `<value>` may be a curated short name, an alias, an `hf:` URI, or an existing `.gguf` path. With no value, opens an interactive picker (in scripts it prints the catalog and exits 1 instead). An `mlx:` URI is refused: MLX downloads are not supported yet. |
+| `agency local remove <name> [-f]` | Remove the alias for a model and keep its files, printing where they are. With `-f`, delete the files too: the `.gguf` file, or the whole MLX model directory. Files outside the models directory are never deleted. |
+| `agency local resolve <value>` | Show the backend and what a name/alias maps to, without downloading. |
 | `agency local refresh [url]` | Fetch the remote model catalog and update the `source:"remote"` aliases in `agency.json`. Adds/updates models from the catalog, removes ones it dropped, and skips any name you've aliased yourself (printing what it would have set). |
 | `agency local alias list` | List usable short names. Curated entries show params, category, size, context window, and license (with the description on the next line); your aliases show their target. |
-| `agency local alias add <name> <uri>` | Add a short-name alias. Prints the `agency.json` path that was edited. |
+| `agency local alias add <name> <target>` | Add a short-name alias. The target is an `hf:` URI, a `.gguf` path, an `mlx:` URI, or an MLX model directory. Prints the `agency.json` path that was edited. |
 | `agency local alias remove <name>` | Remove a short-name alias. Prints the `agency.json` path that was inspected (the file is left untouched if the alias wasn't present). |
 
 ### Refreshing the catalog
@@ -79,7 +115,10 @@ read at runtime, so edits take effect on the next call:
 {
   "client": {
     "modelAliases": {
-      "my7b": "hf:Qwen/Qwen2.5-7B-Instruct-GGUF:Q4_K_M"
+      "my7b": "hf:Qwen/Qwen2.5-7B-Instruct-GGUF:Q4_K_M",
+      "coder": "mlx:mlx-community/Qwen3-Coder-Next-4bit",
+      // The object form needs a "backend" that matches the uri.
+      "big": { "backend": "mlx", "uri": "mlx:mlx-community/DeepSeek-V4-Flash-4bit", "params": "300B" }
     },
     "modelsDir": "/data/agency-models",
     // Override the URL `agency local refresh` fetches the model catalog from.
@@ -93,4 +132,4 @@ read at runtime, so edits take effect on the next call:
 
 - [Using local models guide](../guide/using-local-models) — the walkthrough, from install to `llm()` calls in code.
 - [`agency agent --local`](./agent) — the easy button that composes the local-model primitives.
-- [Custom providers guide](../guide/custom-providers) — for using any non-llama provider.
+- [Custom providers guide](../guide/custom-providers) — for using any other provider.

--- a/packages/agency-lang/docs/site/guide/using-local-models.md
+++ b/packages/agency-lang/docs/site/guide/using-local-models.md
@@ -75,10 +75,11 @@ The first line of `agency local list` names the models directory. By default it 
 }
 ```
 
-To free up disk space, delete a downloaded file by name:
+To free up disk space, delete a model's files with `-f`. Without `-f` the
+command only removes the alias and tells you where the files are.
 
 ```bash
-agency local remove hf_unsloth_Qwen3.5-2B.Q4_K_M.gguf
+agency local remove qwen3.5-2b -f
 ```
 
 ## Refresh the catalog

--- a/packages/agency-lang/docs/site/stdlib/agency/local.md
+++ b/packages/agency-lang/docs/site/stdlib/agency/local.md
@@ -24,21 +24,31 @@ Manage and run local GGUF models. Download models by curated short name or
 
 ### DownloadedModel
 
+A model on disk. For a GGUF file, `name` is the file name. For an MLX
+    model, `name` is the repo id and `path` is its directory. `complete` is
+    false for an MLX model whose download was interrupted.
+
 ```ts
+/** A model on disk. For a GGUF file, `name` is the file name. For an MLX
+    model, `name` is the repo id and `path` is its directory. `complete` is
+    false for an MLX model whose download was interrupted. */
 export type DownloadedModel = {
   name: string;
   path: string;
-  sizeBytes: number
+  sizeBytes: number;
+  backend: string;
+  complete: bool
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L34))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L39))
 
 ### ModelName
 
 ```ts
 export type ModelName = {
   name: string;
+  backend: string;
   target: string;
   source: string;
   params?: string;
@@ -50,7 +60,7 @@ export type ModelName = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L40))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L47))
 
 ### SkippedAlias
 
@@ -67,7 +77,7 @@ export type SkippedAlias = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L156))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L187))
 
 ### RefreshResult
 
@@ -87,7 +97,7 @@ export type RefreshResult = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L163))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L194))
 
 ## Functions
 
@@ -101,7 +111,7 @@ True if smoltalk-llama-cpp is installed.
 
 **Returns:** `bool`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L52))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L60))
 
 ### resolveModelName
 
@@ -122,7 +132,7 @@ Map a curated short name or alias to its Hugging Face URI. Pass URIs and
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L59))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L67))
 
 ### downloadModel
 
@@ -145,7 +155,7 @@ Download a model and return its local .gguf path.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L69))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L77))
 
 ### listDownloadedModels
 
@@ -153,7 +163,7 @@ Download a model and return its local .gguf path.
 listDownloadedModels(cacheDir: string = ""): DownloadedModel[]
 ```
 
-List downloaded .gguf models.
+List downloaded models: .gguf files and MLX model directories.
 
   @param cacheDir - models dir (empty string = per-user cache)
 
@@ -165,7 +175,7 @@ List downloaded .gguf models.
 
 **Returns:** `DownloadedModel[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L80))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L88))
 
 ### listModelNames
 
@@ -177,7 +187,7 @@ List usable short names: curated built-ins and your aliases.
 
 **Returns:** `ModelName[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L89))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L97))
 
 ### aliasModel
 
@@ -200,7 +210,7 @@ Add a short-name alias for a model URI
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L96))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L104))
 
 ### unaliasModel
 
@@ -221,7 +231,7 @@ Remove a short-name alias.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L107))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L115))
 
 ### removeModel
 
@@ -229,8 +239,9 @@ Remove a short-name alias.
 removeModel(name: string, cacheDir: string = ""): bool
 ```
 
-Delete a downloaded model file.
-  Returns false if the model was not present.
+Delete a downloaded GGUF file from the models directory. This is what
+  `agency local remove -f` does; without -f that command only removes the
+  alias. Returns false if the file was not present.
 
   @param name - the .gguf filename
   @param cacheDir - models dir (empty string = per-user cache)
@@ -244,7 +255,49 @@ Delete a downloaded model file.
 
 **Returns:** `bool`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L117))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L125))
+
+### localModelBackend
+
+```ts
+localModelBackend(value: string): string
+```
+
+Which engine runs a model: "llama-cpp" for GGUF files, "mlx" for MLX
+  models served by `agency local serve`.
+
+  @param value - name, alias, hf: URI, mlx: URI, .gguf path, or model directory
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| value | `string` |  |
+
+**Returns:** `string`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L137))
+
+### mlxServedName
+
+```ts
+mlxServedName(value: string): string
+```
+
+The model name to send to the MLX server for this model. It is the same
+  string `agency local serve` gives the server.
+
+  @param value - name, alias, mlx: URI, or model directory
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| value | `string` |  |
+
+**Returns:** `string`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L147))
 
 ### registerLocalProvider
 
@@ -254,7 +307,7 @@ registerLocalProvider()
 
 Register the llama-cpp provider so local models can be used for LLM calls.
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L128))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L157))
 
 ### registerLocalModel
 
@@ -264,8 +317,10 @@ registerLocalModel(value: string, cacheDir: string = ""): string
 
 Register the provider and ensure the model is downloaded. Returns the local
   .gguf path to use as the model for LLM calls with provider "llama-cpp".
+  For an MLX model this registers nothing and returns the name to send to
+  the server. Start the server first with `agency local serve`.
 
-  @param value - name, alias, hf: URI, or .gguf path
+  @param value - name, alias, hf: URI, mlx: URI, .gguf path, or model directory
   @param cacheDir - download dir (empty string = per-user cache)
 
 **Parameters:**
@@ -277,7 +332,7 @@ Register the provider and ensure the model is downloaded. Returns the local
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L135))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L164))
 
 ### printLocalCatalog
 
@@ -288,7 +343,7 @@ printLocalCatalog()
 Print the usable-model catalog (curated names + your aliases) as an
     aligned table, the same listing as `agency local alias list`.
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L146))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L177))
 
 ### refreshCatalog
 
@@ -316,4 +371,4 @@ Same operation as the `agency local refresh` CLI command.
 
 **Returns:** [RefreshResult](#refreshresult)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L175))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L206))

--- a/packages/agency-lang/docs/site/stdlib/agency/local.md
+++ b/packages/agency-lang/docs/site/stdlib/agency/local.md
@@ -1,14 +1,14 @@
 ---
 name: "local"
-description: "Manage and run local GGUF models: download by short name or Hugging Face URI, alias them, and register the local provider."
+description: "Manage and run local models: GGUF files through llama.cpp, and MLX models through a server."
 ---
 
 # local
 
-Manage and run local GGUF models. Download models by curated short name or
-  Hugging Face URI, alias them, list or remove downloads, and register the local
-  provider so `llm()` calls can use them. Requires the smoltalk-llama-cpp
-  package.
+Manage and run local models. A GGUF model downloads by curated short name
+  or Hugging Face URI and runs inside the Agency process; that needs the
+  smoltalk-llama-cpp package. An MLX model is named with an mlx: URI or a
+  model directory and runs in mlx_lm.server, which you start yourself.
 
   ```ts
   import { registerLocalModel } from "std::agency/local"
@@ -37,7 +37,7 @@ export type DownloadedModel = {
   path: string;
   sizeBytes: number;
   backend: string;
-  complete: bool
+  complete: boolean
 }
 ```
 
@@ -77,7 +77,7 @@ export type SkippedAlias = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L187))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L190))
 
 ### RefreshResult
 
@@ -97,7 +97,7 @@ export type RefreshResult = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L194))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L197))
 
 ## Functions
 
@@ -119,10 +119,11 @@ True if smoltalk-llama-cpp is installed.
 resolveModelName(value: string): string
 ```
 
-Map a curated short name or alias to its Hugging Face URI. Pass URIs and
-  .gguf paths through unchanged.
+Map a curated short name or alias to its target: an hf: URI or .gguf path
+  for a GGUF model, an mlx: URI or directory for an MLX model. Pass URIs and
+  paths through unchanged.
 
-  @param value - name, alias, hf: URI, or .gguf path
+  @param value - name, alias, hf: URI, mlx: URI, .gguf path, or model directory
 
 **Parameters:**
 
@@ -140,7 +141,8 @@ Map a curated short name or alias to its Hugging Face URI. Pass URIs and
 downloadModel(value: string, cacheDir: string = ""): string
 ```
 
-Download a model and return its local .gguf path.
+Download a model and return its local .gguf path. For an MLX model this
+  returns the model directory; downloading one is not supported yet.
   Skips the download if the file already exists in the cache dir.
 
   @param value - what to download
@@ -155,7 +157,7 @@ Download a model and return its local .gguf path.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L77))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L78))
 
 ### listDownloadedModels
 
@@ -175,7 +177,7 @@ List downloaded models: .gguf files and MLX model directories.
 
 **Returns:** `DownloadedModel[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L88))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L90))
 
 ### listModelNames
 
@@ -187,7 +189,7 @@ List usable short names: curated built-ins and your aliases.
 
 **Returns:** `ModelName[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L97))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L99))
 
 ### aliasModel
 
@@ -199,7 +201,7 @@ Add a short-name alias for a model URI
   Returns the path to the agency.json file that the alias was written to.
 
   @param name - the alias
-  @param uri - the hf: URI it maps to
+  @param uri - the hf: URI, mlx: URI, .gguf path, or model directory it maps to
 
 **Parameters:**
 
@@ -210,7 +212,7 @@ Add a short-name alias for a model URI
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L104))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L106))
 
 ### unaliasModel
 
@@ -231,7 +233,7 @@ Remove a short-name alias.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L115))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L117))
 
 ### removeModel
 
@@ -255,7 +257,7 @@ Delete a downloaded GGUF file from the models directory. This is what
 
 **Returns:** `bool`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L125))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L127))
 
 ### localModelBackend
 
@@ -264,7 +266,7 @@ localModelBackend(value: string): string
 ```
 
 Which engine runs a model: "llama-cpp" for GGUF files, "mlx" for MLX
-  models served by `agency local serve`.
+  models served by mlx_lm.server.
 
   @param value - name, alias, hf: URI, mlx: URI, .gguf path, or model directory
 
@@ -276,7 +278,7 @@ Which engine runs a model: "llama-cpp" for GGUF files, "mlx" for MLX
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L137))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L139))
 
 ### mlxServedName
 
@@ -284,8 +286,9 @@ Which engine runs a model: "llama-cpp" for GGUF files, "mlx" for MLX
 mlxServedName(value: string): string
 ```
 
-The model name to send to the MLX server for this model. It is the same
-  string `agency local serve` gives the server.
+The model name to send to the MLX server for this model: the repo id for
+  an mlx: URI, or the absolute path for a model directory. Start
+  mlx_lm.server with the same string.
 
   @param value - name, alias, mlx: URI, or model directory
 
@@ -297,7 +300,7 @@ The model name to send to the MLX server for this model. It is the same
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L147))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L149))
 
 ### registerLocalProvider
 
@@ -307,7 +310,7 @@ registerLocalProvider()
 
 Register the llama-cpp provider so local models can be used for LLM calls.
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L157))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L160))
 
 ### registerLocalModel
 
@@ -318,7 +321,7 @@ registerLocalModel(value: string, cacheDir: string = ""): string
 Register the provider and ensure the model is downloaded. Returns the local
   .gguf path to use as the model for LLM calls with provider "llama-cpp".
   For an MLX model this registers nothing and returns the name to send to
-  the server. Start the server first with `agency local serve`.
+  the server. Start mlx_lm.server on that model first.
 
   @param value - name, alias, hf: URI, mlx: URI, .gguf path, or model directory
   @param cacheDir - download dir (empty string = per-user cache)
@@ -332,7 +335,7 @@ Register the provider and ensure the model is downloaded. Returns the local
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L164))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L167))
 
 ### printLocalCatalog
 
@@ -343,7 +346,7 @@ printLocalCatalog()
 Print the usable-model catalog (curated names + your aliases) as an
     aligned table, the same listing as `agency local alias list`.
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L177))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L180))
 
 ### refreshCatalog
 
@@ -371,4 +374,4 @@ Same operation as the `agency local refresh` CLI command.
 
 **Returns:** [RefreshResult](#refreshresult)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L206))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L209))

--- a/packages/agency-lang/lib/agents/agency-agent/lib/args.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/args.agency
@@ -98,7 +98,7 @@ export def parseAgentArgs() {
         local: {
           type: "string",
           optional: true,
-          description: "Run a local model (downloads if needed): a curated short name, an hf: URI, or a .gguf path. Run without a value for guided setup. Pins all slots to the local model; mutually exclusive with --model/--fastmodel/--slowmodel. Requires: npm i -g smoltalk-llama-cpp"
+          description: "Run a local model: a curated short name, an alias, an hf: URI, a .gguf path, an mlx: URI, or a model directory. GGUF models download if needed and need: npm i -g smoltalk-llama-cpp. MLX models need a running server: agency local serve <model>. Run without a value for guided setup. Pins all slots to the local model; mutually exclusive with --model/--fastmodel/--slowmodel."
         },
         "local-model": {
           type: "string",

--- a/packages/agency-lang/lib/agents/agency-agent/lib/args.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/args.agency
@@ -98,7 +98,7 @@ export def parseAgentArgs() {
         local: {
           type: "string",
           optional: true,
-          description: "Run a local model: a curated short name, an alias, an hf: URI, a .gguf path, an mlx: URI, or a model directory. GGUF models download if needed and need: npm i -g smoltalk-llama-cpp. MLX models need a running server: agency local serve <model>. Run without a value for guided setup. Pins all slots to the local model; mutually exclusive with --model/--fastmodel/--slowmodel."
+          description: "Run a local model: a curated short name, an alias, an hf: URI, a .gguf path, an mlx: URI, or a model directory. GGUF models download if needed and need: npm i -g smoltalk-llama-cpp. MLX models need a running mlx_lm.server on http://127.0.0.1:8080 (or MLX_BASE_URL). Run without a value for guided setup. Pins all slots to the local model; mutually exclusive with --model/--fastmodel/--slowmodel."
         },
         "local-model": {
           type: "string",

--- a/packages/agency-lang/lib/agents/agency-agent/lib/capabilities.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/capabilities.agency
@@ -114,6 +114,10 @@ export static const PROVIDER_CAPABILITIES: Record<string, CapabilityPatch> = {
     summarize: false,
     memory: false,
     maxTokens: 2000
+  },
+  // No embeddings endpoint. The models are large enough for the full prompt.
+  mlx: {
+    memory: false
   }
 }
 

--- a/packages/agency-lang/lib/agents/agency-agent/shared.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/shared.agency
@@ -447,7 +447,7 @@ export def configureModels(
 /** Apply a local model (from `--local`) as BOTH the fast and slow model,
  *  so a fully-local run needs no hosted-provider key. A GGUF model: register
  *  the llama-cpp provider and download if needed. An MLX model: point every
- *  slot at the server the user started with `agency local serve`. */
+ *  slot at the mlx_lm.server the user started. */
 export def configureLocalModel(value: string) {
   // An MLX model runs in a server the user started. Nothing to download or
   // register: point every slot at the name the server knows it by.

--- a/packages/agency-lang/lib/agents/agency-agent/shared.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/shared.agency
@@ -6,7 +6,7 @@
  *   - Enable persistent memory so each subagent's `remember`/`recall`
  *     calls land in a stable on-disk knowledge graph.
  */
-import { registerLocalModel } from "std::agency/local"
+import { registerLocalModel, localModelBackend, mlxServedName } from "std::agency/local"
 import { keys } from "std::object"
 import { setLlmOptions, envVarFor } from "std::llm"
 import { enableMemory, MemoryConfig } from "std::memory"
@@ -444,11 +444,35 @@ export def configureModels(
   applyResolved(promoteAll(all.value))
 }
 
-/** Apply a local model (from `--local-model`) as BOTH the fast and slow
- *  model: register the llama-cpp provider, download the model if needed into
- *  the agent's models cache, and point every LLM call — including the deep
- *  subagents — at it, so a fully-local run needs no hosted-provider key. */
+/** Apply a local model (from `--local`) as BOTH the fast and slow model,
+ *  so a fully-local run needs no hosted-provider key. A GGUF model: register
+ *  the llama-cpp provider and download if needed. An MLX model: point every
+ *  slot at the server the user started with `agency local serve`. */
 export def configureLocalModel(value: string) {
+  // An MLX model runs in a server the user started with `agency local
+  // serve`. Nothing to download or register: point every slot at the name
+  // the server knows it by.
+  const backend = localModelBackend(value)
+  if (backend == "mlx") {
+    const m: Resolved = {
+      model: mlxServedName(value),
+      provider: "mlx",
+      via: "local"
+    }
+    applyResolved(
+      {
+      main: m,
+      reasoning: m,
+      embedding: {
+        model: "",
+        provider: "mlx",
+        via: "local"
+      }
+    },
+    )
+    refreshCapabilities(value, "mlx")
+    return
+  }
   // `try` captures any failure (smoltalk-llama-cpp not installed, an unknown
   // model name, a download error) as a Result instead of letting the runtime
   // convert the throw to a Failure and silently continue into the REPL. A

--- a/packages/agency-lang/lib/agents/agency-agent/shared.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/shared.agency
@@ -449,11 +449,15 @@ export def configureModels(
  *  the llama-cpp provider and download if needed. An MLX model: point every
  *  slot at the server the user started with `agency local serve`. */
 export def configureLocalModel(value: string) {
-  // An MLX model runs in a server the user started with `agency local
-  // serve`. Nothing to download or register: point every slot at the name
-  // the server knows it by.
-  const backend = localModelBackend(value)
-  if (backend == "mlx") {
+  // An MLX model runs in a server the user started. Nothing to download or
+  // register: point every slot at the name the server knows it by.
+  const backendResult = try localModelBackend(value)
+  if (isFailure(backendResult)) {
+    print(backendResult.error)
+    process.exit(1)
+    return
+  }
+  if (backendResult.value == "mlx") {
     const m: Resolved = {
       model: mlxServedName(value),
       provider: "mlx",

--- a/packages/agency-lang/lib/cli/local.test.ts
+++ b/packages/agency-lang/lib/cli/local.test.ts
@@ -9,6 +9,7 @@ import {
   formatRefreshOutput,
   runList,
   runResolve,
+  runRemove,
   runDownload,
   downloadChoices,
   CUSTOM_CHOICE,
@@ -163,6 +164,100 @@ describe("runResolve", () => {
       expect(log).toHaveBeenCalledWith("mlx  mlx:mlx-community/Qwen3-Coder-Next-4bit");
     } finally {
       log.mockRestore();
+    }
+  });
+});
+
+describe("runRemove", () => {
+  let cwd: string;
+  let models: string;
+  let gguf: string;
+  let output: string[];
+  let log: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    cwd = process.cwd();
+    process.chdir(dir);
+    models = path.join(dir, "models");
+    fs.mkdirSync(models);
+    gguf = path.join(models, "coder.gguf");
+    fs.writeFileSync(gguf, "xxxx");
+    fs.writeFileSync(
+      path.join(models, "downloads.json"),
+      JSON.stringify({ "hf:org/coder:Q4_K_M": "coder.gguf" }),
+    );
+    fs.writeFileSync(
+      aliasFile,
+      JSON.stringify({ client: { modelAliases: { coder: "hf:org/coder:Q4_K_M" } } }),
+    );
+    process.env.AGENCY_MODELS_DIR = models;
+    process.env.AGENCY_LLAMA_PROVIDER_MODULE = "/nonexistent/fake.mjs";
+    output = [];
+    log = vi.spyOn(console, "log").mockImplementation((line: string) => {
+      output.push(line);
+    });
+  });
+  afterEach(() => {
+    log.mockRestore();
+    delete process.env.AGENCY_MODELS_DIR;
+    delete process.env.AGENCY_LLAMA_PROVIDER_MODULE;
+    process.chdir(cwd);
+  });
+
+  it("without -f removes the alias, keeps the files, and says how to delete them", () => {
+    runRemove("coder", { force: false });
+    expect(output[0]).toBe(`Removed alias "coder" from ${aliasFile}.`);
+    expect(output[1]).toBe(`The model files are still at ${gguf} (0.00 GB).`);
+    expect(output[2]).toBe("Run again with -f to delete them.");
+    expect(fs.existsSync(gguf)).toBe(true);
+    expect(JSON.parse(fs.readFileSync(aliasFile, "utf-8")).client.modelAliases).toEqual({});
+  });
+
+  it("with -f deletes the files", () => {
+    runRemove("coder", { force: true });
+    expect(output[0]).toBe(`Deleted ${gguf} (0.00 GB)`);
+    expect(fs.existsSync(gguf)).toBe(false);
+  });
+
+  it("a curated name without -f says there is no alias and where the file is", () => {
+    runRemove("smollm2-135m", { force: false });
+    expect(output[0]).toBe(
+      '"smollm2-135m" is a built-in catalog entry, so there is no alias to remove.',
+    );
+    expect(output.length).toBe(1);
+  });
+
+  it("with -f deletes an mlx model directory under the cache", () => {
+    const model = path.join(models, "mlx", "org--repo");
+    fs.mkdirSync(model, { recursive: true });
+    fs.writeFileSync(path.join(model, "config.json"), "{}");
+    fs.writeFileSync(path.join(model, "model.safetensors"), "xx");
+    fs.writeFileSync(
+      path.join(model, ".agency-model.json"),
+      JSON.stringify({ repo: "org/repo", revision: "a", files: {} }),
+    );
+    runRemove("mlx:org/repo", { force: true });
+    expect(output[0]).toMatch(/^Deleted .*org--repo/);
+    expect(fs.existsSync(model)).toBe(false);
+  });
+
+  it("refuses to delete a model directory outside the cache", () => {
+    const outside = path.join(dir, "elsewhere");
+    fs.mkdirSync(outside);
+    fs.writeFileSync(path.join(outside, "config.json"), "{}");
+    fs.writeFileSync(path.join(outside, "model.safetensors"), "xx");
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("exit called");
+    }) as never);
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      expect(() => runRemove(outside, { force: true })).toThrow("exit called");
+      expect(err).toHaveBeenCalledWith(
+        "That model is not in the models directory; remove it yourself.",
+      );
+      expect(fs.existsSync(outside)).toBe(true);
+    } finally {
+      exitSpy.mockRestore();
+      err.mockRestore();
     }
   });
 });

--- a/packages/agency-lang/lib/cli/local.test.ts
+++ b/packages/agency-lang/lib/cli/local.test.ts
@@ -8,6 +8,7 @@ import {
   aliasRemove,
   formatRefreshOutput,
   runList,
+  runResolve,
   runDownload,
   downloadChoices,
   CUSTOM_CHOICE,
@@ -149,5 +150,19 @@ describe("formatRefreshOutput", () => {
     expect(
       lines.some((l) => l.includes("2 added, 0 updated, 1 unchanged, 1 removed, 1 skipped")),
     ).toBe(true);
+  });
+});
+
+describe("runResolve", () => {
+  it("prints the backend and the target", () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      runResolve("smollm2-135m");
+      expect(log).toHaveBeenCalledWith("llama-cpp  hf:unsloth/SmolLM2-135M-Instruct-GGUF:Q4_K_M");
+      runResolve("mlx:mlx-community/Qwen3-Coder-Next-4bit");
+      expect(log).toHaveBeenCalledWith("mlx  mlx:mlx-community/Qwen3-Coder-Next-4bit");
+    } finally {
+      log.mockRestore();
+    }
   });
 });

--- a/packages/agency-lang/lib/cli/local.test.ts
+++ b/packages/agency-lang/lib/cli/local.test.ts
@@ -92,6 +92,33 @@ describe("downloadChoices", () => {
 });
 
 describe("runDownload without a value, non-interactive", () => {
+  it("does not need smoltalk-llama-cpp before the user has picked a model", async () => {
+    // No override and no package: the non-interactive path must still print
+    // the catalog and the hint rather than the install message.
+    delete process.env.AGENCY_LLAMA_PROVIDER_MODULE;
+    const savedIn = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`exit:${code}`);
+    }) as never);
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      await expect(runDownload(undefined)).rejects.toThrow("exit:1");
+      expect(errSpy.mock.calls.some((c) => String(c[0]).includes("smoltalk-llama-cpp"))).toBe(
+        false,
+      );
+      expect(
+        errSpy.mock.calls.some((c) => String(c[0]).includes("agency local download <name>")),
+      ).toBe(true);
+    } finally {
+      Object.defineProperty(process.stdin, "isTTY", { value: savedIn, configurable: true });
+      exitSpy.mockRestore();
+      logSpy.mockRestore();
+      errSpy.mockRestore();
+    }
+  });
+
   /** Run runDownload(undefined) with the given TTY shape; expect the
    *  non-interactive path: catalog + hint + exit 1. */
   async function expectNonInteractive(stdinTTY: boolean, stdoutTTY: boolean) {
@@ -214,7 +241,8 @@ describe("runRemove", () => {
 
   it("with -f deletes the files", () => {
     runRemove("coder", { force: true });
-    expect(output[0]).toBe(`Deleted ${gguf} (0.00 GB)`);
+    expect(output[0]).toBe(`Removed alias "coder" from ${aliasFile}.`);
+    expect(output[1]).toBe(`Deleted ${gguf} (0.00 GB)`);
     expect(fs.existsSync(gguf)).toBe(false);
   });
 
@@ -238,6 +266,34 @@ describe("runRemove", () => {
     runRemove("mlx:org/repo", { force: true });
     expect(output[0]).toMatch(/^Deleted .*org--repo/);
     expect(fs.existsSync(model)).toBe(false);
+  });
+
+  it("with -f removes the alias as well as the files", () => {
+    runRemove("coder", { force: true });
+    expect(JSON.parse(fs.readFileSync(aliasFile, "utf-8")).client.modelAliases).toEqual({});
+    expect(fs.existsSync(gguf)).toBe(false);
+  });
+
+  it("removes an alias whose directory has gone", () => {
+    fs.writeFileSync(
+      aliasFile,
+      JSON.stringify({ client: { modelAliases: { gone: path.join(dir, "vanished") } } }),
+    );
+    runRemove("gone", { force: false });
+    expect(output[0]).toBe(`Removed alias "gone" from ${aliasFile}.`);
+    expect(JSON.parse(fs.readFileSync(aliasFile, "utf-8")).client.modelAliases).toEqual({});
+  });
+
+  it("without -f, an alias to a directory outside the cache says to delete it yourself", () => {
+    const outside = path.join(dir, "elsewhere");
+    fs.mkdirSync(outside);
+    fs.writeFileSync(path.join(outside, "config.json"), "{}");
+    fs.writeFileSync(path.join(outside, "model.safetensors"), "xx");
+    fs.writeFileSync(aliasFile, JSON.stringify({ client: { modelAliases: { ext: outside } } }));
+    runRemove("ext", { force: false });
+    expect(output[0]).toBe(`Removed alias "ext" from ${aliasFile}.`);
+    expect(output[1]).toContain("outside the models directory, so delete them yourself");
+    expect(output.some((l) => l.includes("-f"))).toBe(false);
   });
 
   it("refuses to delete a model directory outside the cache", () => {

--- a/packages/agency-lang/lib/cli/local.test.ts
+++ b/packages/agency-lang/lib/cli/local.test.ts
@@ -75,12 +75,13 @@ describe("downloadChoices", () => {
     const choices = downloadChoices([
       {
         name: "tiny",
+        backend: "llama-cpp",
         target: "hf:o/t:Q4",
         source: "curated",
         params: "135M",
         sizeBytes: 100_000_000,
       },
-      { name: "plain-alias", target: "hf:x/y:Q4", source: "alias" },
+      { name: "plain-alias", backend: "llama-cpp", target: "hf:x/y:Q4", source: "alias" },
     ]);
     expect(choices[0]).toEqual({ title: "tiny  (135M, 0.10 GB)", value: "tiny" });
     expect(choices[1]).toEqual({ title: "plain-alias", value: "plain-alias" });

--- a/packages/agency-lang/lib/cli/local.ts
+++ b/packages/agency-lang/lib/cli/local.ts
@@ -90,13 +90,16 @@ export function downloadChoices(entries: ModelNameEntry[]): { title: string; val
         : e.name,
     value: e.name,
   }));
-  return [...rows, { title: "custom (hf: URI or .gguf path)…", value: CUSTOM_CHOICE }];
+  return [
+    ...rows,
+    { title: "custom (hf: URI, .gguf path, mlx: URI, or model directory)…", value: CUSTOM_CHOICE },
+  ];
 }
 
 export async function runDownload(value?: string): Promise<void> {
-  gate();
   let picked = value;
   if (picked === undefined) {
+    gate();
     // Prompting needs BOTH ends of the terminal: a TTY stdout to draw on and
     // a TTY stdin to read from (`agency local download < /dev/null` from a
     // terminal has a TTY stdout but nothing to read).
@@ -121,7 +124,7 @@ export async function runDownload(value?: string): Promise<void> {
       const custom = await prompts({
         type: "text",
         name: "value",
-        message: "hf: URI or .gguf path:",
+        message: "hf: URI, .gguf path, mlx: URI, or model directory:",
       });
       if (custom.value == null || custom.value === "") return;
       picked = custom.value as string;
@@ -130,7 +133,11 @@ export async function runDownload(value?: string): Promise<void> {
   // Show the source it resolved to (the hf: URI for a name/alias) and the
   // local path it landed at. For a .gguf-path input the two are the same, so
   // the source line is skipped.
-  const source = _resolveModelName(picked);
+  const resolved = _resolveModel(picked);
+  if (resolved.backend === "llama-cpp") {
+    gate();
+  }
+  const source = resolved.target;
   const modelPath = await _downloadModel(picked);
   if (source !== modelPath) {
     console.log(`source: ${source}`);

--- a/packages/agency-lang/lib/cli/local.ts
+++ b/packages/agency-lang/lib/cli/local.ts
@@ -1,7 +1,14 @@
 import prompts from "prompts";
+import * as path from "node:path";
 import {
+  CURATED_LOCAL_MODELS,
   _resolveModel,
   _resolveModelName,
+  _removeMlxModel,
+  _modelFilesOnDisk,
+  readModelAliases,
+  isMlxUri,
+  parseMlxUri,
   _downloadModel,
   _listDownloadedModels,
   _listModelNames,
@@ -131,10 +138,52 @@ export async function runDownload(value?: string): Promise<void> {
   console.log(`model:  ${modelPath}`);
 }
 
-export function runRemove(name: string): void {
+/** Without `-f`: drop the alias, keep the files, and say where they are.
+ *  With `-f`: delete the files too. Models are large, so deleting is the
+ *  step that needs the flag. */
+export function runRemove(name: string, opts: { force: boolean }): void {
+  const resolved = _resolveModel(name);
+  const aliases = readModelAliases();
+  const files = _modelFilesOnDisk(resolved);
+  const where = files === null ? null : `${files.path} (${formatGB(files.sizeBytes)})`;
+  const isAlias = Object.hasOwn(aliases, name);
+  const isCurated = Object.hasOwn(CURATED_LOCAL_MODELS, name);
+
+  if (!opts.force) {
+    if (isAlias) {
+      const { file } = _unaliasModel(name);
+      console.log(`Removed alias "${name}" from ${file}.`);
+    } else if (isCurated) {
+      console.log(`"${name}" is a built-in catalog entry, so there is no alias to remove.`);
+    }
+    if (where !== null) {
+      console.log(`The model files are still at ${where}.`);
+      console.log("Run again with -f to delete them.");
+    } else if (!isAlias && !isCurated) {
+      console.log(`Nothing to remove for "${name}".`);
+    }
+    return;
+  }
+
+  if (files === null) {
+    console.log(`Not found: ${name}`);
+    return;
+  }
+  if (!files.insideCache) {
+    console.error("That model is not in the models directory; remove it yourself.");
+    process.exit(1);
+  }
+  if (resolved.backend === "mlx") {
+    const repo = isMlxUri(resolved.target)
+      ? parseMlxUri(resolved.target).repo
+      : path.basename(files.path).replace("--", "/");
+    const removed = _removeMlxModel(repo);
+    console.log(removed ? `Deleted ${where}` : `Not found: ${name}`);
+    return;
+  }
   gate();
-  const removed = _removeModel(name);
-  console.log(removed ? `Removed ${name}` : `Not found: ${name}`);
+  const removed = _removeModel(path.basename(files.path));
+  console.log(removed ? `Deleted ${where}` : `Not found: ${name}`);
 }
 
 export function runResolve(value: string): void {

--- a/packages/agency-lang/lib/cli/local.ts
+++ b/packages/agency-lang/lib/cli/local.ts
@@ -1,5 +1,6 @@
 import prompts from "prompts";
 import {
+  _resolveModel,
   _resolveModelName,
   _downloadModel,
   _listDownloadedModels,
@@ -137,7 +138,8 @@ export function runRemove(name: string): void {
 }
 
 export function runResolve(value: string): void {
-  console.log(_resolveModelName(value));
+  const { backend, target } = _resolveModel(value);
+  console.log(`${backend}  ${target}`);
 }
 
 export function runAliasList(): void {

--- a/packages/agency-lang/lib/cli/local.ts
+++ b/packages/agency-lang/lib/cli/local.ts
@@ -7,6 +7,7 @@ import {
   _removeMlxModel,
   _modelFilesOnDisk,
   readModelAliases,
+  type ResolvedModel,
   isMlxUri,
   parseMlxUri,
   _downloadModel,
@@ -99,7 +100,6 @@ export function downloadChoices(entries: ModelNameEntry[]): { title: string; val
 export async function runDownload(value?: string): Promise<void> {
   let picked = value;
   if (picked === undefined) {
-    gate();
     // Prompting needs BOTH ends of the terminal: a TTY stdout to draw on and
     // a TTY stdin to read from (`agency local download < /dev/null` from a
     // terminal has a TTY stdout but nothing to read).
@@ -149,21 +149,38 @@ export async function runDownload(value?: string): Promise<void> {
  *  With `-f`: delete the files too. Models are large, so deleting is the
  *  step that needs the flag. */
 export function runRemove(name: string, opts: { force: boolean }): void {
-  const resolved = _resolveModel(name);
   const aliases = readModelAliases();
-  const files = _modelFilesOnDisk(resolved);
-  const where = files === null ? null : `${files.path} (${formatGB(files.sizeBytes)})`;
   const isAlias = Object.hasOwn(aliases, name);
   const isCurated = Object.hasOwn(CURATED_LOCAL_MODELS, name);
 
-  if (!opts.force) {
-    if (isAlias) {
-      const { file } = _unaliasModel(name);
-      console.log(`Removed alias "${name}" from ${file}.`);
-    } else if (isCurated) {
-      console.log(`"${name}" is a built-in catalog entry, so there is no alias to remove.`);
+  // Resolve before touching the alias, but let a stale alias (its directory
+  // moved or deleted) still be removed: the alias is the thing being removed,
+  // and its target no longer matters.
+  let resolved: ResolvedModel | null;
+  try {
+    resolved = _resolveModel(name);
+  } catch (err) {
+    if (!isAlias) {
+      throw err;
     }
-    if (where !== null) {
+    resolved = null;
+  }
+  const files = resolved === null ? null : _modelFilesOnDisk(resolved);
+  const where = files === null ? null : `${files.path} (${formatGB(files.sizeBytes)})`;
+
+  if (isAlias) {
+    const { file } = _unaliasModel(name);
+    console.log(`Removed alias "${name}" from ${file}.`);
+  } else if (isCurated && !opts.force) {
+    console.log(`"${name}" is a built-in catalog entry, so there is no alias to remove.`);
+  }
+
+  if (!opts.force) {
+    if (files !== null && !files.insideCache) {
+      console.log(
+        `The model files are still at ${where}. They are outside the models directory, so delete them yourself if you want them gone.`,
+      );
+    } else if (where !== null) {
       console.log(`The model files are still at ${where}.`);
       console.log("Run again with -f to delete them.");
     } else if (!isAlias && !isCurated) {
@@ -172,7 +189,7 @@ export function runRemove(name: string, opts: { force: boolean }): void {
     return;
   }
 
-  if (files === null) {
+  if (files === null || resolved === null) {
     console.log(`Not found: ${name}`);
     return;
   }

--- a/packages/agency-lang/lib/cli/localFlag.test.ts
+++ b/packages/agency-lang/lib/cli/localFlag.test.ts
@@ -62,3 +62,27 @@ describe("resolveLocalRunFlag", () => {
     await expect(resolveLocalRunFlag("qwen3.5-0.8b")).rejects.toThrow(/smoltalk-llama-cpp/);
   });
 });
+
+describe("resolveLocalRunFlag for mlx", () => {
+  it("pins the mlx provider and passes the repo id, with no download", async () => {
+    const flag = await resolveLocalRunFlag("mlx:mlx-community/Qwen3-Coder-Next-4bit");
+    expect(flag).toEqual({
+      model: "mlx-community/Qwen3-Coder-Next-4bit",
+      explicitProvider: "mlx",
+    });
+    expect(smoltalkPkg.hasProvider("llama-cpp")).toBe(false);
+  });
+
+  it("passes a model directory as its absolute path", async () => {
+    const model = path.join(here, `__tmp_model_${process.pid}`);
+    fs.mkdirSync(model, { recursive: true });
+    fs.writeFileSync(path.join(model, "config.json"), "{}");
+    fs.writeFileSync(path.join(model, "model.safetensors"), "");
+    try {
+      const flag = await resolveLocalRunFlag(model);
+      expect(flag).toEqual({ model, explicitProvider: "mlx" });
+    } finally {
+      fs.rmSync(model, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/agency-lang/lib/cli/localFlag.ts
+++ b/packages/agency-lang/lib/cli/localFlag.ts
@@ -16,7 +16,7 @@ import { _registerLocalModel, _resolveModel, _mlxServedName } from "@/stdlib/loc
 export async function resolveLocalRunFlag(value: string): Promise<ResolvedModelFlag> {
   const resolved = _resolveModel(value);
   if (resolved.backend === "mlx") {
-    // The server is already running, started with `agency local serve`.
+    // The user has already started mlx_lm.server on this model.
     // Nothing to download or register.
     return { model: _mlxServedName(resolved), explicitProvider: "mlx" };
   }

--- a/packages/agency-lang/lib/cli/localFlag.ts
+++ b/packages/agency-lang/lib/cli/localFlag.ts
@@ -1,11 +1,12 @@
 import * as path from "node:path";
 import type { ResolvedModelFlag } from "@/config.js";
-import { _registerLocalModel } from "@/stdlib/localModels.js";
+import { _registerLocalModel, _resolveModel, _mlxServedName } from "@/stdlib/localModels.js";
 
 /** Turn `agency run --local <value>` into the shared model-flag shape:
- *  resolve the name (curated / alias / hf: URI / .gguf path), download and
- *  verify if needed (progress prints here, in the parent, before the program
- *  starts), and pin the llama-cpp provider. Errors (package missing, unknown
+ *  resolve the name, and for a GGUF model download and verify if needed
+ *  (progress prints here, in the parent, before the program starts) and pin
+ *  the llama-cpp provider. An MLX model pins the mlx provider and the name
+ *  the running server knows it by. Errors (package missing, unknown
  *  name, failed download) carry user-ready messages from localModels.
  *
  *  The path is absolutized before it is baked into config: LlamaCPP rejects a
@@ -13,6 +14,12 @@ import { _registerLocalModel } from "@/stdlib/localModels.js";
  *  a user-supplied `--local model.gguf` would otherwise arrive as, and an
  *  absolute path also keeps the child process independent of cwd drift. */
 export async function resolveLocalRunFlag(value: string): Promise<ResolvedModelFlag> {
+  const resolved = _resolveModel(value);
+  if (resolved.backend === "mlx") {
+    // The server is already running, started with `agency local serve`.
+    // Nothing to download or register.
+    return { model: _mlxServedName(resolved), explicitProvider: "mlx" };
+  }
   const modelPath = await _registerLocalModel(value);
   return { model: path.resolve(modelPath), explicitProvider: "llama-cpp" };
 }

--- a/packages/agency-lang/lib/config.modelAliases.test.ts
+++ b/packages/agency-lang/lib/config.modelAliases.test.ts
@@ -13,6 +13,7 @@ describe("config client.modelAliases", () => {
     // what the refresh actually puts on disk (this is what broke: refresh
     // wrote objects that the config loader then rejected on the next run).
     const entry = {
+      backend: "llama-cpp",
       uri: "hf:unsloth/Qwen3.5-2B-GGUF:Q4_K_M",
       source: "remote",
       params: "2B",
@@ -28,11 +29,16 @@ describe("config client.modelAliases", () => {
   });
   it("accepts string and object aliases side by side", () => {
     const parsed = AgencyConfigSchema.parse({
-      client: { modelAliases: { my7b: "hf:org/repo:Q4_K_M", managed: { uri: "hf:o/m:Q4" } } },
+      client: {
+        modelAliases: {
+          my7b: "hf:org/repo:Q4_K_M",
+          managed: { backend: "llama-cpp", uri: "hf:o/m:Q4" },
+        },
+      },
     });
     expect(parsed.client?.modelAliases).toEqual({
       my7b: "hf:org/repo:Q4_K_M",
-      managed: { uri: "hf:o/m:Q4" },
+      managed: { backend: "llama-cpp", uri: "hf:o/m:Q4" },
     });
   });
   it("rejects a value that is neither a string nor an object", () => {
@@ -42,5 +48,11 @@ describe("config client.modelAliases", () => {
     expect(() =>
       AgencyConfigSchema.parse({ client: { modelAliases: { x: { params: "2B" } } } }),
     ).toThrow();
+  });
+  it("an object alias needs a backend", () => {
+    const result = AgencyConfigSchema.safeParse({
+      client: { modelAliases: { x: { uri: "hf:org/repo:Q4_K_M" } } },
+    });
+    expect(result.success).toBe(false);
   });
 });

--- a/packages/agency-lang/lib/config.ts
+++ b/packages/agency-lang/lib/config.ts
@@ -449,6 +449,7 @@ export const ModelAliasSchema = z.union([
   z.string(),
   z
     .object({
+      backend: z.enum(["llama-cpp", "mlx"]),
       uri: z.string(),
       source: z.literal("remote").optional(),
       params: z.string().optional(),

--- a/packages/agency-lang/lib/stdlib/localModels.test.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.test.ts
@@ -970,6 +970,19 @@ describe("backend field", () => {
     expect(entry?.backend).toBe("mlx");
   });
 
+  it("a catalog entry with a valid backend and a bad uri is skipped, not thrown", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const parsed = parseCatalog(
+      JSON.stringify({
+        version: 1,
+        models: { bad: { backend: "llama-cpp", uri: "ftp://nope" } },
+      }),
+    );
+    expect(Object.keys(parsed)).toEqual([]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('skipping "bad"'));
+    warn.mockRestore();
+  });
+
   it("a remote catalog entry without backend, or with the wrong one, is skipped with a warning", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const parsed = parseCatalog(
@@ -1061,6 +1074,22 @@ describe("formatLocalList with mlx models", () => {
     expect(out).not.toMatch(/OTHER FILES[\s\S]*org\/coder/);
   });
 
+  it("ticks a pinned revision only when it matches the record", () => {
+    const pinned: ModelNameEntry[] = [
+      { name: "coder", backend: "mlx", target: "mlx:org/coder@7b93", source: "alias" },
+    ];
+    const withRev = [{ ...files[0], revision: "7b9321eabb85ce79625cac3f61ea691e4ea984b5" }];
+    const ok = formatLocalList({ dir: "/d", entries: pinned, manifest: {}, files: withRev });
+    expect(ok.split("\n").find((l) => l.includes("coder"))).toContain("✓");
+    const other = formatLocalList({
+      dir: "/d",
+      entries: pinned,
+      manifest: {},
+      files: [{ ...files[0], revision: "9c1f0a2" }],
+    });
+    expect(other.split("\n").find((l) => l.includes("coder"))).not.toContain("✓");
+  });
+
   it("does not tick an incomplete mlx model", () => {
     const out = formatLocalList({
       dir: "/d",
@@ -1100,6 +1129,7 @@ describe("_listDownloadedModels with mlx directories", () => {
         sizeBytes: expect.any(Number),
         backend: "mlx",
         complete: true,
+        revision: "abc",
       },
     ]);
     expect(listed[0].sizeBytes).toBeGreaterThan(10);

--- a/packages/agency-lang/lib/stdlib/localModels.test.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.test.ts
@@ -23,6 +23,7 @@ import {
   verifyModelFile,
   pinnedSha256,
   backendOfTarget,
+  _resolveModel,
   isMlxUri,
   parseMlxUri,
   isModelDir,
@@ -950,5 +951,31 @@ describe("backend field", () => {
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('skipping "missing"'));
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('skipping "wrong"'));
     warn.mockRestore();
+  });
+});
+
+describe("_resolveModel", () => {
+  it("returns backend and target for a curated name", () => {
+    expect(_resolveModel("smollm2-135m")).toEqual({
+      backend: "llama-cpp",
+      target: CURATED_LOCAL_MODELS["smollm2-135m"].uri,
+    });
+  });
+
+  it("returns mlx for an mlx: URI and for a directory alias", () => {
+    const model = path.join(dir, "m");
+    fs.mkdirSync(model);
+    fs.writeFileSync(path.join(model, "config.json"), "{}");
+    fs.writeFileSync(path.join(model, "model.safetensors"), "");
+    fs.writeFileSync(aliasFile, JSON.stringify({ client: { modelAliases: { local: model } } }));
+    expect(_resolveModel("mlx:org/repo")).toEqual({ backend: "mlx", target: "mlx:org/repo" });
+    expect(_resolveModel("local", aliasFile)).toEqual({ backend: "mlx", target: model });
+    expect(_resolveModel(model)).toEqual({ backend: "mlx", target: model });
+  });
+
+  it("the unknown-name error mentions mlx: URIs", () => {
+    expect(() => _resolveModel("nope")).toThrow(
+      /or pass a \.gguf path, an "hf:" URI, an "mlx:" URI, or a model directory/,
+    );
   });
 });

--- a/packages/agency-lang/lib/stdlib/localModels.test.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.test.ts
@@ -88,6 +88,7 @@ describe("aliases", () => {
     expect(_resolveModelName("my7b", aliasFile)).toBe("hf:org/repo:Q4_K_M");
     expect(_listModelNames(aliasFile)).toContainEqual({
       name: "my7b",
+      backend: "llama-cpp",
       target: "hf:org/repo:Q4_K_M",
       source: "alias",
     });
@@ -254,7 +255,9 @@ describe("provider register + download (fake plugin module)", () => {
       .digest("hex");
     fs.writeFileSync(
       aliasFile,
-      JSON.stringify({ client: { modelAliases: { mymodel: { uri: target, sha256: sha } } } }),
+      JSON.stringify({
+        client: { modelAliases: { mymodel: { backend: "llama-cpp", uri: target, sha256: sha } } },
+      }),
     );
     const cwd = process.cwd();
     process.chdir(dir);
@@ -272,7 +275,11 @@ describe("provider register + download (fake plugin module)", () => {
     fs.writeFileSync(
       aliasFile,
       JSON.stringify({
-        client: { modelAliases: { mymodel: { uri: "hf:org/x:Q4", sha256: "0".repeat(64) } } },
+        client: {
+          modelAliases: {
+            mymodel: { backend: "llama-cpp", uri: "hf:org/x:Q4", sha256: "0".repeat(64) },
+          },
+        },
       }),
     );
     const cwd = process.cwd();
@@ -295,7 +302,11 @@ describe("provider register + download (fake plugin module)", () => {
     fs.writeFileSync(
       aliasFile,
       JSON.stringify({
-        client: { modelAliases: { mymodel: { uri: "hf:org/x:Q4", sha256: "0".repeat(64) } } },
+        client: {
+          modelAliases: {
+            mymodel: { backend: "llama-cpp", uri: "hf:org/x:Q4", sha256: "0".repeat(64) },
+          },
+        },
       }),
     );
     const cwd = process.cwd();
@@ -422,7 +433,9 @@ describe("object-valued aliases", () => {
   it("resolves an object alias to its uri", () => {
     fs.writeFileSync(
       aliasFile,
-      JSON.stringify({ client: { modelAliases: { foo: { uri: "hf:org/repo:Q4_K_M" } } } }),
+      JSON.stringify({
+        client: { modelAliases: { foo: { backend: "llama-cpp", uri: "hf:org/repo:Q4_K_M" } } },
+      }),
     );
     expect(_resolveModelName("foo", aliasFile)).toBe("hf:org/repo:Q4_K_M");
   });
@@ -441,7 +454,12 @@ describe("object-valued aliases", () => {
       JSON.stringify({
         client: {
           modelAliases: {
-            "smollm2-135m": { uri: "hf:custom/smol:Q4_K_M", params: "999M", source: "remote" },
+            "smollm2-135m": {
+              backend: "llama-cpp",
+              uri: "hf:custom/smol:Q4_K_M",
+              params: "999M",
+              source: "remote",
+            },
           },
         },
       }),
@@ -468,6 +486,7 @@ describe("formatModelCatalog with rich aliases", () => {
           client: {
             modelAliases: {
               "rich-model": {
+                backend: "llama-cpp",
                 uri: "hf:org/rich:Q4_K_M",
                 params: "7B",
                 sizeBytes: 4_000_000_000,
@@ -522,7 +541,15 @@ describe("resolveCatalogUrl", () => {
 describe("parseCatalog", () => {
   const good = JSON.stringify({
     version: 1,
-    models: { m1: { uri: "hf:org/m1:Q4_K_M", params: "2B", sizeBytes: 1, category: "general" } },
+    models: {
+      m1: {
+        backend: "llama-cpp",
+        uri: "hf:org/m1:Q4_K_M",
+        params: "2B",
+        sizeBytes: 1,
+        category: "general",
+      },
+    },
   });
   it("parses a valid catalog", () => {
     const out = parseCatalog(good);
@@ -541,7 +568,10 @@ describe("parseCatalog", () => {
   it("skips an entry with a bad uri but keeps the good ones", () => {
     const mixed = JSON.stringify({
       version: 1,
-      models: { bad: { uri: "ftp://nope" }, good: { uri: "hf:org/g:Q4_K_M" } },
+      models: {
+        bad: { uri: "ftp://nope" },
+        good: { backend: "llama-cpp", uri: "hf:org/g:Q4_K_M" },
+      },
     });
     // Silence the expected `console.warn("[catalog] skipping …")` so the
     // suite output stays clean; also asserts the warn fires.
@@ -564,9 +594,9 @@ describe("parseCatalog", () => {
           version: 1,
           models: {
             insecure: { uri: "http://example.com/m.gguf" },
-            secureHttps: { uri: "https://example.com/m.gguf" },
-            hf: { uri: "hf:org/m:Q4_K_M" },
-            gguf: { uri: "/abs/path/m.gguf" },
+            secureHttps: { backend: "llama-cpp", uri: "https://example.com/m.gguf" },
+            hf: { backend: "llama-cpp", uri: "hf:org/m:Q4_K_M" },
+            gguf: { backend: "llama-cpp", uri: "/abs/path/m.gguf" },
           },
         }),
       );
@@ -584,7 +614,9 @@ describe("parseCatalog", () => {
     const out = parseCatalog(
       JSON.stringify({
         version: 1,
-        models: { m: { uri: "hf:org/m:Q4_K_M", params: 7, sizeBytes: "big" } },
+        models: {
+          m: { backend: "llama-cpp", uri: "hf:org/m:Q4_K_M", params: 7, sizeBytes: "big" },
+        },
       }),
     );
     expect(out.m.uri).toBe("hf:org/m:Q4_K_M");
@@ -598,9 +630,9 @@ describe("parseCatalog", () => {
       JSON.stringify({
         version: 1,
         models: {
-          good: { uri: "hf:org/g:Q4_K_M", sha256: upper },
-          tooShort: { uri: "hf:org/s:Q4_K_M", sha256: "abc123" },
-          notString: { uri: "hf:org/n:Q4_K_M", sha256: 123 },
+          good: { backend: "llama-cpp", uri: "hf:org/g:Q4_K_M", sha256: upper },
+          tooShort: { backend: "llama-cpp", uri: "hf:org/s:Q4_K_M", sha256: "abc123" },
+          notString: { backend: "llama-cpp", uri: "hf:org/n:Q4_K_M", sha256: 123 },
         },
       }),
     );
@@ -617,12 +649,14 @@ describe("_refreshCatalog", () => {
     fs.writeFileSync(aliasFile, "{}");
     const r = await _refreshCatalog({
       file: aliasFile,
-      fetcher: async () => blob({ "qwen3.5-2b": { uri: "hf:org/q:Q4_K_M", params: "2B" } }),
+      fetcher: async () =>
+        blob({ "qwen3.5-2b": { backend: "llama-cpp", uri: "hf:org/q:Q4_K_M", params: "2B" } }),
     });
     expect(r.added).toEqual(["qwen3.5-2b"]);
     expect(r.modelCount).toBe(1); // total catalog entries
     const cfg = JSON.parse(fs.readFileSync(aliasFile, "utf8"));
     expect(cfg.client.modelAliases["qwen3.5-2b"]).toEqual({
+      backend: "llama-cpp",
       uri: "hf:org/q:Q4_K_M",
       params: "2B",
       source: "remote",
@@ -636,7 +670,8 @@ describe("_refreshCatalog", () => {
     );
     const r = await _refreshCatalog({
       file: aliasFile,
-      fetcher: async () => blob({ "qwen3.5-2b": { uri: "hf:org/remote:Q4_K_M" } }),
+      fetcher: async () =>
+        blob({ "qwen3.5-2b": { backend: "llama-cpp", uri: "hf:org/remote:Q4_K_M" } }),
     });
     expect(r.skipped).toEqual([
       { name: "qwen3.5-2b", keptUri: "hf:mine/custom:Q4_K_M", remoteUri: "hf:org/remote:Q4_K_M" },
@@ -654,8 +689,8 @@ describe("_refreshCatalog", () => {
       file: aliasFile,
       fetcher: async () =>
         blob({
-          a: { uri: "hf:org/a:Q4_K_M", params: "1B" },
-          b: { uri: "hf:org/b:Q4_K_M" },
+          a: { backend: "llama-cpp", uri: "hf:org/a:Q4_K_M", params: "1B" },
+          b: { backend: "llama-cpp", uri: "hf:org/b:Q4_K_M" },
         }),
     });
     // Second run: `a` unchanged, `b` dropped, `c` added with same-uri but no
@@ -665,8 +700,8 @@ describe("_refreshCatalog", () => {
       file: aliasFile,
       fetcher: async () =>
         blob({
-          a: { uri: "hf:org/a:Q4_K_M", params: "2B" }, // metadata changed
-          c: { uri: "hf:org/c:Q4_K_M" }, // new
+          a: { backend: "llama-cpp", uri: "hf:org/a:Q4_K_M", params: "2B" }, // metadata changed
+          c: { backend: "llama-cpp", uri: "hf:org/c:Q4_K_M" }, // new
         }),
     });
     expect(r.added).toEqual(["c"]);
@@ -680,7 +715,8 @@ describe("_refreshCatalog", () => {
 
   it("reports unchanged when a re-run writes a byte-identical value", async () => {
     fs.writeFileSync(aliasFile, "{}");
-    const fetcher = async () => blob({ a: { uri: "hf:org/a:Q4_K_M", params: "1B" } });
+    const fetcher = async () =>
+      blob({ a: { backend: "llama-cpp", uri: "hf:org/a:Q4_K_M", params: "1B" } });
     await _refreshCatalog({ file: aliasFile, fetcher });
     const r = await _refreshCatalog({ file: aliasFile, fetcher });
     expect(r.added).toEqual([]);
@@ -707,7 +743,10 @@ describe("_refreshCatalog", () => {
     await _refreshCatalog({
       file: aliasFile,
       fetcher: async () =>
-        JSON.stringify({ version: 1, models: { m: { uri: "hf:org/m:Q4_K_M", sha256: sha } } }),
+        JSON.stringify({
+          version: 1,
+          models: { m: { backend: "llama-cpp", uri: "hf:org/m:Q4_K_M", sha256: sha } },
+        }),
     });
     const cfg = JSON.parse(fs.readFileSync(aliasFile, "utf8"));
     expect(cfg.client.modelAliases.m.sha256).toBe(sha);
@@ -719,7 +758,7 @@ describe("_refreshCatalog", () => {
     // would falsely report a collision. With own-property checks it's added.
     const r = await _refreshCatalog({
       file: aliasFile,
-      fetcher: async () => blob({ toString: { uri: "hf:org/ts:Q4_K_M" } }),
+      fetcher: async () => blob({ toString: { backend: "llama-cpp", uri: "hf:org/ts:Q4_K_M" } }),
     });
     expect(r.added).toEqual(["toString"]);
     expect(r.skipped).toEqual([]);
@@ -734,12 +773,16 @@ describe("_refreshCatalog", () => {
     const catalogPath = path.join(dir, "catalog.json");
     fs.writeFileSync(
       catalogPath,
-      JSON.stringify({ version: 1, models: { m: { uri: "hf:org/m:Q4_K_M", params: "2B" } } }),
+      JSON.stringify({
+        version: 1,
+        models: { m: { backend: "llama-cpp", uri: "hf:org/m:Q4_K_M", params: "2B" } },
+      }),
     );
     const r = await _refreshCatalog({ url: catalogPath, file: aliasFile });
     expect(r.added).toEqual(["m"]);
     const cfg = JSON.parse(fs.readFileSync(aliasFile, "utf8"));
     expect(cfg.client.modelAliases.m).toEqual({
+      backend: "llama-cpp",
       uri: "hf:org/m:Q4_K_M",
       params: "2B",
       source: "remote",
@@ -791,7 +834,7 @@ describe("model file verification", () => {
       JSON.stringify({
         client: {
           modelAliases: {
-            obj: { uri: "hf:o/x:Q4", sha256: "aa" },
+            obj: { backend: "llama-cpp", uri: "hf:o/x:Q4", sha256: "aa" },
             str: "hf:o/y:Q4",
           },
         },
@@ -848,5 +891,64 @@ describe("backend of a target", () => {
     expect(() => backendOfTarget(path.join(dir, "nothing-here"))).toThrow(
       /not a model: expected a \.gguf file or a directory containing config\.json/,
     );
+  });
+});
+
+describe("backend field", () => {
+  it("every curated entry has a backend that matches its uri", () => {
+    for (const [name, info] of Object.entries(CURATED_LOCAL_MODELS)) {
+      expect(info.backend, name).toBe(backendOfTarget(info.uri));
+    }
+  });
+
+  it("an object alias without backend is an error naming the file", () => {
+    fs.writeFileSync(
+      aliasFile,
+      JSON.stringify({ client: { modelAliases: { coder: { uri: "hf:org/repo:Q4_K_M" } } } }),
+    );
+    expect(() => _resolveModelName("coder", aliasFile)).toThrow(
+      `alias "coder" has no "backend". Add "backend": "llama-cpp" or "backend": "mlx" to the entry in ${aliasFile}.`,
+    );
+  });
+
+  it("an object alias whose backend disagrees with its uri is an error", () => {
+    fs.writeFileSync(
+      aliasFile,
+      JSON.stringify({
+        client: { modelAliases: { coder: { backend: "mlx", uri: "hf:org/repo:Q4_K_M" } } },
+      }),
+    );
+    expect(() => _resolveModelName("coder", aliasFile)).toThrow(
+      /says backend "mlx" but its uri "hf:org\/repo:Q4_K_M" is a GGUF file/,
+    );
+  });
+
+  it("a string alias reads its backend from the prefix", () => {
+    fs.writeFileSync(
+      aliasFile,
+      JSON.stringify({
+        client: { modelAliases: { coder: "mlx:mlx-community/Qwen3-Coder-Next-4bit" } },
+      }),
+    );
+    const entry = _listModelNames(aliasFile).find((e) => e.name === "coder");
+    expect(entry?.backend).toBe("mlx");
+  });
+
+  it("a remote catalog entry without backend, or with the wrong one, is skipped with a warning", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const parsed = parseCatalog(
+      JSON.stringify({
+        version: 1,
+        models: {
+          ok: { backend: "llama-cpp", uri: "hf:org/ok:Q4_K_M" },
+          missing: { uri: "hf:org/bad:Q4_K_M" },
+          wrong: { backend: "mlx", uri: "hf:org/wrong:Q4_K_M" },
+        },
+      }),
+    );
+    expect(Object.keys(parsed)).toEqual(["ok"]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('skipping "missing"'));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('skipping "wrong"'));
+    warn.mockRestore();
   });
 });

--- a/packages/agency-lang/lib/stdlib/localModels.test.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.test.ts
@@ -1118,3 +1118,19 @@ describe("_removeMlxModel", () => {
     expect(_removeMlxModel("../../etc", dir)).toBe(false);
   });
 });
+
+describe("_downloadModel for mlx", () => {
+  it("says MLX downloads are not supported yet", async () => {
+    await expect(_downloadModel("mlx:org/repo", dir)).rejects.toThrow(
+      "Downloading MLX models is not supported yet. Download it another way and alias its directory: agency local alias add <name> <dir>",
+    );
+  });
+
+  it("returns a model directory as is", async () => {
+    const model = path.join(dir, "m");
+    fs.mkdirSync(model);
+    fs.writeFileSync(path.join(model, "config.json"), "{}");
+    fs.writeFileSync(path.join(model, "model.safetensors"), "");
+    await expect(_downloadModel(model, dir)).resolves.toBe(model);
+  });
+});

--- a/packages/agency-lang/lib/stdlib/localModels.test.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.test.ts
@@ -325,6 +325,7 @@ describe("formatLocalList", () => {
   const entries: ModelNameEntry[] = [
     {
       name: "tiny",
+      backend: "llama-cpp",
       target: "hf:o/tiny:Q4",
       source: "curated",
       params: "135M",
@@ -334,6 +335,7 @@ describe("formatLocalList", () => {
     },
     {
       name: "mid",
+      backend: "llama-cpp",
       target: "hf:o/mid:Q4",
       source: "curated",
       params: "2B",
@@ -349,7 +351,15 @@ describe("formatLocalList", () => {
       dir: "/home/u/.agency-agent/models",
       entries,
       manifest: { "hf:o/tiny:Q4": "tiny.Q4.gguf" },
-      files: [{ name: "tiny.Q4.gguf", path: "/x/tiny.Q4.gguf", sizeBytes: 99_000_000 }],
+      files: [
+        {
+          name: "tiny.Q4.gguf",
+          path: "/x/tiny.Q4.gguf",
+          sizeBytes: 99_000_000,
+          backend: "llama-cpp",
+          complete: true,
+        },
+      ],
     });
     const lines = out.split("\n");
     expect(lines[0]).toBe("Models directory: /home/u/.agency-agent/models");
@@ -366,7 +376,15 @@ describe("formatLocalList", () => {
       dir: "/d",
       entries,
       manifest: { "hf:o/tiny:Q4": "gone.gguf" },
-      files: [{ name: "mystery.gguf", path: "/d/mystery.gguf", sizeBytes: 2_100_000_000 }],
+      files: [
+        {
+          name: "mystery.gguf",
+          path: "/d/mystery.gguf",
+          sizeBytes: 2_100_000_000,
+          backend: "llama-cpp",
+          complete: true,
+        },
+      ],
     });
     expect(out.split("\n").find((l) => l.includes("tiny"))).not.toContain("✓");
     expect(out).toContain("OTHER FILES");
@@ -379,7 +397,15 @@ describe("formatLocalList", () => {
       dir: "/d",
       entries,
       manifest: { "hf:raw/repo:Q4": "raw.gguf" },
-      files: [{ name: "raw.gguf", path: "/d/raw.gguf", sizeBytes: 500_000_000 }],
+      files: [
+        {
+          name: "raw.gguf",
+          path: "/d/raw.gguf",
+          sizeBytes: 500_000_000,
+          backend: "llama-cpp",
+          complete: true,
+        },
+      ],
     });
     expect(out).toContain("OTHER FILES");
     expect(out).toContain("raw.gguf");
@@ -407,7 +433,15 @@ describe("formatLocalList", () => {
       dir: "/d",
       entries,
       manifest: {},
-      files: [{ name: "raw.gguf", path: "/d/raw.gguf", sizeBytes: 500_000_000 }],
+      files: [
+        {
+          name: "raw.gguf",
+          path: "/d/raw.gguf",
+          sizeBytes: 500_000_000,
+          backend: "llama-cpp",
+          complete: true,
+        },
+      ],
       long: true,
     });
     const lines = out.split("\n");
@@ -977,5 +1011,96 @@ describe("_resolveModel", () => {
     expect(() => _resolveModel("nope")).toThrow(
       /or pass a \.gguf path, an "hf:" URI, an "mlx:" URI, or a model directory/,
     );
+  });
+});
+
+describe("formatLocalList with mlx models", () => {
+  const entries: ModelNameEntry[] = [
+    {
+      name: "coder",
+      backend: "mlx",
+      target: "mlx:org/coder",
+      source: "alias",
+      sizeBytes: 44_900_000_000,
+    },
+    { name: "tiny", backend: "llama-cpp", target: "hf:o/tiny:Q4", source: "curated" },
+  ];
+  const files = [
+    {
+      name: "org/coder",
+      path: "/d/mlx/org--coder",
+      sizeBytes: 44_000_000_000,
+      backend: "mlx" as const,
+      complete: true,
+    },
+    {
+      name: "org/other",
+      path: "/d/mlx/org--other",
+      sizeBytes: 1_000_000_000,
+      backend: "mlx" as const,
+      complete: false,
+    },
+  ];
+
+  it("shows a BACKEND column and ticks a complete mlx model by repo id", () => {
+    const out = formatLocalList({ dir: "/d", entries, manifest: {}, files });
+    const lines = out.split("\n");
+    expect(lines[2]).toContain("BACKEND");
+    const coder = lines.find((l) => l.includes("coder"));
+    expect(coder).toContain("✓");
+    expect(coder).toContain("mlx");
+    expect(coder).toContain("44.00 GB");
+    expect(lines.find((l) => l.includes("tiny"))).toContain("llama-cpp");
+  });
+
+  it("lists an unclaimed mlx directory under OTHER FILES with its state", () => {
+    const out = formatLocalList({ dir: "/d", entries, manifest: {}, files });
+    expect(out).toContain("OTHER FILES");
+    expect(out).toContain("org/other  (mlx, incomplete)  1.00 GB");
+    expect(out).not.toMatch(/OTHER FILES[\s\S]*org\/coder/);
+  });
+
+  it("does not tick an incomplete mlx model", () => {
+    const out = formatLocalList({
+      dir: "/d",
+      entries,
+      manifest: {},
+      files: [{ ...files[0], complete: false }],
+    });
+    expect(out.split("\n").find((l) => l.includes("coder"))).not.toContain("✓");
+  });
+});
+
+describe("_listDownloadedModels with mlx directories", () => {
+  it("lists a recorded mlx directory by repo id with its size and completeness", () => {
+    const cache = path.join(dir, "models");
+    const model = path.join(cache, "mlx", "org--repo");
+    fs.mkdirSync(model, { recursive: true });
+    fs.writeFileSync(path.join(model, "config.json"), "{}");
+    fs.writeFileSync(path.join(model, "model.safetensors"), "xxxxxxxx");
+    fs.writeFileSync(
+      path.join(model, ".agency-model.json"),
+      JSON.stringify({
+        repo: "org/repo",
+        revision: "abc",
+        files: {
+          "config.json": { size: 2, complete: true },
+          "model.safetensors": { size: 8, complete: true },
+        },
+      }),
+    );
+    // A directory with no record is not a model.
+    fs.mkdirSync(path.join(cache, "mlx", "junk"));
+    const listed = _listDownloadedModels(cache);
+    expect(listed).toEqual([
+      {
+        name: "org/repo",
+        path: model,
+        sizeBytes: expect.any(Number),
+        backend: "mlx",
+        complete: true,
+      },
+    ]);
+    expect(listed[0].sizeBytes).toBeGreaterThan(10);
   });
 });

--- a/packages/agency-lang/lib/stdlib/localModels.test.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.test.ts
@@ -24,6 +24,7 @@ import {
   pinnedSha256,
   backendOfTarget,
   _resolveModel,
+  _removeMlxModel,
   isMlxUri,
   parseMlxUri,
   isModelDir,
@@ -1102,5 +1103,18 @@ describe("_listDownloadedModels with mlx directories", () => {
       },
     ]);
     expect(listed[0].sizeBytes).toBeGreaterThan(10);
+  });
+});
+
+describe("_removeMlxModel", () => {
+  it("deletes the model directory under mlx/ and refuses anything else", () => {
+    const model = path.join(dir, "mlx", "org--repo");
+    fs.mkdirSync(model, { recursive: true });
+    fs.writeFileSync(path.join(model, "config.json"), "{}");
+    expect(_removeMlxModel("org/repo", dir)).toBe(true);
+    expect(fs.existsSync(model)).toBe(false);
+    expect(_removeMlxModel("org/repo", dir)).toBe(false);
+    // The slash becomes "--", so a repo id cannot name a path outside mlx/.
+    expect(_removeMlxModel("../../etc", dir)).toBe(false);
   });
 });

--- a/packages/agency-lang/lib/stdlib/localModels.test.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.test.ts
@@ -22,6 +22,10 @@ import {
   fileSha256,
   verifyModelFile,
   pinnedSha256,
+  backendOfTarget,
+  isMlxUri,
+  parseMlxUri,
+  isModelDir,
 } from "./localModels.js";
 
 let dir: string;
@@ -807,5 +811,42 @@ describe("model file verification", () => {
     );
     // string alias governs → no pin (must NOT fall back to the curated hash)
     expect(pinnedSha256(k, aliasFile)).toBeUndefined();
+  });
+});
+
+describe("backend of a target", () => {
+  it("hf: URIs and .gguf paths are llama-cpp", () => {
+    expect(backendOfTarget("hf:org/repo:Q4_K_M")).toBe("llama-cpp");
+    expect(backendOfTarget("/models/x.gguf")).toBe("llama-cpp");
+  });
+
+  it("mlx: URIs are mlx, with and without a revision", () => {
+    expect(isMlxUri("mlx:mlx-community/Qwen3-Coder-Next-4bit")).toBe(true);
+    expect(parseMlxUri("mlx:mlx-community/Qwen3-Coder-Next-4bit")).toEqual({
+      repo: "mlx-community/Qwen3-Coder-Next-4bit",
+      revision: undefined,
+    });
+    expect(parseMlxUri("mlx:mlx-community/Qwen3-Coder-Next-4bit@7b9321e")).toEqual({
+      repo: "mlx-community/Qwen3-Coder-Next-4bit",
+      revision: "7b9321e",
+    });
+    expect(backendOfTarget("mlx:mlx-community/Qwen3-Coder-Next-4bit")).toBe("mlx");
+    expect(() => parseMlxUri("mlx:no-slash")).toThrow(/is not an mlx: URI/);
+  });
+
+  it("a directory with config.json and a safetensors file is an mlx model", () => {
+    const model = path.join(dir, "m");
+    fs.mkdirSync(model);
+    fs.writeFileSync(path.join(model, "config.json"), "{}");
+    expect(isModelDir(model)).toBe(false);
+    fs.writeFileSync(path.join(model, "model.safetensors"), "");
+    expect(isModelDir(model)).toBe(true);
+    expect(backendOfTarget(model)).toBe("mlx");
+  });
+
+  it("a path that is neither is an error", () => {
+    expect(() => backendOfTarget(path.join(dir, "nothing-here"))).toThrow(
+      /not a model: expected a \.gguf file or a directory containing config\.json/,
+    );
   });
 });

--- a/packages/agency-lang/lib/stdlib/localModels.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.ts
@@ -588,6 +588,17 @@ export function _resolveModelName(value: string, file: string = ""): string {
   return _resolveModel(value, file).target;
 }
 
+/** The model name to send to the MLX server for this model. `agency local
+ *  serve` gives the server the same string, so a run against your own server
+ *  never names a model it is not serving. A repo id for an `mlx:` URI; the
+ *  absolute directory path for a model directory. */
+export function _mlxServedName(resolved: ResolvedModel): string {
+  if (isMlxUri(resolved.target)) {
+    return parseMlxUri(resolved.target).repo;
+  }
+  return path.resolve(resolved.target);
+}
+
 type EntryMeta = Pick<
   ModelNameEntry,
   "params" | "sizeBytes" | "category" | "description" | "contextWindow" | "license" | "sha256"
@@ -1231,6 +1242,10 @@ export async function _downloadModel(value: string, cacheDir: string = ""): Prom
 
 /** Convenience: register the provider + ensure the model is downloaded. */
 export async function _registerLocalModel(value: string, cacheDir: string = ""): Promise<string> {
+  const resolved = _resolveModel(value);
+  if (resolved.backend === "mlx") {
+    return _mlxServedName(resolved);
+  }
   await _registerLocalProvider();
   return await _downloadModel(value, cacheDir);
 }

--- a/packages/agency-lang/lib/stdlib/localModels.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.ts
@@ -24,6 +24,10 @@ import { __ctx } from "../runtime/asyncContext.js";
 import { recordDownload } from "./localModelManifest.js";
 import { ttyColor } from "../utils/termcolors.js";
 
+/** Which engine runs a model. GGUF files run in-process through llama.cpp.
+ *  MLX models run in a server started with `agency local serve`. */
+export type Backend = "llama-cpp" | "mlx";
+
 /** What a model is FOR — a single axis, orthogonal to size (size is conveyed
  *  by `params` / `sizeBytes`). Lets the CLI group + filter without parsing the
  *  description. */
@@ -34,7 +38,10 @@ export type ModelCategory =
   | "embedding"; // returns vectors, not text
 
 export type ModelInfo = {
-  /** Hugging Face URI passed to `node-llama-cpp`'s `resolveModelFile`. */
+  /** Which engine runs the model. Required; must agree with `uri`. */
+  backend: Backend;
+  /** For llama-cpp, an `hf:` URI passed to `node-llama-cpp`'s
+   *  `resolveModelFile`. For mlx, an `mlx:` URI naming a Hugging Face repo. */
   uri: string;
   /** Human-readable parameter count, e.g. "1.7B" or "70B". */
   params: string;
@@ -68,6 +75,7 @@ export type ModelInfo = {
 export const CURATED_LOCAL_MODELS: Record<string, ModelInfo> = {
   // ── General ─────────────────────────────────────────────────────────────
   "smollm2-135m": {
+    backend: "llama-cpp",
     uri: "hf:unsloth/SmolLM2-135M-Instruct-GGUF:Q4_K_M",
     params: "135M",
     sizeBytes: 105000000,
@@ -79,6 +87,7 @@ export const CURATED_LOCAL_MODELS: Record<string, ModelInfo> = {
     sha256: "ed5fa30c487b282ec156c29062f1222e5c20875a944ac98289dbd242e947f747",
   },
   "qwen3.5-0.8b": {
+    backend: "llama-cpp",
     uri: "hf:unsloth/Qwen3.5-0.8B-GGUF:Q4_K_M",
     params: "0.8B",
     sizeBytes: 500000000,
@@ -89,6 +98,7 @@ export const CURATED_LOCAL_MODELS: Record<string, ModelInfo> = {
     sha256: "bd258782e35f7f458f8aced1adc053e6e92e89bc735ba3be89d38a06121dc517",
   },
   "qwen3.5-2b": {
+    backend: "llama-cpp",
     uri: "hf:unsloth/Qwen3.5-2B-GGUF:Q4_K_M",
     params: "2B",
     sizeBytes: 1280000000,
@@ -99,6 +109,7 @@ export const CURATED_LOCAL_MODELS: Record<string, ModelInfo> = {
     sha256: "aaf42c8b7c3cab2bf3d69c355048d4a0ee9973d48f16c731c0520ee914699223",
   },
   "qwen3.5-4b": {
+    backend: "llama-cpp",
     uri: "hf:unsloth/Qwen3.5-4B-GGUF:Q4_K_M",
     params: "4B",
     sizeBytes: 2400000000,
@@ -109,6 +120,7 @@ export const CURATED_LOCAL_MODELS: Record<string, ModelInfo> = {
     sha256: "00fe7986ff5f6b463e62455821146049db6f9313603938a70800d1fb69ef11a4",
   },
   "gemma-4-e2b": {
+    backend: "llama-cpp",
     uri: "hf:unsloth/gemma-4-E2B-it-GGUF:Q4_K_M",
     params: "2B (E2B)",
     sizeBytes: 3110000000,
@@ -119,6 +131,7 @@ export const CURATED_LOCAL_MODELS: Record<string, ModelInfo> = {
     sha256: "740185b21d22ceb83a11c3aa62ad5842ef32c70f6096d756bbee85a1e4ec34b8",
   },
   "gemma-4-e4b": {
+    backend: "llama-cpp",
     uri: "hf:unsloth/gemma-4-E4B-it-GGUF:Q4_K_M",
     params: "4B (E4B)",
     sizeBytes: 4980000000,
@@ -130,6 +143,7 @@ export const CURATED_LOCAL_MODELS: Record<string, ModelInfo> = {
     sha256: "85a896a047553e842f25297ee5b031d64ff30147d9c4af17b1e4b394cd1fab87",
   },
   "granite-4.1-8b": {
+    backend: "llama-cpp",
     uri: "hf:unsloth/granite-4.1-8b-GGUF:Q4_K_M",
     params: "8B",
     sizeBytes: 5350000000,
@@ -140,6 +154,7 @@ export const CURATED_LOCAL_MODELS: Record<string, ModelInfo> = {
     sha256: "0f45c1af986e9900bb3b6ba46a25937e1bb80426935bc242d88c9ca90e9f5c88",
   },
   "qwen3.5-9b": {
+    backend: "llama-cpp",
     uri: "hf:unsloth/Qwen3.5-9B-GGUF:Q4_K_M",
     params: "9B",
     sizeBytes: 5500000000,
@@ -150,6 +165,7 @@ export const CURATED_LOCAL_MODELS: Record<string, ModelInfo> = {
     sha256: "03b74727a860a56338e042c4420bb3f04b2fec5734175f4cb9fa853daf52b7e8",
   },
   "gemma-4-12b": {
+    backend: "llama-cpp",
     uri: "hf:unsloth/gemma-4-12b-it-GGUF:Q4_K_M",
     params: "12B",
     sizeBytes: 7120000000,
@@ -160,6 +176,7 @@ export const CURATED_LOCAL_MODELS: Record<string, ModelInfo> = {
     sha256: "0a270ec9fe6b34f4a0d33992b6135117b484ebc4766ab76b51d4ae8c457e4c42",
   },
   "gpt-oss-20b": {
+    backend: "llama-cpp",
     uri: "hf:unsloth/gpt-oss-20b-GGUF:Q4_K_M",
     params: "20B",
     sizeBytes: 12000000000,
@@ -170,6 +187,7 @@ export const CURATED_LOCAL_MODELS: Record<string, ModelInfo> = {
     sha256: "c27536640e410032865dc68781d80a08b98f8db5e93575919af8ccc0568aeb4f",
   },
   "mistral-small-3.1": {
+    backend: "llama-cpp",
     uri: "hf:unsloth/Mistral-Small-3.1-24B-Instruct-2503-GGUF:Q4_K_M",
     params: "24B",
     sizeBytes: 14000000000,
@@ -180,6 +198,7 @@ export const CURATED_LOCAL_MODELS: Record<string, ModelInfo> = {
     sha256: "6d670773c3908584349d41a5048d1472226b593c881fd394e8ac196c802e81e2",
   },
   "mistral-small-3.2": {
+    backend: "llama-cpp",
     uri: "hf:unsloth/Mistral-Small-3.2-24B-Instruct-2506-GGUF:Q4_K_M",
     params: "24B",
     sizeBytes: 14333000000,
@@ -191,6 +210,7 @@ export const CURATED_LOCAL_MODELS: Record<string, ModelInfo> = {
     sha256: "a3cc56310807ed0d145eaf9f018ccda9ae7ad8edb41ec870aa2454b0d4700b3c",
   },
   "qwen3.5-27b": {
+    backend: "llama-cpp",
     uri: "hf:unsloth/Qwen3.5-27B-GGUF:Q4_K_M",
     params: "27B",
     sizeBytes: 16000000000,
@@ -201,6 +221,7 @@ export const CURATED_LOCAL_MODELS: Record<string, ModelInfo> = {
     sha256: "84b5f7f112156d63836a01a69dc3f11a6ba63b10a23b8ca7a7efaf52d5a2d806",
   },
   "gemma-4-26b-a4b": {
+    backend: "llama-cpp",
     uri: "hf:unsloth/gemma-4-26B-A4B-it-GGUF:Q4_K_M",
     params: "26B (A4B)",
     sizeBytes: 16900000000,
@@ -211,6 +232,7 @@ export const CURATED_LOCAL_MODELS: Record<string, ModelInfo> = {
     sha256: "f2c28b3dc4776931ac6f879e11f203dec637ea0f14267a86ec8f6165f63f293f",
   },
   "gemma-4-31b": {
+    backend: "llama-cpp",
     uri: "hf:unsloth/gemma-4-31B-it-GGUF:Q4_K_M",
     params: "31B",
     sizeBytes: 18300000000,
@@ -221,6 +243,7 @@ export const CURATED_LOCAL_MODELS: Record<string, ModelInfo> = {
     sha256: "38bd64c852c4b460434cc7162fa9bdcf242faf86502581a754cb72956bb17f84",
   },
   "qwen3.5-35b-a3b": {
+    backend: "llama-cpp",
     uri: "hf:unsloth/Qwen3.5-35B-A3B-GGUF:Q4_K_M",
     params: "35B (A3B)",
     sizeBytes: 22016000000,
@@ -231,6 +254,7 @@ export const CURATED_LOCAL_MODELS: Record<string, ModelInfo> = {
     sha256: "3b46d1066bc91cc2d613e3bc22ce691dd77e6f0d33c9060690d24ce6de494375",
   },
   "deepseek-r1-distill-llama-8b": {
+    backend: "llama-cpp",
     uri: "hf:unsloth/DeepSeek-R1-Distill-Llama-8B-GGUF:Q4_K_M",
     params: "8B",
     sizeBytes: 4920000000,
@@ -241,6 +265,7 @@ export const CURATED_LOCAL_MODELS: Record<string, ModelInfo> = {
     sha256: "0addb1339a82385bcd973186cd80d18dcc71885d45eabd899781a118d03827d9",
   },
   "deepseek-r1-0528-qwen3-8b": {
+    backend: "llama-cpp",
     uri: "hf:unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF:Q4_K_M",
     params: "8B",
     sizeBytes: 5030000000,
@@ -251,6 +276,7 @@ export const CURATED_LOCAL_MODELS: Record<string, ModelInfo> = {
     sha256: "a86349a4180c4e6bb43f874c29c404fa2be3f90b15509bd6d86f697dba724ec1",
   },
   "phi-4-reasoning": {
+    backend: "llama-cpp",
     uri: "hf:unsloth/Phi-4-reasoning-GGUF:Q4_K_M",
     params: "14B",
     sizeBytes: 9050000000,
@@ -262,6 +288,7 @@ export const CURATED_LOCAL_MODELS: Record<string, ModelInfo> = {
     sha256: "960d3870b218f91116c55bf81dc313e6cdbce31b1047bb2bc8bc7ea47899b032",
   },
   "magistral-small-2509": {
+    backend: "llama-cpp",
     uri: "hf:unsloth/Magistral-Small-2509-GGUF:Q4_K_M",
     params: "24B",
     sizeBytes: 14333000000,
@@ -273,6 +300,7 @@ export const CURATED_LOCAL_MODELS: Record<string, ModelInfo> = {
     sha256: "6d3e5f2a83ed9d64bd3382fb03be2f6e0bc7596a9de16e107bf22f959891945b",
   },
   "devstral-small-2507": {
+    backend: "llama-cpp",
     uri: "hf:mistralai/Devstral-Small-2507_gguf:Q4_K_M",
     params: "24B",
     sizeBytes: 14300000000,
@@ -283,6 +311,7 @@ export const CURATED_LOCAL_MODELS: Record<string, ModelInfo> = {
     sha256: "1bcc2b1b7b7ea3168ba2dbe782432c464f2240598bd193930122c41b117c1796",
   },
   "devstral-small-2-24b": {
+    backend: "llama-cpp",
     uri: "hf:unsloth/Devstral-Small-2-24B-Instruct-2512-GGUF:Q4_K_M",
     params: "24B",
     sizeBytes: 14334000000,
@@ -293,6 +322,7 @@ export const CURATED_LOCAL_MODELS: Record<string, ModelInfo> = {
     sha256: "d14ba9edee1bb4c4996a726deb81e49ae81800a3216f0774634238c380aee496",
   },
   "qwen3-coder-30b-a3b": {
+    backend: "llama-cpp",
     uri: "hf:unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF:Q4_K_M",
     params: "30B (A3B)",
     sizeBytes: 19000000000,
@@ -303,6 +333,7 @@ export const CURATED_LOCAL_MODELS: Record<string, ModelInfo> = {
     sha256: "fadc3e5f8d42bf7e894a785b05082e47daee4df26680389817e2093056f088ad",
   },
   "nomic-embed-text": {
+    backend: "llama-cpp",
     uri: "hf:nomic-ai/nomic-embed-text-v1.5-GGUF:Q4_K_M",
     params: "137M",
     sizeBytes: 89000000,
@@ -351,10 +382,6 @@ function isGgufPath(v: string): boolean {
 function isModelUri(v: string): boolean {
   return /^(hf:|https?:|mlx:)/.test(v);
 }
-
-/** Which engine runs a model. GGUF files run in-process through llama.cpp.
- *  MLX models run in a server started with `agency local serve`. */
-export type Backend = "llama-cpp" | "mlx";
 
 /** `mlx:<org>/<repo>` with an optional `@<revision>`. */
 const MLX_URI = /^mlx:([^@\s/]+\/[^@\s/]+)(?:@([\w.-]+))?$/;
@@ -469,6 +496,7 @@ function writeJson(file: string, value: unknown): void {
  *  marks an entry written by `agency local refresh` (see `_refreshCatalog`);
  *  hand-added aliases have no `source`. */
 export type AliasObject = {
+  backend: Backend;
   uri: string;
   source?: "remote";
   params?: string;
@@ -487,14 +515,38 @@ export function aliasUri(value: AliasValue): string {
   return typeof value === "string" ? value : value.uri;
 }
 
+/** Read `client.modelAliases`. An object alias must carry a `backend` that
+ *  agrees with its uri; a string alias reads its backend from its prefix. */
 export function readModelAliases(file: string = ""): Record<string, AliasValue> {
-  const cfg = readJson(resolveAliasFile(file));
-  return (cfg.client?.modelAliases ?? {}) as Record<string, AliasValue>;
+  const resolved = resolveAliasFile(file);
+  const cfg = readJson(resolved);
+  const aliases = (cfg.client?.modelAliases ?? {}) as Record<string, AliasValue>;
+  for (const [name, value] of Object.entries(aliases)) {
+    if (typeof value === "string") {
+      continue;
+    }
+    if (value.backend === undefined) {
+      throw new Error(
+        `${path.basename(resolved)}: alias "${name}" has no "backend". ` +
+          `Add "backend": "llama-cpp" or "backend": "mlx" to the entry in ${resolved}.`,
+      );
+    }
+    const fromUri = backendOfTarget(value.uri);
+    if (value.backend !== fromUri) {
+      const what = fromUri === "llama-cpp" ? "a GGUF file" : "an MLX model";
+      throw new Error(
+        `${path.basename(resolved)}: alias "${name}" says backend "${value.backend}" ` +
+          `but its uri "${value.uri}" is ${what}. Change one of them in ${resolved}.`,
+      );
+    }
+  }
+  return aliases;
 }
 
 /** Entry returned by `_listModelNames`. */
 export type ModelNameEntry = {
   name: string;
+  backend: Backend;
   target: string;
   source: "curated" | "alias";
   params?: string;
@@ -552,6 +604,7 @@ export function _listModelNames(file: string = ""): ModelNameEntry[] {
   const curatedEntries: ModelNameEntry[] = Object.entries(CURATED_LOCAL_MODELS).map(
     ([name, info]) => ({
       name,
+      backend: info.backend,
       target: info.uri,
       source: "curated",
       ...metaFrom(info),
@@ -560,6 +613,7 @@ export function _listModelNames(file: string = ""): ModelNameEntry[] {
   const aliasEntries: ModelNameEntry[] = Object.entries(readModelAliases(file)).map(
     ([name, value]) => ({
       name,
+      backend: backendOfTarget(aliasUri(value)),
       target: aliasUri(value),
       source: "alias",
       ...metaFrom(value),
@@ -647,6 +701,7 @@ const SUPPORTED_CATALOG_VERSION = 1;
 /** A validated entry from the remote catalog. Mirrors `AliasObject` minus the
  *  `source` tag (which `_refreshCatalog` adds on write). */
 export type CatalogModel = {
+  backend: Backend;
   uri: string;
   params?: string;
   sizeBytes?: number;
@@ -682,23 +737,28 @@ const CATALOG_MAX_BYTES = 5_000_000;
 // metadata fields are `.optional().catch(undefined)` so a wrongly-typed field
 // is dropped rather than failing the whole entry (lenient metadata); a
 // missing/insecure `uri` fails the entry (it's then skipped + warned).
-const CatalogModelSchema = z.object({
-  uri: z.string().refine(isCatalogUri, "uri must be an hf:/https: URI or a .gguf path"),
-  params: z.string().optional().catch(undefined),
-  sizeBytes: z.number().optional().catch(undefined),
-  category: z.enum(CATALOG_CATEGORIES).optional().catch(undefined),
-  contextWindow: z.number().optional().catch(undefined),
-  license: z.string().optional().catch(undefined),
-  description: z.string().optional().catch(undefined),
-  // Must be a 64-hex SHA-256; normalized to lowercase. A malformed value (from
-  // an untrusted catalog) is dropped via `.catch`, not stored as a bad pin.
-  sha256: z
-    .string()
-    .regex(/^[0-9a-fA-F]{64}$/)
-    .transform((s) => s.toLowerCase())
-    .optional()
-    .catch(undefined),
-});
+const CatalogModelSchema = z
+  .object({
+    backend: z.enum(["llama-cpp", "mlx"]),
+    uri: z.string().refine(isCatalogUri, "uri must be an hf:/mlx:/https: URI or a .gguf path"),
+    params: z.string().optional().catch(undefined),
+    sizeBytes: z.number().optional().catch(undefined),
+    category: z.enum(CATALOG_CATEGORIES).optional().catch(undefined),
+    contextWindow: z.number().optional().catch(undefined),
+    license: z.string().optional().catch(undefined),
+    description: z.string().optional().catch(undefined),
+    // Must be a 64-hex SHA-256; normalized to lowercase. A malformed value (from
+    // an untrusted catalog) is dropped via `.catch`, not stored as a bad pin.
+    sha256: z
+      .string()
+      .regex(/^[0-9a-fA-F]{64}$/)
+      .transform((s) => s.toLowerCase())
+      .optional()
+      .catch(undefined),
+  })
+  .refine((m) => m.backend === backendOfTarget(m.uri), {
+    message: "backend does not match the uri",
+  });
 
 // Top-level catalog shape: a supported version + a name→entry object. Entries
 // are validated individually (below) so one bad entry is skipped, not fatal.
@@ -753,6 +813,7 @@ export function parseCatalog(text: string): Record<string, CatalogModel> {
       }
       const d = parsed.data;
       const model: CatalogModel = {
+        backend: d.backend,
         uri: d.uri,
         ...compact({
           params: d.params,

--- a/packages/agency-lang/lib/stdlib/localModels.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.ts
@@ -349,7 +349,58 @@ function isGgufPath(v: string): boolean {
 }
 
 function isModelUri(v: string): boolean {
-  return /^(hf:|https?:)/.test(v);
+  return /^(hf:|https?:|mlx:)/.test(v);
+}
+
+/** Which engine runs a model. GGUF files run in-process through llama.cpp.
+ *  MLX models run in a server started with `agency local serve`. */
+export type Backend = "llama-cpp" | "mlx";
+
+/** `mlx:<org>/<repo>` with an optional `@<revision>`. */
+const MLX_URI = /^mlx:([^@\s/]+\/[^@\s/]+)(?:@([\w.-]+))?$/;
+
+export function isMlxUri(v: string): boolean {
+  return MLX_URI.test(v);
+}
+
+/** Split "mlx:org/repo@rev" into its parts. Throws on any other shape. */
+export function parseMlxUri(v: string): { repo: string; revision: string | undefined } {
+  const m = MLX_URI.exec(v);
+  if (m === null) {
+    throw new Error(
+      `"${v}" is not an mlx: URI. Expected mlx:<org>/<repo> or mlx:<org>/<repo>@<revision>.`,
+    );
+  }
+  return { repo: m[1], revision: m[2] };
+}
+
+/** A Hugging Face model directory: config.json plus at least one weights
+ *  file. This is the layout `mlx_lm.server` loads. A GGUF model is one file
+ *  with that information inside it, so it never has a config.json. */
+export function isModelDir(p: string): boolean {
+  const located = wholePath(p);
+  const info = stat(located.root, located.target);
+  if (info === null || !info.isDirectory()) {
+    return false;
+  }
+  const entries = list(root(p), ".");
+  const hasConfig = entries.some((e) => e.type === "file" && e.name === "config.json");
+  const hasWeights = entries.some((e) => e.type === "file" && e.name.endsWith(".safetensors"));
+  return hasConfig && hasWeights;
+}
+
+/** Which engine runs a resolved target. Throws for a path that is neither a
+ *  GGUF file nor a model directory. */
+export function backendOfTarget(target: string): Backend {
+  if (isGgufPath(target) || /^(hf:|https?:)/.test(target)) {
+    return "llama-cpp";
+  }
+  if (isMlxUri(target) || isModelDir(target)) {
+    return "mlx";
+  }
+  throw new Error(
+    `"${target}" is not a model: expected a .gguf file or a directory containing config.json.`,
+  );
 }
 
 /** A model URI we'll accept from the *remote catalog*. Stricter than
@@ -361,7 +412,7 @@ function isCatalogUri(v: string): boolean {
   if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(v)) {
     return /^https:\/\//.test(v);
   }
-  return v.startsWith("hf:") || isGgufPath(v);
+  return v.startsWith("hf:") || isMlxUri(v) || isGgufPath(v);
 }
 
 /** The agency.json that owns aliases: nearest `agency.json` walking up from

--- a/packages/agency-lang/lib/stdlib/localModels.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.ts
@@ -22,6 +22,7 @@ import {
 } from "../runtime/localProvider.js";
 import { __ctx } from "../runtime/asyncContext.js";
 import { recordDownload } from "./localModelManifest.js";
+import { MLX_SUBDIR, readMlxModelRecord, isMlxModelComplete } from "./mlxModelRecord.js";
 import { ttyColor } from "../utils/termcolors.js";
 
 /** Which engine runs a model. GGUF files run in-process through llama.cpp.
@@ -676,15 +677,58 @@ export function _unaliasModel(name: string, file: string = ""): UnaliasResult {
   return { file: resolved, removed: true };
 }
 
-export function _listDownloadedModels(
-  cacheDir: string = "",
-): { name: string; path: string; sizeBytes: number }[] {
+/** One model on disk. For a GGUF file, `name` is the file name. For an MLX
+ *  model, `name` is the repo id and `path` is its directory. */
+export type DownloadedModel = {
+  name: string;
+  path: string;
+  sizeBytes: number;
+  backend: Backend;
+  /** False for an MLX model whose download was interrupted. */
+  complete: boolean;
+};
+
+export function _listDownloadedModels(cacheDir: string = ""): DownloadedModel[] {
   const dir = resolveCacheDir(cacheDir);
-  return ggufEntries(dir).map((entry) => ({
+  const gguf: DownloadedModel[] = ggufEntries(dir).map((entry) => ({
     name: entry.name,
     path: path.join(dir, entry.name),
     sizeBytes: entry.size,
+    backend: "llama-cpp",
+    complete: true,
   }));
+  return [...gguf, ...mlxEntries(dir)];
+}
+
+/** The MLX model directories under `<dir>/mlx` that carry a record. */
+function mlxEntries(dir: string): DownloadedModel[] {
+  const mlxDir = path.join(dir, MLX_SUBDIR);
+  const cache = root(dir);
+  if (stat(cache, MLX_SUBDIR) === null) {
+    return [];
+  }
+  const out: DownloadedModel[] = [];
+  for (const entry of list(cache, MLX_SUBDIR)) {
+    if (entry.type !== "dir") {
+      continue;
+    }
+    const modelDir = path.join(mlxDir, entry.name);
+    const record = readMlxModelRecord(modelDir);
+    if (record === null) {
+      continue;
+    }
+    const sizeBytes = list(root(modelDir), ".")
+      .filter((f) => f.type === "file")
+      .reduce((sum, f) => sum + f.size, 0);
+    out.push({
+      name: record.repo,
+      path: modelDir,
+      sizeBytes,
+      backend: "mlx",
+      complete: isMlxModelComplete(record),
+    });
+  }
+  return out;
 }
 
 /** The `.gguf` files directly in `dir`, by name. A missing dir has none. */
@@ -1286,16 +1330,28 @@ export function formatLocalList(args: {
   dir: string;
   entries: ModelNameEntry[];
   manifest: Record<string, string>;
-  files: { name: string; path: string; sizeBytes: number }[];
+  files: DownloadedModel[];
   long?: boolean;
 }): string {
   const byName = Object.fromEntries(args.files.map((f) => [f.name, f]));
+  const byPath = Object.fromEntries(args.files.map((f) => [f.path, f]));
+  // The file on disk that backs a catalog row, if any. A GGUF row goes
+  // through the manifest. An MLX row matches by repo id, or by directory
+  // for an alias that points straight at one.
+  const fileFor = (e: ModelNameEntry): DownloadedModel | undefined => {
+    if (e.backend === "llama-cpp") {
+      const manifestFile = args.manifest[e.target];
+      return manifestFile === undefined ? undefined : byName[manifestFile];
+    }
+    const file = isMlxUri(e.target) ? byName[parseMlxUri(e.target).repo] : byPath[e.target];
+    return file !== undefined && file.complete ? file : undefined;
+  };
   const rows = args.entries.map((e) => {
-    const manifestFile = args.manifest[e.target];
-    const file = manifestFile === undefined ? undefined : byName[manifestFile];
+    const file = fileFor(e);
     return {
       mark: file !== undefined ? "✓" : "",
       name: e.name,
+      backend: e.backend,
       params: e.params ?? "",
       size:
         file !== undefined
@@ -1312,11 +1368,12 @@ export function formatLocalList(args: {
   // Only files claimed by a CATALOG row are excluded from OTHER FILES. The
   // manifest also records raw-URI downloads, which have no row here — their
   // files must stay visible.
-  const claimedFiles: string[] = args.entries
-    .map((e) => args.manifest[e.target])
-    .filter((f): f is string => f !== undefined);
-  const others = args.files.filter((f) => !claimedFiles.includes(f.name));
-  const headers = ["", "NAME", "PARAMS", "SIZE", "CONTEXT", "CATEGORY", "LICENSE"];
+  const claimedPaths: string[] = args.entries
+    .map(fileFor)
+    .filter((f): f is DownloadedModel => f !== undefined)
+    .map((f) => f.path);
+  const others = args.files.filter((f) => !claimedPaths.includes(f.path));
+  const headers = ["", "NAME", "BACKEND", "PARAMS", "SIZE", "CONTEXT", "CATEGORY", "LICENSE"];
   const cols = [
     colWidth(
       headers[0],
@@ -1328,22 +1385,26 @@ export function formatLocalList(args: {
     ),
     colWidth(
       headers[2],
-      rows.map((r) => r.params),
+      rows.map((r) => r.backend),
     ),
     colWidth(
       headers[3],
-      rows.map((r) => r.size),
+      rows.map((r) => r.params),
     ),
     colWidth(
       headers[4],
-      rows.map((r) => r.ctx),
+      rows.map((r) => r.size),
     ),
     colWidth(
       headers[5],
-      rows.map((r) => r.category),
+      rows.map((r) => r.ctx),
     ),
     colWidth(
       headers[6],
+      rows.map((r) => r.category),
+    ),
+    colWidth(
+      headers[7],
       rows.map((r) => r.license),
     ),
   ];
@@ -1360,14 +1421,17 @@ export function formatLocalList(args: {
     // Blank line *between* models, not after the last one, so the sections
     // below (which push their own leading "") aren't double-spaced.
     if (args.long === true && i > 0) lines.push("");
-    lines.push(render([r.mark, r.name, r.params, r.size, r.ctx, r.category, r.license]));
+    lines.push(render([r.mark, r.name, r.backend, r.params, r.size, r.ctx, r.category, r.license]));
     if (args.long === true && r.description !== "") {
       lines.push(ttyColor.dim(`${descIndent}${r.description}`));
     }
   });
   if (others.length > 0) {
     lines.push("", "OTHER FILES");
-    for (const f of others) lines.push(`  ${f.name}  ${formatGB(f.sizeBytes)}`);
+    for (const f of others) {
+      const tag = f.backend === "mlx" ? (f.complete ? "  (mlx)" : "  (mlx, incomplete)") : "";
+      lines.push(`  ${f.name}${tag}  ${formatGB(f.sizeBytes)}`);
+    }
   }
   const total = args.files.reduce((sum, f) => sum + f.sizeBytes, 0);
   lines.push("", `Total downloaded: ${formatGB(total)}`);

--- a/packages/agency-lang/lib/stdlib/localModels.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.ts
@@ -1315,8 +1315,18 @@ export function snapshotFreshness(dir: string): FreshnessProbe {
 
 /** Resolve a name/uri/path to a local .gguf path, downloading if needed. */
 export async function _downloadModel(value: string, cacheDir: string = ""): Promise<string> {
+  const model = _resolveModel(value);
+  if (model.backend === "mlx") {
+    if (isModelDir(model.target)) {
+      return path.resolve(model.target);
+    }
+    throw new Error(
+      "Downloading MLX models is not supported yet. Download it another way and alias " +
+        "its directory: agency local alias add <name> <dir>",
+    );
+  }
   requireSupport();
-  const target = _resolveModelName(value);
+  const target = model.target;
   const dir = resolveCacheDir(cacheDir);
   const mod = await loadLocalProvider();
   // Snapshot freshness BEFORE resolving so we verify the bytes only once, right

--- a/packages/agency-lang/lib/stdlib/localModels.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.ts
@@ -692,6 +692,8 @@ export type DownloadedModel = {
   backend: Backend;
   /** False for an MLX model whose download was interrupted. */
   complete: boolean;
+  /** The commit an MLX model was downloaded from. Absent for GGUF. */
+  revision?: string;
 };
 
 export function _listDownloadedModels(cacheDir: string = ""): DownloadedModel[] {
@@ -732,6 +734,7 @@ function mlxEntries(dir: string): DownloadedModel[] {
       sizeBytes,
       backend: "mlx",
       complete: isMlxModelComplete(record),
+      revision: record.revision,
     });
   }
   return out;
@@ -872,7 +875,7 @@ const CatalogModelSchema = z
       .optional()
       .catch(undefined),
   })
-  .refine((m) => m.backend === backendOfTarget(m.uri), {
+  .refine((m) => !isCatalogUri(m.uri) || m.backend === backendOfTarget(m.uri), {
     message: "backend does not match the uri",
   });
 
@@ -1403,8 +1406,21 @@ export function formatLocalList(args: {
       const manifestFile = args.manifest[e.target];
       return manifestFile === undefined ? undefined : byName[manifestFile];
     }
-    const file = isMlxUri(e.target) ? byName[parseMlxUri(e.target).repo] : byPath[e.target];
-    return file !== undefined && file.complete ? file : undefined;
+    if (!isMlxUri(e.target)) {
+      const file = byPath[e.target];
+      return file !== undefined && file.complete ? file : undefined;
+    }
+    // A pinned revision must match what was downloaded. The pin may be a
+    // short prefix of the full commit hash.
+    const { repo, revision } = parseMlxUri(e.target);
+    const file = byName[repo];
+    if (file === undefined || !file.complete) {
+      return undefined;
+    }
+    if (revision !== undefined && !(file.revision ?? "").startsWith(revision)) {
+      return undefined;
+    }
+    return file;
   };
   const rows = args.entries.map((e) => {
     const file = fileFor(e);

--- a/packages/agency-lang/lib/stdlib/localModels.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.ts
@@ -558,23 +558,34 @@ export type ModelNameEntry = {
   sha256?: string;
 };
 
-export function _resolveModelName(value: string, file: string = ""): string {
-  if (isGgufPath(value) || isModelUri(value)) {
-    return value;
+/** A model name resolved to the engine that runs it and the target that
+ *  engine takes: an `hf:` URI or `.gguf` path for llama-cpp, an `mlx:` URI
+ *  or a model directory for mlx. */
+export type ResolvedModel = { backend: Backend; target: string };
+
+export function _resolveModel(value: string, file: string = ""): ResolvedModel {
+  if (isGgufPath(value) || isModelUri(value) || isModelDir(value)) {
+    return { backend: backendOfTarget(value), target: value };
   }
   const aliases = readModelAliases(file);
   const aliasVal = aliases[value];
-  const aliasTarget = aliasVal === undefined ? undefined : aliasUri(aliasVal);
-  const curated = CURATED_LOCAL_MODELS[value];
-  const mapped = aliasTarget ?? curated?.uri;
-  if (!mapped) {
-    const names = [...Object.keys(CURATED_LOCAL_MODELS), ...Object.keys(aliases)].join(", ");
-    throw new Error(
-      `Unknown local model "${value}". Known names: ${names || "(none)"}; ` +
-        `or pass a .gguf path or an "hf:" URI.`,
-    );
+  if (aliasVal !== undefined) {
+    const target = aliasUri(aliasVal);
+    return { backend: backendOfTarget(target), target };
   }
-  return mapped;
+  const curated = CURATED_LOCAL_MODELS[value];
+  if (curated !== undefined) {
+    return { backend: curated.backend, target: curated.uri };
+  }
+  const names = [...Object.keys(CURATED_LOCAL_MODELS), ...Object.keys(aliases)].join(", ");
+  throw new Error(
+    `Unknown local model "${value}". Known names: ${names || "(none)"}; ` +
+      `or pass a .gguf path, an "hf:" URI, an "mlx:" URI, or a model directory.`,
+  );
+}
+
+export function _resolveModelName(value: string, file: string = ""): string {
+  return _resolveModel(value, file).target;
 }
 
 type EntryMeta = Pick<

--- a/packages/agency-lang/lib/stdlib/localModels.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.ts
@@ -21,8 +21,14 @@ import {
   resolveSmoltalkLlamaCppEntry,
 } from "../runtime/localProvider.js";
 import { __ctx } from "../runtime/asyncContext.js";
-import { recordDownload } from "./localModelManifest.js";
-import { MLX_SUBDIR, readMlxModelRecord, isMlxModelComplete } from "./mlxModelRecord.js";
+import { recordDownload, readDownloadManifest } from "./localModelManifest.js";
+import {
+  MLX_SUBDIR,
+  mlxModelDir,
+  mlxModelDirName,
+  readMlxModelRecord,
+  isMlxModelComplete,
+} from "./mlxModelRecord.js";
 import { ttyColor } from "../utils/termcolors.js";
 
 /** Which engine runs a model. GGUF files run in-process through llama.cpp.
@@ -753,6 +759,50 @@ export function _removeModel(name: string, cacheDir: string = ""): boolean {
   }
   remove(cache, name);
   return true;
+}
+
+/** Delete an MLX model directory from the cache. Only a directory under
+ *  `<cacheDir>/mlx` is ever removed; `remove` refuses symlinks. */
+export function _removeMlxModel(repo: string, cacheDir: string = ""): boolean {
+  const cache = root(path.join(resolveCacheDir(cacheDir), MLX_SUBDIR));
+  const name = mlxModelDirName(repo);
+  const info = stat(cache, name);
+  if (info === null || !info.isDirectory()) {
+    return false;
+  }
+  remove(cache, name);
+  return true;
+}
+
+/** Where a resolved model's files are on disk, or null when nothing is
+ *  there. A GGUF model is found through the download manifest; an MLX model
+ *  through its record under the cache, or the directory it points at. */
+export function _modelFilesOnDisk(
+  resolved: ResolvedModel,
+  cacheDir: string = "",
+): { path: string; sizeBytes: number; insideCache: boolean } | null {
+  const dir = resolveCacheDir(cacheDir);
+  const onDisk = _listDownloadedModels(dir);
+  const found = (match: (f: DownloadedModel) => boolean) => {
+    const f = onDisk.find(match);
+    return f === undefined ? null : { path: f.path, sizeBytes: f.sizeBytes, insideCache: true };
+  };
+  if (resolved.backend === "llama-cpp") {
+    if (isGgufPath(resolved.target)) {
+      return found((f) => f.path === path.resolve(resolved.target));
+    }
+    const fileName = readDownloadManifest(dir)[resolved.target];
+    return fileName === undefined ? null : found((f) => f.name === fileName);
+  }
+  if (isMlxUri(resolved.target)) {
+    const modelDir = mlxModelDir(dir, parseMlxUri(resolved.target).repo);
+    return found((f) => f.path === modelDir);
+  }
+  const target = path.resolve(resolved.target);
+  const sizeBytes = list(root(target), ".")
+    .filter((f) => f.type === "file")
+    .reduce((sum, f) => sum + f.size, 0);
+  return { path: target, sizeBytes, insideCache: onDisk.some((f) => f.path === target) };
 }
 
 // =============================================================================

--- a/packages/agency-lang/lib/stdlib/localModels.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.ts
@@ -23,6 +23,21 @@ import {
 import { __ctx } from "../runtime/asyncContext.js";
 import { recordDownload, readDownloadManifest } from "./localModelManifest.js";
 import {
+  type Backend,
+  isGgufPath,
+  isMlxUri,
+  parseMlxUri,
+  isModelDir,
+  backendOfTarget,
+} from "./modelBackend.js";
+export {
+  type Backend,
+  isMlxUri,
+  parseMlxUri,
+  isModelDir,
+  backendOfTarget,
+} from "./modelBackend.js";
+import {
   MLX_SUBDIR,
   mlxModelDir,
   mlxModelDirName,
@@ -30,10 +45,6 @@ import {
   isMlxModelComplete,
 } from "./mlxModelRecord.js";
 import { ttyColor } from "../utils/termcolors.js";
-
-/** Which engine runs a model. GGUF files run in-process through llama.cpp.
- *  MLX models run in a server started with `agency local serve`. */
-export type Backend = "llama-cpp" | "mlx";
 
 /** What a model is FOR — a single axis, orthogonal to size (size is conveyed
  *  by `params` / `sizeBytes`). Lets the CLI group + filter without parsing the
@@ -382,59 +393,8 @@ export function _modelsCacheDir(cacheDir: string = ""): string {
   return resolveCacheDir(cacheDir);
 }
 
-function isGgufPath(v: string): boolean {
-  return v.endsWith(".gguf");
-}
-
 function isModelUri(v: string): boolean {
   return /^(hf:|https?:|mlx:)/.test(v);
-}
-
-/** `mlx:<org>/<repo>` with an optional `@<revision>`. */
-const MLX_URI = /^mlx:([^@\s/]+\/[^@\s/]+)(?:@([\w.-]+))?$/;
-
-export function isMlxUri(v: string): boolean {
-  return MLX_URI.test(v);
-}
-
-/** Split "mlx:org/repo@rev" into its parts. Throws on any other shape. */
-export function parseMlxUri(v: string): { repo: string; revision: string | undefined } {
-  const m = MLX_URI.exec(v);
-  if (m === null) {
-    throw new Error(
-      `"${v}" is not an mlx: URI. Expected mlx:<org>/<repo> or mlx:<org>/<repo>@<revision>.`,
-    );
-  }
-  return { repo: m[1], revision: m[2] };
-}
-
-/** A Hugging Face model directory: config.json plus at least one weights
- *  file. This is the layout `mlx_lm.server` loads. A GGUF model is one file
- *  with that information inside it, so it never has a config.json. */
-export function isModelDir(p: string): boolean {
-  const located = wholePath(p);
-  const info = stat(located.root, located.target);
-  if (info === null || !info.isDirectory()) {
-    return false;
-  }
-  const entries = list(root(p), ".");
-  const hasConfig = entries.some((e) => e.type === "file" && e.name === "config.json");
-  const hasWeights = entries.some((e) => e.type === "file" && e.name.endsWith(".safetensors"));
-  return hasConfig && hasWeights;
-}
-
-/** Which engine runs a resolved target. Throws for a path that is neither a
- *  GGUF file nor a model directory. */
-export function backendOfTarget(target: string): Backend {
-  if (isGgufPath(target) || /^(hf:|https?:)/.test(target)) {
-    return "llama-cpp";
-  }
-  if (isMlxUri(target) || isModelDir(target)) {
-    return "mlx";
-  }
-  throw new Error(
-    `"${target}" is not a model: expected a .gguf file or a directory containing config.json.`,
-  );
 }
 
 /** A model URI we'll accept from the *remote catalog*. Stricter than

--- a/packages/agency-lang/lib/stdlib/mlxModelRecord.test.ts
+++ b/packages/agency-lang/lib/stdlib/mlxModelRecord.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+  mlxModelDirName,
+  mlxModelDir,
+  readMlxModelRecord,
+  writeMlxModelRecord,
+  isMlxModelComplete,
+  RECORD_FILE,
+} from "./mlxModelRecord.js";
+
+let dir: string;
+beforeEach(() => {
+  dir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "mlxrec-")));
+});
+afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+describe("mlx model record", () => {
+  it("names the directory org--repo under mlx/", () => {
+    expect(mlxModelDirName("mlx-community/Qwen3-Coder-Next-4bit")).toBe(
+      "mlx-community--Qwen3-Coder-Next-4bit",
+    );
+    expect(mlxModelDir(dir, "org/repo")).toBe(path.join(dir, "mlx", "org--repo"));
+  });
+
+  it("round-trips a record and reports completeness", () => {
+    const model = path.join(dir, "mlx", "org--repo");
+    fs.mkdirSync(model, { recursive: true });
+    const record = {
+      repo: "org/repo",
+      revision: "abc",
+      files: {
+        "config.json": { size: 10, complete: true },
+        "model.safetensors": { size: 100, sha256: "00", complete: false, chunks: [0] },
+      },
+    };
+    writeMlxModelRecord(model, record);
+    expect(readMlxModelRecord(model)).toEqual(record);
+    expect(isMlxModelComplete(record)).toBe(false);
+    record.files["model.safetensors"].complete = true;
+    expect(isMlxModelComplete(record)).toBe(true);
+  });
+
+  it("a missing or corrupt record reads as null", () => {
+    const model = path.join(dir, "mlx", "org--repo");
+    fs.mkdirSync(model, { recursive: true });
+    expect(readMlxModelRecord(model)).toBeNull();
+    fs.writeFileSync(path.join(model, RECORD_FILE), "{not json");
+    expect(readMlxModelRecord(model)).toBeNull();
+    fs.writeFileSync(path.join(model, RECORD_FILE), JSON.stringify({ repo: 1 }));
+    expect(readMlxModelRecord(model)).toBeNull();
+  });
+});

--- a/packages/agency-lang/lib/stdlib/mlxModelRecord.test.ts
+++ b/packages/agency-lang/lib/stdlib/mlxModelRecord.test.ts
@@ -51,5 +51,10 @@ describe("mlx model record", () => {
     expect(readMlxModelRecord(model)).toBeNull();
     fs.writeFileSync(path.join(model, RECORD_FILE), JSON.stringify({ repo: 1 }));
     expect(readMlxModelRecord(model)).toBeNull();
+    fs.writeFileSync(
+      path.join(model, RECORD_FILE),
+      JSON.stringify({ repo: "o/r", revision: "x", files: { model: null } }),
+    );
+    expect(readMlxModelRecord(model)).toBeNull();
   });
 });

--- a/packages/agency-lang/lib/stdlib/mlxModelRecord.ts
+++ b/packages/agency-lang/lib/stdlib/mlxModelRecord.ts
@@ -1,0 +1,70 @@
+import * as path from "node:path";
+import { root, stat, readText, writeText, mkdir } from "./contained.js";
+
+/** MLX models live under `<modelsDir>/mlx/<org>--<repo>/`. */
+export const MLX_SUBDIR = "mlx";
+
+/** The per-model record: which revision the files came from and how much of
+ *  each file is on disk. Written by the downloader, read by `list`, `serve`,
+ *  and `remove`. */
+export const RECORD_FILE = ".agency-model.json";
+
+export type MlxFileRecord = {
+  size: number;
+  sha256?: string;
+  complete: boolean;
+  /** Indexes of the chunks already written, for a file still downloading. */
+  chunks?: number[];
+};
+
+export type MlxModelRecord = {
+  repo: string;
+  revision: string;
+  files: Record<string, MlxFileRecord>;
+};
+
+export function mlxModelDirName(repo: string): string {
+  return repo.replace("/", "--");
+}
+
+export function mlxModelDir(cacheDir: string, repo: string): string {
+  return path.join(cacheDir, MLX_SUBDIR, mlxModelDirName(repo));
+}
+
+/** The record in `dir`, or null when it is missing or not a valid record. */
+export function readMlxModelRecord(dir: string): MlxModelRecord | null {
+  const r = root(dir);
+  if (stat(r, RECORD_FILE) === null) {
+    return null;
+  }
+  try {
+    const parsed: unknown = JSON.parse(readText(r, RECORD_FILE));
+    if (parsed === null || typeof parsed !== "object") {
+      return null;
+    }
+    const rec = parsed as MlxModelRecord;
+    if (
+      typeof rec.repo !== "string" ||
+      typeof rec.revision !== "string" ||
+      rec.files === null ||
+      typeof rec.files !== "object"
+    ) {
+      return null;
+    }
+    return rec;
+  } catch {
+    return null;
+  }
+}
+
+/** Replaces the file through a temp file and a rename, so a crash mid-write
+ *  leaves the previous record. */
+export function writeMlxModelRecord(dir: string, record: MlxModelRecord): void {
+  const r = root(dir);
+  mkdir(r, ".");
+  writeText(r, RECORD_FILE, JSON.stringify(record, null, 2) + "\n");
+}
+
+export function isMlxModelComplete(record: MlxModelRecord): boolean {
+  return Object.values(record.files).every((f) => f.complete);
+}

--- a/packages/agency-lang/lib/stdlib/mlxModelRecord.ts
+++ b/packages/agency-lang/lib/stdlib/mlxModelRecord.ts
@@ -31,6 +31,20 @@ export function mlxModelDir(cacheDir: string, repo: string): string {
   return path.join(cacheDir, MLX_SUBDIR, mlxModelDirName(repo));
 }
 
+function isFileRecord(v: unknown): v is MlxFileRecord {
+  if (v === null || typeof v !== "object") {
+    return false;
+  }
+  const f = v as Record<string, unknown>;
+  return (
+    typeof f.size === "number" &&
+    typeof f.complete === "boolean" &&
+    (f.sha256 === undefined || typeof f.sha256 === "string") &&
+    (f.chunks === undefined ||
+      (Array.isArray(f.chunks) && f.chunks.every((c) => typeof c === "number")))
+  );
+}
+
 /** The record in `dir`, or null when it is missing or not a valid record. */
 export function readMlxModelRecord(dir: string): MlxModelRecord | null {
   const r = root(dir);
@@ -47,7 +61,8 @@ export function readMlxModelRecord(dir: string): MlxModelRecord | null {
       typeof rec.repo !== "string" ||
       typeof rec.revision !== "string" ||
       rec.files === null ||
-      typeof rec.files !== "object"
+      typeof rec.files !== "object" ||
+      !Object.values(rec.files).every(isFileRecord)
     ) {
       return null;
     }

--- a/packages/agency-lang/lib/stdlib/modelBackend.ts
+++ b/packages/agency-lang/lib/stdlib/modelBackend.ts
@@ -1,0 +1,56 @@
+import { root, wholePath, stat, list } from "./contained.js";
+
+/** Which engine runs a model. GGUF files run in-process through llama.cpp.
+ *  MLX models run in mlx_lm.server, which the user starts. */
+export type Backend = "llama-cpp" | "mlx";
+
+export function isGgufPath(v: string): boolean {
+  return v.endsWith(".gguf");
+}
+
+/** `mlx:<org>/<repo>` with an optional `@<revision>`. */
+const MLX_URI = /^mlx:([^@\s/]+\/[^@\s/]+)(?:@([\w.-]+))?$/;
+
+export function isMlxUri(v: string): boolean {
+  return MLX_URI.test(v);
+}
+
+/** Split "mlx:org/repo@rev" into its parts. Throws on any other shape. */
+export function parseMlxUri(v: string): { repo: string; revision: string | undefined } {
+  const m = MLX_URI.exec(v);
+  if (m === null) {
+    throw new Error(
+      `"${v}" is not an mlx: URI. Expected mlx:<org>/<repo> or mlx:<org>/<repo>@<revision>.`,
+    );
+  }
+  return { repo: m[1], revision: m[2] };
+}
+
+/** A Hugging Face model directory: config.json plus at least one weights
+ *  file. This is the layout `mlx_lm.server` loads. A GGUF model is one file
+ *  with that information inside it, so it never has a config.json. */
+export function isModelDir(p: string): boolean {
+  const located = wholePath(p);
+  const info = stat(located.root, located.target);
+  if (info === null || !info.isDirectory()) {
+    return false;
+  }
+  const entries = list(root(p), ".");
+  const hasConfig = entries.some((e) => e.type === "file" && e.name === "config.json");
+  const hasWeights = entries.some((e) => e.type === "file" && e.name.endsWith(".safetensors"));
+  return hasConfig && hasWeights;
+}
+
+/** Which engine runs a resolved target. Throws for a path that is neither a
+ *  GGUF file nor a model directory. */
+export function backendOfTarget(target: string): Backend {
+  if (isGgufPath(target) || /^(hf:|https?:)/.test(target)) {
+    return "llama-cpp";
+  }
+  if (isMlxUri(target) || isModelDir(target)) {
+    return "mlx";
+  }
+  throw new Error(
+    `"${target}" is not a model: expected a .gguf file or a directory containing config.json.`,
+  );
+}

--- a/packages/agency-lang/package.json
+++ b/packages/agency-lang/package.json
@@ -113,7 +113,7 @@
     "nanoid": "^5.1.6",
     "picomatch": "^4.0.4",
     "prompts": "^2.4.2",
-    "smoltalk": "^0.12.1",
+    "smoltalk": "^0.13.0",
     "tarsec": "0.5.4",
     "typestache": "^0.6.0",
     "vscode-languageserver": "^9.0.1",

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -1746,9 +1746,12 @@ export function createProgram(deps: CliDependencies = {}): Command {
     .action(localDownload);
   localCmd
     .command("remove")
-    .description("Delete a downloaded model")
+    .description("Remove a model's alias. With -f, also delete its files from the models directory")
     .argument("<name>")
-    .action(localRemove);
+    .option("-f, --force", "Delete the model files")
+    .action((name: string, opts: { force?: boolean }) =>
+      localRemove(name, { force: opts.force === true }),
+    );
   localCmd
     .command("resolve")
     .description("Show what a name/alias resolves to")

--- a/packages/agency-lang/stdlib/agency/local.agency
+++ b/packages/agency-lang/stdlib/agency/local.agency
@@ -33,14 +33,20 @@ import {
   ```
 */
 
+/** A model on disk. For a GGUF file, `name` is the file name. For an MLX
+    model, `name` is the repo id and `path` is its directory. `complete` is
+    false for an MLX model whose download was interrupted. */
 export type DownloadedModel = {
   name: string;
   path: string;
-  sizeBytes: number
+  sizeBytes: number;
+  backend: string;
+  complete: bool
 }
 
 export type ModelName = {
   name: string;
+  backend: string;
   target: string;
   source: string;
   params?: string;
@@ -81,7 +87,7 @@ export def downloadModel(value: string, cacheDir: string = ""): string {
 
 export def listDownloadedModels(cacheDir: string = ""): DownloadedModel[] {
   """
-  List downloaded .gguf models.
+  List downloaded models: .gguf files and MLX model directories.
 
   @param cacheDir - models dir (empty string = per-user cache)
   """

--- a/packages/agency-lang/stdlib/agency/local.agency
+++ b/packages/agency-lang/stdlib/agency/local.agency
@@ -124,8 +124,9 @@ export def unaliasModel(name: string): string {
 
 export def removeModel(name: string, cacheDir: string = ""): bool {
   """
-  Delete a downloaded model file.
-  Returns false if the model was not present.
+  Delete a downloaded GGUF file from the models directory. This is what
+  `agency local remove -f` does; without -f that command only removes the
+  alias. Returns false if the file was not present.
 
   @param name - the .gguf filename
   @param cacheDir - models dir (empty string = per-user cache)

--- a/packages/agency-lang/stdlib/agency/local.agency
+++ b/packages/agency-lang/stdlib/agency/local.agency
@@ -9,6 +9,8 @@ import {
   _removeModel,
   _registerLocalProvider,
   _registerLocalModel,
+  _resolveModel,
+  _mlxServedName,
   _printLocalCatalog,
   _refreshCatalog,
  } from "agency-lang/stdlib-lib/localModels.js"
@@ -125,6 +127,26 @@ export def removeModel(name: string, cacheDir: string = ""): bool {
   return _removeModel(name, cacheDir)
 }
 
+export def localModelBackend(value: string): string {
+  """
+  Which engine runs a model: "llama-cpp" for GGUF files, "mlx" for MLX
+  models served by `agency local serve`.
+
+  @param value - name, alias, hf: URI, mlx: URI, .gguf path, or model directory
+  """
+  return _resolveModel(value).backend
+}
+
+export def mlxServedName(value: string): string {
+  """
+  The model name to send to the MLX server for this model. It is the same
+  string `agency local serve` gives the server.
+
+  @param value - name, alias, mlx: URI, or model directory
+  """
+  return _mlxServedName(_resolveModel(value))
+}
+
 export def registerLocalProvider() {
   """
   Register the llama-cpp provider so local models can be used for LLM calls.
@@ -136,8 +158,10 @@ export def registerLocalModel(value: string, cacheDir: string = ""): string {
   """
   Register the provider and ensure the model is downloaded. Returns the local
   .gguf path to use as the model for LLM calls with provider "llama-cpp".
+  For an MLX model this registers nothing and returns the name to send to
+  the server. Start the server first with `agency local serve`.
 
-  @param value - name, alias, hf: URI, or .gguf path
+  @param value - name, alias, hf: URI, mlx: URI, .gguf path, or model directory
   @param cacheDir - download dir (empty string = per-user cache)
   """
   return _registerLocalModel(value, cacheDir)

--- a/packages/agency-lang/stdlib/agency/local.agency
+++ b/packages/agency-lang/stdlib/agency/local.agency
@@ -16,11 +16,11 @@ import {
  } from "agency-lang/stdlib-lib/localModels.js"
 
 /** @module
-  @summary Manage and run local GGUF models: download by short name or Hugging Face URI, alias them, and register the local provider.
-  Manage and run local GGUF models. Download models by curated short name or
-  Hugging Face URI, alias them, list or remove downloads, and register the local
-  provider so `llm()` calls can use them. Requires the smoltalk-llama-cpp
-  package.
+  @summary Manage and run local models: GGUF files through llama.cpp, and MLX models through a server.
+  Manage and run local models. A GGUF model downloads by curated short name
+  or Hugging Face URI and runs inside the Agency process; that needs the
+  smoltalk-llama-cpp package. An MLX model is named with an mlx: URI or a
+  model directory and runs in mlx_lm.server, which you start yourself.
 
   ```ts
   import { registerLocalModel } from "std::agency/local"
@@ -41,7 +41,7 @@ export type DownloadedModel = {
   path: string;
   sizeBytes: number;
   backend: string;
-  complete: bool
+  complete: boolean
 }
 
 export type ModelName = {
@@ -66,17 +66,19 @@ export def localModelsSupported(): bool {
 
 export def resolveModelName(value: string): string {
   """
-  Map a curated short name or alias to its Hugging Face URI. Pass URIs and
-  .gguf paths through unchanged.
+  Map a curated short name or alias to its target: an hf: URI or .gguf path
+  for a GGUF model, an mlx: URI or directory for an MLX model. Pass URIs and
+  paths through unchanged.
 
-  @param value - name, alias, hf: URI, or .gguf path
+  @param value - name, alias, hf: URI, mlx: URI, .gguf path, or model directory
   """
   return _resolveModelName(value)
 }
 
 export def downloadModel(value: string, cacheDir: string = ""): string {
   """
-  Download a model and return its local .gguf path.
+  Download a model and return its local .gguf path. For an MLX model this
+  returns the model directory; downloading one is not supported yet.
   Skips the download if the file already exists in the cache dir.
 
   @param value - what to download
@@ -107,7 +109,7 @@ export def aliasModel(name: string, uri: string): string {
   Returns the path to the agency.json file that the alias was written to.
 
   @param name - the alias
-  @param uri - the hf: URI it maps to
+  @param uri - the hf: URI, mlx: URI, .gguf path, or model directory it maps to
   """
   return _aliasModel(name, uri)
 }
@@ -137,7 +139,7 @@ export def removeModel(name: string, cacheDir: string = ""): bool {
 export def localModelBackend(value: string): string {
   """
   Which engine runs a model: "llama-cpp" for GGUF files, "mlx" for MLX
-  models served by `agency local serve`.
+  models served by mlx_lm.server.
 
   @param value - name, alias, hf: URI, mlx: URI, .gguf path, or model directory
   """
@@ -146,8 +148,9 @@ export def localModelBackend(value: string): string {
 
 export def mlxServedName(value: string): string {
   """
-  The model name to send to the MLX server for this model. It is the same
-  string `agency local serve` gives the server.
+  The model name to send to the MLX server for this model: the repo id for
+  an mlx: URI, or the absolute path for a model directory. Start
+  mlx_lm.server with the same string.
 
   @param value - name, alias, mlx: URI, or model directory
   """
@@ -166,7 +169,7 @@ export def registerLocalModel(value: string, cacheDir: string = ""): string {
   Register the provider and ensure the model is downloaded. Returns the local
   .gguf path to use as the model for LLM calls with provider "llama-cpp".
   For an MLX model this registers nothing and returns the name to send to
-  the server. Start the server first with `agency local serve`.
+  the server. Start mlx_lm.server on that model first.
 
   @param value - name, alias, hf: URI, mlx: URI, .gguf path, or model directory
   @param cacheDir - download dir (empty string = per-user cache)

--- a/packages/agency-lang/tests/integration/cli-tier2/test.mjs
+++ b/packages/agency-lang/tests/integration/cli-tier2/test.mjs
@@ -398,7 +398,8 @@ function checkLocalIsolated() {
   const resolved = runInstalledAgency(localDir, ["local", "resolve", "smollm2-135m"], { env });
   assertBlank(resolved.stderr, "[local resolve] stderr");
   assert(
-    resolved.stdout.replace(/\r\n/g, "\n").trim() === "hf:unsloth/SmolLM2-135M-Instruct-GGUF:Q4_K_M",
+    resolved.stdout.replace(/\r\n/g, "\n").trim() ===
+      "llama-cpp  hf:unsloth/SmolLM2-135M-Instruct-GGUF:Q4_K_M",
     `local resolve returned: ${resolved.stdout}`,
   );
   console.log("[cli-tier2] local isolated ✓");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,8 +35,8 @@ importers:
         specifier: ^2.4.2
         version: 2.4.2
       smoltalk:
-        specifier: ^0.12.1
-        version: 0.12.1(@modelcontextprotocol/sdk@1.29.0(supports-color@7.2.0)(zod@4.4.3))(supports-color@7.2.0)(ws@8.21.3)
+        specifier: ^0.13.0
+        version: 0.13.0(@modelcontextprotocol/sdk@1.29.0(supports-color@7.2.0)(zod@4.4.3))(supports-color@7.2.0)(ws@8.21.3)
       tarsec:
         specifier: 0.5.4
         version: 0.5.4
@@ -2596,8 +2596,8 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
-  smoltalk@0.12.1:
-    resolution: {integrity: sha512-TcRVKavqJDtongOF5LUmpRsTEmTmZthYmcKrXBVQuDbibertoewHMPT8htSi8s78buW8hqd+biCymRfS2Z7K0Q==}
+  smoltalk@0.13.0:
+    resolution: {integrity: sha512-yWMgz4/jEcv7rXE/S1jEjLQ48l1ODNpYxIC7aXC5ukc3NdGS9lqTwFXlpEtwzLVVB2RzHUS8JVjO0WvTmxa97g==}
     peerDependencies:
       smoltalk-llama-cpp: '>=0.3.0 <1.0.0'
     peerDependenciesMeta:
@@ -5496,7 +5496,7 @@ snapshots:
 
   slash@3.0.0: {}
 
-  smoltalk@0.12.1(@modelcontextprotocol/sdk@1.29.0(supports-color@7.2.0)(zod@4.4.3))(supports-color@7.2.0)(ws@8.21.3):
+  smoltalk@0.13.0(@modelcontextprotocol/sdk@1.29.0(supports-color@7.2.0)(zod@4.4.3))(supports-color@7.2.0)(ws@8.21.3):
     dependencies:
       '@anthropic-ai/sdk': 0.109.1(zod@4.4.3)
       '@google/genai': 2.19.0(@modelcontextprotocol/sdk@1.29.0(supports-color@7.2.0)(zod@4.4.3))(supports-color@7.2.0)


### PR DESCRIPTION
## What this adds

`agency local` now knows about two kinds of model. GGUF files run in-process through llama.cpp, as before. MLX models run in a server on a Mac, and Agency talks to it through smoltalk's new `mlx` provider (smoltalk 0.13.0, egonSchiele/smoltalk#45).

With this PR you can alias a model directory you already have, start `mlx_lm.server` by hand, and run against it:

```bash
agency local alias add coder /Volumes/models/hf/hub/models--mlx-community--Qwen3-Coder-Next-4bit/snapshots/7b93…
agency local resolve coder            # mlx  /Volumes/models/…
agency run --local coder my.agency
agency agent --local coder
```

## Changes

- **`backend` field.** Every catalog entry, every entry in `data/model-catalog.json`, and every object-form alias carries `backend: "llama-cpp" | "mlx"`. It is required and must agree with the URI. A bad alias fails with a message naming the file. A bad remote catalog entry is skipped with a warning.
- **`mlx:` prefix and model directories.** `mlx:org/repo` and `mlx:org/repo@rev` name an MLX model. A directory with `config.json` and a `.safetensors` file is one too.
- **`_resolveModel`** returns `{ backend, target }`. `agency local resolve` prints both.
- **`run --local` and `agent --local`** branch on the backend. For `mlx` they download and register nothing, and send the model name `agency local serve` will give the server. The agent gets an `mlx` capabilities entry with `memory: false`.
- **`agency local list`** has a BACKEND column and marks downloaded MLX models from their `.agency-model.json` record (`lib/stdlib/mlxModelRecord.ts`).
- **`agency local remove` keeps files unless `-f` is passed.** This changes the GGUF behaviour, which deleted the file on the first call. Without `-f` it removes the alias and prints where the files are.
- **`agency local download mlx:…`** says MLX downloads come later and points at `alias add`. The real downloader is the third PR.
- Dev doc: `docs/dev/llm/mlx-local-models.md`.

Spec: `packages/agency-lang/2026-09-07-mlx-local-models-spec.md`. Plan: `2026-09-07-mlx-plan-1-backend-and-naming.md`.

## Testing

- Unit tests for every piece above: 156 tests across the seven touched files, all green. `pnpm run typecheck`, `pnpm run lint:structure`, and prettier are clean.
- End to end without a server: `agency agent --local mlx:org/nothing --print "say hi"` reaches the `SmolMlx` client and reports a connection error, with no download attempt.
- Not yet run: the check against a real server on the Studio (plan task 9, step 1). That is the owner's step before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YcMgUhZzNBrhgu2hMFAwme
