### PR TITLE
Bump smoltalk to 0.13.1 so a transient Anthropic 400 is retried

### DIFF
--- a/packages/agency-lang/docs/dev/llm/smoltalk.md
+++ b/packages/agency-lang/docs/dev/llm/smoltalk.md
@@ -89,6 +89,22 @@ spends the same token budget thinking before it writes anything visible:
 set `maxTokens` too low and the visible output is the empty string, which
 otherwise surfaces as a baffling "expected object, received string".
 
+### A 400 that is really a server hiccup
+
+Anthropic sometimes answers a valid request with a 400 whose whole message
+is `Invalid request data`, several seconds into generation. The same
+request succeeds unchanged on the next try. It showed up on
+`claude-opus-4-8` when a call combined structured output with tools: the
+reviewer in `std::agents/review` hit it on four of eleven calls one day.
+
+Since smoltalk 0.13.1 the Anthropic client maps that exact shape to
+`SmolOverloadedError` and leaves the 400 on `status`. Agency's
+`normalizeError` turns the class into `kind: "overloaded"`, and the retry
+classifier checks the kind before the status, so the call is retried under
+the normal policy (two retries with backoff) instead of failing at once. A
+400 that names the field it rejected, such as `messages.1.content: ...`, is
+still terminal.
+
 ## Where smoltalk is used
 
 - **`lib/runtime/llmClient.ts`** — the only place `smoltalk.text()` is called

--- a/packages/agency-lang/lib/runtime/llmClient.test.ts
+++ b/packages/agency-lang/lib/runtime/llmClient.test.ts
@@ -41,6 +41,17 @@ describe("SmoltalkClient.normalizeError", () => {
     expect(client.normalizeError(new SmolOverloadedError("server busy")).kind).toBe("overloaded");
   });
 
+  it("keeps the typed kind for smoltalk 0.13.1's transient 400", () => {
+    // Anthropic sometimes answers a valid request with a bare 400 "Invalid
+    // request data" mid-generation. smoltalk maps it to SmolOverloadedError
+    // with the 400 left on it; the typed kind must win over the status so
+    // the retry policy treats it as transient rather than terminal.
+    const err = new SmolOverloadedError("400 Invalid request data", { status: 400 });
+    const n = client.normalizeError(err);
+    expect(n.kind).toBe("overloaded");
+    expect(n.status).toBe(400);
+  });
+
   it("returns just the message for a non-smoltalk error", () => {
     const n = client.normalizeError(new Error("ECONNRESET"));
     expect(n).toEqual({ message: "ECONNRESET" });

--- a/packages/agency-lang/lib/runtime/llmRetry.test.ts
+++ b/packages/agency-lang/lib/runtime/llmRetry.test.ts
@@ -93,6 +93,20 @@ const policy = {
 };
 
 describe("decideRetry", () => {
+  it("retries a typed overloaded error even when its status is 400", () => {
+    // Anthropic's bare "Invalid request data" 400 arrives typed as overloaded
+    // (status kept). The typed kind is checked before the status, so this is
+    // a retry, not the terminal path every other 400 takes.
+    const normalized: NormalizedLLMError = { message: "400", kind: "overloaded", status: 400 };
+    expect(decideRetry(new Error("400"), normalized, 0, policy)).toMatchObject({
+      kind: "retry",
+      reason: "overloaded",
+    });
+    expect(decideRetry(new Error("400"), { message: "400", status: 400 }, 0, policy).kind).toBe(
+      "terminal",
+    );
+  });
+
   it("propagates user aborts", () => {
     const err = new AgencyAbort("c", makeAbortCause({ kind: "userInterrupt" }));
     expect(decideRetry(err, { message: "c" }, 0, policy).kind).toBe("propagate");

--- a/packages/agency-lang/package.json
+++ b/packages/agency-lang/package.json
@@ -113,7 +113,7 @@
     "nanoid": "^5.1.6",
     "picomatch": "^4.0.4",
     "prompts": "^2.4.2",
-    "smoltalk": "^0.13.0",
+    "smoltalk": "^0.13.1",
     "tarsec": "0.5.4",
     "typestache": "^0.6.0",
     "vscode-languageserver": "^9.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,8 +35,8 @@ importers:
         specifier: ^2.4.2
         version: 2.4.2
       smoltalk:
-        specifier: ^0.13.0
-        version: 0.13.0(@modelcontextprotocol/sdk@1.29.0(supports-color@7.2.0)(zod@4.4.3))(supports-color@7.2.0)(ws@8.21.3)
+        specifier: ^0.13.1
+        version: 0.13.1(@modelcontextprotocol/sdk@1.29.0(supports-color@7.2.0)(zod@4.4.3))(supports-color@7.2.0)(ws@8.21.3)
       tarsec:
         specifier: 0.5.4
         version: 0.5.4
@@ -2596,8 +2596,8 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
-  smoltalk@0.13.0:
-    resolution: {integrity: sha512-yWMgz4/jEcv7rXE/S1jEjLQ48l1ODNpYxIC7aXC5ukc3NdGS9lqTwFXlpEtwzLVVB2RzHUS8JVjO0WvTmxa97g==}
+  smoltalk@0.13.1:
+    resolution: {integrity: sha512-ZOZXULp5ecs3Ygyab0Q8zSgoekDf4syrb1kgw/5Wa/0AJohH5Mn8NOfqUqTm4C2B0WwK1Edq/LFmqCFWql3dWA==}
     peerDependencies:
       smoltalk-llama-cpp: '>=0.3.0 <1.0.0'
     peerDependenciesMeta:
@@ -5496,7 +5496,7 @@ snapshots:
 
   slash@3.0.0: {}
 
-  smoltalk@0.13.0(@modelcontextprotocol/sdk@1.29.0(supports-color@7.2.0)(zod@4.4.3))(supports-color@7.2.0)(ws@8.21.3):
+  smoltalk@0.13.1(@modelcontextprotocol/sdk@1.29.0(supports-color@7.2.0)(zod@4.4.3))(supports-color@7.2.0)(ws@8.21.3):
     dependencies:
       '@anthropic-ai/sdk': 0.109.1(zod@4.4.3)
       '@google/genai': 2.19.0(@modelcontextprotocol/sdk@1.29.0(supports-color@7.2.0)(zod@4.4.3))(supports-color@7.2.0)


### PR DESCRIPTION
## What

Bumps smoltalk to 0.13.1, which maps Anthropic's bare `Invalid request data` 400 to `SmolOverloadedError` (egonSchiele/smoltalk#46). Agency's `normalizeError` already turns that class into `kind: "overloaded"`, and the retry classifier checks the kind before the status, so the call now gets the normal two retries with backoff instead of failing on the first attempt.

## Why

`agency agent` on `claude-opus-4-8` was failing the reviewer (`judgeWork` in `std::agents/review`) four times out of eleven with this 400. Replaying the exact request body showed it is a server-side, mid-generation failure that succeeds unchanged on the next try, triggered when structured output and tools are combined. Details in the smoltalk PR.

## Changes

- `package.json`: smoltalk `^0.13.0` → `^0.13.1`, lockfile updated.
- `llmClient.test.ts`: `normalizeError` keeps the typed kind when an overloaded error carries status 400.
- `llmRetry.test.ts`: `decideRetry` retries a typed overloaded error with status 400, and still treats a plain status-400 error as terminal.
- `docs/dev/llm/smoltalk.md`: a short section recording the case and how the two halves handle it.

No runtime code changes on the Agency side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018R8oUe2cMFctPzRzLmi9cz


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of certain transient provider errors that appear as HTTP 400 responses.
  * These errors are now recognized as temporary overloads and retried according to the standard policy, including backoff.
  * Valid requests with specific field-validation errors remain terminal and are not retried.

* **Documentation**
  * Added guidance explaining how these provider responses are classified and handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->