### PR TITLE
Typechecker bug batch: handler and dead-code narrowing, AG4012, AG7007, static value args, clean import errors

### DIFF
--- a/packages/agency-lang/docs/dev/compiler/typechecker/README.md
+++ b/packages/agency-lang/docs/dev/compiler/typechecker/README.md
@@ -352,6 +352,20 @@ enabled, disabled, and tested as a unit, and makes it cheap to add a new one.
 | `undefinedVariableDiagnostic.ts` | `checkUndefinedVariables` | A variable reference that resolves to nothing. Severity from `typechecker.undefinedVariables`. |
 | `toolBlockBinding.ts` | `checkToolBlockBindings` | At each `llm(...)` with a known tools array, require every function-typed parameter to be bound. |
 | `validateStaticInit.ts` | `validateStaticInit` | Validate static initializers and `static <bare>` statements. |
+| `paramRedeclaration.ts` | `checkParameterRedeclarations` | A `let`/`const` may not reuse a parameter name (AG4012). Codegen keeps parameters and locals in different slots and resolves later reads to the parameter, so the redeclare would be invisible. |
+| `valueArgReferences.ts` | `checkValueArgReferences` | A value argument to a value-parameterized type must be a literal, a `static const`, an import, or a value parameter of the enclosing alias (AG7007). Anything else is not a JavaScript identifier where the type is declared. |
+
+### Import errors that are not diagnostics
+
+A re-export of a name the source does not define, and a `pkg::` import of a
+package that is not installed, are caught while the symbol table is built,
+before the checker runs. They throw `ImportResolutionError`
+(`lib/importResolutionError.ts`) with the statement's `loc` and file. The
+compiler lets that propagate so programmatic callers can catch it. The CLI
+catches it once, in `runCli`, and prints `file:line:col - error: message`
+with no stack trace; `agency typecheck` catches it per file so the other
+files still check. Any other error out of the symbol table keeps its stack,
+because it is a bug.
 
 All modules are under `lib/typeChecker/`.
 

--- a/packages/agency-lang/docs/dev/compiler/typechecker/README.md
+++ b/packages/agency-lang/docs/dev/compiler/typechecker/README.md
@@ -353,7 +353,7 @@ enabled, disabled, and tested as a unit, and makes it cheap to add a new one.
 | `toolBlockBinding.ts` | `checkToolBlockBindings` | At each `llm(...)` with a known tools array, require every function-typed parameter to be bound. |
 | `validateStaticInit.ts` | `validateStaticInit` | Validate static initializers and `static <bare>` statements. |
 | `paramRedeclaration.ts` | `checkParameterRedeclarations` | A `let`/`const` may not reuse a parameter name (AG4012). Codegen keeps parameters and locals in different slots and resolves later reads to the parameter, so the redeclare would be invisible. |
-| `valueArgReferences.ts` | `checkValueArgReferences` | A value argument to a value-parameterized type must be a literal, a `static const`, an import, or a value parameter of the enclosing alias (AG7007). Anything else is not a JavaScript identifier where the type is declared. Covers annotations, alias bodies and value-parameter defaults, `schema(T)`, and `x is T`. A name that resolves to nothing is reported through the undefined-variable severity, since that pass does not look inside types. |
+| `valueArgReferences.ts` | `checkValueArgReferences` | A value argument to a value-parameterized type must be a literal, a `static const`, an import, or a value parameter of the enclosing alias (AG7007). The generated validator is module-level JavaScript, and a plain top-level variable, a parameter, or a local is not an identifier there. Walks every type-bearing AST position with the checker's scopes; a name that resolves to nothing is reported through the undefined-variable severity. |
 
 ### Import errors that are not diagnostics
 
@@ -363,9 +363,9 @@ before the checker runs. They throw `ImportResolutionError`
 (`lib/importResolutionError.ts`) with the statement's `loc` and file. The
 compiler lets that propagate so programmatic callers can catch it. The CLI
 catches it once, in `runCli`, and prints `file:line:col - error: message`
-with no stack trace; `agency typecheck` catches it per file so the other
-files still check. Any other error out of the symbol table keeps its stack,
-because it is a bug.
+with no stack trace. `agency typecheck` prints it once, drops the input file
+it is in, and checks the rest. Any other error out of the symbol table keeps
+its stack, because it is a bug.
 
 All modules are under `lib/typeChecker/`.
 

--- a/packages/agency-lang/docs/dev/compiler/typechecker/README.md
+++ b/packages/agency-lang/docs/dev/compiler/typechecker/README.md
@@ -353,7 +353,7 @@ enabled, disabled, and tested as a unit, and makes it cheap to add a new one.
 | `toolBlockBinding.ts` | `checkToolBlockBindings` | At each `llm(...)` with a known tools array, require every function-typed parameter to be bound. |
 | `validateStaticInit.ts` | `validateStaticInit` | Validate static initializers and `static <bare>` statements. |
 | `paramRedeclaration.ts` | `checkParameterRedeclarations` | A `let`/`const` may not reuse a parameter name (AG4012). Codegen keeps parameters and locals in different slots and resolves later reads to the parameter, so the redeclare would be invisible. |
-| `valueArgReferences.ts` | `checkValueArgReferences` | A value argument to a value-parameterized type must be a literal, a `static const`, an import, or a value parameter of the enclosing alias (AG7007). Anything else is not a JavaScript identifier where the type is declared. |
+| `valueArgReferences.ts` | `checkValueArgReferences` | A value argument to a value-parameterized type must be a literal, a `static const`, an import, or a value parameter of the enclosing alias (AG7007). Anything else is not a JavaScript identifier where the type is declared. Covers annotations, alias bodies and value-parameter defaults, `schema(T)`, and `x is T`. A name that resolves to nothing is reported through the undefined-variable severity, since that pass does not look inside types. |
 
 ### Import errors that are not diagnostics
 

--- a/packages/agency-lang/docs/dev/compiler/typechecker/narrowing/README.md
+++ b/packages/agency-lang/docs/dev/compiler/typechecker/narrowing/README.md
@@ -193,6 +193,22 @@ Success for the rest of the block. `alwaysExits` decides this and is deliberatel
 conservative: it counts only `return` (a `raise`/interrupt may resume, and
 `propagate` semantics are non-trivial, so treating them as exits could be unsound).
 
+### Inline handler bodies and dead code
+
+An inline handler (`handle { … } with (e) { … }`) runs when a statement in the
+handle body raises, so it can start after any prefix of that body. Its flow
+starts from the pre-body flow with every name the body rebinds reset to its
+declared type (`handlerEntryFlow` in `flowBuilder.ts`). Starting it from the
+body's end flow was wrong: a body that always returns ends in `exit`, so the
+handler got no flow nodes at all and every guard inside it was ignored
+(issue #612).
+
+Statements after an unconditional `return` are still walked, on a side flow
+rooted at a fresh `start` node, so guards in dead code narrow like anywhere
+else. The scope's terminal flow stays `exit`, so definite-return checking is
+unchanged. Without this, a guarded `r.value` after `return match(...)` fell
+back to the declared `Result` type and reported a false AG2009 (issue #538).
+
 ### Soundness
 
 Every narrowing is a false-negative-only approximation. A whole-body reassignment

--- a/packages/agency-lang/docs/dev/compiler/typechecker/narrowing/README.md
+++ b/packages/agency-lang/docs/dev/compiler/typechecker/narrowing/README.md
@@ -197,19 +197,17 @@ conservative: it counts only `return` (a `raise`/interrupt may resume, and
 
 An inline handler (`handle { … } with (e) { … }`) runs when a statement in the
 handle body raises, so it can start after any prefix of that body. Its flow
-starts from the pre-body flow with every name the body rebinds reset to its
-declared type, and every name the body declares set to `T | null`, since the
-declaration may not have run yet (`handlerEntryFlow` in `flowBuilder.ts`; the
-same `T | null` treatment a finalize block gets). Starting it from the
-body's end flow was wrong: a body that always returns ends in `exit`, so the
-handler got no flow nodes at all and every guard inside it was ignored
-(issue #612).
+starts from the pre-body flow, adjusted for what the body may have done by
+then: a name the body rebinds is reset to its declared type, and a name it
+declares is `T | null`, since the declaration may not have run yet. This is
+the same `T | null` treatment a finalize block gets. The handler's own
+parameter is always bound on entry, so a body local of the same name leaves
+it alone. See `handlerEntryFlow` in `flowBuilder.ts`.
 
 Statements after an unconditional `return` are still walked, on a side flow
-rooted at a fresh `start` node, so guards in dead code narrow like anywhere
-else. The scope's terminal flow stays `exit`, so definite-return checking is
-unchanged. Without this, a guarded `r.value` after `return match(...)` fell
-back to the declared `Result` type and reported a false AG2009 (issue #538).
+rooted at the flow before the exit, so guards in dead code narrow like
+anywhere else and a narrowing established before the exit stays visible. The
+scope's terminal flow stays `exit`, so definite-return checking is unchanged.
 
 ### Soundness
 

--- a/packages/agency-lang/docs/dev/compiler/typechecker/narrowing/README.md
+++ b/packages/agency-lang/docs/dev/compiler/typechecker/narrowing/README.md
@@ -198,7 +198,9 @@ conservative: it counts only `return` (a `raise`/interrupt may resume, and
 An inline handler (`handle { … } with (e) { … }`) runs when a statement in the
 handle body raises, so it can start after any prefix of that body. Its flow
 starts from the pre-body flow with every name the body rebinds reset to its
-declared type (`handlerEntryFlow` in `flowBuilder.ts`). Starting it from the
+declared type, and every name the body declares set to `T | null`, since the
+declaration may not have run yet (`handlerEntryFlow` in `flowBuilder.ts`; the
+same `T | null` treatment a finalize block gets). Starting it from the
 body's end flow was wrong: a body that always returns ends in `exit`, so the
 handler got no flow nodes at all and every guard inside it was ignored
 (issue #612).

--- a/packages/agency-lang/docs/dev/language/validation-annotations.md
+++ b/packages/agency-lang/docs/dev/language/validation-annotations.md
@@ -541,6 +541,18 @@ The codegen divergence rule is expressed in exactly one predicate,
 `typeAliasVariable` should consult the same predicate to stay
 consistent.
 
+### The factory call is deferred
+
+A use site of a validated value-param alias emits
+`{ kind: "ref", get: () => GreaterThan(minAge) }` rather than the bare call.
+A top-level `type Age = GreaterThan(minAge)` runs at module load, before
+static init, so an eager call would hand the factory the uninitialized-static
+sentinel and the validator would fail with "Cannot convert a Symbol value to
+a number" (issue #440). The walker resolves the ref at validation time, when
+every static exists. The checker's AG7007 rejects a value argument that is
+not a literal, a `static const`, an import, or an enclosing value parameter,
+because nothing else is a JavaScript identifier at that point.
+
 ### Why inline-at-use-site instead of a schema factory function?
 
 A natural alternative is to emit a factory:

--- a/packages/agency-lang/docs/dev/language/validation-annotations.md
+++ b/packages/agency-lang/docs/dev/language/validation-annotations.md
@@ -544,14 +544,21 @@ consistent.
 ### The factory call is deferred
 
 A use site of a validated value-param alias emits
-`{ kind: "ref", get: () => GreaterThan(minAge) }` rather than the bare call.
-A top-level `type Age = GreaterThan(minAge)` runs at module load, before
-static init, so an eager call would hand the factory the uninitialized-static
-sentinel and the validator would fail with "Cannot convert a Symbol value to
-a number" (issue #440). The walker resolves the ref at validation time, when
-every static exists. The checker's AG7007 rejects a value argument that is
-not a literal, a `static const`, an import, or an enclosing value parameter,
-because nothing else is a JavaScript identifier at that point.
+`{ kind: "ref", get: () => GreaterThan(minAge) }` rather than the bare call,
+and `get` caches its first result. A top-level `type Age = GreaterThan(minAge)`
+runs at module load, before static init, so an eager call would hand the
+factory the uninitialized-static sentinel (issue #440). The walker resolves
+the ref at validation time, when every static exists.
+
+Use-site validators are merged by the runtime's `__withUseSiteValidators`,
+which wraps a ref so the merge happens on the descriptor it resolves to. The
+walker follows a ref before it reads validators, so validators set on the ref
+itself would never run.
+
+The checker's AG7007 rejects a value argument that is not a literal, a
+`static const`, an import, or an enclosing value parameter. The generated
+factory call is module-level JavaScript, and nothing else is an identifier
+there.
 
 ### Why inline-at-use-site instead of a schema factory function?
 

--- a/packages/agency-lang/docs/site/diagnostics/index.md
+++ b/packages/agency-lang/docs/site/diagnostics/index.md
@@ -91,6 +91,7 @@ or suppress a type-checker one on the next line with `// @tc-ignore AG####`.
 | [AG4009](names.md#ag4009) | Cannot find module '&#123;module&#125;'. |
 | [AG4010](names.md#ag4010) | '&#123;name&#125;' is defined in '&#123;module&#125;' but is not exported. Add the 'export' keyword to its definition. |
 | [AG4011](names.md#ag4011) | '&#123;name&#125;' is not accessible under --agency-only. It reaches JavaScript's Function or prototype chain, which pure Agency code may not use. |
+| [AG4012](names.md#ag4012) | Cannot redeclare parameter '&#123;name&#125;' with '&#123;declKind&#125;'. Reads after the redeclare would still see the parameter. Assign to it instead, or pick a different name. |
 
 ## Match and narrowing
 
@@ -130,8 +131,8 @@ or suppress a type-checker one on the next line with `// @tc-ignore AG####`.
 | [AG6025](tools.md#ag6025) | Unknown named argument '&#123;name&#125;' in call to '&#123;fn&#125;'. |
 | [AG6026](tools.md#ag6026) | Named argument '&#123;name&#125;' conflicts with positional argument at position &#123;position&#125; in call to '&#123;fn&#125;'. |
 | [AG6027](tools.md#ag6027) | Positional argument cannot feed variadic parameter '&#123;param&#125;' when it is also bound by name in call to '&#123;fn&#125;'. |
-| [AG6028](tools.md#ag6028) | Tool '&#123;tool&#125;' has required function-typed parameter '&#123;param&#125;' is unbound. Bind it with .partial(&#123;param&#125;: &lt;value&gt;) before passing as a tool. |
-| [AG6029](tools.md#ag6029) | Tool '&#123;tool&#125;' has required function-typed parameter '&#123;param&#125;' is unbound (&#123;type&#125;). Bind it with .partial(&#123;param&#125;: &lt;value&gt;) before passing as a tool. |
+| [AG6028](tools.md#ag6028) | Tool '&#123;tool&#125;' has a required function-typed parameter '&#123;param&#125;' that is unbound. Bind it with .partial(&#123;param&#125;: &lt;value&gt;) before passing it as a tool. |
+| [AG6029](tools.md#ag6029) | Tool '&#123;tool&#125;' has a required function-typed parameter '&#123;param&#125;' that is unbound (its type is &#123;type&#125;). Bind it with .partial(&#123;param&#125;: &lt;value&gt;) before passing it as a tool. |
 | [AG6030](tools.md#ag6030) | Tool '&#123;tool&#125;' will be exposed to the LLM without optional function-typed parameter(s): &#123;params&#125;. The function body must be prepared to run with the declared default for each. |
 | [AG6031](tools.md#ag6031) | saveDraft() cannot be called at module top level — there is no enclosing function, node, or block scope to save a draft for. |
 | [AG6032](tools.md#ag6032) | A scope can declare at most one finalize block. Combine the logic into one block. |
@@ -153,6 +154,7 @@ or suppress a type-checker one on the next line with `// @tc-ignore AG####`.
 | [AG7004](static-init.md#ag7004) | Cannot reassign static `&#123;name&#125;` at module top level — statics are immutable after initialization. Use a global (`const`/`let` without `static`) if you need a mutable value. |
 | [AG7005](static-init.md#ag7005) | Cannot mutate static `&#123;name&#125;` via `.&#123;method&#125;(...)` at module top level — statics are deep-frozen after initialization. Use a global (`const`/`let` without `static`) if you need a mutable value. |
 | [AG7006](static-init.md#ag7006) | Function '&#123;name&#125;' cannot be both destructive and idempotent — those markers are contradictory. Pick one. |
+| [AG7007](static-init.md#ag7007) | Type '&#123;alias&#125;' takes value argument '&#123;name&#125;', which is &#123;what&#125;. A value argument must be a literal, a 'static const', an imported name, or a value parameter of the enclosing type alias. |
 
 ## Code templates and holes
 

--- a/packages/agency-lang/docs/site/diagnostics/names.md
+++ b/packages/agency-lang/docs/site/diagnostics/names.md
@@ -119,3 +119,13 @@ An import names a symbol that its target module defines but does not `export`. A
 *Default severity: error.*
 
 Under `--agency-only` (`typechecker.jsGlobals: "sandbox"`), a program may not read `constructor`, `prototype`, or `__proto__` from a value, spelled or as a string-literal key. Those property names walk from any value to JavaScript's `Function` and the prototype chain, which is a way for pure Agency code to reach the host with no interrupt. This is a best-effort compile-time catch; the runtime backstop is code-generation-from-strings being disabled.
+
+<a id="ag4012"></a>
+
+## AG4012 — Cannot redeclare parameter '&#123;name&#125;' with '&#123;declKind&#125;'. Reads after the redeclare would still see the parameter. Assign to it instead, or pick a different name.
+
+*Default severity: error.*
+
+A `let` or `const` inside a function or node body reuses the name of one of its parameters. Parameters and locals live in different slots at runtime, and a read after the redeclare still resolves to the parameter slot, so the new value would silently never be seen.
+
+Assign to the parameter instead (`u = { tag: "b", n: 1 }`), or give the local a different name.

--- a/packages/agency-lang/docs/site/diagnostics/static-init.md
+++ b/packages/agency-lang/docs/site/diagnostics/static-init.md
@@ -63,3 +63,18 @@ Statics are deep-frozen after initialization, so mutating one through a method (
 A function was marked both `destructive` and `idempotent`, but those markers contradict each other: destructive means a retry can cause additional effects, while idempotent means a retry is safe to repeat. A function cannot be both.
 
 **How to fix:** keep the one marker that describes the function and remove the other.
+
+<a id="ag7007"></a>
+
+## AG7007 — Type '&#123;alias&#125;' takes value argument '&#123;name&#125;', which is &#123;what&#125;. A value argument must be a literal, a 'static const', an imported name, or a value parameter of the enclosing type alias.
+
+*Default severity: error.*
+
+A value-parameterized type was instantiated with a plain top-level variable, a parameter, or a local. The validator the compiler generates for a type is module-level JavaScript, and it names a value argument as a bare identifier. A `static const` and an imported name are identifiers there. A plain top-level variable lives in the global store and a parameter or local lives on the stack frame, so the generated code cannot reach them and the program would crash at validation time. What works is a literal, a `static const`, an imported name, or a value parameter of the enclosing type alias (`type Above(floor: number) = GreaterThan(floor)`). A value parameter's default follows the same rule, and may also name an earlier parameter of the same alias.
+
+Mark the variable `static const`, or pass a literal:
+
+```agency
+static const minAge: number = 5
+type Adult = GreaterThan(minAge)
+```

--- a/packages/agency-lang/docs/site/diagnostics/tools.md
+++ b/packages/agency-lang/docs/site/diagnostics/tools.md
@@ -276,7 +276,7 @@ A positional argument would feed a variadic parameter that is also being bound b
 
 <a id="ag6028"></a>
 
-## AG6028 — Tool '&#123;tool&#125;' has required function-typed parameter '&#123;param&#125;' is unbound. Bind it with .partial(&#123;param&#125;: &lt;value&gt;) before passing as a tool.
+## AG6028 — Tool '&#123;tool&#125;' has a required function-typed parameter '&#123;param&#125;' that is unbound. Bind it with .partial(&#123;param&#125;: &lt;value&gt;) before passing it as a tool.
 
 *Default severity: error.*
 
@@ -286,7 +286,7 @@ A function passed as a tool has a required function-typed parameter that is stil
 
 <a id="ag6029"></a>
 
-## AG6029 — Tool '&#123;tool&#125;' has required function-typed parameter '&#123;param&#125;' is unbound (&#123;type&#125;). Bind it with .partial(&#123;param&#125;: &lt;value&gt;) before passing as a tool.
+## AG6029 — Tool '&#123;tool&#125;' has a required function-typed parameter '&#123;param&#125;' that is unbound (its type is &#123;type&#125;). Bind it with .partial(&#123;param&#125;: &lt;value&gt;) before passing it as a tool.
 
 *Default severity: error.*
 

--- a/packages/agency-lang/lib/backends/typescriptBuilder.integration.test.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.integration.test.ts
@@ -492,11 +492,10 @@ node main() {
   return h
 }
 `);
-    // Use-site validators must be concatenated via an IIFE that binds the
-    // factory call to a local, so the factory (and its min.partial(...)
-    // allocations) is evaluated exactly once, not twice.
-    expect(out).toContain("(__d) =>");
-    // The factory call appears once (as the IIFE argument), not spread + read.
+    // Use-site validators are merged by the runtime helper, which takes the
+    // factory call as an argument, so the factory (and its min.partial(...)
+    // allocations) is evaluated exactly once.
+    expect(out).toContain("__withUseSiteValidators(");
     const calls = out.match(/NumberInRange\(1, 10\)/g) ?? [];
     expect(calls.length).toBe(1);
   });

--- a/packages/agency-lang/lib/backends/typescriptGenerator/validationDescriptor.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator/validationDescriptor.ts
@@ -189,11 +189,10 @@ function schemaNode(
  * descriptor expression. Returns `base` unchanged when there are none.
  * Shared by the `__agency_descriptor` and value-param factory-call paths.
  *
- * `base` is bound to a local via an IIFE so it is evaluated exactly once:
- * `((__d) => ({ ...__d, validators: [...(__d?.validators ?? []), ...useSite] }))(base)`.
- * For the factory-call path `base` is a function call (`NumberInRange(1, 10)`),
- * so spreading it AND reading `.validators` off it directly would rebuild the
- * whole descriptor — including the `min.partial(...)` allocations — twice.
+ * Emits `__withUseSiteValidators(base, [...useSite])`. The runtime helper
+ * evaluates `base` once, and when `base` is a `{ kind: "ref" }` it merges
+ * onto the descriptor the ref resolves to, since the walker follows a ref
+ * before it reads validators.
  */
 function withUseSiteValidators(base: TsNode, useSiteValidators: TsNode[]): TsNode {
   if (useSiteValidators.length === 0) {

--- a/packages/agency-lang/lib/backends/typescriptGenerator/validationDescriptor.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator/validationDescriptor.ts
@@ -196,19 +196,10 @@ function schemaNode(
  * whole descriptor — including the `min.partial(...)` allocations — twice.
  */
 function withUseSiteValidators(base: TsNode, useSiteValidators: TsNode[]): TsNode {
-  if (useSiteValidators.length === 0) return base;
-  const d = ts.id("__d");
-  const existingValidators = ts.binOp(
-    ts.prop(d, "validators", { optional: true }),
-    "??",
-    ts.arr([]),
-    { parenLeft: true },
-  );
-  const merged = ts.obj([
-    ts.setSpread(d),
-    ts.set('"validators"', ts.arr([ts.spread(existingValidators), ...useSiteValidators])),
-  ]);
-  return ts.call(ts.arrowFn([{ name: "__d" }], ts.statements([ts.return(merged)])), [base]);
+  if (useSiteValidators.length === 0) {
+    return base;
+  }
+  return ts.call(ts.id("__withUseSiteValidators"), [base, ts.arr(useSiteValidators)]);
 }
 
 /**
@@ -247,13 +238,10 @@ function valueParamDescriptor(
     const argList = (variableType.valueArgs ?? []).map((a) => tagArgToTs(a)).join(", ");
     const call = ts.raw(`${variableType.aliasName}(${argList})`);
     // Deferred, like the bare-alias ref below: a value argument can name a
-    // `static const`, and a top-level `type Age = GreaterThan(minAge)` would
-    // otherwise read it at module load, before static init has run, and
-    // hand the factory the uninitialized-static sentinel (issue #440).
-    // The walker resolves a ref once per element of an array, so the first
-    // result is cached: the arguments are literals, statics, or imports and
-    // cannot change between reads.
-    return cachedRef(withUseSiteValidators(call, useSiteValidators));
+    // `static const`, and a top-level `type Age = GreaterThan(minAge)` runs
+    // at module load, before static init (issue #440). The first result is
+    // cached because the walker resolves a ref once per array element.
+    return withUseSiteValidators(cachedRef(call), useSiteValidators);
   }
   const substituted = applyValueArgs(entry!, variableType.valueArgs, variableType.aliasName);
   const merged = mergeTagSets(substituted.tags, variableType.tags);

--- a/packages/agency-lang/lib/backends/typescriptGenerator/validationDescriptor.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator/validationDescriptor.ts
@@ -250,11 +250,10 @@ function valueParamDescriptor(
     // `static const`, and a top-level `type Age = GreaterThan(minAge)` would
     // otherwise read it at module load, before static init has run, and
     // hand the factory the uninitialized-static sentinel (issue #440).
-    const resolved = withUseSiteValidators(call, useSiteValidators);
-    return ts.obj([
-      ts.set('"kind"', ts.str("ref")),
-      ts.set('"get"', ts.arrowFn([], ts.statements([ts.return(resolved)]))),
-    ]);
+    // The walker resolves a ref once per element of an array, so the first
+    // result is cached: the arguments are literals, statics, or imports and
+    // cannot change between reads.
+    return cachedRef(withUseSiteValidators(call, useSiteValidators));
   }
   const substituted = applyValueArgs(entry!, variableType.valueArgs, variableType.aliasName);
   const merged = mergeTagSets(substituted.tags, variableType.tags);
@@ -263,6 +262,25 @@ function valueParamDescriptor(
     tags: mergeTagSets(substituted.body.tags, merged),
   };
   return descriptor(bodyWithTags, typeAliases, typeAliasesFull, seen, pendingAliases);
+}
+
+/**
+ * `{ kind: "ref", get }` whose `get` builds `resolved` on the first call and
+ * hands back the same descriptor after that:
+ *
+ *   (() => { let __d: any; return { kind: "ref", get: () => { if (__d === undefined) { __d = <resolved>; } return __d; } }; })()
+ */
+function cachedRef(resolved: TsNode): TsNode {
+  const cached = ts.id("__cached");
+  const fill = ts.if(
+    ts.binOp(cached, "===", ts.raw("undefined")),
+    ts.statements([ts.assign(cached, resolved)]),
+  );
+  const get = ts.arrowFn([], ts.statements([fill, ts.return(cached)]));
+  const ref = ts.obj([ts.set('"kind"', ts.str("ref")), ts.set('"get"', get)]);
+  return ts.iife({
+    body: [ts.letDecl("__cached", undefined, "any"), ts.return(ref)],
+  });
 }
 
 function descriptor(

--- a/packages/agency-lang/lib/backends/typescriptGenerator/validationDescriptor.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator/validationDescriptor.ts
@@ -246,7 +246,15 @@ function valueParamDescriptor(
   if (entry && hasAliasValidate(entry, typeAliasesFull)) {
     const argList = (variableType.valueArgs ?? []).map((a) => tagArgToTs(a)).join(", ");
     const call = ts.raw(`${variableType.aliasName}(${argList})`);
-    return withUseSiteValidators(call, useSiteValidators);
+    // Deferred, like the bare-alias ref below: a value argument can name a
+    // `static const`, and a top-level `type Age = GreaterThan(minAge)` would
+    // otherwise read it at module load, before static init has run, and
+    // hand the factory the uninitialized-static sentinel (issue #440).
+    const resolved = withUseSiteValidators(call, useSiteValidators);
+    return ts.obj([
+      ts.set('"kind"', ts.str("ref")),
+      ts.set('"get"', ts.arrowFn([], ts.statements([ts.return(resolved)]))),
+    ]);
   }
   const substituted = applyValueArgs(entry!, variableType.valueArgs, variableType.aliasName);
   const merged = mergeTagSets(substituted.tags, variableType.tags);

--- a/packages/agency-lang/lib/compiler/initDepGraph.test.ts
+++ b/packages/agency-lang/lib/compiler/initDepGraph.test.ts
@@ -111,6 +111,29 @@ describe("buildInitDepGraphs", () => {
     }
   });
 
+  it("does not treat a followed alias's own value parameter as a reference", () => {
+    const { dir, programs, symbolTable, abs } = writeFixture({
+      "entry.agency":
+        `def gt(minValue: number, value: number): Result<number> { return success(value) }\n` +
+        `@validate(gt.partial(minValue: minValue))\n` +
+        `type GreaterThan(minValue: number) = number\n` +
+        `type Above(floor: number) = GreaterThan(floor)\n` +
+        `type Age = Above(minAge)\n` +
+        `static const minAge: number = 5\n` +
+        `static const age: Age! = 10\n` +
+        `const floor: number = 1\n` +
+        `node main() { return age }\n`,
+    });
+    try {
+      const { staticGraph } = buildInitDepGraphs(programs, symbolTable, abs("entry.agency"));
+      const keyAge = makeKey(abs("entry.agency"), "age");
+      const keyMin = makeKey(abs("entry.agency"), "minAge");
+      expect(staticGraph.edges[keyAge]).toEqual([keyMin]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("adds a cross-module edge when an import is referenced", () => {
     const { dir, programs, symbolTable, abs } = writeFixture({
       "foo.agency":

--- a/packages/agency-lang/lib/compiler/initDepGraph.test.ts
+++ b/packages/agency-lang/lib/compiler/initDepGraph.test.ts
@@ -90,6 +90,27 @@ describe("buildInitDepGraphs", () => {
     }
   });
 
+  it("adds an edge for a static the declaration's type reads through a value argument", () => {
+    const { dir, programs, symbolTable, abs } = writeFixture({
+      "entry.agency":
+        `def gt(minValue: number, value: number): Result<number> { return success(value) }\n` +
+        `@validate(gt.partial(minValue: minValue))\n` +
+        `type GreaterThan(minValue: number) = number\n` +
+        `type Age = GreaterThan(minAge)\n` +
+        `static const age: Age! = 10\n` +
+        `static const minAge: number = 5\n` +
+        `node main() { return age }\n`,
+    });
+    try {
+      const { staticGraph } = buildInitDepGraphs(programs, symbolTable, abs("entry.agency"));
+      const keyAge = makeKey(abs("entry.agency"), "age");
+      const keyMin = makeKey(abs("entry.agency"), "minAge");
+      expect(staticGraph.edges[keyAge]).toEqual([keyMin]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("adds a cross-module edge when an import is referenced", () => {
     const { dir, programs, symbolTable, abs } = writeFixture({
       "foo.agency":

--- a/packages/agency-lang/lib/compiler/initDepGraph.ts
+++ b/packages/agency-lang/lib/compiler/initDepGraph.ts
@@ -912,23 +912,35 @@ function topLevelTypeAliases(nodes: AgencyNode[]): Record<string, TypeAlias> {
 function typeValueArgRefs(type: VariableType, aliases: Record<string, TypeAlias>): FreeRef[] {
   const out: FreeRef[] = [];
   const followed: string[] = [];
-  const visit = (current: VariableType): void => {
+  // `bound` holds the value parameters of the alias whose body is being
+  // walked. A body reference to one of them is the alias's own formal, as
+  // in `type Above(floor) = GreaterThan(floor)`, and names nothing at top
+  // level; the argument it stands for was collected at the use site.
+  const visit = (current: VariableType, bound: string[]): void => {
     visitTypes(current, (inner) => {
       if (inner.type !== "typeAliasVariable" && inner.type !== "genericType") {
         return;
       }
       for (const arg of inner.valueArgs ?? []) {
-        out.push(...collectFreeIdentifiers(arg));
+        for (const ref of collectFreeIdentifiers(arg)) {
+          if (ref.kind === "name" && bound.includes(ref.name)) {
+            continue;
+          }
+          out.push(ref);
+        }
       }
       const name = inner.type === "typeAliasVariable" ? inner.aliasName : inner.name;
       const alias = aliases[name];
       if (alias && !followed.includes(name)) {
         followed.push(name);
-        visit(alias.aliasedType);
+        visit(
+          alias.aliasedType,
+          (alias.valueParams ?? []).map((param) => param.name),
+        );
       }
     });
   };
-  visit(type);
+  visit(type, []);
   return out;
 }
 

--- a/packages/agency-lang/lib/compiler/initDepGraph.ts
+++ b/packages/agency-lang/lib/compiler/initDepGraph.ts
@@ -44,14 +44,16 @@
  *     no edge (statics are already initialized at Phase B time).
  */
 
-import type { AgencyProgram, AgencyNode, Expression } from "../types.js";
+import type { AgencyProgram, AgencyNode, Expression, VariableType } from "../types.js";
 import { declaredName } from "../types/hole.js";
 import type { Assignment } from "../types.js";
 import type { SourceLocation } from "../types/base.js";
 import type { FunctionDefinition } from "../types/function.js";
+import type { TypeAlias } from "../types/typeHints.js";
 import type { SymbolTable } from "../symbolTable.js";
 import { isAgencyImport, resolveAgencyImportPath } from "../importPaths.js";
 import { walkNodes } from "../utils/node.js";
+import { visitTypes } from "../typeChecker/typeWalker.js";
 
 export type InitVarKind = "static" | "global";
 
@@ -76,6 +78,11 @@ export type InitVarNode = {
   /** For bare statements (global graph only) this is the wrapping
    * statement node; for assignments it's the right-hand side. */
   initExpr: Expression | AgencyNode;
+  /** Names the declaration's type annotation reads through value
+   *  arguments, as in `const age: Age! = 10` with
+   *  `type Age = GreaterThan(minAge)`. Validating the value reads
+   *  `minAge`, so it has to be initialized first. */
+  typeRefs: FreeRef[];
   loc?: SourceLocation;
   exported: boolean;
   sequenceHint: number;
@@ -415,8 +422,9 @@ export function buildInitDepGraphs(
     if (!program) continue;
     const depthBase = sequenceHints[moduleId] ?? 0;
 
+    const aliases = topLevelTypeAliases(program.nodes);
     for (const node of program.nodes) {
-      const varNode = nodeFromTopLevel(node, moduleId, depthBase);
+      const varNode = nodeFromTopLevel(node, moduleId, depthBase, aliases);
       if (!varNode) continue;
       const target = varNode.kind === "static" ? staticNodes : globalNodes;
       target[makeKey(varNode.moduleId, varNode.varName)] = varNode;
@@ -454,6 +462,7 @@ function nodeFromTopLevel(
   node: AgencyNode,
   moduleId: string,
   depthBase: number,
+  aliases: Record<string, TypeAlias>,
 ): InitVarNode | null {
   const { stmt: afterApprove, withApprove } = unwrapWithApprove(node);
   const { stmt, isStaticBare, wrapperLoc: staticWrapperLoc } = unwrapStaticStatement(afterApprove);
@@ -465,6 +474,7 @@ function nodeFromTopLevel(
       varName: stmt.variableName,
       kind: stmt.static ? "static" : "global",
       initExpr: stmt.value as Expression,
+      typeRefs: stmt.typeHint ? typeValueArgRefs(stmt.typeHint, aliases) : [],
       loc: stmt.loc,
       exported: !!stmt.exported,
       sequenceHint: depthBase + line,
@@ -499,6 +509,7 @@ function nodeFromTopLevel(
       varName: `__bareStmt_${line}_${col}`,
       kind: isStaticBare ? "static" : "global",
       initExpr: stmt,
+      typeRefs: [],
       loc: effectiveLoc,
       exported: false,
       sequenceHint: depthBase + line,
@@ -647,7 +658,7 @@ function depsFor(
     seen[refKey] = true;
     out.push(refKey);
   };
-  for (const ref of collectFreeIdentifiers(node.initExpr)) {
+  for (const ref of [...collectFreeIdentifiers(node.initExpr), ...node.typeRefs]) {
     if (ref.kind === "name" && ref.name === node.varName) continue;
     addRef(resolveFreeRef(ref, node.moduleId, resolver));
   }
@@ -703,7 +714,7 @@ function rejectStaticReferencesGlobal(
       const offender = globalNodes[refKey];
       if (offender) throw new StaticReferencesGlobalError(node, offender);
     };
-    for (const ref of collectFreeIdentifiers(node.initExpr)) {
+    for (const ref of [...collectFreeIdentifiers(node.initExpr), ...node.typeRefs]) {
       if (ref.kind === "name" && ref.name === node.varName) continue;
       check(resolveFreeRef(ref, node.moduleId, resolver));
     }
@@ -877,6 +888,47 @@ export function collectFreeIdentifiers(expr: Expression | AgencyNode): FreeRef[]
     }
     out.push({ kind: "name", name: node.value });
   }
+  return out;
+}
+
+/** The module's own top-level type aliases, by name. */
+function topLevelTypeAliases(nodes: AgencyNode[]): Record<string, TypeAlias> {
+  const aliases: Record<string, TypeAlias> = {};
+  for (const node of nodes) {
+    if (node.type === "typeAlias") {
+      aliases[node.aliasName] = node;
+    }
+  }
+  return aliases;
+}
+
+/**
+ * The free references inside the value arguments of a type, followed
+ * through the module's own aliases: `Age` with `type Age = GreaterThan(minAge)`
+ * yields `minAge`. An alias from another module is not followed; the
+ * runtime read-before-init trap covers that case, as it does depth-2
+ * function calls.
+ */
+function typeValueArgRefs(type: VariableType, aliases: Record<string, TypeAlias>): FreeRef[] {
+  const out: FreeRef[] = [];
+  const followed: string[] = [];
+  const visit = (current: VariableType): void => {
+    visitTypes(current, (inner) => {
+      if (inner.type !== "typeAliasVariable" && inner.type !== "genericType") {
+        return;
+      }
+      for (const arg of inner.valueArgs ?? []) {
+        out.push(...collectFreeIdentifiers(arg));
+      }
+      const name = inner.type === "typeAliasVariable" ? inner.aliasName : inner.name;
+      const alias = aliases[name];
+      if (alias && !followed.includes(name)) {
+        followed.push(name);
+        visit(alias.aliasedType);
+      }
+    });
+  };
+  visit(type);
   return out;
 }
 

--- a/packages/agency-lang/lib/compiler/topSortInitGraph.test.ts
+++ b/packages/agency-lang/lib/compiler/topSortInitGraph.test.ts
@@ -28,6 +28,7 @@ function makeGraph(opts: {
       varName: n.name,
       kind: n.kind ?? "static",
       initExpr: { type: "number", value: "0", loc: { line: 0, col: 0 } } as any,
+      typeRefs: [],
       loc: { line: n.line ?? 0, col: 0, start: 0, end: 0 },
       exported: false,
       sequenceHint: n.hint ?? 0,

--- a/packages/agency-lang/lib/importPaths.test.ts
+++ b/packages/agency-lang/lib/importPaths.test.ts
@@ -1,3 +1,4 @@
+import { ImportResolutionError } from "./importResolutionError.js";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import {
   findPackageRoot,
@@ -553,5 +554,22 @@ describe("findFileUp", () => {
   });
   it("returns null when nothing matches", () => {
     expect(findFileUp(dir, "definitely-not-a-real-file.xyz")).toBeNull();
+  });
+});
+
+describe("resolvePkgAgencyPath", () => {
+  it("throws an ImportResolutionError naming the importer when the package is not installed", () => {
+    const fromFile = path.join(process.cwd(), "lib", "importPaths.test.ts");
+    let thrown: unknown;
+    try {
+      resolvePkgAgencyPath("pkg::agency-package-that-is-not-installed", fromFile);
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(ImportResolutionError);
+    const err = thrown as ImportResolutionError;
+    expect(err.message).toContain("'agency-package-that-is-not-installed'");
+    expect(err.message).toContain("is not installed");
+    expect(err.file).toBe(fromFile);
   });
 });

--- a/packages/agency-lang/lib/importPaths.ts
+++ b/packages/agency-lang/lib/importPaths.ts
@@ -1,4 +1,5 @@
 import * as fs from "fs";
+import { ImportResolutionError } from "./importResolutionError.js";
 import * as path from "path";
 import { fileURLToPath } from "url";
 import { createRequire } from "module";
@@ -437,7 +438,18 @@ function findPkgDir(
 export function resolvePkgAgencyPath(importPath: string, fromFile: string): string {
   const { packageName, subpath } = parsePkgImport(importPath);
   const req = createRequire(fromFile);
-  const { pkgJsonPath, pkgDir } = findPkgDir(packageName, req);
+  let located: { pkgJsonPath: string; pkgDir: string };
+  try {
+    located = findPkgDir(packageName, req);
+  } catch (e: any) {
+    if (e?.code !== "MODULE_NOT_FOUND") throw e;
+    throw new ImportResolutionError(
+      `Package '${packageName}' for import "${importPath}" is not installed. Add it to package.json and run pnpm install.`,
+      undefined,
+      fromFile,
+    );
+  }
+  const { pkgJsonPath, pkgDir } = located;
 
   if (subpath) {
     const resolved = path.join(pkgDir, subpath + ".agency");

--- a/packages/agency-lang/lib/importPaths.ts
+++ b/packages/agency-lang/lib/importPaths.ts
@@ -430,17 +430,18 @@ function findPkgDir(
 }
 
 /**
- * Resolve a pkg:: import to an absolute filesystem path to the .agency file.
- * Uses createRequire rooted at the importing file's directory to find the
- * package via Node's module resolution, then reads its package.json "agency"
- * field for the entry point.
+ * `findPkgDir` for a package the user named in an import: a package that is
+ * not installed is a user error, reported as an ImportResolutionError on the
+ * importing file rather than as Node's MODULE_NOT_FOUND stack.
  */
-export function resolvePkgAgencyPath(importPath: string, fromFile: string): string {
-  const { packageName, subpath } = parsePkgImport(importPath);
-  const req = createRequire(fromFile);
-  let located: { pkgJsonPath: string; pkgDir: string };
+function findInstalledPkgDir(
+  packageName: string,
+  req: NodeRequire,
+  importPath: string,
+  fromFile: string,
+): { pkgJsonPath: string; pkgDir: string } {
   try {
-    located = findPkgDir(packageName, req);
+    return findPkgDir(packageName, req);
   } catch (e: any) {
     if (e?.code !== "MODULE_NOT_FOUND") throw e;
     throw new ImportResolutionError(
@@ -449,7 +450,18 @@ export function resolvePkgAgencyPath(importPath: string, fromFile: string): stri
       fromFile,
     );
   }
-  const { pkgJsonPath, pkgDir } = located;
+}
+
+/**
+ * Resolve a pkg:: import to an absolute filesystem path to the .agency file.
+ * Uses createRequire rooted at the importing file's directory to find the
+ * package via Node's module resolution, then reads its package.json "agency"
+ * field for the entry point.
+ */
+export function resolvePkgAgencyPath(importPath: string, fromFile: string): string {
+  const { packageName, subpath } = parsePkgImport(importPath);
+  const req = createRequire(fromFile);
+  const { pkgJsonPath, pkgDir } = findInstalledPkgDir(packageName, req, importPath, fromFile);
 
   if (subpath) {
     const resolved = path.join(pkgDir, subpath + ".agency");

--- a/packages/agency-lang/lib/importResolutionError.ts
+++ b/packages/agency-lang/lib/importResolutionError.ts
@@ -1,0 +1,33 @@
+import type { SourceLocation } from "./types/base.js";
+
+/**
+ * An import that cannot be resolved: an unknown or non-exported symbol, a
+ * misused marker, a re-export of a name the source does not define, or a
+ * `pkg::` package that is not installed. Carries the offending statement's
+ * `loc` so a caller can anchor a diagnostic to it.
+ *
+ * The CLI entry points catch this class specifically and print only the
+ * message. A blanket catch would hide the stack of a genuine internal bug,
+ * which is exactly the case where the stack is wanted.
+ */
+export class ImportResolutionError extends Error {
+  loc?: SourceLocation;
+  /** The file holding the offending statement, when the thrower knows it. */
+  file?: string;
+  constructor(message: string, loc?: SourceLocation, file?: string) {
+    super(message);
+    this.name = "ImportResolutionError";
+    this.loc = loc;
+    this.file = file;
+  }
+}
+
+/** One line for the terminal: `file:line:col - error: message`. The error's
+ *  own file wins over the caller's guess; the position is omitted when the
+ *  error carries none. */
+export function formatImportResolutionError(err: ImportResolutionError, file?: string): string {
+  const at = err.file ?? file;
+  if (at === undefined) return `error: ${err.message}`;
+  if (err.loc === undefined) return `${at} - error: ${err.message}`;
+  return `${at}:${err.loc.line + 1}:${err.loc.col + 1} - error: ${err.message}`;
+}

--- a/packages/agency-lang/lib/preprocessors/importResolver.ts
+++ b/packages/agency-lang/lib/preprocessors/importResolver.ts
@@ -5,24 +5,11 @@ import type {
   NamedImport,
 } from "../types/importStatement.js";
 import type { SourceLocation } from "../types/base.js";
+import { ImportResolutionError } from "../importResolutionError.js";
 import type { SymbolTable, SymbolInfo, FileSymbols } from "../symbolTable.js";
 import { resolveAgencyImportPath, isAgencyImport, isPkgImport } from "../importPaths.js";
 
-/**
- * An import that cannot be resolved (unknown symbol, non-exported symbol, a
- * misused marker, …). Carries the offending import statement's `loc` so
- * callers can anchor a diagnostic to it instead of falling back to the top of
- * the file. The LSP relies on this to report the error on the import line
- * while still type-checking the rest of the document.
- */
-export class ImportResolutionError extends Error {
-  loc?: SourceLocation;
-  constructor(message: string, loc?: SourceLocation) {
-    super(message);
-    this.name = "ImportResolutionError";
-    this.loc = loc;
-  }
-}
+export { ImportResolutionError } from "../importResolutionError.js";
 
 /**
  * Resolve unified imports: rewrite `import { x, y } from "./foo.agency"`
@@ -93,9 +80,17 @@ export function resolveImports(
       newNodes.push(node);
       continue;
     }
-    newNodes.push(
-      ...resolveImportStatement(node, symbolTable, currentFile, allowTestImports, onUnresolvable),
-    );
+    try {
+      newNodes.push(
+        ...resolveImportStatement(node, symbolTable, currentFile, allowTestImports, onUnresolvable),
+      );
+    } catch (error) {
+      // Stamp the file so the CLI can print `file:line:col` for it.
+      if (error instanceof ImportResolutionError && error.file === undefined) {
+        error.file = currentFile;
+      }
+      throw error;
+    }
   }
 
   return { ...program, nodes: newNodes };

--- a/packages/agency-lang/lib/preprocessors/importResolver.ts
+++ b/packages/agency-lang/lib/preprocessors/importResolver.ts
@@ -85,9 +85,10 @@ export function resolveImports(
         ...resolveImportStatement(node, symbolTable, currentFile, allowTestImports, onUnresolvable),
       );
     } catch (error) {
-      // Stamp the file so the CLI can print `file:line:col` for it.
-      if (error instanceof ImportResolutionError && error.file === undefined) {
-        error.file = currentFile;
+      // Stamp the file and the statement so the CLI can print `file:line:col`.
+      if (error instanceof ImportResolutionError) {
+        error.file = error.file ?? currentFile;
+        error.loc = error.loc ?? node.loc;
       }
       throw error;
     }

--- a/packages/agency-lang/lib/runtime/index.ts
+++ b/packages/agency-lang/lib/runtime/index.ts
@@ -166,7 +166,11 @@ export { __coarseTypeTest } from "./typeTest.js";
 export { __eq } from "./eq.js";
 export { __requireLength } from "./requireLength.js";
 export { __nn } from "./nn.js";
-export { __validateChain, __validateChainRecursive } from "./validateChain.js";
+export {
+  __validateChain,
+  __validateChainRecursive,
+  __withUseSiteValidators,
+} from "./validateChain.js";
 export type {
   AgencyValidator,
   TypeValidationDescriptor,

--- a/packages/agency-lang/lib/runtime/toolBlockDiagnostics.ts
+++ b/packages/agency-lang/lib/runtime/toolBlockDiagnostics.ts
@@ -8,14 +8,14 @@ import { DIAGNOSTICS, renderMessage } from "../typeChecker/diagnostics.js";
  * (`lib/typeChecker/toolBlockBinding.ts`) and the runtime backstop
  * (`AgencyFunction.validateForLLM` in `agencyFunction.ts`) emit messages
  * built from `formatUnboundClause`. The canonical clause
- *   `required function-typed parameter '<name>' is unbound`
+ *   `a required function-typed parameter '<name>' that is unbound`
  * appears in both messages — the test plan (§5.4 #42) pins that overlap
  * explicitly so the checker and runtime cannot drift apart silently.
  */
 
 /** Canonical clause shared by compile-time and runtime errors. */
 export function formatUnboundClause(paramName: string): string {
-  return `required function-typed parameter '${paramName}' is unbound`;
+  return `a required function-typed parameter '${paramName}' that is unbound`;
 }
 
 /** Compile-time tool-binding diagnostic — rendered from the diagnostic
@@ -42,8 +42,8 @@ export function formatRequiredUnboundError(
 /** Runtime backstop diagnostic — same canonical clause, slightly different framing. */
 export function formatRequiredUnboundRuntimeError(toolName: string, paramName: string): string {
   return (
-    `Tool '${toolName}' cannot be passed to llm(): ${formatUnboundClause(paramName)}. ` +
-    `Use ${toolName}.partial(${paramName}: <value>) before passing.`
+    `Tool '${toolName}' cannot be passed to llm(): it has ${formatUnboundClause(paramName)}. ` +
+    `Bind it with ${toolName}.partial(${paramName}: <value>) before passing it.`
   );
 }
 

--- a/packages/agency-lang/lib/runtime/validateChain.test.ts
+++ b/packages/agency-lang/lib/runtime/validateChain.test.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import {
   __validateChain,
   __validateChainRecursive,
+  __withUseSiteValidators,
   type AgencyValidator,
   type TypeValidationDescriptor,
 } from "./validateChain.js";
@@ -373,5 +374,36 @@ describe("the predicate contract (validators may not modify the value)", () => {
     await expect(
       __validateChain(1, z.number(), [async (v) => success((v as number) + 1)]),
     ).rejects.toThrow(/validator '\(anonymous\)' modified the value/);
+  });
+});
+
+describe("__withUseSiteValidators", () => {
+  it("appends to a plain descriptor's own validators", async () => {
+    const leaf: TypeValidationDescriptor = {
+      kind: "leaf",
+      schema: z.number(),
+      validators: [isPos],
+    };
+    const merged = __withUseSiteValidators(leaf, [isEven]);
+    expect(isSuccess(await __validateChainRecursive(4, merged))).toBe(true);
+    expect(isFailure(await __validateChainRecursive(3, merged))).toBe(true);
+    expect(isFailure(await __validateChainRecursive(-2, merged))).toBe(true);
+  });
+
+  it("merges onto the descriptor a ref resolves to, so the walker runs them", async () => {
+    const leaf: TypeValidationDescriptor = {
+      kind: "leaf",
+      schema: z.number(),
+      validators: [isPos],
+    };
+    const ref: TypeValidationDescriptor = { kind: "ref", get: () => leaf };
+    const merged = __withUseSiteValidators(ref, [isEven]);
+    expect(isSuccess(await __validateChainRecursive(4, merged))).toBe(true);
+    expect(isFailure(await __validateChainRecursive(3, merged))).toBe(true);
+  });
+
+  it("returns the descriptor itself when there is nothing to add", () => {
+    const leaf: TypeValidationDescriptor = { kind: "leaf", schema: z.number(), validators: [] };
+    expect(__withUseSiteValidators(leaf, [])).toBe(leaf);
   });
 });

--- a/packages/agency-lang/lib/runtime/validateChain.test.ts
+++ b/packages/agency-lang/lib/runtime/validateChain.test.ts
@@ -402,6 +402,16 @@ describe("__withUseSiteValidators", () => {
     expect(isFailure(await __validateChainRecursive(3, merged))).toBe(true);
   });
 
+  it("merges a ref once, however many times the walker resolves it", () => {
+    const leaf: TypeValidationDescriptor = { kind: "leaf", schema: z.number(), validators: [] };
+    const get = vi.fn(() => leaf);
+    const merged = __withUseSiteValidators({ kind: "ref", get }, [isPos]);
+    const first = (merged as { get: () => TypeValidationDescriptor }).get();
+    const second = (merged as { get: () => TypeValidationDescriptor }).get();
+    expect(second).toBe(first);
+    expect(get).toHaveBeenCalledTimes(1);
+  });
+
   it("returns the descriptor itself when there is nothing to add", () => {
     const leaf: TypeValidationDescriptor = { kind: "leaf", schema: z.number(), validators: [] };
     expect(__withUseSiteValidators(leaf, [])).toBe(leaf);

--- a/packages/agency-lang/lib/runtime/validateChain.ts
+++ b/packages/agency-lang/lib/runtime/validateChain.ts
@@ -164,6 +164,25 @@ export type TypeValidationDescriptor =
       get: () => TypeValidationDescriptor;
     };
 
+/**
+ * `descriptor` with `validators` added after its own. A ref is wrapped so
+ * the merge happens on the descriptor it resolves to: the walker follows a
+ * ref before it reads validators, so validators set on the ref itself would
+ * never run.
+ */
+export function __withUseSiteValidators(
+  descriptor: TypeValidationDescriptor,
+  validators: AgencyValidator[],
+): TypeValidationDescriptor {
+  if (validators.length === 0) {
+    return descriptor;
+  }
+  if (descriptor.kind === "ref") {
+    return { kind: "ref", get: () => __withUseSiteValidators(descriptor.get(), validators) };
+  }
+  return { ...descriptor, validators: [...descriptor.validators, ...validators] };
+}
+
 export type RecursiveValidationOpts = {
   /** Hard cap on traversal depth. Default 64. */
   maxDepth?: number;

--- a/packages/agency-lang/lib/runtime/validateChain.ts
+++ b/packages/agency-lang/lib/runtime/validateChain.ts
@@ -178,7 +178,18 @@ export function __withUseSiteValidators(
     return descriptor;
   }
   if (descriptor.kind === "ref") {
-    return { kind: "ref", get: () => __withUseSiteValidators(descriptor.get(), validators) };
+    // Merged once: the walker resolves the same ref for every element of an
+    // array or record.
+    let merged: TypeValidationDescriptor | undefined;
+    return {
+      kind: "ref",
+      get: () => {
+        if (merged === undefined) {
+          merged = __withUseSiteValidators(descriptor.get(), validators);
+        }
+        return merged;
+      },
+    };
   }
   return { ...descriptor, validators: [...descriptor.validators, ...validators] };
 }

--- a/packages/agency-lang/lib/runtime/validateToolForLLM.test.ts
+++ b/packages/agency-lang/lib/runtime/validateToolForLLM.test.ts
@@ -74,7 +74,7 @@ describe("AgencyFunction.validateForLLM (runtime tool backstop)", () => {
   });
 
   // #42 — unified runtime/compile-time error wording. The canonical clause
-  // `required function-typed parameter '<name>' is unbound` appears in BOTH
+  // `a required function-typed parameter '<name>' that is unbound` appears in BOTH
   // the compile-time error message (toolBlockBinding.test.ts #12) and the
   // runtime error message thrown here. Pinning the shared substring keeps
   // the two paths from drifting apart silently.
@@ -82,7 +82,7 @@ describe("AgencyFunction.validateForLLM (runtime tool backstop)", () => {
     const fn = makeFn([{ name: "block", isFunctionTyped: true }]);
     expect(() => fn.validateForLLM()).toThrow(formatUnboundClause("block"));
     expect(formatUnboundClause("block")).toBe(
-      "required function-typed parameter 'block' is unbound",
+      "a required function-typed parameter 'block' that is unbound",
     );
   });
 });

--- a/packages/agency-lang/lib/symbolTable.test.ts
+++ b/packages/agency-lang/lib/symbolTable.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { ImportResolutionError } from "./importResolutionError.js";
 import { classifySymbols, SymbolTable } from "./symbolTable.js";
 import { parseAgency } from "./parser.js";
 import { writeFileSync, unlinkSync } from "fs";
@@ -299,6 +300,27 @@ describe("SymbolTable: re-export reachability and merging", () => {
       const reSyms = st.getFile(path.resolve(paths.reexporter))!;
       expect((reSyms["foo"] as any).markers?.destructive).toBe(true);
       expect((reSyms["bar"] as any).markers?.destructive).toBeFalsy();
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("throws an ImportResolutionError carrying the re-exporter file and statement position", () => {
+    const { paths, cleanup } = withTempFiles({
+      source: `export def foo() { return 1 }`,
+      reexporter: `export { nope } from "@source@"`,
+    });
+    try {
+      let thrown: unknown;
+      try {
+        SymbolTable.build(paths.reexporter);
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown).toBeInstanceOf(ImportResolutionError);
+      const err = thrown as ImportResolutionError;
+      expect(err.file).toBe(paths.reexporter);
+      expect(err.loc?.line).toBe(0);
     } finally {
       cleanup();
     }

--- a/packages/agency-lang/lib/symbolTable.ts
+++ b/packages/agency-lang/lib/symbolTable.ts
@@ -22,6 +22,7 @@ import type { EffectDeclaration } from "./types/effectDeclaration.js";
 import { walkNodes } from "./utils/node.js";
 import { effectDeclarationsWithTags } from "./utils/tagsAbove.js";
 import { resolveAgencyImportPath, isAgencyImport, isNonTemplatedStdlib } from "./importPaths.js";
+import { ImportResolutionError } from "./importResolutionError.js";
 
 export type InterruptEffect = {
   effect: string;
@@ -560,7 +561,11 @@ export function mergeExportsFrom(
 ): void {
   const sourceSymbols = files[sourcePath];
   if (!sourceSymbols) {
-    throw new Error(`Re-export source '${stmt.modulePath}' could not be resolved`);
+    throw new ImportResolutionError(
+      `Re-export source '${stmt.modulePath}' could not be resolved`,
+      stmt.loc,
+      reExporterPath,
+    );
   }
   const targetSymbols: FileSymbols = files[reExporterPath] ?? {};
   files[reExporterPath] = targetSymbols;
@@ -579,26 +584,36 @@ export function mergeExportsFrom(
   for (const originalName of stmt.body.names) {
     const sym = sourceSymbols[originalName];
     if (!sym) {
-      throw new Error(`Symbol '${originalName}' is not defined in '${stmt.modulePath}'`);
+      throw new ImportResolutionError(
+        `Symbol '${originalName}' is not defined in '${stmt.modulePath}'`,
+        stmt.loc,
+        reExporterPath,
+      );
     }
     if (!isExportedSymbol(sym)) {
-      throw new Error(
+      throw new ImportResolutionError(
         `${symbolKindLabel(sym)} '${originalName}' in '${stmt.modulePath}' is not exported. Add the 'export' keyword to its definition.`,
+        stmt.loc,
+        reExporterPath,
       );
     }
     const localName = stmt.body.aliases[originalName] ?? originalName;
     if (sym.kind === "node" && localName !== originalName) {
-      throw new Error(
+      throw new ImportResolutionError(
         `Node '${originalName}' from '${stmt.modulePath}' cannot be re-exported under a different name. ` +
           `Re-exported nodes preserve their original name because the source graph is merged wholesale.`,
+        stmt.loc,
+        reExporterPath,
       );
     }
     const isDestructive = stmt.body.destructiveNames?.includes(originalName) ?? false;
     const isIdempotent = stmt.body.idempotentNames?.includes(originalName) ?? false;
     if (sym.kind === "node" && (isDestructive || isIdempotent)) {
-      throw new Error(
+      throw new ImportResolutionError(
         `A retry-safety marker (destructive/idempotent) cannot be applied to node '${originalName}' from '${stmt.modulePath}'. ` +
           `Markers are only meaningful for functions.`,
+        stmt.loc,
+        reExporterPath,
       );
     }
     mergeOne(
@@ -628,14 +643,18 @@ function mergeOne(
   if (existing) {
     if (!("reExportedFrom" in existing) || !existing.reExportedFrom) {
       const at = existing.loc ? ` at line ${existing.loc.line + 1}` : "";
-      throw new Error(`Re-exported name '${localName}' collides with local declaration${at}`);
+      throw new ImportResolutionError(
+        `Re-exported name '${localName}' collides with local declaration${at}`,
+        stmt.loc,
+      );
     }
     const sameSource =
       existing.reExportedFrom.sourceFile === sourcePath &&
       existing.reExportedFrom.originalName === originalName;
     if (!sameSource) {
-      throw new Error(
+      throw new ImportResolutionError(
         `Name '${localName}' is re-exported from both '${existing.reExportedFrom.sourceFile}' and '${sourcePath}'. Disambiguate with explicit 'export { ${localName} as ... } from ...'.`,
+        stmt.loc,
       );
     }
     return; // idempotent re-merge

--- a/packages/agency-lang/lib/symbolTable.ts
+++ b/packages/agency-lang/lib/symbolTable.ts
@@ -575,7 +575,7 @@ export function mergeExportsFrom(
       if (!isExportedSymbol(sym)) continue;
       // Star re-exports carry no per-name modifiers; markers are inherited
       // from the source symbol via the spread inside mergeOne.
-      mergeOne(targetSymbols, name, name, sym, false, false, sourcePath, stmt);
+      mergeOne(targetSymbols, name, name, sym, false, false, sourcePath, stmt, reExporterPath);
     }
     return;
   }
@@ -625,6 +625,7 @@ export function mergeExportsFrom(
       isIdempotent,
       sourcePath,
       stmt,
+      reExporterPath,
     );
   }
 }
@@ -638,6 +639,7 @@ function mergeOne(
   forceIdempotent: boolean,
   sourcePath: string,
   stmt: ExportFromStatement,
+  reExporterPath: string,
 ): void {
   const existing = targetSymbols[localName];
   if (existing) {
@@ -646,6 +648,7 @@ function mergeOne(
       throw new ImportResolutionError(
         `Re-exported name '${localName}' collides with local declaration${at}`,
         stmt.loc,
+        reExporterPath,
       );
     }
     const sameSource =
@@ -655,6 +658,7 @@ function mergeOne(
       throw new ImportResolutionError(
         `Name '${localName}' is re-exported from both '${existing.reExportedFrom.sourceFile}' and '${sourcePath}'. Disambiguate with explicit 'export { ${localName} as ... } from ...'.`,
         stmt.loc,
+        reExporterPath,
       );
     }
     return; // idempotent re-merge

--- a/packages/agency-lang/lib/symbolTable.ts
+++ b/packages/agency-lang/lib/symbolTable.ts
@@ -247,11 +247,13 @@ export class SymbolTable {
       for (const node of entry.program.nodes) {
         if (node.type !== "exportFromStatement") continue;
         if (!isAgencyImport(node.modulePath)) {
-          throw new Error(
+          throw new ImportResolutionError(
             `Re-export source must be an Agency module (std::, pkg::, or .agency path): '${node.modulePath}'`,
+            node.loc,
+            filePath,
           );
         }
-        const sourcePath = resolveAgencyImportPath(node.modulePath, filePath);
+        const sourcePath = resolveReExportSource(node.modulePath, filePath, node.loc);
         resolveReExports(sourcePath, newVisiting);
         mergeExportsFrom(files, filePath, sourcePath, node);
       }
@@ -545,6 +547,25 @@ function symbolKindLabel(sym: SymbolInfo): string {
     // ConstantSymbol is only ever added when `exported && static && const`.
     case "constant":
       return "Constant";
+  }
+}
+
+/** `resolveAgencyImportPath` for a re-export, with the statement's file and
+ *  position stamped on an uninstalled-package error so the CLI can print
+ *  `file:line:col`. */
+function resolveReExportSource(
+  modulePath: string,
+  fromFile: string,
+  loc: SourceLocation | undefined,
+): string {
+  try {
+    return resolveAgencyImportPath(modulePath, fromFile);
+  } catch (error) {
+    if (error instanceof ImportResolutionError) {
+      error.file = error.file ?? fromFile;
+      error.loc = error.loc ?? loc;
+    }
+    throw error;
   }
 }
 

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
@@ -35,7 +35,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/lib/typeChecker/diagnosticExplanations.ts
+++ b/packages/agency-lang/lib/typeChecker/diagnosticExplanations.ts
@@ -581,7 +581,7 @@ def f(): string {
 
 **How to fix:** keep the one marker that describes the function and remove the other.`,
 
-  valueArgNotStatic: `A value-parameterized type was instantiated with a plain top-level variable, a parameter, or a local. The generated code reads a value argument once, when the type is declared, so none of those is in scope there and the program would crash with "<name> is not defined". What works is a literal, a \`static const\`, an imported name, or a value parameter of the enclosing type alias (\`type Above(floor: number) = GreaterThan(floor)\`). The same rule applies to a value parameter's default.
+  valueArgNotStatic: `A value-parameterized type was instantiated with a plain top-level variable, a parameter, or a local. The validator the compiler generates for a type is module-level JavaScript, and it names a value argument as a bare identifier. A \`static const\` and an imported name are identifiers there. A plain top-level variable lives in the global store and a parameter or local lives on the stack frame, so the generated code cannot reach them and the program would crash at validation time. What works is a literal, a \`static const\`, an imported name, or a value parameter of the enclosing type alias (\`type Above(floor: number) = GreaterThan(floor)\`). A value parameter's default follows the same rule, and may also name an earlier parameter of the same alias.
 
 Mark the variable \`static const\`, or pass a literal:
 

--- a/packages/agency-lang/lib/typeChecker/diagnosticExplanations.ts
+++ b/packages/agency-lang/lib/typeChecker/diagnosticExplanations.ts
@@ -362,6 +362,9 @@ node main() {
 **How to fix:** write the block without \`as\`, e.g. the keyword followed immediately by its \`{ ... }\` body.`,
 
   sandboxForbiddenProperty: `Under \`--agency-only\` (\`typechecker.jsGlobals: "sandbox"\`), a program may not read \`constructor\`, \`prototype\`, or \`__proto__\` from a value, spelled or as a string-literal key. Those property names walk from any value to JavaScript's \`Function\` and the prototype chain, which is a way for pure Agency code to reach the host with no interrupt. This is a best-effort compile-time catch; the runtime backstop is code-generation-from-strings being disabled.`,
+  parameterRedeclared: `A \`let\` or \`const\` inside a function or node body reuses the name of one of its parameters. Parameters and locals live in different slots at runtime, and a read after the redeclare still resolves to the parameter slot, so the new value would silently never be seen.
+
+Assign to the parameter instead (\`u = { tag: "b", n: 1 }\`), or give the local a different name.`,
   undefinedVariable: `The type checker walks every scope — nodes, function bodies, blocks — and resolves each name to a declaration. This error means a name was used with no \`let\`, \`const\`, parameter, or import that introduces it in reach.
 
 **How to fix:** declare it before use (\`let x = …\` / \`const x = …\`), fix a typo in the name, or import it if it lives in another module. Agency has no implicit variables: a bare assignment like \`x = 5\` without a prior \`let\`/\`const\` is not a declaration.`,
@@ -578,6 +581,14 @@ def f(): string {
 
 **How to fix:** keep the one marker that describes the function and remove the other.`,
 
+  valueArgNotStatic: `A value-parameterized type was instantiated with a variable that is not a \`static const\`. The generated code reads a value argument once, when the type is declared, so a plain top-level \`const\`, a parameter, or a local is not in scope there and the program would crash with "<name> is not defined".
+
+Mark the variable \`static const\`, or pass a literal:
+
+\`\`\`agency
+static const minAge: number = 5
+type Adult = GreaterThan(minAge)
+\`\`\``,
   // ---- AG8: code templates and holes ----
   spliceTopLevelStatement: `A splice at the top level of a file adds the generator's output to the file, so that output is held to the same rule as anything you write there yourself: top-level code runs at initialization and cannot branch, loop, or wait.
 

--- a/packages/agency-lang/lib/typeChecker/diagnosticExplanations.ts
+++ b/packages/agency-lang/lib/typeChecker/diagnosticExplanations.ts
@@ -581,7 +581,7 @@ def f(): string {
 
 **How to fix:** keep the one marker that describes the function and remove the other.`,
 
-  valueArgNotStatic: `A value-parameterized type was instantiated with a variable that is not a \`static const\`. The generated code reads a value argument once, when the type is declared, so a plain top-level \`const\`, a parameter, or a local is not in scope there and the program would crash with "<name> is not defined".
+  valueArgNotStatic: `A value-parameterized type was instantiated with a plain top-level variable, a parameter, or a local. The generated code reads a value argument once, when the type is declared, so none of those is in scope there and the program would crash with "<name> is not defined". What works is a literal, a \`static const\`, an imported name, or a value parameter of the enclosing type alias (\`type Above(floor: number) = GreaterThan(floor)\`). The same rule applies to a value parameter's default.
 
 Mark the variable \`static const\`, or pass a literal:
 

--- a/packages/agency-lang/lib/typeChecker/diagnostics.ts
+++ b/packages/agency-lang/lib/typeChecker/diagnostics.ts
@@ -650,7 +650,7 @@ export const DIAGNOSTICS = {
     code: "AG7007",
     severity: "error",
     message:
-      "Type '{alias}' takes value argument '{name}', which is {what}. A value argument is read when the type is declared, so it must be a literal, a 'static const', or a value parameter of the enclosing type alias.",
+      "Type '{alias}' takes value argument '{name}', which is {what}. A value argument is read when the type is declared, so it must be a literal, a 'static const', an imported name, or a value parameter of the enclosing type alias.",
   },
   unfilledHoles: {
     code: "AG8001",

--- a/packages/agency-lang/lib/typeChecker/diagnostics.ts
+++ b/packages/agency-lang/lib/typeChecker/diagnostics.ts
@@ -650,7 +650,7 @@ export const DIAGNOSTICS = {
     code: "AG7007",
     severity: "error",
     message:
-      "Type '{alias}' takes value argument '{name}', which is {what}. A value argument is read when the type is declared, so it must be a literal, a 'static const', an imported name, or a value parameter of the enclosing type alias.",
+      "Type '{alias}' takes value argument '{name}', which is {what}. A value argument must be a literal, a 'static const', an imported name, or a value parameter of the enclosing type alias.",
   },
   unfilledHoles: {
     code: "AG8001",

--- a/packages/agency-lang/lib/typeChecker/diagnostics.ts
+++ b/packages/agency-lang/lib/typeChecker/diagnostics.ts
@@ -530,6 +530,12 @@ export const DIAGNOSTICS = {
     message:
       "'{name}' is not accessible under --agency-only. It reaches JavaScript's Function or prototype chain, which pure Agency code may not use.",
   },
+  parameterRedeclared: {
+    code: "AG4012",
+    severity: "error",
+    message:
+      "Cannot redeclare parameter '{name}' with '{declKind}'. Reads after the redeclare would still see the parameter. Assign to it instead, or pick a different name.",
+  },
   undefinedVariable: {
     code: "AG4007",
     severity: "error",
@@ -555,13 +561,13 @@ export const DIAGNOSTICS = {
     code: "AG6028",
     severity: "error",
     message:
-      "Tool '{tool}' has required function-typed parameter '{param}' is unbound. Bind it with .partial({param}: <value>) before passing as a tool.",
+      "Tool '{tool}' has a required function-typed parameter '{param}' that is unbound. Bind it with .partial({param}: <value>) before passing it as a tool.",
   },
   toolRequiredParamUnboundTyped: {
     code: "AG6029",
     severity: "error",
     message:
-      "Tool '{tool}' has required function-typed parameter '{param}' is unbound ({type}). Bind it with .partial({param}: <value>) before passing as a tool.",
+      "Tool '{tool}' has a required function-typed parameter '{param}' that is unbound (its type is {type}). Bind it with .partial({param}: <value>) before passing it as a tool.",
   },
   toolOptionalParamsDropped: {
     code: "AG6030",
@@ -639,6 +645,12 @@ export const DIAGNOSTICS = {
     severity: "error",
     message:
       "Function '{name}' cannot be both destructive and idempotent — those markers are contradictory. Pick one.",
+  },
+  valueArgNotStatic: {
+    code: "AG7007",
+    severity: "error",
+    message:
+      "Type '{alias}' takes value argument '{name}', which is {what}. A value argument is read when the type is declared, so it must be a literal, a 'static const', or a value parameter of the enclosing type alias.",
   },
   unfilledHoles: {
     code: "AG8001",

--- a/packages/agency-lang/lib/typeChecker/flowBuilder.ts
+++ b/packages/agency-lang/lib/typeChecker/flowBuilder.ts
@@ -122,16 +122,23 @@ function maybeUnset(declared: ScopeType, env: FlowEnvironment): ScopeType {
  * handler can happen after any prefix of the handle body, so the pre-body
  * flow is adjusted for what the body may have done by then: a name it
  * rebinds is reset to its declared type, and a name it declares may not
- * exist yet, so it is `T | null`. The body's end flow says nothing about
- * either when the body always returns.
+ * exist yet, so it is `T | null`. The handler's own parameter is always
+ * bound on entry, so a body local of the same name does not widen it.
  */
-function handlerEntryFlow(flow: FlowNode, body: AgencyNode[], env: FlowEnvironment): FlowNode {
+function handlerEntryFlow(
+  flow: FlowNode,
+  body: AgencyNode[],
+  param: string,
+  env: FlowEnvironment,
+): FlowNode {
   const widened: Record<string, ScopeType> = Object.create(null);
   for (const name of assignedNames(body)) {
+    if (name === param) continue;
     const ref: Reference = { variable: name, chain: [] };
     widened[referenceKey(ref)] = declaredPathType(env.scope, ref, env.typeAliases);
   }
   for (const name of declaredNames(body)) {
+    if (name === param) continue;
     const ref: Reference = { variable: name, chain: [] };
     widened[referenceKey(ref)] = maybeUnset(declaredPathType(env.scope, ref, env.typeAliases), env);
   }
@@ -355,11 +362,10 @@ const statementRules: StatementRuleTable = {
   handleBlock: (node, flow, env) => {
     const afterBody = buildFlowGraph(node.body, flow, env);
     if (node.handler.kind === "inline") {
-      // The handler runs when a statement in the body raises, so it can start
-      // after any prefix of the body. Entering it from `afterBody` was wrong:
-      // a body that always returns leaves `afterBody` at `exit`, so the
-      // handler body got no flow nodes and lost all narrowing (issue #612).
-      buildFlowGraph(node.handler.body, handlerEntryFlow(flow, node.body, env), env);
+      // The handler runs when a statement in the body raises, so it starts
+      // from the pre-body flow, not from `afterBody` (issue #612).
+      const entry = handlerEntryFlow(flow, node.body, node.handler.param.name, env);
+      buildFlowGraph(node.handler.body, entry, env);
     }
     return afterBody;
   },
@@ -439,11 +445,10 @@ const passThrough = (node: AgencyNode, flow: FlowNode, env: FlowEnvironment): Fl
  * Build the flow graph for one body. A fold: each statement's rule maps the
  * incoming flow to the next. Once `flow` is `exit`, the remaining statements
  * are unreachable and the fold's result stays `exit`. Those statements are
- * still walked, on a side flow rooted at a fresh `start` node, so that
- * narrowing inside dead code works the same as anywhere else. Leaving them
- * unattached made every reference fall back to its declared type, which
- * turned a guarded `r.value` after `return match(...)` into a false AG2009
- * (issue #538). No node is ever rooted at `exit`, where typeAt throws.
+ * still walked, on a side flow rooted at the flow before the exit, so that
+ * narrowing inside dead code works the same as anywhere else and what was
+ * known before the exit stays known (issue #538). No node is ever rooted at
+ * `exit`, where typeAt throws.
  */
 export function buildFlowGraph(
   nodes: AgencyNode[],
@@ -451,7 +456,8 @@ export function buildFlowGraph(
   env: FlowEnvironment,
 ): FlowNode {
   // `live` is the fold's result. `dead` is the side flow the statements
-  // after an exit are walked on, so their guards still narrow.
+  // after an exit are walked on, so their guards still narrow. It is null
+  // while the body is live; a body entered at `exit` gets a fresh start.
   type Fold = { live: FlowNode; dead: FlowNode | null };
   const step = ({ live, dead }: Fold, node: AgencyNode): Fold => {
     const flow = live;
@@ -480,10 +486,12 @@ export function buildFlowGraph(
       env: FlowEnvironment,
     ) => FlowNode;
     if (flow.kind === "exit") {
-      const next = rule(node, dead ?? { kind: "start", scope: env.scope }, env);
-      return { live, dead: next.kind === "exit" ? null : next };
+      const root = dead ?? { kind: "start", scope: env.scope };
+      const next = rule(node, root, env);
+      return { live, dead: next.kind === "exit" ? root : next };
     }
-    return { live: rule(node, flow, env), dead: null };
+    const next = rule(node, flow, env);
+    return { live: next, dead: next.kind === "exit" ? flow : null };
   };
   return nodes.reduce<Fold>(step, { live: entry, dead: null }).live;
 }

--- a/packages/agency-lang/lib/typeChecker/flowBuilder.ts
+++ b/packages/agency-lang/lib/typeChecker/flowBuilder.ts
@@ -99,6 +99,21 @@ export function attachExpressionsToFlow(
 }
 
 /**
+ * The flow an inline handler body starts from. The pre-body flow, with every
+ * name the handle body rebinds reset to its declared type: the raise that
+ * runs the handler can happen after any of those assignments, and the body's
+ * end flow says nothing about them when the body always returns.
+ */
+function handlerEntryFlow(flow: FlowNode, body: AgencyNode[], env: FlowEnvironment): FlowNode {
+  const widened: Record<string, ScopeType> = Object.create(null);
+  for (const name of assignedNames(body)) {
+    const ref: Reference = { variable: name, chain: [] };
+    widened[referenceKey(ref)] = declaredPathType(env.scope, ref, env.typeAliases);
+  }
+  return { kind: "loop", prev: flow, widened };
+}
+
+/**
  * Names of variables a body rebinds (for loop widening). Bare `x = …` only —
  * access-chain mutations and destructuring patterns are excluded, matching the
  * `assignment` rule below.
@@ -303,7 +318,11 @@ const statementRules: StatementRuleTable = {
   handleBlock: (node, flow, env) => {
     const afterBody = buildFlowGraph(node.body, flow, env);
     if (node.handler.kind === "inline") {
-      buildFlowGraph(node.handler.body, afterBody, env);
+      // The handler runs when a statement in the body raises, so it can start
+      // after any prefix of the body. Entering it from `afterBody` was wrong:
+      // a body that always returns leaves `afterBody` at `exit`, so the
+      // handler body got no flow nodes and lost all narrowing (issue #612).
+      buildFlowGraph(node.handler.body, handlerEntryFlow(flow, node.body, env), env);
     }
     return afterBody;
   },
@@ -380,17 +399,21 @@ const passThrough = (node: AgencyNode, flow: FlowNode, env: FlowEnvironment): Fl
 };
 
 /**
- * Build the flow graph for one body. A pure fold: each statement's rule maps
- * the incoming flow to the next. Once `flow` is `exit`, the remaining
- * statements are unreachable, so the rule is not applied (no node is built
- * rooted at `exit`, where typeAt throws; dead-code refs go unattached, which
- * is harmless — PR 2 falls back to scope.lookup for nodes with no flow).
+ * Build the flow graph for one body. A fold: each statement's rule maps the
+ * incoming flow to the next. Once `flow` is `exit`, the remaining statements
+ * are unreachable and the fold's result stays `exit`. Those statements are
+ * still walked, on a side flow rooted at a fresh `start` node, so that
+ * narrowing inside dead code works the same as anywhere else. Leaving them
+ * unattached made every reference fall back to its declared type, which
+ * turned a guarded `r.value` after `return match(...)` into a false AG2009
+ * (issue #538). No node is ever rooted at `exit`, where typeAt throws.
  */
 export function buildFlowGraph(
   nodes: AgencyNode[],
   entry: FlowNode,
   env: FlowEnvironment,
 ): FlowNode {
+  let deadFlow: FlowNode | null = null;
   return nodes.reduce<FlowNode>((flow, node) => {
     if (node.type === "finalizeBlock") {
       // A finalize is a declaration: position-free, and NOT dead code
@@ -422,14 +445,16 @@ export function buildFlowGraph(
       buildFlowGraph(node.body, { kind: "loop", prev: start, widened }, env);
       return flow;
     }
-    if (flow.kind === "exit") {
-      return flow;
-    }
     const rule = (statementRules[node.type] ?? passThrough) as (
       node: AgencyNode,
       flow: FlowNode,
       env: FlowEnvironment,
     ) => FlowNode;
+    if (flow.kind === "exit") {
+      const next = rule(node, deadFlow ?? { kind: "start", scope: env.scope }, env);
+      deadFlow = next.kind === "exit" ? null : next;
+      return flow;
+    }
     return rule(node, flow, env);
   }, entry);
 }

--- a/packages/agency-lang/lib/typeChecker/flowBuilder.ts
+++ b/packages/agency-lang/lib/typeChecker/flowBuilder.ts
@@ -99,10 +99,31 @@ export function attachExpressionsToFlow(
 }
 
 /**
- * The flow an inline handler body starts from. The pre-body flow, with every
- * name the handle body rebinds reset to its declared type: the raise that
- * runs the handler can happen after any of those assignments, and the body's
- * end flow says nothing about them when the body always returns.
+ * `T | null` for a local that may not have been assigned yet when a side
+ * branch (a finalize, an inline handler) runs. A `!= null` guard inside the
+ * branch narrows it back through the ordinary machinery.
+ *
+ * A union-typed local is flattened before the null is added: uniteTypes
+ * dedupes but does not flatten, and presence narrowing only drops TOP-LEVEL
+ * null members, so `(T | null) | null` would keep its inner null through an
+ * `if (x != null)` guard.
+ */
+function maybeUnset(declared: ScopeType, env: FlowEnvironment): ScopeType {
+  if (isAnyType(declared)) return declared;
+  const members =
+    (declared as VariableType).type === "unionType"
+      ? (declared as { types: VariableType[] }).types
+      : [declared];
+  return uniteTypes([...members, NULL_T], env.typeAliases);
+}
+
+/**
+ * The flow an inline handler body starts from. The raise that runs the
+ * handler can happen after any prefix of the handle body, so the pre-body
+ * flow is adjusted for what the body may have done by then: a name it
+ * rebinds is reset to its declared type, and a name it declares may not
+ * exist yet, so it is `T | null`. The body's end flow says nothing about
+ * either when the body always returns.
  */
 function handlerEntryFlow(flow: FlowNode, body: AgencyNode[], env: FlowEnvironment): FlowNode {
   const widened: Record<string, ScopeType> = Object.create(null);
@@ -110,7 +131,23 @@ function handlerEntryFlow(flow: FlowNode, body: AgencyNode[], env: FlowEnvironme
     const ref: Reference = { variable: name, chain: [] };
     widened[referenceKey(ref)] = declaredPathType(env.scope, ref, env.typeAliases);
   }
+  for (const name of declaredNames(body)) {
+    const ref: Reference = { variable: name, chain: [] };
+    widened[referenceKey(ref)] = maybeUnset(declaredPathType(env.scope, ref, env.typeAliases), env);
+  }
   return { kind: "loop", prev: flow, widened };
+}
+
+/** Names a body declares with `let`/`const`, outside nested definitions. */
+function declaredNames(body: AgencyNode[]): string[] {
+  const names: string[] = [];
+  for (const { node, ancestors } of walkNodes(body)) {
+    const insideNestedDef = ancestors.some((a) => a.type === "function" || a.type === "graphNode");
+    if (!insideNestedDef && node.type === "assignment" && node.declKind) {
+      names.push(node.variableName);
+    }
+  }
+  return names;
 }
 
 /**
@@ -432,18 +469,7 @@ export function buildFlowGraph(
       const widened: Record<string, ScopeType> = Object.create(null);
       for (const name of env.scope.declaredNames()) {
         const ref: Reference = { variable: name, chain: [] };
-        const declared = typeAt(ref, start, env);
-        // Flatten a union-typed local before re-uniting: uniteTypes
-        // dedupes but does not flatten, and presence narrowing only
-        // drops TOP-LEVEL null members — `(T | null) | null` would
-        // keep its inner null through an `if (x != null)` guard.
-        const members =
-          !isAnyType(declared) && (declared as VariableType).type === "unionType"
-            ? (declared as { types: VariableType[] }).types
-            : [declared];
-        widened[referenceKey(ref)] = isAnyType(declared)
-          ? declared
-          : uniteTypes([...members, NULL_T], env.typeAliases);
+        widened[referenceKey(ref)] = maybeUnset(typeAt(ref, start, env), env);
       }
       buildFlowGraph(node.body, { kind: "loop", prev: start, widened }, env);
       return { live, dead };

--- a/packages/agency-lang/lib/typeChecker/flowBuilder.ts
+++ b/packages/agency-lang/lib/typeChecker/flowBuilder.ts
@@ -413,8 +413,11 @@ export function buildFlowGraph(
   entry: FlowNode,
   env: FlowEnvironment,
 ): FlowNode {
-  let deadFlow: FlowNode | null = null;
-  return nodes.reduce<FlowNode>((flow, node) => {
+  // `live` is the fold's result. `dead` is the side flow the statements
+  // after an exit are walked on, so their guards still narrow.
+  type Fold = { live: FlowNode; dead: FlowNode | null };
+  const step = ({ live, dead }: Fold, node: AgencyNode): Fold => {
+    const flow = live;
     if (node.type === "finalizeBlock") {
       // A finalize is a declaration: position-free, and NOT dead code
       // after an unconditional return (which turns `flow` to exit). Its
@@ -443,7 +446,7 @@ export function buildFlowGraph(
           : uniteTypes([...members, NULL_T], env.typeAliases);
       }
       buildFlowGraph(node.body, { kind: "loop", prev: start, widened }, env);
-      return flow;
+      return { live, dead };
     }
     const rule = (statementRules[node.type] ?? passThrough) as (
       node: AgencyNode,
@@ -451,12 +454,12 @@ export function buildFlowGraph(
       env: FlowEnvironment,
     ) => FlowNode;
     if (flow.kind === "exit") {
-      const next = rule(node, deadFlow ?? { kind: "start", scope: env.scope }, env);
-      deadFlow = next.kind === "exit" ? null : next;
-      return flow;
+      const next = rule(node, dead ?? { kind: "start", scope: env.scope }, env);
+      return { live, dead: next.kind === "exit" ? null : next };
     }
-    return rule(node, flow, env);
-  }, entry);
+    return { live: rule(node, flow, env), dead: null };
+  };
+  return nodes.reduce<Fold>(step, { live: entry, dead: null }).live;
 }
 
 /**

--- a/packages/agency-lang/lib/typeChecker/handlerAndDeadCodeNarrowing.test.ts
+++ b/packages/agency-lang/lib/typeChecker/handlerAndDeadCodeNarrowing.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "vitest";
+import { parseAgency } from "../parser.js";
+import { buildCompilationUnit } from "../compilationUnit.js";
+import { typeCheck } from "./index.js";
+
+function errors(source: string): string[] {
+  const parsed = parseAgency(source);
+  if (!parsed.success) {
+    throw new Error(`parse failed: ${parsed.message}`);
+  }
+  const info = buildCompilationUnit(parsed.result, undefined, undefined, source);
+  return typeCheck(parsed.result, {}, info)
+    .errors.filter((e) => e.severity === "error")
+    .map((e) => e.message);
+}
+
+const RAISER = `
+effect ask { q: string }
+def raiser(): string {
+  interrupt ask("x", { q: "h" })
+  return "ok"
+}
+`;
+
+describe("narrowing inside an inline handler body (issue #612)", () => {
+  it("narrows a Result guarded with `is success` / `is failure` in the handler", () => {
+    expect(
+      errors(`
+${RAISER}
+node main() {
+  handle {
+    return raiser()
+  } with (data) {
+    const contents = try raiser()
+    if (contents is failure(err)) {
+      let m: string = err
+    }
+    if (contents is success(text)) {
+      let t: string = text
+    }
+    return approve()
+  }
+}
+`),
+    ).toEqual([]);
+  });
+
+  it("narrows with isSuccess / isFailure in the handler too", () => {
+    expect(
+      errors(`
+${RAISER}
+def work(): string {
+  handle {
+    return raiser()
+  } with (data) {
+    const contents = try raiser()
+    if (isFailure(contents)) {
+      let m = contents.error
+    }
+    return approve()
+  }
+  return "x"
+}
+`),
+    ).toEqual([]);
+  });
+
+  it("does not keep a narrowing the handle body may have undone", () => {
+    const out = errors(`
+type U = { kind: "a", v: string } | { kind: "b", w: number }
+${RAISER}
+def work(u: U, other: U): string {
+  if (u.kind == "a") {
+    handle {
+      u = other
+      return raiser()
+    } with (data) {
+      let s = u.v
+      return approve()
+    }
+  }
+  return "x"
+}
+`);
+    expect(out.some((m) => m.includes("not available on every member"))).toBe(true);
+  });
+});
+
+describe("narrowing in code after a `return match(...)` (issue #538)", () => {
+  it("still narrows a try-result guarded with `is success` / `is failure`", () => {
+    expect(
+      errors(`
+${RAISER}
+def cmd(): boolean { return true }
+
+def dispatch(m: string): boolean {
+  return match(m) {
+    "" => true
+    "/x" => cmd()
+  }
+  const r = try raiser()
+  if (r is success(v)) {
+    let s: string = v
+  } else if (r is failure(e)) {
+    let msg: string = e
+  }
+  return true
+}
+`),
+    ).toEqual([]);
+  });
+
+  it("keeps post-guard narrowing across statements in dead code", () => {
+    expect(
+      errors(`
+${RAISER}
+def f(): string {
+  return "early"
+  const r = try raiser()
+  if (isFailure(r)) {
+    return "failed"
+  }
+  return r.value
+}
+`),
+    ).toEqual([]);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/handlerAndDeadCodeNarrowing.test.ts
+++ b/packages/agency-lang/lib/typeChecker/handlerAndDeadCodeNarrowing.test.ts
@@ -103,6 +103,24 @@ def work(u: U, other: U): string {
 `);
     expect(out.some((m) => m.includes("not available on every member"))).toBe(true);
   });
+
+  it("keeps the handler parameter bound when the handle body declares a local of the same name", () => {
+    expect(
+      errors(`
+${RAISER}
+def work(): string {
+  handle {
+    const data: number = 1
+    return raiser()
+  } with (data) {
+    let m: string = data.message
+    return approve()
+  }
+  return "x"
+}
+`),
+    ).toEqual([]);
+  });
 });
 
 describe("narrowing in code after a `return match(...)` (issue #538)", () => {
@@ -138,6 +156,49 @@ def f(): string {
   const r = try raiser()
   if (isFailure(r)) {
     return "failed"
+  }
+  return r.value
+}
+`),
+    ).toEqual([]);
+  });
+
+  it("keeps a narrowing established before the exit in the dead code after it", () => {
+    expect(
+      errors(`
+${RAISER}
+def f(): string {
+  const r = try raiser()
+  if (isFailure(r)) {
+    return "failed"
+  }
+  return r.value
+  let again: string = r.value
+  return again
+}
+`),
+    ).toEqual([]);
+  });
+
+  it("does not let a dead match yield undo narrowing established before the match", () => {
+    expect(
+      errors(`
+${RAISER}
+def f(c: boolean): string {
+  const r = try raiser()
+  if (isFailure(r)) {
+    return "f"
+  }
+  const x = match (r.value) {
+    "a" => {
+      if (c) {
+        return "1"
+      } else {
+        return "2"
+      }
+      return "3"
+    }
+    _ => "5"
   }
   return r.value
 }

--- a/packages/agency-lang/lib/typeChecker/handlerAndDeadCodeNarrowing.test.ts
+++ b/packages/agency-lang/lib/typeChecker/handlerAndDeadCodeNarrowing.test.ts
@@ -65,6 +65,25 @@ def work(): string {
     ).toEqual([]);
   });
 
+  it("treats a local the handle body declares as possibly unset in the handler", () => {
+    const out = errors(`
+${RAISER}
+def work(): string {
+  handle {
+    const name: string = raiser()
+    return name
+  } with (data) {
+    let seen: string = name
+    return approve()
+  }
+  return "x"
+}
+`);
+    expect(out.some((m) => m.includes("'string | null' is not assignable to type 'string'"))).toBe(
+      true,
+    );
+  });
+
   it("does not keep a narrowing the handle body may have undone", () => {
     const out = errors(`
 type U = { kind: "a", v: string } | { kind: "b", w: number }

--- a/packages/agency-lang/lib/typeChecker/index.ts
+++ b/packages/agency-lang/lib/typeChecker/index.ts
@@ -393,9 +393,9 @@ export class TypeChecker {
     // would keep reading the parameter slot (issue #717).
     checkParameterRedeclarations(ctx);
 
-    // A value argument to a value-parameterized type must be something the
-    // generated code can name where the type is declared (issue #441).
-    checkValueArgReferences(ctx);
+    // A value argument to a value-parameterized type must be a name the
+    // generated validator can reach (issue #441).
+    checkValueArgReferences(scopes, ctx);
 
     this.stampFileOnErrors();
 

--- a/packages/agency-lang/lib/typeChecker/index.ts
+++ b/packages/agency-lang/lib/typeChecker/index.ts
@@ -57,6 +57,8 @@ import { checkToolBlockBindings } from "./toolBlockBinding.js";
 import { RESERVED_FUNCTION_NAMES } from "./resolveCall.js";
 import { RESERVED_GENERIC_NAMES } from "./builtinGenerics.js";
 import { validateStaticInit } from "./validateStaticInit.js";
+import { checkParameterRedeclarations } from "./paramRedeclaration.js";
+import { checkValueArgReferences } from "./valueArgReferences.js";
 import { walkNodes } from "../utils/node.js";
 import { diagnostic } from "./diagnostics.js";
 
@@ -386,6 +388,14 @@ export class TypeChecker {
     // `rejectStaticReferencesGlobal`, which has access to the full
     // import closure.
     validateStaticInit(this.program, this.errors);
+
+    // A `let`/`const` may not reuse a parameter name: the generated code
+    // would keep reading the parameter slot (issue #717).
+    checkParameterRedeclarations(ctx);
+
+    // A value argument to a value-parameterized type must be something the
+    // generated code can name where the type is declared (issue #441).
+    checkValueArgReferences(ctx);
 
     this.stampFileOnErrors();
 

--- a/packages/agency-lang/lib/typeChecker/paramRedeclaration.test.ts
+++ b/packages/agency-lang/lib/typeChecker/paramRedeclaration.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { typecheckSource } from "./testUtils.js";
+
+const codes = (src: string): string[] =>
+  typecheckSource(src)
+    .filter((e) => e.code === "AG4012")
+    .map((e) => e.message);
+
+describe("AG4012: redeclaring a parameter name", () => {
+  it("rejects a const that reuses a parameter name inside a match arm (issue #717)", () => {
+    const errors = codes(`
+type Sa = { tag: "a"; s: string }
+type Sb = { tag: "b"; n: number }
+type Su = Sa | Sb
+
+def pick(u: Su): string {
+  return match(u) {
+    { tag: "a", s } => {
+      const u: Su = { tag: "b", n: 1 }
+      return s
+    }
+    _ => "other"
+  }
+}
+`);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("Cannot redeclare parameter 'u' with 'const'");
+  });
+
+  it("rejects a let at the top of a node body too", () => {
+    const errors = codes(`
+node greet(name: string) {
+  let name = "x"
+  return name
+}
+`);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("'name' with 'let'");
+  });
+
+  it("allows a plain assignment to the parameter", () => {
+    expect(
+      codes(`
+def f(n: number): number {
+  n = n + 1
+  return n
+}
+`),
+    ).toEqual([]);
+  });
+
+  it("allows a local with a different name, and a same name in another function", () => {
+    expect(
+      codes(`
+def f(n: number): number {
+  const m = n
+  return m
+}
+def g(m: number): number {
+  const n = m
+  return n
+}
+`),
+    ).toEqual([]);
+  });
+
+  it("allows a block-local that shadows a parameter, since a block has its own scope", () => {
+    expect(
+      codes(`
+def f(x: number): number[] {
+  return fork([1, 2]) as item {
+    const x = item + 1
+    return x
+  }
+}
+`),
+    ).toEqual([]);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/paramRedeclaration.ts
+++ b/packages/agency-lang/lib/typeChecker/paramRedeclaration.ts
@@ -1,5 +1,4 @@
 import type { AgencyNode } from "../types.js";
-import type { FunctionParameter } from "../types/function.js";
 import { walkNodes, type WalkAncestor } from "../utils/node.js";
 import { diagnostic } from "./diagnostics.js";
 import type { TypeCheckerContext } from "./types.js";
@@ -20,7 +19,7 @@ import type { TypeCheckerContext } from "./types.js";
 export function checkParameterRedeclarations(ctx: TypeCheckerContext): void {
   const defs = [...Object.values(ctx.functionDefs), ...Object.values(ctx.nodeDefs)];
   for (const def of defs) {
-    const paramNames = def.parameters.map((p: FunctionParameter) => p.name);
+    const paramNames = def.parameters.map((param) => param.name);
     if (paramNames.length === 0) continue;
     for (const { node, ancestors } of walkNodes(def.body)) {
       if (node.type !== "assignment" || !node.declKind) continue;

--- a/packages/agency-lang/lib/typeChecker/paramRedeclaration.ts
+++ b/packages/agency-lang/lib/typeChecker/paramRedeclaration.ts
@@ -1,0 +1,45 @@
+import type { AgencyNode } from "../types.js";
+import type { FunctionParameter } from "../types/function.js";
+import { walkNodes, type WalkAncestor } from "../utils/node.js";
+import { diagnostic } from "./diagnostics.js";
+import type { TypeCheckerContext } from "./types.js";
+
+/**
+ * A `let`/`const` in a function or node body may not reuse a parameter name
+ * (AG4012).
+ *
+ * The generated code keeps parameters and locals in different slots. The
+ * redeclare writes the local slot, but the preprocessor resolves every later
+ * read of that name to the parameter slot, so the new value is never seen
+ * (issue #717). Rejecting the shape is the cheap way to make the checker and
+ * the runtime agree.
+ *
+ * Declarations inside a block argument are skipped: a block has its own
+ * scope, and reads inside it resolve to the block's binding first.
+ */
+export function checkParameterRedeclarations(ctx: TypeCheckerContext): void {
+  const defs = [...Object.values(ctx.functionDefs), ...Object.values(ctx.nodeDefs)];
+  for (const def of defs) {
+    const paramNames = def.parameters.map((p: FunctionParameter) => p.name);
+    if (paramNames.length === 0) continue;
+    for (const { node, ancestors } of walkNodes(def.body)) {
+      if (node.type !== "assignment" || !node.declKind) continue;
+      if (!paramNames.includes(node.variableName)) continue;
+      if (ancestors.some(isOwnScope)) continue;
+      ctx.errors.push(
+        diagnostic(
+          "parameterRedeclared",
+          { name: node.variableName, declKind: node.declKind },
+          node.loc ?? null,
+        ),
+      );
+    }
+  }
+}
+
+/** Ancestors that open a scope of their own, where a same-named declaration
+ *  is a real shadow rather than a redeclare of the enclosing parameter. */
+function isOwnScope(ancestor: WalkAncestor): boolean {
+  const kind = (ancestor as AgencyNode).type;
+  return kind === "blockArgument" || kind === "function" || kind === "graphNode";
+}

--- a/packages/agency-lang/lib/typeChecker/staticInitRules.ts
+++ b/packages/agency-lang/lib/typeChecker/staticInitRules.ts
@@ -27,19 +27,6 @@ import type { TypeCheckError } from "./types.js";
 import { walkNodes } from "../utils/node.js";
 
 /**
- * Per-run primitives that need an execution context to run. Calling
- * any of these from a `static` initializer (which runs once at
- * process startup, before any agent run has begun) is a logic error
- * — there is no per-run ctx, no thread, no checkpoint store, no LLM
- * client wired up yet.
- *
- * `interrupt` lives on this list as a *function name* even though
- * the parser usually emits an `interruptStatement` node — a bare
- * call like `interrupt("foo")` could parse as either depending on
- * surrounding shape, so we check both. See `checkInterruptStatement`
- * below for the statement form.
- */
-/**
  * The assignments at module top level, with a `with handler { ... }`
  * wrapper peeled off. Both `static const x = ...` and `with handler
  * { static const x = ... }` count, the same way `sectionAssembler` and
@@ -56,6 +43,19 @@ export function topLevelAssignments(nodes: AgencyNode[]): Assignment[] {
   return assignments;
 }
 
+/**
+ * Per-run primitives that need an execution context to run. Calling
+ * any of these from a `static` initializer (which runs once at
+ * process startup, before any agent run has begun) is a logic error
+ * — there is no per-run ctx, no thread, no checkpoint store, no LLM
+ * client wired up yet.
+ *
+ * `interrupt` lives on this list as a *function name* even though
+ * the parser usually emits an `interruptStatement` node — a bare
+ * call like `interrupt("foo")` could parse as either depending on
+ * surrounding shape, so we check both. See `checkInterruptStatement`
+ * below for the statement form.
+ */
 export const BANNED_BUILTINS_IN_STATIC_INIT: Record<string, string> = {
   llm: "`llm()` requires a per-run execution context",
   chat: "`chat()` requires a per-run execution context",

--- a/packages/agency-lang/lib/typeChecker/staticInitRules.ts
+++ b/packages/agency-lang/lib/typeChecker/staticInitRules.ts
@@ -22,7 +22,7 @@
  * the inner expression / statement.
  */
 import { diagnostic, type DiagnosticParams } from "./diagnostics.js";
-import type { AgencyNode, Expression } from "../types.js";
+import type { AgencyNode, Assignment, Expression } from "../types.js";
 import type { TypeCheckError } from "./types.js";
 import { walkNodes } from "../utils/node.js";
 
@@ -39,6 +39,23 @@ import { walkNodes } from "../utils/node.js";
  * surrounding shape, so we check both. See `checkInterruptStatement`
  * below for the statement form.
  */
+/**
+ * The assignments at module top level, with a `with handler { ... }`
+ * wrapper peeled off. Both `static const x = ...` and `with handler
+ * { static const x = ... }` count, the same way `sectionAssembler` and
+ * `initDepGraph` see them.
+ */
+export function topLevelAssignments(nodes: AgencyNode[]): Assignment[] {
+  const assignments: Assignment[] = [];
+  for (const node of nodes) {
+    const inner = node.type === "withModifier" ? node.statement : node;
+    if (inner.type === "assignment") {
+      assignments.push(inner as Assignment);
+    }
+  }
+  return assignments;
+}
+
 export const BANNED_BUILTINS_IN_STATIC_INIT: Record<string, string> = {
   llm: "`llm()` requires a per-run execution context",
   chat: "`chat()` requires a per-run execution context",

--- a/packages/agency-lang/lib/typeChecker/validateStaticInit.ts
+++ b/packages/agency-lang/lib/typeChecker/validateStaticInit.ts
@@ -23,19 +23,19 @@
  */
 import type { AgencyProgram, AgencyNode, Assignment } from "../types.js";
 import type { TypeCheckError } from "./types.js";
-import { checkBannedBuiltinCalls, checkStaticMutation } from "./staticInitRules.js";
+import {
+  checkBannedBuiltinCalls,
+  checkStaticMutation,
+  topLevelAssignments,
+} from "./staticInitRules.js";
 
 export function validateStaticInit(program: AgencyProgram, errors: TypeCheckError[]): void {
   // First sweep: collect static names so the mutation rule has
-  // something to match against. Both `static const` and `with handler
-  // { static const ... }` shapes count; the `withModifier` wrapper
-  // here mirrors how `sectionAssembler` / `initDepGraph` peel it off.
+  // something to match against.
   const staticNames: Record<string, true> = {};
-  for (const node of program.nodes) {
-    const inner = node.type === "withModifier" ? node.statement : node;
-    if (inner.type !== "assignment") continue;
-    if ((inner as Assignment).static) {
-      staticNames[(inner as Assignment).variableName] = true;
+  for (const assignment of topLevelAssignments(program.nodes)) {
+    if (assignment.static) {
+      staticNames[assignment.variableName] = true;
     }
   }
 

--- a/packages/agency-lang/lib/typeChecker/valueArgReferences.test.ts
+++ b/packages/agency-lang/lib/typeChecker/valueArgReferences.test.ts
@@ -120,4 +120,69 @@ type Age = GreaterThan(mniAge)
     expect(errors).toHaveLength(1);
     expect(errors[0]).toContain("mniAge");
   });
+  it("lets a static const win over a same-named local elsewhere in the body", () => {
+    expect(
+      codes(`
+static const minAge: number = 18
+${GREATER_THAN}
+def check(age: GreaterThan(minAge)): boolean {
+  if (age > 10) {
+    let minAge = 1
+  }
+  return true
+}
+`),
+    ).toEqual([]);
+  });
+
+  it("rejects a block parameter and a loop variable", () => {
+    const errors = codes(`
+${GREATER_THAN}
+def each(items: number[], cb: (number) => void): void {
+  for (item in items) {
+    cb(item)
+  }
+}
+def check(xs: number[]): boolean {
+  for (x in xs) {
+    const a: GreaterThan(x)! = 1
+  }
+  each(xs) as y {
+    const b: GreaterThan(y)! = 1
+  }
+  return true
+}
+`);
+    expect(errors).toHaveLength(2);
+    expect(errors[0]).toContain("'x', which is a local variable");
+    expect(errors[1]).toContain("'y', which is a local variable");
+  });
+
+  it("lets a default name an earlier value parameter of the same alias", () => {
+    const src = `
+def between(low: number, high: number, value: number): Result<number> {
+  return success(value)
+}
+@validate(between.partial(low: low, high: high))
+type Between(low: number, high: number = low) = number
+`;
+    expect(codes(src)).toEqual([]);
+    expect(
+      typecheckSource(src, { typechecker: { undefinedVariables: "error" } }).filter(
+        (e) => e.code === "AG4007",
+      ),
+    ).toEqual([]);
+  });
+
+  it("does not mistake a prototype property name for a known binding", () => {
+    const src = `
+${GREATER_THAN}
+type Age = GreaterThan(toString)
+`;
+    const errors = typecheckSource(src, { typechecker: { undefinedVariables: "error" } })
+      .filter((e) => e.code === "AG4007")
+      .map((e) => e.message);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("toString");
+  });
 });

--- a/packages/agency-lang/lib/typeChecker/valueArgReferences.test.ts
+++ b/packages/agency-lang/lib/typeChecker/valueArgReferences.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { typecheckSource } from "./testUtils.js";
 
-const codes = (src: string): string[] =>
+const codes = (src: string, code = "AG7007"): string[] =>
   typecheckSource(src)
-    .filter((e) => e.code === "AG7007")
+    .filter((e) => e.code === code)
     .map((e) => e.message);
 
 const GREATER_THAN = `
@@ -65,5 +65,59 @@ node main() {
 }
 `),
     ).toEqual([]);
+  });
+
+  it("treats an aliased import by its local name, so a same-named parameter is still rejected", () => {
+    const errors = codes(`
+import { min as low } from "std::validation"
+${GREATER_THAN}
+def check(min: number, v: number): boolean {
+  const a: GreaterThan(low)! = v
+  const b: GreaterThan(min)! = v
+  return isSuccess(a) && isSuccess(b)
+}
+`);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("'min', which is a parameter");
+  });
+
+  it("checks schema(T) and `x is T` sites too", () => {
+    const errors = codes(`
+${GREATER_THAN}
+def check(low: number, v: number): boolean {
+  const s = schema(GreaterThan(low))
+  return v is GreaterThan(low)
+}
+`);
+    expect(errors).toHaveLength(2);
+  });
+
+  it("checks a value parameter default", () => {
+    const errors = codes(`
+const minAge: number = 5
+def atLeast(minValue: number, value: number): Result<number> {
+  return success(value)
+}
+@validate(atLeast.partial(minValue: floor))
+type AtLeast(floor: number = minAge) = number
+`);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain(
+      "Type 'AtLeast' takes value argument 'minAge', which is a top-level variable",
+    );
+  });
+
+  it("reports a name that resolves to nothing as an undefined variable when that pass is on", () => {
+    const src = `
+static const minAge: number = 5
+${GREATER_THAN}
+type Age = GreaterThan(mniAge)
+`;
+    expect(codes(src, "AG4007")).toEqual([]);
+    const errors = typecheckSource(src, { typechecker: { undefinedVariables: "error" } })
+      .filter((e) => e.code === "AG4007")
+      .map((e) => e.message);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("mniAge");
   });
 });

--- a/packages/agency-lang/lib/typeChecker/valueArgReferences.test.ts
+++ b/packages/agency-lang/lib/typeChecker/valueArgReferences.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { typecheckSource } from "./testUtils.js";
+
+const codes = (src: string): string[] =>
+  typecheckSource(src)
+    .filter((e) => e.code === "AG7007")
+    .map((e) => e.message);
+
+const GREATER_THAN = `
+def greaterThan(minValue: number, value: number): Result<number> {
+  if (value > minValue) {
+    return success(value)
+  }
+  return failure("expected \${value} to be > \${minValue}")
+}
+
+@validate(greaterThan.partial(minValue: minValue))
+type GreaterThan(minValue: number) = number
+`;
+
+describe("AG7007: a value argument that is not a static", () => {
+  it("rejects a plain top-level const used in a node-body alias (issue #441)", () => {
+    const errors = codes(`
+const minAge: number = 5
+${GREATER_THAN}
+node main() {
+  type Age = GreaterThan(minAge)
+  const ages: Age[]! = [-1, 2, 3]
+  return ages
+}
+`);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain(
+      "Type 'GreaterThan' takes value argument 'minAge', which is a top-level variable",
+    );
+  });
+
+  it("rejects a parameter and a local used as a value argument", () => {
+    const errors = codes(`
+${GREATER_THAN}
+def check(low: number, v: number): boolean {
+  const floor = low
+  const a: GreaterThan(low)! = v
+  const b: GreaterThan(floor)! = v
+  return isSuccess(a) && isSuccess(b)
+}
+`);
+    expect(errors).toHaveLength(2);
+    expect(errors[0]).toContain("'low', which is a parameter");
+    expect(errors[1]).toContain("'floor', which is a local variable");
+  });
+
+  it("allows a static const, a literal, and a forwarded value parameter", () => {
+    expect(
+      codes(`
+static const minAge: number = 5
+${GREATER_THAN}
+type Age = GreaterThan(minAge)
+type Zero = GreaterThan(0)
+type Above(floor: number) = GreaterThan(floor)
+node main() {
+  type Local = GreaterThan(minAge)
+  const a: Age! = 10
+  return a
+}
+`),
+    ).toEqual([]);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/valueArgReferences.ts
+++ b/packages/agency-lang/lib/typeChecker/valueArgReferences.ts
@@ -1,0 +1,119 @@
+import type { AgencyNode, Expression, VariableType } from "../types.js";
+import type { TypeAlias } from "../types/typeHints.js";
+import { expressionChildren, walkNodes } from "../utils/node.js";
+import { diagnostic } from "./diagnostics.js";
+import type { TypeCheckerContext } from "./types.js";
+import { visitTypes } from "./typeWalker.js";
+
+/**
+ * A value argument to a value-parameterized type (`type Age = GreaterThan(minAge)`)
+ * may only name a `static const`, an imported name, or a value parameter of
+ * the enclosing alias (AG7007).
+ *
+ * Codegen prints a value argument as a bare identifier and reads it once,
+ * where the type is declared. A plain top-level `const` lives in the global
+ * store, and a parameter or local lives on the stack frame, so neither is a
+ * JavaScript identifier there: the program crashed with "minAge is not
+ * defined" (issue #441). Only a name the checker can prove is one of those
+ * is reported. An unknown name is the undefined-variable diagnostic's job.
+ */
+export function checkValueArgReferences(ctx: TypeCheckerContext): void {
+  const legal: string[] = [];
+  const globals: string[] = [];
+  for (const top of ctx.programNodes) {
+    const node = top.type === "withModifier" ? top.statement : top;
+    if (node.type === "assignment" && node.declKind) {
+      (node.static ? legal : globals).push(node.variableName);
+    }
+    if (node.type === "importStatement") {
+      for (const entry of node.importedNames) {
+        if (entry.type !== "namedImport") continue;
+        for (const name of entry.importedNames) {
+          if (typeof name === "string") legal.push(name);
+        }
+      }
+    }
+    if (node.type === "typeAlias") {
+      checkAlias(node, legal, globals, ctx);
+    }
+  }
+
+  const defs = [...Object.values(ctx.functionDefs), ...Object.values(ctx.nodeDefs)];
+  for (const def of defs) {
+    const params = def.parameters.map((p) => p.name);
+    const locals: string[] = [];
+    for (const { node } of walkNodes(def.body)) {
+      if (node.type === "assignment" && node.declKind) locals.push(node.variableName);
+    }
+    const kindOf = (name: string): string | null => {
+      if (params.includes(name)) return "a parameter";
+      if (locals.includes(name)) return "a local variable";
+      if (globals.includes(name)) return "a top-level variable";
+      return null;
+    };
+    for (const p of def.parameters) {
+      if (p.typeHint) checkType(p.typeHint, legal, kindOf, def.loc, ctx);
+    }
+    if (def.returnType) checkType(def.returnType, legal, kindOf, def.loc, ctx);
+    for (const { node } of walkNodes(def.body)) {
+      if (node.type === "typeAlias") {
+        checkAliasWith(node, legal, kindOf, ctx);
+      } else if (node.type === "assignment" && node.typeHint) {
+        checkType(node.typeHint, legal, kindOf, node.loc, ctx);
+      }
+    }
+  }
+}
+
+function checkAlias(
+  alias: TypeAlias,
+  legal: string[],
+  globals: string[],
+  ctx: TypeCheckerContext,
+): void {
+  const kindOf = (name: string): string | null =>
+    globals.includes(name) ? "a top-level variable" : null;
+  checkAliasWith(alias, legal, kindOf, ctx);
+}
+
+function checkAliasWith(
+  alias: TypeAlias,
+  legal: string[],
+  kindOf: (name: string) => string | null,
+  ctx: TypeCheckerContext,
+): void {
+  const ownParams = (alias.valueParams ?? []).map((p) => p.name);
+  const legalHere = [...legal, ...ownParams];
+  checkType(alias.aliasedType, legalHere, kindOf, alias.loc, ctx);
+}
+
+function checkType(
+  t: VariableType,
+  legal: string[],
+  kindOf: (name: string) => string | null,
+  loc: AgencyNode["loc"],
+  ctx: TypeCheckerContext,
+): void {
+  visitTypes(t, (inner) => {
+    if (inner.type !== "typeAliasVariable" && inner.type !== "genericType") return;
+    const alias = inner.type === "typeAliasVariable" ? inner.aliasName : inner.name;
+    for (const arg of inner.valueArgs ?? []) {
+      for (const name of variableNamesIn(arg)) {
+        if (legal.includes(name)) continue;
+        const what = kindOf(name);
+        if (what === null) continue;
+        ctx.errors.push(diagnostic("valueArgNotStatic", { alias, name, what }, loc ?? null));
+      }
+    }
+  });
+}
+
+function variableNamesIn(expr: Expression): string[] {
+  const names: string[] = [];
+  const visit = (node: AgencyNode): void => {
+    if (node.type === "variableName") names.push(node.value);
+    for (const child of expressionChildren(node)) visit(child);
+  };
+  visit(expr as AgencyNode);
+  return names;
+}

--- a/packages/agency-lang/lib/typeChecker/valueArgReferences.ts
+++ b/packages/agency-lang/lib/typeChecker/valueArgReferences.ts
@@ -1,7 +1,11 @@
 import type { AgencyNode, Expression, VariableType } from "../types.js";
+import type { SourceLocation } from "../types/base.js";
+import type { FunctionDefinition } from "../types/function.js";
+import type { GraphNodeDefinition } from "../types/graphNode.js";
 import type { TypeAlias } from "../types/typeHints.js";
 import { expressionChildren, walkNodes } from "../utils/node.js";
 import { diagnostic } from "./diagnostics.js";
+import { topLevelAssignments } from "./staticInitRules.js";
 import type { TypeCheckerContext } from "./types.js";
 import { visitTypes } from "./typeWalker.js";
 
@@ -14,105 +18,163 @@ import { visitTypes } from "./typeWalker.js";
  * where the type is declared. A plain top-level `const` lives in the global
  * store, and a parameter or local lives on the stack frame, so neither is a
  * JavaScript identifier there: the program crashed with "minAge is not
- * defined" (issue #441). Only a name the checker can prove is one of those
- * is reported. An unknown name is the undefined-variable diagnostic's job.
+ * defined" (issue #441).
+ *
+ * The rule is `REJECTED_ORIGINS`. The rest of this file gathers where each
+ * name was declared and where each type annotation sits.
  */
+
+/** Where a name referenced from a value argument was declared. */
+type NameOrigin = "static" | "import" | "valueParam" | "global" | "param" | "local";
+
+/** Origins that are not a JavaScript identifier where a type is declared,
+ *  with the wording the diagnostic uses for each. An origin missing here is
+ *  legal. A name with no origin at all is the undefined-variable pass's job. */
+const REJECTED_ORIGINS: Partial<Record<NameOrigin, string>> = {
+  global: "a top-level variable",
+  param: "a parameter",
+  local: "a local variable",
+};
+
+type Origins = Record<string, NameOrigin>;
+
+type Definition = FunctionDefinition | GraphNodeDefinition;
+
+/** One type annotation to check, with the value parameters it declares itself. */
+type TypeSite = {
+  type: VariableType;
+  loc: SourceLocation | undefined;
+  valueParams: string[];
+};
+
 export function checkValueArgReferences(ctx: TypeCheckerContext): void {
-  const legal: string[] = [];
-  const globals: string[] = [];
-  for (const top of ctx.programNodes) {
-    const node = top.type === "withModifier" ? top.statement : top;
-    if (node.type === "assignment" && node.declKind) {
-      (node.static ? legal : globals).push(node.variableName);
+  const module = moduleOrigins(ctx.programNodes);
+  for (const site of topLevelTypeSites(ctx.programNodes)) {
+    checkSite(site, module, ctx);
+  }
+  const definitions: Definition[] = [
+    ...Object.values(ctx.functionDefs),
+    ...Object.values(ctx.nodeDefs),
+  ];
+  for (const definition of definitions) {
+    const origins = { ...module, ...definitionOrigins(definition) };
+    for (const site of definitionTypeSites(definition)) {
+      checkSite(site, origins, ctx);
     }
-    if (node.type === "importStatement") {
-      for (const entry of node.importedNames) {
-        if (entry.type !== "namedImport") continue;
-        for (const name of entry.importedNames) {
-          if (typeof name === "string") legal.push(name);
+  }
+}
+
+function checkSite(site: TypeSite, origins: Origins, ctx: TypeCheckerContext): void {
+  const withOwnParams: Origins = { ...origins };
+  for (const name of site.valueParams) {
+    withOwnParams[name] = "valueParam";
+  }
+  for (const { alias, name } of valueArgNames(site.type)) {
+    const what = REJECTED_ORIGINS[withOwnParams[name]];
+    if (what === undefined) continue;
+    ctx.errors.push(diagnostic("valueArgNotStatic", { alias, name, what }, site.loc ?? null));
+  }
+}
+
+/** Static, imported, and plain top-level names. */
+function moduleOrigins(nodes: AgencyNode[]): Origins {
+  const origins: Origins = {};
+  for (const node of nodes) {
+    if (node.type !== "importStatement") continue;
+    for (const entry of node.importedNames) {
+      if (entry.type !== "namedImport") continue;
+      for (const name of entry.importedNames) {
+        if (typeof name === "string") {
+          origins[name] = "import";
         }
       }
     }
+  }
+  for (const assignment of topLevelAssignments(nodes)) {
+    if (assignment.declKind) {
+      origins[assignment.variableName] = assignment.static ? "static" : "global";
+    }
+  }
+  return origins;
+}
+
+/** Parameters and locals of one function or node body. */
+function definitionOrigins(definition: Definition): Origins {
+  const origins: Origins = {};
+  for (const param of definition.parameters) {
+    origins[param.name] = "param";
+  }
+  for (const { node } of walkNodes(definition.body)) {
+    if (node.type === "assignment" && node.declKind) {
+      origins[node.variableName] = "local";
+    }
+  }
+  return origins;
+}
+
+function topLevelTypeSites(nodes: AgencyNode[]): TypeSite[] {
+  const sites: TypeSite[] = [];
+  for (const node of nodes) {
     if (node.type === "typeAlias") {
-      checkAlias(node, legal, globals, ctx);
+      sites.push(aliasSite(node));
     }
   }
+  return sites;
+}
 
-  const defs = [...Object.values(ctx.functionDefs), ...Object.values(ctx.nodeDefs)];
-  for (const def of defs) {
-    const params = def.parameters.map((p) => p.name);
-    const locals: string[] = [];
-    for (const { node } of walkNodes(def.body)) {
-      if (node.type === "assignment" && node.declKind) locals.push(node.variableName);
-    }
-    const kindOf = (name: string): string | null => {
-      if (params.includes(name)) return "a parameter";
-      if (locals.includes(name)) return "a local variable";
-      if (globals.includes(name)) return "a top-level variable";
-      return null;
-    };
-    for (const p of def.parameters) {
-      if (p.typeHint) checkType(p.typeHint, legal, kindOf, def.loc, ctx);
-    }
-    if (def.returnType) checkType(def.returnType, legal, kindOf, def.loc, ctx);
-    for (const { node } of walkNodes(def.body)) {
-      if (node.type === "typeAlias") {
-        checkAliasWith(node, legal, kindOf, ctx);
-      } else if (node.type === "assignment" && node.typeHint) {
-        checkType(node.typeHint, legal, kindOf, node.loc, ctx);
-      }
+/** Parameter and return annotations, plus every annotation and alias in the body. */
+function definitionTypeSites(definition: Definition): TypeSite[] {
+  const sites: TypeSite[] = [];
+  for (const param of definition.parameters) {
+    if (param.typeHint) {
+      sites.push({ type: param.typeHint, loc: definition.loc, valueParams: [] });
     }
   }
+  if (definition.returnType) {
+    sites.push({ type: definition.returnType, loc: definition.loc, valueParams: [] });
+  }
+  for (const { node } of walkNodes(definition.body)) {
+    if (node.type === "typeAlias") {
+      sites.push(aliasSite(node));
+    } else if (node.type === "assignment" && node.typeHint) {
+      sites.push({ type: node.typeHint, loc: node.loc, valueParams: [] });
+    }
+  }
+  return sites;
 }
 
-function checkAlias(
-  alias: TypeAlias,
-  legal: string[],
-  globals: string[],
-  ctx: TypeCheckerContext,
-): void {
-  const kindOf = (name: string): string | null =>
-    globals.includes(name) ? "a top-level variable" : null;
-  checkAliasWith(alias, legal, kindOf, ctx);
+function aliasSite(alias: TypeAlias): TypeSite {
+  return {
+    type: alias.aliasedType,
+    loc: alias.loc,
+    valueParams: (alias.valueParams ?? []).map((param) => param.name),
+  };
 }
 
-function checkAliasWith(
-  alias: TypeAlias,
-  legal: string[],
-  kindOf: (name: string) => string | null,
-  ctx: TypeCheckerContext,
-): void {
-  const ownParams = (alias.valueParams ?? []).map((p) => p.name);
-  const legalHere = [...legal, ...ownParams];
-  checkType(alias.aliasedType, legalHere, kindOf, alias.loc, ctx);
-}
-
-function checkType(
-  t: VariableType,
-  legal: string[],
-  kindOf: (name: string) => string | null,
-  loc: AgencyNode["loc"],
-  ctx: TypeCheckerContext,
-): void {
-  visitTypes(t, (inner) => {
+/** Every `(alias, name)` pair where a value argument to `alias` mentions `name`. */
+function valueArgNames(type: VariableType): { alias: string; name: string }[] {
+  const found: { alias: string; name: string }[] = [];
+  visitTypes(type, (inner) => {
     if (inner.type !== "typeAliasVariable" && inner.type !== "genericType") return;
     const alias = inner.type === "typeAliasVariable" ? inner.aliasName : inner.name;
     for (const arg of inner.valueArgs ?? []) {
       for (const name of variableNamesIn(arg)) {
-        if (legal.includes(name)) continue;
-        const what = kindOf(name);
-        if (what === null) continue;
-        ctx.errors.push(diagnostic("valueArgNotStatic", { alias, name, what }, loc ?? null));
+        found.push({ alias, name });
       }
     }
   });
+  return found;
 }
 
 function variableNamesIn(expr: Expression): string[] {
   const names: string[] = [];
   const visit = (node: AgencyNode): void => {
-    if (node.type === "variableName") names.push(node.value);
-    for (const child of expressionChildren(node)) visit(child);
+    if (node.type === "variableName") {
+      names.push(node.value);
+    }
+    for (const child of expressionChildren(node)) {
+      visit(child);
+    }
   };
   visit(expr as AgencyNode);
   return names;

--- a/packages/agency-lang/lib/typeChecker/valueArgReferences.ts
+++ b/packages/agency-lang/lib/typeChecker/valueArgReferences.ts
@@ -2,9 +2,14 @@ import type { AgencyNode, Expression, VariableType } from "../types.js";
 import type { SourceLocation } from "../types/base.js";
 import type { FunctionDefinition } from "../types/function.js";
 import type { GraphNodeDefinition } from "../types/graphNode.js";
+import { getImportedNames } from "../types/importStatement.js";
 import type { TypeAlias } from "../types/typeHints.js";
 import { expressionChildren, walkNodes } from "../utils/node.js";
 import { diagnostic } from "./diagnostics.js";
+import { hasFunctionOrNodeAncestor } from "./nameReferences.js";
+import { JS_GLOBALS, SANDBOX_JS_GLOBALS } from "./resolveCall.js";
+import { resolveVariable } from "./resolveVariable.js";
+import { collectProgramShadowing } from "./shadowing.js";
 import { topLevelAssignments } from "./staticInitRules.js";
 import type { TypeCheckerContext } from "./types.js";
 import { visitTypes } from "./typeWalker.js";
@@ -12,13 +17,16 @@ import { visitTypes } from "./typeWalker.js";
 /**
  * A value argument to a value-parameterized type (`type Age = GreaterThan(minAge)`)
  * may only name a `static const`, an imported name, or a value parameter of
- * the enclosing alias (AG7007).
+ * the enclosing alias (AG7007). A value parameter's default follows the same
+ * rule, minus the alias's own parameters.
  *
  * Codegen prints a value argument as a bare identifier and reads it once,
  * where the type is declared. A plain top-level `const` lives in the global
  * store, and a parameter or local lives on the stack frame, so neither is a
  * JavaScript identifier there: the program crashed with "minAge is not
- * defined" (issue #441).
+ * defined" (issue #441). A name that resolves to nothing at all is reported
+ * as an undefined variable, since the general pass does not look inside
+ * type annotations.
  *
  * The rule is `REJECTED_ORIGINS`. The rest of this file gathers where each
  * name was declared and where each type annotation sits.
@@ -29,7 +37,7 @@ type NameOrigin = "static" | "import" | "valueParam" | "global" | "param" | "loc
 
 /** Origins that are not a JavaScript identifier where a type is declared,
  *  with the wording the diagnostic uses for each. An origin missing here is
- *  legal. A name with no origin at all is the undefined-variable pass's job. */
+ *  legal. */
 const REJECTED_ORIGINS: Partial<Record<NameOrigin, string>> = {
   global: "a top-level variable",
   param: "a parameter",
@@ -40,17 +48,25 @@ type Origins = Record<string, NameOrigin>;
 
 type Definition = FunctionDefinition | GraphNodeDefinition;
 
-/** One type annotation to check, with the value parameters it declares itself. */
+/** One `(alias, name)` pair: a value argument to `alias` mentions `name`. */
+type ValueArgRef = { alias: string; name: string; loc: SourceLocation | undefined };
+
+/** One type-bearing position: an annotation, an alias body, a `schema(T)`,
+ *  or an `x is T`. An alias site also carries its own value parameters and
+ *  their defaults. */
 type TypeSite = {
   type: VariableType;
   loc: SourceLocation | undefined;
   valueParams: string[];
+  defaults: Expression[];
+  aliasName: string | undefined;
 };
 
 export function checkValueArgReferences(ctx: TypeCheckerContext): void {
+  const report = makeReporter(ctx);
   const module = moduleOrigins(ctx.programNodes);
   for (const site of topLevelTypeSites(ctx.programNodes)) {
-    checkSite(site, module, ctx);
+    checkSite(site, module, report);
   }
   const definitions: Definition[] = [
     ...Object.values(ctx.functionDefs),
@@ -59,20 +75,59 @@ export function checkValueArgReferences(ctx: TypeCheckerContext): void {
   for (const definition of definitions) {
     const origins = { ...module, ...definitionOrigins(definition) };
     for (const site of definitionTypeSites(definition)) {
-      checkSite(site, origins, ctx);
+      checkSite(site, origins, report);
     }
   }
 }
 
-function checkSite(site: TypeSite, origins: Origins, ctx: TypeCheckerContext): void {
-  const withOwnParams: Origins = { ...origins };
-  for (const name of site.valueParams) {
-    withOwnParams[name] = "valueParam";
+type Reporter = (ref: ValueArgRef, origin: NameOrigin | undefined) => void;
+
+/** Reports a rejected origin as AG7007 and a name with no origin as an
+ *  undefined variable, at the severity the general undefined-variable pass
+ *  uses, so a typo in a value argument does not reach generated code. */
+function makeReporter(ctx: TypeCheckerContext): Reporter {
+  const sandbox = ctx.config.typechecker?.jsGlobals === "sandbox";
+  const undefinedMode = sandbox
+    ? "error"
+    : (ctx.config.typechecker?.undefinedVariables ?? "silent");
+  const { importedNodeNames } = collectProgramShadowing(ctx.programNodes);
+  const resolveInput = {
+    functionDefs: ctx.functionDefs,
+    nodeDefs: ctx.nodeDefs,
+    importedFunctions: ctx.importedFunctions,
+    importedNodeNames,
+    jsImportedNames: ctx.jsImportedNames,
+    scopeHas: () => false,
+    registry: sandbox ? SANDBOX_JS_GLOBALS : JS_GLOBALS,
+  };
+  return (ref, origin) => {
+    if (origin !== undefined) {
+      const what = REJECTED_ORIGINS[origin];
+      if (what !== undefined) {
+        const params = { alias: ref.alias, name: ref.name, what };
+        ctx.errors.push(diagnostic("valueArgNotStatic", params, ref.loc ?? null));
+      }
+      return;
+    }
+    if (undefinedMode === "silent") return;
+    if (resolveVariable(ref.name, resolveInput).kind !== "unresolved") return;
+    ctx.errors.push(
+      diagnostic("undefinedVariable", { name: ref.name }, ref.loc ?? null, {
+        severity: undefinedMode === "warn" ? "warning" : "error",
+      }),
+    );
+  };
+}
+
+function checkSite(site: TypeSite, origins: Origins, report: Reporter): void {
+  for (const ref of valueArgRefs(site.type, site.loc)) {
+    const origin = site.valueParams.includes(ref.name) ? "valueParam" : origins[ref.name];
+    report(ref, origin);
   }
-  for (const { alias, name } of valueArgNames(site.type)) {
-    const what = REJECTED_ORIGINS[withOwnParams[name]];
-    if (what === undefined) continue;
-    ctx.errors.push(diagnostic("valueArgNotStatic", { alias, name, what }, site.loc ?? null));
+  for (const expr of site.defaults) {
+    for (const name of variableNamesIn(expr)) {
+      report({ alias: site.aliasName ?? "", name, loc: site.loc }, origins[name]);
+    }
   }
 }
 
@@ -82,11 +137,8 @@ function moduleOrigins(nodes: AgencyNode[]): Origins {
   for (const node of nodes) {
     if (node.type !== "importStatement") continue;
     for (const entry of node.importedNames) {
-      if (entry.type !== "namedImport") continue;
-      for (const name of entry.importedNames) {
-        if (typeof name === "string") {
-          origins[name] = "import";
-        }
+      for (const name of getImportedNames(entry)) {
+        origins[name] = "import";
       }
     }
   }
@@ -112,54 +164,81 @@ function definitionOrigins(definition: Definition): Origins {
   return origins;
 }
 
+/** Sites outside any function or node body. Bodies are covered per
+ *  definition, with their own parameters and locals in scope. */
 function topLevelTypeSites(nodes: AgencyNode[]): TypeSite[] {
   const sites: TypeSite[] = [];
-  for (const node of nodes) {
-    if (node.type === "typeAlias") {
-      sites.push(aliasSite(node));
+  for (const { node, ancestors } of walkNodes(nodes)) {
+    if (hasFunctionOrNodeAncestor(ancestors)) continue;
+    if (node.type === "function" || node.type === "graphNode") continue;
+    const site = siteOf(node);
+    if (site !== null) {
+      sites.push(site);
     }
   }
   return sites;
 }
 
-/** Parameter and return annotations, plus every annotation and alias in the body. */
+/** Parameter and return annotations, plus every site in the body. */
 function definitionTypeSites(definition: Definition): TypeSite[] {
   const sites: TypeSite[] = [];
   for (const param of definition.parameters) {
     if (param.typeHint) {
-      sites.push({ type: param.typeHint, loc: definition.loc, valueParams: [] });
+      sites.push(plainSite(param.typeHint, definition.loc));
     }
   }
   if (definition.returnType) {
-    sites.push({ type: definition.returnType, loc: definition.loc, valueParams: [] });
+    sites.push(plainSite(definition.returnType, definition.loc));
   }
   for (const { node } of walkNodes(definition.body)) {
-    if (node.type === "typeAlias") {
-      sites.push(aliasSite(node));
-    } else if (node.type === "assignment" && node.typeHint) {
-      sites.push({ type: node.typeHint, loc: node.loc, valueParams: [] });
+    const site = siteOf(node);
+    if (site !== null) {
+      sites.push(site);
     }
   }
   return sites;
 }
 
+/** The type a statement or expression node carries, if it carries one. */
+function siteOf(node: AgencyNode): TypeSite | null {
+  switch (node.type) {
+    case "typeAlias":
+      return aliasSite(node);
+    case "assignment":
+      return node.typeHint ? plainSite(node.typeHint, node.loc) : null;
+    case "schemaExpression":
+      return plainSite(node.typeArg, node.loc);
+    case "typeTestExpression":
+      return plainSite(node.typeHint, node.loc);
+    default:
+      return null;
+  }
+}
+
+function plainSite(type: VariableType, loc: SourceLocation | undefined): TypeSite {
+  return { type, loc, valueParams: [], defaults: [], aliasName: undefined };
+}
+
 function aliasSite(alias: TypeAlias): TypeSite {
+  const valueParams = alias.valueParams ?? [];
   return {
     type: alias.aliasedType,
     loc: alias.loc,
-    valueParams: (alias.valueParams ?? []).map((param) => param.name),
+    valueParams: valueParams.map((param) => param.name),
+    defaults: valueParams.flatMap((param) => (param.default ? [param.default] : [])),
+    aliasName: alias.aliasName,
   };
 }
 
-/** Every `(alias, name)` pair where a value argument to `alias` mentions `name`. */
-function valueArgNames(type: VariableType): { alias: string; name: string }[] {
-  const found: { alias: string; name: string }[] = [];
+/** Every value-argument reference inside a type. */
+function valueArgRefs(type: VariableType, loc: SourceLocation | undefined): ValueArgRef[] {
+  const found: ValueArgRef[] = [];
   visitTypes(type, (inner) => {
     if (inner.type !== "typeAliasVariable" && inner.type !== "genericType") return;
     const alias = inner.type === "typeAliasVariable" ? inner.aliasName : inner.name;
     for (const arg of inner.valueArgs ?? []) {
       for (const name of variableNamesIn(arg)) {
-        found.push({ alias, name });
+        found.push({ alias, name, loc });
       }
     }
   });

--- a/packages/agency-lang/lib/typeChecker/valueArgReferences.ts
+++ b/packages/agency-lang/lib/typeChecker/valueArgReferences.ts
@@ -2,115 +2,124 @@ import type { AgencyNode, Expression, VariableType } from "../types.js";
 import type { SourceLocation } from "../types/base.js";
 import type { FunctionDefinition } from "../types/function.js";
 import type { GraphNodeDefinition } from "../types/graphNode.js";
-import { getImportedNames } from "../types/importStatement.js";
-import type { TypeAlias } from "../types/typeHints.js";
 import { expressionChildren, walkNodes } from "../utils/node.js";
 import { diagnostic } from "./diagnostics.js";
 import { hasFunctionOrNodeAncestor } from "./nameReferences.js";
 import { JS_GLOBALS, SANDBOX_JS_GLOBALS } from "./resolveCall.js";
 import { resolveVariable } from "./resolveVariable.js";
+import type { Scope } from "./scope.js";
 import { collectProgramShadowing } from "./shadowing.js";
 import { topLevelAssignments } from "./staticInitRules.js";
-import type { TypeCheckerContext } from "./types.js";
+import type { ScopeInfo, TypeCheckerContext } from "./types.js";
+import type { ValueParam } from "../types/typeHints.js";
 import { visitTypes } from "./typeWalker.js";
 
 /**
  * A value argument to a value-parameterized type (`type Age = GreaterThan(minAge)`)
- * may only name a `static const`, an imported name, or a value parameter of
- * the enclosing alias (AG7007). A value parameter's default follows the same
- * rule, minus the alias's own parameters.
+ * must be a literal, a `static const`, an imported name, or a value parameter
+ * of the enclosing alias (AG7007). A value parameter's default may also name
+ * an earlier value parameter of the same alias.
  *
- * Codegen prints a value argument as a bare identifier and reads it once,
- * where the type is declared. A plain top-level `const` lives in the global
- * store, and a parameter or local lives on the stack frame, so neither is a
- * JavaScript identifier there: the program crashed with "minAge is not
- * defined" (issue #441). A name that resolves to nothing at all is reported
- * as an undefined variable, since the general pass does not look inside
- * type annotations.
+ * The generated validator for a type is module-level JavaScript, and it
+ * prints a value argument as a bare identifier. A `static const` and an
+ * import are JavaScript identifiers there. A plain top-level variable lives
+ * in the global store and a parameter or local lives on the stack frame, so
+ * the program would crash with "minAge is not defined" (issue #441).
  *
- * The rule is `REJECTED_ORIGINS`. The rest of this file gathers where each
- * name was declared and where each type annotation sits.
+ * A name that resolves to nothing at all is reported as an undefined
+ * variable, since the general pass does not look inside types.
  */
+export function checkValueArgReferences(scopes: ScopeInfo[], ctx: TypeCheckerContext): void {
+  const report = makeReporter(ctx);
+  const module = moduleOrigins(ctx.programNodes);
+  for (const info of scopes) {
+    const isTopLevel = info.name === "top-level";
+    const definition = isTopLevel ? undefined : definitionNamed(info.name, ctx);
+    const params = definition?.parameters.map((param) => param.name) ?? [];
+    const classify = (name: string, site: TypeSite): Verdict => {
+      const isOwnValueParam = site.valueParams.some((param) => param.name === name);
+      if (isOwnValueParam || module[name] === "static") {
+        return { kind: "legal" };
+      }
+      if (module[name] === "global") {
+        return { kind: "rejected", what: "a top-level variable" };
+      }
+      if (params.includes(name)) {
+        return { kind: "rejected", what: "a parameter" };
+      }
+      if (!isTopLevel && info.scope.lookupInFunction(name) !== undefined) {
+        return { kind: "rejected", what: "a local variable" };
+      }
+      return { kind: "unknown", scope: info.scope };
+    };
+    if (definition) {
+      for (const site of signatureSites(definition)) {
+        checkSite(site, classify, report);
+      }
+    }
+    for (const { node, ancestors } of walkNodes(info.body)) {
+      if (isTopLevel && hasFunctionOrNodeAncestor(ancestors)) continue;
+      for (const site of sitesOf(node)) {
+        checkSite(site, classify, report);
+      }
+    }
+  }
+}
 
-/** Where a name referenced from a value argument was declared. */
-type NameOrigin = "static" | "import" | "valueParam" | "global" | "param" | "local";
+/** Where a top-level name was declared. Anything else is not in this map. */
+type ModuleOrigin = "static" | "global";
 
-/** Origins that are not a JavaScript identifier where a type is declared,
- *  with the wording the diagnostic uses for each. An origin missing here is
- *  legal. */
-const REJECTED_ORIGINS: Partial<Record<NameOrigin, string>> = {
-  global: "a top-level variable",
-  param: "a parameter",
-  local: "a local variable",
-};
+type Verdict =
+  { kind: "legal" } | { kind: "rejected"; what: string } | { kind: "unknown"; scope: Scope };
 
-type Origins = Record<string, NameOrigin>;
+type Classify = (name: string, site: TypeSite) => Verdict;
 
 type Definition = FunctionDefinition | GraphNodeDefinition;
 
 /** One `(alias, name)` pair: a value argument to `alias` mentions `name`. */
 type ValueArgRef = { alias: string; name: string; loc: SourceLocation | undefined };
 
-/** One type-bearing position: an annotation, an alias body, a `schema(T)`,
- *  or an `x is T`. An alias site also carries its own value parameters and
- *  their defaults. */
+/** One type-bearing position. An alias site also carries its own value
+ *  parameters, whose defaults are checked too. */
 type TypeSite = {
   type: VariableType;
   loc: SourceLocation | undefined;
-  valueParams: string[];
-  defaults: Expression[];
+  valueParams: ValueParam[];
   aliasName: string | undefined;
 };
 
-export function checkValueArgReferences(ctx: TypeCheckerContext): void {
-  const report = makeReporter(ctx);
-  const module = moduleOrigins(ctx.programNodes);
-  for (const site of topLevelTypeSites(ctx.programNodes)) {
-    checkSite(site, module, report);
-  }
-  const definitions: Definition[] = [
-    ...Object.values(ctx.functionDefs),
-    ...Object.values(ctx.nodeDefs),
-  ];
-  for (const definition of definitions) {
-    const origins = { ...module, ...definitionOrigins(definition) };
-    for (const site of definitionTypeSites(definition)) {
-      checkSite(site, origins, report);
-    }
-  }
-}
+type Reporter = (ref: ValueArgRef, verdict: Verdict) => void;
 
-type Reporter = (ref: ValueArgRef, origin: NameOrigin | undefined) => void;
-
-/** Reports a rejected origin as AG7007 and a name with no origin as an
- *  undefined variable, at the severity the general undefined-variable pass
- *  uses, so a typo in a value argument does not reach generated code. */
+/** Reports a rejected name as AG7007 and a name that resolves to nothing as
+ *  an undefined variable, at the severity the general undefined-variable
+ *  pass uses, so a typo in a value argument does not reach generated code. */
 function makeReporter(ctx: TypeCheckerContext): Reporter {
   const sandbox = ctx.config.typechecker?.jsGlobals === "sandbox";
   const undefinedMode = sandbox
     ? "error"
     : (ctx.config.typechecker?.undefinedVariables ?? "silent");
   const { importedNodeNames } = collectProgramShadowing(ctx.programNodes);
-  const resolveInput = {
-    functionDefs: ctx.functionDefs,
-    nodeDefs: ctx.nodeDefs,
-    importedFunctions: ctx.importedFunctions,
-    importedNodeNames,
-    jsImportedNames: ctx.jsImportedNames,
-    scopeHas: () => false,
-    registry: sandbox ? SANDBOX_JS_GLOBALS : JS_GLOBALS,
-  };
-  return (ref, origin) => {
-    if (origin !== undefined) {
-      const what = REJECTED_ORIGINS[origin];
-      if (what !== undefined) {
-        const params = { alias: ref.alias, name: ref.name, what };
-        ctx.errors.push(diagnostic("valueArgNotStatic", params, ref.loc ?? null));
-      }
+  return (ref, verdict) => {
+    if (verdict.kind === "rejected") {
+      const params = { alias: ref.alias, name: ref.name, what: verdict.what };
+      ctx.errors.push(diagnostic("valueArgNotStatic", params, ref.loc ?? null));
       return;
     }
-    if (undefinedMode === "silent") return;
-    if (resolveVariable(ref.name, resolveInput).kind !== "unresolved") return;
+    if (verdict.kind === "legal" || undefinedMode === "silent") {
+      return;
+    }
+    const resolution = resolveVariable(ref.name, {
+      functionDefs: ctx.functionDefs,
+      nodeDefs: ctx.nodeDefs,
+      importedFunctions: ctx.importedFunctions,
+      importedNodeNames,
+      jsImportedNames: ctx.jsImportedNames,
+      scopeHas: (name) => verdict.scope.has(name),
+      registry: sandbox ? SANDBOX_JS_GLOBALS : JS_GLOBALS,
+    });
+    if (resolution.kind !== "unresolved") {
+      return;
+    }
     ctx.errors.push(
       diagnostic("undefinedVariable", { name: ref.name }, ref.loc ?? null, {
         severity: undefinedMode === "warn" ? "warning" : "error",
@@ -119,29 +128,28 @@ function makeReporter(ctx: TypeCheckerContext): Reporter {
   };
 }
 
-function checkSite(site: TypeSite, origins: Origins, report: Reporter): void {
+function checkSite(site: TypeSite, classify: Classify, report: Reporter): void {
   for (const ref of valueArgRefs(site.type, site.loc)) {
-    const origin = site.valueParams.includes(ref.name) ? "valueParam" : origins[ref.name];
-    report(ref, origin);
+    report(ref, classify(ref.name, site));
   }
-  for (const expr of site.defaults) {
-    for (const name of variableNamesIn(expr)) {
-      report({ alias: site.aliasName ?? "", name, loc: site.loc }, origins[name]);
+  // A default may name an earlier value parameter, as in
+  // `type Between(low: number, high: number = low)`: the generated factory
+  // is a JavaScript function, and a default parameter sees the ones before it.
+  site.valueParams.forEach((param, index) => {
+    if (!param.default) {
+      return;
     }
-  }
+    const earlier = { ...site, valueParams: site.valueParams.slice(0, index) };
+    for (const name of variableNamesIn(param.default)) {
+      report({ alias: site.aliasName ?? "", name, loc: site.loc }, classify(name, earlier));
+    }
+  });
 }
 
-/** Static, imported, and plain top-level names. */
-function moduleOrigins(nodes: AgencyNode[]): Origins {
-  const origins: Origins = {};
-  for (const node of nodes) {
-    if (node.type !== "importStatement") continue;
-    for (const entry of node.importedNames) {
-      for (const name of getImportedNames(entry)) {
-        origins[name] = "import";
-      }
-    }
-  }
+/** Which top-level `let`/`const` names are static. Null-prototype, since
+ *  the keys are user-written identifiers. */
+function moduleOrigins(nodes: AgencyNode[]): Record<string, ModuleOrigin> {
+  const origins: Record<string, ModuleOrigin> = Object.create(null);
   for (const assignment of topLevelAssignments(nodes)) {
     if (assignment.declKind) {
       origins[assignment.variableName] = assignment.static ? "static" : "global";
@@ -150,37 +158,12 @@ function moduleOrigins(nodes: AgencyNode[]): Origins {
   return origins;
 }
 
-/** Parameters and locals of one function or node body. */
-function definitionOrigins(definition: Definition): Origins {
-  const origins: Origins = {};
-  for (const param of definition.parameters) {
-    origins[param.name] = "param";
-  }
-  for (const { node } of walkNodes(definition.body)) {
-    if (node.type === "assignment" && node.declKind) {
-      origins[node.variableName] = "local";
-    }
-  }
-  return origins;
+function definitionNamed(name: string, ctx: TypeCheckerContext): Definition | undefined {
+  return ctx.functionDefs[name] ?? ctx.nodeDefs[name];
 }
 
-/** Sites outside any function or node body. Bodies are covered per
- *  definition, with their own parameters and locals in scope. */
-function topLevelTypeSites(nodes: AgencyNode[]): TypeSite[] {
-  const sites: TypeSite[] = [];
-  for (const { node, ancestors } of walkNodes(nodes)) {
-    if (hasFunctionOrNodeAncestor(ancestors)) continue;
-    if (node.type === "function" || node.type === "graphNode") continue;
-    const site = siteOf(node);
-    if (site !== null) {
-      sites.push(site);
-    }
-  }
-  return sites;
-}
-
-/** Parameter and return annotations, plus every site in the body. */
-function definitionTypeSites(definition: Definition): TypeSite[] {
+/** Parameter and return annotations. */
+function signatureSites(definition: Definition): TypeSite[] {
   const sites: TypeSite[] = [];
   for (const param of definition.parameters) {
     if (param.typeHint) {
@@ -190,51 +173,66 @@ function definitionTypeSites(definition: Definition): TypeSite[] {
   if (definition.returnType) {
     sites.push(plainSite(definition.returnType, definition.loc));
   }
-  for (const { node } of walkNodes(definition.body)) {
-    const site = siteOf(node);
-    if (site !== null) {
-      sites.push(site);
-    }
-  }
   return sites;
 }
 
-/** The type a statement or expression node carries, if it carries one. */
-function siteOf(node: AgencyNode): TypeSite | null {
+/**
+ * The types a statement or expression node carries. This lists every AST
+ * node with a `VariableType` field that a value-parameterized alias can
+ * appear in, other than a definition's signature (`signatureSites`). Type
+ * patterns in a `match` are lowered to `typeTestExpression` before the
+ * checker runs, so they are covered by that case.
+ */
+function sitesOf(node: AgencyNode): TypeSite[] {
   switch (node.type) {
     case "typeAlias":
-      return aliasSite(node);
+      return [
+        {
+          type: node.aliasedType,
+          loc: node.loc,
+          valueParams: node.valueParams ?? [],
+          aliasName: node.aliasName,
+        },
+      ];
     case "assignment":
-      return node.typeHint ? plainSite(node.typeHint, node.loc) : null;
+      return node.typeHint ? [plainSite(node.typeHint, node.loc)] : [];
     case "schemaExpression":
-      return plainSite(node.typeArg, node.loc);
+      return [plainSite(node.typeArg, node.loc)];
     case "typeTestExpression":
-      return plainSite(node.typeHint, node.loc);
+      return [plainSite(node.typeHint, node.loc)];
+    case "handleBlock":
+      return node.handler.kind === "inline" && node.handler.param.typeHint
+        ? [plainSite(node.handler.param.typeHint, node.loc)]
+        : [];
+    case "functionCall": {
+      const block = node.block;
+      if (!block) {
+        return [];
+      }
+      const types = block.params.map((param) => param.typeHint ?? null);
+      types.push(block.declaredYieldType ?? null);
+      return types.filter(isPresent).map((type) => plainSite(type, node.loc));
+    }
     default:
-      return null;
+      return [];
   }
 }
 
-function plainSite(type: VariableType, loc: SourceLocation | undefined): TypeSite {
-  return { type, loc, valueParams: [], defaults: [], aliasName: undefined };
+function isPresent<T>(value: T | null): value is T {
+  return value !== null;
 }
 
-function aliasSite(alias: TypeAlias): TypeSite {
-  const valueParams = alias.valueParams ?? [];
-  return {
-    type: alias.aliasedType,
-    loc: alias.loc,
-    valueParams: valueParams.map((param) => param.name),
-    defaults: valueParams.flatMap((param) => (param.default ? [param.default] : [])),
-    aliasName: alias.aliasName,
-  };
+function plainSite(type: VariableType, loc: SourceLocation | undefined): TypeSite {
+  return { type, loc, valueParams: [], aliasName: undefined };
 }
 
 /** Every value-argument reference inside a type. */
 function valueArgRefs(type: VariableType, loc: SourceLocation | undefined): ValueArgRef[] {
   const found: ValueArgRef[] = [];
   visitTypes(type, (inner) => {
-    if (inner.type !== "typeAliasVariable" && inner.type !== "genericType") return;
+    if (inner.type !== "typeAliasVariable" && inner.type !== "genericType") {
+      return;
+    }
     const alias = inner.type === "typeAliasVariable" ? inner.aliasName : inner.name;
     for (const arg of inner.valueArgs ?? []) {
       for (const name of variableNamesIn(arg)) {

--- a/packages/agency-lang/scripts/agency.test.ts
+++ b/packages/agency-lang/scripts/agency.test.ts
@@ -1078,3 +1078,66 @@ describe("schedule --backend remote dispatch", () => {
     }
   });
 });
+
+describe("typecheck with a bad re-export among several files", () => {
+  const SRC = "export def src(): number {\n  return 1\n}\n";
+  const BAD_REEXPORT = 'export { nope } from "./src.agency"\n';
+  const CLEAN = 'node main() {\n  let y: number = "t"\n  return y\n}\n';
+  let exit: ReturnType<typeof vi.spyOn>;
+  let errors: string[];
+  let logs: string[];
+
+  beforeEach(() => {
+    errors = [];
+    logs = [];
+    exit = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`exit ${code}`);
+    }) as never);
+    vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+      errors.push(args.join(" "));
+    });
+    vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      logs.push(args.join(" "));
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const write = (name: string, contents: string): string => {
+    const file = path.join(tmpDir, name);
+    fs.writeFileSync(file, contents, "utf-8");
+    return file;
+  };
+
+  it("reports the bad input file once, drops it, and still checks the others", async () => {
+    write("src.agency", SRC);
+    const bad = write("bad.agency", BAD_REEXPORT + "node main() {\n  return 2\n}\n");
+    const clean = write("clean.agency", CLEAN);
+    await expect(
+      createProgram().parseAsync(["node", "agency", "typecheck", bad, clean]),
+    ).rejects.toThrow("exit 1");
+    const importLines = errors.filter((line) => line.includes("Symbol 'nope' is not defined"));
+    expect(importLines).toHaveLength(1);
+    expect(importLines[0]).toContain(`${bad}:1:1`);
+    expect(errors.some((line) => line.includes("AG2001"))).toBe(true);
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it("reports a bad dependency once and still checks the files that do not import it", async () => {
+    write("src.agency", SRC);
+    const lib = write("lib.agency", BAD_REEXPORT);
+    const importer = 'import { nope } from "./lib.agency"\nnode main() {\n  return 1\n}\n';
+    const a = write("a.agency", importer);
+    const b = write("b.agency", importer);
+    const clean = write("clean.agency", CLEAN);
+    await expect(
+      createProgram().parseAsync(["node", "agency", "typecheck", a, b, clean]),
+    ).rejects.toThrow("exit 1");
+    const importLines = errors.filter((line) => line.includes("Symbol 'nope' is not defined"));
+    expect(importLines).toHaveLength(1);
+    expect(importLines[0]).toContain(`${lib}:1:1`);
+    expect(errors.some((line) => line.includes("AG2001"))).toBe(true);
+  });
+});

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -1586,20 +1586,25 @@ export function createProgram(deps: CliDependencies = {}): Command {
         console.error(formatImportResolutionError(error, file));
         hasErrors = true;
       };
-      let symbolTable: SymbolTable | undefined;
+      // One shared table for every file. When one file's imports make the
+      // shared build fail, each file gets its own table instead, so the bad
+      // import is reported against its file and the other files still check.
+      let sharedTable: SymbolTable | undefined;
       try {
-        symbolTable = filePaths.length ? SymbolTable.build(filePaths, config) : undefined;
+        sharedTable = filePaths.length ? SymbolTable.build(filePaths, config) : undefined;
       } catch (error) {
-        reportImportError(error);
-        process.exit(1);
+        if (!(error instanceof ImportResolutionError)) throw error;
+        sharedTable = undefined;
       }
+      const tableFor = (file: string): SymbolTable =>
+        sharedTable ?? SymbolTable.build([path.resolve(file)], config);
       for (const src of sources) {
         const contents = await readSource(src);
         try {
           if (src.kind === "stdin") {
             runTypeCheck(contents);
           } else {
-            runTypeCheck(contents, src.path, symbolTable);
+            runTypeCheck(contents, src.path, tableFor(src.path));
           }
         } catch (error) {
           reportImportError(error, src.kind === "file" ? src.path : undefined);

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -79,6 +79,7 @@ import { buildCompilationUnit } from "@/compilationUnit.js";
 import { expandSplices } from "@/preprocessors/expandSplices.js";
 import { formatSpliceDiagnostic } from "@/compiler/splice/report.js";
 import { SymbolTable } from "@/symbolTable.js";
+import { ImportResolutionError, formatImportResolutionError } from "@/importResolutionError.js";
 import { formatErrors, formatDiagnosticsHint, typeCheck } from "@/typeChecker/index.js";
 import { Command, InvalidArgumentError } from "@/vendor/commander/index.js";
 import * as fs from "fs";
@@ -1578,13 +1579,30 @@ export function createProgram(deps: CliDependencies = {}): Command {
       // whole directory complete. The symbol table stays file-keyed, so adding
       // more entrypoints never merges or pollutes across files.
       const filePaths = sources.filter((s) => s.kind === "file").map((s) => path.resolve(s.path));
-      const symbolTable = filePaths.length ? SymbolTable.build(filePaths, config) : undefined;
+      // A bad import (a re-export of a name the source lacks, an uninstalled
+      // pkg::) is a user error: print its message, not a stack trace.
+      const reportImportError = (error: unknown, file?: string): void => {
+        if (!(error instanceof ImportResolutionError)) throw error;
+        console.error(formatImportResolutionError(error, file));
+        hasErrors = true;
+      };
+      let symbolTable: SymbolTable | undefined;
+      try {
+        symbolTable = filePaths.length ? SymbolTable.build(filePaths, config) : undefined;
+      } catch (error) {
+        reportImportError(error);
+        process.exit(1);
+      }
       for (const src of sources) {
         const contents = await readSource(src);
-        if (src.kind === "stdin") {
-          runTypeCheck(contents);
-        } else {
-          runTypeCheck(contents, src.path, symbolTable);
+        try {
+          if (src.kind === "stdin") {
+            runTypeCheck(contents);
+          } else {
+            runTypeCheck(contents, src.path, symbolTable);
+          }
+        } catch (error) {
+          reportImportError(error, src.kind === "file" ? src.path : undefined);
         }
       }
       if (hasErrors) process.exit(1);
@@ -2396,7 +2414,17 @@ export async function runCli(
   const program = createProgram(deps);
   // No argv rewriting: the program boundary and flag ownership live inside
   // the vendored commander fork (passThroughOptions, fallbackCommand).
-  await program.parseAsync(argv);
+  try {
+    await program.parseAsync(argv);
+  } catch (error) {
+    // A bad import (a re-export of a name the source lacks, an uninstalled
+    // pkg::) is a user error: print its message, not a stack trace. The
+    // compiler throws it rather than exiting so programmatic callers can
+    // catch it; this is the one place the CLI turns it into an exit.
+    if (!(error instanceof ImportResolutionError)) throw error;
+    console.error(formatImportResolutionError(error));
+    process.exit(1);
+  }
 }
 
 const isMain =

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -1580,34 +1580,54 @@ export function createProgram(deps: CliDependencies = {}): Command {
       // more entrypoints never merges or pollutes across files.
       const filePaths = sources.filter((s) => s.kind === "file").map((s) => path.resolve(s.path));
       // A bad import (a re-export of a name the source lacks, an uninstalled
-      // pkg::) is a user error: print its message, not a stack trace.
+      // pkg::) is a user error: print its message once, not a stack trace.
+      const printed: string[] = [];
       const reportImportError = (error: unknown, file?: string): void => {
         if (!(error instanceof ImportResolutionError)) throw error;
-        console.error(formatImportResolutionError(error, file));
+        const line = formatImportResolutionError(error, file);
+        if (!printed.includes(line)) {
+          console.error(line);
+        }
+        printed.push(line);
         hasErrors = true;
       };
-      // One shared table for every file. When one file's imports make the
-      // shared build fail, each file gets its own table instead, so the bad
-      // import is reported against its file and the other files still check.
+      // One shared table for every file. When an input file's own imports
+      // break the build, that file is reported and dropped, and the table is
+      // rebuilt for the rest. When the bad import is in a file the inputs only
+      // reach through imports, the shared build cannot succeed, so each file
+      // builds its own table; the ones that reach the bad file repeat the
+      // same error, which is printed once.
+      const dropped: string[] = [];
+      let remaining = filePaths;
       let sharedTable: SymbolTable | undefined;
-      try {
-        sharedTable = filePaths.length ? SymbolTable.build(filePaths, config) : undefined;
-      } catch (error) {
-        if (!(error instanceof ImportResolutionError)) throw error;
-        sharedTable = undefined;
+      while (remaining.length > 0 && sharedTable === undefined) {
+        try {
+          sharedTable = SymbolTable.build(remaining, config);
+        } catch (error) {
+          reportImportError(error);
+          const bad = (error as ImportResolutionError).file;
+          if (bad === undefined || !remaining.includes(bad)) {
+            break;
+          }
+          dropped.push(bad);
+          remaining = remaining.filter((file) => file !== bad);
+        }
       }
-      const tableFor = (file: string): SymbolTable =>
-        sharedTable ?? SymbolTable.build([path.resolve(file)], config);
       for (const src of sources) {
+        if (src.kind === "stdin") {
+          runTypeCheck(await readSource(src));
+          continue;
+        }
+        const filePath = path.resolve(src.path);
+        if (dropped.includes(filePath)) {
+          continue;
+        }
         const contents = await readSource(src);
         try {
-          if (src.kind === "stdin") {
-            runTypeCheck(contents);
-          } else {
-            runTypeCheck(contents, src.path, tableFor(src.path));
-          }
+          const table = sharedTable ?? SymbolTable.build([filePath], config);
+          runTypeCheck(contents, src.path, table);
         } catch (error) {
-          reportImportError(error, src.kind === "file" ? src.path : undefined);
+          reportImportError(error, src.path);
         }
       }
       if (hasErrors) process.exit(1);

--- a/packages/agency-lang/tests/agency/validation/valueParamAliasPropertyValidator.agency
+++ b/packages/agency-lang/tests/agency/validation/valueParamAliasPropertyValidator.agency
@@ -1,0 +1,32 @@
+// A property-level validator on a field whose type is a value-parameterized
+// alias runs alongside the alias's own validator.
+def greaterThan(minValue: number, value: number): Result<number> {
+  if (value > minValue) {
+    return success(value)
+  }
+  return failure("expected ${value} to be > ${minValue}")
+}
+
+def atMost(limit: number, value: number): Result<number> {
+  if (value <= limit) {
+    return success(value)
+  }
+  return failure("expected ${value} to be <= ${limit}")
+}
+
+@validate(greaterThan.partial(minValue: minValue))
+type GreaterThan(minValue: number) = number
+
+type Age = GreaterThan(5)
+
+type Person = {
+  @validate(atMost.partial(limit: 100))
+  age: Age
+}
+
+node main() {
+  const big: Person! = { age: 500 }
+  const ok: Person! = { age: 50 }
+  const small: Person! = { age: 1 }
+  return { big: isSuccess(big), ok: isSuccess(ok), small: isSuccess(small) }
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamAliasPropertyValidator.test.json
+++ b/packages/agency-lang/tests/agency/validation/valueParamAliasPropertyValidator.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "{\"big\":false,\"ok\":true,\"small\":false}",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "A property-level validator on a value-parameterized alias field runs together with the alias validator."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamStaticArg.agency
+++ b/packages/agency-lang/tests/agency/validation/valueParamStaticArg.agency
@@ -1,0 +1,22 @@
+// A top-level alias may pass a `static const` as a value argument. The
+// alias is declared at module load, before static init runs, so the
+// factory call has to be deferred until validation time (issue #440).
+static const minAge: number = 5
+
+def greaterThan(minValue: number, value: number): Result<number> {
+  if (value > minValue) {
+    return success(value)
+  }
+  return failure("expected ${value} to be > ${minValue}")
+}
+
+@validate(greaterThan.partial(minValue: minValue))
+type GreaterThan(minValue: number) = number
+
+type Age = GreaterThan(minAge)
+
+node main() {
+  const bad: Age[]! = [-1, 20]
+  const ok: Age[]! = [10, 20]
+  return { bad: isSuccess(bad), ok: isSuccess(ok) }
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamStaticArg.test.json
+++ b/packages/agency-lang/tests/agency/validation/valueParamStaticArg.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "{\"bad\":false,\"ok\":true}",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "A top-level alias whose value argument is a static const validates instead of reading the uninitialized static."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptBuilder/simple.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/simple.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/array.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/array.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/codeLiteral.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/codeLiteral.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/comments.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comments.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/comprehension.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comprehension.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/destructiveBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/destructiveBlock.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/destructiveNested.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/destructiveNested.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/effectAlways.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/effectAlways.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/goto.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/goto.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/imports.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/imports.mjs
@@ -45,7 +45,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/input.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/input.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/intersectionTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/intersectionTypes.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlockBlockArms.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlockBlockArms.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/matchExpression.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchExpression.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/recursiveTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recursiveTypes.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/schemaChaining.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaChaining.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
@@ -31,7 +31,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/simple.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/simple.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/skill.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/skill.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/slice.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/slice.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/splat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/splat.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/static.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/static.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/type-patterns.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/type-patterns.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/typeOperators.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeOperators.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/utilityTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/utilityTypes.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,

--- a/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
@@ -30,7 +30,7 @@ import {
   registerModuleFingerprint as __registerModuleFingerprint,
   head, tail, empty,
   success, failure, runtimeFailure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn, __requireLength,
-  Schema, __validateType, __validateChain, __validateChainRecursive, __coarseTypeTest,
+  Schema, __validateType, __validateChain, __validateChainRecursive, __withUseSiteValidators, __coarseTypeTest,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,


### PR DESCRIPTION
Seven of the eight typechecker issues in the batch, plus a check on the eighth.

## What changed, per issue

**#612 (narrowing lost inside inline handler bodies).** The flow builder started the handler body from the handle body's end flow. A handle body that always returns ends in `exit`, so the handler body got no flow nodes and every guard in it was ignored. This affected `isFailure(x)` too, not only the `is failure(...)` pattern form. The handler now starts from the pre-body flow, with every name the handle body rebinds reset to its declared type, because the raise can happen after any of those assignments. There is a test that a narrowing undone by an assignment in the handle body is not kept in the handler.

**#538 (false AG2009 after `return match`).** On current main a `return match(...)` returns `null` when no arm matches, so the code after it is dead. The flow builder skipped dead statements, so their references fell back to the declared un-narrowed type and the guarded `r.value` was reported. Dead statements are now walked on a side flow rooted at a fresh start node. The scope terminal stays `exit`, so definite-return checking is unchanged.

**#717 (redeclaring a parameter name).** New diagnostic AG4012 rejects a `let`/`const` that reuses a parameter name in a function or node body. Declarations inside a block argument are allowed since a block has its own scope. Codegen keeps resolving later reads to the parameter slot, so rejecting the shape is the cheap way to make the checker and the runtime agree.

**#441 (value argument that is a plain global).** New diagnostic AG7007 rejects a value argument that names a plain top-level variable, a parameter, or a local. Only a name the checker can prove is one of those is reported. A static const, a literal, an import, or a value parameter of the enclosing alias is fine.

**#440 (value argument that is a static const throws at runtime).** A top-level `type Age = GreaterThan(minAge)` ran the factory at module load, before static init, and passed the uninitialized-static sentinel to the validator. The factory call is now emitted behind the same `{ kind: "ref", get }` thunk a bare alias reference uses, so it runs at validation time. There is an execution test for the issue's program.

**#532 (bad re-export and uninstalled pkg:: import splat a stack trace).** Option 2 from the issue. The re-export validation throws and the uninstalled-package case throw `ImportResolutionError`, which moved from the import resolver to `lib/importResolutionError.ts` and now carries the file as well as the position. The compiler still lets it propagate, so programmatic callers and the buildSession tests are unchanged. The CLI catches it once in `runCli` and prints `file:line:col - error: message`. `agency typecheck` catches it per file so the other files still check. Any other error out of the symbol table keeps its stack.

**#518 (AG6028/AG6029 wording).** The two registry entries and the runtime backstop message are reworded. The shared clause is now `a required function-typed parameter 'p' that is unbound`, and the cross-check tests are updated to it.

**#752 (missing required node argument).** Already fixed on main. `node main() { goto greet() }` reports AG6016 today, so this PR closes it without a change.

## Checks

The new diagnostics were run over `stdlib/`, `examples/`, `lib/agents/`, and `packages/examples/` with no hits. The typechecker, compiler, preprocessor, backend, and LSP test directories pass. `pnpm run typecheck`, `pnpm run fmt:ts`, and `pnpm run lint:structure` are clean.

Closes #440, #441, #717, #612, #538, #532, #518, #752.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DxBM2wuQmh2pDRCNQBdAs9
