### PR TITLE
llm(): accept the messages option and seed the active thread with it

### DIFF
--- a/packages/agency-lang/docs/dev/language/handoff-functions.md
+++ b/packages/agency-lang/docs/dev/language/handoff-functions.md
@@ -28,10 +28,9 @@ the body's messages can land on the caller's thread as valid history.
 3. `runInvokeStep` runs the body in a frame whose thread store is a
    view of the caller's store with the prompt's own thread active, the
    thread carrying the marker (`ThreadStore.viewWithActive`). That is
-   the active thread for an ordinary prompt, a subthread for an `async`
-   prompt, and an unregistered thread for a prompt given explicit
-   `messages`; in every case the body's `llm()` calls land on the same
-   thread as the marker. The view has its own active stack, so two
+   the active thread for an ordinary prompt and a subthread for an
+   `async` prompt; in either case the body's `llm()` calls land on the
+   same thread as the marker. The view has its own active stack, so two
    prompts running at once cannot disturb each other.
 4. When the body returns, `finishHandoff` removes every system-role
    message after this dispatch's marker and pushes a user-role

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -809,10 +809,12 @@ export async function runPrompt(args: {
     backoff: ccBackoff,
     validationRetries: ccValidationRetries,
     label: ccLabel,
+    messages: seedMessages,
     ...restClientConfig
   } = (args.clientConfig || {}) as Partial<smoltalk.SmolConfig> &
     RetryConfig & {
       tools?: any[];
+      messages?: smoltalk.MessageJSON[];
       memory?: boolean | { model?: string };
       maxToolResultChars?: number;
       maxRepeatedToolCalls?: number;
@@ -890,15 +892,19 @@ export async function runPrompt(args: {
   //
   // See restoreThreadForResume for how the alias is preserved and when a
   // restore is refused (a snapshot that predates a thread repair).
+  //
+  // The `messages` option seeds the conversation: its messages are appended
+  // to the thread ahead of the prompt. They join the thread rather than
+  // replacing it, so a system message pushed earlier is still sent and the
+  // seed stays readable after the call.
   let messages: MessageThread;
   if (self.messagesJSON) {
     messages = restoreThreadForResume(self.messagesJSON, args.messages);
-  } else if (clientConfig.messages) {
-    messages = MessageThread.fromJSON(clientConfig.messages);
-  } else if (args.messages) {
-    messages = args.messages;
   } else {
-    messages = new MessageThread();
+    messages = args.messages ?? new MessageThread();
+    for (const seeded of MessageThread.fromJSON(seedMessages ?? []).getMessages()) {
+      messages.push(seeded);
+    }
   }
 
   /** The ONE way this function snapshots the thread for checkpoint/resume.
@@ -1133,8 +1139,8 @@ export async function runPrompt(args: {
         // A handoff continues this prompt's conversation: the body's llm()
         // calls append to `messages`, the thread that carries the marker.
         // That is usually the active thread, but an async prompt runs on a
-        // subthread and explicit `messages` are not in the store at all,
-        // so bind the body to `messages` rather than to whatever is active.
+        // subthread, so bind the body to `messages` rather than to whatever
+        // is active.
         // Every other tool gets a fresh store.
         const continuesCallerThread = !!handler.markers?.handoff;
         if (continuesCallerThread) {

--- a/packages/agency-lang/lib/typeChecker/builtinNamedArgs.test.ts
+++ b/packages/agency-lang/lib/typeChecker/builtinNamedArgs.test.ts
@@ -122,6 +122,29 @@ describe("builtin named-arg validation (llm options)", () => {
   });
 });
 
+describe("llm() messages option", () => {
+  it("accepts messages: as a named argument", () => {
+    const errors = errorsFrom(
+      `node main() { let r = llm("hi", messages: [{ role: "user", content: "earlier" }])\n print(r) }`,
+    );
+    expect(errors).toHaveLength(0);
+  });
+
+  it("accepts messages: in the options object", () => {
+    const errors = errorsFrom(
+      `node main() { let r = llm("hi", { messages: [{ role: "user", content: "earlier" }] })\n print(r) }`,
+    );
+    expect(errors).toHaveLength(0);
+  });
+
+  it("rejects a message without a role", () => {
+    const errors = errorsFrom(
+      `node main() { let r = llm("hi", messages: [{ content: "earlier" }])\n print(r) }`,
+    );
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});
+
 describe("llm() validationRetries option", () => {
   it("accepts validationRetries on llm()", () => {
     const errors = errorsFrom(

--- a/packages/agency-lang/lib/typeChecker/builtins.ts
+++ b/packages/agency-lang/lib/typeChecker/builtins.ts
@@ -11,6 +11,16 @@ import {
 
 const anyArray = { type: "arrayType", elementType: ANY_T } as const;
 const stringArray = { type: "arrayType", elementType: string } as const;
+const messageArray: VariableType = {
+  type: "arrayType",
+  elementType: {
+    type: "objectType",
+    properties: [
+      { key: "role", value: string },
+      { key: "content", value: ANY_T },
+    ],
+  },
+};
 
 /** Types for `BUILTIN_VARIABLES` (lib/config.ts) that the checker knows.
  *  `__dirname` is the per-module directory constant every compiled module
@@ -82,6 +92,9 @@ const llmOptionProperties: { key: string; value: VariableType }[] = [
     }),
   },
   { key: "tools", value: optional(anyArray) },
+  // Seed the conversation: these messages are appended to the active thread
+  // ahead of the prompt. See the `messages` handling in lib/runtime/prompt.ts.
+  { key: "messages", value: optional(messageArray) },
   // Provider hosted tools (server-side) to enable for this call, by
   // capability name, e.g. ["web_search"]. Forwarded to smoltalk via the
   // LLMClient PromptConfig. See lib/runtime/llmClient.ts.

--- a/packages/agency-lang/tests/agency-js/handoff/agent.agency
+++ b/packages/agency-lang/tests/agency-js/handoff/agent.agency
@@ -204,8 +204,8 @@ node cancelledHandoff(): any {
   return map(infos, \info -> getThread(info.id, 0, 1000) catch [])
 }
 
-// Explicit messages give the prompt a thread the store has never seen. A
-// handoff inside it must land on that thread.
+// Explicit messages seed the active thread. A handoff inside the prompt
+// lands on that thread, and the next prompt sees the whole conversation.
 node explicitMessages() {
   const options: any = {
     tools: [subagent],

--- a/packages/agency-lang/tests/agency-js/handoff/fixture.json
+++ b/packages/agency-lang/tests/agency-js/handoff/fixture.json
@@ -264,9 +264,16 @@
       "user"
     ],
     "activeThreadRoles": [
+      "user",
+      "user",
+      "assistant",
+      "user",
+      "assistant",
+      "user",
+      "assistant",
       "user"
     ],
-    "activeThreadSawHandoff": 0
+    "activeThreadSawHandoff": 3
   },
   "callerSystemVisible": {
     "result": "caller done",

--- a/packages/agency-lang/tests/agency-js/handoff/test.js
+++ b/packages/agency-lang/tests/agency-js/handoff/test.js
@@ -398,9 +398,8 @@ const results = {};
   };
 }
 
-// A handoff inside a prompt with explicit messages lands on that thread,
-// which the store had never seen. The active thread's next request must
-// not see any of it.
+// Explicit messages seed the active thread, so a handoff inside that
+// prompt lands on the active thread and the next request sees all of it.
 {
   const { state, callbacks } = makeCapture();
   const result = await explicitMessages({ callbacks });

--- a/packages/agency-lang/tests/agency/llm-seed-messages.agency
+++ b/packages/agency-lang/tests/agency/llm-seed-messages.agency
@@ -1,0 +1,16 @@
+import { systemMessage, listThreads, getThread } from "std::thread"
+
+// Seeding llm() with `messages` adds those messages to the active thread.
+// Anything already on the thread (here a system message) stays, and the
+// seeded messages stay visible after the call.
+node seedKeepsSystemMessage(): string {
+  systemMessage("Call yourself Agency.")
+  const answer = llm(
+    "What's your name?",
+    messages: [{ role: "user", content: "Some earlier context." }],
+  )
+  const threads = listThreads(lazySummarize: false) catch []
+  const messages = getThread(threads[0].id, 0, 100) catch []
+  const roles = map(messages, \m -> m.role)
+  return "${answer}|${roles}"
+}

--- a/packages/agency-lang/tests/agency/llm-seed-messages.agency
+++ b/packages/agency-lang/tests/agency/llm-seed-messages.agency
@@ -14,3 +14,25 @@ node seedKeepsSystemMessage(): string {
   const roles = map(messages, \m -> m.role)
   return "${answer}|${roles}"
 }
+
+handoff def helper(question: string): string {
+  return llm("brief: ${question}")
+}
+
+// A handoff inside a seeded prompt continues that prompt's conversation.
+// Since the seed lives on the active thread, the dispatch marker, the
+// body's reply, and the hand-back all end up on the active thread too.
+node seedWithHandoff(): string {
+  systemMessage("Call yourself Agency.")
+  const answer = llm(
+    "Ask the helper.",
+    tools: [helper],
+    messages: [{ role: "user", content: "Some earlier context." }],
+  )
+  const threads = listThreads(lazySummarize: false) catch []
+  const messages = getThread(threads[0].id, 0, 100) catch []
+  const roles = map(messages, \m -> m.role)
+  // The marker replaces the assistant tool call at index 3; the hand-back
+  // is the user message at index 6.
+  return "${answer}|${roles}|${messages[3].content}|${messages[6].content}"
+}

--- a/packages/agency-lang/tests/agency/llm-seed-messages.test.json
+++ b/packages/agency-lang/tests/agency/llm-seed-messages.test.json
@@ -4,10 +4,46 @@
       "nodeName": "seedKeepsSystemMessage",
       "input": "",
       "expectedOutput": "\"Agency|system,user,user,assistant\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
-      "llmMocks": [{ "return": "Agency" }],
+      "llmMocks": [
+        {
+          "return": "Agency"
+        }
+      ],
       "description": "messages: seeds the active thread instead of replacing it, so an earlier systemMessage is still sent"
+    },
+    {
+      "nodeName": "seedWithHandoff",
+      "input": "",
+      "expectedOutput": "\"done|system,user,user,assistant,user,assistant,user,assistant|[dispatching helper: {\\\"question\\\":\\\"hi\\\"}]|[helper finished. helper says hi]\\nContinue with the user's request.\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        {
+          "toolCall": {
+            "name": "helper",
+            "args": {
+              "question": "hi"
+            }
+          }
+        },
+        {
+          "return": "helper says hi"
+        },
+        {
+          "return": "done"
+        }
+      ],
+      "description": "a handoff inside a seeded prompt lands on the active thread, next to the system message and the seed"
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/llm-seed-messages.test.json
+++ b/packages/agency-lang/tests/agency/llm-seed-messages.test.json
@@ -1,0 +1,13 @@
+{
+  "tests": [
+    {
+      "nodeName": "seedKeepsSystemMessage",
+      "input": "",
+      "expectedOutput": "\"Agency|system,user,user,assistant\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "Agency" }],
+      "description": "messages: seeds the active thread instead of replacing it, so an earlier systemMessage is still sent"
+    }
+  ]
+}


### PR DESCRIPTION
## Two bugs in the `messages` option of `llm()`

**The type checker rejected it.** The checker keeps its own list of `llm()` options in `lib/typeChecker/builtins.ts`, and `messages` was never on it, so `llm("hi", messages: [...])` failed with AG6012 even though the runtime accepts it. The one existing test that seeds messages only got past the checker by typing its options as `any`.

**Seeding dropped the system message.** In `lib/runtime/prompt.ts`, a `messages` option built a brand-new thread from the seed and ignored the active thread. A `systemMessage()` call before the prompt pushed onto the active thread, so the model never saw it. The seed and the reply also landed on a thread the thread store never saw, so nothing after the call could read them.

## What changed

- `messages` is an allowed `llm()` option, typed as an array of `{ role: string, content: any }`. Both the named-argument and options-object forms type-check.
- Seeded messages are appended to the active thread ahead of the prompt instead of replacing it.
- Behaviour change: a handoff inside a prompt seeded with `messages` now lands on the active thread, since the throwaway thread is gone. The handoff agency-js fixture and the handoff dev doc are updated to match.

## Tests

- New agency test `tests/agency/llm-seed-messages` fails on main and passes here: an earlier system message is still sent, and the seed stays on the active thread.
- Three new cases in `lib/typeChecker/builtinNamedArgs.test.ts`.
- Verified against a real model: the script that reproduced the bug now sends system, user, user and answers as the system message instructs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9cmFhwjShxuWY5oGEi8WU
